### PR TITLE
Cleanup clippy lints and format cli crate

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,20 +5,16 @@ authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Dominik Boehi <dominik.boehi@gm
 edition = "2018"
 
 [dependencies]
+ocd = { path = "../ocd", version = "0.2.0" }
+ocd-targets = { path = "../ocd-targets", version = "0.2.0" }
+
 pretty_env_logger = "0.3.0"
 log = "0.4.6"
 structopt = "0.2.14"
-ocd = { path = "../ocd", version = "0.2.0" }
-ocd-targets = { path = "../ocd-targets", version = "0.2.0" }
-scroll = "*"
+scroll = "0.9.2"
 rustyline = "5.0.2"
 capstone = "0.6.0"
-serde = "*"
 ron = "0.5.1"
-gimli = "*"
-object = "*"
-memmap = "*"
-rustc-demangle = "0.1.16"
+memmap = "0.7.0"
 ihex = "1.1.2"
-console = "0.9"
 colored = "1.8.0"

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -1,14 +1,8 @@
 use crate::common::CliError;
-use capstone::Capstone;
 
-use ocd::{
-    debug::debug::DebugInfo,
-    memory::MI,
-    collection::{
-        cores::CortexDump,
-    },
-    session::Session,
-};
+use ocd::{collection::cores::CortexDump, debug::debug::DebugInfo, memory::MI, session::Session};
+
+use capstone::Capstone;
 
 use std::fs::File;
 use std::io::prelude::*;
