### PR TITLE
Point cargo-project at a fixed version

### DIFF
--- a/cargo-flash/Cargo.toml
+++ b/cargo-flash/Cargo.toml
@@ -13,10 +13,13 @@ keywords = ["embedded"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-structopt = "0.3.2"
-cargo-project = "0.2.2"
-failure = "0.1.5"
-colored = "1.8.0"
 probe-rs = { path = "../probe-rs", version = "0.2.0" }
 probe-rs-targets = { path = "../probe-rs-targets", version = "0.2.0" }
+structopt = "0.3.2"
+failure = "0.1.5"
+colored = "1.8.0"
 pretty_env_logger = "0.3.0"
+
+[dependencies.cargo-project]
+git = "https://github.com/probe-rs/cargo-project.git"
+rev = "9a5a81a"


### PR DESCRIPTION
Points the dependency at the git branch containing https://github.com/japaric/cargo-project/pull/7. This makes `cargo-flash` usable for the Rubble demo. Unfortunately that still doesn't work (and is very slow), but this is good progress.

Closes https://github.com/probe-rs/probe-rs/issues/42