### PR TITLE
Fix checks for STLINK-V3

### DIFF
--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -422,7 +422,7 @@ impl STLink {
     }
 
     pub fn open_ap(&mut self, apsel: u8) -> Result<(), DebugProbeError> {
-        if self.jtag_version < Self::MIN_JTAG_VERSION_MULTI_AP {
+        if self.hw_version < 3 && self.jtag_version < Self::MIN_JTAG_VERSION_MULTI_AP {
             Err(StlinkError::JTagDoesNotSupportMultipleAP.into())
         } else {
             let mut buf = [0; 2];
@@ -438,7 +438,7 @@ impl STLink {
     }
 
     pub fn close_ap(&mut self, apsel: u8) -> Result<(), DebugProbeError> {
-        if self.jtag_version < Self::MIN_JTAG_VERSION_MULTI_AP {
+        if self.hw_version < 3 && self.jtag_version < Self::MIN_JTAG_VERSION_MULTI_AP {
             Err(StlinkError::JTagDoesNotSupportMultipleAP.into())
         } else {
             let mut buf = [0; 2];


### PR DESCRIPTION
According to the PyOCD sources, [this check](https://github.com/mbedmicro/pyOCD/blob/89a53ca63ac2557be9d77bc81cee95891f62a3b8/pyocd/probe/stlink/stlink.py#L261) performs not only a JTAG version check, but also a [hardware version check](https://github.com/mbedmicro/pyOCD/blob/89a53ca63ac2557be9d77bc81cee95891f62a3b8/pyocd/probe/stlink/stlink.py#L149-L150).