### PR TITLE
Fix it's->its typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ They all implement the GDB protocol and their own protocol on top of it to enabl
 Only Segger provides a closed source DLL which you can use for talking to the JLink.
 
 This project gets rid of the GDB layer and provides a direct interface to the debug probe,
-which then enables other software to use it's debug functionality.
+which then enables other software to use its debug functionality.
 
 **The end goal of this project is to have a complete library toolset to enable other tools to communicate with embedded targets.**
 
@@ -101,7 +101,7 @@ Any contributions are very welcome!
 
 Also have a look at [CONTRIBUTING.md](CONTRIBUTING.md).
 
-### Our company needs feature X and would pay for it's development
+### Our company needs feature X and would pay for its development
 
 Please reach out to [@Yatekii](https://github.com/Yatekii)
 

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -154,7 +154,7 @@ impl Registry {
                     {
                         if variant.name.to_ascii_lowercase() != name.to_ascii_lowercase() {
                             log::warn!(
-                                "Found chip {} which matches given partial name {}. Consider specifying it's full name.",
+                                "Found chip {} which matches given partial name {}. Consider specifying its full name.",
                                 variant.name,
                                 name,
                             )

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -87,7 +87,7 @@ impl FlashSector {
 }
 
 /// A struct to hold all the information about one region
-/// in the flash that is erased during flashing and has to be restored to it's original value afterwards.
+/// in the flash that is erased during flashing and has to be restored to its original value afterwards.
 #[derive(Clone)]
 pub struct FlashFill {
     address: u32,
@@ -259,7 +259,7 @@ impl<'a> FlashBuilder<'a> {
             Ok(_) => return Err(FlashError::DataOverlap(address)),
             // Add it to the list if it is not present yet.
             Err(position) => {
-                // If we have a prior block (prevent u32 underflow), check if it's range intersects
+                // If we have a prior block (prevent u32 underflow), check if its range intersects
                 // the range of the block we are trying to insert. If so, return an error.
                 if position > 0 {
                     if let Some(block) = self.data_blocks.get(position - 1) {
@@ -271,7 +271,7 @@ impl<'a> FlashBuilder<'a> {
                 }
 
                 // If we have a block after the one we are trying to insert,
-                // check if it's range intersects the range of the block we are trying to insert.
+                // check if its range intersects the range of the block we are trying to insert.
                 // If so, return an error.
                 // We don't add 1 to the position here, because we have not insert an element yet.
                 // So the ones on the right are not shifted yet!
@@ -381,7 +381,7 @@ impl<'a> FlashBuilder<'a> {
                     // Where the fillup ends which is by default the end of the page.
                     let mut fill_end_address = (page_address + page_size) as usize;
 
-                    // Try to get the address of the next block and adjust the address to it's start
+                    // Try to get the address of the next block and adjust the address to its start
                     // if it is smaller than the end of the last page.
                     if let Some((_, next_block)) = data_iter.peek() {
                         fill_end_address = fill_end_address.min(next_block.address as usize);

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -439,7 +439,7 @@ impl STLink {
         Ok((self.hw_version, self.jtag_version))
     }
 
-    /// Opens the ST-Link USB device and tries to identify the ST-Links version and it's target voltage.
+    /// Opens the ST-Link USB device and tries to identify the ST-Links version and its target voltage.
     /// Internal helper.
     fn init(&mut self) -> Result<(), DebugProbeError> {
         log::debug!("Initializing STLink...");


### PR DESCRIPTION
I noticed this in the registry error message which is user-facing but cleared it up elsewhere too.