### PR TITLE
[FIX] typo: tms_enter_idle -> tdi_enter_idle

### DIFF
--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -199,7 +199,7 @@ impl JLink {
             }
         }
 
-        tdi.extend_from_slice(&tms_enter_idle);
+        tdi.extend_from_slice(&tdi_enter_idle);
 
         log::trace!("tms: {:?}", tms);
         log::trace!("tdi: {:?}", tdi);


### PR DESCRIPTION
I suppose this is just a mere typo.

I was experimenting with multi tap JTAG chain and noticed this bug.
More precisely total number of bits in IR register chain of GD32VF103 is 10, leading tms.len() == 16 and tdi.len() == 17, hence JayLink::jtag_io() complaining "TMS and TDI must have the same number of bits" .
note : JayLink::jtag_io() is actually counting byte-wise.