### PR TITLE
Specify endianness for pread/pwrite everywhere

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -193,7 +193,7 @@ fn reset_target_of_device(
 }
 
 fn trace_u32_on_target(shared_options: &SharedOptions, loc: u32) -> Result<(), CliError> {
-    use scroll::Pwrite;
+    use scroll::{Pwrite, LE};
     use std::io::prelude::*;
     use std::thread::sleep;
     use std::time::Duration;
@@ -221,8 +221,8 @@ fn trace_u32_on_target(shared_options: &SharedOptions, loc: u32) -> Result<(), C
             // Unwrap is safe as there is always an stdin in our case!
             let mut buf = [0 as u8; 8];
             // Unwrap is safe!
-            buf.pwrite(instant, 0).unwrap();
-            buf.pwrite(value, 4).unwrap();
+            buf.pwrite_with(instant, 0, LE).unwrap();
+            buf.pwrite_with(value, 4, LE).unwrap();
             std::io::stdout().write_all(&buf)?;
 
             std::io::stdout().flush()?;

--- a/probe-rs-t2rust/src/lib.rs
+++ b/probe-rs-t2rust/src/lib.rs
@@ -1,4 +1,4 @@
-use scroll::Pread;
+use scroll::{Pread, LE};
 use std::fs;
 use std::fs::{read_dir, read_to_string};
 use std::io;
@@ -113,7 +113,7 @@ fn extract_algorithms(chip: &serde_yaml::Value) -> Vec<(String, proc_macro2::Tok
                 base64::decode(algorithm.get("instructions").unwrap().as_str().unwrap())
                     .unwrap()
                     .chunks(4)
-                    .map(|bytes| bytes.pread(0).unwrap())
+                    .map(|bytes| bytes.pread_with(0, LE).unwrap())
                     .collect();
             let pc_init =
                 quote_option(algorithm.get("pc_init").unwrap().as_u64().map(|v| v as u32));

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -7,7 +7,7 @@ use crate::architecture::arm::{
     ArmCommunicationInterface,
 };
 use crate::{CommunicationInterface, Error, MemoryInterface};
-use scroll::Pread;
+use scroll::{Pread, LE};
 
 /// A struct to give access to a targets memory using a certain DAP.
 pub struct ADIMemoryInterface<AP>
@@ -535,7 +535,10 @@ where
             aligned_address,
             data[pre_bytes..data.len() - post_bytes]
                 .chunks(4)
-                .map(|c| c.pread::<u32>(0).expect("This is a bug. Please report it."))
+                .map(|c| {
+                    c.pread_with::<u32>(0, LE)
+                        .expect("This is a bug. Please report it.")
+                })
                 .collect::<Vec<_>>()
                 .as_slice(),
         )?;

--- a/probe-rs/src/probe/daplink/commands/general/info.rs
+++ b/probe-rs/src/probe/daplink/commands/general/info.rs
@@ -1,6 +1,6 @@
 use super::super::{Category, CmsisDapError, Request, Response, Result};
 
-use scroll::Pread;
+use scroll::{Pread, LE};
 
 #[allow(unused)]
 #[derive(Copy, Clone)]
@@ -118,7 +118,7 @@ impl Response for TestDomainTime {
     fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self> {
         if buffer[offset + 1] == 0x08 {
             let res = buffer
-                .pread::<u32>(offset + 2)
+                .pread_with::<u32>(offset + 2, LE)
                 .expect("This is a bug. Please report it.");
             Ok(TestDomainTime(res))
         } else {
@@ -133,7 +133,7 @@ impl Response for SWOTraceBufferSize {
     fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self> {
         if buffer[offset + 1] == 0x04 {
             let res = buffer
-                .pread::<u32>(offset + 2)
+                .pread_with::<u32>(offset + 2, LE)
                 .expect("This is a bug. Please report it.");
             Ok(SWOTraceBufferSize(res))
         } else {
@@ -149,7 +149,7 @@ impl Response for PacketCount {
     fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self> {
         if buffer[offset] == 0x01 {
             let res = buffer
-                .pread::<u8>(offset + 1)
+                .pread_with::<u8>(offset + 1, LE)
                 .expect("This is a bug. Please report it.");
             Ok(PacketCount(res))
         } else {
@@ -165,7 +165,7 @@ impl Response for PacketSize {
     fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self> {
         if buffer[offset] == 0x02 {
             let res = buffer
-                .pread::<u16>(offset + 1)
+                .pread_with::<u16>(offset + 1, LE)
                 .expect("This is a bug. Please report it.");
             Ok(PacketSize(res))
         } else {

--- a/probe-rs/src/probe/daplink/commands/swj/clock.rs
+++ b/probe-rs/src/probe/daplink/commands/swj/clock.rs
@@ -7,10 +7,10 @@ impl Request for SWJClockRequest {
     const CATEGORY: Category = Category(0x11);
 
     fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize> {
-        use scroll::Pwrite;
+        use scroll::{Pwrite, LE};
 
         buffer
-            .pwrite(self.0, offset)
+            .pwrite_with(self.0, offset, LE)
             .expect("This is a bug. Please report it.");
         Ok(4)
     }

--- a/probe-rs/src/probe/daplink/commands/transfer/configure.rs
+++ b/probe-rs/src/probe/daplink/commands/transfer/configure.rs
@@ -14,14 +14,14 @@ impl Request for ConfigureRequest {
     const CATEGORY: Category = Category(0x04);
 
     fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize> {
-        use scroll::Pwrite;
+        use scroll::{Pwrite, LE};
 
         buffer[offset] = self.idle_cycles;
         buffer
-            .pwrite(self.wait_retry, offset + 1)
+            .pwrite_with(self.wait_retry, offset + 1, LE)
             .expect("This is a bug. Please report it.");
         buffer
-            .pwrite(self.match_retry, offset + 3)
+            .pwrite_with(self.match_retry, offset + 3, LE)
             .expect("This is a bug. Please report it.");
         Ok(5)
     }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -235,7 +235,7 @@ impl DAPAccess for STLink {
             self.device.write(cmd, &[], &mut buf, TIMEOUT)?;
             Self::check_status(&buf)?;
             // Unwrap is ok!
-            Ok((&buf[4..8]).pread(0).unwrap())
+            Ok((&buf[4..8]).pread_with(0, LE).unwrap())
         } else {
             Err(StlinkError::BlanksNotAllowedOnDPRegister.into())
         }
@@ -319,8 +319,8 @@ impl STLink {
         {
             Ok(_) => {
                 // The next two unwraps are safe!
-                let a0 = (&buf[0..4]).pread::<u32>(0).unwrap() as f32;
-                let a1 = (&buf[4..8]).pread::<u32>(0).unwrap() as f32;
+                let a0 = (&buf[0..4]).pread_with::<u32>(0, LE).unwrap() as f32;
+                let a1 = (&buf[4..8]).pread_with::<u32>(0, LE).unwrap() as f32;
                 if a0 != 0.0 {
                     Ok((2.0 * a1 * 1.2 / a0) as f32)
                 } else {
@@ -421,7 +421,7 @@ impl STLink {
                 .write(vec![commands::GET_VERSION_EXT], &[], &mut buf, TIMEOUT)
             {
                 Ok(_) => {
-                    let version: u8 = (&buf[2..3]).pread(0).unwrap();
+                    let version: u8 = (&buf[2..3]).pread_with(0, LE).unwrap();
                     self.jtag_version = version;
                 }
                 Err(e) => return Err(e),


### PR DESCRIPTION
If endianness isn't specified, host machine endianness is assumed. Everybody is probably using a little endian machine, so I specified little endian wherever it was undefined.