### PR TITLE
Fix parsing of yaml files on the go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix a bug where parsing a `ChipFamily` from source would always fail.
+- Fixed a bug where reading a chip definition from a YAML file would always fail because parsing a `ChipFamily` from YAML was broken.
 
 ## [0.5.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix a bug where parsing a `ChipFamily` from source would always fail.
+
 ## [0.5.1]
 
 ### Fixed

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -40,6 +40,7 @@ maplit = "1.0.2"
 hexdump = { version = "0.1.0", optional = true }
 thiserror = "1.0.10"
 jaylink = "0.1.1"
+base64 = "0.12.0"
 
 [build-dependencies]
 probe-rs-t2rust  = { path = "../probe-rs-t2rust", version ="0.5.0" }


### PR DESCRIPTION
This fixes a bug where `ChipFamily::from_yaml_reader(file)` would fail because it didn't expect a base64 encoded string.

This function is used for cargo-flash to add additional chips. It is really useful for testing new chip configurations.