### PR TITLE
Ensure core is running when requesting reset

### DIFF
--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -417,6 +417,14 @@ impl CoreInterface for M0 {
 
         self.memory.write32(Aircr::ADDRESS, value.into())?;
 
+        // The reset does not have to occur immediately.
+        // We start running the core again, so that the reset takes place.
+        // Here, we don't actually know if the core reset.
+        self.run()?;
+
+        // TODO: We can check the DHCSR register to verify that the core has actually reset.
+        // See ARM V6 ARM, C1.6.3
+
         Ok(())
     }
 

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -94,13 +94,18 @@ impl CoreInterface for M33 {
             .map_err(Into::into)
     }
     fn reset(&self) -> Result<(), Error> {
-        // Set THE AIRCR.SYSRESETREQ control bit to 1 to request a reset. (ARM V6 ARM, B1.5.16)
+        // Set THE AIRCR.SYSRESETREQ control bit to 1 to request a reset. (ARM V8 ARM, D1.2.3)
 
         let mut value = Aircr(0);
         value.vectkey();
         value.set_sysresetreq(true);
 
         self.memory.write32(Aircr::ADDRESS, value.into())?;
+
+        self.run()?;
+
+        // TODO: We can check the DHCSR register to verify that the core has actually reset.
+        // See ARM V8 ARM, D1.2.38
 
         Ok(())
     }


### PR DESCRIPTION
It seems that the core has to be running, i.e. not halted by the debugger, when a reset is requested.

This should fix probe-rs/cargo-flash#9.

I've tested it on a STM32WB55 chip, where reset after flash did not work before.