### PR TITLE
J-Link: Log some useful information when attaching

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -37,7 +37,7 @@ ihex = "3.0.0"
 goblin = "0.2.0"
 hexdump = { version = "0.1.0", optional = true }
 thiserror = "1.0.10"
-jaylink = "0.1.1"
+jaylink = "0.1.2"
 base64 = "0.12.0"
 svg = "0.7.1"
 anyhow = "1.0.31"

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -336,7 +336,7 @@ impl DebugProbe for JLink {
                 super::ProbeCreationError::NotFound,
             ));
         } else if jlinks.len() > 1 {
-            log::warn!("More than one matching JLink was found. Opening the first one.")
+            log::warn!("More than one matching J-Link was found. Opening the first one.")
         }
         let jlink_handle = jlinks.pop().unwrap()?;
 
@@ -459,7 +459,20 @@ impl DebugProbe for JLink {
 
         log::debug!("Attaching with protocol '{}'", actual_protocol);
 
-        let jlink = self.handle.get_mut().unwrap();
+        // Get reference to JayLink instance
+        let jlink: &mut JayLink = self.handle.get_mut().unwrap();
+        let capabilities = jlink.read_capabilities()?;
+
+        // Log some information about the probe
+        let serial = jlink.serial_string().trim_start_matches('0');
+        log::info!("J-Link: S/N: {}", serial);
+        log::debug!("J-Link: Capabilities: {:?}", capabilities);
+        let fw_version = jlink.read_firmware_version().unwrap_or_else(|_| "?".into());
+        log::info!("J-Link: Firmware version: {}", fw_version);
+        match jlink.read_hardware_version() {
+            Ok(hw_version) => log::info!("J-Link: Hardware version: {}", hw_version),
+            Err(_) => log::info!("J-Link: Hardware version: ?"),
+        };
 
         // Verify target voltage (VTref pin, mV). If this is 0, the device is not powered.
         let target_voltage = jlink.read_target_voltage()?;


### PR DESCRIPTION
On INFO level, log the following information:

- Serial number
- Firmware version
- Hardware version

![probe rs](https://user-images.githubusercontent.com/105168/85908770-d32db200-b816-11ea-97a4-05aba42bd7b6.png)

Debug also includes capabilities:

![probe rs2](https://user-images.githubusercontent.com/105168/85908771-d5900c00-b816-11ea-9c91-b8072793f30f.png)

Based on #285, merge that first.

Firmware version will look shitty until https://github.com/jonas-schievink/jaylink/pull/16 is merged and released.