### PR TITLE
Add flush method to Probe interface

### DIFF
--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -2,7 +2,7 @@ use super::super::{APAccess, Register};
 use super::{APRegister, AddressIncrement, DataSize, MemoryAP, CSW, DRW, TAR};
 use crate::{
     architecture::arm::dp::{DPAccess, DPRegister, DebugPortError},
-    CommunicationInterface,
+    CommunicationInterface, DebugProbeError,
 };
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -38,7 +38,11 @@ impl MockMemoryAP {
     }
 }
 
-impl CommunicationInterface for MockMemoryAP {}
+impl CommunicationInterface for MockMemoryAP {
+    fn flush(&mut self) -> Result<(), DebugProbeError> {
+        Ok(())
+    }
+}
 
 impl<R> APAccess<MemoryAP, R> for MockMemoryAP
 where

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod generic_ap;
 pub(crate) mod memory_ap;
 
 use crate::architecture::arm::dp::DebugPortError;
+use crate::DebugProbeError;
 
 pub use generic_ap::{APClass, APType, GenericAP, IDR};
 pub(crate) use memory_ap::mock;
@@ -36,6 +37,8 @@ pub enum AccessPortError {
     OutOfBoundsError,
     #[error("Error while communicating with debug port")]
     DebugPort(#[from] DebugPortError),
+    #[error("Failed to flush batched writes")]
+    FlushError(#[from] DebugProbeError),
 }
 
 impl AccessPortError {

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -69,7 +69,7 @@ pub fn setup_swv(core: &mut Core, component: &Component, config: &SwoConfig) -> 
     let mut dwt = component.dwt(core).map_err(Error::architecture_specific)?;
     dwt.enable()?;
 
-    Ok(())
+    core.flush()
 }
 
 fn setup_swv_vendor(

--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -422,9 +422,8 @@ impl<'probe> CoreInterface for M0<'probe> {
         value.set_c_debugen(true);
         value.enable_write();
 
-        self.memory
-            .write_word_32(Dhcsr::ADDRESS, value.into())
-            .map_err(Into::into)
+        self.memory.write_word_32(Dhcsr::ADDRESS, value.into())?;
+        self.memory.flush()
     }
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
@@ -621,5 +620,8 @@ impl<'probe> MemoryInterface for M0<'probe> {
     }
     fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), Error> {
         self.memory.write_8(address, data)
+    }
+    fn flush(&mut self) -> Result<(), Error> {
+        self.memory.flush()
     }
 }

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -125,9 +125,8 @@ impl<'probe> CoreInterface for M33<'probe> {
         value.set_c_debugen(true);
         value.enable_write();
 
-        self.memory
-            .write_word_32(Dhcsr::ADDRESS, value.into())
-            .map_err(Into::into)
+        self.memory.write_word_32(Dhcsr::ADDRESS, value.into())?;
+        self.memory.flush()
     }
     fn reset(&mut self) -> Result<(), Error> {
         // Set THE AIRCR.SYSRESETREQ control bit to 1 to request a reset. (ARM V6 ARM, B1.5.16)
@@ -359,6 +358,9 @@ impl<'probe> MemoryInterface for M33<'probe> {
     }
     fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), Error> {
         self.memory.write_8(address, data)
+    }
+    fn flush(&mut self) -> Result<(), Error> {
+        self.memory.flush()
     }
 }
 

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -531,6 +531,7 @@ impl<'probe> CoreInterface for M4<'probe> {
         value.enable_write();
 
         self.memory.write_word_32(Dhcsr::ADDRESS, value.into())?;
+        self.memory.flush()?;
 
         // We assume that the core is running now
         self.state.current_state = CoreStatus::Running;
@@ -691,6 +692,9 @@ impl<'probe> MemoryInterface for M4<'probe> {
     }
     fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), Error> {
         self.memory.write_8(address, data)
+    }
+    fn flush(&mut self) -> Result<(), Error> {
+        self.memory.flush()
     }
 }
 

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -482,6 +482,13 @@ where
 
         Ok(())
     }
+
+    pub fn flush(&mut self) -> Result<(), AccessPortError> {
+        match self.interface.flush() {
+            Ok(_) => Ok(()),
+            Err(e) => Err(AccessPortError::FlushError(e)),
+        }
+    }
 }
 
 /// Calculates a 32-bit word aligned range from an address/length pair.
