### PR TITLE
Prevent index out of bounds for USB devices without language support

### DIFF
--- a/probe-rs/src/probe/daplink/tools.rs
+++ b/probe-rs/src/probe/daplink/tools.rs
@@ -180,14 +180,11 @@ pub fn open_device_from_selector(
             };
 
             let timeout = Duration::from_millis(100);
-            let language = match handle.read_languages(timeout)?.get(0) {
-                Some(lang) => lang.clone(),
-                None => continue,
-            };
-
             let sn_str = handle
-                .read_serial_number_string(language, &d_desc, timeout)
-                .ok();
+                .read_languages(timeout)?
+                .get(0)
+                .map(|lang| handle.read_serial_number_string(*lang, &d_desc, timeout))
+                .transpose()?;
 
             // We have to ensure the handle gets closed after reading the serial number,
             // multiple open handles are not allowed on Windows.

--- a/probe-rs/src/probe/daplink/tools.rs
+++ b/probe-rs/src/probe/daplink/tools.rs
@@ -180,11 +180,11 @@ pub fn open_device_from_selector(
             };
 
             let timeout = Duration::from_millis(100);
-            let sn_str = handle
-                .read_languages(timeout)?
-                .get(0)
-                .map(|lang| handle.read_serial_number_string(*lang, &d_desc, timeout))
-                .transpose()?;
+            let sn_str = handle.read_languages(timeout)?.get(0).and_then(|lang| {
+                handle
+                    .read_serial_number_string(*lang, &d_desc, timeout)
+                    .ok()
+            });
 
             // We have to ensure the handle gets closed after reading the serial number,
             // multiple open handles are not allowed on Windows.

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -71,6 +71,10 @@ pub(super) fn read_serial_number<T: rusb::UsbContext>(
     let timeout = Duration::from_millis(100);
 
     let handle = device.open()?;
-    let language = handle.read_languages(timeout)?[0];
+    let language = handle
+        .read_languages(timeout)?
+        .get(0)
+        .cloned()
+        .ok_or(rusb::Error::BadDescriptor)?;
     handle.read_serial_number_string(language, &descriptor, timeout)
 }


### PR DESCRIPTION
See #301

Open for comments regarding explicit `cloned` calls and the usage of `rusb::Error::BadDescriptor`