### PR TITLE
First proposal of a SessionBuilder

### DIFF
--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -1,7 +1,7 @@
 use probe_rs::{
     config::registry::{Registry, SelectionStrategy},
     coresight::memory::MI,
-    probe::{DebugProbe, DebugProbeType, MasterProbe, WireProtocol},
+    probe::MasterProbe,
     session::Session,
     target::info::ChipInfo,
 };


### PR DESCRIPTION
I did this proposal so we can see where issues with the API are from a top down user view.

We somehow need to ensure that the API is easy to use and still features all the things we want.

For target autodetection a `MasterProbe` is required. So somehow the builder needs to already contain it to infer the `Target`. How do we want to approach this?

Also, how do we handle erroring? Do the different builder methods return all the same error type or does just the `build()` method return the error and the error is stored inside the builder until `build()` for a simpler API on the outside? Do we evern need to yield a specific error? Or is an `Option<Session>` with a `log::xx!()` of the error enough?