### PR TITLE
Improve cargo-flash error handling

### DIFF
--- a/cargo-flash/src/main.rs
+++ b/cargo-flash/src/main.rs
@@ -212,7 +212,7 @@ fn main_try() -> Result<(), failure::Error> {
     let strategy = if let Some(name) = opt.chip {
         SelectionStrategy::Name(name)
     } else {
-        SelectionStrategy::ChipInfo(ChipInfo::read_from_rom_table(&mut probe).unwrap())
+        SelectionStrategy::ChipInfo(ChipInfo::read_from_rom_table(&mut probe)?)
     };
     let target = if let Some(target) = target_override {
         target

--- a/probe-rs/src/probe/flash/download.rs
+++ b/probe-rs/src/probe/flash/download.rs
@@ -29,7 +29,6 @@ pub enum FileDownloadError {
     IhexRead(ihex::reader::ReaderError),
     IO(std::io::Error),
     Object(&'static str),
-    TargetDoesNotExist,
 }
 
 impl Error for FileDownloadError {}
@@ -43,7 +42,6 @@ impl fmt::Display for FileDownloadError {
             IhexRead(ref e) => e.fmt(f),
             IO(ref e) => e.fmt(f),
             Object(ref s) => write!(f, "Object Error: {}.", s),
-            TargetDoesNotExist => write!(f, "File Downlaod: Target does not exist."),
         }
     }
 }
@@ -97,7 +95,7 @@ impl<'a> FileDownloader {
     ) -> Result<(), FileDownloadError> {
         let mut file = match File::open(path) {
             Ok(file) => file,
-            Err(_e) => return Err(FileDownloadError::TargetDoesNotExist),
+            Err(e) => return Err(FileDownloadError::IO(e)),
         };
         let mut buffer = vec![];
         // IMPORTANT: Change this to an actual memory map of a real chip

--- a/probe-rs/src/target/info.rs
+++ b/probe-rs/src/target/info.rs
@@ -1,4 +1,4 @@
-use crate::probe::debug_probe::MasterProbe;
+use crate::probe::debug_probe::{DebugProbeError, MasterProbe};
 use crate::{
     coresight::{
         access_ports::{
@@ -7,9 +7,41 @@ use crate::{
         },
         ap_access::{valid_access_ports, APAccess},
     },
-    memory::romtable::{CSComponent, CSComponentId, PeripheralID},
+    memory::romtable::{CSComponent, CSComponentId, PeripheralID, RomTableError},
 };
 use jep106::JEP106Code;
+use std::{error::Error, fmt};
+
+#[derive(Debug)]
+pub enum ReadError {
+    DebugProbeError(DebugProbeError),
+    RomTableError(RomTableError),
+    NotFound,
+}
+
+impl From<DebugProbeError> for ReadError {
+    fn from(e: DebugProbeError) -> Self {
+        ReadError::DebugProbeError(e)
+    }
+}
+
+impl From<RomTableError> for ReadError {
+    fn from(e: RomTableError) -> Self {
+        ReadError::RomTableError(e)
+    }
+}
+
+impl fmt::Display for ReadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReadError::DebugProbeError(e) => write!(f, "failed to access target: {}", e),
+            ReadError::RomTableError(e) => write!(f, "failed to parse ROM table: {}", e),
+            ReadError::NotFound => f.write_str("chip info not found in IDR"),
+        }
+    }
+}
+
+impl Error for ReadError {}
 
 pub struct ChipInfo {
     pub manufacturer: JEP106Code,
@@ -17,32 +49,32 @@ pub struct ChipInfo {
 }
 
 impl ChipInfo {
-    pub fn read_from_rom_table(probe: &mut MasterProbe) -> Option<Self> {
+    pub fn read_from_rom_table(probe: &mut MasterProbe) -> Result<Self, ReadError> {
         for access_port in valid_access_ports(probe) {
-            let idr = probe.read_register_ap(access_port, IDR::default()).ok()?;
+            let idr = probe.read_register_ap(access_port, IDR::default())?;
             println!("{:#x?}", idr);
 
             if idr.CLASS == APClass::MEMAP {
                 let access_port: MemoryAP = access_port.into();
 
-                let base_register = probe.read_register_ap(access_port, BASE::default()).ok()?;
+                let base_register = probe.read_register_ap(access_port, BASE::default())?;
 
                 let mut baseaddr = if BaseaddrFormat::ADIv5 == base_register.Format {
-                    let base2 = probe.read_register_ap(access_port, BASE2::default()).ok()?;
+                    let base2 = probe.read_register_ap(access_port, BASE2::default())?;
                     (u64::from(base2.BASEADDR) << 32)
                 } else {
                     0
                 };
                 baseaddr |= u64::from(base_register.BASEADDR << 12);
 
-                let component_table = CSComponent::try_parse(&probe.into(), baseaddr as u64);
+                let component_table = CSComponent::try_parse(&probe.into(), baseaddr as u64)?;
 
-                match component_table.ok()? {
+                match component_table {
                     CSComponent::Class1RomTable(
                         CSComponentId {
                             peripheral_id:
                                 PeripheralID {
-                                    JEP106: jep106,
+                                    JEP106: Some(jep106),
                                     PART: part,
                                     ..
                                 },
@@ -50,16 +82,29 @@ impl ChipInfo {
                         },
                         ..,
                     ) => {
-                        return Some(ChipInfo {
-                            manufacturer: jep106?,
+                        return Ok(ChipInfo {
+                            manufacturer: jep106,
                             part,
-                        })
+                        });
                     }
                     _ => continue,
                 }
             }
         }
 
-        None
+        Err(ReadError::NotFound)
+    }
+}
+
+impl fmt::Display for ChipInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let manu = match self.manufacturer.get() {
+            Some(name) => name.to_string(),
+            None => format!(
+                "<unknown manufacturer (cc={:2x}, id={:2x})>",
+                self.manufacturer.cc, self.manufacturer.id
+            ),
+        };
+        write!(f, "{} 0x{:4x}", manu, self.part)
     }
 }

--- a/probe-rs/src/target/info.rs
+++ b/probe-rs/src/target/info.rs
@@ -10,6 +10,7 @@ use crate::{
     memory::romtable::{CSComponent, CSComponentId, PeripheralID, RomTableError},
 };
 use jep106::JEP106Code;
+use log::debug;
 use std::{error::Error, fmt};
 
 #[derive(Debug)]
@@ -52,7 +53,7 @@ impl ChipInfo {
     pub fn read_from_rom_table(probe: &mut MasterProbe) -> Result<Self, ReadError> {
         for access_port in valid_access_ports(probe) {
             let idr = probe.read_register_ap(access_port, IDR::default())?;
-            println!("{:#x?}", idr);
+            debug!("{:#x?}", idr);
 
             if idr.CLASS == APClass::MEMAP {
                 let access_port: MemoryAP = access_port.into();

--- a/probe-rs/src/target/mod.rs
+++ b/probe-rs/src/target/mod.rs
@@ -2,6 +2,7 @@ pub mod info;
 
 use serde::de::{Error, Unexpected};
 
+use self::info::ReadError;
 use crate::{
     collection::get_core,
     probe::{
@@ -146,7 +147,7 @@ impl<'de> serde::Deserialize<'de> for Box<dyn Core> {
 
 #[derive(Debug)]
 pub enum TargetSelectionError {
-    CouldNotAutodetect,
+    InfoReadError(ReadError),
     TargetNotFound(String),
     TargetCouldNotBeParsed(TargetParseError),
 }
@@ -156,7 +157,7 @@ impl fmt::Display for TargetSelectionError {
         use TargetSelectionError::*;
 
         match self {
-            CouldNotAutodetect => write!(f, "Target could not be automatically identified."),
+            InfoReadError(e) => write!(f, "Failed to read target into: {}", e),
             TargetNotFound(ref t) => write!(f, "Failed to find target defintion for target {}", t),
             TargetCouldNotBeParsed(ref e) => {
                 write!(f, "Failed to parse target definition for target: ")?;
@@ -171,5 +172,11 @@ impl std::error::Error for TargetSelectionError {}
 impl From<TargetParseError> for TargetSelectionError {
     fn from(error: TargetParseError) -> Self {
         TargetSelectionError::TargetCouldNotBeParsed(error)
+    }
+}
+
+impl From<ReadError> for TargetSelectionError {
+    fn from(e: ReadError) -> Self {
+        TargetSelectionError::InfoReadError(e)
     }
 }


### PR DESCRIPTION
This gets rid of all the unwraps, moves error printing to a single spot, and makes errors look like Cargo ones.

This required adding yet another error type and error variants. We should try to remove some of them, or at least switch to a crate that makes us write less boilerplate.