### PR TITLE
Fix math errors in ADIMemoryInterface::read_block8

### DIFF
--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -280,12 +280,12 @@ where
         // Convert 32-bit words to bytes
         let mut buf8 = vec![0u8; (aligned_end_addr - aligned_addr) as usize];
         for i in 0..buf32.len() {
-            buf8[i*4..(i+1)*4].copy_from_slice(&buf32[i].to_le_bytes());
+            buf8[i * 4..(i + 1) * 4].copy_from_slice(&buf32[i].to_le_bytes());
         }
 
         // Copy relevant part of aligned block to output data
         let start = (address - aligned_addr) as usize;
-        data.copy_from_slice(&buf8[start..start+data.len()]);
+        data.copy_from_slice(&buf8[start..start + data.len()]);
 
         Ok(())
     }


### PR DESCRIPTION
Reading for certain address/length values was crashing with errors such as

    thread 'main' panicked at 'attempt to subtract with overflow', /home/matti/.cargo/registry/src/github.com-1ecc6299db9ec823/probe-rs-0.5.1/src/architecture/arm/memory/adi_v5_memory_interface.rs:290:13

The code was pretty complicated so I ended up rewriting it to be simpler. There's an extra `Vec` now which could be avoided by using a transmute but I don't want to be the guy to add the first `unsafe` to the project.

Is there an easy way to test this? I did check the math and tried it with a program that reads from all sorts of random address/length values.