### PR TITLE
Improve stlink error messages

### DIFF
--- a/probe-rs/src/probe/debug_probe.rs
+++ b/probe-rs/src/probe/debug_probe.rs
@@ -9,6 +9,7 @@ use log::debug;
 use crate::memory::adi_v5_memory_interface::ADIMemoryInterface;
 use crate::memory::MI;
 use crate::probe::protocol::WireProtocol;
+use crate::probe::stlink::constants::Status as StLinkStatus;
 use std::error::Error;
 use std::fmt;
 
@@ -33,6 +34,7 @@ pub enum DebugProbeError {
     TargetPowerUpFailed,
     Timeout,
     AccessPortError(AccessPortError),
+    Custom(String),
 }
 
 impl Error for DebugProbeError {
@@ -54,6 +56,15 @@ impl fmt::Display for DebugProbeError {
 impl From<AccessPortError> for DebugProbeError {
     fn from(e: AccessPortError) -> Self {
         DebugProbeError::AccessPortError(e)
+    }
+}
+
+impl From<StLinkStatus> for DebugProbeError {
+    fn from(status: StLinkStatus) -> Self {
+        Self::Custom(format!(
+            "Unexpected STLink status {}: {:?}",
+            status as u8, status
+        ))
     }
 }
 

--- a/probe-rs/src/probe/stlink/constants.rs
+++ b/probe-rs/src/probe/stlink/constants.rs
@@ -63,7 +63,7 @@ pub mod commands {
 }
 
 /// STLink status codes and messages.
-#[derive(Primitive)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Primitive)]
 pub enum Status {
     JtagOk = 0x80,
     JtagUnknownError = 0x01,

--- a/probe-rs/src/probe/stlink/constants.rs
+++ b/probe-rs/src/probe/stlink/constants.rs
@@ -1,3 +1,6 @@
+use enum_primitive_derive::Primitive;
+use num_traits::FromPrimitive;
+
 pub mod commands {
     // Common commands.
     pub const GET_VERSION: u8 = 0xf1;
@@ -60,6 +63,7 @@ pub mod commands {
 }
 
 /// STLink status codes and messages.
+#[derive(Primitive)]
 pub enum Status {
     JtagOk = 0x80,
     JtagUnknownError = 0x01,
@@ -90,6 +94,12 @@ pub enum Status {
     SwvNotAvailable = 0x20,
     JtagFreqNotSupported = 0x41,
     JtagUnknownCmd = 0x42,
+}
+
+impl From<u8> for Status {
+    fn from(status_byte: u8) -> Status {
+        Status::from_u8(status_byte).unwrap_or(Status::JtagUnknownError)
+    }
 }
 
 /// Map from SWD frequency in Hertz to delay loop count.

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -67,12 +67,12 @@ impl DebugProbe for STLink {
             &mut buf,
             TIMEOUT,
         )?;
-        Self::check_status(&buf).and_then(|_| {
-            // After we checked the status with success,
-            // We store the current protocol.
-            self.protocol = protocol;
-            Ok(protocol)
-        })
+        Self::check_status(&buf)?;
+
+        // After we checked the status with success,
+        // We store the current protocol.
+        self.protocol = protocol;
+        Ok(protocol)
     }
 
     /// Leave debug mode.
@@ -93,7 +93,8 @@ impl DebugProbe for STLink {
             &mut buf,
             TIMEOUT,
         )?;
-        Self::check_status(&buf)
+        Self::check_status(&buf)?;
+        Ok(())
     }
 }
 
@@ -326,7 +327,8 @@ impl STLink {
             &mut buf,
             TIMEOUT,
         )?;
-        Self::check_status(&buf)
+        Self::check_status(&buf)?;
+        Ok(())
     }
 
     /// Sets the JTAG frequency.
@@ -345,7 +347,8 @@ impl STLink {
             &mut buf,
             TIMEOUT,
         )?;
-        Self::check_status(&buf)
+        Self::check_status(&buf)?;
+        Ok(())
     }
 
     pub fn open_ap(&mut self, apsel: impl AccessPort) -> Result<(), DebugProbeError> {
@@ -364,7 +367,8 @@ impl STLink {
                 &mut buf,
                 TIMEOUT,
             )?;
-            Self::check_status(&buf)
+            Self::check_status(&buf)?;
+            Ok(())
         }
     }
 
@@ -383,7 +387,8 @@ impl STLink {
                 &mut buf,
                 TIMEOUT,
             )?;
-            Self::check_status(&buf)
+            Self::check_status(&buf)?;
+            Ok(())
         }
     }
 
@@ -402,18 +407,20 @@ impl STLink {
             &mut buf,
             TIMEOUT,
         )?;
-        Self::check_status(&buf)
+        Self::check_status(&buf)?;
+        Ok(())
     }
 
     /// Validates the status given.
     /// Returns an `Err(DebugProbeError::UnknownError)` if the status is not `Status::JtagOk`.
     /// Returns Ok(()) otherwise.
     /// This can be called on any status returned from the attached target.
-    fn check_status(status: &[u8]) -> Result<(), DebugProbeError> {
+    fn check_status(status: &[u8]) -> Result<(), Status> {
         log::trace!("check_status({:?})", status);
-        if status[0] != Status::JtagOk as u8 {
+        let status = Status::from(status[0]);
+        if status != Status::JtagOk {
             log::debug!("check_status failed: {:?}", status);
-            Err(DebugProbeError::UnknownError)
+            Err(status)
         } else {
             Ok(())
         }


### PR DESCRIPTION
While this definitely gives us better error messages when ST-Link fails, I'm not really sure if the `Custom` error is the right thing to do.
I wanted to avoid having prober specific error variants in the enum, but now the `DebugProbeError` implementation needs to implement the error formatting.
What do you guys think?