@@ -539,6 +546,10 @@ where
 
     fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), Error> {
         ADIMemoryInterface::write_8(self, address, data).map_err(Error::architecture_specific)
+    }
+
+    fn flush(&mut self) -> Result<(), Error> {
+        ADIMemoryInterface::flush(self).map_err(Error::architecture_specific)
     }
 }
 

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -942,6 +942,10 @@ impl<'probe> MemoryInterface for RiscvCommunicationInterface<'probe> {
 
         Ok(())
     }
+
+    fn flush(&mut self) -> Result<(), crate::Error> {
+        Ok(())
+    }
 }
 
 /// Access width for bus access.

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -559,6 +559,9 @@ impl<'probe> MemoryInterface for Riscv32<'probe> {
     fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), Error> {
         self.interface.write_8(address, data)
     }
+    fn flush(&mut self) -> Result<(), Error> {
+        self.interface.flush()
+    }
 }
 
 bitfield! {

--- a/probe-rs/src/core/communication_interface.rs
+++ b/probe-rs/src/core/communication_interface.rs
@@ -1,1 +1,5 @@
-pub trait CommunicationInterface {}
+use crate::DebugProbeError;
+
+pub trait CommunicationInterface {
+    fn flush(&mut self) -> Result<(), DebugProbeError>;
+}

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -223,6 +223,10 @@ impl<'probe> MemoryInterface for Core<'probe> {
     fn write_8(&mut self, addr: u32, data: &[u8]) -> Result<(), Error> {
         self.inner.write_8(addr, data)
     }
+
+    fn flush(&mut self) -> Result<(), Error> {
+        self.inner.flush()
+    }
 }
 
 #[derive(Copy, Clone)]

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -38,6 +38,14 @@ pub trait MemoryInterface {
 
     /// Write a block of 8bit words at `address`.
     fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), error::Error>;
+
+    /// Flush any outstanding operations.
+    ///
+    /// For performance, debug probe implementations may choose to batch writes;
+    /// to assure that any such batched writes have in fact been issued, `flush`
+    /// can be called.  Takes no arguments, but may return failure if a batched
+    /// operation fails.
+    fn flush(&mut self) -> Result<(), error::Error>;
 }
 
 impl<T> MemoryInterface for &mut T
@@ -75,6 +83,10 @@ where
     fn write_8(&mut self, addr: u32, data: &[u8]) -> Result<(), error::Error> {
         (*self).write_8(addr, data)
     }
+
+    fn flush(&mut self) -> Result<(), error::Error> {
+        (*self).flush()
+    }
 }
 
 pub struct MemoryDummy;
@@ -102,6 +114,10 @@ impl<'probe> MemoryInterface for MemoryDummy {
         unimplemented!()
     }
     fn write_8(&mut self, _address: u32, _data: &[u8]) -> Result<(), error::Error> {
+        unimplemented!()
+    }
+
+    fn flush(&mut self) -> Result<(), error::Error> {
         unimplemented!()
     }
 }
@@ -159,6 +175,10 @@ impl<'probe> Memory<'probe> {
 
     pub fn write_8(&mut self, addr: u32, data: &[u8]) -> Result<(), error::Error> {
         self.inner.write_8(addr, data)
+    }
+
+    pub fn flush(&mut self) -> Result<(), error::Error> {
+        self.inner.flush()
     }
 }
 

--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -507,6 +507,11 @@ impl DAPAccess for DAPLink {
 
         Ok(())
     }
+
+    fn flush(&mut self) -> Result<(), DebugProbeError> {
+        self.process_batch()?;
+        Ok(())
+    }
 }
 
 impl Drop for DAPLink {


### PR DESCRIPTION
This PR is @bcantrill's https://github.com/oxidecomputer/probe-rs/commit/a12a8ffc0d537fb74d31fc5dc1e763a5deda9fc8 plus adding a call to `flush()` to `setup_swv()`. The commit message describes the motivation:

> With probes batching writes, there is a need for higher-level
software to flush any buffered writes.  This assures that (say)
operations like run() do not run the risk of returning to the caller
with their operations not sent to the MCU.  (This issue was the
reason for failures in SWO processing on the LPC55, as higher level
software's resume of the halted part was not, in fact, resuming
the part.)