### PR TITLE
Adapt CLI to new attach

### DIFF
--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -76,7 +76,6 @@ pub(crate) fn open_probe(index: Option<usize>) -> Result<Probe, CliError> {
     };
 
     let probe = device.open()?;
-
     Ok(probe)
 }
 

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -13,7 +13,8 @@ use probe_rs::{
 };
 
 pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<(), CliError> {
-    let probe = open_probe(shared_options.n)?;
+    let mut probe = open_probe(shared_options.n)?;
+    probe.attach_to_unspecified()?;
 
     /*
         The following code only works with debug port v2,

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -213,6 +213,12 @@ impl Probe {
         Session::new(self, target)
     }
 
+    pub fn attach_to_unspecified(&mut self) -> Result<(), Error> {
+        self.inner.attach()?;
+        self.attached = true;
+        Ok(())
+    }
+
     /// Selects the transport protocol to be used by the debug probe.
     pub fn select_protocol(&mut self, protocol: WireProtocol) -> Result<(), DebugProbeError> {
         if !self.attached {


### PR DESCRIPTION
This fixes the unattached error when determining the chip info from a probe.
Before a probe would always attach on creation.
Now this has to be done manually.