### PR TITLE
Add support for CMSIS-DAP v2 probes

### DIFF
--- a/probe-rs/src/probe/daplink/commands/mod.rs
+++ b/probe-rs/src/probe/daplink/commands/mod.rs
@@ -21,6 +21,8 @@ pub enum CmsisDapError {
     TooMuchData,
     #[error("Error in the USB HID access: {0}")]
     HidApi(#[from] hidapi::HidError),
+    #[error("Error in the USB access: {0}")]
+    USBError(#[from] rusb::Error),
     #[error("An error with the DAP communication occured: {0}")]
     Dap(#[from] DapError),
 }

--- a/probe-rs/src/probe/daplink/commands/mod.rs
+++ b/probe-rs/src/probe/daplink/commands/mod.rs
@@ -5,8 +5,8 @@ pub mod transfer;
 
 use crate::architecture::arm::DapError;
 use crate::DebugProbeError;
-use std::time::Duration;
 use core::ops::Deref;
+use std::time::Duration;
 
 use thiserror::Error;
 
@@ -39,38 +39,45 @@ pub enum DAPLinkDevice {
     V1(hidapi::HidDevice),
 
     /// CMSIS-DAP v2 over WinUSB/Bulk. Stores an rusb device handle and out/in EP addresses.
-    V2 { handle: rusb::DeviceHandle<rusb::Context>, out_ep: u8, in_ep: u8 },
+    V2 {
+        handle: rusb::DeviceHandle<rusb::Context>,
+        out_ep: u8,
+        in_ep: u8,
+    },
 }
 
 impl DAPLinkDevice {
     /// Read from the probe into `buf`, returning the number of bytes read on success.
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
         match self {
-            DAPLinkDevice::V1(device) => {
-                Ok(device.read(buf)?)
-            },
-            DAPLinkDevice::V2 { handle, out_ep: _, in_ep } => {
+            DAPLinkDevice::V1(device) => Ok(device.read(buf)?),
+            DAPLinkDevice::V2 {
+                handle,
+                out_ep: _,
+                in_ep,
+            } => {
                 let timeout = Duration::from_millis(100);
                 Ok(handle.read_bulk(*in_ep, buf, timeout)?)
-            },
+            }
         }
     }
 
     /// Write `buf` to the probe, returning the number of bytes written on success.
     fn write(&self, buf: &[u8]) -> Result<usize> {
         match self {
-            DAPLinkDevice::V1(device) => {
-                Ok(device.write(buf)?)
-            },
-            DAPLinkDevice::V2 { handle, out_ep, in_ep: _ } => {
+            DAPLinkDevice::V1(device) => Ok(device.write(buf)?),
+            DAPLinkDevice::V2 {
+                handle,
+                out_ep,
+                in_ep: _,
+            } => {
                 let timeout = Duration::from_millis(100);
                 // Skip first byte as it's set to 0 for HID transfers
                 Ok(handle.write_bulk(*out_ep, &buf[1..], timeout)?)
-            },
+            }
         }
     }
 }
-
 
 #[derive(Debug)]
 pub(crate) enum Status {
@@ -131,7 +138,9 @@ pub(crate) fn send_command<Req: Request, Res: Response>(
     // write exactly 64 (+1 for report ID) bytes for HID.
     // For v2 devices, we can write the precise request size.
     match device.get_mut().unwrap() {
-        DAPLinkDevice::V1(_) => { size = 65; },
+        DAPLinkDevice::V1(_) => {
+            size = 65;
+        }
         _ => (),
     }
 

--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -72,7 +72,7 @@ impl DAPLink {
                         _ => break,
                     }
                 }
-            },
+            }
             _ => (),
         }
 
