### PR TITLE
Improve error handling when flashing

### DIFF
--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -12,8 +12,7 @@ use crate::{
     Error, MemoryInterface,
 };
 use crate::{DebugProbeError, Memory, Probe};
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
 pub trait CoreRegister: Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug {
     const ADDRESS: u32;

--- a/probe-rs/src/flash/progress.rs
+++ b/probe-rs/src/flash/progress.rs
@@ -37,8 +37,16 @@ impl FlashProgress {
         self.emit(ProgressEvent::SectorErased { size, time });
     }
 
+    pub fn failed_programming(&self) {
+        self.emit(ProgressEvent::FailedProgramming);
+    }
+
     pub fn finished_programming(&self) {
         self.emit(ProgressEvent::FinishedProgramming);
+    }
+
+    pub fn failed_erasing(&self) {
+        self.emit(ProgressEvent::FailedErasing);
     }
 
     pub fn finished_erasing(&self) {
@@ -62,6 +70,8 @@ pub enum ProgressEvent {
         size: u32,
         time: u128,
     },
+    FailedProgramming,
     FinishedProgramming,
+    FailedErasing,
     FinishedErasing,
 }


### PR DESCRIPTION
Add additional progress states to indicate when erasing or programming fails. This can be used to improve the error output in cargo-flash.

The error handling in the flash module now uses the `thiserror` crate as well. The endless loop while waiting for a flash algorithm function to finish is changed to a timeout, to avoid waiting forever.