### PR TITLE
Refactor probe error handling, especially regarding st-link

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -26,7 +26,6 @@ jep106 = "0.2.3"
 scroll = "0.10.1"
 rusb = "0.5.1"
 lazy_static = "1.2.0"
-rental = "0.5.4"
 hidapi = "1.1.0"
 gimli = "0.19.0"
 object = "0.17.0"
@@ -42,6 +41,7 @@ hexdump = "0.1.0"
 maplit = "1.0.2"
 dyn-clone = "1.0.1"
 colored = "1.8.0"
+thiserror = "1.0"
 
 [build-dependencies]
 probe-rs-t2rust  = { path = "../probe-rs-t2rust", version ="0.4.0" }

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -1,7 +1,7 @@
 use probe_rs::{
     config::registry::{Registry, SelectionStrategy},
     coresight::memory::MI,
-    probe::{DebugProbe, DebugProbeType, MasterProbe, WireProtocol},
+    probe::MasterProbe,
     session::Session,
     target::info::ChipInfo,
 };

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -6,8 +6,6 @@
 #[macro_use]
 pub extern crate derivative;
 #[macro_use]
-extern crate rental;
-#[macro_use]
 extern crate maplit;
 #[macro_use]
 extern crate serde_derive;

--- a/probe-rs/src/probe/daplink/commands/mod.rs
+++ b/probe-rs/src/probe/daplink/commands/mod.rs
@@ -62,11 +62,11 @@ impl From<Error> for DebugProbeError {
     fn from(error: Error) -> Self {
         match error {
             Error::NotEnoughSpace => DebugProbeError::UnknownError,
-            Error::USB => DebugProbeError::USBError,
+            Error::USB => DebugProbeError::USBError(None),
             Error::UnexpectedAnswer => DebugProbeError::UnknownError,
             Error::DAP => DebugProbeError::UnknownError,
             Error::TooMuchData => DebugProbeError::UnknownError,
-            Error::HidApi => DebugProbeError::USBError,
+            Error::HidApi => DebugProbeError::USBError(None),
         }
     }
 }

--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -266,7 +266,7 @@ impl DebugProbe for DAPLink {
     /// Leave debug mode.
     fn detach(&mut self) -> Result<(), DebugProbeError> {
         commands::send_command(&mut self.device, DisconnectRequest {})
-            .map_err(|_| DebugProbeError::USBError)
+            .map_err(|_e| DebugProbeError::USBError(None))
             .and_then(|v: DisconnectResponse| match v {
                 DisconnectResponse(Status::DAPOk) => Ok(()),
                 DisconnectResponse(Status::DAPError) => Err(DebugProbeError::UnknownError),
@@ -298,7 +298,7 @@ impl DAPAccess for DAPLink {
         .and_then(|v| {
             if v.transfer_count == 1 {
                 if v.transfer_response.protocol_error {
-                    Err(DebugProbeError::USBError)
+                    Err(DebugProbeError::USBError(None))
                 } else {
                     match v.transfer_response.ack {
                         Ack::Ok => Ok(v.transfer_data),
@@ -326,7 +326,7 @@ impl DAPAccess for DAPLink {
         .and_then(|v| {
             if v.transfer_count == 1 {
                 if v.transfer_response.protocol_error {
-                    Err(DebugProbeError::USBError)
+                    Err(DebugProbeError::USBError(None))
                 } else {
                     match v.transfer_response.ack {
                         Ack::Ok => Ok(()),

--- a/probe-rs/src/probe/stlink/constants.rs
+++ b/probe-rs/src/probe/stlink/constants.rs
@@ -8,12 +8,6 @@ pub mod commands {
     pub const GET_TARGET_VOLTAGE: u8 = 0xf7;
     pub const GET_VERSION_EXT: u8 = 0xfb;
 
-    // Modes returned by GET_CURRENT_MODE.
-    pub const DEV_DFU_MODE: u8 = 0x00;
-    pub const DEV_MASS_MODE: u8 = 0x01;
-    pub const DEV_JTAG_MODE: u8 = 0x02;
-    pub const DEV_SWIM_MODE: u8 = 0x03;
-
     // Commands to exit other modes.
     pub const DFU_EXIT: u8 = 0x07;
     pub const SWIM_EXIT: u8 = 0x01;
@@ -118,4 +112,17 @@ pub enum JTagFrequencyToDivider {
     Hz560000 = 64,
     Hz280000 = 128,
     Hz140000 = 256,
+}
+
+/// Modes returned by GET_CURRENT_MODE.
+#[derive(Debug)]
+pub(crate) enum Mode {
+    /// Device is in DFU (Device Firmware Update) mode
+    Dfu = 0x00,
+    /// Device is in mass storage mode?
+    MassStorage = 0x01,
+    /// Device is in JTAG mode
+    Jtag = 0x02,
+    /// Device is in SWIM (Single Wire Interface) mode
+    Swim = 0x03,
 }


### PR DESCRIPTION
Move ST-Link specific errors to a ST-Link specific error type,
to clean up the DebugProbeError type.

The rental crate is also removed, to simply the implementation of
the ST-Link support.