### PR TITLE
Public types

### DIFF
--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -83,8 +83,8 @@ mod session;
 pub use crate::config::Target;
 pub use crate::core::CoreType;
 pub use crate::core::{
-    Breakpoint, BreakpointId, CommunicationInterface, Core, CoreInterface, CoreList,
-    CoreRegisterAddress, CoreStatus, HaltReason,
+    Architecture, Breakpoint, BreakpointId, CommunicationInterface, Core,
+    CoreInterface, CoreInformation, CoreList, CoreRegisterAddress, CoreStatus, HaltReason,
 };
 pub use crate::error::Error;
 pub use crate::memory::{Memory, MemoryInterface, MemoryList};

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -83,8 +83,8 @@ mod session;
 pub use crate::config::Target;
 pub use crate::core::CoreType;
 pub use crate::core::{
-    Architecture, Breakpoint, BreakpointId, CommunicationInterface, Core,
-    CoreInterface, CoreInformation, CoreList, CoreRegisterAddress, CoreStatus, HaltReason,
+    Architecture, Breakpoint, BreakpointId, CommunicationInterface, Core, CoreInformation,
+    CoreInterface, CoreList, CoreRegisterAddress, CoreStatus, HaltReason,
 };
 pub use crate::error::Error;
 pub use crate::memory::{Memory, MemoryInterface, MemoryList};


### PR DESCRIPTION
* CoreInformation is used as return type in our debugging functions (halt, step etc.)
* Architecture is the return type of the architecture functions, defined for Core, Session etc.
