### PR TITLE
Fix windows build (close #53)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,23 @@ name: CI
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }} 
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
       
       - name: Install libusb
         run: sudo apt install -y libusb-dev libusb-1.0
+        # Only install on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Fix the probe-rs build on Windows.

Points to fix:

- [x]  Ensure paths in probe-rs-targets are platform-indepent
- [x] Fix signal handling in cargo-flash/src/main.rs  