### PR TITLE
Make DebugProbeType public and prepare 0.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+## [0.7.1]
+
+### Changed
+
 - `DebugProbeType` is now public.
+- Update LPC55S66/LPC55S69 targets.
 
 ### Fixed
+
+- Add missing core value for LPC55S66 and LPC55S69.
 
 ## [0.7.0]
 
@@ -196,7 +205,8 @@ Initial release on crates.io
 - Working basic flash downloader with nRF51.
 - Introduce cargo-flash which can automatically build & flash the target elf file.
 
-[Unreleased]: https://github.com/probe-rs/probe-rs/compare/v0.7.0...master
+[Unreleased]: https://github.com/probe-rs/probe-rs/compare/v0.7.1...master
+[0.7.1]: https://github.com/probe-rs/probe-rs/releases/tag/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/probe-rs/probe-rs/releases/tag/v0.6.2...v0.7.0
 [0.6.2]: https://github.com/probe-rs/probe-rs/releases/tag/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/probe-rs/probe-rs/releases/tag/v0.6.0...v0.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `DebugProbeType` is now public.
+
 ### Fixed
 
 ## [0.7.0]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "probe-rs-cli"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Dominik Boehi <dominik.boehi@gmail.ch>"]
 edition = "2018"
 description = "A cli for on chip debugging and flashing of ARM chips."
@@ -13,7 +13,7 @@ keywords = ["embedded"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-probe-rs = { path = "../probe-rs", version = "0.7.0" }
+probe-rs = { path = "../probe-rs", version = "0.7.1" }
 
 pretty_env_logger = "0.4.0"
 log = "0.4.6"

--- a/gdb-server/Cargo.toml
+++ b/gdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gdb-server"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Dominik Boehi <dominik.boehi@gmail.ch>"]
 edition = "2018"
 description = "A gdb stub implementation for on chip debugging and flashing of ARM chips."
@@ -29,7 +29,7 @@ pretty_env_logger = { version = "0.4.0", optional = true }
 structopt = { version = "0.3.2", optional = true }
 failure = { version = "0.1.5", optional = true }
 colored = { version = "1.8.0", optional = true }
-probe-rs = { path = "../probe-rs", version = "0.7.0" }
+probe-rs = { path = "../probe-rs", version = "0.7.1" }
 gdb-protocol = { version = "0.1.0" }
 recap = "0.1.1"
 serde = "1.0.1"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "probe-rs"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Dominik Boehi <dominik.boehi@gmail.ch>"]
 edition = "2018"
 description = "A collection of on chip debugging tools to comminicate with microchips."

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -89,6 +89,7 @@ pub use crate::core::{
 pub use crate::error::Error;
 pub use crate::memory::{Memory, MemoryInterface, MemoryList};
 pub use crate::probe::{
-    DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe, WireProtocol,
+    DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType, Probe,
+    WireProtocol,
 };
 pub use crate::session::Session;


### PR DESCRIPTION
I will add an entry to the changelog once https://github.com/probe-rs/probe-rs/pull/261 is merged, to avoid conflicts.