### PR TITLE
Add support for STM32WB55, small fixes for multiple AP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Flashing support for the STM32G0 series.
 - Flashing support for the STM32F0 series.
+- Flashing support for the STM32WB55 series.
 - Support for RISCV debugging using a Jlink debug probe.
 - Support for SWD debugging using a Jlink debug probe.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Please have a look at the docs and examples to get an idea of the new interface.
   The new API supports multiple architectures and makes the initialization process until the point where you can talk to a core easier.
   The core methods don't need a passed probe anymore. Instead it stores an Rc to the Session object internally. The Probe object is taken by the Session which then can attach to multiple cores.
-  The modules have been cleaned up. Some heavily nested hierarchy has been flattened.$
+  The modules have been cleaned up. Some heavily nested hierarchy has been flattened.
 - More consistent and clean naming and reporting of errors in the stlink and daplink modules. Also the errorhandling for the probe has been improved.
-- Updated pretty_env_logger, gimly and goblin.
 
 ### Fixed
 

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -109,7 +109,7 @@ define_ap_register!(
         (BASEADDR: u32),
         (_RES0: u8),
         (Format: BaseaddrFormat),
-        (P: DebugEntryState),
+        (present: bool),
     ],
     value,
     BASE {
@@ -120,16 +120,16 @@ define_ap_register!(
             1 => BaseaddrFormat::ADIv5,
             _ => panic!("This is a bug. Please report it."),
         },
-        P: match (value & 0x01) as u8 {
-            0 => DebugEntryState::NotPresent,
-            1 => DebugEntryState::Present,
+        present: match (value & 0x01) as u8 {
+            0 => false,
+            1 => true,
             _ => panic!("This is a bug. Please report it."),
         },
     },
     (value.BASEADDR << 12)
     // _RES0
     | (u32::from(value.Format as u8   ) << 1)
-    | (u32::from(value.P as u8))
+    | (if value.present { 1 } else { 0 })
 );
 
 define_ap_register!(

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -133,7 +133,7 @@ where
 {
     (0..=255)
         .map(GenericAP::new)
-        .filter(|port| access_port_is_valid(debug_port, *port))
+        .take_while(|port| access_port_is_valid(debug_port, *port))
         .collect::<Vec<GenericAP>>()
 }
 

--- a/probe-rs/src/architecture/arm/ap/register_generation.rs
+++ b/probe-rs/src/architecture/arm/ap/register_generation.rs
@@ -49,7 +49,7 @@ macro_rules! define_ap_register {
 #[macro_export]
 macro_rules! define_ap {
     ($name:ident) => {
-        #[derive(Clone, Copy)]
+        #[derive(Clone, Copy, Debug)]
         pub struct $name {
             port_number: u8,
         }

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -155,10 +155,9 @@ struct InnerArmCommunicationInterface {
 }
 
 impl InnerArmCommunicationInterface {
-    fn new(probe: Probe) -> Result<Self, DebugProbeError> {
-        let mut my_probe = probe;
+    fn new(mut probe: Probe) -> Result<Self, DebugProbeError> {
         // Check the version of debug port used
-        let interface = my_probe
+        let interface = probe
             .get_interface_dap_mut()
             .ok_or_else(|| DebugProbeError::InterfaceNotAvailable("ARM"))?;
 
@@ -169,7 +168,7 @@ impl InnerArmCommunicationInterface {
         log::debug!("Debug Port version: {:?}", version);
 
         let mut s = Self {
-            probe: my_probe,
+            probe,
             debug_port_version: version,
             current_dpbanksel: 0,
             current_apsel: 0,

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -22,7 +22,6 @@ where
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum DPBankSel {
-    Unknown,
     DontCare,
     Bank(u8),
 }
@@ -197,6 +196,36 @@ impl DPRegister<DPv1> for DPIDR {
 impl Register for DPIDR {
     const ADDRESS: u8 = 0x0;
     const NAME: &'static str = "DPIDR";
+}
+
+bitfield! {
+    #[derive(Clone)]
+    pub struct TARGETID(u32);
+    impl Debug;
+    pub u8, trevision, _: 31, 28;
+    pub u16, tpartno, _: 27, 12;
+    pub u16, tdesigner, _: 11, 1;
+}
+
+impl From<u32> for TARGETID {
+    fn from(raw: u32) -> Self {
+        Self(raw)
+    }
+}
+
+impl From<TARGETID> for u32 {
+    fn from(raw: TARGETID) -> Self {
+        raw.0
+    }
+}
+
+impl DPRegister<DPv2> for TARGETID {
+    const DP_BANK: DPBankSel = DPBankSel::Bank(2);
+}
+
+impl Register for TARGETID {
+    const ADDRESS: u8 = 0x4;
+    const NAME: &'static str = "TARGETID";
 }
 
 #[derive(Debug)]

--- a/probe-rs/src/flash/loader.rs
+++ b/probe-rs/src/flash/loader.rs
@@ -113,7 +113,7 @@ impl<'a, 'b> FlashLoader<'a, 'b> {
         // Iterate over builders we've created and program the data.
         for (region, builder) in &self.builders {
             log::debug!(
-                "Using builder for regioon (0x{:08x}..0x{:08x})",
+                "Using builder for region (0x{:08x}..0x{:08x})",
                 region.range.start,
                 region.range.end
             );

--- a/probe-rs/src/probe/stlink/constants.rs
+++ b/probe-rs/src/probe/stlink/constants.rs
@@ -20,6 +20,9 @@ pub mod commands {
     pub const JTAG_READMEM_8BIT: u8 = 0x0c;
     pub const JTAG_WRITEMEM_8BIT: u8 = 0x0d;
     pub const JTAG_EXIT: u8 = 0x21;
+
+    // The following commands are from Version 2 of the API,
+    // supported
     pub const JTAG_ENTER2: u8 = 0x30;
     pub const JTAG_GETLASTRWSTATUS2: u8 = 0x3e; // From V2J15
     pub const JTAG_DRIVE_NRST: u8 = 0x3c;

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -432,7 +432,6 @@ impl STLink {
                     commands::JTAG_COMMAND,
                     commands::JTAG_INIT_AP,
                     apsel,
-                    //                    commands::JTAG_AP_NO_CORE,
                 ],
                 &[],
                 &mut buf,

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -428,11 +428,7 @@ impl STLink {
             let mut buf = [0; 2];
             log::trace!("JTAG_INIT_AP {}", apsel);
             self.device.write(
-                vec![
-                    commands::JTAG_COMMAND,
-                    commands::JTAG_INIT_AP,
-                    apsel,
-                ],
+                vec![commands::JTAG_COMMAND, commands::JTAG_INIT_AP, apsel],
                 &[],
                 &mut buf,
                 TIMEOUT,

--- a/probe-rs/targets/STM32WB Series.yaml
+++ b/probe-rs/targets/STM32WB Series.yaml
@@ -1,0 +1,153 @@
+---
+name: STM32WB Series
+variants:
+  - name: STM32WB55CCUx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134479872
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
+  - name: STM32WB55CEUx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
+  - name: STM32WB55CGUx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
+  - name: STM32WB55RCVx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134479872
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
+  - name: STM32WB55REVx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
+  - name: STM32WB55RGVx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 150994944
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
+  - name: STM32WB55VCYx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134479872
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
+  - name: STM32WB55VEYx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
+  - name: STM32WB55VGYx
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 150994944
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
+flash_algorithms:
+  STM32WB_M4:
+    name: STM32WB_M4
+    description: STM32WB_M4 Flash
+    default: true
+    instructions: Qfb4cQHqUCBwR0pISEmBYElJgWAAIHBHRkhBaUHwAEFBYQAgcEcBIHBHELVK9qoiQklASADgCmADadsD+9RE8vo0BGFI8gQDQ2FDaUP0gDNDYQDgCmADadsD+9QAIUFhAWkhQgLQBGEBIBC9ACAQvUH2+HEB6lAiELUuSAFpEfRAP/vRAWlJA/zUAWkJA/zURPL6NARhQvACAUFhQWlB9IAxQWFK9qohJEoA4BFgA2nbA/vUACFBYQFpIUIC0ARhASAQvQAgEL0QtRpLyR1A8v8UIfAHARxhASRcYR/gHGkU9EA/+9EcaWQD/NQcaSQD/NQUaARgVGhEYBxpFPRAP/vRHGlkA/zUHGkkA/zUHGmkBwHVASAQvQgwCDkIMgAp3dFYaSDwAQBYYQAgEL0AACMBZ0UAQABYq4nvzQAwAEAAAAAA
+    pc_init: 11
+    pc_uninit: 25
+    pc_program_page: 201
+    pc_erase_sector: 113
+    pc_erase_all: 43
+    data_section_offset: 320
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 135266304
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 4096
+          address: 0
+core: M4


### PR DESCRIPTION
Add support for the STM32WB55 chips.

Also fixes some small issues with support for multiple APs which I found while using them.
It also includes initial support to read the TARGETID, which is only present on DP version 2.