### PR TITLE
Add timeout for CMSIS-DAPv1 read operations

### DIFF
--- a/probe-rs/src/probe/daplink/commands/mod.rs
+++ b/probe-rs/src/probe/daplink/commands/mod.rs
@@ -51,7 +51,7 @@ impl DAPLinkDevice {
     /// Read from the probe into `buf`, returning the number of bytes read on success.
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
         match self {
-            DAPLinkDevice::V1(device) => Ok(device.read(buf)?),
+            DAPLinkDevice::V1(device) => Ok(device.read_timeout(buf, 100)?),
             DAPLinkDevice::V2 {
                 handle,
                 out_ep: _,


### PR DESCRIPTION
Add a timeout to reads from USB HID devices, so that we at least don't block forever when there are problems.

Inspired by the problems with the correct report size :wink: 