### PR TITLE
API changes to make multithreading easier.

### DIFF
--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -88,7 +88,7 @@ pub(crate) fn open_probe(index: Option<usize>) -> Result<Probe, CliError> {
 /// even in an error case inside the closure!
 pub(crate) fn with_device<F>(shared_options: &SharedOptions, f: F) -> Result<(), CliError>
 where
-    for<'a> F: FnOnce(Session) -> Result<(), CliError>,
+    F: FnOnce(Session) -> Result<(), CliError>,
 {
     let mut probe = open_probe(shared_options.n)?;
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -39,7 +39,7 @@ impl DebugCli {
 
                 let mut code = [0u8; 16 * 2];
 
-                cli_data.core.read_block8(cpu_info.pc, &mut code)?;
+                cli_data.core.read_8(cpu_info.pc, &mut code)?;
 
                 /*
                 let instructions = cli_data
@@ -118,7 +118,7 @@ impl DebugCli {
 
                 let mut buff = vec![0u32; num_words];
 
-                cli_data.core.read_block32(address, &mut buff)?;
+                cli_data.core.read_32(address, &mut buff)?;
 
                 for (offset, word) in buff.iter().enumerate() {
                     println!("0x{:08x} = 0x{:08x}", address + (offset * 4) as u32, word);
@@ -139,7 +139,7 @@ impl DebugCli {
                 let data_str = args.get(1).ok_or(CliError::MissingArgument)?;
                 let data = u32::from_str_radix(data_str, 16).unwrap();
 
-                cli_data.core.write32(address, data)?;
+                cli_data.core.write_word_32(address, data)?;
 
                 Ok(CliState::Continue)
             },
@@ -230,7 +230,7 @@ impl DebugCli {
 
                 let mut stack = vec![0u8; (stack_top - stack_bot) as usize];
 
-                cli_data.core.read_block8(stack_bot, &mut stack[..])?;
+                cli_data.core.read_8(stack_bot, &mut stack[..])?;
 
                 let mut dump = CortexDump::new(stack_bot, stack);
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -3,7 +3,7 @@ use crate::common::CliError;
 use capstone::Capstone;
 use probe_rs::architecture::arm::CortexDump;
 use probe_rs::debug::DebugInfo;
-use probe_rs::{Core, CoreRegisterAddress};
+use probe_rs::{Core, CoreRegisterAddress, MemoryInterface};
 use std::fs::File;
 use std::io::prelude::*;
 
@@ -39,7 +39,7 @@ impl DebugCli {
 
                 let mut code = [0u8; 16 * 2];
 
-                cli_data.core.memory().read_block8(cpu_info.pc, &mut code)?;
+                cli_data.core.read_block8(cpu_info.pc, &mut code)?;
 
                 /*
                 let instructions = cli_data
@@ -118,7 +118,7 @@ impl DebugCli {
 
                 let mut buff = vec![0u32; num_words];
 
-                cli_data.core.memory().read_block32(address, &mut buff)?;
+                cli_data.core.read_block32(address, &mut buff)?;
 
                 for (offset, word) in buff.iter().enumerate() {
                     println!("0x{:08x} = 0x{:08x}", address + (offset * 4) as u32, word);
@@ -139,7 +139,7 @@ impl DebugCli {
                 let data_str = args.get(1).ok_or(CliError::MissingArgument)?;
                 let data = u32::from_str_radix(data_str, 16).unwrap();
 
-                cli_data.core.memory().write32(address, data)?;
+                cli_data.core.write32(address, data)?;
 
                 Ok(CliState::Continue)
             },
@@ -184,7 +184,7 @@ impl DebugCli {
                 let program_counter = cli_data.core.read_core_reg(regs.program_counter())?;
 
                 if let Some(di) = &cli_data.debug_info {
-                    let frames = di.try_unwind(&cli_data.core, u64::from(program_counter));
+                    let frames = di.try_unwind(&mut cli_data.core, u64::from(program_counter));
 
                     for frame in frames {
                         println!("{}", frame);
@@ -230,10 +230,7 @@ impl DebugCli {
 
                 let mut stack = vec![0u8; (stack_top - stack_bot) as usize];
 
-                cli_data
-                    .core
-                    .memory()
-                    .read_block8(stack_bot, &mut stack[..])?;
+                cli_data.core.read_block8(stack_bot, &mut stack[..])?;
 
                 let mut dump = CortexDump::new(stack_bot, stack);
 
@@ -315,8 +312,8 @@ impl DebugCli {
     }
 }
 
-pub struct CliData {
-    pub core: Core,
+pub struct CliData<'p> {
+    pub core: Core<'p>,
     pub debug_info: Option<DebugInfo>,
     pub capstone: Capstone,
 }

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -7,7 +7,7 @@ use probe_rs::{
     architecture::arm::{
         ap::{valid_access_ports, APAccess, APClass, BaseaddrFormat, MemoryAP, BASE, BASE2, IDR},
         memory::{ADIMemoryInterface, CSComponent},
-        ArmCommunicationInterface, ArmCommunicationInterfaceState,
+        ArmCommunicationInterface,
     },
     Memory,
 };

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -7,7 +7,7 @@ use probe_rs::{
     architecture::arm::{
         ap::{valid_access_ports, APAccess, APClass, BaseaddrFormat, MemoryAP, BASE, BASE2, IDR},
         memory::{ADIMemoryInterface, CSComponent},
-        ArmCommunicationInterface,
+        ArmCommunicationInterface, ArmCommunicationInterfaceState,
     },
     Memory,
 };
@@ -38,7 +38,7 @@ pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<(), 
 
     */
 
-    let mut state = ArmCommunicationInterface::create_state(&mut probe)?;
+    let mut state = ArmCommunicationInterfaceState::new();
     let interface = ArmCommunicationInterface::new(&mut probe, &mut state)?;
 
     if let Some(mut interface) = interface {
@@ -68,7 +68,7 @@ pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<(), 
                 baseaddr |= u64::from(base_register.BASEADDR << 12);
 
                 let mut memory = Memory::new(ADIMemoryInterface::<ArmCommunicationInterface>::new(
-                    interface.borrow(),
+                    interface.reborrow(),
                     access_port,
                 )?);
                 let component_table = CSComponent::try_parse(&mut memory, baseaddr as u64);

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -7,7 +7,7 @@ use probe_rs::{
     architecture::arm::{
         ap::{valid_access_ports, APAccess, APClass, BaseaddrFormat, MemoryAP, BASE, BASE2, IDR},
         memory::{ADIMemoryInterface, CSComponent},
-        ArmCommunicationInterface,
+        ArmCommunicationInterface, ArmCommunicationInterfaceState,
     },
     Memory,
 };
@@ -38,51 +38,58 @@ pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<(), 
 
     */
 
-    let mut interface = ArmCommunicationInterface::new(probe).map_err(|(_probe, error)| error)?;
+    let mut state = ArmCommunicationInterface::create_state(&mut probe)?;
+    let interface = ArmCommunicationInterface::new(&mut probe, &mut state)?;
 
-    println!("\nAvailable Access Ports:");
+    if let Some(mut interface) = interface {
+        println!("\nAvailable Access Ports:");
 
-    for access_port in valid_access_ports(&mut interface) {
-        let idr = interface.read_ap_register(access_port, IDR::default())?;
-        println!("{:#x?}", idr);
+        for access_port in valid_access_ports(&mut interface) {
+            let idr = interface.read_ap_register(access_port, IDR::default())?;
+            println!("{:#x?}", idr);
 
-        if idr.CLASS == APClass::MEMAP {
-            let access_port: MemoryAP = access_port.into();
+            if idr.CLASS == APClass::MEMAP {
+                let access_port: MemoryAP = access_port.into();
 
-            let base_register = interface.read_ap_register(access_port, BASE::default())?;
+                let base_register = interface.read_ap_register(access_port, BASE::default())?;
 
-            if !base_register.present {
-                // No debug entry present
-                println!("No debug entry present.");
-                continue;
+                if !base_register.present {
+                    // No debug entry present
+                    println!("No debug entry present.");
+                    continue;
+                }
+
+                let mut baseaddr = if BaseaddrFormat::ADIv5 == base_register.Format {
+                    let base2 = interface.read_ap_register(access_port, BASE2::default())?;
+                    u64::from(base2.BASEADDR) << 32
+                } else {
+                    0
+                };
+                baseaddr |= u64::from(base_register.BASEADDR << 12);
+
+                let mut memory = Memory::new(ADIMemoryInterface::<ArmCommunicationInterface>::new(
+                    interface.borrow(),
+                    access_port,
+                )?);
+                let component_table = CSComponent::try_parse(&mut memory, baseaddr as u64);
+
+                component_table
+                    .iter()
+                    .for_each(|entry| println!("{:#08x?}", entry));
+
+                // let mut reader = crate::memory::romtable::RomTableReader::new(&link_ref, baseaddr as u64);
+
+                // for e in reader.entries() {
+                //     if let Ok(e) = e {
+                //         println!("ROM Table Entry: Component @ 0x{:08x}", e.component_addr());
+                //     }
+                // }
             }
-
-            let mut baseaddr = if BaseaddrFormat::ADIv5 == base_register.Format {
-                let base2 = interface.read_ap_register(access_port, BASE2::default())?;
-                u64::from(base2.BASEADDR) << 32
-            } else {
-                0
-            };
-            baseaddr |= u64::from(base_register.BASEADDR << 12);
-
-            let memory = Memory::new(ADIMemoryInterface::<ArmCommunicationInterface>::new(
-                interface.clone(),
-                access_port,
-            )?);
-            let component_table = CSComponent::try_parse(memory, baseaddr as u64);
-
-            component_table
-                .iter()
-                .for_each(|entry| println!("{:#08x?}", entry));
-
-            // let mut reader = crate::memory::romtable::RomTableReader::new(&link_ref, baseaddr as u64);
-
-            // for e in reader.entries() {
-            //     if let Ok(e) = e {
-            //         println!("ROM Table Entry: Component @ 0x{:08x}", e.component_addr());
-            //     }
-            // }
         }
+    } else {
+        println!(
+            "No DAP interface was found on the connected probe. Thus, ARM info cannot be printed."
+        )
     }
 
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -144,7 +144,7 @@ fn list_connected_devices() -> Result<(), CliError> {
 }
 
 fn dump_memory(shared_options: &SharedOptions, loc: u32, words: u32) -> Result<(), CliError> {
-    with_device(shared_options, |session| {
+    with_device(shared_options, |mut session| {
         let mut data = vec![0 as u32; words as usize];
 
         // Start timer.
@@ -174,8 +174,8 @@ fn dump_memory(shared_options: &SharedOptions, loc: u32, words: u32) -> Result<(
 }
 
 fn download_program_fast(shared_options: &SharedOptions, path: &str) -> Result<(), CliError> {
-    with_device(shared_options, |session| {
-        download_file(&session, std::path::Path::new(&path), Format::Elf)?;
+    with_device(shared_options, |mut session| {
+        download_file(&mut session, std::path::Path::new(&path), Format::Elf)?;
 
         Ok(())
     })
@@ -185,7 +185,7 @@ fn reset_target_of_device(
     shared_options: &SharedOptions,
     _assert: Option<bool>,
 ) -> Result<(), CliError> {
-    with_device(shared_options, |session| {
+    with_device(shared_options, |mut session| {
         session.attach_to_core(0)?.reset()?;
 
         Ok(())
@@ -203,7 +203,7 @@ fn trace_u32_on_target(shared_options: &SharedOptions, loc: u32) -> Result<(), C
 
     let start = Instant::now();
 
-    with_device(shared_options, |session| {
+    with_device(shared_options, |mut session| {
         let mut core = session.attach_to_core(0)?;
 
         loop {
@@ -238,7 +238,7 @@ fn trace_u32_on_target(shared_options: &SharedOptions, loc: u32) -> Result<(), C
 }
 
 fn debug(shared_options: &SharedOptions, exe: Option<PathBuf>) -> Result<(), CliError> {
-    let runner = |session: Session| {
+    let runner = |mut session: Session| {
         let cs = Capstone::new()
             .arm()
             .mode(ArchMode::Thumb)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -152,7 +152,7 @@ fn dump_memory(shared_options: &SharedOptions, loc: u32, words: u32) -> Result<(
 
         // let loc = 220 * 1024;
 
-        let mut core = session.attach_to_core(0)?;
+        let mut core = session.core(0)?;
 
         core.read_32(loc, &mut data.as_mut_slice())?;
         // Stop timer.
@@ -186,7 +186,7 @@ fn reset_target_of_device(
     _assert: Option<bool>,
 ) -> Result<(), CliError> {
     with_device(shared_options, |mut session| {
-        session.attach_to_core(0)?.reset()?;
+        session.core(0)?.reset()?;
 
         Ok(())
     })
@@ -204,7 +204,7 @@ fn trace_u32_on_target(shared_options: &SharedOptions, loc: u32) -> Result<(), C
     let start = Instant::now();
 
     with_device(shared_options, |mut session| {
-        let mut core = session.attach_to_core(0)?;
+        let mut core = session.core(0)?;
 
         loop {
             // Prepare read.
@@ -252,7 +252,7 @@ fn debug(shared_options: &SharedOptions, exe: Option<PathBuf>) -> Result<(), Cli
 
         let cli = debugger::DebugCli::new();
 
-        let core = session.attach_to_core(0)?;
+        let core = session.core(0)?;
 
         let mut cli_data = debugger::CliData {
             core,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -154,7 +154,7 @@ fn dump_memory(shared_options: &SharedOptions, loc: u32, words: u32) -> Result<(
 
         let mut core = session.attach_to_core(0)?;
 
-        core.read_block32(loc, &mut data.as_mut_slice())?;
+        core.read_32(loc, &mut data.as_mut_slice())?;
         // Stop timer.
         let elapsed = instant.elapsed();
 
@@ -212,7 +212,7 @@ fn trace_u32_on_target(shared_options: &SharedOptions, loc: u32) -> Result<(), C
             let instant = elapsed.as_secs() * 1000 + u64::from(elapsed.subsec_millis());
 
             // Read data.
-            let value: u32 = core.read32(loc)?;
+            let value: u32 = core.read_word_32(loc)?;
 
             xs.push(instant);
             ys.push(value);

--- a/gdb-server/src/handlers.rs
+++ b/gdb-server/src/handlers.rs
@@ -66,7 +66,7 @@ pub(crate) fn read_memory(packet_string: String, core: &mut Core) -> Option<Stri
     let m = packet_string.parse::<M>().unwrap();
 
     let mut readback_data = vec![0u8; usize::from_str_radix(&m.length, 16).unwrap()];
-    match core.read_block8(
+    match core.read_8(
         u32::from_str_radix(&m.addr, 16).unwrap(),
         &mut readback_data,
     ) {
@@ -159,7 +159,7 @@ pub(crate) fn write_memory(packet_string: String, data: &[u8], core: &mut Core) 
     let length = usize::from_str_radix(&x.length, 16).unwrap();
     let data = &data[data.len() - length..];
 
-    core.write_block8(u32::from_str_radix(&x.addr, 16).unwrap(), data)
+    core.write_8(u32::from_str_radix(&x.addr, 16).unwrap(), data)
         .unwrap();
 
     Some("OK".into())

--- a/gdb-server/src/worker.rs
+++ b/gdb-server/src/worker.rs
@@ -20,7 +20,7 @@ pub async fn worker(
     session: Arc<Mutex<Session>>,
 ) -> ServerResult<()> {
     let mut session = session.lock().unwrap();
-    let mut core = session.attach_to_core(0).unwrap();
+    let mut core = session.core(0).unwrap();
     let mut awaits_halt = false;
 
     loop {

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -36,10 +36,10 @@ fn main() -> Result<(), &'static str> {
     probe
         .select_protocol(WireProtocol::Swd)
         .map_err(|_| "Failed to select SWD as the transport protocol")?;
-    let session = probe
+    let mut session = probe
         .attach(target_selector)
         .map_err(|_| "Failed to attach probe to target")?;
-    let core = session
+    let mut core = session
         .attach_to_core(0)
         .map_err(|_| "Failed to attach to core")?;
 

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -1,4 +1,4 @@
-use probe_rs::{config::TargetSelector, Probe, WireProtocol};
+use probe_rs::{config::TargetSelector, MemoryInterface, Probe, WireProtocol};
 
 use std::num::ParseIntError;
 use std::time::Instant;

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -39,9 +39,7 @@ fn main() -> Result<(), &'static str> {
     let mut session = probe
         .attach(target_selector)
         .map_err(|_| "Failed to attach probe to target")?;
-    let mut core = session
-        .attach_to_core(0)
-        .map_err(|_| "Failed to attach to core")?;
+    let mut core = session.core(0).map_err(|_| "Failed to attach to core")?;
 
     let data_size_words = matches.size;
 

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -102,7 +102,7 @@ where
     ) -> Result<(), Self::Error>;
 }
 
-impl<'a, T, PORT, R> APAccess<PORT, R> for &'a mut T
+impl<T, PORT, R> APAccess<PORT, R> for &mut T
 where
     T: APAccess<PORT, R>,
     PORT: AccessPort,

--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -285,33 +285,33 @@ impl<'probe> M0<'probe> {
         mut memory: Memory<'probe>,
         state: &'probe mut CortexState,
     ) -> Result<Self, Error> {
-        // determine current state
-        let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
-
-        let core_state = if dhcsr.s_sleep() {
-            CoreStatus::Sleeping
-        } else if dhcsr.s_halt() {
-            log::debug!("Core was halted when connecting");
-
-            let dfsr = Dfsr(memory.read_word_32(Dfsr::ADDRESS)?);
-
-            let reason = dfsr.halt_reason();
-
-            CoreStatus::Halted(reason)
-        } else {
-            CoreStatus::Running
-        };
-
         if !state.initialized() {
+            // determine current state
+            let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
+
+            let core_state = if dhcsr.s_sleep() {
+                CoreStatus::Sleeping
+            } else if dhcsr.s_halt() {
+                log::debug!("Core was halted when connecting");
+
+                let dfsr = Dfsr(memory.read_word_32(Dfsr::ADDRESS)?);
+
+                let reason = dfsr.halt_reason();
+
+                CoreStatus::Halted(reason)
+            } else {
+                CoreStatus::Running
+            };
+
+            // Clear DFSR register. The bits in the register are sticky,
+            // so we clear them here to ensure that that none are set.
+            let dfsr_clear = Dfsr::clear_all();
+
+            memory.write_word_32(Dfsr::ADDRESS, dfsr_clear.into())?;
+
             state.current_state = core_state;
             state.initialize();
         }
-
-        // Clear DFSR register. The bits in the register are sticky,
-        // so we clear them here to ensure that that none are set.
-        let dfsr_clear = Dfsr::clear_all();
-
-        memory.write_word_32(Dfsr::ADDRESS, dfsr_clear.into())?;
 
         Ok(Self { memory, state })
     }

--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -274,16 +274,16 @@ const XPSR: RegisterDescription = RegisterDescription {
     address: CoreRegisterAddress(0b1_0000),
 };
 
-pub struct M0<'a> {
-    memory: Memory<'a>,
+pub struct M0<'probe> {
+    memory: Memory<'probe>,
 
     hw_breakpoints_enabled: bool,
 
     current_state: CoreStatus,
 }
 
-impl<'a> M0<'a> {
-    pub fn new(mut memory: Memory<'a>) -> Result<Self, Error> {
+impl<'probe> M0<'probe> {
+    pub fn new(mut memory: Memory<'probe>) -> Result<Self, Error> {
         // determine current state
         let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
 
@@ -328,7 +328,7 @@ impl<'a> M0<'a> {
     }
 }
 
-impl<'a> CoreInterface<'a> for M0<'a> {
+impl<'probe> CoreInterface<'probe> for M0<'probe> {
     fn wait_for_core_halted(&mut self) -> Result<(), Error> {
         // Wait until halted state is active again.
         for _ in 0..100 {
@@ -602,7 +602,7 @@ impl<'a> CoreInterface<'a> for M0<'a> {
     }
 }
 
-impl<'a> MemoryInterface for M0<'a> {
+impl<'probe> MemoryInterface for M0<'probe> {
     fn read_word_32(&mut self, address: u32) -> Result<u32, Error> {
         self.memory.read_word_32(address)
     }

--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -328,7 +328,7 @@ impl<'probe> M0<'probe> {
     }
 }
 
-impl<'probe> CoreInterface<'probe> for M0<'probe> {
+impl<'probe> CoreInterface for M0<'probe> {
     fn wait_for_core_halted(&mut self) -> Result<(), Error> {
         // Wait until halted state is active again.
         for _ in 0..100 {
@@ -542,7 +542,7 @@ impl<'probe> CoreInterface<'probe> for M0<'probe> {
     }
 
     fn architecture(&self) -> Architecture {
-        Architecture::ARM
+        Architecture::Arm
     }
     fn status(&mut self) -> Result<crate::core::CoreStatus, Error> {
         let dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -18,16 +18,16 @@ use bitfield::bitfield;
 use super::{Dfsr, ARM_REGISTER_FILE};
 use std::mem::size_of;
 
-pub struct M33<'a> {
-    memory: Memory<'a>,
+pub struct M33<'probe> {
+    memory: Memory<'probe>,
 
     hw_breakpoints_enabled: bool,
 
     current_state: CoreStatus,
 }
 
-impl<'a> M33<'a> {
-    pub fn new(mut memory: Memory<'a>) -> Result<Self, Error> {
+impl<'probe> M33<'probe> {
+    pub fn new(mut memory: Memory<'probe>) -> Result<Self, Error> {
         // determine current state
         let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
 
@@ -72,7 +72,7 @@ impl<'a> M33<'a> {
     }
 }
 
-impl<'a> CoreInterface<'a> for M33<'a> {
+impl<'probe> CoreInterface<'probe> for M33<'probe> {
     fn wait_for_core_halted(&mut self) -> Result<(), Error> {
         // Wait until halted state is active again.
         for _ in 0..100 {
@@ -343,7 +343,7 @@ impl<'a> CoreInterface<'a> for M33<'a> {
     }
 }
 
-impl<'a> MemoryInterface for M33<'a> {
+impl<'probe> MemoryInterface for M33<'probe> {
     fn read_word_32(&mut self, address: u32) -> Result<u32, Error> {
         self.memory.read_word_32(address)
     }

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -15,23 +15,24 @@ use crate::{architecture::arm::core::register, MemoryInterface};
 
 use bitfield::bitfield;
 
-use super::{Dfsr, ARM_REGISTER_FILE};
+use super::{CortexState, Dfsr, ARM_REGISTER_FILE};
 use std::mem::size_of;
 
 pub struct M33<'probe> {
     memory: Memory<'probe>,
 
-    hw_breakpoints_enabled: bool,
-
-    current_state: CoreStatus,
+    state: &'probe mut CortexState,
 }
 
 impl<'probe> M33<'probe> {
-    pub fn new(mut memory: Memory<'probe>) -> Result<Self, Error> {
+    pub(crate) fn new(
+        mut memory: Memory<'probe>,
+        state: &'probe mut CortexState,
+    ) -> Result<Self, Error> {
         // determine current state
         let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
 
-        let state = if dhcsr.s_sleep() {
+        let core_state = if dhcsr.s_sleep() {
             CoreStatus::Sleeping
         } else if dhcsr.s_halt() {
             log::debug!("Core was halted when connecting");
@@ -45,17 +46,18 @@ impl<'probe> M33<'probe> {
             CoreStatus::Running
         };
 
+        if !state.initialized() {
+            state.current_state = core_state;
+            state.initialize();
+        }
+
         // Clear DFSR register. The bits in the register are sticky,
         // so we clear them here to ensure that that none are set.
         let dfsr_clear = Dfsr::clear_all();
 
         memory.write_word_32(Dfsr::ADDRESS, dfsr_clear.into())?;
 
-        Ok(Self {
-            memory,
-            hw_breakpoints_enabled: false,
-            current_state: state,
-        })
+        Ok(Self { memory, state })
     }
 
     fn wait_for_core_register_transfer(&mut self) -> Result<(), Error> {
@@ -240,7 +242,7 @@ impl<'probe> CoreInterface for M33<'probe> {
 
         self.memory.write_word_32(FpCtrl::ADDRESS, val.into())?;
 
-        self.hw_breakpoints_enabled = true;
+        self.state.hw_breakpoints_enabled = true;
 
         Ok(())
     }
@@ -278,7 +280,7 @@ impl<'probe> CoreInterface for M33<'probe> {
     }
 
     fn hw_breakpoints_enabled(&self) -> bool {
-        self.hw_breakpoints_enabled
+        self.state.hw_breakpoints_enabled
     }
 
     fn architecture(&self) -> Architecture {
@@ -290,11 +292,11 @@ impl<'probe> CoreInterface for M33<'probe> {
 
         if dhcsr.s_sleep() {
             // Check if we assumed the core to be halted
-            if self.current_state.is_halted() {
+            if self.state.current_state.is_halted() {
                 log::warn!("Expected core to be halted, but core is running");
             }
 
-            self.current_state = CoreStatus::Sleeping;
+            self.state.current_state = CoreStatus::Sleeping;
 
             return Ok(CoreStatus::Sleeping);
         }
@@ -312,32 +314,32 @@ impl<'probe> CoreInterface for M33<'probe> {
 
             // If the core was halted before, we cannot read the halt reason from the chip,
             // because we clear it directly after reading.
-            if self.current_state.is_halted() {
+            if self.state.current_state.is_halted() {
                 // There shouldn't be any bits set, otherwise it means
                 // that the reason for the halt has changed. No bits set
                 // means that we have an unkown HaltReason.
                 if reason == HaltReason::Unknown {
-                    return Ok(self.current_state);
+                    return Ok(self.state.current_state);
                 }
 
                 log::warn!(
                     "Reason for halt has changed, old reason was {:?}, new reason is {:?}",
-                    &self.current_state,
+                    &self.state.current_state,
                     &reason
                 );
             }
 
-            self.current_state = CoreStatus::Halted(reason);
+            self.state.current_state = CoreStatus::Halted(reason);
 
             return Ok(CoreStatus::Halted(reason));
         }
 
         // Core is neither halted nor sleeping, so we assume it is running.
-        if self.current_state.is_halted() {
+        if self.state.current_state.is_halted() {
             log::warn!("Core is running, but we expected it to be halted");
         }
 
-        self.current_state = CoreStatus::Running;
+        self.state.current_state = CoreStatus::Running;
 
         Ok(CoreStatus::Running)
     }

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -29,33 +29,33 @@ impl<'probe> M33<'probe> {
         mut memory: Memory<'probe>,
         state: &'probe mut CortexState,
     ) -> Result<Self, Error> {
-        // determine current state
-        let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
-
-        let core_state = if dhcsr.s_sleep() {
-            CoreStatus::Sleeping
-        } else if dhcsr.s_halt() {
-            log::debug!("Core was halted when connecting");
-
-            let dfsr = Dfsr(memory.read_word_32(Dfsr::ADDRESS)?);
-
-            let reason = dfsr.halt_reason();
-
-            CoreStatus::Halted(reason)
-        } else {
-            CoreStatus::Running
-        };
-
         if !state.initialized() {
+            // determine current state
+            let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
+
+            let core_state = if dhcsr.s_sleep() {
+                CoreStatus::Sleeping
+            } else if dhcsr.s_halt() {
+                log::debug!("Core was halted when connecting");
+
+                let dfsr = Dfsr(memory.read_word_32(Dfsr::ADDRESS)?);
+
+                let reason = dfsr.halt_reason();
+
+                CoreStatus::Halted(reason)
+            } else {
+                CoreStatus::Running
+            };
+
+            // Clear DFSR register. The bits in the register are sticky,
+            // so we clear them here to ensure that that none are set.
+            let dfsr_clear = Dfsr::clear_all();
+
+            memory.write_word_32(Dfsr::ADDRESS, dfsr_clear.into())?;
+
             state.current_state = core_state;
             state.initialize();
         }
-
-        // Clear DFSR register. The bits in the register are sticky,
-        // so we clear them here to ensure that that none are set.
-        let dfsr_clear = Dfsr::clear_all();
-
-        memory.write_word_32(Dfsr::ADDRESS, dfsr_clear.into())?;
 
         Ok(Self { memory, state })
     }

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -72,7 +72,7 @@ impl<'probe> M33<'probe> {
     }
 }
 
-impl<'probe> CoreInterface<'probe> for M33<'probe> {
+impl<'probe> CoreInterface for M33<'probe> {
     fn wait_for_core_halted(&mut self) -> Result<(), Error> {
         // Wait until halted state is active again.
         for _ in 0..100 {
@@ -282,7 +282,7 @@ impl<'probe> CoreInterface<'probe> for M33<'probe> {
     }
 
     fn architecture(&self) -> Architecture {
-        Architecture::ARM
+        Architecture::Arm
     }
 
     fn status(&mut self) -> Result<crate::core::CoreStatus, Error> {

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -381,7 +381,7 @@ impl<'probe> M4<'probe> {
     }
 }
 
-impl<'probe> CoreInterface<'probe> for M4<'probe> {
+impl<'probe> CoreInterface for M4<'probe> {
     fn wait_for_core_halted(&mut self) -> Result<(), Error> {
         // Wait until halted state is active again.
         for _ in 0..100 {
@@ -670,7 +670,7 @@ impl<'probe> CoreInterface<'probe> for M4<'probe> {
     }
 
     fn architecture(&self) -> Architecture {
-        Architecture::ARM
+        Architecture::Arm
     }
 }
 

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -341,14 +341,14 @@ impl<'a> M4<'a> {
         'a: 'b,
     {
         // determine current state
-        let dhcsr = Dhcsr(memory.read32(Dhcsr::ADDRESS)?);
+        let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
 
         let state = if dhcsr.s_sleep() {
             CoreStatus::Sleeping
         } else if dhcsr.s_halt() {
             log::debug!("Core was halted when connecting");
 
-            let dfsr = Dfsr(memory.read32(Dfsr::ADDRESS)?);
+            let dfsr = Dfsr(memory.read_word_32(Dfsr::ADDRESS)?);
 
             let reason = dfsr.halt_reason();
 
@@ -361,7 +361,7 @@ impl<'a> M4<'a> {
         // so we clear them here to ensure that that none are set.
         let dfsr_clear = Dfsr::clear_all();
 
-        memory.write32(Dfsr::ADDRESS, dfsr_clear.into())?;
+        memory.write_word_32(Dfsr::ADDRESS, dfsr_clear.into())?;
 
         Ok(Self {
             memory,
@@ -374,7 +374,7 @@ impl<'a> M4<'a> {
         // now we have to poll the dhcsr register, until the dhcsr.s_regrdy bit is set
         // (see C1-292, cortex m0 arm)
         for _ in 0..100 {
-            let dhcsr_val = Dhcsr(self.memory.read32(Dhcsr::ADDRESS)?);
+            let dhcsr_val = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
 
             if dhcsr_val.s_regrdy() {
                 return Ok(());
@@ -388,7 +388,7 @@ impl<'a> CoreInterface<'a> for M4<'a> {
     fn wait_for_core_halted(&mut self) -> Result<(), Error> {
         // Wait until halted state is active again.
         for _ in 0..100 {
-            let dhcsr_val = Dhcsr(self.memory.read32(Dhcsr::ADDRESS)?);
+            let dhcsr_val = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
             if dhcsr_val.s_halt() {
                 // update halted state
                 self.status()?;
@@ -401,7 +401,7 @@ impl<'a> CoreInterface<'a> for M4<'a> {
 
     fn core_halted(&mut self) -> Result<bool, Error> {
         // Wait until halted state is active again.
-        let dhcsr_val = Dhcsr(self.memory.read32(Dhcsr::ADDRESS)?);
+        let dhcsr_val = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
 
         if dhcsr_val.s_halt() {
             Ok(true)
@@ -411,7 +411,7 @@ impl<'a> CoreInterface<'a> for M4<'a> {
     }
 
     fn status(&mut self) -> Result<CoreStatus, Error> {
-        let dhcsr = Dhcsr(self.memory.read32(Dhcsr::ADDRESS)?);
+        let dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
 
         if dhcsr.s_sleep() {
             // Check if we assumed the core to be halted
@@ -427,13 +427,13 @@ impl<'a> CoreInterface<'a> for M4<'a> {
         // TODO: Handle lockup
 
         if dhcsr.s_halt() {
-            let dfsr = Dfsr(self.memory.read32(Dfsr::ADDRESS)?);
+            let dfsr = Dfsr(self.memory.read_word_32(Dfsr::ADDRESS)?);
 
             let reason = dfsr.halt_reason();
 
             // Clear bits from Dfsr register
             self.memory
-                .write32(Dfsr::ADDRESS, Dfsr::clear_all().into())?;
+                .write_word_32(Dfsr::ADDRESS, Dfsr::clear_all().into())?;
 
             // If the core was halted before, we cannot read the halt reason from the chip,
             // because we clear it directly after reading.
@@ -473,17 +473,18 @@ impl<'a> CoreInterface<'a> for M4<'a> {
         dcrsr_val.set_regwnr(false); // Perform a read.
         dcrsr_val.set_regsel(addr.into()); // The address of the register to read.
 
-        self.memory.write32(Dcrsr::ADDRESS, dcrsr_val.into())?;
+        self.memory
+            .write_word_32(Dcrsr::ADDRESS, dcrsr_val.into())?;
 
         self.wait_for_core_register_transfer()?;
 
-        self.memory.read32(Dcrdr::ADDRESS).map_err(From::from)
+        self.memory.read_word_32(Dcrdr::ADDRESS).map_err(From::from)
     }
 
     fn write_core_reg(&mut self, addr: CoreRegisterAddress, value: u32) -> Result<(), Error> {
         let result: Result<(), Error> = self
             .memory
-            .write32(Dcrdr::ADDRESS, value)
+            .write_word_32(Dcrdr::ADDRESS, value)
             .map_err(From::from);
         result?;
 
@@ -492,7 +493,8 @@ impl<'a> CoreInterface<'a> for M4<'a> {
         dcrsr_val.set_regwnr(true); // Perform a write.
         dcrsr_val.set_regsel(addr.into()); // The address of the register to write.
 
-        self.memory.write32(Dcrsr::ADDRESS, dcrsr_val.into())?;
+        self.memory
+            .write_word_32(Dcrsr::ADDRESS, dcrsr_val.into())?;
 
         self.wait_for_core_register_transfer()
     }
@@ -505,7 +507,7 @@ impl<'a> CoreInterface<'a> for M4<'a> {
         value.set_c_debugen(true);
         value.enable_write();
 
-        self.memory.write32(Dhcsr::ADDRESS, value.into())?;
+        self.memory.write_word_32(Dhcsr::ADDRESS, value.into())?;
 
         self.wait_for_core_halted()?;
 
@@ -522,7 +524,7 @@ impl<'a> CoreInterface<'a> for M4<'a> {
         value.set_c_debugen(true);
         value.enable_write();
 
-        self.memory.write32(Dhcsr::ADDRESS, value.into())?;
+        self.memory.write_word_32(Dhcsr::ADDRESS, value.into())?;
 
         // We assume that the core is running now
         self.current_state = CoreStatus::Running;
@@ -540,7 +542,7 @@ impl<'a> CoreInterface<'a> for M4<'a> {
         value.set_c_maskints(true);
         value.enable_write();
 
-        self.memory.write32(Dhcsr::ADDRESS, value.into())?;
+        self.memory.write_word_32(Dhcsr::ADDRESS, value.into())?;
 
         self.wait_for_core_halted()?;
 
@@ -557,28 +559,29 @@ impl<'a> CoreInterface<'a> for M4<'a> {
         value.vectkey();
         value.set_sysresetreq(true);
 
-        self.memory.write32(Aircr::ADDRESS, value.into())?;
+        self.memory.write_word_32(Aircr::ADDRESS, value.into())?;
 
         Ok(())
     }
 
     fn reset_and_halt(&mut self) -> Result<CoreInformation, Error> {
         // Ensure debug mode is enabled
-        let dhcsr_val = Dhcsr(self.memory.read32(Dhcsr::ADDRESS)?);
+        let dhcsr_val = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
         if !dhcsr_val.c_debugen() {
             let mut dhcsr = Dhcsr(0);
             dhcsr.set_c_debugen(true);
             dhcsr.enable_write();
-            self.memory.write32(Dhcsr::ADDRESS, dhcsr.into())?;
+            self.memory.write_word_32(Dhcsr::ADDRESS, dhcsr.into())?;
         }
 
         // Set the vc_corereset bit in the DEMCR register.
         // This will halt the core after reset.
-        let demcr_val = Demcr(self.memory.read32(Demcr::ADDRESS)?);
+        let demcr_val = Demcr(self.memory.read_word_32(Demcr::ADDRESS)?);
         if !demcr_val.vc_corereset() {
             let mut demcr_enabled = demcr_val;
             demcr_enabled.set_vc_corereset(true);
-            self.memory.write32(Demcr::ADDRESS, demcr_enabled.into())?;
+            self.memory
+                .write_word_32(Demcr::ADDRESS, demcr_enabled.into())?;
         }
 
         self.reset()?;
@@ -591,7 +594,8 @@ impl<'a> CoreInterface<'a> for M4<'a> {
             self.write_core_reg(register::XPSR.address, xpsr_value | XPSR_THUMB)?;
         }
 
-        self.memory.write32(Demcr::ADDRESS, demcr_val.into())?;
+        self.memory
+            .write_word_32(Demcr::ADDRESS, demcr_val.into())?;
 
         // try to read the program counter
         let pc_value = self.read_core_reg(register::PC.address)?;
@@ -601,7 +605,7 @@ impl<'a> CoreInterface<'a> for M4<'a> {
     }
 
     fn get_available_breakpoint_units(&mut self) -> Result<u32, Error> {
-        let raw_val = self.memory.read32(FpCtrl::ADDRESS)?;
+        let raw_val = self.memory.read_word_32(FpCtrl::ADDRESS)?;
 
         let reg = FpCtrl::from(raw_val);
 
@@ -618,7 +622,7 @@ impl<'a> CoreInterface<'a> for M4<'a> {
         val.set_key(true);
         val.set_enable(state);
 
-        self.memory.write32(FpCtrl::ADDRESS, val.into())?;
+        self.memory.write_word_32(FpCtrl::ADDRESS, val.into())?;
 
         self.hw_breakpoints_enabled = true;
 
@@ -626,7 +630,7 @@ impl<'a> CoreInterface<'a> for M4<'a> {
     }
 
     fn set_breakpoint(&mut self, bp_unit_index: usize, addr: u32) -> Result<(), Error> {
-        let raw_val = self.memory.read32(FpCtrl::ADDRESS)?;
+        let raw_val = self.memory.read_word_32(FpCtrl::ADDRESS)?;
         let ctrl_reg = FpCtrl::from(raw_val);
 
         let val: u32;
@@ -644,7 +648,7 @@ impl<'a> CoreInterface<'a> for M4<'a> {
         // address spaces than Rev1.
         let reg_addr = FpRev1CompX::ADDRESS + (bp_unit_index * size_of::<u32>()) as u32;
 
-        self.memory.write32(reg_addr, val)?;
+        self.memory.write_word_32(reg_addr, val)?;
 
         Ok(())
     }
@@ -659,7 +663,7 @@ impl<'a> CoreInterface<'a> for M4<'a> {
 
         let reg_addr = FpRev1CompX::ADDRESS + (bp_unit_index * size_of::<u32>()) as u32;
 
-        self.memory.write32(reg_addr, val.into())?;
+        self.memory.write_word_32(reg_addr, val.into())?;
 
         Ok(())
     }
@@ -674,29 +678,29 @@ impl<'a> CoreInterface<'a> for M4<'a> {
 }
 
 impl<'a> MemoryInterface for M4<'a> {
-    fn read32(&mut self, address: u32) -> Result<u32, Error> {
-        self.memory.read32(address)
+    fn read_word_32(&mut self, address: u32) -> Result<u32, Error> {
+        self.memory.read_word_32(address)
     }
-    fn read8(&mut self, address: u32) -> Result<u8, Error> {
-        self.memory.read8(address)
+    fn read_word_8(&mut self, address: u32) -> Result<u8, Error> {
+        self.memory.read_word_8(address)
     }
-    fn read_block32(&mut self, address: u32, data: &mut [u32]) -> Result<(), Error> {
-        self.memory.read_block32(address, data)
+    fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), Error> {
+        self.memory.read_32(address, data)
     }
-    fn read_block8(&mut self, address: u32, data: &mut [u8]) -> Result<(), Error> {
-        self.memory.read_block8(address, data)
+    fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), Error> {
+        self.memory.read_8(address, data)
     }
-    fn write32(&mut self, address: u32, data: u32) -> Result<(), Error> {
-        self.memory.write32(address, data)
+    fn write_word_32(&mut self, address: u32, data: u32) -> Result<(), Error> {
+        self.memory.write_word_32(address, data)
     }
-    fn write8(&mut self, address: u32, data: u8) -> Result<(), Error> {
-        self.memory.write8(address, data)
+    fn write_word_8(&mut self, address: u32, data: u8) -> Result<(), Error> {
+        self.memory.write_word_8(address, data)
     }
-    fn write_block32(&mut self, address: u32, data: &[u32]) -> Result<(), Error> {
-        self.memory.write_block32(address, data)
+    fn write_32(&mut self, address: u32, data: &[u32]) -> Result<(), Error> {
+        self.memory.write_32(address, data)
     }
-    fn write_block8(&mut self, address: u32, data: &[u8]) -> Result<(), Error> {
-        self.memory.write_block8(address, data)
+    fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), Error> {
+        self.memory.write_8(address, data)
     }
 }
 

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -327,19 +327,16 @@ impl FpRev2CompX {
 pub const MSP: CoreRegisterAddress = CoreRegisterAddress(0b000_1001);
 pub const PSP: CoreRegisterAddress = CoreRegisterAddress(0b000_1010);
 
-pub struct M4<'a> {
-    memory: Memory<'a>,
+pub struct M4<'probe> {
+    memory: Memory<'probe>,
 
     hw_breakpoints_enabled: bool,
 
     current_state: CoreStatus,
 }
 
-impl<'a> M4<'a> {
-    pub fn new<'b>(mut memory: Memory<'a>) -> Result<M4<'a>, Error>
-    where
-        'a: 'b,
-    {
+impl<'probe> M4<'probe> {
+    pub fn new(mut memory: Memory<'probe>) -> Result<M4<'probe>, Error> {
         // determine current state
         let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
 
@@ -384,7 +381,7 @@ impl<'a> M4<'a> {
     }
 }
 
-impl<'a> CoreInterface<'a> for M4<'a> {
+impl<'probe> CoreInterface<'probe> for M4<'probe> {
     fn wait_for_core_halted(&mut self) -> Result<(), Error> {
         // Wait until halted state is active again.
         for _ in 0..100 {
@@ -677,7 +674,7 @@ impl<'a> CoreInterface<'a> for M4<'a> {
     }
 }
 
-impl<'a> MemoryInterface for M4<'a> {
+impl<'probe> MemoryInterface for M4<'probe> {
     fn read_word_32(&mut self, address: u32) -> Result<u32, Error> {
         self.memory.read_word_32(address)
     }

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{CoreRegister, CoreRegisterAddress, RegisterDescription, RegisterFile, RegisterKind},
-    HaltReason,
+    CoreStatus, HaltReason,
 };
 
 use bitfield::bitfield;
@@ -238,4 +238,30 @@ impl From<Dfsr> for u32 {
 impl CoreRegister for Dfsr {
     const ADDRESS: u32 = 0xE000_ED30;
     const NAME: &'static str = "DFSR";
+}
+
+pub(crate) struct CortexState {
+    initialized: bool,
+
+    hw_breakpoints_enabled: bool,
+
+    current_state: CoreStatus,
+}
+
+impl CortexState {
+    pub(crate) fn new() -> Self {
+        Self {
+            initialized: false,
+            hw_breakpoints_enabled: false,
+            current_state: CoreStatus::Unknown,
+        }
+    }
+
+    fn initialize(&mut self) {
+        self.initialized = true;
+    }
+
+    fn initialized(&self) -> bool {
+        self.initialized
+    }
 }

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -3,7 +3,7 @@ use super::super::ap::{
     MemoryAP, CSW, DRW, TAR,
 };
 use crate::architecture::arm::{dp::DPAccess, ArmCommunicationInterface};
-use crate::{CommunicationInterface, Error, MemoryInterface};
+use crate::{CommunicationInterface, Core, Error, MemoryInterface};
 use scroll::{Pread, Pwrite, LE};
 use std::convert::TryInto;
 use std::ops::Range;
@@ -22,12 +22,12 @@ where
     only_32bit_data_size: bool,
 }
 
-impl ADIMemoryInterface<ArmCommunicationInterface> {
+impl<'a> ADIMemoryInterface<ArmCommunicationInterface<'a>> {
     /// Creates a new MemoryInterface for given AccessPort.
     pub fn new(
-        interface: ArmCommunicationInterface,
+        interface: ArmCommunicationInterface<'a>,
         access_port_number: impl Into<MemoryAP>,
-    ) -> Result<Self, AccessPortError> {
+    ) -> Result<ADIMemoryInterface<ArmCommunicationInterface<'a>>, AccessPortError> {
         let mut interface = Self {
             interface,
             access_port: access_port_number.into(),
@@ -40,7 +40,10 @@ impl ADIMemoryInterface<ArmCommunicationInterface> {
 
 impl ADIMemoryInterface<MockMemoryAP> {
     /// Creates a new MemoryInterface for given AccessPort.
-    pub fn new(mock: MockMemoryAP, access_port_number: impl Into<MemoryAP>) -> Self {
+    pub fn new(
+        mock: MockMemoryAP,
+        access_port_number: impl Into<MemoryAP>,
+    ) -> ADIMemoryInterface<MockMemoryAP> {
         Self {
             interface: mock,
             access_port: access_port_number.into(),

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -27,7 +27,7 @@ impl<'probe> ADIMemoryInterface<ArmCommunicationInterface<'probe>> {
     pub fn new(
         interface: ArmCommunicationInterface<'probe>,
         access_port_number: impl Into<MemoryAP>,
-    ) -> Result<ADIMemoryInterface<ArmCommunicationInterface<'probe>>, AccessPortError> {
+    ) -> Result<ADIMemoryInterface<ArmCommunicationInterface>, AccessPortError> {
         let mut interface = Self {
             interface,
             access_port: access_port_number.into(),

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -22,12 +22,12 @@ where
     only_32bit_data_size: bool,
 }
 
-impl<'a> ADIMemoryInterface<ArmCommunicationInterface<'a>> {
+impl<'probe> ADIMemoryInterface<ArmCommunicationInterface<'probe>> {
     /// Creates a new MemoryInterface for given AccessPort.
     pub fn new(
-        interface: ArmCommunicationInterface<'a>,
+        interface: ArmCommunicationInterface<'probe>,
         access_port_number: impl Into<MemoryAP>,
-    ) -> Result<ADIMemoryInterface<ArmCommunicationInterface<'a>>, AccessPortError> {
+    ) -> Result<ADIMemoryInterface<ArmCommunicationInterface<'probe>>, AccessPortError> {
         let mut interface = Self {
             interface,
             access_port: access_port_number.into(),

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -3,7 +3,7 @@ use super::super::ap::{
     MemoryAP, CSW, DRW, TAR,
 };
 use crate::architecture::arm::{dp::DPAccess, ArmCommunicationInterface};
-use crate::{CommunicationInterface, Core, Error, MemoryInterface};
+use crate::{CommunicationInterface, Error, MemoryInterface};
 use scroll::{Pread, Pwrite, LE};
 use std::convert::TryInto;
 use std::ops::Range;

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -73,7 +73,7 @@ impl<'r, 'a, 'c> Iterator for RomTableIterator<'r, 'a, 'c> {
         if let Err(e) = self
             .rom_table_reader
             .memory
-            .read_block32(component_address as u32, &mut entry_data)
+            .read_32(component_address as u32, &mut entry_data)
         {
             return Some(Err(RomTableError::Memory(e)));
         }
@@ -229,7 +229,7 @@ impl<'a: 'b, 'b> ComponentInformationReader<'a, 'b> {
         let mut cidr = [0u32; 4];
 
         self.memory
-            .read_block32(self.base_address as u32 + 0xFF0, &mut cidr)
+            .read_32(self.base_address as u32 + 0xFF0, &mut cidr)
             .map_err(RomTableError::Memory)?;
 
         log::debug!("CIDR: {:x?}", cidr);
@@ -269,10 +269,10 @@ impl<'a: 'b, 'b> ComponentInformationReader<'a, 'b> {
         );
 
         self.memory
-            .read_block32(self.base_address as u32 + 0xFD0, &mut data[4..])
+            .read_32(self.base_address as u32 + 0xFD0, &mut data[4..])
             .map_err(RomTableError::Memory)?;
         self.memory
-            .read_block32(self.base_address as u32 + 0xFE0, &mut data[..4])
+            .read_32(self.base_address as u32 + 0xFE0, &mut data[..4])
             .map_err(RomTableError::Memory)?;
 
         log::debug!("Raw peripheral id: {:x?}", data);

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -4,7 +4,9 @@ pub(crate) mod core;
 pub mod dp;
 pub mod memory;
 
-pub use communication_interface::{ArmChipInfo, ArmCommunicationInterface, DAPAccess, DapError};
+pub use communication_interface::{
+    ArmChipInfo, ArmCommunicationInterface, ArmCommunicationInterfaceState, DAPAccess, DapError,
+};
 pub use communication_interface::{PortType, Register};
 
 pub use self::core::m0;

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -600,55 +600,56 @@ impl<'a> RiscvCommunicationInterface<'a> {
 }
 
 impl<'a> MemoryInterface for RiscvCommunicationInterface<'a> {
-    fn read32(&mut self, address: u32) -> Result<u32, crate::Error> {
+    fn read_word_32(&mut self, address: u32) -> Result<u32, crate::Error> {
         let result = self.perform_memory_read(address, RiscvBusAccess::A32)?;
 
         Ok(result)
     }
 
-    fn read8(&mut self, address: u32) -> Result<u8, crate::Error> {
+    fn read_word_8(&mut self, address: u32) -> Result<u8, crate::Error> {
         let value = self.perform_memory_read(address, RiscvBusAccess::A8)?;
 
         Ok((value & 0xff) as u8)
     }
 
-    fn read_block32(&mut self, address: u32, data: &mut [u32]) -> Result<(), crate::Error> {
+    fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), crate::Error> {
         for (offset, word) in data.iter_mut().enumerate() {
-            *word = self.read32(address + ((offset * 4) as u32))?;
+            *word = self.read_word_32(address + ((offset * 4) as u32))?;
         }
 
         Ok(())
     }
 
-    fn read_block8(&mut self, address: u32, data: &mut [u8]) -> Result<(), crate::Error> {
+    fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), crate::Error> {
         for (offset, byte) in data.iter_mut().enumerate() {
-            *byte = self.read8(address + (offset as u32))?;
+            *byte = self.read_word_8(address + (offset as u32))?;
         }
 
         Ok(())
     }
 
-    fn write32(&mut self, address: u32, data: u32) -> Result<(), crate::Error> {
+    fn write_word_32(&mut self, address: u32, data: u32) -> Result<(), crate::Error> {
         self.perform_memory_write(address, RiscvBusAccess::A32, data)?;
 
         Ok(())
     }
 
-    fn write8(&mut self, address: u32, data: u8) -> Result<(), crate::Error> {
+    fn write_word_8(&mut self, address: u32, data: u8) -> Result<(), crate::Error> {
         self.perform_memory_write(address, RiscvBusAccess::A8, data as u32)?;
 
         Ok(())
     }
-    fn write_block32(&mut self, address: u32, data: &[u32]) -> Result<(), crate::Error> {
+
+    fn write_32(&mut self, address: u32, data: &[u32]) -> Result<(), crate::Error> {
         for (offset, word) in data.iter().enumerate() {
-            self.write32(address + ((offset * 4) as u32), *word)?;
+            self.write_word_32(address + ((offset * 4) as u32), *word)?;
         }
 
         Ok(())
     }
-    fn write_block8(&mut self, address: u32, data: &[u8]) -> Result<(), crate::Error> {
+    fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), crate::Error> {
         for (offset, byte) in data.iter().enumerate() {
-            self.write8(address + (offset as u32), *byte)?;
+            self.write_word_8(address + (offset as u32), *byte)?;
         }
 
         Ok(())

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -7,12 +7,9 @@
 use super::{register, Dmcontrol, Dmstatus};
 use crate::architecture::riscv::{Abstractcs, Command, Data0, Progbuf0, Progbuf1};
 use crate::DebugProbeError;
-use crate::{Memory, MemoryInterface, Probe};
+use crate::{MemoryInterface, Probe};
 
 use crate::{CoreRegisterAddress, Error as ProbeRsError};
-
-use std::cell::RefCell;
-use std::rc::Rc;
 
 use std::{
     convert::TryInto,

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -140,15 +140,15 @@ impl RiscvCommunicationInterfaceState {
     }
 }
 
-pub struct RiscvCommunicationInterface<'a> {
-    probe: &'a mut Probe,
-    state: &'a mut RiscvCommunicationInterfaceState,
+pub struct RiscvCommunicationInterface<'probe> {
+    probe: &'probe mut Probe,
+    state: &'probe mut RiscvCommunicationInterfaceState,
 }
 
-impl<'a> RiscvCommunicationInterface<'a> {
+impl<'probe> RiscvCommunicationInterface<'probe> {
     pub fn new(
-        probe: &'a mut Probe,
-        state: &'a mut RiscvCommunicationInterfaceState,
+        probe: &'probe mut Probe,
+        state: &'probe mut RiscvCommunicationInterfaceState,
     ) -> Result<Option<Self>, ProbeRsError> {
         if probe.has_jtag_interface() {
             let mut s = Self { probe, state };
@@ -599,7 +599,7 @@ impl<'a> RiscvCommunicationInterface<'a> {
     }
 }
 
-impl<'a> MemoryInterface for RiscvCommunicationInterface<'a> {
+impl<'probe> MemoryInterface for RiscvCommunicationInterface<'probe> {
     fn read_word_32(&mut self, address: u32) -> Result<u32, crate::Error> {
         let result = self.perform_memory_read(address, RiscvBusAccess::A32)?;
 

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -105,7 +105,7 @@ pub struct RiscvCommunicationInterfaceState {
 const RISCV_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl RiscvCommunicationInterfaceState {
-    pub(crate) fn new(probe: &mut Probe) -> Result<Self, RiscvError> {
+    fn new(probe: &mut Probe) -> Result<Self, RiscvError> {
         // We need a jtag interface
 
         log::debug!("Building RISCV interface");
@@ -149,10 +149,10 @@ pub struct RiscvCommunicationInterface<'a> {
 }
 
 impl<'a> RiscvCommunicationInterface<'a> {
-    pub(crate) fn new(
+    pub fn new(
         probe: &'a mut Probe,
         state: &'a mut RiscvCommunicationInterfaceState,
-    ) -> Result<Option<Self>, RiscvError> {
+    ) -> Result<Option<Self>, ProbeRsError> {
         if probe.has_jtag_interface() {
             let mut s = Self { probe, state };
 
@@ -167,6 +167,12 @@ impl<'a> RiscvCommunicationInterface<'a> {
 
             Ok(None)
         }
+    }
+
+    pub fn create_state(
+        probe: &mut Probe,
+    ) -> Result<RiscvCommunicationInterfaceState, ProbeRsError> {
+        Ok(RiscvCommunicationInterfaceState::new(probe)?)
     }
 
     // TODO: N

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -110,7 +110,7 @@ impl<'probe> Riscv32<'probe> {
     }
 }
 
-impl<'probe> CoreInterface<'probe> for Riscv32<'probe> {
+impl<'probe> CoreInterface for Riscv32<'probe> {
     fn wait_for_core_halted(&mut self) -> Result<(), crate::Error> {
         // poll the
         let num_retries = 10;
@@ -499,8 +499,9 @@ impl<'probe> CoreInterface<'probe> for Riscv32<'probe> {
     }
 
     fn architecture(&self) -> Architecture {
-        Architecture::RISCV
+        Architecture::Riscv
     }
+
     fn status(&mut self) -> Result<crate::core::CoreStatus, crate::Error> {
         // TODO: We should use hartsum to determine if any hart is halted
         //       quickly

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -538,29 +538,29 @@ impl<'a> CoreInterface<'a> for Riscv32<'a> {
 }
 
 impl<'a> MemoryInterface for Riscv32<'a> {
-    fn read32(&mut self, address: u32) -> Result<u32, Error> {
-        self.interface.read32(address)
+    fn read_word_32(&mut self, address: u32) -> Result<u32, Error> {
+        self.interface.read_word_32(address)
     }
-    fn read8(&mut self, address: u32) -> Result<u8, Error> {
-        self.interface.read8(address)
+    fn read_word_8(&mut self, address: u32) -> Result<u8, Error> {
+        self.interface.read_word_8(address)
     }
-    fn read_block32(&mut self, address: u32, data: &mut [u32]) -> Result<(), Error> {
-        self.interface.read_block32(address, data)
+    fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), Error> {
+        self.interface.read_32(address, data)
     }
-    fn read_block8(&mut self, address: u32, data: &mut [u8]) -> Result<(), Error> {
-        self.interface.read_block8(address, data)
+    fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), Error> {
+        self.interface.read_8(address, data)
     }
-    fn write32(&mut self, address: u32, data: u32) -> Result<(), Error> {
-        self.interface.write32(address, data)
+    fn write_word_32(&mut self, address: u32, data: u32) -> Result<(), Error> {
+        self.interface.write_word_32(address, data)
     }
-    fn write8(&mut self, address: u32, data: u8) -> Result<(), Error> {
-        self.interface.write8(address, data)
+    fn write_word_8(&mut self, address: u32, data: u8) -> Result<(), Error> {
+        self.interface.write_word_8(address, data)
     }
-    fn write_block32(&mut self, address: u32, data: &[u32]) -> Result<(), Error> {
-        self.interface.write_block32(address, data)
+    fn write_32(&mut self, address: u32, data: &[u32]) -> Result<(), Error> {
+        self.interface.write_32(address, data)
     }
-    fn write_block8(&mut self, address: u32, data: &[u8]) -> Result<(), Error> {
-        self.interface.write_block8(address, data)
+    fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), Error> {
+        self.interface.write_8(address, data)
     }
 }
 

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -19,12 +19,12 @@ mod register;
 
 pub mod communication_interface;
 
-pub struct Riscv32<'a> {
-    interface: RiscvCommunicationInterface<'a>,
+pub struct Riscv32<'probe> {
+    interface: RiscvCommunicationInterface<'probe>,
 }
 
-impl<'a> Riscv32<'a> {
-    pub fn new(interface: RiscvCommunicationInterface<'a>) -> Self {
+impl<'probe> Riscv32<'probe> {
+    pub fn new(interface: RiscvCommunicationInterface<'probe>) -> Self {
         Self { interface }
     }
 
@@ -110,7 +110,7 @@ impl<'a> Riscv32<'a> {
     }
 }
 
-impl<'a> CoreInterface<'a> for Riscv32<'a> {
+impl<'probe> CoreInterface<'probe> for Riscv32<'probe> {
     fn wait_for_core_halted(&mut self) -> Result<(), crate::Error> {
         // poll the
         let num_retries = 10;
@@ -537,7 +537,7 @@ impl<'a> CoreInterface<'a> for Riscv32<'a> {
     }
 }
 
-impl<'a> MemoryInterface for Riscv32<'a> {
+impl<'probe> MemoryInterface for Riscv32<'probe> {
     fn read_word_32(&mut self, address: u32) -> Result<u32, Error> {
         self.interface.read_word_32(address)
     }

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -68,14 +68,14 @@ pub enum TargetSelector {
     Auto,
 }
 
-impl<'a> From<&'a str> for TargetSelector {
-    fn from(value: &'a str) -> Self {
+impl From<&str> for TargetSelector {
+    fn from(value: &str) -> Self {
         TargetSelector::Unspecified(value.into())
     }
 }
 
-impl<'a> From<&'a String> for TargetSelector {
-    fn from(value: &'a String) -> Self {
+impl From<&String> for TargetSelector {
+    fn from(value: &String) -> Self {
         TargetSelector::Unspecified(value.into())
     }
 }

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -51,12 +51,12 @@ impl Target {
 
     pub fn architecture(&self) -> Architecture {
         match &self.core_type {
-            CoreType::M0 => Architecture::ARM,
-            CoreType::M3 => Architecture::ARM,
-            CoreType::M33 => Architecture::ARM,
-            CoreType::M4 => Architecture::ARM,
-            CoreType::Riscv => Architecture::RISCV,
-            CoreType::M7 => Architecture::ARM,
+            CoreType::M0 => Architecture::Arm,
+            CoreType::M3 => Architecture::Arm,
+            CoreType::M33 => Architecture::Arm,
+            CoreType::M4 => Architecture::Arm,
+            CoreType::M7 => Architecture::Arm,
+            CoreType::Riscv => Architecture::Riscv,
         }
     }
 }

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -125,7 +125,7 @@ impl RegisterFile {
     }
 }
 
-pub trait CoreInterface<'probe>: MemoryInterface {
+pub trait CoreInterface: MemoryInterface {
     /// Wait until the core is halted. If the core does not halt on its own,
     /// a [`DebugProbeError::Timeout`] error will be returned.
     ///
@@ -301,15 +301,12 @@ impl CoreState {
 }
 
 pub struct Core<'probe> {
-    inner: Box<dyn CoreInterface<'probe> + 'probe>,
+    inner: Box<dyn CoreInterface + 'probe>,
     state: &'probe mut CoreState,
 }
 
 impl<'probe> Core<'probe> {
-    pub fn new(
-        core: impl CoreInterface<'probe> + 'probe,
-        state: &'probe mut CoreState,
-    ) -> Core<'probe> {
+    pub fn new(core: impl CoreInterface + 'probe, state: &'probe mut CoreState) -> Core<'probe> {
         Self {
             inner: Box::new(core),
             state,
@@ -528,8 +525,8 @@ pub struct Breakpoint {
 }
 
 pub enum Architecture {
-    ARM,
-    RISCV,
+    Arm,
+    Riscv,
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -521,16 +521,16 @@ impl<'probe> Core<'probe> {
     }
 }
 
-pub struct CoreList<'probe>(&'probe Vec<CoreType>);
+pub struct CoreList<'probe>(&'probe [CoreType]);
 
 impl<'probe> CoreList<'probe> {
-    pub fn new(cores: &'probe Vec<CoreType>) -> Self {
+    pub fn new(cores: &'probe [CoreType]) -> Self {
         Self(cores)
     }
 }
 
 impl<'probe> std::ops::Deref for CoreList<'probe> {
-    type Target = Vec<CoreType>;
+    type Target = [CoreType];
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -354,21 +354,6 @@ impl<'probe> Core<'probe> {
         CoreState::new()
     }
 
-    // TODO: N
-    // pub fn auto_attach(target: impl Into<TargetSelector>) -> Result<Core<'probe>, error::Error> {
-    //     // Get a list of all available debug probes.
-    //     let probes = Probe::list_all();
-
-    //     // Use the first probe found.
-    //     let probe = probes[0].open()?;
-
-    //     // Attach to a chip.
-    //     let session = probe.attach(target)?;
-
-    //     // Select a core.
-    //     session.attach_to_core(0)
-    // }
-
     /// Wait until the core is halted. If the core does not halt on its own,
     /// a [`DebugProbeError::Timeout`] error will be returned.
     ///

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -187,36 +187,36 @@ pub trait CoreInterface<'a>: MemoryInterface {
 }
 
 impl<'a> MemoryInterface for Core<'a> {
-    fn read32(&mut self, address: u32) -> Result<u32, Error> {
-        self.read_word_32(address)
+    fn read_word_32(&mut self, address: u32) -> Result<u32, Error> {
+        self.inner.read_word_32(address)
     }
 
-    fn read8(&mut self, address: u32) -> Result<u8, Error> {
-        self.read_word_8(address)
+    fn read_word_8(&mut self, address: u32) -> Result<u8, Error> {
+        self.inner.read_word_8(address)
     }
 
-    fn read_block32(&mut self, address: u32, data: &mut [u32]) -> Result<(), Error> {
-        self.read_32(address, data)
+    fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), Error> {
+        self.inner.read_32(address, data)
     }
 
-    fn read_block8(&mut self, address: u32, data: &mut [u8]) -> Result<(), Error> {
-        self.read_8(address, data)
+    fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), Error> {
+        self.inner.read_8(address, data)
     }
 
-    fn write32(&mut self, addr: u32, data: u32) -> Result<(), Error> {
-        self.write_word_32(addr, data)
+    fn write_word_32(&mut self, addr: u32, data: u32) -> Result<(), Error> {
+        self.inner.write_word_32(addr, data)
     }
 
-    fn write8(&mut self, addr: u32, data: u8) -> Result<(), Error> {
-        self.write_word_8(addr, data)
+    fn write_word_8(&mut self, addr: u32, data: u8) -> Result<(), Error> {
+        self.inner.write_word_8(addr, data)
     }
 
-    fn write_block32(&mut self, addr: u32, data: &[u32]) -> Result<(), Error> {
-        self.write_32(addr, data)
+    fn write_32(&mut self, addr: u32, data: &[u32]) -> Result<(), Error> {
+        self.inner.write_32(addr, data)
     }
 
-    fn write_block8(&mut self, addr: u32, data: &[u8]) -> Result<(), Error> {
-        self.write_8(addr, data)
+    fn write_8(&mut self, addr: u32, data: &[u8]) -> Result<(), Error> {
+        self.inner.write_8(addr, data)
     }
 }
 
@@ -410,38 +410,6 @@ impl<'a> Core<'a> {
 
     pub fn registers(&self) -> &'static RegisterFile {
         self.inner.registers()
-    }
-
-    pub fn read_word_32(&mut self, address: u32) -> Result<u32, error::Error> {
-        self.read32(address)
-    }
-
-    pub fn read_word_8(&mut self, address: u32) -> Result<u8, error::Error> {
-        self.read8(address)
-    }
-
-    pub fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), error::Error> {
-        self.read_block32(address, data)
-    }
-
-    pub fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error> {
-        self.read_block8(address, data)
-    }
-
-    pub fn write_word_32(&mut self, addr: u32, data: u32) -> Result<(), error::Error> {
-        self.write32(addr, data)
-    }
-
-    pub fn write_word_8(&mut self, addr: u32, data: u8) -> Result<(), error::Error> {
-        self.write8(addr, data)
-    }
-
-    pub fn write_32(&mut self, addr: u32, data: &[u32]) -> Result<(), error::Error> {
-        self.write_block32(addr, data)
-    }
-
-    pub fn write_8(&mut self, addr: u32, data: &[u8]) -> Result<(), error::Error> {
-        self.write_block8(addr, data)
     }
 
     /// Set a hardware breakpoint

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -2,7 +2,6 @@ pub(crate) mod communication_interface;
 
 pub use communication_interface::CommunicationInterface;
 
-use crate::config::TargetSelector;
 use crate::error;
 use crate::{
     architecture::{
@@ -11,8 +10,7 @@ use crate::{
     },
     Error, MemoryInterface,
 };
-use crate::{DebugProbeError, Memory, Probe};
-use std::{cell::RefCell, rc::Rc};
+use crate::{DebugProbeError, Memory};
 
 pub trait CoreRegister: Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug {
     const ADDRESS: u32;
@@ -190,35 +188,35 @@ pub trait CoreInterface<'a>: MemoryInterface {
 
 impl<'a> MemoryInterface for Core<'a> {
     fn read32(&mut self, address: u32) -> Result<u32, Error> {
-        self.read32(address)
+        self.read_word_32(address)
     }
 
     fn read8(&mut self, address: u32) -> Result<u8, Error> {
-        self.read8(address)
+        self.read_word_8(address)
     }
 
     fn read_block32(&mut self, address: u32, data: &mut [u32]) -> Result<(), Error> {
-        self.read_block32(address, data)
+        self.read_32(address, data)
     }
 
     fn read_block8(&mut self, address: u32, data: &mut [u8]) -> Result<(), Error> {
-        self.read_block8(address, data)
+        self.read_8(address, data)
     }
 
     fn write32(&mut self, addr: u32, data: u32) -> Result<(), Error> {
-        self.write32(addr, data)
+        self.write_word_32(addr, data)
     }
 
     fn write8(&mut self, addr: u32, data: u8) -> Result<(), Error> {
-        self.write8(addr, data)
+        self.write_word_8(addr, data)
     }
 
     fn write_block32(&mut self, addr: u32, data: &[u32]) -> Result<(), Error> {
-        self.write_block32(addr, data)
+        self.write_32(addr, data)
     }
 
     fn write_block8(&mut self, addr: u32, data: &[u8]) -> Result<(), Error> {
-        self.write_block8(addr, data)
+        self.write_8(addr, data)
     }
 }
 

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -718,7 +718,7 @@ impl<'a> UnitInfo<'a> {
                 Complete => break,
                 RequiresMemory { address, size, .. } => {
                     let mut buff = vec![0u8; size as usize];
-                    core.read_block8(address as u32, &mut buff)
+                    core.read_8(address as u32, &mut buff)
                         .expect("Failed to read memory");
                     match size {
                         1 => evaluation.resume_with_memory(gimli::Value::U8(buff[0]))?,

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -153,14 +153,14 @@ impl FlashLayout {
 
 /// A block of data that is to be written to flash.
 #[derive(Clone, Copy)]
-pub(super) struct FlashDataBlock<'a> {
+pub(super) struct FlashDataBlock<'data> {
     address: u32,
-    data: &'a [u8],
+    data: &'data [u8],
 }
 
-impl<'a> FlashDataBlock<'a> {
+impl<'data> FlashDataBlock<'data> {
     /// Create a new `FlashDataBlock`.
-    fn new(address: u32, data: &'a [u8]) -> Self {
+    fn new(address: u32, data: &'data [u8]) -> Self {
         Self { address, data }
     }
 
@@ -194,7 +194,7 @@ impl FlashDataBlockSpan {
     }
 }
 
-impl<'a> From<FlashDataBlock<'a>> for FlashDataBlockSpan {
+impl<'data> From<FlashDataBlock<'data>> for FlashDataBlockSpan {
     fn from(block: FlashDataBlock) -> Self {
         Self {
             address: block.address(),
@@ -203,7 +203,7 @@ impl<'a> From<FlashDataBlock<'a>> for FlashDataBlockSpan {
     }
 }
 
-impl<'a> From<&FlashDataBlock<'a>> for FlashDataBlockSpan {
+impl<'data> From<&FlashDataBlock<'data>> for FlashDataBlockSpan {
     fn from(block: &FlashDataBlock) -> Self {
         Self {
             address: block.address(),
@@ -214,11 +214,11 @@ impl<'a> From<&FlashDataBlock<'a>> for FlashDataBlockSpan {
 
 /// A helper structure to build a flash layout from a set of data blocks.
 #[derive(Default)]
-pub(super) struct FlashBuilder<'a> {
-    data_blocks: Vec<FlashDataBlock<'a>>,
+pub(super) struct FlashBuilder<'data> {
+    data_blocks: Vec<FlashDataBlock<'data>>,
 }
 
-impl<'a> FlashBuilder<'a> {
+impl<'data> FlashBuilder<'data> {
     /// Creates a new `FlashBuilder` with empty data.
     pub(super) fn new() -> Self {
         Self {
@@ -229,7 +229,7 @@ impl<'a> FlashBuilder<'a> {
     /// Add a block of data to be programmed.
     ///
     /// Programming does not start until the `program` method is called.
-    pub(super) fn add_data(&mut self, address: u32, data: &'a [u8]) -> Result<(), FlashError> {
+    pub(super) fn add_data(&mut self, address: u32, data: &'data [u8]) -> Result<(), FlashError> {
         // Add the operation to the sorted data list.
         match self
             .data_blocks

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -441,11 +441,11 @@ impl<'data> FlashBuilder<'data> {
 }
 
 /// Adds a new sector to the sectors.
-fn add_sector<'b>(
+fn add_sector<'sector>(
     flash_algorithm: &FlashAlgorithm,
     address: u32,
-    sectors: &'b mut Vec<FlashSector>,
-) -> Result<&'b mut FlashSector, FlashError> {
+    sectors: &'sector mut Vec<FlashSector>,
+) -> Result<&'sector mut FlashSector, FlashError> {
     let sector_info = flash_algorithm.sector_info(address);
     if let Some(sector_info) = sector_info {
         let new_sector = FlashSector::new(&sector_info);
@@ -463,11 +463,11 @@ fn add_sector<'b>(
 }
 
 /// Adds a new page to the pages.
-fn add_page<'b>(
+fn add_page<'page>(
     flash_algorithm: &FlashAlgorithm,
     address: u32,
-    pages: &'b mut Vec<FlashPage>,
-) -> Result<&'b mut FlashPage, FlashError> {
+    pages: &'page mut Vec<FlashPage>,
+) -> Result<&'page mut FlashPage, FlashError> {
     let page_info = flash_algorithm.page_info(address);
     if let Some(page_info) = page_info {
         let new_page = FlashPage::new(&page_info);

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -1,4 +1,3 @@
-use ihex;
 use ihex::record::Record::*;
 
 use std::{
@@ -88,7 +87,7 @@ pub fn download_file_with_options(
     let mut buffer = vec![];
     let mut buffer_vec = vec![];
     // IMPORTANT: Change this to an actual memory map of a real chip
-    let memory_map = session.memory_map().iter().cloned().collect::<Vec<_>>();
+    let memory_map = session.memory_map().to_vec();
     let mut loader = FlashLoader::new(&memory_map, options.keep_unwritten_bytes);
 
     match format {

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -88,7 +88,7 @@ pub fn download_file_with_options(
     let mut buffer = vec![];
     let mut buffer_vec = vec![];
     // IMPORTANT: Change this to an actual memory map of a real chip
-    let memory_map = session.memory_map().clone();
+    let memory_map = session.memory_map().iter().cloned().collect::<Vec<_>>();
     let mut loader = FlashLoader::new(&memory_map, options.keep_unwritten_bytes);
 
     match format {

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -107,10 +107,10 @@ pub fn download_file_with_options(
 }
 
 /// Starts the download of a binary file.
-fn download_bin<'b, T: Read + Seek>(
-    buffer: &'b mut Vec<u8>,
-    file: &'b mut T,
-    loader: &mut FlashLoader<'_, 'b>,
+fn download_bin<'buffer, T: Read + Seek>(
+    buffer: &'buffer mut Vec<u8>,
+    file: &'buffer mut T,
+    loader: &mut FlashLoader<'_, 'buffer>,
     options: BinOptions,
 ) -> Result<(), FileDownloadError> {
     // Skip the specified bytes.
@@ -133,10 +133,10 @@ fn download_bin<'b, T: Read + Seek>(
 }
 
 /// Starts the download of a hex file.
-fn download_hex<'b, T: Read + Seek>(
-    buffer: &'b mut Vec<(u32, Vec<u8>)>,
+fn download_hex<'buffer, T: Read + Seek>(
+    buffer: &'buffer mut Vec<(u32, Vec<u8>)>,
     file: &mut T,
-    loader: &mut FlashLoader<'_, 'b>,
+    loader: &mut FlashLoader<'_, 'buffer>,
 ) -> Result<(), FileDownloadError> {
     let mut _extended_segment_address = 0;
     let mut extended_linear_address = 0;
@@ -169,10 +169,10 @@ fn download_hex<'b, T: Read + Seek>(
 }
 
 /// Starts the download of a elf file.
-fn download_elf<'b, T: Read + Seek>(
-    buffer: &'b mut Vec<u8>,
-    file: &'b mut T,
-    loader: &mut FlashLoader<'_, 'b>,
+fn download_elf<'buffer, T: Read + Seek>(
+    buffer: &'buffer mut Vec<u8>,
+    file: &'buffer mut T,
+    loader: &mut FlashLoader<'_, 'buffer>,
 ) -> Result<(), FileDownloadError> {
     use goblin::elf::program_header::*;
 

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -51,9 +51,9 @@ pub enum FileDownloadError {
 
 /// Options for downloading a file onto a target chip.
 #[derive(Default)]
-pub struct DownloadOptions<'a> {
+pub struct DownloadOptions<'progress> {
     /// An optional progress reporter which is used if this argument is set to Some(...).
-    pub progress: Option<&'a FlashProgress>,
+    pub progress: Option<&'progress FlashProgress>,
     /// If `keep_unwritten_bytes` is `true`, erased portions that are not overwritten by the ELF data
     /// are restored afterwards, such that the old contents are untouched.
     pub keep_unwritten_bytes: bool,
@@ -75,11 +75,11 @@ pub fn download_file(
 /// Downloads a file of given `format` at `path` to the flash of the target given in `session`.
 ///
 /// This will ensure that memory bounderies are honored and does unlocking, erasing and programming of the flash for you.
-pub fn download_file_with_options<'a>(
+pub fn download_file_with_options(
     session: &mut Session,
     path: &Path,
     format: Format,
-    options: DownloadOptions<'a>,
+    options: DownloadOptions<'_>,
 ) -> Result<(), FileDownloadError> {
     let mut file = match File::open(path) {
         Ok(file) => file,

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -65,7 +65,7 @@ pub struct DownloadOptions<'a> {
 ///
 /// If you are looking for more options, have a look at `download_file_with_options`.
 pub fn download_file(
-    session: &Session,
+    session: &mut Session,
     path: &Path,
     format: Format,
 ) -> Result<(), FileDownloadError> {
@@ -76,7 +76,7 @@ pub fn download_file(
 ///
 /// This will ensure that memory bounderies are honored and does unlocking, erasing and programming of the flash for you.
 pub fn download_file_with_options<'a>(
-    session: &Session,
+    session: &mut Session,
     path: &Path,
     format: Format,
     options: DownloadOptions<'a>,
@@ -88,7 +88,7 @@ pub fn download_file_with_options<'a>(
     let mut buffer = vec![];
     let mut buffer_vec = vec![];
     // IMPORTANT: Change this to an actual memory map of a real chip
-    let memory_map = session.memory_map();
+    let memory_map = session.memory_map().clone();
     let mut loader = FlashLoader::new(&memory_map, options.keep_unwritten_bytes);
 
     match format {

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -116,11 +116,11 @@ impl<'s> Flasher<'s> {
             algo.load_address
         );
 
-        core.write_block32(algo.load_address, algo.instructions.as_slice())
+        core.write_32(algo.load_address, algo.instructions.as_slice())
             .map_err(FlashError::Memory)?;
 
         let mut data = vec![0; algo.instructions.len()];
-        core.read_block32(algo.load_address, &mut data)
+        core.read_32(algo.load_address, &mut data)
             .map_err(FlashError::Memory)?;
 
         for (offset, (original, read_back)) in algo.instructions.iter().zip(data.iter()).enumerate()
@@ -661,7 +661,7 @@ impl<'p, O: Operation> ActiveFlasher<'p, O> {
         'p: 'a,
     {
         self.core
-            .read_block8(address, data)
+            .read_8(address, data)
             .map_err(FlashError::Memory)?;
         Ok(())
     }
@@ -744,7 +744,7 @@ impl<'p> ActiveFlasher<'p, Program> {
 
         // Transfer the bytes to RAM.
         self.core
-            .write_block8(self.flash_algorithm.begin_data, bytes)
+            .write_8(self.flash_algorithm.begin_data, bytes)
             .map_err(FlashError::Memory)?;
 
         let result = self.call_function_and_wait(
@@ -820,7 +820,7 @@ impl<'p> ActiveFlasher<'p, Program> {
         // Transfer the buffer bytes to RAM.
         flasher
             .core
-            .write_block8(algo.page_buffers[buffer_number as usize], bytes)
+            .write_8(algo.page_buffers[buffer_number as usize], bytes)
             .map_err(FlashError::Memory)?;
 
         Ok(())

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -91,7 +91,7 @@ impl<'session> Flasher<'session> {
         }
 
         // Attach to memory and core.
-        let mut core = self.session.attach_to_core(0).map_err(FlashError::Memory)?;
+        let mut core = self.session.core(0).map_err(FlashError::Memory)?;
 
         // TODO: Halt & reset target.
         log::debug!("Halting core.");

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -84,7 +84,7 @@ impl<'a, 'b> FlashLoader<'a, 'b> {
     /// If `do_chip_erase` is `true` the entire flash will be erased.
     pub(super) fn commit(
         &mut self,
-        session: &Session,
+        session: &mut Session,
         progress: &FlashProgress,
         do_chip_erase: bool,
     ) -> Result<(), FlashError> {
@@ -107,7 +107,7 @@ impl<'a, 'b> FlashLoader<'a, 'b> {
                 );
             }
 
-            let algorithms: Vec<_> = session.flash_algorithms();
+            let algorithms = session.flash_algorithms();
             let algorithms = algorithms
                 .iter()
                 .filter(|fa| {
@@ -147,7 +147,7 @@ impl<'a, 'b> FlashLoader<'a, 'b> {
             let flash_algorithm = raw_flash_algorithm.assemble(unwrapped_ram);
 
             // Program the data.
-            let mut flasher = Flasher::new(session.clone(), &flash_algorithm, region);
+            let mut flasher = Flasher::new(session, flash_algorithm, region.clone());
             flasher.program(builder, do_chip_erase, self.keep_unwritten, false, progress)?
         }
 

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -8,14 +8,14 @@ use std::collections::HashMap;
 /// Once you are done adding all your data, use `commit()` to flash the data.
 /// The flash loader will make sure to select the appropriate flash region for the right data chunks.
 /// Region crossing data chunks are allowed as long as the regions are contiguous.
-pub(super) struct FlashLoader<'a, 'b> {
-    memory_map: &'a [MemoryRegion],
-    builders: HashMap<FlashRegion, FlashBuilder<'b>>,
+pub(super) struct FlashLoader<'mmap, 'data> {
+    memory_map: &'mmap [MemoryRegion],
+    builders: HashMap<FlashRegion, FlashBuilder<'data>>,
     keep_unwritten: bool,
 }
 
-impl<'a, 'b> FlashLoader<'a, 'b> {
-    pub(super) fn new(memory_map: &'a [MemoryRegion], keep_unwritten: bool) -> Self {
+impl<'mmap, 'data> FlashLoader<'mmap, 'data> {
+    pub(super) fn new(memory_map: &'mmap [MemoryRegion], keep_unwritten: bool) -> Self {
         Self {
             memory_map,
             builders: HashMap::new(),
@@ -25,7 +25,11 @@ impl<'a, 'b> FlashLoader<'a, 'b> {
     /// Stages a chunk of data to be programmed.
     ///
     /// The chunk can cross flash boundaries as long as one flash region connects to another flash region.
-    pub(super) fn add_data(&mut self, mut address: u32, data: &'b [u8]) -> Result<(), FlashError> {
+    pub(super) fn add_data(
+        &mut self,
+        mut address: u32,
+        data: &'data [u8],
+    ) -> Result<(), FlashError> {
         let size = data.len();
         let mut remaining = size;
         while remaining > 0 {

--- a/probe-rs/src/flashing/visualizer.rs
+++ b/probe-rs/src/flashing/visualizer.rs
@@ -7,12 +7,12 @@ use svg::{
 use super::*;
 
 /// A structure which can be used to visualize the built contents of a flash.
-pub struct FlashVisualizer<'a> {
-    flash_layout: &'a FlashLayout,
+pub struct FlashVisualizer<'layout> {
+    flash_layout: &'layout FlashLayout,
 }
 
-impl<'a> FlashVisualizer<'a> {
-    pub(super) fn new(flash_layout: &'a FlashLayout) -> Self {
+impl<'layout> FlashVisualizer<'layout> {
+    pub(super) fn new(flash_layout: &'layout FlashLayout) -> Self {
         Self { flash_layout }
     }
 

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -38,7 +38,7 @@
 //! use probe_rs::Session;
 //! use probe_rs::MemoryInterface;
 //!
-//! let mut session = Session::auto("nrf52")?;
+//! let mut session = Session::auto_attach("nrf52")?;
 //! let mut core = session.core(0)?;
 //!
 //! // Read a block of 50 32 bit words.

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -18,13 +18,13 @@
 //! let probes = Probe::list_all();
 //!
 //! // Use the first probe found.
-//! let probe = probes[0].open()?;
+//! let mut probe = probes[0].open()?;
 //!
 //! // Attach to a chip.
-//! let session = probe.attach("nrf52")?;
+//! let mut session = probe.attach("nrf52")?;
 //!
 //! // Select a core.
-//! let core = session.attach_to_core(0)?;
+//! let mut core = session.attach_to_core(0)?;
 //!
 //! // Halt the attached core.
 //! core.halt()?;

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -24,7 +24,7 @@
 //! let mut session = probe.attach("nrf52")?;
 //!
 //! // Select a core.
-//! let mut core = session.attach_to_core(0)?;
+//! let mut core = session.core(0)?;
 //!
 //! // Halt the attached core.
 //! core.halt()?;
@@ -35,8 +35,11 @@
 //!
 //! ```no_run
 //! # use probe_rs::Error;
-//! use probe_rs::Core;
-//! let core = Core::auto_attach("nrf52")?;
+//! use probe_rs::Session;
+//! use probe_rs::MemoryInterface;
+//!
+//! let mut session = Session::auto("nrf52")?;
+//! let mut core = session.core(0)?;
 //!
 //! // Read a block of 50 32 bit words.
 //! let mut buff = [0u32;50];

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -125,39 +125,39 @@ impl<'probe> Memory<'probe> {
         self.inner.as_ref()
     }
 
-    pub fn memory_interface_mut<'b>(&'b mut self) -> &mut dyn MemoryInterface {
+    pub fn memory_interface_mut(&mut self) -> &mut dyn MemoryInterface {
         self.inner.as_mut()
     }
 
-    pub fn read_word_32<'b>(&'b mut self, address: u32) -> Result<u32, error::Error> {
+    pub fn read_word_32(&mut self, address: u32) -> Result<u32, error::Error> {
         self.inner.read_word_32(address)
     }
 
-    pub fn read_word_8<'b>(&'b mut self, address: u32) -> Result<u8, error::Error> {
+    pub fn read_word_8(&mut self, address: u32) -> Result<u8, error::Error> {
         self.inner.read_word_8(address)
     }
 
-    pub fn read_32<'b>(&'b mut self, address: u32, data: &mut [u32]) -> Result<(), error::Error> {
+    pub fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), error::Error> {
         self.inner.read_32(address, data)
     }
 
-    pub fn read_8<'b>(&'b mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error> {
+    pub fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error> {
         self.inner.read_8(address, data)
     }
 
-    pub fn write_word_32<'b>(&'b mut self, addr: u32, data: u32) -> Result<(), error::Error> {
+    pub fn write_word_32(&mut self, addr: u32, data: u32) -> Result<(), error::Error> {
         self.inner.write_word_32(addr, data)
     }
 
-    pub fn write_word_8<'b>(&'b mut self, addr: u32, data: u8) -> Result<(), error::Error> {
+    pub fn write_word_8(&mut self, addr: u32, data: u8) -> Result<(), error::Error> {
         self.inner.write_word_8(addr, data)
     }
 
-    pub fn write_32<'b>(&'b mut self, addr: u32, data: &[u32]) -> Result<(), error::Error> {
+    pub fn write_32(&mut self, addr: u32, data: &[u32]) -> Result<(), error::Error> {
         self.inner.write_32(addr, data)
     }
 
-    pub fn write_8<'b>(&'b mut self, addr: u32, data: &[u8]) -> Result<(), error::Error> {
+    pub fn write_8(&mut self, addr: u32, data: &[u8]) -> Result<(), error::Error> {
         self.inner.write_8(addr, data)
     }
 }

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -79,7 +79,7 @@ where
 
 pub struct MemoryDummy;
 
-impl<'a> MemoryInterface for MemoryDummy {
+impl<'probe> MemoryInterface for MemoryDummy {
     fn read_word_32(&mut self, _address: u32) -> Result<u32, error::Error> {
         unimplemented!()
     }
@@ -106,12 +106,12 @@ impl<'a> MemoryInterface for MemoryDummy {
     }
 }
 
-pub struct Memory<'a> {
-    inner: Box<dyn MemoryInterface + 'a>,
+pub struct Memory<'probe> {
+    inner: Box<dyn MemoryInterface + 'probe>,
 }
 
-impl<'a> Memory<'a> {
-    pub fn new(memory: impl MemoryInterface + 'a + Sized) -> Memory<'a> {
+impl<'probe> Memory<'probe> {
+    pub fn new(memory: impl MemoryInterface + 'probe + Sized) -> Memory<'probe> {
         Self {
             inner: Box::new(memory),
         }
@@ -162,16 +162,16 @@ impl<'a> Memory<'a> {
     }
 }
 
-pub struct MemoryList<'a>(Vec<Memory<'a>>);
+pub struct MemoryList<'probe>(Vec<Memory<'probe>>);
 
-impl<'a> MemoryList<'a> {
-    pub fn new(memories: Vec<Memory<'a>>) -> Self {
+impl<'probe> MemoryList<'probe> {
+    pub fn new(memories: Vec<Memory<'probe>>) -> Self {
         Self(memories)
     }
 }
 
-impl<'a> std::ops::Deref for MemoryList<'a> {
-    type Target = Vec<Memory<'a>>;
+impl<'probe> std::ops::Deref for MemoryList<'probe> {
+    type Target = Vec<Memory<'probe>>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -1,6 +1,4 @@
 use crate::error;
-use std::cell::{Ref, RefCell, RefMut};
-use std::rc::Rc;
 
 pub trait MemoryInterface {
     /// Read a 32bit word of at `address`.

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -5,103 +5,103 @@ pub trait MemoryInterface {
     ///
     /// The address where the read should be performed at has to be word aligned.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    fn read32(&mut self, address: u32) -> Result<u32, error::Error>;
+    fn read_word_32(&mut self, address: u32) -> Result<u32, error::Error>;
 
     /// Read an 8bit word of at `address`.
-    fn read8(&mut self, address: u32) -> Result<u8, error::Error>;
+    fn read_word_8(&mut self, address: u32) -> Result<u8, error::Error>;
 
     /// Read a block of 32bit words at `address`.
     ///
     /// The number of words read is `data.len()`.
     /// The address where the read should be performed at has to be word aligned.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    fn read_block32(&mut self, address: u32, data: &mut [u32]) -> Result<(), error::Error>;
+    fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), error::Error>;
 
     /// Read a block of 8bit words at `address`.
-    fn read_block8(&mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error>;
+    fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error>;
 
     /// Write a 32bit word at `address`.
     ///
     /// The address where the write should be performed at has to be word aligned.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    fn write32(&mut self, address: u32, data: u32) -> Result<(), error::Error>;
+    fn write_word_32(&mut self, address: u32, data: u32) -> Result<(), error::Error>;
 
     /// Write an 8bit word at `address`.
-    fn write8(&mut self, address: u32, data: u8) -> Result<(), error::Error>;
+    fn write_word_8(&mut self, address: u32, data: u8) -> Result<(), error::Error>;
 
     /// Write a block of 32bit words at `address`.
     ///
     /// The number of words written is `data.len()`.
     /// The address where the write should be performed at has to be word aligned.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    fn write_block32(&mut self, address: u32, data: &[u32]) -> Result<(), error::Error>;
+    fn write_32(&mut self, address: u32, data: &[u32]) -> Result<(), error::Error>;
 
     /// Write a block of 8bit words at `address`.
-    fn write_block8(&mut self, address: u32, data: &[u8]) -> Result<(), error::Error>;
+    fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), error::Error>;
 }
 
 impl<T> MemoryInterface for &mut T
 where
     T: MemoryInterface,
 {
-    fn read32(&mut self, address: u32) -> Result<u32, error::Error> {
-        (*self).read32(address)
+    fn read_word_32(&mut self, address: u32) -> Result<u32, error::Error> {
+        (*self).read_word_32(address)
     }
 
-    fn read8(&mut self, address: u32) -> Result<u8, error::Error> {
-        (*self).read8(address)
+    fn read_word_8(&mut self, address: u32) -> Result<u8, error::Error> {
+        (*self).read_word_8(address)
     }
 
-    fn read_block32(&mut self, address: u32, data: &mut [u32]) -> Result<(), error::Error> {
-        (*self).read_block32(address, data)
+    fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), error::Error> {
+        (*self).read_32(address, data)
     }
 
-    fn read_block8(&mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error> {
-        (*self).read_block8(address, data)
+    fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error> {
+        (*self).read_8(address, data)
     }
 
-    fn write32(&mut self, addr: u32, data: u32) -> Result<(), error::Error> {
-        (*self).write32(addr, data)
+    fn write_word_32(&mut self, addr: u32, data: u32) -> Result<(), error::Error> {
+        (*self).write_word_32(addr, data)
     }
 
-    fn write8(&mut self, addr: u32, data: u8) -> Result<(), error::Error> {
-        (*self).write8(addr, data)
+    fn write_word_8(&mut self, addr: u32, data: u8) -> Result<(), error::Error> {
+        (*self).write_word_8(addr, data)
     }
 
-    fn write_block32(&mut self, addr: u32, data: &[u32]) -> Result<(), error::Error> {
-        (*self).write_block32(addr, data)
+    fn write_32(&mut self, addr: u32, data: &[u32]) -> Result<(), error::Error> {
+        (*self).write_32(addr, data)
     }
 
-    fn write_block8(&mut self, addr: u32, data: &[u8]) -> Result<(), error::Error> {
-        (*self).write_block8(addr, data)
+    fn write_8(&mut self, addr: u32, data: &[u8]) -> Result<(), error::Error> {
+        (*self).write_8(addr, data)
     }
 }
 
 pub struct MemoryDummy;
 
 impl<'a> MemoryInterface for MemoryDummy {
-    fn read32(&mut self, _address: u32) -> Result<u32, error::Error> {
+    fn read_word_32(&mut self, _address: u32) -> Result<u32, error::Error> {
         unimplemented!()
     }
-    fn read8(&mut self, _address: u32) -> Result<u8, error::Error> {
+    fn read_word_8(&mut self, _address: u32) -> Result<u8, error::Error> {
         unimplemented!()
     }
-    fn read_block32(&mut self, _address: u32, _data: &mut [u32]) -> Result<(), error::Error> {
+    fn read_32(&mut self, _address: u32, _data: &mut [u32]) -> Result<(), error::Error> {
         unimplemented!()
     }
-    fn read_block8(&mut self, _address: u32, _data: &mut [u8]) -> Result<(), error::Error> {
+    fn read_8(&mut self, _address: u32, _data: &mut [u8]) -> Result<(), error::Error> {
         unimplemented!()
     }
-    fn write32(&mut self, _address: u32, _data: u32) -> Result<(), error::Error> {
+    fn write_word_32(&mut self, _address: u32, _data: u32) -> Result<(), error::Error> {
         unimplemented!()
     }
-    fn write8(&mut self, _address: u32, _data: u8) -> Result<(), error::Error> {
+    fn write_word_8(&mut self, _address: u32, _data: u8) -> Result<(), error::Error> {
         unimplemented!()
     }
-    fn write_block32(&mut self, _address: u32, _data: &[u32]) -> Result<(), error::Error> {
+    fn write_32(&mut self, _address: u32, _data: &[u32]) -> Result<(), error::Error> {
         unimplemented!()
     }
-    fn write_block8(&mut self, _address: u32, _data: &[u8]) -> Result<(), error::Error> {
+    fn write_8(&mut self, _address: u32, _data: &[u8]) -> Result<(), error::Error> {
         unimplemented!()
     }
 }
@@ -129,44 +129,36 @@ impl<'a> Memory<'a> {
         self.inner.as_mut()
     }
 
-    pub fn read32<'b>(&'b mut self, address: u32) -> Result<u32, error::Error> {
-        self.inner.read32(address)
+    pub fn read_word_32<'b>(&'b mut self, address: u32) -> Result<u32, error::Error> {
+        self.inner.read_word_32(address)
     }
 
-    pub fn read8<'b>(&'b mut self, address: u32) -> Result<u8, error::Error> {
-        self.inner.read8(address)
+    pub fn read_word_8<'b>(&'b mut self, address: u32) -> Result<u8, error::Error> {
+        self.inner.read_word_8(address)
     }
 
-    pub fn read_block32<'b>(
-        &'b mut self,
-        address: u32,
-        data: &mut [u32],
-    ) -> Result<(), error::Error> {
-        self.inner.read_block32(address, data)
+    pub fn read_32<'b>(&'b mut self, address: u32, data: &mut [u32]) -> Result<(), error::Error> {
+        self.inner.read_32(address, data)
     }
 
-    pub fn read_block8<'b>(
-        &'b mut self,
-        address: u32,
-        data: &mut [u8],
-    ) -> Result<(), error::Error> {
-        self.inner.read_block8(address, data)
+    pub fn read_8<'b>(&'b mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error> {
+        self.inner.read_8(address, data)
     }
 
-    pub fn write32<'b>(&'b mut self, addr: u32, data: u32) -> Result<(), error::Error> {
-        self.inner.write32(addr, data)
+    pub fn write_word_32<'b>(&'b mut self, addr: u32, data: u32) -> Result<(), error::Error> {
+        self.inner.write_word_32(addr, data)
     }
 
-    pub fn write8<'b>(&'b mut self, addr: u32, data: u8) -> Result<(), error::Error> {
-        self.inner.write8(addr, data)
+    pub fn write_word_8<'b>(&'b mut self, addr: u32, data: u8) -> Result<(), error::Error> {
+        self.inner.write_word_8(addr, data)
     }
 
-    pub fn write_block32<'b>(&'b mut self, addr: u32, data: &[u32]) -> Result<(), error::Error> {
-        self.inner.write_block32(addr, data)
+    pub fn write_32<'b>(&'b mut self, addr: u32, data: &[u32]) -> Result<(), error::Error> {
+        self.inner.write_32(addr, data)
     }
 
-    pub fn write_block8<'b>(&'b mut self, addr: u32, data: &[u8]) -> Result<(), error::Error> {
-        self.inner.write_block8(addr, data)
+    pub fn write_8<'b>(&'b mut self, addr: u32, data: &[u8]) -> Result<(), error::Error> {
+        self.inner.write_8(addr, data)
     }
 }
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -136,7 +136,7 @@ impl Session {
     /// Automatically creates a session from a single attached probe.
     ///
     /// This will fail to attach if there is not exactly one probe discovered.
-    pub fn auto(target: impl Into<TargetSelector>) -> Result<Session, Error> {
+    pub fn auto_attach(target: impl Into<TargetSelector>) -> Result<Session, Error> {
         // Get a list of all available debug probes.
         let probes = Probe::list_all();
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -1,37 +1,29 @@
 use crate::architecture::{
-    arm::{memory::ADIMemoryInterface, ArmChipInfo, ArmCommunicationInterface},
-    riscv::communication_interface::RiscvCommunicationInterface,
+    arm::{ArmChipInfo, ArmCommunicationInterface, ArmCommunicationInterfaceState},
+    riscv::communication_interface::{
+        RiscvCommunicationInterface, RiscvCommunicationInterfaceState,
+    },
 };
 use crate::config::{
     ChipInfo, MemoryRegion, RawFlashAlgorithm, RegistryError, Target, TargetSelector,
 };
 use crate::core::Architecture;
-use crate::{Core, CoreList, Error, Memory, MemoryList, Probe};
-use std::cell::RefCell;
-use std::rc::Rc;
+use crate::{Core, CoreType, DebugProbeError, Error, Probe};
 
-#[derive(Clone)]
 pub struct Session {
-    inner: Rc<RefCell<InnerSession>>,
-}
-
-struct InnerSession {
     target: Target,
-    architecture_session: ArchitectureSession,
+    probe: Probe,
+    cores: Vec<(CoreType, ArchitectureState)>,
 }
 
-enum ArchitectureSession {
-    Arm(ArmCommunicationInterface),
-    Riscv(RiscvCommunicationInterface),
+pub enum ArchitectureState {
+    Arm(ArmCommunicationInterfaceState),
+    Riscv(RiscvCommunicationInterfaceState),
 }
 
 impl Session {
     /// Open a new session with a given debug target
-    pub fn new(probe: Probe, target: impl Into<TargetSelector>) -> Result<Self, Error> {
-        // TODO: Handle different architectures
-
-        let mut generic_probe = Some(probe);
-
+    pub fn new(mut probe: Probe, target: impl Into<TargetSelector>) -> Result<Self, Error> {
         let target = match target.into() {
             TargetSelector::Unspecified(name) => {
                 match crate::config::registry::get_target_by_name(name) {
@@ -41,178 +33,107 @@ impl Session {
             }
             TargetSelector::Specified(target) => target,
             TargetSelector::Auto => {
-                let (returned_probe, found_chip) =
-                    try_arm_autodetect(generic_probe.take().unwrap());
+                let mut found_chip = None;
 
-                // Ignore errors during autodetect
-                let found_chip = found_chip.unwrap_or_else(|e| {
-                    log::debug!("Error during autodetect: {}", e);
-                    None
-                });
+                let state = &mut ArmCommunicationInterfaceState::new(&mut probe)?;
+                let interface = ArmCommunicationInterface::new(&mut probe, state)?;
+                if let Some(interface) = interface {
+                    let chip_result = try_arm_autodetect(interface);
 
-                generic_probe = Some(returned_probe);
+                    // Ignore errors during autodetect
+                    found_chip = chip_result.unwrap_or_else(|e| {
+                        log::debug!("An error occured during ARM autodetect: {}", e);
+                        None
+                    });
+                } else {
+                    log::debug!("No DAP interface was present. This is not an ARM core. Skipping ARM autodetect.");
+                }
 
-                if found_chip.is_none() && generic_probe.as_ref().unwrap().has_jtag_interface() {
-                    let riscv_interface =
-                        RiscvCommunicationInterface::new(generic_probe.take().unwrap())?;
+                if found_chip.is_none() && probe.has_jtag_interface() {
+                    let state = &mut RiscvCommunicationInterfaceState::new(&mut probe)?;
+                    let interface = RiscvCommunicationInterface::new(&mut probe, state)?;
 
-                    let idcode = riscv_interface.read_idcode();
+                    if let Some(mut interface) = interface {
+                        let idcode = interface.read_idcode();
 
-                    log::debug!("ID Code read over JTAG: {:x?}", idcode);
+                        log::debug!("ID Code read over JTAG: {:x?}", idcode);
+                    } else {
+                        log::debug!("No JTAG interface was present. Skipping Riscv autodetect.");
+                    }
 
                     // TODO: Implement autodetect for RISC-V
-
-                    // This will always work, the interface is created and used only in this function
-                    generic_probe = Some(riscv_interface.close().unwrap());
                 }
 
                 if let Some(chip) = found_chip {
                     crate::config::registry::get_target_by_chip_info(chip)?
                 } else {
-                    // Not sure if this is ok.
                     return Err(Error::ChipNotFound(RegistryError::ChipAutodetectFailed));
                 }
             }
         };
 
-        let session = match target.architecture() {
+        let core = match target.architecture() {
             Architecture::ARM => {
-                let arm_interface = ArmCommunicationInterface::new(generic_probe.unwrap())
-                    .map_err(|(_probe, err)| err)?;
-                ArchitectureSession::Arm(arm_interface)
-            }
-            Architecture::RISCV => {
-                let riscv_interface = RiscvCommunicationInterface::new(generic_probe.unwrap())?;
-                ArchitectureSession::Riscv(riscv_interface)
-            }
+                let arm_interface = ArmCommunicationInterfaceState::new(&mut probe)?;
+                (target.core_type, ArchitectureState::Arm(arm_interface))
+            } // Architecture::RISCV => {
+            //     let riscv_interface = RiscvCommunicationInterface::new(generic_probe.unwrap())?;
+            //     ArchitectureState::Riscv(riscv_interface)
+            // }
+            _ => unimplemented!(),
         };
 
         Ok(Self {
-            inner: Rc::new(RefCell::new(InnerSession {
-                target,
-                architecture_session: session,
-            })),
+            target,
+            probe,
+            cores: vec![core],
         })
     }
 
-    pub fn list_cores(&self) -> CoreList {
-        CoreList::new(vec![self.inner.borrow().target.core_type])
+    pub fn list_cores<'a>(&'a self) -> &'a Vec<(CoreType, ArchitectureState)> {
+        &self.cores
     }
 
-    pub fn attach_to_core(&self, n: usize) -> Result<Core, Error> {
-        let core = *self
-            .list_cores()
-            .get(n)
+    pub fn list_cores_mut<'a>(&'a mut self) -> &'a mut Vec<(CoreType, ArchitectureState)> {
+        &mut self.cores
+    }
+
+    pub fn attach_to_core<'a: 'p, 'p>(&'a mut self, n: usize) -> Result<Core<'p>, Error> {
+        let (core, state) = self
+            .cores
+            .get_mut(n)
             .ok_or_else(|| Error::CoreNotFound(n))?;
 
-        match self.inner.borrow().architecture_session {
-            ArchitectureSession::Arm(ref arm_interface) => core.attach_arm(arm_interface.clone()),
-            ArchitectureSession::Riscv(ref riscv_interface) => {
-                core.attach_riscv(riscv_interface.clone())
-            }
+        match state {
+            ArchitectureState::Arm(state) => core.attach_arm(
+                ArmCommunicationInterface::new(&mut self.probe, state)?
+                    .ok_or_else(|| DebugProbeError::InterfaceNotAvailable("DAP"))?,
+            ),
+            ArchitectureState::Riscv(state) => core.attach_riscv(
+                RiscvCommunicationInterface::new(&mut self.probe, state)?
+                    .ok_or_else(|| DebugProbeError::InterfaceNotAvailable("DAP"))?,
+            ),
         }
     }
 
-    pub fn list_memories(&self) -> MemoryList {
-        MemoryList::new(vec![])
+    pub fn flash_algorithms(&self) -> &Vec<RawFlashAlgorithm> {
+        &self.target.flash_algorithms
     }
 
-    pub fn attach_to_memory(&self, _id: usize) -> Result<Memory, Error> {
-        match self.inner.borrow().architecture_session {
-            ArchitectureSession::Arm(ref interface) => {
-                if let Some(memory) = interface.dedicated_memory_interface()? {
-                    Ok(memory)
-                } else {
-                    // TODO: Change this to actually grab the proper memory IF.
-                    // For now always use the ARM IF.
-                    Ok(Memory::new(
-                        ADIMemoryInterface::<ArmCommunicationInterface>::new(interface.clone(), 0)
-                            .map_err(Error::architecture_specific)?,
-                    ))
-                }
-            }
-            ArchitectureSession::Riscv(ref _interface) => {
-                // We don't need a memory interface..
-                Ok(Memory::new_dummy())
-            }
-        }
-    }
-
-    pub fn flash_algorithms(&self) -> Vec<RawFlashAlgorithm> {
-        self.inner.borrow().target.flash_algorithms.clone()
-    }
-
-    pub fn memory_map(&self) -> Vec<MemoryRegion> {
-        self.inner.borrow().target.memory_map.clone()
+    pub fn memory_map(&self) -> &Vec<MemoryRegion> {
+        &self.target.memory_map
     }
 }
 
-fn try_arm_autodetect(probe: Probe) -> (Probe, Result<Option<ChipInfo>, Error>) {
-    if probe.has_dap_interface() {
-        log::debug!("Autodetect: Trying DAP interface...");
+fn try_arm_autodetect(arm_interface: ArmCommunicationInterface) -> Result<Option<ChipInfo>, Error> {
+    log::debug!("Autodetect: Trying DAP interface...");
 
-        let arm_interface = ArmCommunicationInterface::new(probe);
+    let found_chip = ArmChipInfo::read_from_rom_table(arm_interface).unwrap_or_else(|e| {
+        log::info!("Error during auto-detection of ARM chips: {}", e);
+        None
+    });
 
-        match arm_interface {
-            Ok(mut arm_interface) => {
-                let found_chip = ArmChipInfo::read_from_rom_table(&mut arm_interface)
-                    .unwrap_or_else(|e| {
-                        log::info!("Error during auto-detection of ARM chips: {}", e);
-                        None
-                    });
+    let found_chip = found_chip.map(ChipInfo::from);
 
-                // This will always work, the interface is created and used only in this function
-                let probe = arm_interface.close().unwrap();
-
-                let found_chip = found_chip.map(ChipInfo::from);
-
-                (probe, Ok(found_chip))
-            }
-            Err((probe, error)) => (probe, Err(error.into())),
-        }
-    } else {
-        log::debug!("No DAP interface available on Probe");
-
-        (probe, Ok(None))
-    }
+    Ok(found_chip)
 }
-
-// pub struct Session {
-//     probe: Probe,
-// }
-
-// pub trait Session {
-//     fn get_core(n: usize) -> Result<Core, Error>;
-// }
-
-// pub struct ArmSession {
-//     pub target: Target,
-//     pub probe: Rc<RefCell<dyn DAPAccess>>,
-// }
-
-// impl ArmSession {
-//     pub fn new(target: Target, probe: impl DAPAccess) -> Self {
-//         Self {
-//             target,
-//             probe: Rc::new(RefCell::new(probe)),
-//         }
-//     }
-// }
-
-// pub struct RiscVSession {
-//     pub target: Target,
-//     pub probe: Rc<RefCell<dyn DAPAccess>>,
-// }
-
-// impl RiscVSession {
-//     pub fn new(target: Target, probe: impl DAPAccess) -> Self {
-//         Self {
-//             target,
-//             probe: Rc::new(RefCell::new(probe)),
-//         }
-//     }
-// }
-
-// impl Session for RiscVSession {
-//     fn get_core(n: usize) -> Result<Core, Error> {}
-// }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -133,6 +133,21 @@ impl Session {
         })
     }
 
+    /// Automatically creates a session from a single attached probe.
+    ///
+    /// This will fail to attach if there is not exactly one probe discovered.
+    pub fn auto(target: impl Into<TargetSelector>) -> Result<Session, Error> {
+        // Get a list of all available debug probes.
+        let probes = Probe::list_all();
+
+        // Use the first probe found.
+        let probe = probes[0].open()?;
+
+        // Attach to a chip.
+        probe.attach(target)
+    }
+
+    /// Lists the available cores with their number and their type.
     pub fn list_cores(&self) -> Vec<(usize, CoreType)> {
         self.cores
             .iter()
@@ -141,7 +156,8 @@ impl Session {
             .collect()
     }
 
-    pub fn attach_to_core(&mut self, n: usize) -> Result<Core<'_>, Error> {
+    /// Attaches to the core with the given number.
+    pub fn core(&mut self, n: usize) -> Result<Core<'_>, Error> {
         let (core, core_state) = self
             .cores
             .get_mut(n)
@@ -151,11 +167,13 @@ impl Session {
             .attach(&mut self.probe, core, core_state)
     }
 
-    pub fn flash_algorithms(&self) -> &[RawFlashAlgorithm] {
+    /// Returns a list of the flash algotithms on the target.
+    pub(crate) fn flash_algorithms(&self) -> &[RawFlashAlgorithm] {
         &self.target.flash_algorithms
     }
 
-    pub fn memory_map(&self) -> &[MemoryRegion] {
+    /// Returns the memory map of the target.
+    pub(crate) fn memory_map(&self) -> &[MemoryRegion] {
         &self.target.memory_map
     }
 }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -89,7 +89,6 @@ impl Session {
                     ArchitectureState::Riscv(riscv_interface),
                 )
             }
-            _ => unimplemented!(),
         };
 
         Ok(Self {

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -98,17 +98,15 @@ impl Session {
         })
     }
 
-    pub fn list_cores<'a>(&'a self) -> &'a Vec<(CoreType, CoreState, ArchitectureState)> {
+    pub fn list_cores(&self) -> &Vec<(CoreType, CoreState, ArchitectureState)> {
         &self.cores
     }
 
-    pub fn list_cores_mut<'a>(
-        &'a mut self,
-    ) -> &'a mut Vec<(CoreType, CoreState, ArchitectureState)> {
+    pub fn list_cores_mut(&mut self) -> &mut Vec<(CoreType, CoreState, ArchitectureState)> {
         &mut self.cores
     }
 
-    pub fn attach_to_core<'a: 'p, 'p>(&'a mut self, n: usize) -> Result<Core<'p>, Error> {
+    pub fn attach_to_core(&mut self, n: usize) -> Result<Core<'_>, Error> {
         let (core, core_state, architecture_state) = self
             .cores
             .get_mut(n)

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -133,9 +133,7 @@ impl Session {
         })
     }
 
-    /// Automatically creates a session from a single attached probe.
-    ///
-    /// This will fail to attach if there is not exactly one probe discovered.
+    /// Automatically creates a session with the first connected probe found.
     pub fn auto_attach(target: impl Into<TargetSelector>) -> Result<Session, Error> {
         // Get a list of all available debug probes.
         let probes = Probe::list_all();


### PR DESCRIPTION
# What

This PR is intended to adjust the probe-rs API just slightly, such that the user can use it as conveniently as before while being threadsafe.

# Why

Before this change, the `Core`, `Memory`, `Session` etc. structs all contained an `Rc<RefCell<dyn T>>` with `T` being the respective interface trait. This enabled us to have `Core`, `Memory`, `Session` etc. implement clone such that the user could pass around objects conveniently without ever worrying about lifetimes etc.

While this is not very nice from an engineering view, it also can't be used across threads due to the nature of `RefCell<T>`.

# How

While it is possible to just always operate probe-rs single threaded with taking turns on reading/writing to the probe and basically do this polling based, this is not very nice for implementers to use.

A GDB server couldn't be self contained, only borrowing a `Session` object with that approach. It would have to provide some inner machinery that an outside read/write-poller could notify it when there is new data. This could be done with channels/message-queues.

This approach seems very cumbersome to me, since maybe someone would implement a GDB server using the standard single-threaded probe-rs API and someone would implement an ITM reader using the channel-based API. Now we have two applications that are not really compatible and require lots of glue. Not to speak of the additional effort needed to essentially maintain two APIs.

If we assume that we don't want this alternative API, we need to look elsewhere.
There is two possible solutions I see here.

## Approach1: Use internal `Arc<Mutex<dyn T>>`s as a thread-safe replacement for the `Rc<RefCell<dyn T>>`
This solution seems doable, but to me poses great potential to shoot yourself in the leg as a user.
For example, assume the implementor of the `CoreInterface` implements its two hypothetical methods `a` and `b` like this:

```rust
impl CoreInterface for FictionalCore {
    fn a(&self) {
        let handle = self.inner.lock().unwrap();
        do_sth_with_handle(handle);
    }

    fn b(&self) {
        let handle = self.inner.lock().unwrap();
        do_sth_with_handle(handle);
        self.a() // We constructed a deadlock.
    }
}
```

Also, now we would need different locks on different levels which, to me, sounds like there is potential fuckups luring everywhere.

When I initially worked on the 0.5.0 (current) API, I asked many Rust folks on the discord about the design and they all explicitly told me not to do this and leave locking to the user.
For very much those reasons mentioned above and some more I cannot really recall.
I felt like I was smarter and now I payed the price of having to overhaul this now.

## Approach 2 (this implementation): The session object creates temporary handles
The approach I chose here and I like very much is simple from a layer perspective:

You start with a `Probe` which, together with a `Target` describing the target attached, will be consumed by a `Session` struct.

The `Session` struct then provides temporary views into the target, such as a `Core` or later on a `Memory`.
Those views are a struct containing a `&mut Probe` and possibly a state (for the `Core` it is for example the used breakpoints) struct. Both are borrowed from the `Session` once you have full ownership/borrowership of the `Session`.

Once you are done working with your `Core` view, it goes out of scope, full ownership of the `Session` is regained.

For a single threaded environment, this didn't change anything at all, API-wise, except that the `Core<'p>` now has a lifetime argument to carry, which is needed for the internal reference to the `Probe`. You can still store the `Core<'a>` in a structure for later usage if you only care about your single thread. The API even got a bit cleaner internally, since we got rid of all the `Rc<RefCell<T>>`s and we don't have to `self.inner.borrow().do_stuff()` all the time anymore.
Now that I think about it, we maybe could now implement `DeRef<CoreInterface> for Core` too. Not sure, maybe someone knows this?

The only thing that I have no solution for for single threadded use is this:

```rust
pub fn auto_attach(target: impl Into<TargetSelector>) -> Result<Core<'a>, error::Error> {
        // Get a list of all available debug probes.
        let probes = Probe::list_all();

        // Use the first probe found.
        let probe = probes[0].open()?; // Lives until the end of the scope.

        // Attach to a chip.
        let session = probe.attach(target)?; // Lives until the end of the scope.

        // Select a core.
        session.attach_to_core(0) // ERROR: Borrows the probe for 'a which lives longer than the scope.
}
```
I don't think this is possible anymore, but I think just creating the session is enough.

For multi-threaded use, the API is ofc the same. All you do on top of that is wrap the `Session` struct in a `Arc<Mutex<Session>>` and lock on that once you need it. You get your core via `Session::attach_to_core(0)`, work with it and once you are done, you let it go out of scope, then the lock goes out of scope and the next user can take it's turn on `Session`.

# Final words

I hope this sums it up pretty well. If there is any concerns or hints how to make this even better, please post this here. Any input is valuable.

I have to say that I kinda love this approach, as it seems very clean and is promising to solve all out problems without any kind of API-cumbersomeness introduced.

Also the lifetime elision is so good nowadays, that there is really close to no need of ever specifying a lifetime manually!

Cheers
Yatekii