### PR TITLE
Queue DAPlink read/write register commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- DAPlink implementation now batches `read_register` and `write_register`
+  commands, executing the entire batch when either the batch is full or a
+  `read_register` is requested, returning the read result or an error which
+  may indicate an error with a batched command. As a consequence,
+  `write_register` calls may return `Ok(())` even if they have not been
+  submitted to the probe yet, but any read will immediately execute the batch.
+  Operations such as device flashing see around 350% speedup.
+
 ### Fixed
 
 ## [0.6.0]

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -2,10 +2,7 @@ use super::super::ap::{
     mock::MockMemoryAP, APAccess, APRegister, AccessPortError, AddressIncrement, DataSize,
     MemoryAP, CSW, DRW, TAR,
 };
-use crate::architecture::arm::{
-    dp::{DPAccess, RdBuff},
-    ArmCommunicationInterface,
-};
+use crate::architecture::arm::{dp::DPAccess, ArmCommunicationInterface};
 use crate::{CommunicationInterface, Error, MemoryInterface};
 use scroll::{Pread, Pwrite, LE};
 use std::convert::TryInto;
@@ -332,8 +329,8 @@ where
         self.write_ap_register(tar)?;
         self.write_ap_register(drw)?;
 
-        // Ensure the write is actually performed
-        let _: RdBuff = self.interface.read_dp_register()?;
+        // Ensure the write is actually performed.
+        let _ = self.write_ap_register(csw);
 
         Ok(())
     }
@@ -458,7 +455,7 @@ where
         }
 
         // Ensure the last write is actually performed
-        let _: RdBuff = self.interface.read_dp_register()?;
+        self.write_ap_register(csw)?;
 
         log::debug!("Finished writing block");
 

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -99,8 +99,8 @@ impl<'a> Flasher<'a> {
 
         // TODO: Halt & reset target.
         log::debug!("Halting core.");
-        let cpu_info = core.halt();
-        log::debug!("PC = 0x{:08x}", cpu_info.unwrap().pc);
+        let cpu_info = core.halt().map_err(FlashError::Core)?;
+        log::debug!("PC = 0x{:08x}", cpu_info.pc);
         core.wait_for_core_halted().map_err(FlashError::Core)?;
         log::debug!("Reset and halt");
         core.reset_and_halt().map_err(FlashError::Core)?;
@@ -594,6 +594,7 @@ impl<'a, O: Operation> ActiveFlasher<'a, O> {
         loop {
             match self.core.wait_for_core_halted() {
                 Ok(()) => break,
+                Err(error::Error::Probe(DebugProbeError::Timeout)) => (),
                 Err(e) => {
                     log::warn!("Error while waiting for core halted: {}", e);
                 }

--- a/probe-rs/src/probe/daplink/commands/transfer/mod.rs
+++ b/probe-rs/src/probe/daplink/commands/transfer/mod.rs
@@ -83,7 +83,7 @@ impl InnerTransferRequest {
             | (if self.td_timestamp_request { 1 } else { 0 }) << 7;
         if let Some(data) = self.data {
             let data = data.to_le_bytes();
-            buffer[offset+1..offset+5].copy_from_slice(&data[..]);
+            buffer[offset + 1..offset + 5].copy_from_slice(&data[..]);
             Ok(5)
         } else {
             Ok(1)

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -40,7 +40,6 @@ impl std::str::FromStr for WireProtocol {
     }
 }
 
-
 /// A command queued in a batch for later execution
 ///
 /// Mostly used internally but returned in DebugProbeError to indicate
@@ -54,10 +53,12 @@ pub enum BatchCommand {
 impl fmt::Display for BatchCommand {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            BatchCommand::Read(port, addr) =>
-                write!(f, "Read(port={:?}, addr={})", port, addr),
-            BatchCommand::Write(port, addr, data) =>
-                write!(f, "Write(port={:?}, addr={}, data=0x{:08x}", port, addr, data),
+            BatchCommand::Read(port, addr) => write!(f, "Read(port={:?}, addr={})", port, addr),
+            BatchCommand::Write(port, addr, data) => write!(
+                f,
+                "Write(port={:?}, addr={}, data=0x{:08x}",
+                port, addr, data
+            ),
         }
     }
 }

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -40,6 +40,28 @@ impl std::str::FromStr for WireProtocol {
     }
 }
 
+
+/// A command queued in a batch for later execution
+///
+/// Mostly used internally but returned in DebugProbeError to indicate
+/// which batched command actually encountered the error.
+#[derive(Copy, Clone, Debug)]
+pub enum BatchCommand {
+    Read(PortType, u16),
+    Write(PortType, u16, u32),
+}
+
+impl fmt::Display for BatchCommand {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            BatchCommand::Read(port, addr) =>
+                write!(f, "Read(port={:?}, addr={})", port, addr),
+            BatchCommand::Write(port, addr, data) =>
+                write!(f, "Write(port={:?}, addr={}, data=0x{:08x}", port, addr, data),
+        }
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum DebugProbeError {
     #[error("USB Communication Error")]
@@ -76,6 +98,8 @@ pub enum DebugProbeError {
     Attached,
     #[error("Some functionality was not implemented yet")]
     NotImplemented(&'static str),
+    #[error("Error in previous batched command: {0}")]
+    BatchError(BatchCommand),
 }
 
 /// The Probe struct is a generic wrapper over the different


### PR DESCRIPTION
This PR implements automatic queuing of `read_register` and `write_register` commands for CMSIS-DAP probes. I see a typical 1kB page program time improvement of **2.5x** with this enabled (290ms -> 118ms or 3.4kB/s -> 8.5kB/s), mainly because the `write32` and `read32` commands in `write_core_reg` during `call_function` are each run as a single CMSIS-DAP `DAP_Transfer` command instead of seven.

At first I tried to implement this by exposing a queue interface in DAPAccess, which then had to be exposed in APAccess and DPAccess, and then in MemoryInterface and ADIMemoryInterface, which ended up being really complicated, especially because APAccess and DPAccess are different traits so it wasn't clear how you combine AP and DP operations in a single queue.

Instead, this PR is much simpler conceptually: inside the DAPlink probe implementation, all DAPAccess `read_register` and `write_register` calls are added to a batch, and whenever the batch is full or we receive a `read_register` command, the whole batch is executed. This means reads always run and return the result right away, so higher level APIs don't need to change, but writes may return `Ok(())` even if they weren't executed yet. When the batch is executed, errors in the final batched command are returned as normal, but errors that occurred on an earlier command are returned as a new `BatchError` which contains the command that failed. Additionally, we execute the batch (if any) before calling other operations in case there are any pending writes.

This doesn't buy us the full performance gain that a generic queue interface could -- for example, `write32` will always run in a batch by itself, but it's possible to fit two `write32` calls into a single batch which would be faster. Doing so requires* multiple reads in a batch, which requires API changes all the way up the stack. If you think that's ultimately the better approach, it might not be worth merging this PR, I don't mind. It might be worth having this now while we wait for a future queue API.

\* technically, if we remove the unused read of `RDBUFF` from `write32`, then `write32` would queue, which brings 1kB page program times from 118ms (8.5kB/s) to 86ms (11.6kB/s), an overall improvement of **3.4x** compared to 290ms (3.4kB/s) without batching, but I'm not sure about this -- we might want `write32` to always commit right away, not just "some time later". On the other hand it seems to work and if we can get away with it it's another big win...

I've tested this on my own CMSIS-DAP implementation where it works really well, but I haven't tested it on an official DAPlink as I don't have any.