### PR TITLE
Add status function (implement #138)

### DIFF
--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -3,7 +3,7 @@ use crate::common::CliError;
 use capstone::Capstone;
 use probe_rs::architecture::arm::CortexDump;
 use probe_rs::debug::DebugInfo;
-use probe_rs::{Core, CoreRegisterAddress, CoreStatus, HaltReason};
+use probe_rs::{Core, CoreRegisterAddress};
 use std::fs::File;
 use std::io::prelude::*;
 
@@ -73,16 +73,11 @@ impl DebugCli {
 
                 println!("Status: {:?}", &status);
 
-                if let CoreStatus::Halted(reason) = status {
-                    match reason {
-                        HaltReason::Breakpoint => {
-                            let pc = cli_data
-                                .core
-                                .read_core_reg(cli_data.core.registers().program_counter())?;
-                            println!("Hit breakpoint at address {:#010x}", pc);
-                        }
-                        _ => (),
-                    }
+                if status.is_halted() {
+                    let pc = cli_data
+                        .core
+                        .read_core_reg(cli_data.core.registers().program_counter())?;
+                    println!("Core halted at address {:#010x}", pc);
                 }
 
                 Ok(CliState::Continue)

--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -304,7 +304,7 @@ impl M0 {
 }
 
 impl CoreInterface for M0 {
-    fn wait_for_core_halted(&self) -> Result<(), Error> {
+    fn wait_for_core_halted(&mut self) -> Result<(), Error> {
         // Wait until halted state is active again.
         for _ in 0..100 {
             let dhcsr_val = Dhcsr(self.memory.read32(Dhcsr::ADDRESS)?);
@@ -357,7 +357,7 @@ impl CoreInterface for M0 {
         self.wait_for_core_register_transfer()
     }
 
-    fn halt(&self) -> Result<CoreInformation, Error> {
+    fn halt(&mut self) -> Result<CoreInformation, Error> {
         // TODO: Generic halt support
 
         let mut value = Dhcsr(0);
@@ -376,7 +376,7 @@ impl CoreInterface for M0 {
         Ok(CoreInformation { pc: pc_value })
     }
 
-    fn run(&self) -> Result<(), Error> {
+    fn run(&mut self) -> Result<(), Error> {
         let mut value = Dhcsr(0);
         value.set_c_halt(false);
         value.set_c_debugen(true);
@@ -387,7 +387,7 @@ impl CoreInterface for M0 {
             .map_err(Into::into)
     }
 
-    fn step(&self) -> Result<CoreInformation, Error> {
+    fn step(&mut self) -> Result<CoreInformation, Error> {
         let mut value = Dhcsr(0);
         // Leave halted state.
         // Step one instruction.
@@ -420,7 +420,7 @@ impl CoreInterface for M0 {
         Ok(())
     }
 
-    fn reset_and_halt(&self) -> Result<CoreInformation, Error> {
+    fn reset_and_halt(&mut self) -> Result<CoreInformation, Error> {
         // Ensure debug mode is enabled
         let dhcsr_val = Dhcsr(self.memory.read32(Dhcsr::ADDRESS)?);
         if !dhcsr_val.c_debugen() {
@@ -518,5 +518,8 @@ impl CoreInterface for M0 {
 
     fn architecture(&self) -> Architecture {
         Architecture::ARM
+    }
+    fn status(&mut self) -> Result<crate::core::CoreStatus, Error> {
+        todo!()
     }
 }

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -45,7 +45,7 @@ impl M33 {
 }
 
 impl CoreInterface for M33 {
-    fn wait_for_core_halted(&self) -> Result<(), Error> {
+    fn wait_for_core_halted(&mut self) -> Result<(), Error> {
         // Wait until halted state is active again.
         for _ in 0..100 {
             let dhcsr_val = Dhcsr(self.memory.read32(Dhcsr::ADDRESS)?);
@@ -67,7 +67,7 @@ impl CoreInterface for M33 {
         }
     }
 
-    fn halt(&self) -> Result<CoreInformation, Error> {
+    fn halt(&mut self) -> Result<CoreInformation, Error> {
         let mut value = Dhcsr(0);
         value.set_c_halt(true);
         value.set_c_debugen(true);
@@ -83,7 +83,7 @@ impl CoreInterface for M33 {
         // get pc
         Ok(CoreInformation { pc: pc_value })
     }
-    fn run(&self) -> Result<(), Error> {
+    fn run(&mut self) -> Result<(), Error> {
         let mut value = Dhcsr(0);
         value.set_c_halt(false);
         value.set_c_debugen(true);
@@ -105,7 +105,7 @@ impl CoreInterface for M33 {
         Ok(())
     }
 
-    fn reset_and_halt(&self) -> Result<CoreInformation, Error> {
+    fn reset_and_halt(&mut self) -> Result<CoreInformation, Error> {
         // Ensure debug mode is enabled
         let dhcsr_val = Dhcsr(self.memory.read32(Dhcsr::ADDRESS)?);
         if !dhcsr_val.c_debugen() {
@@ -143,7 +143,7 @@ impl CoreInterface for M33 {
         Ok(CoreInformation { pc: pc_value })
     }
 
-    fn step(&self) -> Result<CoreInformation, Error> {
+    fn step(&mut self) -> Result<CoreInformation, Error> {
         let mut value = Dhcsr(0);
         // Leave halted state.
         // Step one instruction.
@@ -255,6 +255,9 @@ impl CoreInterface for M33 {
 
     fn architecture(&self) -> Architecture {
         Architecture::ARM
+    }
+    fn status(&mut self) -> Result<crate::core::CoreStatus, Error> {
+        todo!()
     }
 }
 

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -1,33 +1,61 @@
 //! Support for Cortex-M33
 //!
 
-use crate::core::{
-    CoreInformation, CoreInterface, CoreRegister, CoreRegisterAddress, RegisterFile,
-};
 use crate::error::Error;
 use crate::memory::Memory;
-use crate::DebugProbeError;
+use crate::{
+    core::{
+        Architecture, CoreInformation, CoreInterface, CoreRegister, CoreRegisterAddress,
+        RegisterFile,
+    },
+    CoreStatus, DebugProbeError, HaltReason,
+};
 
 use crate::architecture::arm::core::register;
 
 use bitfield::bitfield;
 
-use super::ARM_REGISTER_FILE;
-use crate::core::Architecture;
+use super::{Dfsr, ARM_REGISTER_FILE};
 use std::mem::size_of;
 
 pub struct M33 {
     memory: Memory,
 
     hw_breakpoints_enabled: bool,
+
+    current_state: CoreStatus,
 }
 
 impl M33 {
-    pub fn new(memory: Memory) -> Self {
-        Self {
+    pub fn new(memory: Memory) -> Result<Self, Error> {
+        // determine current state
+        let dhcsr = Dhcsr(memory.read32(Dhcsr::ADDRESS)?);
+
+        let state = if dhcsr.s_sleep() {
+            CoreStatus::Sleeping
+        } else if dhcsr.s_halt() {
+            log::debug!("Core was halted when connecting");
+
+            let dfsr = Dfsr(memory.read32(Dfsr::ADDRESS)?);
+
+            let reason = dfsr.halt_reason();
+
+            CoreStatus::Halted(reason)
+        } else {
+            CoreStatus::Running
+        };
+
+        // Clear DFSR register. The bits in the register are sticky,
+        // so we clear them here to ensure that that none are set.
+        let dfsr_clear = Dfsr::clear_all();
+
+        memory.write32(Dfsr::ADDRESS, dfsr_clear.into())?;
+
+        Ok(Self {
             memory,
             hw_breakpoints_enabled: false,
-        }
+            current_state: state,
+        })
     }
 
     fn wait_for_core_register_transfer(&self) -> Result<(), Error> {
@@ -256,8 +284,62 @@ impl CoreInterface for M33 {
     fn architecture(&self) -> Architecture {
         Architecture::ARM
     }
+
     fn status(&mut self) -> Result<crate::core::CoreStatus, Error> {
-        todo!()
+        let dhcsr = Dhcsr(self.memory.read32(Dhcsr::ADDRESS)?);
+
+        if dhcsr.s_sleep() {
+            // Check if we assumed the core to be halted
+            if self.current_state.is_halted() {
+                log::warn!("Expected core to be halted, but core is running");
+            }
+
+            self.current_state = CoreStatus::Sleeping;
+
+            return Ok(CoreStatus::Sleeping);
+        }
+
+        // TODO: Handle lockup
+
+        if dhcsr.s_halt() {
+            let dfsr = Dfsr(self.memory.read32(Dfsr::ADDRESS)?);
+
+            let reason = dfsr.halt_reason();
+
+            // Clear bits from Dfsr register
+            self.memory
+                .write32(Dfsr::ADDRESS, Dfsr::clear_all().into())?;
+
+            // If the core was halted before, we cannot read the halt reason from the chip,
+            // because we clear it directly after reading.
+            if self.current_state.is_halted() {
+                // There shouldn't be any bits set, otherwise it means
+                // that the reason for the halt has changed. No bits set
+                // means that we have an unkown HaltReason.
+                if reason == HaltReason::Unknown {
+                    return Ok(self.current_state);
+                }
+
+                log::warn!(
+                    "Reason for halt has changed, old reason was {:?}, new reason is {:?}",
+                    &self.current_state,
+                    &reason
+                );
+            }
+
+            self.current_state = CoreStatus::Halted(reason);
+
+            return Ok(CoreStatus::Halted(reason));
+        }
+
+        // Core is neither halted nor sleeping, so we assume it is running.
+        if self.current_state.is_halted() {
+            log::warn!("Core is running, but we expected it to be halted");
+        }
+
+        self.current_state = CoreStatus::Running;
+
+        Ok(CoreStatus::Running)
     }
 }
 

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -31,21 +31,19 @@ impl Dfsr {
             // We cannot identify why the chip halted,
             // it could be for multiple reasons.
             HaltReason::Unknown
+        } else if self.bkpt() {
+            HaltReason::Breakpoint
+        } else if self.external() {
+            HaltReason::External
+        } else if self.dwttrap() {
+            HaltReason::Watchpoint
+        } else if self.halted() {
+            HaltReason::Request
+        } else if self.vcatch() {
+            HaltReason::Exception
         } else {
-            if self.bkpt() {
-                HaltReason::Breakpoint
-            } else if self.external() {
-                HaltReason::External
-            } else if self.dwttrap() {
-                HaltReason::Watchpoint
-            } else if self.halted() {
-                HaltReason::Request
-            } else if self.vcatch() {
-                HaltReason::Exception
-            } else {
-                // We check that exactly one bit is set, so we should hit one of the cases above.
-                panic!("This should not happen. Please open a bug report.")
-            }
+            // We check that exactly one bit is set, so we should hit one of the cases above.
+            panic!("This should not happen. Please open a bug report.")
         }
     }
 }
@@ -66,7 +64,7 @@ impl From<Dfsr> for u32 {
 }
 
 impl CoreRegister for Dfsr {
-    const ADDRESS: u32 = 0xE000ED30;
+    const ADDRESS: u32 = 0xE000_ED30;
     const NAME: &'static str = "DFSR";
 }
 

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -4,69 +4,12 @@ use crate::core::{
 use crate::error::Error;
 use crate::memory::Memory;
 use crate::DebugProbeError;
-use bitfield::bitfield;
 
-use super::{register, ARM_REGISTER_FILE};
+use super::{register, Dfsr, ARM_REGISTER_FILE};
 use crate::core::{Architecture, CoreStatus, HaltReason};
+
+use bitfield::bitfield;
 use std::mem::size_of;
-
-bitfield! {
-    #[derive(Copy, Clone)]
-    pub struct Dfsr(u32);
-    impl Debug;
-    pub external, set_external: 4;
-    pub vcatch, set_vcatch: 3;
-    pub dwttrap, set_dwttrap: 2;
-    pub bkpt, set_bkpt: 1;
-    pub halted, set_halted: 0;
-}
-
-impl Dfsr {
-    fn clear_all() -> Self {
-        Dfsr(0b11111)
-    }
-
-    fn halt_reason(&self) -> HaltReason {
-        if self.0.count_ones() != 1 {
-            // We cannot identify why the chip halted,
-            // it could be for multiple reasons.
-            HaltReason::Unknown
-        } else if self.bkpt() {
-            HaltReason::Breakpoint
-        } else if self.external() {
-            HaltReason::External
-        } else if self.dwttrap() {
-            HaltReason::Watchpoint
-        } else if self.halted() {
-            HaltReason::Request
-        } else if self.vcatch() {
-            HaltReason::Exception
-        } else {
-            // We check that exactly one bit is set, so we should hit one of the cases above.
-            panic!("This should not happen. Please open a bug report.")
-        }
-    }
-}
-
-impl From<u32> for Dfsr {
-    fn from(val: u32) -> Self {
-        // Ensure that all unused bits are set to zero
-        // This makes it possible to check the number of
-        // set bits using count_ones().
-        Dfsr(val & 0b11111)
-    }
-}
-
-impl From<Dfsr> for u32 {
-    fn from(register: Dfsr) -> Self {
-        register.0
-    }
-}
-
-impl CoreRegister for Dfsr {
-    const ADDRESS: u32 = 0xE000_ED30;
-    const NAME: &'static str = "DFSR";
-}
 
 bitfield! {
     #[derive(Copy, Clone)]

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -112,7 +112,7 @@ impl Riscv32 {
 }
 
 impl CoreInterface for Riscv32 {
-    fn wait_for_core_halted(&self) -> Result<(), crate::Error> {
+    fn wait_for_core_halted(&mut self) -> Result<(), crate::Error> {
         // poll the
         let num_retries = 10;
 
@@ -135,7 +135,7 @@ impl CoreInterface for Riscv32 {
         Ok(dmstatus.allhalted())
     }
 
-    fn halt(&self) -> Result<CoreInformation, crate::Error> {
+    fn halt(&mut self) -> Result<CoreInformation, crate::Error> {
         // write 1 to the haltreq register, which is part
         // of the dmcontrol register
 
@@ -164,7 +164,7 @@ impl CoreInterface for Riscv32 {
         Ok(CoreInformation { pc })
     }
 
-    fn run(&self) -> Result<(), crate::Error> {
+    fn run(&mut self) -> Result<(), crate::Error> {
         // TODO: test if core halted?
 
         // set resume request
@@ -248,7 +248,7 @@ impl CoreInterface for Riscv32 {
         Ok(())
     }
 
-    fn reset_and_halt(&self) -> Result<crate::core::CoreInformation, crate::Error> {
+    fn reset_and_halt(&mut self) -> Result<crate::core::CoreInformation, crate::Error> {
         log::debug!("Resetting core, setting hartreset bit");
 
         let mut dmcontrol = Dmcontrol(0);
@@ -310,7 +310,7 @@ impl CoreInterface for Riscv32 {
         Ok(CoreInformation { pc })
     }
 
-    fn step(&self) -> Result<crate::core::CoreInformation, crate::Error> {
+    fn step(&mut self) -> Result<crate::core::CoreInformation, crate::Error> {
         let mut dcsr = Dcsr(self.read_core_reg(CoreRegisterAddress(0x7b0))?);
 
         dcsr.set_step(true);
@@ -505,6 +505,9 @@ impl CoreInterface for Riscv32 {
 
     fn architecture(&self) -> Architecture {
         Architecture::RISCV
+    }
+    fn status(&mut self) -> Result<crate::core::CoreStatus, crate::Error> {
+        todo!()
     }
 }
 

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -274,11 +274,11 @@ impl CoreType {
             // TODO: Change this once the new archtecture structure for ARM hits.
             // Cortex-M3, M4 and M7 use the Armv7[E]-M architecture and are
             // identical for our purposes.
-            CoreType::M3 => Core::new(crate::architecture::arm::m4::M4::new(memory)?),
-            CoreType::M4 => Core::new(crate::architecture::arm::m4::M4::new(memory)?),
-            CoreType::M7 => Core::new(crate::architecture::arm::m4::M4::new(memory)?),
-            CoreType::M33 => Core::new(crate::architecture::arm::m33::M33::new(memory)),
-            CoreType::M0 => Core::new(crate::architecture::arm::m0::M0::new(memory)),
+            CoreType::M3 | CoreType::M4 | CoreType::M7 => {
+                Core::new(crate::architecture::arm::m4::M4::new(memory)?)
+            }
+            CoreType::M33 => Core::new(crate::architecture::arm::m33::M33::new(memory)?),
+            CoreType::M0 => Core::new(crate::architecture::arm::m0::M0::new(memory)?),
             _ => {
                 return Err(Error::UnableToOpenProbe(
                     "Core architecture and Probe mismatch.",

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -81,7 +81,7 @@ pub use crate::config::Target;
 pub use crate::core::CoreType;
 pub use crate::core::{
     Breakpoint, BreakpointId, CommunicationInterface, Core, CoreInterface, CoreList,
-    CoreRegisterAddress,
+    CoreRegisterAddress, CoreStatus, HaltReason,
 };
 pub use crate::error::Error;
 pub use crate::memory::{Memory, MemoryInterface, MemoryList};


### PR DESCRIPTION
This is an intial draft of a status function, which can be used to retrieve the current state.

It is implemented for RISCV and Cortex-M4 currently. The other ARM cores would be similar.

It is trickier than expected, due to the need to cache the current core state for the Cortex-M4. This is necessary because the bits which indicate what the reason for the halt was are sticky, so we always need to clear them, otherwise you cannot reliably figure out what caused the reset. But this means that we have to cache the state, as we can get multiple calls to the status function and have to answer them.

Please have a look at this, especially also at `CoreStatus` and `HaltReason`, if this looks good.