### PR TITLE
Initial implementation of new register description

### DIFF
--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -136,7 +136,7 @@ impl DebugCli {
             help_text: "Show backtrace",
 
             function: |cli_data, _args| {
-                let regs = cli_data.core.registers().clone();
+                let regs = cli_data.core.registers();
                 let program_counter = cli_data.core.read_core_reg(regs.program_counter())?;
 
                 if let Some(di) = &cli_data.debug_info {

--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -1,13 +1,11 @@
-use super::arm_register_file;
+use super::ARM_REGISTER_FILE;
 use crate::core::RegisterDescription;
 use crate::core::{
-    Breakpoint, CoreInformation, CoreInterface, CoreRegister, CoreRegisterAddress, RegisterFile,
-    RegisterKind,
+    CoreInformation, CoreInterface, CoreRegister, CoreRegisterAddress, RegisterFile, RegisterKind,
 };
 use crate::error::Error;
 use crate::memory::Memory;
 use crate::DebugProbeError;
-use crate::Session;
 use bitfield::bitfield;
 use log::debug;
 use std::mem::size_of;
@@ -278,22 +276,15 @@ const XPSR: RegisterDescription = RegisterDescription {
 
 pub struct M0 {
     memory: Memory,
-    session: Session,
-
-    registers: RegisterFile,
 
     hw_breakpoints_enabled: bool,
-    active_breakpoints: Vec<Breakpoint>,
 }
 
 impl M0 {
-    pub fn new(session: Session, memory: Memory) -> Self {
+    pub fn new(memory: Memory) -> Self {
         Self {
-            session,
             memory,
-            registers: arm_register_file(),
             hw_breakpoints_enabled: false,
-            active_breakpoints: vec![],
         }
     }
 
@@ -501,8 +492,8 @@ impl CoreInterface for M0 {
         Ok(())
     }
 
-    fn registers(&self) -> &RegisterFile {
-        &self.registers
+    fn registers(&self) -> &'static RegisterFile {
+        &ARM_REGISTER_FILE
     }
 
     fn clear_breakpoint(&self, bp_unit_index: usize) -> Result<(), Error> {

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -4,6 +4,7 @@
 use crate::core::Breakpoint;
 use crate::core::{
     BasicRegisterAddresses, CoreInformation, CoreInterface, CoreRegister, CoreRegisterAddress,
+    RegisterFile,
 };
 use crate::error::Error;
 use crate::memory::Memory;
@@ -11,12 +12,14 @@ use crate::{DebugProbeError, Session};
 
 use bitfield::bitfield;
 
+use super::arm_register_file;
 use std::mem::size_of;
 
-#[derive(Clone)]
 pub struct M33 {
     memory: Memory,
     session: Session,
+
+    registers: RegisterFile,
 
     hw_breakpoints_enabled: bool,
     active_breakpoints: Vec<Breakpoint>,
@@ -27,6 +30,7 @@ impl M33 {
         Self {
             session,
             memory,
+            registers: arm_register_file(),
             hw_breakpoints_enabled: false,
             active_breakpoints: vec![],
         }
@@ -231,8 +235,8 @@ impl CoreInterface for M33 {
         Ok(())
     }
 
-    fn registers<'a>(&self) -> &'a BasicRegisterAddresses {
-        &REGISTERS
+    fn registers(&self) -> &RegisterFile {
+        &self.registers
     }
 
     fn clear_breakpoint(&self, bp_unit_index: usize) -> Result<(), Error> {

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -1,12 +1,14 @@
 use crate::core::Breakpoint;
 use crate::core::{
     BasicRegisterAddresses, CoreInformation, CoreInterface, CoreRegister, CoreRegisterAddress,
+    RegisterFile,
 };
 use crate::error::Error;
 use crate::memory::Memory;
 use crate::{DebugProbeError, Session};
 use bitfield::bitfield;
 
+use super::arm_register_file;
 use std::mem::size_of;
 
 bitfield! {
@@ -299,10 +301,11 @@ pub const REGISTERS: BasicRegisterAddresses = BasicRegisterAddresses {
 pub const MSP: CoreRegisterAddress = CoreRegisterAddress(0b000_1001);
 pub const PSP: CoreRegisterAddress = CoreRegisterAddress(0b000_1010);
 
-#[derive(Clone)]
 pub struct M4 {
     memory: Memory,
     session: Session,
+
+    registers: RegisterFile,
 
     hw_breakpoints_enabled: bool,
     active_breakpoints: Vec<Breakpoint>,
@@ -313,6 +316,7 @@ impl M4 {
         Self {
             session,
             memory,
+            registers: arm_register_file(),
             hw_breakpoints_enabled: false,
             active_breakpoints: vec![],
         }
@@ -521,8 +525,8 @@ impl CoreInterface for M4 {
         Ok(())
     }
 
-    fn registers<'a>(&self) -> &'a BasicRegisterAddresses {
-        &REGISTERS
+    fn registers(&self) -> &RegisterFile {
+        &self.registers
     }
 
     fn clear_breakpoint(&self, bp_unit_index: usize) -> Result<(), Error> {

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -1,3 +1,8 @@
+use crate::core::CoreRegisterAddress;
+use crate::core::RegisterDescription;
+use crate::core::RegisterFile;
+use crate::core::RegisterKind;
+
 pub mod m0;
 pub mod m33;
 pub mod m4;
@@ -16,5 +21,146 @@ impl CortexDump {
             stack_addr,
             stack,
         }
+    }
+}
+
+fn arm_register_file() -> RegisterFile {
+    RegisterFile {
+        platform_registers: vec![
+            RegisterDescription {
+                name: "R0",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(0),
+            },
+            RegisterDescription {
+                name: "R1",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(1),
+            },
+            RegisterDescription {
+                name: "R2",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(2),
+            },
+            RegisterDescription {
+                name: "R3",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(3),
+            },
+            RegisterDescription {
+                name: "R4",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(4),
+            },
+            RegisterDescription {
+                name: "R5",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(5),
+            },
+            RegisterDescription {
+                name: "R6",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(6),
+            },
+            RegisterDescription {
+                name: "R7",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(7),
+            },
+            RegisterDescription {
+                name: "R8",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(8),
+            },
+            RegisterDescription {
+                name: "R9",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(9),
+            },
+            RegisterDescription {
+                name: "R10",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(10),
+            },
+            RegisterDescription {
+                name: "R11",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(11),
+            },
+            RegisterDescription {
+                name: "R12",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(12),
+            },
+            RegisterDescription {
+                name: "R13",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(13),
+            },
+            RegisterDescription {
+                name: "R14",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(14),
+            },
+            RegisterDescription {
+                name: "R15",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(15),
+            },
+        ],
+
+        program_counter: RegisterDescription {
+            name: "PC",
+            kind: RegisterKind::PC,
+            address: CoreRegisterAddress(15),
+        },
+
+        stack_pointer: RegisterDescription {
+            name: "SP",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(13),
+        },
+
+        return_address: RegisterDescription {
+            name: "LR",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(14),
+        },
+
+        argument_registers: vec![
+            RegisterDescription {
+                name: "a1",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(0),
+            },
+            RegisterDescription {
+                name: "a2",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(1),
+            },
+            RegisterDescription {
+                name: "a3",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(2),
+            },
+            RegisterDescription {
+                name: "a4",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(3),
+            },
+        ],
+
+        result_registers: vec![
+            RegisterDescription {
+                name: "a1",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(0),
+            },
+            RegisterDescription {
+                name: "a2",
+                kind: RegisterKind::General,
+                address: CoreRegisterAddress(1),
+            },
+        ],
     }
 }

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -24,143 +24,158 @@ impl CortexDump {
     }
 }
 
-fn arm_register_file() -> RegisterFile {
-    RegisterFile {
-        platform_registers: vec![
-            RegisterDescription {
-                name: "R0",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(0),
-            },
-            RegisterDescription {
-                name: "R1",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(1),
-            },
-            RegisterDescription {
-                name: "R2",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(2),
-            },
-            RegisterDescription {
-                name: "R3",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(3),
-            },
-            RegisterDescription {
-                name: "R4",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(4),
-            },
-            RegisterDescription {
-                name: "R5",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(5),
-            },
-            RegisterDescription {
-                name: "R6",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(6),
-            },
-            RegisterDescription {
-                name: "R7",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(7),
-            },
-            RegisterDescription {
-                name: "R8",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(8),
-            },
-            RegisterDescription {
-                name: "R9",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(9),
-            },
-            RegisterDescription {
-                name: "R10",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(10),
-            },
-            RegisterDescription {
-                name: "R11",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(11),
-            },
-            RegisterDescription {
-                name: "R12",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(12),
-            },
-            RegisterDescription {
-                name: "R13",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(13),
-            },
-            RegisterDescription {
-                name: "R14",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(14),
-            },
-            RegisterDescription {
-                name: "R15",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(15),
-            },
-        ],
+pub(crate) mod register {
+    use crate::{
+        core::{RegisterDescription, RegisterKind},
+        CoreRegisterAddress,
+    };
 
-        program_counter: RegisterDescription {
-            name: "PC",
-            kind: RegisterKind::PC,
-            address: CoreRegisterAddress(15),
+    pub const PC: RegisterDescription = RegisterDescription {
+        name: "PC",
+        kind: RegisterKind::PC,
+        address: CoreRegisterAddress(15),
+    };
+
+    pub const XPSR: RegisterDescription = RegisterDescription {
+        name: "XPSR",
+        kind: RegisterKind::General,
+        address: CoreRegisterAddress(0b1_0000),
+    };
+
+    pub const SP: RegisterDescription = RegisterDescription {
+        name: "SP",
+        kind: RegisterKind::General,
+        address: CoreRegisterAddress(13),
+    };
+
+    pub const LR: RegisterDescription = RegisterDescription {
+        name: "LR",
+        kind: RegisterKind::General,
+        address: CoreRegisterAddress(14),
+    };
+}
+
+static ARM_REGISTER_FILE: RegisterFile = RegisterFile {
+    platform_registers: &[
+        RegisterDescription {
+            name: "R0",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(0),
         },
-
-        stack_pointer: RegisterDescription {
-            name: "SP",
+        RegisterDescription {
+            name: "R1",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(1),
+        },
+        RegisterDescription {
+            name: "R2",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(2),
+        },
+        RegisterDescription {
+            name: "R3",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(3),
+        },
+        RegisterDescription {
+            name: "R4",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(4),
+        },
+        RegisterDescription {
+            name: "R5",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(5),
+        },
+        RegisterDescription {
+            name: "R6",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(6),
+        },
+        RegisterDescription {
+            name: "R7",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(7),
+        },
+        RegisterDescription {
+            name: "R8",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(8),
+        },
+        RegisterDescription {
+            name: "R9",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(9),
+        },
+        RegisterDescription {
+            name: "R10",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(10),
+        },
+        RegisterDescription {
+            name: "R11",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(11),
+        },
+        RegisterDescription {
+            name: "R12",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(12),
+        },
+        RegisterDescription {
+            name: "R13",
             kind: RegisterKind::General,
             address: CoreRegisterAddress(13),
         },
-
-        return_address: RegisterDescription {
-            name: "LR",
+        RegisterDescription {
+            name: "R14",
             kind: RegisterKind::General,
             address: CoreRegisterAddress(14),
         },
+        RegisterDescription {
+            name: "R15",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(15),
+        },
+    ],
 
-        argument_registers: vec![
-            RegisterDescription {
-                name: "a1",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(0),
-            },
-            RegisterDescription {
-                name: "a2",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(1),
-            },
-            RegisterDescription {
-                name: "a3",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(2),
-            },
-            RegisterDescription {
-                name: "a4",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(3),
-            },
-        ],
+    program_counter: &register::PC,
+    stack_pointer: &register::SP,
+    return_address: &register::LR,
 
-        result_registers: vec![
-            RegisterDescription {
-                name: "a1",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(0),
-            },
-            RegisterDescription {
-                name: "a2",
-                kind: RegisterKind::General,
-                address: CoreRegisterAddress(1),
-            },
-        ],
-    }
-}
+    argument_registers: &[
+        RegisterDescription {
+            name: "a1",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(0),
+        },
+        RegisterDescription {
+            name: "a2",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(1),
+        },
+        RegisterDescription {
+            name: "a3",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(2),
+        },
+        RegisterDescription {
+            name: "a4",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(3),
+        },
+    ],
+
+    result_registers: &[
+        RegisterDescription {
+            name: "a1",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(0),
+        },
+        RegisterDescription {
+            name: "a2",
+            kind: RegisterKind::General,
+            address: CoreRegisterAddress(1),
+        },
+    ],
+};

--- a/probe-rs/src/flash/flasher.rs
+++ b/probe-rs/src/flash/flasher.rs
@@ -1,7 +1,7 @@
 use super::builder::FlashBuilder;
 use super::FlashProgress;
 use crate::config::{FlashAlgorithm, FlashRegion, MemoryRange, SectorInfo};
-use crate::core::Core;
+use crate::core::{Core, RegisterFile};
 use crate::error;
 use crate::session::Session;
 use thiserror::Error;
@@ -381,7 +381,7 @@ impl<'a, O: Operation> ActiveFlasher<'a, O> {
         );
 
         let algo = &self.flash_algorithm;
-        let regs = self.core.registers();
+        let regs: &'static RegisterFile = self.core.registers();
 
         [
             (regs.program_counter(), Some(pc)),

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -73,12 +73,12 @@ impl Session {
             .list_cores()
             .get(n)
             .ok_or_else(|| Error::CoreNotFound(n))?
-            .attach(self.clone(), self.attach_to_memory(0)?);
+            .attach(self.attach_to_memory(0)?);
         Ok(core)
     }
 
     pub fn attach_to_specific_core(&self, core_type: CoreType) -> Result<Core, Error> {
-        let core = core_type.attach(self.clone(), self.attach_to_memory(0)?);
+        let core = core_type.attach(self.attach_to_memory(0)?);
         Ok(core)
     }
 
@@ -91,13 +91,10 @@ impl Session {
             .list_cores()
             .get(n)
             .ok_or_else(|| Error::CoreNotFound(n))?
-            .attach(
-                self.clone(),
-                match memory {
-                    Some(memory) => memory,
-                    None => self.attach_to_memory(0)?,
-                },
-            );
+            .attach(match memory {
+                Some(memory) => memory,
+                None => self.attach_to_memory(0)?,
+            });
         Ok(core)
     }
 


### PR DESCRIPTION
Initial implementation of a more generic way to describe registers.

The goal is to have a struct which works for different platforms, at least RISCV and ARM.

The code of the ARM cores itself is not yet fully adapted right now.