### PR TITLE
WIP: Add support for lpc84x MCUs

### DIFF
--- a/probe-rs-targets/algorithms/lpc84x.yaml
+++ b/probe-rs-targets/algorithms/lpc84x.yaml
@@ -1,0 +1,18 @@
+# Flashing algorithm file for lpc84x MCUs
+#
+# TODO: None of the values below are correct!
+
+load_address: 0x00000000
+instructions: []
+pc_init: 0
+pc_uninit: null
+pc_program_page: 0
+pc_erase_sector: 0
+pc_erase_all: 0
+static_base: 0
+begin_stack: 0
+begin_data: 0
+page_buffers: [0, 0]
+min_program_length: 2
+analyzer_supported: true
+analyzer_address: 0

--- a/probe-rs-targets/targets/lpc84x.yaml
+++ b/probe-rs-targets/targets/lpc84x.yaml
@@ -1,0 +1,33 @@
+# WIP target file for LPC84x MCUs
+
+name: "LPC84x"
+# TODO: Manufacturer and Part are not correct yet. They are only needed for autodetection.
+manufacturer:
+  cc: 0x05
+  id: 0x01
+part: 0x0
+flash_algorithm: "lpc84x.yaml"
+memory_map:
+    - Flash:
+        range:
+          start: 0x00000000
+          end:   0x00004000
+        is_boot_memory: true
+        is_testable: true
+        blocksize: 0x10
+        sector_size: 0x10
+        page_size: 0x10
+        phrase_size: 0x10
+        erase_all_weight: 0.174 # TODO: Replace with proper constant later.
+        erase_sector_weight: 0.048 # TODO: Replace with proper constant later.
+        program_page_weight: 0.130 # TODO: Replace with proper constant later.
+        erased_byte_value: 0xFF
+        access: 0b00000101 # TODO: Replace with proper constant later.
+        are_erased_sectors_readable: true
+    - Ram:
+        range:
+          start: 0x10000000
+          end: 0x10001000
+        is_boot_memory: false
+        is_testable: true
+core: "M0+"

--- a/probe-rs/src/collection/mod.rs
+++ b/probe-rs/src/collection/mod.rs
@@ -50,6 +50,7 @@ pub fn get_algorithm(name: impl AsRef<str>) -> Option<FlashAlgorithm> {
 pub fn get_core(name: impl AsRef<str>) -> Option<Box<dyn Core>> {
     let map: HashMap<&'static str, Box<dyn Core>> = hashmap! {
         "M0" => Box::new(self::cores::m0::M0) as _,
+        "M0+" => Box::new(self::cores::m0::M0) as _,
         "M4" => Box::new(self::cores::m4::M4) as _,
     };
 


### PR DESCRIPTION
Hi there, very impressed with `probe-rs`, this is awesome work! :+1: 

Since I happen to have lpc84x, I figured I'd try to add support for it.  At the moment, reset, halting, stepping, etc. work. However, flashing is very broken. 

Specifically, I'm wondering how the information for the yaml files in `probe-rs-targets/algorithms` was collected? An example for an STM32 part might be useful! 

Any advice here would be helpful! :)