### PR TITLE
Fix build without builtin-targets

### DIFF
--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -131,7 +131,7 @@ impl Registry {
     #[cfg(not(feature = "builtin-targets"))]
     fn from_builtin_families() -> Self {
         Self {
-            families: Vec::from(generic_targets),
+            families: GENERIC_TARGETS.iter().cloned().collect(),
         }
     }
 


### PR DESCRIPTION
Fix building probe-rs without built-in targets.
