### PR TITLE
SwoAccess and SwoConfig updates

### DIFF
--- a/probe-rs/examples/tcp_itm.rs
+++ b/probe-rs/examples/tcp_itm.rs
@@ -23,7 +23,9 @@ fn main() -> Result<(), Error> {
     let mut session = probe.attach("stm32f407")?;
 
     // Create a new SwoConfig with a system clock frequency of 16MHz
-    let cfg = SwoConfig::new(16_000_000);
+    let cfg = SwoConfig::new(16_000_000)
+        .set_baud(2_000_000)
+        .set_continuous_formatting(false);
 
     session.setup_swv(&cfg)?;
 

--- a/probe-rs/examples/tcp_itm.rs
+++ b/probe-rs/examples/tcp_itm.rs
@@ -1,5 +1,5 @@
 use probe_rs::architecture::arm::swo::{
-    Decoder, SwoConfig, SwoMode, SwoPublisher, TracePacket, UpdaterChannel,
+    Decoder, SwoConfig, SwoPublisher, TracePacket, UpdaterChannel,
 };
 use probe_rs::Error;
 use serde::{Deserialize, Serialize};
@@ -22,11 +22,8 @@ fn main() -> Result<(), Error> {
     // Attach to a chip.
     let mut session = probe.attach("stm32f407")?;
 
-    let cfg = SwoConfig {
-        mode: SwoMode::UART,
-        baud: 2000000,
-        tpiu_clk: 16000000,
-    };
+    // Create a new SwoConfig with a system clock frequency of 16MHz
+    let cfg = SwoConfig::new(16_000_000);
 
     session.setup_swv(&cfg)?;
 

--- a/probe-rs/src/architecture/arm/swo/mod.rs
+++ b/probe-rs/src/architecture/arm/swo/mod.rs
@@ -48,19 +48,31 @@ impl SwoConfig {
     }
 
     /// Set the baud rate in Hz.
-    pub fn set_baud(&mut self, baud: u32) -> &Self {
+    pub fn set_baud(mut self, baud: u32) -> Self {
         self.baud = baud;
         self
     }
 
     /// Set the mode in this SwoConfig.
-    pub fn set_mode(&mut self, mode: SwoMode) -> &Self {
+    pub fn set_mode(mut self, mode: SwoMode) -> Self {
         self.mode = mode;
         self
     }
 
+    /// Set the mode to UART
+    pub fn set_mode_uart(mut self) -> Self {
+        self.mode = SwoMode::UART;
+        self
+    }
+
+    /// Set the mode to Manchester
+    pub fn set_mode_manchester(mut self) -> Self {
+        self.mode = SwoMode::Manchester;
+        self
+    }
+
     /// Set the TPIU continuous formatting setting.
-    pub fn set_continuous_formatting(&mut self, enabled: bool) -> &Self {
+    pub fn set_continuous_formatting(mut self, enabled: bool) -> Self {
         self.tpiu_continuous_formatting = enabled;
         self
     }

--- a/probe-rs/src/architecture/arm/swo/mod.rs
+++ b/probe-rs/src/architecture/arm/swo/mod.rs
@@ -34,25 +34,32 @@ pub struct SwoConfig {
 }
 
 impl SwoConfig {
-    /// Create a new SwoConfig using the specified TPIU clock and SWO baud rate,
-    /// both in Hz. By default the UART mode is used and
+    /// Create a new SwoConfig using the specified TPIU clock in Hz.
+    ///
+    /// By default the UART mode is used at 1MBd and
     /// TPIU continuous formatting is disabled (DWT/ITM only).
-    pub fn new(tpiu_clk: u32, baud: u32) -> Self {
+    pub fn new(tpiu_clk: u32) -> Self {
         SwoConfig {
             mode: SwoMode::UART,
-            baud: baud,
+            baud: 1_000_000,
             tpiu_clk: tpiu_clk,
             tpiu_continuous_formatting: false,
         }
     }
 
-    /// Change the mode in this SwoConfig.
+    /// Set the baud rate in Hz.
+    pub fn set_baud(&mut self, baud: u32) -> &Self {
+        self.baud = baud;
+        self
+    }
+
+    /// Set the mode in this SwoConfig.
     pub fn set_mode(&mut self, mode: SwoMode) -> &Self {
         self.mode = mode;
         self
     }
 
-    /// Change the TPIU bypass setting.
+    /// Set the TPIU continuous formatting setting.
     pub fn set_continuous_formatting(&mut self, enabled: bool) -> &Self {
         self.tpiu_continuous_formatting = enabled;
         self

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -703,7 +703,7 @@ impl<D: StLinkUsb> STLink<D> {
     pub fn start_trace_reception(&mut self, config: &SwoConfig) -> Result<(), DebugProbeError> {
         let mut buf = [0; 2];
         let bufsize = 4096u16.to_le_bytes();
-        let baud = config.baud.to_le_bytes();
+        let baud = config.baud().to_le_bytes();
         let mut command = vec![commands::JTAG_COMMAND, commands::SWO_START_TRACE_RECEPTION];
         command.extend_from_slice(&bufsize);
         command.extend_from_slice(&baud);
@@ -760,7 +760,7 @@ impl<D: StLinkUsb> STLink<D> {
 
 impl<D: StLinkUsb> SwoAccess for STLink<D> {
     fn enable_swo(&mut self, config: &SwoConfig) -> Result<(), ProbeRsError> {
-        match config.mode {
+        match config.mode() {
             SwoMode::UART => {
                 self.start_trace_reception(config)?;
                 Ok(())


### PR DESCRIPTION
After chatting with @jonas-schievink about jlink today it seems like adding this new optional `poll_interval_hint` could be useful: right now we don't have anything for end user applications to do except poll `read_swo` in a loop, and no way to know how frequently they should poll. For some probes (cmsis-dap in bulk endpoint mode) it doesn't matter; they can just block waiting for new data. However for polled probes (jlink, cmsis-dap without bulk endpoint, stlink), it wastes USB bandwidth and CPU time to send polls too often. Probe drivers know the SWO buffer size and baud rate, so they can estimate how frequently it makes sense to poll.

I've also extended `SwoConfig` in two ways:
* It now has a constructor and accessor methods, rather than pub fields. This way we can add additional fields in the future with default values without it being a breaking change.
* For example, I've added a new TPIU setting, because currently we force TPIU formatter off, which is fine (good, even) for ITM and DWT, but makes ETM data inaccessible.