### PR TITLE
just bump the version to 0.3.1

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "probe-rs"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Dominik Boehi <dominik.boehi@gmail.ch>"]
 edition = "2018"
 description = "A collection of on chip debugging tools to comminicate with ARM chips."


### PR DESCRIPTION
Maybe we should bump to version 0.3.1, indicating that its beyond 0.3.0?

What do you think?