### PR TITLE
Better handling of old ST-Links

### DIFF
--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -67,8 +67,6 @@ impl fmt::Display for BatchCommand {
 pub enum DebugProbeError {
     #[error("USB Communication Error")]
     USB(#[source] Option<Box<dyn std::error::Error + Send + Sync>>),
-    #[error("JTAG not supported on probe")]
-    JTAGNotSupportedOnProbe,
     #[error("The firmware on the probe is outdated")]
     ProbeFirmwareOutdated,
     #[error("An error specific to a probe type occured: {0}")]


### PR DESCRIPTION
Improve error handling when multiple APs are not supported, as long as only a single one is used it now works fine. Also, the error is changed to indicate that the probe firmware should be updated.