### PR TITLE
Add missing core value for LPC55S66 and LPC55S69

### DIFF
--- a/probe-rs/targets/LPC55S66.yaml
+++ b/probe-rs/targets/LPC55S66.yaml
@@ -52,4 +52,4 @@ flash_algorithms:
       sectors:
         - size: 32768
           address: 0
-core: ""
+core: M33

--- a/probe-rs/targets/LPC55S69.yaml
+++ b/probe-rs/targets/LPC55S69.yaml
@@ -76,4 +76,4 @@ flash_algorithms:
       sectors:
         - size: 32768
           address: 0
-core: ""
+core: M33


### PR DESCRIPTION
Without this patch `gdb-server` hangs. 
```
% cargo run --features="build-binary" -- --chip LPC55S69JBD100
[...]
Firing up GDB stub at localhost:1337
GDB stub listening on localhost:1337
```

Also tested with program:

```
use probe_rs::Probe;
use std::{thread, time};

fn main() -> () {
    let probes = Probe::list_all();
    let probe = probes[0].open().unwrap();
    let mut session = probe.attach("LPC55S69JBD100").unwrap();
    let mut core = session.core(0).unwrap();
    core.halt().unwrap();
    thread::sleep(time::Duration::from_secs(5));
    core.run().unwrap();
}
```