### PR TITLE
Changed part identifier for the nRF52480 target

### DIFF
--- a/ocd-targets/targets/nRF52840.yaml
+++ b/ocd-targets/targets/nRF52840.yaml
@@ -3,7 +3,7 @@ name: "nRF52840"
 manufacturer:
   cc: 0x02
   id: 0x44
-part: 0x000001
+part: 0x000008
 flash_algorithm: "nRF52840.yaml"
 memory_map:
     - Flash:


### PR DESCRIPTION
Tested on nRF52840-MSK with cargo-flash.