### PR TITLE
add STM32G0 series

### DIFF
--- a/probe-rs/targets/STM32G0 Series.yaml
+++ b/probe-rs/targets/STM32G0 Series.yaml
@@ -42,9 +42,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -58,9 +58,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -74,9 +74,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -90,9 +90,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -138,9 +138,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -218,9 +218,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -250,9 +250,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134234112
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_16
       - stm32g0xx_otp
@@ -282,9 +282,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -314,9 +314,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -330,9 +330,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134234112
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_16
       - stm32g0xx_otp
@@ -378,9 +378,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -410,9 +410,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -506,9 +506,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -522,9 +522,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -570,9 +570,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -586,9 +586,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -634,9 +634,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536879104
-          is_boot_memory: false
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -714,9 +714,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -730,9 +730,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -746,9 +746,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -826,9 +826,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -842,9 +842,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -906,9 +906,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -922,9 +922,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -970,9 +970,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -986,9 +986,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -1002,9 +1002,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1034,9 +1034,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1066,9 +1066,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -1114,9 +1114,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1146,9 +1146,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1210,9 +1210,9 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1290,36 +1290,14 @@ variants:
           is_boot_memory: false
       - Flash:
           range:
-            start: 536870912
-            end: 536907776
-          is_boot_memory: false
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
       - stm32g0x1_opt
 flash_algorithms:
-  STM32G0x1_OPT:
-    name: STM32G0x1_OPT
-    description: STM32G0x1 Flash Options
-    default: false
-    instructions: v/NPj3BHPEg6SYFgO0mBYDtJwWA7ScFgO0kBYQAgcEcBITVIyQdBYUEEQWEAIHBHASBwRzBINEsDYTRJAWI/IcFiAWP/IUFiACKCYkFjgmMpSYAxCmABIUkEQWG/80+PAWnJA/zUQmEBaRlCBNABaRlDAWEBIHBHACBwRwAgcEfwtRd7Fn28Rhd+FWi+RlRok2gRaRhI0mkbTwdhHE89QAViHE0sQMRiK0ADY2dG+7JDYhlLGUCBYvGyQWN3RvmygWMWSQpADEmAMQpgmQtBYb/zT48BackD/NQCaQpJCkIE0AJpCkMCYQEg8L0AIPC9QBhwRyMBZ0UAIAJAq4nvzTsqGQh/bl1M+sMAAKr+Tzj//08/PwA/AP8AAID/AAEAAAAAAA==
-    pc_init: 7
-    pc_uninit: 33
-    pc_program_page: 129
-    pc_erase_sector: 125
-    pc_erase_all: 53
-    data_section_offset: 288
-    flash_properties:
-      address_range:
-        start: 536836096
-        end: 536836128
-      page_size: 32
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
-      sectors:
-        - size: 32
-          address: 0
   STM32G0xx_OTP:
     name: STM32G0xx_OTP
     description: STM32G0xx Flash OTP
@@ -1342,9 +1320,9 @@ flash_algorithms:
       sectors:
         - size: 1024
           address: 0
-  STM32G0xx_32:
-    name: STM32G0xx_32
-    description: STM32G0xx 32 KB Flash
+  STM32G0xx_16:
+    name: STM32G0xx_16
+    description: STM32G0xx 16 KB Flash
     default: true
     instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
     pc_init: 13
@@ -1356,13 +1334,35 @@ flash_algorithms:
     flash_properties:
       address_range:
         start: 134217728
-        end: 134250496
+        end: 134234112
       page_size: 1024
       erased_byte_value: 255
       program_page_timeout: 400
       erase_sector_timeout: 400
       sectors:
         - size: 2048
+          address: 0
+  STM32G0x1_OPT:
+    name: STM32G0x1_OPT
+    description: STM32G0x1 Flash Options
+    default: false
+    instructions: v/NPj3BHPEg6SYFgO0mBYDtJwWA7ScFgO0kBYQAgcEcBITVIyQdBYUEEQWEAIHBHASBwRzBINEsDYTRJAWI/IcFiAWP/IUFiACKCYkFjgmMpSYAxCmABIUkEQWG/80+PAWnJA/zUQmEBaRlCBNABaRlDAWEBIHBHACBwRwAgcEfwtRd7Fn28Rhd+FWi+RlRok2gRaRhI0mkbTwdhHE89QAViHE0sQMRiK0ADY2dG+7JDYhlLGUCBYvGyQWN3RvmygWMWSQpADEmAMQpgmQtBYb/zT48BackD/NQCaQpJCkIE0AJpCkMCYQEg8L0AIPC9QBhwRyMBZ0UAIAJAq4nvzTsqGQh/bl1M+sMAAKr+Tzj//08/PwA/AP8AAID/AAEAAAAAAA==
+    pc_init: 7
+    pc_uninit: 33
+    pc_program_page: 129
+    pc_erase_sector: 125
+    pc_erase_all: 53
+    data_section_offset: 288
+    flash_properties:
+      address_range:
+        start: 536836096
+        end: 536836128
+      page_size: 32
+      erased_byte_value: 255
+      program_page_timeout: 3000
+      erase_sector_timeout: 3000
+      sectors:
+        - size: 32
           address: 0
   STM32G0xx_64:
     name: STM32G0xx_64
