### PR TITLE
Fix memory writes on ST-Link

### DIFF
--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -2,7 +2,7 @@ use super::super::{APAccess, Register};
 use super::{APRegister, AddressIncrement, DataSize, MemoryAP, CSW, DRW, TAR};
 use crate::config::ChipInfo;
 use crate::{
-    architecture::arm::dp::{DPAccess, DPRegister, DebugPort},
+    architecture::arm::dp::{DPAccess, DPRegister, DebugPortError},
     CommunicationInterface, Error,
 };
 use std::collections::HashMap;
@@ -191,17 +191,12 @@ where
 }
 
 impl DPAccess for MockMemoryAP {
-    type Error = MockMemoryError;
-
-    fn read_dp_register<R: DPRegister<P>, P: DebugPort>(&mut self) -> Result<R, Self::Error> {
+    fn read_dp_register<R: DPRegister>(&mut self) -> Result<R, DebugPortError> {
         // Ignore for Tests
         Ok(0.into())
     }
 
-    fn write_dp_register<R: DPRegister<P>, P: DebugPort>(
-        &mut self,
-        _register: R,
-    ) -> Result<(), Self::Error> {
+    fn write_dp_register<R: DPRegister>(&mut self, _register: R) -> Result<(), DebugPortError> {
         Ok(())
     }
 }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -194,13 +194,14 @@ impl DPAccess for MockMemoryAP {
     type Error = MockMemoryError;
 
     fn read_dp_register<R: DPRegister<P>, P: DebugPort>(&mut self) -> Result<R, Self::Error> {
-        unimplemented!()
+        // Ignore for Tests
+        Ok(0.into())
     }
 
     fn write_dp_register<R: DPRegister<P>, P: DebugPort>(
         &mut self,
         _register: R,
     ) -> Result<(), Self::Error> {
-        unimplemented!()
+        Ok(())
     }
 }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -1,7 +1,10 @@
 use super::super::{APAccess, Register};
 use super::{APRegister, AddressIncrement, DataSize, MemoryAP, CSW, DRW, TAR};
 use crate::config::ChipInfo;
-use crate::{CommunicationInterface, Error};
+use crate::{
+    architecture::arm::dp::{DPAccess, DPRegister, DebugPort},
+    CommunicationInterface, Error,
+};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -184,5 +187,20 @@ where
         }
 
         Ok(())
+    }
+}
+
+impl DPAccess for MockMemoryAP {
+    type Error = MockMemoryError;
+
+    fn read_dp_register<R: DPRegister<P>, P: DebugPort>(&mut self) -> Result<R, Self::Error> {
+        unimplemented!()
+    }
+
+    fn write_dp_register<R: DPRegister<P>, P: DebugPort>(
+        &mut self,
+        _register: R,
+    ) -> Result<(), Self::Error> {
+        unimplemented!()
     }
 }

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -4,6 +4,8 @@ pub(crate) mod custom_ap;
 pub(crate) mod generic_ap;
 pub(crate) mod memory_ap;
 
+use crate::architecture::arm::dp::DebugPortError;
+
 pub use generic_ap::{APClass, GenericAP, IDR};
 pub(crate) use memory_ap::mock;
 pub use memory_ap::{
@@ -13,7 +15,7 @@ pub use memory_ap::{
 use super::Register;
 use thiserror::Error;
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error)]
 pub enum AccessPortError {
     #[error("Invalid Access PortType Number")]
     InvalidAccessPortNumber,
@@ -25,6 +27,8 @@ pub enum AccessPortError {
     RegisterWriteError { address: u8, name: &'static str },
     #[error("Out of bounds access")]
     OutOfBoundsError,
+    #[error("Error while communicating with debug port: {0}")]
+    DebugPort(#[from] DebugPortError),
 }
 
 impl AccessPortError {

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -3,7 +3,7 @@ use super::super::ap::{
     MemoryAP, CSW, DRW, TAR,
 };
 use crate::architecture::arm::{
-    dp::{DPAccess, DPv1, RdBuff},
+    dp::{DPAccess, RdBuff},
     ArmCommunicationInterface,
 };
 use crate::{CommunicationInterface, Error, MemoryInterface};
@@ -372,7 +372,10 @@ where
         self.write_ap_register(drw)?;
 
         // Ensure the write is actually performed
-        let _: RdBuff = self.interface.read_dp_register::<_, DPv1>().unwrap();
+        let _: RdBuff = self
+            .interface
+            .read_dp_register()
+            .map_err(|_| AccessPortError::InvalidAccessPortNumber)?;
 
         Ok(())
     }
@@ -399,7 +402,7 @@ where
         self.write_ap_register(drw)?;
 
         // Ensure the last write is actually performed
-        let _: RdBuff = self.interface.read_dp_register::<_, DPv1>().unwrap();
+        let _: RdBuff = self.interface.read_dp_register()?;
 
         Ok(())
     }
@@ -496,7 +499,7 @@ where
         }
 
         // Ensure the last write is actually performed
-        let _: RdBuff = self.interface.read_dp_register::<_, DPv1>().unwrap();
+        let _: RdBuff = self.interface.read_dp_register()?;
 
         log::debug!("Finished writing block");
 

--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -122,10 +122,10 @@ impl DAPLink {
     }
 }
 
