### PR TITLE
Support setting SWD speed on DAP probes

### DIFF
--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -196,10 +196,7 @@ impl DebugProbe for DAPLink {
         self.packet_count = Some(packet_count);
         self.packet_size = Some(packet_size);
 
-        let clock = 1_000_000;
-
-        debug!("Attaching to target system (clock = {})", clock);
-        self.set_swj_clock(clock)?;
+        debug!("Attaching to target system (clock = {}kHz)", self.speed_khz);
 
         let protocol = if let Some(protocol) = self.protocol {
             match protocol {
@@ -216,7 +213,8 @@ impl DebugProbe for DAPLink {
             ConnectResponse::InitFailed => Err(CmsisDapError::ErrorResponse),
         })?;
 
-        self.set_swj_clock(clock)?;
+        // Set speed after connecting as it can be reset during protocol selection
+        self.set_speed(self.speed_khz)?;
 
         self.transfer_configure(ConfigureRequest {
             idle_cycles: 0,


### PR DESCRIPTION
Currently DAP probes always set a clock of 1MHz in `attach()`, even if `set_speed()` has been previously called. Since you can't call `set_speed()` after `attach()` (because the returned Session borrows the probe), this means there's no way to set the SWD speed.

This patch sets the speed at attach to whatever was previously set by `set_speed()`, which defaults to the same 1MHz, but allows users to call `set_speed()` on the Probe before calling `attach()`.

I removed the first `set_speed()` call and left the second one, because the there are no SWD transfers initiated due to connecting (so only the second call made any difference), and because sometimes the clock speed is reset by connecting (so it makes sense to set it afterwards instead of before).