@@ -1379,6 +1379,28 @@ flash_algorithms:
       address_range:
         start: 134217728
         end: 134283264
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 2048
+          address: 0
+  STM32G0xx_128:
+    name: STM32G0xx_128
+    description: STM32G0xx 128 KB Flash
+    default: true
+    instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
+    pc_init: 13
+    pc_uninit: 31
+    pc_program_page: 157
+    pc_erase_sector: 101
+    pc_erase_all: 47
+    data_section_offset: 240
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 134348800
       page_size: 1024
       erased_byte_value: 255
       program_page_timeout: 400
@@ -1408,9 +1430,9 @@ flash_algorithms:
       sectors:
         - size: 12
           address: 0
-  STM32G0xx_16:
-    name: STM32G0xx_16
-    description: STM32G0xx 16 KB Flash
+  STM32G0xx_32:
+    name: STM32G0xx_32
+    description: STM32G0xx 32 KB Flash
     default: true
     instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
     pc_init: 13
@@ -1422,29 +1444,7 @@ flash_algorithms:
     flash_properties:
       address_range:
         start: 134217728
-        end: 134234112
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
-      sectors:
-        - size: 2048
-          address: 0
-  STM32G0xx_128:
-    name: STM32G0xx_128
-    description: STM32G0xx 128 KB Flash
-    default: true
-    instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
-    pc_init: 13
-    pc_uninit: 31
-    pc_program_page: 157
-    pc_erase_sector: 101
-    pc_erase_all: 47
-    data_section_offset: 240
-    flash_properties:
-      address_range:
-        start: 134217728
-        end: 134348800
+        end: 134250496
       page_size: 1024
       erased_byte_value: 255
       program_page_timeout: 400

