### PR TITLE
Add feature to unlock nRF52 micros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `nrf-recover` feature that unlocks nRF52 chips through Nordic's custom `AP`
+
 ### Changed
 
 ### Fixed

--- a/cargo-flash/Cargo.toml
+++ b/cargo-flash/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["embedded"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+pretty_env_logger = "0.3.0"
 structopt = "0.3.2"
 cargo-project = "0.2.2"
 failure = "0.1.5"

--- a/cargo-flash/Cargo.toml
+++ b/cargo-flash/Cargo.toml
@@ -20,4 +20,3 @@ failure = "0.1.5"
 colored = "1.8.0"
 probe-rs = { path = "../probe-rs", version = "0.2.0" }
 probe-rs-targets = { path = "../probe-rs-targets", version = "0.2.0" }
-pretty_env_logger = "0.3.0"

--- a/cargo-flash/src/main.rs
+++ b/cargo-flash/src/main.rs
@@ -127,7 +127,7 @@ fn main_try() -> Result<(), failure::Error> {
         args.remove(index);
     }
 
-    // Remove possible `--nrf_recover` argument as cargo build does not understand it.
+    // Remove possible `--nrf-recover` argument as cargo build does not understand it.
     if let Some(index) = args.iter().position(|x| x.starts_with("--nrf-recover")) {
         args.remove(index);
     }

--- a/cargo-flash/src/main.rs
+++ b/cargo-flash/src/main.rs
@@ -204,7 +204,7 @@ fn main_try() -> Result<(), failure::Error> {
             link.attach(Some(WireProtocol::Swd))?;
 
             if opt.nrf_recover {
-                return format_err!("It isn't possible to recover with a ST-Link");
+                return Err(format_err!("It isn't possible to recover with a ST-Link"));
             }
             MasterProbe::from_specific_probe(link)
         }

--- a/probe-rs-targets/targets/nRF52832.yaml
+++ b/probe-rs-targets/targets/nRF52832.yaml
@@ -1,9 +1,8 @@
 name: "nRF52832"
-# TODO: Manufacturer and Part are not correct yet. They are only needed for autodetection.
 manufacturer:
   cc: 0x02
   id: 0x44
-part: 0x000111
+part: 0x000006
 flash_algorithm: "nRF52832.yaml"
 memory_map:
     - Flash:

--- a/probe-rs/src/coresight/access_ports/custom_ap/mod.rs
+++ b/probe-rs/src/coresight/access_ports/custom_ap/mod.rs
@@ -1,0 +1,72 @@
+//! Definition of some custom (proprietary) access ports
+
+use crate::coresight::common::Register;
+
+use crate::coresight::access_ports::generic_ap::GenericAP;
+use crate::coresight::access_ports::APRegister;
+use crate::coresight::ap_access::AccessPort;
+
+// Ctrl-Ap
+// The Control Access Port (CTRL-AP) is a Nordic's custom access port that enables control of the
+// device even if the other access ports in the DAP are being disabled by the access port protection.
+define_ap!(CtrlAP);
+
+impl From<GenericAP> for CtrlAP {
+    fn from(other: GenericAP) -> Self {
+        CtrlAP {
+            port_number: other.get_port_number(),
+        }
+    }
+}
+
+define_ap_register!(
+    /// Soft reset triggered through CTRL-AP
+    CtrlAP,
+    RESET,
+    0x000,
+    [(RESET: bool),],
+    value,
+    RESET {
+        RESET: if value == 1 { true } else { false },
+    },
+    if value.RESET { 1 } else { 0 }
+);
+
+define_ap_register!(
+    /// Soft reset triggered through CTRL-AP
+    CtrlAP,
+    ERASEALL,
+    0x004,
+    [(ERASEALL: bool),],
+    value,
+    ERASEALL {
+        ERASEALL: if value == 1 { true } else { false },
+    },
+    if value.ERASEALL { 1 } else { 0 }
+);
+
+define_ap_register!(
+    /// Soft reset triggered through CTRL-AP
+    CtrlAP,
+    ERASEALLSTATUS,
+    0x008,
+    [(ERASEALLSTATUS: bool),],
+    value,
+    ERASEALLSTATUS {
+        ERASEALLSTATUS: if value == 1 { true } else { false },
+    },
+    if value.ERASEALLSTATUS { 1 } else { 0 }
+);
+
+define_ap_register!(
+    /// Soft reset triggered through CTRL-AP
+    CtrlAP,
+    APPROTECTSTATUS,
+    0x00C,
+    [(APPROTECTSTATUS: bool),],
+    value,
+    APPROTECTSTATUS {
+        APPROTECTSTATUS: if value == 1 { true } else { false },
+    },
+    if value.APPROTECTSTATUS { 1 } else { 0 }
+);

--- a/probe-rs/src/coresight/access_ports/custom_ap/mod.rs
+++ b/probe-rs/src/coresight/access_ports/custom_ap/mod.rs
@@ -33,7 +33,7 @@ define_ap_register!(
 );
 
 define_ap_register!(
-    /// Soft reset triggered through CTRL-AP
+    /// Start mass erase
     CtrlAP,
     ERASEALL,
     0x004,
@@ -46,7 +46,7 @@ define_ap_register!(
 );
 
 define_ap_register!(
-    /// Soft reset triggered through CTRL-AP
+    /// Flag that indicates if the mass erase process is on-going
     CtrlAP,
     ERASEALLSTATUS,
     0x008,
@@ -59,7 +59,7 @@ define_ap_register!(
 );
 
 define_ap_register!(
-    /// Soft reset triggered through CTRL-AP
+    /// Flag that indicates if the chip is locked, `0` means locked
     CtrlAP,
     APPROTECTSTATUS,
     0x00C,

--- a/probe-rs/src/coresight/access_ports/custom_ap/mod.rs
+++ b/probe-rs/src/coresight/access_ports/custom_ap/mod.rs
@@ -26,9 +26,7 @@ define_ap_register!(
     0x000,
     [(RESET: bool),],
     value,
-    RESET {
-        RESET: if value == 1 { true } else { false },
-    },
+    RESET { RESET: value == 1 },
     if value.RESET { 1 } else { 0 }
 );
 
@@ -40,7 +38,7 @@ define_ap_register!(
     [(ERASEALL: bool),],
     value,
     ERASEALL {
-        ERASEALL: if value == 1 { true } else { false },
+        ERASEALL: value == 1,
     },
     if value.ERASEALL { 1 } else { 0 }
 );
@@ -53,7 +51,7 @@ define_ap_register!(
     [(ERASEALLSTATUS: bool),],
     value,
     ERASEALLSTATUS {
-        ERASEALLSTATUS: if value == 1 { true } else { false },
+        ERASEALLSTATUS: value == 1,
     },
     if value.ERASEALLSTATUS { 1 } else { 0 }
 );
@@ -66,7 +64,7 @@ define_ap_register!(
     [(APPROTECTSTATUS: bool),],
     value,
     APPROTECTSTATUS {
-        APPROTECTSTATUS: if value == 1 { true } else { false },
+        APPROTECTSTATUS: value == 1,
     },
     if value.APPROTECTSTATUS { 1 } else { 0 }
 );

--- a/probe-rs/src/coresight/access_ports/generic_ap/mod.rs
+++ b/probe-rs/src/coresight/access_ports/generic_ap/mod.rs
@@ -21,7 +21,7 @@ impl Default for APClass {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, Primitive, Clone, Copy)]
+#[derive(Debug, Primitive, Clone, Copy, PartialEq)]
 pub enum APType {
     JTAG_COM_AP = 0x0,
     AMBA_AHB3 = 0x1,

--- a/probe-rs/src/coresight/access_ports/memory_ap/mod.rs
+++ b/probe-rs/src/coresight/access_ports/memory_ap/mod.rs
@@ -25,7 +25,7 @@ impl From<GenericAP> for MemoryAP {
     }
 }
 
-#[derive(Debug, Primitive, Clone, Copy)]
+#[derive(Debug, Primitive, Clone, Copy, PartialEq)]
 pub enum DataSize {
     U8 = 0b000,
     U16 = 0b001,
@@ -41,7 +41,7 @@ impl Default for DataSize {
     }
 }
 
-#[derive(Debug, Primitive, Clone, Copy)]
+#[derive(Debug, Primitive, Clone, Copy, PartialEq)]
 pub enum AddressIncrement {
     Off = 0b00,
     Single = 0b01,
@@ -66,7 +66,7 @@ impl Default for BaseaddrFormat {
     }
 }
 
-#[derive(Debug, Primitive, Clone, Copy)]
+#[derive(Debug, Primitive, Clone, Copy, PartialEq)]
 pub enum DebugEntryState {
     NotPresent = 0,
     Present = 1,

--- a/probe-rs/src/coresight/access_ports/mod.rs
+++ b/probe-rs/src/coresight/access_ports/mod.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 mod register_generation;
 
+pub mod custom_ap;
 pub mod generic_ap;
 pub mod memory_ap;
 

--- a/probe-rs/src/coresight/access_ports/mod.rs
+++ b/probe-rs/src/coresight/access_ports/mod.rs
@@ -18,6 +18,7 @@ pub enum AccessPortError {
     RegisterReadError { addr: u8, name: &'static str },
     RegisterWriteError { addr: u8, name: &'static str },
     OutOfBoundsError,
+    CtrlAPNotFound,
 }
 
 impl Error for AccessPortError {}
@@ -40,6 +41,7 @@ impl fmt::Display for AccessPortError {
                 name, addr
             ),
             OutOfBoundsError => write!(f, "Out of bounds access"),
+            CtrlAPNotFound => write!(f, "Could not find Nordic's CTRL-AP"),
         }
     }
 }

--- a/probe-rs/src/coresight/access_ports/register_generation.rs
+++ b/probe-rs/src/coresight/access_ports/register_generation.rs
@@ -16,7 +16,7 @@ macro_rules! define_ap_register {
     => {
         $(#[$outer])*
         #[allow(non_snake_case)]
-        #[derive(Debug, Default, Clone, Copy)]
+        #[derive(Debug, Default, Clone, Copy, PartialEq)]
         pub struct $name {
             $(pub $field: $type,)*
         }

--- a/probe-rs/src/coresight/ap_access.rs
+++ b/probe-rs/src/coresight/ap_access.rs
@@ -61,3 +61,18 @@ where
         .filter(|port| access_port_is_valid(debug_port, *port))
         .collect::<Vec<GenericAP>>()
 }
+
+/// Tries to find the first AP with the given idr value, returns `None` if there isn't any
+pub fn get_ap_by_idr<AP, P>(debug_port: &mut AP, f: P) -> Option<GenericAP>
+where
+    AP: APAccess<GenericAP, IDR>,
+    P: Fn(IDR) -> bool,
+{
+    (0..=255).map(GenericAP::new).find(|ap| {
+        if let Ok(idr) = debug_port.read_register_ap(*ap, IDR::default()) {
+            f(idr)
+        } else {
+            false
+        }
+    })
+}

--- a/probe-rs/src/probe/debug_probe.rs
+++ b/probe-rs/src/probe/debug_probe.rs
@@ -21,6 +21,7 @@ use std::time::Instant;
 
 const UNLOCK_TRIES: usize = 2;
 const UNLOCK_TIMEOUT: u64 = 15;
+const CTRL_AP_IDR: u32 = 0x0288_0000;
 
 #[derive(Debug)]
 pub enum DebugProbeError {
@@ -204,7 +205,7 @@ impl MasterProbe {
     /// Tries to mass erase a locked nRF52 chip, this process may timeout, if it does, the chip
     /// might be unlocked or not, it is advised to try again if flashing fails
     pub fn nrf_recover(&mut self) -> Result<(), DebugProbeError> {
-        let ctrl_port = match get_ap_by_idr(self, |idr| u32::from(idr) == 0x02880000) {
+        let ctrl_port = match get_ap_by_idr(self, |idr| u32::from(idr) == CTRL_AP_IDR) {
             Some(port) => CtrlAP::from(port),
             None => {
                 return Err(DebugProbeError::AccessPortError(

--- a/probe-rs/src/target/info.rs
+++ b/probe-rs/src/target/info.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     memory::romtable::{CSComponent, CSComponentId, PeripheralID, RomTableError},
 };
+use colored::*;
 use jep106::JEP106Code;
 use log::debug;
 use std::{error::Error, fmt};

--- a/probe-rs/src/target/info.rs
+++ b/probe-rs/src/target/info.rs
@@ -92,6 +92,13 @@ impl ChipInfo {
                 }
             }
         }
+        println!(
+            "{}\n{}\n{}\n{}",
+            "If you are using a Nordic chip, it might be locked to debug access".yellow(),
+            "Run cargo flash with --nrf-recover to unlock".yellow(),
+            "WARNING: --nrf-recover will erase the entire code".yellow(),
+            "flash and UICR area of the device, in addition to the entire RAM".yellow()
+        );
 
         Err(ReadError::NotFound)
     }


### PR DESCRIPTION
Nordic has a protection scheme where you can completely lock the MEMAP (AP#0), when that happens the only way to unlock the chip is using the CTRL-AP (AP#1) which has a custom set of registers. For more information see: https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52832.ps.v1.1%2Fdif.html&anchor=debugandtrace

I don't see a reason why this wouldn't work for st-link, but it doesn't. It's only working with dap-link. This is kinda weird, because when the chip isn't locked I can use st-link to successfully communicate with AP#1 and send an erase (unlock) command with no problem, and it works, I know that because the flash gets indeed erased. However, when the chip is locked the stlink only gets the `0x05` error (`JtagNoDeviceConnected`) when communicating with the CTRL-AP, while the dap-link works without a problem.

I tried several init configurations for the st-link without success. I also tried using the `STLink::open_ap` method, which lacks documentation and is never used, so I'm not sure when to use it.