### PR TITLE
Introduce a new function valid_access_ports

### DIFF
--- a/ocd/src/coresight/ap_access.rs
+++ b/ocd/src/coresight/ap_access.rs
@@ -26,14 +26,15 @@ where
 {
     type Error = T::Error;
 
-    fn read_register_ap(&mut self, port: PORT, register: REGISTER)
-        -> Result<REGISTER, Self::Error>
-    {
+    fn read_register_ap(
+        &mut self,
+        port: PORT,
+        register: REGISTER,
+    ) -> Result<REGISTER, Self::Error> {
         (*self).read_register_ap(port, register)
     }
 
-    fn write_register_ap(&mut self, port: PORT, register: REGISTER) -> Result<(), Self::Error>
-    {
+    fn write_register_ap(&mut self, port: PORT, register: REGISTER) -> Result<(), Self::Error> {
         (*self).write_register_ap(port, register)
     }
 }
@@ -48,4 +49,15 @@ where
     } else {
         false
     }
+}
+
+/// Return a Vec of all valid access ports found that the target connected to the debug_probe
+pub fn valid_access_ports<AP>(debug_port: &mut AP) -> Vec<GenericAP>
+where
+    AP: APAccess<GenericAP, IDR>,
+{
+    (0..=255)
+        .map(GenericAP::new)
+        .filter(|port| access_port_is_valid(debug_port, *port))
+        .collect::<Vec<GenericAP>>()
 }


### PR DESCRIPTION
This function returns a Vec of all valid access ports found at the
current target so users don't have to know which ones could exist and
scan them manually.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>