### PR TITLE
Fixed a bug where a probe-selector would not work for the JLink if on…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a bug where a probe-selector would not work for the JLink if only VID & PID were specified but no serial number.
+
 ## [0.7.1]
 
 ### Changed

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -314,16 +314,18 @@ impl DebugProbe for JLink {
             .filter_map(|usb_info| {
                 if usb_info.vid() == selector.vendor_id && usb_info.pid() == selector.product_id {
                     let device = usb_info.open();
-                    if device
-                        .as_ref()
-                        .map(|d| {
-                            d.serial_string() == selector.serial_number.as_deref().unwrap_or("")
-                        })
-                        .unwrap_or(false)
-                    {
-                        Some(device)
+                    if let Some(serial_number) = selector.serial_number.as_deref() {
+                        if device
+                            .as_ref()
+                            .map(|d| d.serial_string() == serial_number)
+                            .unwrap_or(false)
+                        {
+                            Some(device)
+                        } else {
+                            None
+                        }
                     } else {
-                        None
+                        Some(device)
                     }
                 } else {
                     None


### PR DESCRIPTION
…ly VID & PID were specified but no serial number