### PR TITLE
Drain USB HID buffer at connection

### DIFF
--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -57,6 +57,16 @@ impl std::fmt::Debug for DAPLink {
 
 impl DAPLink {
     pub fn new_from_device(device: hidapi::HidDevice) -> Self {
+        // Discard anything left in buffer, as otherwise
+        // we'll get out of sync between requests and responses.
+        let mut discard_buffer = [0u8; 128];
+        loop {
+            match device.read_timeout(&mut discard_buffer, 1) {
+                Ok(n) if n != 0 => continue,
+                _ => break,
+            }
+        }
+
         Self {
             device: Mutex::new(device),
             _hw_version: 0,


### PR DESCRIPTION
At the moment if you interrupt a programming session it can leave a response from the device still in the OS' HID buffer, so when you try to program again, the first response probe-rs sees is an old one to a previous command, which it rejects and quits. Of course, when you retry, you now see the response to that last command, and so on, which only recovers when you unplug and replug the probe.

By reading until the buffer is empty at connection time we ensure the next read is a response to our request and not stale data. In testing I can no longer reproduce the problem.