### PR TITLE
Always call debug_core_start when attaching

### DIFF
--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -1,6 +1,4 @@
-use super::{
-    debug_core_start, reset_catch_clear, reset_catch_set, CortexState, Dfsr, ARM_REGISTER_FILE,
-};
+use super::{reset_catch_clear, reset_catch_set, CortexState, Dfsr, ARM_REGISTER_FILE};
 use crate::core::{
     Architecture, CoreInformation, CoreInterface, CoreRegister, CoreRegisterAddress,
     RegisterDescription, RegisterFile, RegisterKind,
@@ -463,9 +461,6 @@ impl<'probe> CoreInterface for M0<'probe> {
     }
 
     fn reset_and_halt(&mut self, timeout: Duration) -> Result<CoreInformation, Error> {
-        // Ensure debug mode is enabled
-        debug_core_start(self)?;
-
         reset_catch_set(self)?;
 
         self.reset()?;

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -16,9 +16,7 @@ use crate::{architecture::arm::core::register, MemoryInterface};
 
 use bitfield::bitfield;
 
-use super::{
-    debug_core_start, reset_catch_clear, reset_catch_set, CortexState, Dfsr, ARM_REGISTER_FILE,
-};
+use super::{reset_catch_clear, reset_catch_set, CortexState, Dfsr, ARM_REGISTER_FILE};
 use std::{
     mem::size_of,
     time::{Duration, Instant},
@@ -144,9 +142,6 @@ impl<'probe> CoreInterface for M33<'probe> {
     }
 
     fn reset_and_halt(&mut self, timeout: Duration) -> Result<CoreInformation, Error> {
-        // Ensure debug mode is enabled
-        debug_core_start(self)?;
-
         // Set the vc_corereset bit in the DEMCR register.
         // This will halt the core after reset.
         reset_catch_set(self)?;

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -5,10 +5,7 @@ use crate::error::Error;
 use crate::memory::Memory;
 use crate::DebugProbeError;
 
-use super::{
-    debug_core_start, register, reset_catch_clear, reset_catch_set, CortexState, Dfsr,
-    ARM_REGISTER_FILE,
-};
+use super::{register, reset_catch_clear, reset_catch_set, CortexState, Dfsr, ARM_REGISTER_FILE};
 use crate::{
     core::{Architecture, CoreStatus, HaltReason},
     MemoryInterface,
@@ -574,9 +571,6 @@ impl<'probe> CoreInterface for M4<'probe> {
     }
 
     fn reset_and_halt(&mut self, timeout: Duration) -> Result<CoreInformation, Error> {
-        // Ensure debug mode is enabled
-        debug_core_start(self)?;
-
         // Set the vc_corereset bit in the DEMCR register.
         // This will halt the core after reset.
         reset_catch_set(self)?;


### PR DESCRIPTION
Always call `debug_core_start` when attaching. This ensures that the debug mode is always activated when a `Session` is created, regardless of the attach method.

The `reset_and_halt` function now doesn't  call the `debug_core_start` function anymore, which fixes #324 .

Tested with a board which requires attach under reset, and a board which does not require it.

