### PR TITLE
Fix command length on daplink DAP_SWJ_Pins

### DIFF
--- a/probe-rs/src/probe/daplink/commands/swj/pins.rs
+++ b/probe-rs/src/probe/daplink/commands/swj/pins.rs
@@ -126,7 +126,7 @@ impl Request for SWJPinsRequest {
         buffer
             .pwrite_with(self.wait, offset + 2, LE)
             .expect("This is a bug. Please report it.");
-        Ok(4)
+        Ok(6)
     }
 }
 


### PR DESCRIPTION
The [DAP_SWJ_Pins](https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__SWJ__Pins.html) command is two bytes and a word, so six bytes in total.