### PR TITLE
Start using anyhow for errors and get rid of manual error stacking

### DIFF
--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use probe_rs::{
     architecture::arm::{
-        ap::{valid_access_ports, APAccess, APClass, BaseaddrFormat, MemoryAP, BASE, BASE2, IDR},
+        ap::{valid_access_ports, APClass, BaseaddrFormat, MemoryAP, BASE, BASE2, IDR},
         memory::{ADIMemoryInterface, CSComponent},
         ArmCommunicationInterface, ArmCommunicationInterfaceState,
     },

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -40,6 +40,7 @@ thiserror = "1.0.10"
 jaylink = "0.1.1"
 base64 = "0.12.0"
 svg = "0.7.1"
+anyhow = "1.0.31"
 
 [build-dependencies]
 probe-rs-t2rust  = { path = "../probe-rs-t2rust", version ="0.6.0" }

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -34,7 +34,7 @@ pub enum AccessPortError {
     },
     #[error("Out of bounds access")]
     OutOfBoundsError,
-    #[error("Error while communicating with debug port: {0}")]
+    #[error("Error while communicating with debug port")]
     DebugPort(#[from] DebugPortError),
 }
 

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -16,7 +16,7 @@ pub enum DebugPortError {
         register: &'static str,
         version: DebugPortVersion,
     },
-    #[error("A Debug Probe Error occured: {0}")]
+    #[error("A Debug Probe Error occured")]
     DebugProbe(#[from] DebugProbeError),
 }
 

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -16,7 +16,7 @@ pub enum RomTableError {
     ),
     #[error("The CoreSight Component could not be identified")]
     CSComponentIdentification,
-    #[error("Something during memory interaction went wrong")]
+    #[error("Could not access romtable")]
     Memory(#[source] Error),
 }
 

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 pub(crate) enum RiscvError {
     #[error("Error during read/write to the DMI register: {0:?}")]
     DmiTransfer(DmiOperationStatus),
-    #[error("Debug Probe Error: {0}")]
+    #[error("Debug Probe Error")]
     DebugProbe(#[from] DebugProbeError),
     #[error("Timeout during JTAG register access.")]
     Timeout,

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -29,9 +29,9 @@ pub enum RegistryError {
     RamMissing,
     #[error("No flash description was found.")]
     FlashMissing,
-    #[error("An IO error was encountered: {0}")]
+    #[error("An IO error was encountered")]
     Io(#[from] std::io::Error),
-    #[error("Deserializing the yaml encountered an error: {0}")]
+    #[error("Deserializing the yaml encountered an error")]
     Yaml(#[from] serde_yaml::Error),
     #[error("Unable to lock registry")]
     LockUnavailable,

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -24,15 +24,15 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum DebugError {
-    #[error("IO Error while accessing debug data: {0}")]
+    #[error("IO Error while accessing debug data")]
     Io(#[from] io::Error),
-    #[error("Error accessing debug data: {0}")]
+    #[error("Error accessing debug data")]
     DebugData(#[from] object::read::Error),
-    #[error("Error parsing debug data: {0}")]
+    #[error("Error parsing debug data")]
     Parse(#[from] gimli::read::Error),
-    #[error("Non-UTF8 data found in debug data: {0}")]
+    #[error("Non-UTF8 data found in debug data")]
     NonUtf8(#[from] Utf8Error),
-    #[error("Error using the probe: {0}")]
+    #[error("Error using the probe")]
     Probe(#[from] crate::Error),
 }
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -4,15 +4,15 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("An error with the usage of the probe occured: {0}")]
+    #[error("An error with the usage of the probe occured")]
     Probe(#[from] DebugProbeError),
-    #[error("A core architecture specific error occured: {0}")]
+    #[error("A core architecture specific error occured")]
     ArchitectureSpecific(#[from] Box<dyn std::error::Error + Send + Sync>),
     #[error("Probe could not be opened: {0}")]
     UnableToOpenProbe(&'static str),
     #[error("Core {0} does not exist")]
     CoreNotFound(usize),
-    #[error("Unable to load specification for chip: {0}")]
+    #[error("Unable to load specification for chip")]
     ChipNotFound(#[from] RegistryError),
 }
 

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -34,15 +34,15 @@ pub enum Format {
 /// OS permission issues as well as chip connectivity and memory boundary issues.
 #[derive(Debug, Error)]
 pub enum FileDownloadError {
-    #[error("{0}")]
+    #[error("Error while flashing")]
     Flash(#[from] FlashError),
-    #[error("{0}")]
+    #[error("Could not read ihex format")]
     IhexRead(#[from] ihex::reader::ReaderError),
-    #[error("{0}")]
+    #[error("I/O error")]
     IO(#[from] std::io::Error),
     #[error("Object Error: {0}.")]
     Object(&'static str),
-    #[error("{0}")]
+    #[error("Could not read ELF file")]
     Elf(#[from] goblin::error::Error),
     #[error("No loadable ELF sections were found.")]
     NoLoadableSegments,

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -12,9 +12,9 @@ pub enum FlashError {
     RoutineNotSupported(&'static str),
     #[error("Buffer {n}/{max} does not exist")]
     InvalidBufferNumber { n: usize, max: usize },
-    #[error("Something during memory interaction went wrong: {0}")]
+    #[error("Something during memory interaction went wrong")]
     Memory(#[source] error::Error),
-    #[error("Something during the interaction with the core went wrong: {0}")]
+    #[error("Something during the interaction with the core went wrong")]
     Core(#[source] error::Error),
     #[error("{address} is not contained in {region:?}")]
     AddressNotInRegion { address: u32, region: FlashRegion },
@@ -36,4 +36,6 @@ pub enum FlashError {
     NoSuitableFlash { start: u32, end: u32 },
     #[error("Trying to write flash, but no suitable flash loader algorithm is linked to the given target information.")]
     NoFlashLoaderAlgorithmAttached,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }

--- a/probe-rs/src/probe/daplink/commands/general/connect.rs
+++ b/probe-rs/src/probe/daplink/commands/general/connect.rs
@@ -1,4 +1,5 @@
 use super::super::{Category, CmsisDapError, Request, Response, Result};
+use anyhow::{anyhow, Context};
 
 #[derive(Clone, Copy)]
 pub enum ConnectRequest {
@@ -28,7 +29,12 @@ impl Response for ConnectResponse {
             0 => Ok(ConnectResponse::InitFailed),
             1 => Ok(ConnectResponse::SuccessfulInitForSWD),
             2 => Ok(ConnectResponse::SuccessfulInitForJTAG),
-            _ => Err(CmsisDapError::UnexpectedAnswer),
+            _ => Err(anyhow!(CmsisDapError::UnexpectedAnswer)).with_context(|| {
+                format!(
+                    "Connecting to target failed, received: {:x}",
+                    buffer[offset]
+                )
+            }),
         }
     }
 }

--- a/probe-rs/src/probe/daplink/commands/general/info.rs
+++ b/probe-rs/src/probe/daplink/commands/general/info.rs
@@ -1,5 +1,6 @@
 use super::super::{Category, CmsisDapError, Request, Response, Result};
 
+use anyhow::anyhow;
 use scroll::{Pread, LE};
 
 #[allow(unused)]
@@ -107,7 +108,7 @@ impl Response for Capabilities {
                 swo_streaming_trace_implemented: buffer[offset + 2] & 0x40 > 0,
             })
         } else {
-            Err(CmsisDapError::UnexpectedAnswer)
+            Err(anyhow!(CmsisDapError::UnexpectedAnswer))
         }
     }
 }
@@ -122,7 +123,7 @@ impl Response for TestDomainTime {
                 .expect("This is a bug. Please report it.");
             Ok(TestDomainTime(res))
         } else {
-            Err(CmsisDapError::UnexpectedAnswer)
+            Err(anyhow!(CmsisDapError::UnexpectedAnswer))
         }
     }
 }
@@ -137,7 +138,7 @@ impl Response for SWOTraceBufferSize {
                 .expect("This is a bug. Please report it.");
             Ok(SWOTraceBufferSize(res))
         } else {
-            Err(CmsisDapError::UnexpectedAnswer)
+            Err(anyhow!(CmsisDapError::UnexpectedAnswer))
         }
     }
 }
@@ -153,7 +154,7 @@ impl Response for PacketCount {
                 .expect("This is a bug. Please report it.");
             Ok(PacketCount(res))
         } else {
-            Err(CmsisDapError::UnexpectedAnswer)
+            Err(anyhow!(CmsisDapError::UnexpectedAnswer))
         }
     }
 }
@@ -169,7 +170,7 @@ impl Response for PacketSize {
                 .expect("This is a bug. Please report it.");
             Ok(PacketSize(res))
         } else {
-            Err(CmsisDapError::UnexpectedAnswer)
+            Err(anyhow!(CmsisDapError::UnexpectedAnswer))
         }
     }
 }

--- a/probe-rs/src/probe/daplink/commands/general/reset.rs
+++ b/probe-rs/src/probe/daplink/commands/general/reset.rs
@@ -1,4 +1,5 @@
 use super::super::{Category, CmsisDapError, Request, Response, Result, Status};
+use anyhow::anyhow;
 
 #[derive(Debug)]
 pub struct ResetRequest;
@@ -23,7 +24,7 @@ impl Execute {
         match byte {
             0 => Ok(Execute::NoDeviceSpecificResetSequenceImplemented),
             1 => Ok(Execute::DeviceSpecificResetSequenceImplemented),
-            _ => Err(CmsisDapError::UnexpectedAnswer),
+            _ => Err(anyhow!(CmsisDapError::UnexpectedAnswer)),
         }
     }
 }

--- a/probe-rs/src/probe/daplink/commands/swj/sequence.rs
+++ b/probe-rs/src/probe/daplink/commands/swj/sequence.rs
@@ -1,6 +1,7 @@
 /// Implementation of the DAP_SWJ_SEQUENCE command
 ///
 use super::super::{Category, CmsisDapError, Request, Response, Result, Status};
+use anyhow::anyhow;
 
 #[derive(Clone, Copy)]
 pub struct SequenceRequest {
@@ -37,7 +38,7 @@ impl Request for SequenceRequest {
 impl SequenceRequest {
     pub(crate) fn new(data: &[u8]) -> Result<SequenceRequest> {
         if data.len() > 32 {
-            return Err(CmsisDapError::TooMuchData);
+            return Err(anyhow!(CmsisDapError::TooMuchData));
         }
 
         let bit_count = match data.len() {

--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -31,6 +31,7 @@ use log::debug;
 use super::JTAGAccess;
 use std::sync::Mutex;
 
+use anyhow::anyhow;
 use commands::DAPLinkDevice;
 
 pub struct DAPLink {
@@ -98,7 +99,7 @@ impl DAPLink {
         )
         .and_then(|v| match v {
             SWJClockResponse(Status::DAPOk) => Ok(()),
-            SWJClockResponse(Status::DAPError) => Err(CmsisDapError::ErrorResponse),
+            SWJClockResponse(Status::DAPError) => Err(anyhow!(CmsisDapError::ErrorResponse)),
         })?;
         Ok(())
     }
@@ -107,7 +108,7 @@ impl DAPLink {
         commands::send_command::<ConfigureRequest, ConfigureResponse>(&mut self.device, request)
             .and_then(|v| match v {
                 ConfigureResponse(Status::DAPOk) => Ok(()),
-                ConfigureResponse(Status::DAPError) => Err(CmsisDapError::ErrorResponse),
+                ConfigureResponse(Status::DAPError) => Err(anyhow!(CmsisDapError::ErrorResponse)),
             })?;
         Ok(())
     }
@@ -122,7 +123,7 @@ impl DAPLink {
         )
         .and_then(|v| match v {
             swd::configure::ConfigureResponse(Status::DAPOk) => Ok(()),
-            swd::configure::ConfigureResponse(Status::DAPError) => Err(CmsisDapError::ErrorResponse),
+            swd::configure::ConfigureResponse(Status::DAPError) => Err(anyhow!(CmsisDapError::ErrorResponse)),
         })?;
         Ok(())
     }
@@ -136,7 +137,7 @@ impl DAPLink {
         commands::send_command::<SequenceRequest, SequenceResponse>(&mut self.device, request)
             .and_then(|v| match v {
                 SequenceResponse(Status::DAPOk) => Ok(()),
-                SequenceResponse(Status::DAPError) => Err(CmsisDapError::ErrorResponse),
+                SequenceResponse(Status::DAPError) => Err(anyhow!(CmsisDapError::ErrorResponse)),
             })?;
         Ok(())
     }
@@ -172,21 +173,24 @@ impl DAPLink {
 
         let count = response.transfer_count as usize;
 
-        if count == batch.len() {
-            if response.transfer_response.protocol_error {
-                Err(DapError::SwdProtocol.into())
-            } else {
-                match response.transfer_response.ack {
-                    Ack::Ok => Ok(response.transfer_data),
-                    Ack::NoAck => Err(DapError::NoAcknowledge.into()),
-                    Ack::Fault => Err(DapError::FaultResponse.into()),
-                    Ack::Wait => Err(DapError::WaitResponse.into()),
+        match count {
+            _ if count == batch.len() => {
+                if response.transfer_response.protocol_error {
+                    Err(DapError::SwdProtocol.into())
+                } else {
+                    match response.transfer_response.ack {
+                        Ack::Ok => Ok(response.transfer_data),
+                        Ack::NoAck => Err(DapError::NoAcknowledge.into()),
+                        Ack::Fault => Err(DapError::FaultResponse.into()),
+                        Ack::Wait => Err(DapError::WaitResponse.into()),
+                    }
                 }
             }
-        } else if count > 0 && count < batch.len() {
-            Err(DebugProbeError::BatchError(batch[count - 1]))
-        } else {
-            Err(CmsisDapError::UnexpectedAnswer.into())
+            0 => Err(DebugProbeError::Other(anyhow!(
+                "Didn't receive any answer during batch processing: {:?}",
+                batch
+            ))),
+            _ => Err(DebugProbeError::BatchError(batch[count - 1])),
         }
     }
 
@@ -289,7 +293,7 @@ impl DebugProbe for DAPLink {
         let _result = commands::send_command(&mut self.device, protocol).and_then(|v| match v {
             ConnectResponse::SuccessfulInitForSWD => Ok(WireProtocol::Swd),
             ConnectResponse::SuccessfulInitForJTAG => Ok(WireProtocol::Jtag),
-            ConnectResponse::InitFailed => Err(CmsisDapError::ErrorResponse),
+            ConnectResponse::InitFailed => Err(anyhow!(CmsisDapError::ErrorResponse)),
         })?;
 
         // Set speed after connecting as it can be reset during protocol selection

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -69,36 +69,38 @@ pub enum DebugProbeError {
     USB(#[source] Option<Box<dyn std::error::Error + Send + Sync>>),
     #[error("The firmware on the probe is outdated")]
     ProbeFirmwareOutdated,
-    #[error("An error specific to a probe type occured: {0}")]
+    #[error("An error specific to a probe type occured")]
     ProbeSpecific(#[source] Box<dyn std::error::Error + Send + Sync>),
     // TODO: Unknown errors are not very useful, this should be removed.
-    #[error("An unknown error occured.")]
+    #[error("An unknown error occured")]
     Unknown,
-    #[error("Probe could not be created.")]
+    #[error("Probe could not be created")]
     ProbeCouldNotBeCreated,
-    #[error("Probe does not support protocol {0}.")]
+    #[error("Probe does not support protocol")]
     UnsupportedProtocol(WireProtocol),
     // TODO: This is core specific, so should probably be moved there.
-    #[error("Operation timed out.")]
+    #[error("Operation timed out")]
     Timeout,
-    #[error("An error specific to the selected architecture occured: {0}")]
+    #[error("An error specific to the selected architecture occured")]
     ArchitectureSpecific(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("The connected probe does not support the interface '{0}'")]
     InterfaceNotAvailable(&'static str),
-    #[error("An error occured while working with the registry occured: {0}")]
+    #[error("An error occured while working with the registry occured")]
     Registry(#[from] RegistryError),
-    #[error("Tried to close interface while it was still in use.")]
+    #[error("Tried to close interface while it was still in use")]
     InterfaceInUse,
-    #[error("The requested speed setting ({0} kHz) is not supported by the probe.")]
+    #[error("The requested speed setting ({0} kHz) is not supported by the probe")]
     UnsupportedSpeed(u32),
-    #[error("You need to be attached to the target to perform this action.")]
+    #[error("You need to be attached to the target to perform this action")]
     NotAttached,
-    #[error("You need to be detached from the target to perform this action.")]
+    #[error("You need to be detached from the target to perform this action")]
     Attached,
     #[error("Some functionality was not implemented yet")]
     NotImplemented(&'static str),
-    #[error("Error in previous batched command: {0}")]
+    #[error("Error in previous batched command")]
     BatchError(BatchCommand),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 /// The Probe struct is a generic wrapper over the different


### PR DESCRIPTION
In conjunction with `anyhow` enabled applications this generates nicer
error messages like:
```
Error failed to flash /Users/egger/OSS/stm32f429i-disc/target/thumbv7em-none-eabihf/release/examples/serial_echo

Caused by:
    0: Error while flashing
    1: Something during the interaction with the core went wrong
    2: An error with the usage of the probe occured
    3: Operation timed out
```

or

```
Error failed attaching to target

Caused by:
    0: An error with the usage of the probe occured
    1: An error specific to a probe type occured
    2: Command failed with status JtagGetIdcodeError
```

Signed-off-by: Daniel Egger <daniel@eggers-club.de>