### PR TITLE
Remove potential endless loop, and cleanup Core trait a bit.

### DIFF
--- a/probe-rs/src/probe/debug_probe.rs
+++ b/probe-rs/src/probe/debug_probe.rs
@@ -262,11 +262,6 @@ impl MasterProbe {
     }
 }
 
-#[derive(Debug)]
-pub struct CpuInformation {
-    pub pc: u32,
-}
-
 impl<REGISTER> APAccess<MemoryAP, REGISTER> for MasterProbe
 where
     REGISTER: APRegister<MemoryAP>,


### PR DESCRIPTION
This removes a potential endless loop, which could have happened in the `reset_and_halt` function, which was waiting for the core to reset without a timeout.

All functions in the `Core` trait which halt the core now return the `CoreInformation` struct, to make the interface more consistent. The `CoreInformation` struct is also renamed from `CpuInformation`, and placed next to the `Core` trait, where it is actually used.