### PR TITLE
Fix broken vCont and memory-map, add LLDB support

### DIFF
--- a/gdb-server/src/handlers.rs
+++ b/gdb-server/src/handlers.rs
@@ -173,11 +173,7 @@ pub(crate) fn get_memory_map() -> Option<String> {
 <memory type="ram" start="0x20000000" length="0x4000"/>
 <memory type="rom" start="0x00000000" length="0x40000"/>
 </memory-map>"#;
-    Some(
-        std::str::from_utf8(&gdb_sanitize_file(xml.as_bytes().to_vec(), 0, 1000))
-            .unwrap()
-            .to_string(),
-    )
+    Some(String::from_utf8(gdb_sanitize_file(xml.as_bytes(), 0, 1000)).unwrap())
 }
 
 pub(crate) fn user_halt(core: &Core, awaits_halt: &mut bool) -> Option<String> {
@@ -198,7 +194,7 @@ pub(crate) fn reset_halt(core: &Core) -> Option<String> {
     Some("OK".into())
 }
 
-fn gdb_sanitize_file(mut data: Vec<u8>, offset: u32, len: u32) -> Vec<u8> {
+fn gdb_sanitize_file(data: &[u8], offset: u32, len: u32) -> Vec<u8> {
     let offset = offset as usize;
     let len = len as usize;
     let mut end = offset + len;
@@ -208,7 +204,7 @@ fn gdb_sanitize_file(mut data: Vec<u8>, offset: u32, len: u32) -> Vec<u8> {
         if end > data.len() {
             end = data.len();
         }
-        let mut trimmed_data: Vec<u8> = data.drain(offset..end).collect();
+        let mut trimmed_data = Vec::from(&data[offset..end]);
         if trimmed_data.len() >= len {
             // XXX should this be <= or < ?
             trimmed_data.insert(0, b'm');


### PR DESCRIPTION
Some `vCont` commands and the memory-map command had a stray `b` at the end, which meant that they were not working.

This PR also add support for debugging with LLDB, using `gdb-remote <port>`.

LLDB is using some different commands, which we don't support (yet).
It gets confused when we reply with 'OK' to these, so we just send an empty
response now. With these changes, LLDB seems to work pretty well.

See also: https://github.com/llvm/llvm-project/blob/master/lldb/docs/lldb-gdb-remote.txt