### PR TITLE
Refactor daplink specific errors

### DIFF
--- a/probe-rs/src/cores/m0.rs
+++ b/probe-rs/src/cores/m0.rs
@@ -555,7 +555,7 @@ impl Core for FakeM0 {
             .regs
             .get(index as usize)
             .copied()
-            .ok_or(DebugProbeError::UnknownError)
+            .ok_or(DebugProbeError::Unknown)
     }
 
     fn write_core_reg(
@@ -602,11 +602,11 @@ impl Core for FakeM0 {
         if (address < self.dump.stack_addr)
             || (address as usize > (self.dump.stack_addr as usize + self.dump.stack.len()))
         {
-            return Err(DebugProbeError::UnknownError);
+            return Err(DebugProbeError::Unknown);
         }
 
         if address as usize + data.len() > (self.dump.stack_addr as usize + self.dump.stack.len()) {
-            return Err(DebugProbeError::UnknownError);
+            return Err(DebugProbeError::Unknown);
         }
 
         let stack_offset = (address - self.dump.stack_addr) as usize;

--- a/probe-rs/src/cores/m4.rs
+++ b/probe-rs/src/cores/m4.rs
@@ -483,7 +483,7 @@ impl Core for M4 {
             Ok(reg.num_code())
         } else {
             log::warn!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", reg.rev());
-            Err(DebugProbeError::UnknownError)
+            Err(DebugProbeError::Unknown)
         }
     }
 

--- a/probe-rs/src/probe/daplink/commands/mod.rs
+++ b/probe-rs/src/probe/daplink/commands/mod.rs
@@ -59,7 +59,7 @@ pub(crate) enum Error {
     #[error("Error in the USB HID access")]
     HidApi(#[from] hidapi::HidError),
     #[error("An error occured in the SWD communication between DAPlink and device.")]
-    SwdProtocolError,
+    SwdProtocol,
     #[error("Target device did not respond to request.")]
     NoAcknowledge,
     #[error("Target device responded with FAULT response to request.")]
@@ -72,7 +72,7 @@ pub(crate) enum Error {
 
 impl From<Error> for DebugProbeError {
     fn from(error: Error) -> Self {
-        DebugProbeError::ProbeSpecificError(Box::new(error))
+        DebugProbeError::ProbeSpecific(Box::new(error))
     }
 }
 

--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -289,7 +289,7 @@ impl DAPAccess for DAPLink {
         if response.transfer_count == 1 {
             if response.transfer_response.protocol_error {
                 // An SWD Protocol Error occured
-                Err(Error::SwdProtocolError.into())
+                Err(Error::SwdProtocol.into())
             } else {
                 match response.transfer_response.ack {
                     Ack::Ok => Ok(response.transfer_data),
@@ -317,15 +317,15 @@ impl DAPAccess for DAPLink {
 
         if response.transfer_count == 1 {
             if response.transfer_response.protocol_error {
-                Err(DebugProbeError::USBError(None))
+                Err(DebugProbeError::USB(None))
             } else {
                 match response.transfer_response.ack {
                     Ack::Ok => Ok(()),
-                    _ => Err(DebugProbeError::UnknownError),
+                    _ => Err(DebugProbeError::Unknown),
                 }
             }
         } else {
-            Err(DebugProbeError::UnknownError)
+            Err(DebugProbeError::Unknown)
         }
     }
 
@@ -361,7 +361,7 @@ impl DAPAccess for DAPLink {
             debug!("Transfer block: chunk={}, len={} bytes", i, chunk.len() * 4);
 
             let resp: TransferBlockResponse = commands::send_command(&mut self.device, request)
-                .map_err(|_| DebugProbeError::UnknownError)?;
+                .map_err(|_| DebugProbeError::Unknown)?;
 
             assert_eq!(resp.transfer_response, 1);
         }
@@ -404,7 +404,7 @@ impl DAPAccess for DAPLink {
             debug!("Transfer block: chunk={}, len={} bytes", i, chunk.len() * 4);
 
             let resp: TransferBlockResponse = commands::send_command(&mut self.device, request)
-                .map_err(|_| DebugProbeError::UnknownError)?;
+                .map_err(|_| DebugProbeError::Unknown)?;
 
             assert_eq!(resp.transfer_response, 1);
 

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -52,9 +52,6 @@ pub enum DebugProbeError {
     UnknownError,
     #[error("Probe could not be created.")]
     ProbeCouldNotBeCreated,
-    // TODO: This is daplink specific, could be moved there.
-    #[error("Target power-up failed.")]
-    TargetPowerUpFailed,
     // TODO: This is core specific, so should probably be moved there.
     #[error("Operation timed out.")]
     Timeout,

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -40,28 +40,28 @@ const CTRL_AP_IDR: IDR = IDR {
 #[derive(Error, Debug)]
 pub enum DebugProbeError {
     #[error("USB Communication Error")]
-    USBError(#[source] Option<Box<dyn Error + Send + Sync>>),
+    USB(#[source] Option<Box<dyn Error + Send + Sync>>),
     #[error("JTAG not supported on probe")]
     JTAGNotSupportedOnProbe,
     #[error("The firmware on the probe is outdated")]
     ProbeFirmwareOutdated,
     #[error("Error specific to a probe type occured")]
-    ProbeSpecificError(#[source] Box<dyn Error + Send + Sync>),
+    ProbeSpecific(#[source] Box<dyn Error + Send + Sync>),
     // TODO: Unknown errors are not very useful, this should be removed.
     #[error("An unknown error occured.")]
-    UnknownError,
+    Unknown,
     #[error("Probe could not be created.")]
     ProbeCouldNotBeCreated,
     // TODO: This is core specific, so should probably be moved there.
     #[error("Operation timed out.")]
     Timeout,
     #[error("Communication with access port failed: {0:?}")]
-    AccessPortError(#[from] AccessPortError),
+    AccessPort(#[from] AccessPortError),
 }
 
 impl From<stlink::StlinkError> for DebugProbeError {
     fn from(e: stlink::StlinkError) -> Self {
-        DebugProbeError::ProbeSpecificError(Box::new(e))
+        DebugProbeError::ProbeSpecific(Box::new(e))
     }
 }
 
@@ -344,9 +344,7 @@ impl MasterProbe {
         let ctrl_port = match get_ap_by_idr(self, |idr| idr == CTRL_AP_IDR) {
             Some(port) => CtrlAP::from(port),
             None => {
-                return Err(DebugProbeError::AccessPortError(
-                    AccessPortError::CtrlAPNotFound,
-                ));
+                return Err(DebugProbeError::AccessPort(AccessPortError::CtrlAPNotFound));
             }
         };
         log::info!("Starting mass erase...");
@@ -606,14 +604,14 @@ impl DebugProbe for FakeProbe {
 
     /// Resets the target device.
     fn target_reset(&mut self) -> Result<(), DebugProbeError> {
-        Err(DebugProbeError::UnknownError)
+        Err(DebugProbeError::Unknown)
     }
 }
 
 impl DAPAccess for FakeProbe {
     /// Reads the DAP register on the specified port and address
     fn read_register(&mut self, _port: Port, _addr: u16) -> Result<u32, DebugProbeError> {
-        Err(DebugProbeError::UnknownError)
+        Err(DebugProbeError::Unknown)
     }
 
     /// Writes a value to the DAP register on the specified port and address
@@ -623,6 +621,6 @@ impl DAPAccess for FakeProbe {
         _addr: u16,
         _value: u32,
     ) -> Result<(), DebugProbeError> {
-        Err(DebugProbeError::UnknownError)
+        Err(DebugProbeError::Unknown)
     }
 }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -315,7 +315,7 @@ impl STLink {
 
         if let Err(e) = self.enter_idle() {
             match e {
-                DebugProbeError::USBError(_) => {
+                DebugProbeError::USB(_) => {
                     // Reset the device, and try to enter idle mode again
                     self.device.reset()?;
 
@@ -434,7 +434,7 @@ impl STLink {
         log::trace!("check_status({:?})", status);
         if status[0] != Status::JtagOk as u8 {
             log::debug!("check_status failed: {:?}", status);
-            Err(DebugProbeError::UnknownError)
+            Err(DebugProbeError::Unknown)
         } else {
             Ok(())
         }

--- a/probe-rs/src/probe/stlink/usb_interface.rs
+++ b/probe-rs/src/probe/stlink/usb_interface.rs
@@ -69,7 +69,7 @@ pub(super) struct STLinkUSBDevice {
 impl STLinkUSBDevice {
     /// Creates and initializes a new USB device.
     pub fn new_from_info(probe_info: &DebugProbeInfo) -> Result<Self, DebugProbeError> {
-        let context = Context::new().map_err(|e| DebugProbeError::USBError(Some(Box::new(e))))?;
+        let context = Context::new().map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
 
         log::debug!("Acquired libusb context.");
 
@@ -89,19 +89,19 @@ impl STLinkUSBDevice {
 
         let mut device_handle = device
             .open()
-            .map_err(|e| DebugProbeError::USBError(Some(Box::new(e))))?;
+            .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
 
         log::debug!("Aquired handle for probe");
 
         let config = device
             .active_config_descriptor()
-            .map_err(|e| DebugProbeError::USBError(Some(Box::new(e))))?;
+            .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
 
         log::debug!("Active config descriptor: {:?}", &config);
 
         let descriptor = device
             .device_descriptor()
-            .map_err(|e| DebugProbeError::USBError(Some(Box::new(e))))?;
+            .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
 
         log::debug!("Device descriptor: {:?}", &descriptor);
 
@@ -109,7 +109,7 @@ impl STLinkUSBDevice {
 
         device_handle
             .claim_interface(0)
-            .map_err(|e| DebugProbeError::USBError(Some(Box::new(e))))?;
+            .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
 
         log::debug!("Claimed interface 0 of USB device.");
 
@@ -181,7 +181,7 @@ impl STLinkUSBDevice {
         let written_bytes = self
             .device_handle
             .write_bulk(ep_out, &cmd, timeout)
-            .map_err(|e| DebugProbeError::USBError(Some(Box::new(e))))?;
+            .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
 
         if written_bytes != CMD_LEN {
             return Err(StlinkError::NotEnoughBytesRead.into());
@@ -191,7 +191,7 @@ impl STLinkUSBDevice {
             let written_bytes = self
                 .device_handle
                 .write_bulk(ep_out, write_data, timeout)
-                .map_err(|e| DebugProbeError::USBError(Some(Box::new(e))))?;
+                .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
             if written_bytes != write_data.len() {
                 return Err(StlinkError::NotEnoughBytesRead.into());
             }
@@ -201,7 +201,7 @@ impl STLinkUSBDevice {
             let read_bytes = self
                 .device_handle
                 .read_bulk(ep_in, read_data, timeout)
-                .map_err(|e| DebugProbeError::USBError(Some(Box::new(e))))?;
+                .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
             if read_bytes != read_data.len() {
                 return Err(StlinkError::NotEnoughBytesRead.into());
             }
@@ -215,7 +215,7 @@ impl STLinkUSBDevice {
         log::debug!("Resetting USB device of STLink");
         self.device_handle
             .reset()
-            .map_err(|e| DebugProbeError::USBError(Some(Box::new(e))))
+            .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))
     }
 
     /// Closes the USB interface gracefully.

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -37,7 +37,7 @@ impl Session {
             log::warn!("Maximum number of breakpoints ({}) reached, unable to set additional HW breakpoint.", num_hw_breakpoints);
 
             // TODO: Better error here
-            return Err(DebugProbeError::UnknownError);
+            return Err(DebugProbeError::Unknown);
         }
 
         if !self.hw_breakpoint_enabled {
@@ -78,7 +78,7 @@ impl Session {
                 self.active_breakpoints.swap_remove(bp_position);
                 Ok(())
             }
-            None => Err(DebugProbeError::UnknownError),
+            None => Err(DebugProbeError::Unknown),
         }
     }
 


### PR DESCRIPTION
Instead of mapping DAPlink specific error to the `DebugProbeError::UnknownError`, we can wrap them into a `ProbeSpecific` error, so that they don't get lost.