### PR TITLE
Add probe open helper functions

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,7 +9,7 @@ use probe_rs::{
     coresight::memory::MI,
     debug::DebugInfo,
     flash::download::{download_file, Format},
-    probe::{daplink, stlink, DebugProbeInfo},
+    probe::MasterProbe,
 };
 
 use capstone::{arch::arm::ArchMode, prelude::*, Capstone, Endian};
@@ -131,7 +131,7 @@ fn main() {
 }
 
 fn list_connected_devices() -> Result<(), CliError> {
-    let links = get_connected_devices();
+    let links = MasterProbe::list_all();
 
     if !links.is_empty() {
         println!("The following devices were found:");
@@ -238,12 +238,6 @@ fn trace_u32_on_target(shared_options: &SharedOptions, loc: u32) -> Result<(), C
             sleep(Duration::from_millis(time_to_wait));
         }
     })
-}
-
-fn get_connected_devices() -> Vec<DebugProbeInfo> {
-    let mut links = daplink::tools::list_daplink_devices();
-    links.extend(stlink::tools::list_stlink_devices());
-    links
 }
 
 fn debug(


### PR DESCRIPTION
Add some helper functions to the `MasterProbe` struct, which makes it easier to select a debug probe to use.

Also fix a small bug, where a debug probe was selected automatically even though multiple probes are connected.