@@ -239,8 +239,8 @@ impl DebugProbe for DAPLink {
         Self: Sized,
     {
         Ok(Box::new(Self::new_from_device(
-            tools::open_device_from_info(info)
-                   .ok_or(DebugProbeError::ProbeCouldNotBeCreated)?)))
+            tools::open_device_from_info(info).ok_or(DebugProbeError::ProbeCouldNotBeCreated)?,
+        )))
     }
 
     fn get_name(&self) -> &str {

--- a/probe-rs/src/probe/daplink/tools.rs
+++ b/probe-rs/src/probe/daplink/tools.rs
@@ -155,6 +155,11 @@ pub fn open_device_from_info(info: &DebugProbeInfo) -> Option<DAPLinkDevice> {
                 Err(_) => continue,
             };
             let sn_str = handle.read_serial_number_string_ascii(&d_desc).ok();
+
+            // We have to ensure the handle gets closed after reading the serial number,
+            // multiple open handles are not allowed on Windows.
+            drop(handle);
+
             if d_desc.vendor_id() == info.vendor_id
                 && d_desc.product_id() == info.product_id
                 && sn_str == info.serial_number

--- a/probe-rs/src/probe/daplink/tools.rs
+++ b/probe-rs/src/probe/daplink/tools.rs
@@ -1,71 +1,150 @@
+use std::time::Duration;
+use rusb::{Device, UsbContext};
 use crate::probe::{DebugProbeInfo, DebugProbeType};
+use super::DAPLinkDevice;
 
+/// Finds all CMSIS-DAP devices, either v1 (HID) or v2 (WinUSB Bulk).
 pub fn list_daplink_devices() -> Vec<DebugProbeInfo> {
-    match hidapi::HidApi::new() {
-        Ok(api) => api
-            .device_list()
-            .cloned()
-            .filter(|device| is_daplink_device(&device))
-            .map(|v| {
-                DebugProbeInfo::new(
-                    v.product_string()
-                        .unwrap_or_else(|| "Unknown CMSIS-DAP Probe"),
-                    v.vendor_id(),
-                    v.product_id(),
-                    v.serial_number().map(|s| s.to_owned()),
-                    DebugProbeType::DAPLink,
-                )
-            })
-            .collect::<Vec<_>>(),
-        Err(_e) => vec![],
-    }
-}
-
-pub fn is_daplink_device(device: &hidapi::DeviceInfo) -> bool {
-    if let Some(product_string) = device.product_string().as_ref() {
-        product_string.contains("CMSIS-DAP")
+    if let Ok(context) = rusb::Context::new() {
+        if let Ok(devices) = context.devices() {
+            devices
+                .iter()
+                .filter_map(get_daplink_info)
+                .collect::<Vec<_>>()
+        } else {
+            vec![]
+        }
     } else {
-        false
+        vec![]
     }
 }
 
-pub fn _read_status(device: &mut std::sync::Mutex<hidapi::HidDevice>) {
-    let vendor_id: super::commands::general::info::VendorID =
-        super::commands::send_command(device, super::commands::general::info::Command::VendorID)
-            .unwrap();
-    log::info!("{:?}", vendor_id);
-    let product_id: super::commands::general::info::ProductID =
-        super::commands::send_command(device, super::commands::general::info::Command::ProductID)
-            .unwrap();
-    log::info!("{:?}", product_id);
-    let serial_number: super::commands::general::info::SerialNumber =
-        super::commands::send_command(
-            device,
-            super::commands::general::info::Command::SerialNumber,
-        )
-        .unwrap();
-    log::info!("{:?}", serial_number);
-    let firmware_version: super::commands::general::info::FirmwareVersion =
-        super::commands::send_command(
-            device,
-            super::commands::general::info::Command::FirmwareVersion,
-        )
-        .unwrap();
-    log::info!("{:?}", firmware_version);
+/// Checks if a given Device is a CMSIS-DAP probe, returning Some(DebugProbeInfo) if so.
+fn get_daplink_info(device: Device<rusb::Context>) -> Option<DebugProbeInfo> {
+    // Open device handle and read basic information
+    let timeout = Duration::from_millis(100);
+    let d_desc = device.device_descriptor().ok()?;
+    let handle = device.open().ok()?;
+    let language = handle.read_languages(timeout).ok()?[0];
+    let prod_str = handle.read_product_string(language, &d_desc, timeout).ok()?;
+    let sn_str = handle.read_serial_number_string(language, &d_desc, timeout).ok();
 
-    let target_device_vendor: super::commands::general::info::TargetDeviceVendor =
-        super::commands::send_command(
-            device,
-            super::commands::general::info::Command::TargetDeviceVendor,
-        )
-        .unwrap();
-    log::info!("{:?}", target_device_vendor);
+    // All CMSIS-DAP probes must have "CMSIS-DAP" in their product string.
+    if prod_str.contains("CMSIS-DAP") {
+        Some(DebugProbeInfo {
+            identifier: prod_str,
+            vendor_id: d_desc.vendor_id(),
+            product_id: d_desc.product_id(),
+            serial_number: sn_str,
+            probe_type: DebugProbeType::DAPLink,
+        })
+    } else {
+        None
+    }
+}
 
-    let target_device_name: super::commands::general::info::TargetDeviceName =
-        super::commands::send_command(
-            device,
-            super::commands::general::info::Command::TargetDeviceName,
-        )
-        .unwrap();
-    log::info!("{:?}", target_device_name);
+/// Attempt to open the given device in either CMSIS-DAP v1 or v2 mode
+pub fn open_device(device: Device<rusb::Context>) -> Option<DAPLinkDevice> {
+    // Open device handle and read basic information
+    let timeout = Duration::from_millis(100);
+    let d_desc = device.device_descriptor().ok()?;
+    let vid = d_desc.vendor_id();
+    let pid = d_desc.product_id();
+    let mut handle = device.open().ok()?;
+    let language = handle.read_languages(timeout).ok()?[0];
+    let sn_str = handle.read_serial_number_string(language, &d_desc, timeout).ok();
+
+    // Try opening in v1 (HID) mode if possible.
+    // We'll only use this if we can't open in v2 mode.
+    let hid_device = match sn_str {
+        Some(sn) => hidapi::HidApi::new().and_then(|api| api.open_serial(vid, pid, &sn)),
+        None     => hidapi::HidApi::new().and_then(|api| api.open(vid, pid)),
+    }.map(|device| DAPLinkDevice::V1(device)).ok();
+
+    // Go through interfaces to try and find a v2 interface
+    let c_desc = device.config_descriptor(0).ok()?;
+    'interfaces: for interface in c_desc.interfaces() {
+        for i_desc in interface.descriptors() {
+            // Skip interfaces without "CMSIS-DAP" in their string
+            match handle.read_interface_string(language, &i_desc, timeout) {
+                Ok(i_str) if !i_str.contains("CMSIS-DAP") => continue,
+                Err(_) => continue,
+                Ok(_) => (),
+            }
+
+            // Skip interfaces without 2 or 3 endpoints
+            let n_ep = i_desc.num_endpoints();
+            if n_ep < 2 || n_ep > 3 {
+                continue;
+            }
+
+            let eps: Vec<_> = i_desc.endpoint_descriptors().collect();
+
+            // Check the first interface is bulk out
+            if eps[0].transfer_type() != rusb::TransferType::Bulk ||
+               eps[0].direction()     != rusb::Direction::Out
+            {
+                continue;
+            }
+
+            // Check the second interface is bulk in
+            if eps[1].transfer_type() != rusb::TransferType::Bulk ||
+               eps[1].direction()     != rusb::Direction::In
+            {
+                continue;
+            }
+
+            // Store EP address of the in and out EPs
+            let out_ep = eps[0].address();
+            let in_ep = eps[1].address();
+
+            // Attempt to claim this interface
+            match handle.claim_interface(interface.number()) {
+                Ok(()) => return Some(DAPLinkDevice::V2 {handle, out_ep, in_ep}),
+                Err(_) => break 'interfaces,
+            }
+        }
+    }
+
+    // If we didn't detect a v2 interface, return a v1 interface if we got one.
+    hid_device
+}
+
+/// Attempt to open the given DebugProbeInfo in either CMSIS-DAP v1 or v2 mode
+pub fn open_device_from_info(info: &DebugProbeInfo) -> Option<DAPLinkDevice> {
+    let timeout = Duration::from_millis(100);
+    if let Ok(context) = rusb::Context::new() {
+        if let Ok(devices) = context.devices() {
+            for device in devices.iter() {
+                let d_desc = match device.device_descriptor() {
+                    Ok(d_desc) => d_desc,
+                    Err(_) => continue,
+                };
+                let vid = d_desc.vendor_id();
+                let pid = d_desc.product_id();
+                let handle = match device.open() {
+                    Ok(handle) => handle,
+                    Err(_) => continue,
+                };
+                let language = match handle.read_languages(timeout) {
+                    Ok(languages) => languages[0],
+                    Err(_) => continue,
+                };
+                let sn_str = handle.read_serial_number_string(language, &d_desc, timeout).ok();
+                if vid == info.vendor_id &&
+                   pid == info.product_id &&
+                   sn_str == info.serial_number
+                {
+                    // If the VID, PID, and potentially SN all match,
+                    // attempt to open the device in either v1 or v2 mode.
+                    return open_device(device);
+                }
+            }
+            None
+        } else {
+            None
+        }
+    } else {
+        None
+    }
 }

--- a/probe-rs/src/probe/daplink/tools.rs
+++ b/probe-rs/src/probe/daplink/tools.rs
@@ -58,8 +58,8 @@ fn get_daplink_hid_info(device: &hidapi::DeviceInfo) -> Option<DebugProbeInfo> {
     None
 }
 
-/// Attempt to open the given device in either CMSIS-DAP v1 or v2 mode
-pub fn open_device(device: Device<rusb::Context>) -> Option<DAPLinkDevice> {
+/// Attempt to open the given device in CMSIS-DAP v2 mode
+pub fn open_v2_device(device: Device<rusb::Context>) -> Option<DAPLinkDevice> {
     // Open device handle and read basic information
     let timeout = Duration::from_millis(100);
     let d_desc = device.device_descriptor().ok()?;
@@ -67,7 +67,6 @@ pub fn open_device(device: Device<rusb::Context>) -> Option<DAPLinkDevice> {
     let pid = d_desc.product_id();
     let mut handle = device.open().ok()?;
     let language = handle.read_languages(timeout).ok()?[0];
-    let sn_str = handle.read_serial_number_string(language, &d_desc, timeout).ok();
 
     // Go through interfaces to try and find a v2 interface.
     // The CMSIS-DAPv2 spec says that v2 interfaces should use a specific
@@ -122,45 +121,49 @@ pub fn open_device(device: Device<rusb::Context>) -> Option<DAPLinkDevice> {
         }
     }
 
-    // Try opening in v1 (HID) mode if possible.
-    // We'll only use this if we can't open in v2 mode.
-    log::debug!("Couldn't open {:04x}:{:04x} in CMSIS-DAP v2 mode, trying v1", vid, pid);
-    match sn_str {
-        Some(sn) => hidapi::HidApi::new().and_then(|api| api.open_serial(vid, pid, &sn)),
-        None     => hidapi::HidApi::new().and_then(|api| api.open(vid, pid)),
-    }.map(|device| DAPLinkDevice::V1(device)).ok()
+    // Could not open in v2
+    log::debug!("Could not open {:04x}:{:04x} in CMSIS-DAP v2 mode", vid, pid);
+    None
 }
 
-/// Attempt to open the given DebugProbeInfo in either CMSIS-DAP v1 or v2 mode
+/// Attempt to open the given DebugProbeInfo in CMSIS-DAP v2 mode if possible,
+/// otherwise in v1 mode.
 pub fn open_device_from_info(info: &DebugProbeInfo) -> Option<DAPLinkDevice> {
-    let timeout = Duration::from_millis(100);
-    match rusb::Context::new().and_then(|ctx| ctx.devices()) {
-        Ok(devices) => for device in devices.iter() {
+    // Try using rusb to open a v2 device. This might fail if
+    // the device does not support v2 operation or due to driver
+    // or permission issues with opening bulk devices.
+    if let Ok(devices) = rusb::Context::new().and_then(|ctx| ctx.devices()) {
+        for device in devices.iter() {
             let d_desc = match device.device_descriptor() {
                 Ok(d_desc) => d_desc,
                 Err(_) => continue,
             };
-            let vid = d_desc.vendor_id();
-            let pid = d_desc.product_id();
             let handle = match device.open() {
                 Ok(handle) => handle,
                 Err(_) => continue,
             };
-            let language = match handle.read_languages(timeout) {
-                Ok(languages) => languages[0],
-                Err(_) => continue,
-            };
-            let sn_str = handle.read_serial_number_string(language, &d_desc, timeout).ok();
-            if vid == info.vendor_id &&
-               pid == info.product_id &&
+            let sn_str = handle.read_serial_number_string_ascii(&d_desc).ok();
+            if d_desc.vendor_id() == info.vendor_id &&
+               d_desc.product_id() == info.product_id &&
                sn_str == info.serial_number
             {
                 // If the VID, PID, and potentially SN all match,
-                // attempt to open the device in either v1 or v2 mode.
-                return open_device(device);
+                // attempt to open the device in v2 mode.
+                if let Some(device) = open_v2_device(device) {
+                    return Some(device);
+                }
             }
-        },
-        Err(_) => (),
+        }
     }
-    None
+
+    // If rusb failed or the device didn't support v2, try using hidapi to open in v1 mode.
+    // If this doesn't work we give up and return None.
+    let vid = info.vendor_id;
+    let pid = info.product_id;
+    let sn = &info.serial_number;
+    log::debug!("Attempting to open {:04x}:{:04x} in CMSIS-DAP v1 mode", vid, pid);
+    match sn {
+        Some(sn) => hidapi::HidApi::new().and_then(|api| api.open_serial(vid, pid, &sn)),
+        None     => hidapi::HidApi::new().and_then(|api| api.open(vid, pid)),
+    }.map(|device| DAPLinkDevice::V1(device)).ok()
 }

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -403,7 +403,7 @@ impl std::fmt::Debug for DebugProbeInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "{} (VID: {}, PID: {}, {}{:?})",
+            "{} (VID: {:04x}, PID: {:04x}, {}{:?})",
             self.identifier,
             self.vendor_id,
             self.product_id,


### PR DESCRIPTION
This PR adds support for CMSIS-DAP v2 compliant probes, using bulk transfers instead of HID interrupts. It's also called "WinUSB" but that mostly refers to the device descriptors telling Windows what driver to use and doesn't affect probe-rs.

I've modified the existing DAPlink code so the underlying `device` can now be an enum which is either a hidapi device or an rusb device, and implemented read and write methods on that enum. Consequently very little runtime code changes at all (the packet format is identical).

The main difference is in detecting and opening probes, which now uses `rusb` if possible. I've made sure if `rusb` doesn't work, it will always fall back to using `hidapi` to both enumerate and open the device. This is helpful because rusb might fail due to driver or permission errors, but hidapi should pretty much always work (and is what we used to do). Without rusb working there's no way to know if the device could have supported v2 or is v1 only, so there doesn't seem to be much point giving the user an error message in that case. On most platforms, v2 devices should work immediately without any drivers required anyway.

The speedup on supported probes is pretty intense. Using the `ram_download` example:

CMSIS-DAP v1:

```
Wrote 8192 bytes in 319.937082ms (25605.04 bytes/s)
Read  8192 bytes in 319.975224ms (25601.98 bytes/s)
```

CMSIS-DAP v2 (my own probe, USB FS):

```
Wrote 8192 bytes in 35.615237ms (230013.92 bytes/s)
Read  8192 bytes in 43.637393ms (187728.91 bytes/s)
```

That's a speedup of 9x in the RAM writing case. Flash writing is about 3x faster than previously, too. I expect that this PR should also allow USB HS devices (including with 512-byte packets) which should help even more.

I've tested this:

* On my own CMSIS-DAP probe
* On an official micro:bit running latest daplink firmware
* On Linux but not Windows
* On a probe that only has HID, no v2
* With cargo-flash and ram_download