### PR TITLE
Reduce runtime panics. Addresses #190

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,7 +15,7 @@ use capstone::{arch::arm::ArchMode, prelude::*, Capstone, Endian};
 use rustyline::Editor;
 use structopt::StructOpt;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 use std::num::ParseIntError;
 use std::path::PathBuf;
@@ -212,7 +212,6 @@ fn trace_u32_on_target(shared_options: &SharedOptions, loc: u32) -> Result<()> {
             ys.push(value);
 
             // Send value to plot.py.
-            // Unwrap is safe as there is always an stdin in our case!
             let mut buf = [0 as u8; 8];
             // Unwrap is safe!
             buf.pwrite_with(instant, 0, LE).unwrap();
@@ -238,7 +237,7 @@ fn debug(shared_options: &SharedOptions, exe: Option<PathBuf>) -> Result<()> {
             .mode(ArchMode::Thumb)
             .endian(Endian::Little)
             .build()
-            .unwrap();
+            .map_err(|err| anyhow!("Error creating capstone: {:?}", err))?;
 
         let di = exe
             .as_ref()

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -3,7 +3,6 @@ use probe_rs::{config::TargetSelector, MemoryInterface, Probe, WireProtocol};
 use std::num::ParseIntError;
 use std::time::{Duration, Instant};
 
-use pretty_env_logger;
 use rand::prelude::*;
 use structopt::StructOpt;
 

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -14,6 +14,7 @@ use crate::config::ChipInfo;
 use crate::{
     CommunicationInterface, DebugProbe, DebugProbeError, Error as ProbeRsError, Memory, Probe,
 };
+use anyhow::anyhow;
 use jep106::JEP106Code;
 use thiserror::Error;
 
@@ -29,6 +30,8 @@ pub enum DapError {
     WaitResponse,
     #[error("Target power-up failed.")]
     TargetPowerUpFailed,
+    #[error("Incorrect parity on READ request.")]
+    IncorrectParity,
 }
 
 impl From<DapError> for DebugProbeError {
@@ -178,7 +181,7 @@ impl<'probe> ArmCommunicationInterface<'probe> {
 
             Ok(Some(s))
         } else {
-            log::debug!("No DAP interface available on Probe");
+            log::debug!("No DAP interface available on probe");
 
             Ok(None)
         }
@@ -441,11 +444,9 @@ impl<'probe> DPAccess for ArmCommunicationInterface<'probe> {
 
         self.select_dp_bank(R::DP_BANK)?;
 
-        // unwrap is safe, interface is checked when creating the interface
-        let interface = self
-            .probe
-            .get_interface_dap_mut()?
-            .expect("Could not get interface DAP");
+        let interface = self.probe.get_interface_dap_mut()?.ok_or_else(|| {
+            DebugPortError::DebugProbe(anyhow!("Could not get interface DAP").into())
+        })?;
 
         log::debug!("Reading DP register {}", R::NAME);
         let result = interface.read_register(PortType::DebugPort, u16::from(R::ADDRESS))?;
@@ -465,11 +466,9 @@ impl<'probe> DPAccess for ArmCommunicationInterface<'probe> {
 
         self.select_dp_bank(R::DP_BANK)?;
 
-        // unwrap is safe, interface is check when creating the interface
-        let interface = self
-            .probe
-            .get_interface_dap_mut()?
-            .expect("Could not get interface DAP");
+        let interface = self.probe.get_interface_dap_mut()?.ok_or_else(|| {
+            DebugPortError::DebugProbe(anyhow!("Could not get interface DAP").into())
+        })?;
 
         let value = register.into();
 

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -619,7 +619,7 @@ impl<'probe> CoreInterface for M4<'probe> {
             Ok(reg.num_code())
         } else {
             log::warn!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", reg.rev());
-            Err(Error::Probe(DebugProbeError::Unknown))
+            Err(Error::Probe(DebugProbeError::CommandNotSupportedByProbe))
         }
     }
 
@@ -646,7 +646,7 @@ impl<'probe> CoreInterface for M4<'probe> {
             val = FpRev2CompX::breakpoint_configuration(addr).into();
         } else {
             log::warn!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", ctrl_reg.rev());
-            return Err(Error::Probe(DebugProbeError::Unknown));
+            return Err(Error::Probe(DebugProbeError::CommandNotSupportedByProbe));
         }
 
         // This is fine as FpRev1CompX and Rev2CompX are just two different

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -591,7 +591,7 @@ mod tests {
         for address in 0..8 {
             let value = mi
                 .read_word_8(address)
-                .expect(&format!("read_word_8 failed, address = {}", address));
+                .unwrap_or_else(|_| panic!("read_word_8 failed, address = {}", address));
             assert_eq!(value, DATA8[address as usize], "address = {}", address);
         }
     }
@@ -606,7 +606,7 @@ mod tests {
             expected[(address as usize)..(address as usize) + 4].copy_from_slice(&DATA8[..4]);
 
             mi.write_word_32(address, DATA32[0])
-                .expect(&format!("write_word_32 failed, address = {}", address));
+                .unwrap_or_else(|_| panic!("write_word_32 failed, address = {}", address));
             assert_eq!(
                 mi.mock_memory(),
                 expected.as_slice(),
@@ -626,7 +626,7 @@ mod tests {
             expected[address] = DATA8[0];
 
             mi.write_word_8(address as u32, DATA8[0])
-                .expect(&format!("write_word_8 failed, address = {}", address));
+                .unwrap_or_else(|_| panic!("write_word_8 failed, address = {}", address));
             assert_eq!(
                 mi.mock_memory(),
                 expected.as_slice(),
@@ -645,10 +645,9 @@ mod tests {
         for &address in &[0, 4] {
             for len in 0..3 {
                 let mut data = vec![0u32; len];
-                mi.read_32(address, &mut data).expect(&format!(
-                    "read_32 failed, address = {}, len = {}",
-                    address, len
-                ));
+                mi.read_32(address, &mut data).unwrap_or_else(|_| {
+                    panic!("read_32 failed, address = {}, len = {}", address, len)
+                });
 
                 assert_eq!(
                     data.as_slice(),
@@ -680,10 +679,9 @@ mod tests {
         for address in 0..4 {
             for len in 0..12 {
                 let mut data = vec![0u8; len];
-                mi.read_8(address, &mut data).expect(&format!(
-                    "read_8 failed, address = {}, len = {}",
-                    address, len
-                ));
+                mi.read_8(address, &mut data).unwrap_or_else(|_| {
+                    panic!("read_8 failed, address = {}, len = {}", address, len)
+                });
 
                 assert_eq!(
                     data.as_slice(),
@@ -708,10 +706,9 @@ mod tests {
                     .copy_from_slice(&DATA8[..len * 4]);
 
                 let data = &DATA32[..len];
-                mi.write_32(address, data).expect(&format!(
-                    "write_32 failed, address = {}, len = {}",
-                    address, len
-                ));
+                mi.write_32(address, data).unwrap_or_else(|_| {
+                    panic!("write_32 failed, address = {}, len = {}", address, len)
+                });
 
                 assert_eq!(
                     mi.mock_memory(),
@@ -745,10 +742,9 @@ mod tests {
                 expected[address as usize..(address as usize) + len].copy_from_slice(&DATA8[..len]);
 
                 let data = &DATA8[..len];
-                mi.write_8(address, data).expect(&format!(
-                    "write_8 failed, address = {}, len = {}",
-                    address, len
-                ));
+                mi.write_8(address, data).unwrap_or_else(|_| {
+                    panic!("write_8 failed, address = {}, len = {}", address, len)
+                });
 
                 assert_eq!(
                     mi.mock_memory(),

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -18,6 +18,8 @@ pub enum FlashError {
     Core(#[source] error::Error),
     #[error("{address} is not contained in {region:?}")]
     AddressNotInRegion { address: u32, region: FlashRegion },
+    #[error("Flash algorithm length is not 32 bit aligned.")]
+    InvalidFlashAlgorithmLength,
     #[error(
         "The RAM contents did not match the expected contents after loading the flash algorithm."
     )]

--- a/probe-rs/src/probe/daplink/commands/general/info.rs
+++ b/probe-rs/src/probe/daplink/commands/general/info.rs
@@ -120,7 +120,7 @@ impl Response for TestDomainTime {
         if buffer[offset + 1] == 0x08 {
             let res = buffer
                 .pread_with::<u32>(offset + 2, LE)
-                .expect("This is a bug. Please report it.");
+                .map_err(|_| anyhow!("This is a bug. Please report it."))?;
             Ok(TestDomainTime(res))
         } else {
             Err(anyhow!(CmsisDapError::UnexpectedAnswer))
@@ -135,7 +135,7 @@ impl Response for SWOTraceBufferSize {
         if buffer[offset + 1] == 0x04 {
             let res = buffer
                 .pread_with::<u32>(offset + 2, LE)
-                .expect("This is a bug. Please report it.");
+                .map_err(|_| anyhow!("This is a bug. Please report it."))?;
             Ok(SWOTraceBufferSize(res))
         } else {
             Err(anyhow!(CmsisDapError::UnexpectedAnswer))
@@ -151,7 +151,7 @@ impl Response for PacketCount {
         if buffer[offset] == 0x01 {
             let res = buffer
                 .pread_with::<u8>(offset + 1, LE)
-                .expect("This is a bug. Please report it.");
+                .map_err(|_| anyhow!("This is a bug. Please report it."))?;
             Ok(PacketCount(res))
         } else {
             Err(anyhow!(CmsisDapError::UnexpectedAnswer))
@@ -167,7 +167,7 @@ impl Response for PacketSize {
         if buffer[offset] == 0x02 {
             let res = buffer
                 .pread_with::<u16>(offset + 1, LE)
-                .expect("This is a bug. Please report it.");
+                .map_err(|_| anyhow!("This is a bug. Please report it."))?;
             Ok(PacketSize(res))
         } else {
             Err(anyhow!(CmsisDapError::UnexpectedAnswer))
@@ -190,6 +190,6 @@ fn string_from_bytes<R, F: Fn(String) -> R>(
     let string_end = string_start + string_len;
 
     let res = std::str::from_utf8(&buffer[string_start..string_end])
-        .expect("This is a bug. Please report it.");
+        .map_err(|_| anyhow!("This is a bug. Please report it."))?;
     Ok(constructor(res.to_owned()))
 }

--- a/probe-rs/src/probe/daplink/commands/swj/clock.rs
+++ b/probe-rs/src/probe/daplink/commands/swj/clock.rs
@@ -1,4 +1,5 @@
 use super::super::{Category, Request, Response, Result, Status};
+use anyhow::anyhow;
 
 #[derive(Debug)]
 pub struct SWJClockRequest(pub(crate) u32);
@@ -11,7 +12,7 @@ impl Request for SWJClockRequest {
 
         buffer
             .pwrite_with(self.0, offset, LE)
-            .expect("This is a bug. Please report it.");
+            .map_err(|_| anyhow!("This is a bug. Please report it."))?;
         Ok(4)
     }
 }

--- a/probe-rs/src/probe/daplink/commands/transfer/configure.rs
+++ b/probe-rs/src/probe/daplink/commands/transfer/configure.rs
@@ -1,4 +1,5 @@
 use super::super::{Category, Request, Response, Result, Status};
+use anyhow::anyhow;
 
 /// The DAP_TransferConfigure Command sets parameters for DAP_Transfer and DAP_TransferBlock.
 pub struct ConfigureRequest {
@@ -19,10 +20,10 @@ impl Request for ConfigureRequest {
         buffer[offset] = self.idle_cycles;
         buffer
             .pwrite_with(self.wait_retry, offset + 1, LE)
-            .expect("This is a bug. Please report it.");
+            .map_err(|_| anyhow!("This is a bug. Please report it."))?;
         buffer
             .pwrite_with(self.match_retry, offset + 3, LE)
-            .expect("This is a bug. Please report it.");
+            .map_err(|_| anyhow!("This is a bug. Please report it."))?;
         Ok(5)
     }
 }

--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -424,10 +424,12 @@ impl DAPAccess for DAPLink {
 
             debug!("Transfer block: chunk={}, len={} bytes", i, chunk.len() * 4);
 
-            let resp: TransferBlockResponse = commands::send_command(&mut self.device, request)
-                .map_err(|_| DebugProbeError::Unknown)?;
+            let resp: TransferBlockResponse =
+                commands::send_command(&mut self.device, request).map_err(DebugProbeError::from)?;
 
-            assert_eq!(resp.transfer_response, 1);
+            if resp.transfer_response != 1 {
+                return Err(CmsisDapError::ErrorResponse.into());
+            }
         }
 
         Ok(())
@@ -464,10 +466,12 @@ impl DAPAccess for DAPLink {
 
             debug!("Transfer block: chunk={}, len={} bytes", i, chunk.len() * 4);
 
-            let resp: TransferBlockResponse = commands::send_command(&mut self.device, request)
-                .map_err(|_| DebugProbeError::Unknown)?;
+            let resp: TransferBlockResponse =
+                commands::send_command(&mut self.device, request).map_err(DebugProbeError::from)?;
 
-            assert_eq!(resp.transfer_response, 1);
+            if resp.transfer_response != 1 {
+                return Err(CmsisDapError::ErrorResponse.into());
+            }
 
             chunk.clone_from_slice(&resp.transfer_data[..]);
         }

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -71,9 +71,6 @@ pub enum DebugProbeError {
     ProbeFirmwareOutdated,
     #[error("An error specific to a probe type occured")]
     ProbeSpecific(#[source] Box<dyn std::error::Error + Send + Sync>),
-    // TODO: Unknown errors are not very useful, this should be removed.
-    #[error("An unknown error occured")]
-    Unknown,
     #[error("Probe could not be created")]
     ProbeCouldNotBeCreated(#[from] ProbeCreationError),
     #[error("Probe does not support protocol")]
@@ -99,6 +96,10 @@ pub enum DebugProbeError {
     NotImplemented(&'static str),
     #[error("Error in previous batched command")]
     BatchError(BatchCommand),
+    #[error("Command not supported by probe")]
+    CommandNotSupportedByProbe,
+    #[error("Unable to set hardware breakpoint, all available breakpoint units are in use.")]
+    BreakpointUnitsExceeded,
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -585,7 +586,7 @@ impl DebugProbe for FakeProbe {
 
     /// Resets the target device.
     fn target_reset(&mut self) -> Result<(), DebugProbeError> {
-        Err(DebugProbeError::Unknown)
+        Err(DebugProbeError::CommandNotSupportedByProbe)
     }
 
     fn dedicated_memory_interface(&self) -> Option<Memory> {
@@ -612,7 +613,7 @@ impl DebugProbe for FakeProbe {
 impl DAPAccess for FakeProbe {
     /// Reads the DAP register on the specified port and address
     fn read_register(&mut self, _port: PortType, _addr: u16) -> Result<u32, DebugProbeError> {
-        Err(DebugProbeError::Unknown)
+        Err(DebugProbeError::CommandNotSupportedByProbe)
     }
 
     /// Writes a value to the DAP register on the specified port and address
@@ -622,7 +623,7 @@ impl DAPAccess for FakeProbe {
         _addr: u16,
         _value: u32,
     ) -> Result<(), DebugProbeError> {
-        Err(DebugProbeError::Unknown)
+        Err(DebugProbeError::CommandNotSupportedByProbe)
     }
 }
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -496,7 +496,9 @@ impl<D: StLinkUsb> STLink<D> {
         protocol: WireProtocol,
         frequency_khz: u32,
     ) -> Result<(), DebugProbeError> {
-        assert_eq!(self.hw_version, 3);
+        if self.hw_version != 3 {
+            return Err(DebugProbeError::CommandNotSupportedByProbe);
+        }
 
         let cmd_proto = match protocol {
             WireProtocol::Swd => 0,
@@ -515,7 +517,9 @@ impl<D: StLinkUsb> STLink<D> {
         &mut self,
         protocol: WireProtocol,
     ) -> Result<(Vec<u32>, u32), DebugProbeError> {
-        assert_eq!(self.hw_version, 3);
+        if self.hw_version != 3 {
+            return Err(DebugProbeError::CommandNotSupportedByProbe);
+        }
 
         let cmd_proto = match protocol {
             WireProtocol::Swd => 0,
@@ -582,7 +586,9 @@ impl<D: StLinkUsb> STLink<D> {
     /// a JTAG version >= `MIN_JTAG_VERSION_MULTI_AP`.
     fn open_ap(&mut self, apsel: u8) -> Result<(), DebugProbeError> {
         // Ensure this command is actually supported
-        assert!(self.hw_version >= 3 || self.jtag_version >= Self::MIN_JTAG_VERSION_MULTI_AP);
+        if self.hw_version < 3 && self.jtag_version < Self::MIN_JTAG_VERSION_MULTI_AP {
+            return Err(DebugProbeError::CommandNotSupportedByProbe);
+        }
 
         let mut buf = [0; 2];
         log::trace!("JTAG_INIT_AP {}", apsel);
@@ -600,7 +606,9 @@ impl<D: StLinkUsb> STLink<D> {
     /// a JTAG version >= `MIN_JTAG_VERSION_MULTI_AP`.
     fn close_ap(&mut self, apsel: u8) -> Result<(), DebugProbeError> {
         // Ensure this command is actually supported
-        assert!(self.hw_version >= 3 || self.jtag_version >= Self::MIN_JTAG_VERSION_MULTI_AP);
+        if self.hw_version < 3 && self.jtag_version < Self::MIN_JTAG_VERSION_MULTI_AP {
+            return Err(DebugProbeError::CommandNotSupportedByProbe);
+        }
 
         let mut buf = [0; 2];
         log::trace!("JTAG_CLOSE_AP {}", apsel);

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -9,6 +9,7 @@ use crate::config::{
 };
 use crate::core::{Architecture, CoreState, SpecificCoreState};
 use crate::{Core, CoreType, Error, Probe};
+use anyhow::anyhow;
 
 #[derive(Debug)]
 pub struct Session {
@@ -43,11 +44,13 @@ impl ArchitectureInterfaceState {
         match self {
             ArchitectureInterfaceState::Arm(state) => core.attach_arm(
                 core_state,
-                ArmCommunicationInterface::new(probe, state)?.unwrap(),
+                ArmCommunicationInterface::new(probe, state)?
+                    .ok_or_else(|| anyhow!("No DAP interface available on probe"))?,
             ),
             ArchitectureInterfaceState::Riscv(state) => core.attach_riscv(
                 core_state,
-                RiscvCommunicationInterface::new(probe, state)?.unwrap(),
+                RiscvCommunicationInterface::new(probe, state)?
+                    .ok_or_else(|| anyhow!("No JTAG interface available on probe"))?,
             ),
         }
     }


### PR DESCRIPTION
* remove possible runtime panics from riscv code

* replace asserts by returned Err in stlink

* replace asserts by returned Err in jlink

* Remove DebugProbeError::Unknown

* Remove assert in daplink

* remove unreachable!

* replace panic by returning Err

* remove runtime assertion of flash_algorithm length, replace the magic number 4 with size_of

* change unwrap to anyhow error

Co-authored-by: René Rössler <rene@freshx.de>