### PR TITLE
Rework DAPlink scanning for new ProbeSelector

### DIFF
--- a/probe-rs/src/probe/daplink/tools.rs
+++ b/probe-rs/src/probe/daplink/tools.rs
@@ -205,15 +205,15 @@ pub fn open_device_from_selector(
     match hid_device {
         Ok(device) => {
             match device.get_product_string() {
-                Ok(Some(s)) if s.contains("CMSIS-DAP") =>
-                    Ok(DAPLinkDevice::V1(device)),
-                _ =>
+                Ok(Some(s)) if s.contains("CMSIS-DAP") => Ok(DAPLinkDevice::V1(device)),
+                _ => {
                     // Return NotFound if this VID:PID was not a valid CMSIS-DAP probe,
                     // or if it couldn't be opened, so that other probe modules can
                     // attempt to open it instead.
-                    Err(ProbeCreationError::NotFound),
+                    Err(ProbeCreationError::NotFound)
+                }
             }
-        },
+        }
 
         // If hidapi couldn't open the device, it may be because this is not
         // a HID device at all and some other probe module should try to load


### PR DESCRIPTION
This is a PR against #246 to slightly rejig the DAPlink part.

I moved the check that the device is valid to after checking the VID/PID inside the loop, which reduces unnecessary device opening/reading, and rework the HID fallback logic so we don't need the duplicated code and instead check that the HID device is a CMSIS-DAP probe before returning it.

I've tested this on a system with two DAPlink and one STlink devices running at once and was able to select any of them correctly by VID:PID or by VID:PID:SN.