-impl<P: DebugPort, R: DPRegister<P>> DPAccess<P, R> for DAPLink {
+impl DPAccess for DAPLink {
     type Error = DebugProbeError;
 
-    fn read_dp_register(&mut self, _port: &P) -> Result<R, Self::Error> {
+    fn read_dp_register<R: DPRegister<P>, P: DebugPort>(&mut self) -> Result<R, Self::Error> {
         debug!("Reading DP register {}", R::NAME);
         let result = self.read_register(PortType::DebugPort, u16::from(R::ADDRESS))?;
 
@@ -134,7 +134,10 @@ impl<P: DebugPort, R: DPRegister<P>> DPAccess<P, R> for DAPLink {
         Ok(result.into())
     }
 
-    fn write_dp_register(&mut self, _port: &P, register: R) -> Result<(), Self::Error> {
+    fn write_dp_register<R: DPRegister<P>, P: DebugPort>(
+        &mut self,
+        register: R,
+    ) -> Result<(), Self::Error> {
         let value = register.into();
 
         debug!("Writing DP register {}, value=0x{:08x}", R::NAME, value);

--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -2,7 +2,7 @@ pub mod commands;
 pub mod tools;
 
 use crate::architecture::arm::{
-    dp::{DPAccess, DPRegister, DebugPort},
+    dp::{DPAccess, DPRegister, DebugPortError},
     DAPAccess, DapError, PortType,
 };
 use crate::probe::daplink::commands::CmsisDapError;
@@ -123,9 +123,7 @@ impl DAPLink {
 }
 
 impl DPAccess for DAPLink {
-    type Error = DebugProbeError;
-
-    fn read_dp_register<R: DPRegister<P>, P: DebugPort>(&mut self) -> Result<R, Self::Error> {
+    fn read_dp_register<R: DPRegister>(&mut self) -> Result<R, DebugPortError> {
         debug!("Reading DP register {}", R::NAME);
         let result = self.read_register(PortType::DebugPort, u16::from(R::ADDRESS))?;
 
@@ -134,14 +132,13 @@ impl DPAccess for DAPLink {
         Ok(result.into())
     }
 
-    fn write_dp_register<R: DPRegister<P>, P: DebugPort>(
-        &mut self,
-        register: R,
-    ) -> Result<(), Self::Error> {
+    fn write_dp_register<R: DPRegister>(&mut self, register: R) -> Result<(), DebugPortError> {
         let value = register.into();
 
         debug!("Writing DP register {}, value=0x{:08x}", R::NAME, value);
-        self.write_register(PortType::DebugPort, u16::from(R::ADDRESS), value)
+        self.write_register(PortType::DebugPort, u16::from(R::ADDRESS), value)?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
When using a Memory AP to write data into memory, we only
wrote the value into the `DRW` register of the AP.

The problem is that this does not mean that the value will
be actually written into memory. The SWD protocol requires
that the host does continue to clock the SWD clock after
writing data, to ensure that the SWD transfer can be
completed. In the case of the ST-Link, it seems that
the probe itself does not do this, as least in the
way it is used by probe-rs right now. To ensure that
all transfers can be completed, I have added a read
of the DP  register `RDBUFF` after all writes.

This seems to fix probe-rs/cargo-flash#9