### PR TITLE
Better CLI error handling, auto-select probe and target (fix #2)

### DIFF
--- a/cargo-flash/src/main.rs
+++ b/cargo-flash/src/main.rs
@@ -206,7 +206,7 @@ fn main_try() -> Result<(), failure::Error> {
     let strategy = if let Some(name) = opt.chip {
         SelectionStrategy::Name(name)
     } else {
-        SelectionStrategy::ChipInfo(ChipInfo::new(&mut probe).unwrap())
+        SelectionStrategy::ChipInfo(ChipInfo::read_from_rom_table(&mut probe).unwrap())
     };
     let target = if let Some(target) = target_override {
         target

--- a/ocd/src/probe/debug_probe.rs
+++ b/ocd/src/probe/debug_probe.rs
@@ -291,12 +291,13 @@ pub trait DebugProbe: DAPAccess {
     fn target_reset(&mut self) -> Result<(), DebugProbeError>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum DebugProbeType {
     DAPLink,
     STLink,
 }
 
+#[derive(Clone)]
 pub struct DebugProbeInfo {
     pub identifier: String,
     pub vendor_id: u16,

--- a/ocd/src/probe/flash/flasher.rs
+++ b/ocd/src/probe/flash/flasher.rs
@@ -290,7 +290,10 @@ impl<'a> Flasher<'a> {
         log::debug!("Halting core.");
         let cpu_info = flasher.target.core.halt(&mut flasher.probe);
         log::debug!("PC = 0x{:08x}", cpu_info.unwrap().pc);
-        flasher.target.core.wait_for_core_halted(&mut flasher.probe)?;
+        flasher
+            .target
+            .core
+            .wait_for_core_halted(&mut flasher.probe)?;
         log::debug!("Reset and halt");
         flasher.target.core.reset_and_halt(&mut flasher.probe)?;
 

--- a/ocd/src/probe/flash/loader.rs
+++ b/ocd/src/probe/flash/loader.rs
@@ -1,5 +1,7 @@
 use crate::session::Session;
 use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
 
 use super::*;
 
@@ -90,6 +92,20 @@ pub enum FlashLoaderError {
     MemoryRegionNotDefined(u32), // Contains the faulty address.
     MemoryRegionNotFlash(u32),   // Contains the faulty address.
     NoFlashLoaderAlgorithmAttached,
+}
+
+impl Error for FlashLoaderError {}
+
+impl fmt::Display for FlashLoaderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use FlashLoaderError::*;
+
+        match self {
+            MemoryRegionNotDefined(addr) => write!(f, "Trying to access memory at address {:#08x}, which is not inside any defined memory region.", addr),
+            MemoryRegionNotFlash(addr) => write!(f, "Trying to access flash at address {:#08x}, which is not inside any defined flash region.", addr),
+            NoFlashLoaderAlgorithmAttached => write!(f, "Trying to write flash, but no flash loader algorithm is attached."),
+        }
+    }
 }
 
 impl<'a, 'b> FlashLoader<'a, 'b> {

--- a/ocd/src/target/info.rs
+++ b/ocd/src/target/info.rs
@@ -17,53 +17,49 @@ pub struct ChipInfo {
 }
 
 impl ChipInfo {
-    pub fn new(probe: &mut MasterProbe) -> Option<Self> {
-        get_chip_info(probe)
-    }
-}
+    pub fn read_from_rom_table(probe: &mut MasterProbe) -> Option<Self> {
+        for access_port in valid_access_ports(probe) {
+            let idr = probe.read_register_ap(access_port, IDR::default()).ok()?;
+            println!("{:#x?}", idr);
 
-pub fn get_chip_info(probe: &mut MasterProbe) -> Option<ChipInfo> {
-    for access_port in valid_access_ports(probe) {
-        let idr = probe.read_register_ap(access_port, IDR::default()).ok()?;
-        println!("{:#x?}", idr);
+            if idr.CLASS == APClass::MEMAP {
+                let access_port: MemoryAP = access_port.into();
 
-        if idr.CLASS == APClass::MEMAP {
-            let access_port: MemoryAP = access_port.into();
+                let base_register = probe.read_register_ap(access_port, BASE::default()).ok()?;
 
-            let base_register = probe.read_register_ap(access_port, BASE::default()).ok()?;
+                let mut baseaddr = if BaseaddrFormat::ADIv5 == base_register.Format {
+                    let base2 = probe.read_register_ap(access_port, BASE2::default()).ok()?;
+                    (u64::from(base2.BASEADDR) << 32)
+                } else {
+                    0
+                };
+                baseaddr |= u64::from(base_register.BASEADDR << 12);
 
-            let mut baseaddr = if BaseaddrFormat::ADIv5 == base_register.Format {
-                let base2 = probe.read_register_ap(access_port, BASE2::default()).ok()?;
-                (u64::from(base2.BASEADDR) << 32)
-            } else {
-                0
-            };
-            baseaddr |= u64::from(base_register.BASEADDR << 12);
+                let component_table = CSComponent::try_parse(&probe.into(), baseaddr as u64);
 
-            let component_table = CSComponent::try_parse(&probe.into(), baseaddr as u64);
-
-            match component_table.ok()? {
-                CSComponent::Class1RomTable(
-                    CSComponentId {
-                        peripheral_id:
-                            PeripheralID {
-                                JEP106: jep106,
-                                PART: part,
-                                ..
-                            },
-                        ..
-                    },
-                    ..,
-                ) => {
-                    return Some(ChipInfo {
-                        manufacturer: jep106?,
-                        part,
-                    })
+                match component_table.ok()? {
+                    CSComponent::Class1RomTable(
+                        CSComponentId {
+                            peripheral_id:
+                                PeripheralID {
+                                    JEP106: jep106,
+                                    PART: part,
+                                    ..
+                                },
+                            ..
+                        },
+                        ..,
+                    ) => {
+                        return Some(ChipInfo {
+                            manufacturer: jep106?,
+                            part,
+                        })
+                    }
+                    _ => continue,
                 }
-                _ => continue,
             }
         }
-    }
 
-    None
+        None
+    }
 }


### PR DESCRIPTION
Improve CLI error handling by removing some unwraps,
so that a proper error message will be reported.

Also, automatically select the probe if only a single probe
is attached to the system, and try to automatically select the
target.