### PR TITLE
Annotate structs to not serialize Option fields when value is None

### DIFF
--- a/probe-rs/src/config/chip.rs
+++ b/probe-rs/src/config/chip.rs
@@ -11,6 +11,7 @@ pub struct Chip {
     pub name: Cow<'static, str>,
     /// The `PART` register of the chip.
     /// This value can be determined via the `cli info` command.
+    #[serde(skip_serializing_if="Option::is_none")]
     pub part: Option<u16>,
     /// The memory regions available on the chip.
     pub memory_map: Cow<'static, [MemoryRegion]>,

--- a/probe-rs/src/config/chip.rs
+++ b/probe-rs/src/config/chip.rs
@@ -11,7 +11,7 @@ pub struct Chip {
     pub name: Cow<'static, str>,
     /// The `PART` register of the chip.
     /// This value can be determined via the `cli info` command.
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub part: Option<u16>,
     /// The memory regions available on the chip.
     pub memory_map: Cow<'static, [MemoryRegion]>,

--- a/probe-rs/src/config/chip_family.rs
+++ b/probe-rs/src/config/chip_family.rs
@@ -13,7 +13,7 @@ pub struct ChipFamily {
     /// E.g. `nRF52832`.
     pub name: Cow<'static, str>,
     /// The JEP106 code of the manufacturer.
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub manufacturer: Option<JEP106Code>,
     /// This vector holds all the variants of the family.
     pub variants: Cow<'static, [Chip]>,

--- a/probe-rs/src/config/chip_family.rs
+++ b/probe-rs/src/config/chip_family.rs
@@ -13,6 +13,7 @@ pub struct ChipFamily {
     /// E.g. `nRF52832`.
     pub name: Cow<'static, str>,
     /// The JEP106 code of the manufacturer.
+    #[serde(skip_serializing_if="Option::is_none")]
     pub manufacturer: Option<JEP106Code>,
     /// This vector holds all the variants of the family.
     pub variants: Cow<'static, [Chip]>,


### PR DESCRIPTION
Without this patch `target-gen` generates fields with value `~`