### PR TITLE
Ensure default speed is actually used for STLink

### DIFF
--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -131,7 +131,23 @@ impl DebugProbe for STLink {
             TIMEOUT,
         )?;
         Self::check_status(&buf)?;
+
         log::debug!("Successfully initialized SWD.");
+
+        // If the speed is not manually set, the probe will
+        // use whatever speed has been configured before.
+        //
+        // To ensure the default speed is used if not changed,
+        // we set the speed again here.
+        match self.protocol {
+            WireProtocol::Jtag => {
+                self.set_speed(self.jtag_speed_khz)?;
+            }
+            WireProtocol::Swd => {
+                self.set_speed(self.swd_speed_khz)?;
+            }
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
I encountered an issue where the STLink was not using the default speed of 1800 kHz, even though this was reported by the `speed_khz` function.

The problem was that I used a different speed setting during an earlier usage of `cargo-flash`, which meant that this setting was still effect.

I've added an additional call to `set_speed`, to ensure the configured speed actually matches the speed which is used by the STLink.