### PR TITLE
Fix the automatic chip detection

### DIFF
--- a/probe-rs/build.rs
+++ b/probe-rs/build.rs
@@ -224,7 +224,11 @@ fn extract_variants(chip_family: &serde_yaml::Value) -> Vec<proc_macro2::TokenSt
     variants_iter
         .map(|variant| {
             let name = variant.get("name").unwrap().as_str().unwrap();
-            let part = quote_option(variant.get("part").and_then(|v| v.as_u64().map(|v| v as u16)));
+            let part = quote_option(
+                variant
+                    .get("part")
+                    .and_then(|v| v.as_u64().map(|v| v as u16)),
+            );
 
             // Extract all the memory regions into a Vec of TookenStreams.
             let memory_map = extract_memory_map(&variant);
@@ -250,8 +254,18 @@ fn extract_chip_family(chip_family: &serde_yaml::Value) -> proc_macro2::TokenStr
     // Extract all the available variants into a Vec of TokenStreams.
     let variants = extract_variants(&chip_family);
 
-    let name = chip_family.get("name").unwrap().as_str().unwrap().to_ascii_lowercase();
-    let core = chip_family.get("core").unwrap().as_str().unwrap().to_ascii_lowercase();
+    let name = chip_family
+        .get("name")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_ascii_lowercase();
+    let core = chip_family
+        .get("core")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_ascii_lowercase();
     let manufacturer = quote_option(extract_manufacturer(&chip_family));
 
     // Quote the chip.
@@ -274,17 +288,15 @@ fn extract_chip_family(chip_family: &serde_yaml::Value) -> proc_macro2::TokenStr
 
 /// Extracts the jep code token stream from a yaml value.
 fn extract_manufacturer(chip: &serde_yaml::Value) -> Option<proc_macro2::TokenStream> {
-   chip
-        .get("manufacturer")
-        .map(|manufacturer| {
-            let cc = manufacturer.get("cc").map(|v| v.as_u64().unwrap() as u8);
-            let id = manufacturer.get("id").map(|v| v.as_u64().unwrap() as u8);
+    chip.get("manufacturer").map(|manufacturer| {
+        let cc = manufacturer.get("cc").map(|v| v.as_u64().unwrap() as u8);
+        let id = manufacturer.get("id").map(|v| v.as_u64().unwrap() as u8);
 
-            quote::quote! {
-                JEP106Code {
-                    cc: #cc,
-                    id: #id,
-                }
+        quote::quote! {
+            JEP106Code {
+                cc: #cc,
+                id: #id,
             }
-        })
+        }
+    })
 }

--- a/probe-rs/src/config/chip.rs
+++ b/probe-rs/src/config/chip.rs
@@ -8,6 +8,9 @@ pub struct Chip {
     /// This is the name of the chip in base form.
     /// E.g. `nRF52832`.
     pub name: String,
+    /// The `PART` register of the chip.
+    /// This value can be determined via the `cli info` command.
+    pub part: Option<u16>,
     /// The memory regions available on the chip.
     pub memory_map: Vec<MemoryRegion>,
 }

--- a/probe-rs/src/config/chip_family.rs
+++ b/probe-rs/src/config/chip_family.rs
@@ -13,9 +13,6 @@ pub struct ChipFamily {
     pub name: String,
     /// The JEP106 code of the manufacturer.
     pub manufacturer: Option<JEP106Code>,
-    /// The `PART` register of the chip.
-    /// This value can be determined via the `cli info` command.
-    pub part: Option<u16>,
     /// This vector holds all the variants of the family.
     pub variants: Vec<Chip>,
     /// This vector holds all available algorithms.

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -4,8 +4,8 @@ use crate::config::{
     flash_algorithm::RawFlashAlgorithm,
     memory::{FlashRegion, MemoryRegion, RamRegion},
 };
-use jep106::JEP106Code;
 use crate::target::info::ChipInfo;
+use jep106::JEP106Code;
 use std::error::Error;
 use std::fs::File;
 use std::path::Path;
@@ -104,9 +104,11 @@ impl Registry {
                         if variant
                             .name
                             .to_ascii_lowercase()
-                            .starts_with(&identifier.chip_name.to_ascii_lowercase()) {
+                            .starts_with(&identifier.chip_name.to_ascii_lowercase())
+                        {
                             if variant.name.to_ascii_lowercase()
-                                != identifier.chip_name.to_ascii_lowercase() {
+                                != identifier.chip_name.to_ascii_lowercase()
+                            {
                                 log::warn!(
                                     "Found chip {} which matches given partial name {}. Consider specifying it's full name.",
                                     variant.name,
@@ -124,7 +126,8 @@ impl Registry {
                     .flash_algorithms
                     .iter()
                     .find(|flash_algorithm| {
-                        if let Some(flash_algorithm_name) = identifier.flash_algorithm_name.clone() {
+                        if let Some(flash_algorithm_name) = identifier.flash_algorithm_name.clone()
+                        {
                             flash_algorithm.name == flash_algorithm_name
                         } else {
                             flash_algorithm.default
@@ -142,7 +145,8 @@ impl Registry {
                     if family
                         .manufacturer
                         .map(|m| m == chip_info.manufacturer)
-                        .unwrap_or(false) {
+                        .unwrap_or(false)
+                    {
                         for variant in &family.variants {
                             if variant.part.map(|p| p == chip_info.part).unwrap_or(false) {
                                 selected_family_and_chip = Some((family, variant));
@@ -150,7 +154,8 @@ impl Registry {
                         }
                     }
                 }
-                let (family, chip) = selected_family_and_chip.ok_or(RegistryError::ChipAutodetectFailed)?;
+                let (family, chip) =
+                    selected_family_and_chip.ok_or(RegistryError::ChipAutodetectFailed)?;
 
                 // Try get the correspnding flash algorithm.
                 let flash_algorithm = family

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -48,7 +48,7 @@ impl std::fmt::Display for RegistryError {
 
         match self {
             ChipNotFound => write!(f, "The requested chip was not found."),
-            ChipAutodetectFailed => write!(f, "The detected chip is unknown."),
+            ChipAutodetectFailed => write!(f, "The connected chip could not automatically be determined."),
             AlgorithmNotFound => write!(f, "The requested algorithm was not found."),
             CoreNotFound => write!(f, "The requested core was not found."),
             RamMissing => write!(f, "No RAM description was found."),

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -48,7 +48,10 @@ impl std::fmt::Display for RegistryError {
 
         match self {
             ChipNotFound => write!(f, "The requested chip was not found."),
-            ChipAutodetectFailed => write!(f, "The connected chip could not automatically be determined."),
+            ChipAutodetectFailed => write!(
+                f,
+                "The connected chip could not automatically be determined."
+            ),
             AlgorithmNotFound => write!(f, "The requested algorithm was not found."),
             CoreNotFound => write!(f, "The requested core was not found."),
             RamMissing => write!(f, "No RAM description was found."),

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -16,6 +16,7 @@ use crate::cores::get_core;
 #[derive(Debug)]
 pub enum RegistryError {
     ChipNotFound,
+    ChipAutodetectFailed,
     AlgorithmNotFound,
     CoreNotFound,
     RamMissing,
@@ -30,6 +31,7 @@ impl Error for RegistryError {
 
         match self {
             ChipNotFound => None,
+            ChipAutodetectFailed => None,
             AlgorithmNotFound => None,
             CoreNotFound => None,
             RamMissing => None,
@@ -45,7 +47,8 @@ impl std::fmt::Display for RegistryError {
         use RegistryError::*;
 
         match self {
-            ChipNotFound => write!(f, "The requested chip was not found and could not automatically be determined."),
+            ChipNotFound => write!(f, "The requested chip was not found."),
+            ChipAutodetectFailed => write!(f, "The detected chip is unknown."),
             AlgorithmNotFound => write!(f, "The requested algorithm was not found."),
             CoreNotFound => write!(f, "The requested core was not found."),
             RamMissing => write!(f, "No RAM description was found."),
@@ -147,7 +150,7 @@ impl Registry {
                         }
                     }
                 }
-                let (family, chip) = selected_family_and_chip.ok_or(RegistryError::ChipNotFound)?;
+                let (family, chip) = selected_family_and_chip.ok_or(RegistryError::ChipAutodetectFailed)?;
 
                 // Try get the correspnding flash algorithm.
                 let flash_algorithm = family

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -11,11 +11,6 @@ use jep106::JEP106Code;
 pub struct Target {
     /// The complete identifier of the target.
     pub identifier: TargetIdentifier,
-    /// The JEP106 code of the manufacturer.
-    pub manufacturer: Option<JEP106Code>,
-    /// The `PART` register of the chip.
-    /// This value can be determined via the `cli info command`.
-    pub part: Option<u16>,
     /// The name of the flash algorithm.
     pub flash_algorithm: Option<FlashAlgorithm>,
     /// The core type.
@@ -28,7 +23,6 @@ pub type TargetParseError = serde_yaml::Error;
 
 impl Target {
     pub fn new(
-        chip_family: &ChipFamily,
         chip: &Chip,
         ram: &RamRegion,
         flash: &FlashRegion,
@@ -40,8 +34,6 @@ impl Target {
                 chip_name: chip.name.clone(),
                 flash_algorithm_name: Some(flash_algorithm.name.clone()),
             },
-            manufacturer: chip_family.manufacturer,
-            part: chip_family.part,
             flash_algorithm: Some(flash_algorithm.assemble(ram, flash)),
             core,
             memory_map: chip.memory_map.clone(),

--- a/probe-rs/src/target/info.rs
+++ b/probe-rs/src/target/info.rs
@@ -43,6 +43,7 @@ impl fmt::Display for ReadError {
 
 impl Error for ReadError {}
 
+#[derive(Debug)]
 pub struct ChipInfo {
     pub manufacturer: JEP106Code,
     pub part: u16,

--- a/probe-rs/targets/nRF51 Series.yaml
+++ b/probe-rs/targets/nRF51 Series.yaml
@@ -1,5 +1,8 @@
 ---
 name: nRF51 Series
+manufacturer:
+  cc: 0x02
+  id: 0x44
 variants:
   - name: nRF51802_xxAA
     memory_map:
@@ -77,6 +80,7 @@ variants:
           page_size: 1024
           erased_byte_value: 255
   - name: nRF51822_xxAC
+    part: 0x1
     memory_map:
       - Ram:
           range:
@@ -107,6 +111,7 @@ variants:
           page_size: 1024
           erased_byte_value: 255
   - name: nRF51822_xxAB
+    part: 0x1
     memory_map:
       - Ram:
           range:

--- a/probe-rs/targets/nRF52 Series.yaml
+++ b/probe-rs/targets/nRF52 Series.yaml
@@ -1,7 +1,11 @@
 ---
 name: nRF52 Series
+manufacturer:
+  cc: 0x02
+  id: 0x44
 variants:
   - name: nRF52832_xxAA
+    part: 0x000006
     memory_map:
       - Ram:
           range:
@@ -17,6 +21,7 @@ variants:
           page_size: 4096
           erased_byte_value: 255
   - name: nRF52832_xxAB
+    part: 0x000006
     memory_map:
       - Ram:
           range:
@@ -47,6 +52,7 @@ variants:
           page_size: 4096
           erased_byte_value: 255
   - name: nRF52840_xxAA
+    part: 0x000008
     memory_map:
       - Ram:
           range:


### PR DESCRIPTION
During the rewrite of probe-rs targets for automatic CMSIS-Pack usage, the automatic chip detection broke. This has been fixed.

Furthermore, the error messages have been improved to properly report that the chip detection was unfruitful.