--- a/probe-rs/targets/STM32G0 Series.yaml
+++ b/probe-rs/targets/STM32G0 Series.yaml
@@ -1,0 +1,1455 @@
+---
+name: STM32G0 Series
+variants:
+  - name: STM32G030C6Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x0_opt
+  - name: STM32G030C8Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x0_opt
+  - name: STM32G030F6Px
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x0_opt
+  - name: STM32G030J6Mx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x0_opt
+  - name: STM32G030K6Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x0_opt
+  - name: STM32G030K8Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x0_opt
+  - name: STM32G031C4Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134234112
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_16
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031C4Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134234112
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_16
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031C6Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031C6Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031C8Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031C8Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031F4Px
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134234112
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_16
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031F6Px
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031F8Px
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031G4Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_16
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031G6Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031G8Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031J4Mx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134234112
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_16
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031J6Mx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031K4Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_16
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031K4Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134234112
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_16
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031K6Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031K6Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031K8Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031K8Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G031Y8Yx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041C6Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041C6Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041C8Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041C8Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041F6Px
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041F8Px
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041G6Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041G8Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041J6Mx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041K6Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041K6Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134250496
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041K8Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041K8Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G041Y8Yx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536879104
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G070CBTx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x0_opt
+  - name: STM32G070KBTx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x0_opt
+  - name: STM32G070RBTx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x0_opt
+  - name: STM32G071C6Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071C6Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071C8Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071C8Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071CBTx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071CBUx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071EBYx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071G6Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071G8Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071G8UxN
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071GBUx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071GBUxN
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071K6Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071K6Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071K8Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071K8TxN
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071K8Ux
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071K8UxN
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071KBTx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071KBTxN
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071KBUx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071KBUxN
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071R6Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_32
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071R8Tx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_64
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071RBIx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G071RBTx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G081CBTx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G081CBUx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G081EBYx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G081GBUx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G081GBUxN
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G081KBTx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G081KBTxN
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G081KBUx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G081KBUxN
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G081RBIx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+  - name: STM32G081RBTx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 536870912
+            end: 536907776
+          is_boot_memory: false
+    flash_algorithms:
+      - stm32g0xx_128
+      - stm32g0xx_otp
+      - stm32g0x1_opt
+flash_algorithms:
+  STM32G0x1_OPT:
+    name: STM32G0x1_OPT
+    description: STM32G0x1 Flash Options
+    default: false
+    instructions: v/NPj3BHPEg6SYFgO0mBYDtJwWA7ScFgO0kBYQAgcEcBITVIyQdBYUEEQWEAIHBHASBwRzBINEsDYTRJAWI/IcFiAWP/IUFiACKCYkFjgmMpSYAxCmABIUkEQWG/80+PAWnJA/zUQmEBaRlCBNABaRlDAWEBIHBHACBwRwAgcEfwtRd7Fn28Rhd+FWi+RlRok2gRaRhI0mkbTwdhHE89QAViHE0sQMRiK0ADY2dG+7JDYhlLGUCBYvGyQWN3RvmygWMWSQpADEmAMQpgmQtBYb/zT48BackD/NQCaQpJCkIE0AJpCkMCYQEg8L0AIPC9QBhwRyMBZ0UAIAJAq4nvzTsqGQh/bl1M+sMAAKr+Tzj//08/PwA/AP8AAID/AAEAAAAAAA==
+    pc_init: 7
+    pc_uninit: 33
+    pc_program_page: 129
+    pc_erase_sector: 125
+    pc_erase_all: 53
+    data_section_offset: 288
+    flash_properties:
+      address_range:
+        start: 536836096
+        end: 536836128
+      page_size: 32
+      erased_byte_value: 255
+      program_page_timeout: 3000
+      erase_sector_timeout: 3000
+      sectors:
+        - size: 32
+          address: 0
+  STM32G0xx_OTP:
+    name: STM32G0xx_OTP
+    description: STM32G0xx Flash OTP
+    default: false
+    instructions: v/NPj3BHG0gZSYFgGkmBYBpJAWEAIHBHASAWScAHSGEAIHBHASBwRwAgcEfwtckdEEzJCBFNyQAlYQEmACcT4GZhE2gDYFNoQ2C/80+PI2nbA/zUZ2EjaStCAtAlYQEg8L0IMAg5CDIAKenRACDwvSMBZ0UAIAJAq4nvzfrDAAAAAAAA
+    pc_init: 7
+    pc_uninit: 25
+    pc_program_page: 45
+    pc_erase_sector: 41
+    pc_erase_all: ~
+    data_section_offset: 128
+    flash_properties:
+      address_range:
+        start: 536834048
+        end: 536835072
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 3000
+      erase_sector_timeout: 3000
+      sectors:
+        - size: 1024
+          address: 0
+  STM32G0xx_32:
+    name: STM32G0xx_32
+    description: STM32G0xx 32 KB Flash
+    default: true
+    instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
+    pc_init: 13
+    pc_uninit: 31
+    pc_program_page: 157
+    pc_erase_sector: 101
+    pc_erase_all: 47
+    data_section_offset: 240
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 134250496
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 2048
+          address: 0
+  STM32G0xx_64:
+    name: STM32G0xx_64
+    description: STM32G0xx 64 KB Flash
+    default: true
+    instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
+    pc_init: 13
+    pc_uninit: 31
+    pc_program_page: 157
+    pc_erase_sector: 101
+    pc_erase_all: 47
+    data_section_offset: 240
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 134283264
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 2048
+          address: 0
+  STM32G0x0_OPT:
+    name: STM32G0x0_OPT
+    description: STM32G0x0 Flash Options
+    default: false
+    instructions: v/NPj3BHLUgrSYFgLEmBYCxJwWAsScFgLEkBYQAgcEcBISZIyQdBYUEEQWEAIHBHASBwRyFIJUoCYSVJAWI/IcFiAWMBIUkEQWG/80+PAWnJA/zUACFBYQFpEUIE0AFpEUMBYQEgcEcAIHBHACBwRzC1lGgTaFFoEEgUSgJhFU0rQANiFEsZQMFiHEAEYwEhSQRBYb/zT48BackD/NQBaRFCBNABaRFDAWEBIDC9ACAwvUAYcEcAACMBZ0UAIAJAq4nvzTsqGQh/bl1M+sMAAKr+Tzj//08/PwA/AAAAAAA=
+    pc_init: 7
+    pc_uninit: 33
+    pc_program_page: 113
+    pc_erase_sector: 109
+    pc_erase_all: 53
+    data_section_offset: 220
+    flash_properties:
+      address_range:
+        start: 536836096
+        end: 536836108
+      page_size: 12
+      erased_byte_value: 255
+      program_page_timeout: 3000
+      erase_sector_timeout: 3000
+      sectors:
+        - size: 12
+          address: 0
+  STM32G0xx_16:
+    name: STM32G0xx_16
+    description: STM32G0xx 16 KB Flash
+    default: true
+    instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
+    pc_init: 13
+    pc_uninit: 31
+    pc_program_page: 157
+    pc_erase_sector: 101
+    pc_erase_all: 47
+    data_section_offset: 240
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 134234112
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 2048
+          address: 0
+  STM32G0xx_128:
+    name: STM32G0xx_128
+    description: STM32G0xx 128 KB Flash
+    default: true
+    instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
+    pc_init: 13
+    pc_uninit: 31
+    pc_program_page: 157
+    pc_erase_sector: 101
+    pc_erase_all: 47
+    data_section_offset: 240
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 134348800
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 2048
+          address: 0
+core: M0


### PR DESCRIPTION
the 'STM32G0 Series.yaml' file is created with `target-gen` from the
'Keil.STM32G0xx_DFP.1.2.0.pack' downloaded from
https://www.keil.com/dd2/pack/