### PR TITLE
Modifications to allow an external nrf-recover utility

### DIFF
--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -1,12 +1,12 @@
 #[macro_use]
 mod register_generation;
-pub(crate) mod custom_ap;
+pub mod custom_ap;
 pub(crate) mod generic_ap;
 pub(crate) mod memory_ap;
 
 use crate::architecture::arm::dp::DebugPortError;
 
-pub use generic_ap::{APClass, GenericAP, IDR};
+pub use generic_ap::{APClass, APType, GenericAP, IDR};
 pub(crate) use memory_ap::mock;
 pub use memory_ap::{
     AddressIncrement, BaseaddrFormat, DataSize, MemoryAP, BASE, BASE2, CSW, DRW, TAR,

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -1,7 +1,7 @@
 use super::{
     ap::{
-        valid_access_ports, APAccess, APClass, APRegister, AccessPort, BaseaddrFormat, GenericAP,
-        MemoryAP, BASE, BASE2, IDR,
+        custom_ap::CtrlAP, valid_access_ports, APAccess, APClass, APRegister, AccessPort,
+        BaseaddrFormat, GenericAP, MemoryAP, BASE, BASE2, IDR,
     },
     dp::{
         Abort, Ctrl, DPAccess, DPBankSel, DPRegister, DebugPortError, DebugPortId,
@@ -523,6 +523,39 @@ where
     fn read_ap_register_repeated(
         &mut self,
         port: GenericAP,
+        register: R,
+        values: &mut [u32],
+    ) -> Result<(), Self::Error> {
+        self.read_ap_register_repeated(port, register, values)
+    }
+}
+
+impl<'probe, R> APAccess<CtrlAP, R> for ArmCommunicationInterface<'probe>
+where
+    R: APRegister<CtrlAP>,
+{
+    type Error = DebugProbeError;
+
+    fn read_ap_register(&mut self, port: CtrlAP, register: R) -> Result<R, Self::Error> {
+        self.read_ap_register(port, register)
+    }
+
+    fn write_ap_register(&mut self, port: CtrlAP, register: R) -> Result<(), Self::Error> {
+        self.write_ap_register(port, register)
+    }
+
+    fn write_ap_register_repeated(
+        &mut self,
+        port: CtrlAP,
+        register: R,
+        values: &[u32],
+    ) -> Result<(), Self::Error> {
+        self.write_ap_register_repeated(port, register, values)
+    }
+
+    fn read_ap_register_repeated(
+        &mut self,
+        port: CtrlAP,
         register: R,
         values: &mut [u32],
     ) -> Result<(), Self::Error> {

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -88,5 +88,7 @@ pub use crate::core::{
 };
 pub use crate::error::Error;
 pub use crate::memory::{Memory, MemoryInterface, MemoryList};
-pub use crate::probe::{DebugProbe, DebugProbeError, DebugProbeInfo, Probe, WireProtocol};
+pub use crate::probe::{
+    DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeType, Probe, WireProtocol,
+};
 pub use crate::session::Session;

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -383,7 +383,7 @@ pub trait DebugProbe: Send + Sync + fmt::Debug {
     fn get_interface_jtag_mut(&mut self) -> Option<&mut dyn JTAGAccess>;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DebugProbeType {
     DAPLink,
     STLink,


### PR DESCRIPTION
I realized that the `nrf-recover` method is no longer included, which makes sense, it's probably not a good idea to start maintaining very vendor specific code, that's why I wrote an external utility to use probe-rs to do this, but I need these changes to make it work.