### PR TITLE
Add HostStatus command to daplink, allowing control of probe LEDs

### DIFF
--- a/probe-rs/src/probe/daplink/commands/general/host_status.rs
+++ b/probe-rs/src/probe/daplink/commands/general/host_status.rs
@@ -14,6 +14,7 @@ impl HostStatusRequest {
         }
     }
 
+    #[allow(dead_code)]
     pub fn running(running: bool) -> Self {
         HostStatusRequest {
             status_type: 1,
@@ -28,7 +29,7 @@ impl Request for HostStatusRequest {
     fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize> {
         buffer[offset] = self.status_type;
         buffer[offset + 1] = self.status;
-        return Ok(2);
+        Ok(2)
     }
 }
 
@@ -36,7 +37,7 @@ impl Request for HostStatusRequest {
 pub struct HostStatusResponse;
 
 impl Response for HostStatusResponse {
-    fn from_bytes(_buffer: &[u8], offset: usize) -> Result<Self> {
+    fn from_bytes(_buffer: &[u8], _offset: usize) -> Result<Self> {
         Ok(HostStatusResponse)
     }
 }

--- a/probe-rs/src/probe/daplink/commands/general/host_status.rs
+++ b/probe-rs/src/probe/daplink/commands/general/host_status.rs
@@ -1,0 +1,42 @@
+use super::super::{Category, Request, Response, Result};
+
+#[derive(Clone, Copy, Debug)]
+pub struct HostStatusRequest {
+    status_type: u8,
+    status: u8,
+}
+
+impl HostStatusRequest {
+    pub fn connected(connected: bool) -> Self {
+        HostStatusRequest {
+            status_type: 0,
+            status: connected as u8,
+        }
+    }
+
+    pub fn running(running: bool) -> Self {
+        HostStatusRequest {
+            status_type: 1,
+            status: running as u8,
+        }
+    }
+}
+
+impl Request for HostStatusRequest {
+    const CATEGORY: Category = Category(0x01);
+
+    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize> {
+        buffer[offset] = self.status_type;
+        buffer[offset + 1] = self.status;
+        return Ok(2);
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct HostStatusResponse;
+
+impl Response for HostStatusResponse {
+    fn from_bytes(_buffer: &[u8], offset: usize) -> Result<Self> {
+        Ok(HostStatusResponse)
+    }
+}

--- a/probe-rs/src/probe/daplink/commands/general/mod.rs
+++ b/probe-rs/src/probe/daplink/commands/general/mod.rs
@@ -1,4 +1,5 @@
 pub mod connect;
 pub mod disconnect;
+pub mod host_status;
 pub mod info;
 pub mod reset;

--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -14,6 +14,7 @@ use commands::{
     general::{
         connect::{ConnectRequest, ConnectResponse},
         disconnect::{DisconnectRequest, DisconnectResponse},
+        host_status::{HostStatusRequest, HostStatusResponse},
         info::{Capabilities, Command, PacketCount, PacketSize, SWOTraceBufferSize},
         reset::{ResetRequest, ResetResponse},
     },
@@ -455,6 +456,10 @@ impl DebugProbe for DAPLink {
 
         debug!("Successfully changed to SWD.");
 
+        // Tell the probe we are connected so it can turn on an LED.
+        let _: Result<HostStatusResponse, _> =
+            commands::send_command(&mut self.device, HostStatusRequest::connected(true));
+
         Ok(())
     }
 
@@ -468,6 +473,10 @@ impl DebugProbe for DAPLink {
         }
 
         let response = commands::send_command(&mut self.device, DisconnectRequest {})?;
+
+        // Tell probe we are disconnected so it can turn off its LED.
+        let _: Result<HostStatusResponse, _> =
+            commands::send_command(&mut self.device, HostStatusRequest::connected(false));
 
         match response {
             DisconnectResponse(Status::DAPOk) => Ok(()),


### PR DESCRIPTION
The [DAP_HostStatus](https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__HostStatus.html) command lets probe-rs tell the probe that it is connected or not and the target is running or not.

It seems a bit difficult to work out if the target is running at the probe level, but it's very easy to send this command for the 'connected' state during attach and detach, which is what this PR does. The status LED on my CMSIS-DAP probe now lights up during flash programming and SWO printing.

I ignore errors when calling this because it's entirely non-essential functionality, so it would be a shame to error out if for example some probe reported that it didn't support this command. That said probes _should_ all support it, so I could raise the errors up instead.