@@ -28,11 +22,15 @@ impl DebugCli {
             help_text: "Step a single instruction",
 
             function: |cli_data, _args| {
-                let cpu_info = cli_data.session.target.core.step(&mut cli_data.session.probe)?;
+                let cpu_info = cli_data
+                    .session
+                    .target
+                    .core
+                    .step(&mut cli_data.session.probe)?;
                 println!("Core stopped at address 0x{:08x}", cpu_info.pc);
 
                 Ok(CliState::Continue)
-            }
+            },
         });
 
         cli.add_command(Command {
@@ -40,22 +38,28 @@ impl DebugCli {
             help_text: "Stop the CPU",
 
             function: |cli_data, _args| {
-                let cpu_info = cli_data.session.target.core.halt(&mut cli_data.session.probe)?;
+                let cpu_info = cli_data
+                    .session
+                    .target
+                    .core
+                    .halt(&mut cli_data.session.probe)?;
                 println!("Core stopped at address 0x{:08x}", cpu_info.pc);
 
-                let mut code = [0u8;16*2];
+                let mut code = [0u8; 16 * 2];
 
                 cli_data.session.probe.read_block8(cpu_info.pc, &mut code)?;
 
-
-                let instructions = cli_data.capstone.disasm_all(&code, cpu_info.pc as u64).unwrap();
+                let instructions = cli_data
+                    .capstone
+                    .disasm_all(&code, u64::from(cpu_info.pc))
+                    .unwrap();
 
                 for i in instructions.iter() {
                     println!("{}", i);
                 }
 
                 Ok(CliState::Continue)
-            }
+            },
         });
 
         cli.add_command(Command {
@@ -63,19 +67,21 @@ impl DebugCli {
             help_text: "Resume execution of the CPU",
 
             function: |cli_data, _args| {
-                cli_data.session.target.core.run(&mut cli_data.session.probe)?;
+                cli_data
+                    .session
+                    .target
+                    .core
+                    .run(&mut cli_data.session.probe)?;
 
                 Ok(CliState::Continue)
-            }
+            },
         });
 
         cli.add_command(Command {
             name: "quit",
             help_text: "Exit the program",
-            
-            function: |_cli_data, _args| {
-                Ok(CliState::Stop)
-            },
+
+            function: |_cli_data, _args| Ok(CliState::Stop),
         });
 
         cli.add_command(Command {
@@ -88,34 +94,45 @@ impl DebugCli {
                 let address = u32::from_str_radix(address_str, 16).unwrap();
                 //println!("Would read from address 0x{:08x}", address);
 
-                let num_words = args.get(1).map(|c| c.parse::<usize>().unwrap() ).unwrap_or(1);
+                let num_words = args
+                    .get(1)
+                    .map(|c| c.parse::<usize>().unwrap())
+                    .unwrap_or(1);
 
-                let mut buff = vec![0u32;num_words]; 
+                let mut buff = vec![0u32; num_words];
 
                 cli_data.session.probe.read_block32(address, &mut buff)?;
 
                 for (offset, word) in buff.iter().enumerate() {
-                    println!("0x{:08x} = 0x{:08x}", address + (offset*4) as u32, word);
+                    println!("0x{:08x} = 0x{:08x}", address + (offset * 4) as u32, word);
                 }
 
                 Ok(CliState::Continue)
-            }
+            },
         });
 
         cli.add_command(Command {
             name: "break",
             help_text: "Set a breakpoint at a specifc address",
-            
+
             function: |cli_data, args| {
                 let address_str = args.get(0).ok_or(CliError::MissingArgument)?;
                 let address = u32::from_str_radix(address_str, 16).unwrap();
                 //println!("Would read from address 0x{:08x}", address);
 
-                cli_data.session.target.core.enable_breakpoints(&mut cli_data.session.probe, true)?;
-                cli_data.session.target.core.set_breakpoint(&mut cli_data.session.probe, address)?;
+                cli_data
+                    .session
+                    .target
+                    .core
+                    .enable_breakpoints(&mut cli_data.session.probe, true)?;
+                cli_data
+                    .session
+                    .target
+                    .core
+                    .set_breakpoint(&mut cli_data.session.probe, address)?;
 
                 Ok(CliState::Continue)
-            }
+            },
         });
 
         cli.add_command(Command {
@@ -124,11 +141,14 @@ impl DebugCli {
 
             function: |cli_data, _args| {
                 let regs = cli_data.session.target.core.registers();
-                let program_counter = cli_data.session.target.core.read_core_reg(&mut cli_data.session.probe, regs.PC)?;
-
+                let program_counter = cli_data
+                    .session
+                    .target
+                    .core
+                    .read_core_reg(&mut cli_data.session.probe, regs.PC)?;
 
                 if let Some(di) = &cli_data.debug_info {
-                    let frames = di.try_unwind(&mut cli_data.session, program_counter as u64);
+                    let frames = di.try_unwind(&mut cli_data.session, u64::from(program_counter));
 
                     for frame in frames {
                         println!("{}", frame);
@@ -142,12 +162,16 @@ impl DebugCli {
         cli.add_command(Command {
             name: "regs",
             help_text: "Show CPU register values",
-            
+
             function: |cli_data, _args| {
-                let mut regs = [0u32;15];
+                let mut regs = [0u32; 15];
 
                 for i in 0..15 {
-                    regs[i as usize] = cli_data.session.target.core.read_core_reg(&mut cli_data.session.probe, i.into())?; 
+                    regs[i as usize] = cli_data
+                        .session
+                        .target
+                        .core
+                        .read_core_reg(&mut cli_data.session.probe, i.into())?;
                 }
 
                 for (i, val) in regs.iter().enumerate() {
@@ -159,7 +183,7 @@ impl DebugCli {
         });
 
         cli.add_command(Command {
-            name: "dump", 
+            name: "dump",
             help_text: "Store a dump of the current CPU state",
 
             function: |cli_data, _args| {
@@ -169,32 +193,51 @@ impl DebugCli {
 
                 let stack_top: u32 = 0x2000_0000 + 0x4_000;
 
-
                 let regs = cli_data.session.target.core.registers();
 
-                let stack_bot: u32 = cli_data.session.target.core.read_core_reg(&mut cli_data.session.probe, regs.SP)?;
-                let pc: u32 = cli_data.session.target.core.read_core_reg(&mut cli_data.session.probe, regs.PC)?;
-                
-                let mut stack = vec![0u8;(stack_top - stack_bot) as usize];
+                let stack_bot: u32 = cli_data
+                    .session
+                    .target
+                    .core
+                    .read_core_reg(&mut cli_data.session.probe, regs.SP)?;
+                let pc: u32 = cli_data
+                    .session
+                    .target
+                    .core
+                    .read_core_reg(&mut cli_data.session.probe, regs.PC)?;
 
-                cli_data.session.probe.read_block8(stack_bot, &mut stack[..])?;
+                let mut stack = vec![0u8; (stack_top - stack_bot) as usize];
+
+                cli_data
+                    .session
+                    .probe
+                    .read_block8(stack_bot, &mut stack[..])?;
 
                 let mut dump = CortexDump::new(stack_bot, stack);
 
-
                 for i in 0..12 {
-                    dump.regs[i as usize] = cli_data.session.target.core.read_core_reg(&mut cli_data.session.probe, i.into())?;
+                    dump.regs[i as usize] = cli_data
+                        .session
+                        .target
+                        .core
+                        .read_core_reg(&mut cli_data.session.probe, i.into())?;
                 }
 
                 dump.regs[13] = stack_bot;
-                dump.regs[14] = cli_data.session.target.core.read_core_reg(&mut cli_data.session.probe, regs.LR)?;
+                dump.regs[14] = cli_data
+                    .session
+                    .target
+                    .core
+                    .read_core_reg(&mut cli_data.session.probe, regs.LR)?;
                 dump.regs[15] = pc;
 
                 let serialized = ron::ser::to_string(&dump).expect("Failed to serialize dump");
 
                 let mut dump_file = File::create("dump.txt").expect("Failed to create file");
 
-                dump_file.write_all(serialized.as_bytes()).expect("Failed to write dump file");
+                dump_file
+                    .write_all(serialized.as_bytes())
+                    .expect("Failed to write dump file");
 
                 Ok(CliState::Continue)
             },
@@ -202,20 +245,27 @@ impl DebugCli {
 
         cli.add_command(Command {
             name: "reset",
-            
+
             help_text: "Reset the CPU",
-            
+
             function: |cli_data, _args| {
-                cli_data.session.target.core.halt(&mut cli_data.session.probe)?;
+                cli_data
+                    .session
+                    .target
+                    .core
+                    .halt(&mut cli_data.session.probe)?;
 
                 // Enable vector catch after reset (set bit 1 in DEMCR register)
                 cli_data.session.probe.write32(0xE000_EDFC, 1)?;
-                cli_data.session.target.core.reset(&mut cli_data.session.probe)?;
+                cli_data
+                    .session
+                    .target
+                    .core
+                    .reset(&mut cli_data.session.probe)?;
 
                 Ok(CliState::Continue)
             },
         });
-
 
         cli
     }
@@ -223,7 +273,6 @@ impl DebugCli {
     fn add_command(&mut self, command: Command) {
         self.commands.push(command)
     }
-
 
     pub fn handle_line(&self, line: &str, cli_data: &mut CliData) -> Result<CliState, CliError> {
         let mut command_parts = line.split_whitespace();
@@ -240,7 +289,6 @@ impl DebugCli {
 
                 return Ok(CliState::Continue);
             }
-
 
             let cmd = self.commands.iter().find(|c| c.name == command);
 
@@ -270,7 +318,6 @@ pub enum CliState {
     Continue,
     Stop,
 }
-
 
 struct Command {
     pub name: &'static str,

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -1,9 +1,4 @@
-use crate::{
-    SharedOptions,
-    common::{
-        CliError,
-    },
-};
+use crate::{common::CliError, SharedOptions};
 
 use ocd::{
     coresight::{
@@ -16,13 +11,9 @@ use ocd::{
     memory::romtable::CSComponent,
     probe::{
         daplink,
-        stlink,
-        debug_probe::{
-            DebugProbeType,
-            MasterProbe,
-            DebugProbe,
-        },
+        debug_probe::{DebugProbe, DebugProbeType, MasterProbe},
         protocol::WireProtocol,
+        stlink,
     },
 };
 
@@ -39,23 +30,23 @@ pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<(), 
             let mut link = daplink::DAPLink::new_from_probe_info(&device)?;
 
             link.attach(Some(WireProtocol::Swd))?;
-            
+
             MasterProbe::from_specific_probe(link)
-        },
+        }
         DebugProbeType::STLink => {
             let mut link = stlink::STLink::new_from_probe_info(&device)?;
 
             link.attach(Some(WireProtocol::Swd))?;
-            
+
             MasterProbe::from_specific_probe(link)
-        },
+        }
     };
 
     /*
         The following code only works with debug port v2,
         which might not necessarily be present.
 
-        Once the typed interface for the debug port is done, it 
+        Once the typed interface for the debug port is done, it
         can be enabled again.
 
     println!("Device information:");
@@ -73,9 +64,8 @@ pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<(), 
 
     */
 
-
     // Note: Temporary read to ensure the DP information is read at
-    //       least once before reading the ROM table 
+    //       least once before reading the ROM table
     //       (necessary according to STM manual).
     //
     // TODO: Move to proper place somewhere in init code


### PR DESCRIPTION
Fix all clippy lints in the cli/ folder, and use rustfmt on it.