### PR TITLE
Use nom based parser for GDB packets

### DIFF
--- a/gdb-server/Cargo.toml
+++ b/gdb-server/Cargo.toml
@@ -31,8 +31,6 @@ failure = { version = "0.1.5", optional = true }
 colored = { version = "2.0.0", optional = true }
 probe-rs = { path = "../probe-rs", version = "0.8.0" }
 gdb-protocol = { version = "0.1.0" }
-recap = "0.1.1"
-serde = "1.0.1"
 async-std = { version = "1.5.0" }
 futures = "0.3.1"
 log = "0.4.0"

--- a/gdb-server/Cargo.toml
+++ b/gdb-server/Cargo.toml
@@ -37,3 +37,6 @@ async-std = { version = "1.5.0" }
 futures = "0.3.1"
 log = "0.4.0"
 memchr = "2.2.1"
+hex = "0.4.2"
+nom = "5.1.2"
+anyhow = "1.0.31"

--- a/gdb-server/src/handlers.rs
+++ b/gdb-server/src/handlers.rs
@@ -186,8 +186,7 @@ pub(crate) fn detach(break_due: &mut bool) -> Option<String> {
 }
 
 pub(crate) fn reset_halt(core: &mut Core) -> Option<String> {
-    let _cpu_info = core.reset();
-    let _cpu_info = core.halt(Duration::from_millis(100));
+    let _cpu_info = core.reset_and_halt(Duration::from_millis(400));
     Some("OK".into())
 }
 

--- a/gdb-server/src/handlers.rs
+++ b/gdb-server/src/handlers.rs
@@ -66,6 +66,13 @@ pub(crate) fn vcont_supported() -> Option<String> {
     Some("vCont;c;t;s".into())
 }
 
+pub(crate) fn host_info() -> Option<String> {
+    // cputype    12 = arm
+    // cpusubtype 14 = v6m
+    // See https://llvm.org/doxygen/Support_2MachO_8h_source.html
+    Some("cputype:12;cpusubtype:14;triple:armv6m--none-eabi;endian:litte;ptrsize:4".to_string())
+}
+
 pub(crate) fn run(core: &mut Core, awaits_halt: &mut bool) -> Option<String> {
     core.run().unwrap();
     *awaits_halt = true;
@@ -84,14 +91,14 @@ pub(crate) fn step(core: &mut Core, awaits_halt: &mut bool) -> Option<String> {
     Some("S05".into())
 }
 
-pub(crate) fn insert_hardware_break(address: u32, kind: u32, core: &mut Core) -> Option<String> {
+pub(crate) fn insert_hardware_break(address: u32, _kind: u32, core: &mut Core) -> Option<String> {
     core.reset_and_halt(Duration::from_millis(100)).unwrap();
     core.set_hw_breakpoint(address).unwrap();
     core.run().unwrap();
     Some("OK".into())
 }
 
-pub(crate) fn remove_hardware_break(address: u32, kind: u32, core: &mut Core) -> Option<String> {
+pub(crate) fn remove_hardware_break(address: u32, _kind: u32, core: &mut Core) -> Option<String> {
     core.reset_and_halt(Duration::from_millis(100)).unwrap();
     core.clear_hw_breakpoint(address).unwrap();
     core.run().unwrap();

--- a/gdb-server/src/lib.rs
+++ b/gdb-server/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod gdb_server_async;
 mod handlers;
+mod parser;
 mod reader;
 mod worker;
 mod writer;

--- a/gdb-server/src/parser/mod.rs
+++ b/gdb-server/src/parser/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod v_packet;
 
 use nom::{
     branch::alt,
-    bytes::complete::{take, tag},
+    bytes::complete::{tag, take},
     character::complete::char,
     combinator::{all_consuming, cut, value},
     dbg_dmp, map, named,
@@ -272,7 +272,6 @@ fn ctrl_c_interrupt(input: &[u8]) -> IResult<&[u8], Packet> {
     let (input, _) = tag([0x03])(input)?;
 
     Ok((input, Packet::Interrupt))
-
 }
 
 #[cfg(test)]
@@ -288,7 +287,7 @@ mod test {
             ("?", Packet::HaltReason),
             ("g", Packet::ReadGeneralRegister),
             ("D", Packet::Detach),
-            ("qSupported", Packet::Query(QueryPacket::Supported)),
+            ("qSupported", Packet::Query(QueryPacket::Supported(vec![]))),
             ("vCont?", Packet::V(VPacket::QueryContSupport)),
             (
                 "vMustReplyEmpty",

--- a/gdb-server/src/parser/mod.rs
+++ b/gdb-server/src/parser/mod.rs
@@ -24,6 +24,7 @@ pub use query::{Pid, QueryPacket};
 use util::hex_u64;
 pub use v_packet::VPacket;
 
+#[allow(dead_code)]
 #[derive(Debug, PartialEq, Clone)]
 pub enum Packet {
     /// Packet `!`

--- a/gdb-server/src/parser/mod.rs
+++ b/gdb-server/src/parser/mod.rs
@@ -432,4 +432,15 @@ mod test {
             })
         );
     }
+
+    #[test]
+    fn parse_query_crc_packet() {
+        assert_eq!(
+            parse_packet(b"qCRC:8000000,13c").unwrap(),
+            Packet::Query(QueryPacket::Crc {
+                address: 0x8000000,
+                length: 0x13c,
+            })
+        );
+    }
 }

--- a/gdb-server/src/parser/mod.rs
+++ b/gdb-server/src/parser/mod.rs
@@ -1,0 +1,380 @@
+//! Parser for GDB packets
+//!
+//! GDB packets have the format `$packet-data#checksum`. This parser is
+//! focused on the actual packet-data.
+mod query;
+mod v_packet;
+
+use nom::{
+    branch::alt,
+    bytes::complete::take,
+    character::complete::char,
+    combinator::{all_consuming, cut, value},
+    dbg_dmp, map, named,
+    number::complete::hex_u32,
+    IResult,
+};
+
+use anyhow::{anyhow, Result};
+use query::query_packet;
+use v_packet::v_packet;
+
+pub use query::{Pid, QueryPacket};
+pub use v_packet::VPacket;
+
+#[derive(Debug, PartialEq, Clone)]
+enum Packet {
+    /// Packet `!`
+    EnableExtendedMode,
+    /// Packet `?`
+    HaltReason,
+    /// Packet  `A`
+    Arguments,
+    /// Packet `b`.
+    ///
+    /// Not recommended
+    Baud,
+    /// Packet `B`
+    ///
+    /// Not recommended. Use `Z` and `z` instead.
+    Breakpoint,
+    /// Packet `bc`
+    BackwardContinue,
+    /// Packet `bs`
+    BackwardSingleStep,
+    /// Packet `c`
+    Continue,
+    /// Packet `C`
+    ContinueSignal,
+    /// Packet `d`
+    Debug,
+    /// Packet `D`
+    Detach,
+    /// Packet `F`
+    FileIO,
+    /// Packet `g`
+    ReadGeneralRegister,
+    /// Packet `G`
+    WriteGeneralRegister,
+    /// Packet `H`
+    SelectThread,
+    /// Packet `i`
+    StepClockCycle,
+    /// Packet `I`
+    StepClockCycleSignal,
+    /// Packet `k`
+    KillRequest,
+    /// Packet 'm'
+    ReadMemory {
+        address: u32,
+        length: u32,
+    },
+    /// Packet 'M'
+    WriteMemory,
+    /// Packet 'p'
+    ReadRegisterHex(u32),
+    /// Packet 'P'
+    WriteRegisterHex,
+    // Packet 'q'
+    Query(QueryPacket),
+    // Packet 'Q'
+    QuerySet,
+    // Packet 'r'
+    Reset,
+    // Packet 'R'
+    Restart,
+    // Packet 's'
+    SingleStep,
+    // Packet 's'
+    SingleStepSignal,
+    // Packet 't'
+    SearchBackwards,
+    // Packet 'T'
+    ThreadInfo,
+    // Packet 'v'
+    V(VPacket),
+    // Packet 'X'
+    WriteMemoryBinary {
+        address: u32,
+        data: Vec<u8>,
+    },
+    // Packet 'z'
+    RemoveBreakpoint {
+        breakpoint_type: BreakpointType,
+        address: u32,
+    },
+    // Packet 'Z'
+    InsertBreakpoint {
+        breakpoint_type: BreakpointType,
+        address: u32,
+        kind: u32,
+    },
+}
+
+#[derive(Debug, PartialEq, Clone)]
+enum BreakpointType {
+    Software,
+    Hardware,
+    WriteWatchpoint,
+    ReadWatchpoint,
+    AccessWatchpoint,
+}
+
+fn parse_packet(input: &[u8]) -> Result<Packet> {
+    let parse_result = dbg_dmp(
+        all_consuming(alt((
+            extended_mode,
+            detach,
+            halt_reason,
+            read_register,
+            read_register_hex,
+            read_memory,
+            query,
+            v,
+            insert_breakpoint,
+            remove_breakpoint,
+            write_memory_binary,
+        ))),
+        "Parsing packet",
+    )(input);
+
+    match parse_result {
+        Ok((_remaining, packet)) => Ok(packet),
+        Err(e) => Err(anyhow!(e.to_owned())),
+    }
+}
+
+named!(extended_mode<&[u8], Packet>, map!(char('!'), |_| Packet::EnableExtendedMode));
+
+named!(halt_reason<&[u8], Packet>, map!(char('?'), |_| Packet::HaltReason));
+
+fn detach(input: &[u8]) -> IResult<&[u8], Packet> {
+    value(Packet::Detach, char('D'))(input)
+}
+
+fn read_register(input: &[u8]) -> IResult<&[u8], Packet> {
+    let (input, _) = char('g')(input)?;
+
+    Ok((input, Packet::ReadGeneralRegister))
+}
+
+fn read_register_hex(input: &[u8]) -> IResult<&[u8], Packet> {
+    let (input, _) = char('p')(input)?;
+
+    let (input, value) = hex_u32(input)?;
+
+    Ok((input, Packet::ReadRegisterHex(value)))
+}
+
+fn query(input: &[u8]) -> IResult<&[u8], Packet> {
+    let (input, _) = char('q')(input)?;
+    let (input, packet) = query_packet(input)?;
+
+    Ok((input, Packet::Query(packet)))
+}
+
+fn v(input: &[u8]) -> IResult<&[u8], Packet> {
+    let (input, _) = char('v')(input)?;
+
+    let (input, packet) = v_packet(input)?;
+
+    Ok((input, Packet::V(packet)))
+}
+
+fn read_memory(input: &[u8]) -> IResult<&[u8], Packet> {
+    let (input, _) = char('m')(input)?;
+
+    let (input, address) = hex_u32(input)?;
+    let (input, _) = char(',')(input)?;
+    let (input, length) = hex_u32(input)?;
+
+    Ok((input, Packet::ReadMemory { address, length }))
+}
+
+fn breakpoint_type(input: &[u8]) -> IResult<&[u8], BreakpointType> {
+    alt((
+        value(BreakpointType::Software, char('0')),
+        value(BreakpointType::Hardware, char('1')),
+        value(BreakpointType::WriteWatchpoint, char('2')),
+        value(BreakpointType::ReadWatchpoint, char('3')),
+        value(BreakpointType::AccessWatchpoint, char('4')),
+    ))(input)
+}
+
+fn insert_breakpoint(input: &[u8]) -> IResult<&[u8], Packet> {
+    let (input, _) = char('Z')(input)?;
+
+    let (input, breakpoint_type) = breakpoint_type(input)?;
+
+    let (input, _) = char(',')(input)?;
+
+    let (input, address) = hex_u32(input)?;
+
+    let (input, _) = char(',')(input)?;
+
+    let (input, kind) = hex_u32(input)?;
+
+    Ok((
+        input,
+        Packet::InsertBreakpoint {
+            breakpoint_type,
+            address,
+            kind,
+        },
+    ))
+}
+
+fn remove_breakpoint(input: &[u8]) -> IResult<&[u8], Packet> {
+    let (input, _) = char('z')(input)?;
+    let (input, breakpoint_type) = breakpoint_type(input)?;
+
+    let (input, _) = char(',')(input)?;
+
+    let (input, address) = hex_u32(input)?;
+    let (input, _) = char(',')(input)?;
+
+    let (input, kind) = hex_u32(input)?;
+
+    Ok((
+        input,
+        Packet::RemoveBreakpoint {
+            breakpoint_type,
+            address,
+        },
+    ))
+}
+
+fn write_memory_binary(input: &[u8]) -> IResult<&[u8], Packet> {
+    let (input, _) = char('X')(input)?;
+
+    let (input, address) = hex_u32(input)?;
+    let (input, _) = char(',')(input)?;
+    let (input, length) = hex_u32(input)?;
+    let (input, _) = char(':')(input)?;
+
+    let (input, data) = take(length)(input)?;
+
+    Ok((
+        input,
+        Packet::WriteMemoryBinary {
+            address,
+            data: data.to_owned(),
+        },
+    ))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const EMPTY: &[u8] = &[];
+
+    #[test]
+    fn parse_simple_packets() {
+        let test_data = [
+            ("!", Packet::EnableExtendedMode),
+            ("?", Packet::HaltReason),
+            ("g", Packet::ReadGeneralRegister),
+            ("D", Packet::Detach),
+            ("qSupported", Packet::Query(QueryPacket::Supported)),
+            ("vCont?", Packet::V(VPacket::QueryContSupport)),
+            (
+                "vMustReplyEmpty",
+                Packet::V(VPacket::Unknown("MustReplyEmpty".into())),
+            ),
+        ];
+
+        for (input, expected) in test_data.iter() {
+            let parsed = parse_packet(input.as_bytes());
+
+            assert!(parsed.is_ok(), "Failed to parse '{}'", input);
+
+            assert_eq!(parsed.unwrap(), *expected);
+        }
+    }
+
+    #[test]
+    fn parse_packet_read_register_hex() {
+        assert_eq!(parse_packet(b"p03").unwrap(), Packet::ReadRegisterHex(3));
+    }
+
+    #[test]
+    fn parse_query_attached() {
+        assert_eq!(
+            query(b"qAttached").unwrap(),
+            (EMPTY, Packet::Query(QueryPacket::Attached(None)))
+        );
+    }
+
+    #[test]
+    fn parse_query_attached_with_pid() {
+        assert_eq!(
+            query(b"qAttached:02").unwrap(),
+            (EMPTY, Packet::Query(QueryPacket::Attached(Some(2))))
+        );
+    }
+
+    #[test]
+    fn parse_query_command() {
+        assert_eq!(
+            query(b"qRcmd,7265736574").unwrap(),
+            (
+                EMPTY,
+                Packet::Query(QueryPacket::Command(vec![0x72, 0x65, 0x73, 0x65, 0x74]))
+            )
+        );
+    }
+
+    #[test]
+    fn parse_read_register_hex() {
+        assert_eq!(
+            read_register_hex(b"p00").unwrap(),
+            (EMPTY, Packet::ReadRegisterHex(0))
+        );
+    }
+
+    #[test]
+    fn parse_read_memory() {
+        assert_eq!(
+            parse_packet(b"m004512,07").unwrap(),
+            Packet::ReadMemory {
+                address: 0x4512,
+                length: 0x07,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_insert_breakpoint() {
+        assert_eq!(
+            parse_packet(b"Z0,3456,2").unwrap(),
+            Packet::InsertBreakpoint {
+                breakpoint_type: BreakpointType::Software,
+                address: 0x3456,
+                kind: 0x2,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_remove_breakpoint() {
+        assert_eq!(
+            parse_packet(b"z1,274,0").unwrap(),
+            Packet::RemoveBreakpoint {
+                breakpoint_type: BreakpointType::Hardware,
+                address: 0x274,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_write_memory_binary() {
+        assert_eq!(
+            parse_packet(b"X270,7:.sd223!").unwrap(),
+            Packet::WriteMemoryBinary {
+                address: 0x270,
+                data: b".sd223!".to_vec()
+            }
+        );
+    }
+}

--- a/gdb-server/src/parser/query.rs
+++ b/gdb-server/src/parser/query.rs
@@ -1,13 +1,12 @@
+use super::util::hex_bytes;
 use nom::{
     branch::alt,
-    bytes::complete::{tag, take_until, take_while_m_n},
-    character::{complete::char, is_hex_digit},
-    combinator::{map_res, opt, peek},
-    map,
-    multi::{many1, separated_nonempty_list},
-    named,
+    bytes::complete::{tag, take_until, take_while},
+    character::complete::char,
+    combinator::{opt, peek},
+    error::ErrorKind,
+    multi::separated_nonempty_list,
     number::complete::hex_u32,
-    recognize,
     sequence::preceded,
     IResult,
 };
@@ -17,12 +16,13 @@ pub enum QueryPacket {
     ThreadId,
     Attached(Option<Pid>),
     Command(Vec<u8>),
-    Supported(Vec<Vec<u8>>),
+    Supported(Vec<String>),
     /// qXfer command
     Transfer {
         object: Vec<u8>,
         operation: TransferOperation,
     },
+    HostInfo,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -42,7 +42,7 @@ pub enum TransferOperation {
 pub type Pid = u32;
 
 /// Parse PID
-fn pid(input: &[u8]) -> IResult<&[u8], Pid> {
+pub fn pid(input: &[u8]) -> IResult<&[u8], Pid> {
     hex_u32(input)
 }
 
@@ -53,6 +53,7 @@ pub fn query_packet(input: &[u8]) -> IResult<&[u8], QueryPacket> {
         query_command,
         query_supported,
         query_transfer,
+        query_hostinfo,
     ))(input)?;
 
     Ok((input, query_packet))
@@ -77,13 +78,19 @@ fn query_attached(input: &[u8]) -> IResult<&[u8], QueryPacket> {
     Ok((input, QueryPacket::Attached(pid)))
 }
 
+fn query_hostinfo(input: &[u8]) -> IResult<&[u8], QueryPacket> {
+    let (input, _) = tag("HostInfo")(input)?;
+
+    Ok((input, QueryPacket::HostInfo))
+}
+
 fn query_supported(input: &[u8]) -> IResult<&[u8], QueryPacket> {
     let (input, _) = tag("Supported")(input)?;
 
-    let (input, next_char) = peek(char(':'))(input)?;
+    let (input, next_char) = peek(opt(char(':')))(input)?;
 
     // Could also be an empty list
-    let (input, features) = if next_char == ':' {
+    let (input, features) = if next_char.is_some() {
         let (input, _) = char(':')(input)?;
 
         separated_nonempty_list(tag(";"), gdb_feature)(input)?
@@ -94,10 +101,15 @@ fn query_supported(input: &[u8]) -> IResult<&[u8], QueryPacket> {
     Ok((input, QueryPacket::Supported(features)))
 }
 
-fn gdb_feature(input: &[u8]) -> IResult<&[u8], Vec<u8>> {
-    let (input, data) = take_until(";")(input)?;
+fn gdb_feature(input: &[u8]) -> IResult<&[u8], String> {
+    let (input, data) = take_while(|c| c != b';')(input)?;
 
-    Ok((input, data.to_owned()))
+    let feature =
+        std::str::from_utf8(data).map_err(|_e| nom::Err::Failure((input, ErrorKind::IsNot)))?;
+
+    // TODO: Actually recognize features with their flags
+
+    Ok((input, feature.to_owned()))
 }
 
 fn query_transfer(input: &[u8]) -> IResult<&[u8], QueryPacket> {
@@ -130,7 +142,7 @@ fn transfer_operation_read(input: &[u8]) -> IResult<&[u8], TransferOperation> {
 
     let (input, offset) = hex_u32(input)?;
 
-    let (input, _) = char(':')(input)?;
+    let (input, _) = char(',')(input)?;
 
     let (input, length) = hex_u32(input)?;
 
@@ -164,21 +176,6 @@ fn transfer_operation_write(input: &[u8]) -> IResult<&[u8], TransferOperation> {
     ))
 }
 
-fn hex_bytes(input: &[u8]) -> IResult<&[u8], Vec<u8>> {
-    let (input, bytes) = many1(hex_byte)(input)?;
-
-    Ok((input, bytes))
-}
-
-fn hex_byte(input: &[u8]) -> IResult<&[u8], u8> {
-    let (input, digits) = take_while_m_n(2, 2, is_hex_digit)(input)?;
-
-    let result = (digits[0] as char).to_digit(16).unwrap_or(0) << 4
-        | (digits[1] as char).to_digit(16).unwrap_or(0);
-
-    Ok((input, result as u8))
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -188,7 +185,7 @@ mod test {
     #[test]
     fn parse_memory_map_read() {
         assert_eq!(
-            query_packet(b"Xfer:memory-map:read::1:10").unwrap(),
+            query_packet(b"Xfer:memory-map:read::1,10").unwrap(),
             (
                 EMPTY,
                 QueryPacket::Transfer {
@@ -210,28 +207,27 @@ mod test {
 
         assert_eq!(
             query_packet(packet).unwrap(),
-            (EMPTY, QueryPacket::Supported(vec![]))
+            (
+                EMPTY,
+                QueryPacket::Supported(
+                    [
+                        "multiprocess+",
+                        "swbreak+",
+                        "hwbreak+",
+                        "qRelocInsn+",
+                        "fork-events+",
+                        "vfork-events+",
+                        "exec-events+",
+                        "vContSupported+",
+                        "QThreadEvents+",
+                        "no-resumed+",
+                        "xmlRegisters=i386"
+                    ]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect()
+                )
+            )
         );
-    }
-
-    #[test]
-    fn parse_hex_bytes() {
-        assert_eq!(
-            hex_bytes(b"7265736574").unwrap(),
-            (EMPTY, vec![0x72, 0x65, 0x73, 0x65, 0x74])
-        );
-    }
-
-    #[test]
-    fn parse_hex_byte() {
-        assert_eq!(hex_byte(b"72").unwrap(), (EMPTY, 0x72));
-
-        assert_eq!(hex_byte(b"00").unwrap(), (EMPTY, 0x00));
-
-        assert_eq!(hex_byte(b"FF").unwrap(), (EMPTY, 0xff));
-
-        assert_eq!(hex_byte(b"ab").unwrap(), (EMPTY, 0xab));
-
-        assert_eq!(hex_byte(b"853").unwrap(), ("3".as_bytes(), 0x85));
     }
 }

--- a/gdb-server/src/parser/query.rs
+++ b/gdb-server/src/parser/query.rs
@@ -1,0 +1,209 @@
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_until, take_while_m_n},
+    character::{complete::char, is_hex_digit},
+    combinator::{map_res, opt},
+    map,
+    multi::many1,
+    named,
+    number::complete::hex_u32,
+    recognize,
+    sequence::preceded,
+    IResult,
+};
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum QueryPacket {
+    ThreadId,
+    Attached(Option<Pid>),
+    Command(Vec<u8>),
+    Supported,
+    /// qXfer command
+    Transfer {
+        object: Vec<u8>,
+        operation: TransferOperation,
+    },
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum TransferOperation {
+    Read {
+        annex: Vec<u8>,
+        offset: u32,
+        length: u32,
+    },
+    Write {
+        annex: Vec<u8>,
+        offset: u32,
+        data: Vec<u8>,
+    },
+}
+
+pub type Pid = u32;
+
+/// Parse PID
+fn pid(input: &[u8]) -> IResult<&[u8], Pid> {
+    hex_u32(input)
+}
+
+pub fn query_packet(input: &[u8]) -> IResult<&[u8], QueryPacket> {
+    let (input, query_packet) = alt((
+        query_thread_id,
+        query_attached,
+        query_command,
+        query_supported,
+        query_transfer,
+    ))(input)?;
+
+    Ok((input, query_packet))
+}
+
+fn query_thread_id(input: &[u8]) -> IResult<&[u8], QueryPacket> {
+    let (input, _) = char('C')(input)?;
+    Ok((input, QueryPacket::ThreadId))
+}
+
+fn query_command(input: &[u8]) -> IResult<&[u8], QueryPacket> {
+    let (input, _) = tag("Rcmd,")(input)?;
+
+    let (input, command) = hex_bytes(input)?;
+    Ok((input, QueryPacket::Command(command)))
+}
+
+fn query_attached(input: &[u8]) -> IResult<&[u8], QueryPacket> {
+    let (input, _) = tag("Attached")(input)?;
+
+    let (input, pid) = opt(preceded(char(':'), pid))(input)?;
+    Ok((input, QueryPacket::Attached(pid)))
+}
+
+fn query_supported(input: &[u8]) -> IResult<&[u8], QueryPacket> {
+    let (input, _) = tag("Supported")(input)?;
+
+    Ok((input, QueryPacket::Supported))
+}
+
+fn query_transfer(input: &[u8]) -> IResult<&[u8], QueryPacket> {
+    let (input, _) = tag("Xfer")(input)?;
+
+    let (input, _) = char(':')(input)?;
+
+    let (input, object) = take_until(":")(input)?;
+
+    let (input, _) = char(':')(input)?;
+
+    let (input, operation) = alt((transfer_operation_read, transfer_operation_write))(input)?;
+
+    Ok((
+        input,
+        QueryPacket::Transfer {
+            object: object.to_owned(),
+            operation,
+        },
+    ))
+}
+
+fn transfer_operation_read(input: &[u8]) -> IResult<&[u8], TransferOperation> {
+    let (input, _) = tag("read")(input)?;
+    let (input, _) = char(':')(input)?;
+
+    let (input, annex) = take_until(":")(input)?;
+
+    let (input, _) = char(':')(input)?;
+
+    let (input, offset) = hex_u32(input)?;
+
+    let (input, _) = char(':')(input)?;
+
+    let (input, length) = hex_u32(input)?;
+
+    Ok((
+        input,
+        TransferOperation::Read {
+            annex: annex.to_owned(),
+            offset,
+            length,
+        },
+    ))
+}
+
+fn transfer_operation_write(input: &[u8]) -> IResult<&[u8], TransferOperation> {
+    let (input, _) = tag("write")(input)?;
+    let (input, annex) = take_until(":")(input)?;
+
+    let (input, _) = char(':')(input)?;
+
+    let (input, offset) = hex_u32(input)?;
+
+    let (input, _) = char(':')(input)?;
+
+    Ok((
+        &[],
+        TransferOperation::Write {
+            annex: annex.to_owned(),
+            offset,
+            data: input.to_owned(),
+        },
+    ))
+}
+
+fn hex_bytes(input: &[u8]) -> IResult<&[u8], Vec<u8>> {
+    let (input, bytes) = many1(hex_byte)(input)?;
+
+    Ok((input, bytes))
+}
+
+fn hex_byte(input: &[u8]) -> IResult<&[u8], u8> {
+    let (input, digits) = take_while_m_n(2, 2, is_hex_digit)(input)?;
+
+    let result = (digits[0] as char).to_digit(16).unwrap_or(0) << 4
+        | (digits[1] as char).to_digit(16).unwrap_or(0);
+
+    Ok((input, result as u8))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const EMPTY: &[u8] = &[];
+
+    #[test]
+    fn parse_memory_map_read() {
+        assert_eq!(
+            query_packet(b"Xfer:memory-map:read::1:10").unwrap(),
+            (
+                EMPTY,
+                QueryPacket::Transfer {
+                    object: b"memory-map".to_vec(),
+                    operation: TransferOperation::Read {
+                        annex: vec![],
+                        offset: 1,
+                        length: 16
+                    }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn parse_hex_bytes() {
+        assert_eq!(
+            hex_bytes(b"7265736574").unwrap(),
+            (EMPTY, vec![0x72, 0x65, 0x73, 0x65, 0x74])
+        );
+    }
+
+    #[test]
+    fn parse_hex_byte() {
+        assert_eq!(hex_byte(b"72").unwrap(), (EMPTY, 0x72));
+
+        assert_eq!(hex_byte(b"00").unwrap(), (EMPTY, 0x00));
+
+        assert_eq!(hex_byte(b"FF").unwrap(), (EMPTY, 0xff));
+
+        assert_eq!(hex_byte(b"ab").unwrap(), (EMPTY, 0xab));
+
+        assert_eq!(hex_byte(b"853").unwrap(), ("3".as_bytes(), 0x85));
+    }
+}

--- a/gdb-server/src/parser/util.rs
+++ b/gdb-server/src/parser/util.rs
@@ -1,0 +1,79 @@
+use nom::{bytes::complete::take_while_m_n, character::is_hex_digit, multi::many1, IResult};
+
+/// Parse bytes encoded as a ASCII hex string.
+///
+/// For example the string '1275' would result in
+/// the bytes 0x12 0x75.
+pub fn hex_bytes(input: &[u8]) -> IResult<&[u8], Vec<u8>> {
+    let (input, bytes) = many1(hex_byte)(input)?;
+
+    Ok((input, bytes))
+}
+
+fn hex_byte(input: &[u8]) -> IResult<&[u8], u8> {
+    let (input, digits) = take_while_m_n(2, 2, is_hex_digit)(input)?;
+
+    let result = (digits[0] as char).to_digit(16).unwrap_or(0) << 4
+        | (digits[1] as char).to_digit(16).unwrap_or(0);
+
+    Ok((input, result as u8))
+}
+
+pub fn hex_u64(input: &[u8]) -> IResult<&[u8], u64> {
+    // acquire hex_bytes at first
+    let (input, raw_bytes) = take_while_m_n(1, 16, is_hex_digit)(input)?;
+
+    let mut value = 0u64;
+
+    for digit in raw_bytes {
+        value <<= 4;
+
+        // unwrap is safe, we check above that only valid hex digits are in raw_bytes
+        value |= (*digit as char).to_digit(16).unwrap() as u64;
+    }
+
+    Ok((input, value))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const EMPTY: &[u8] = &[];
+
+    #[test]
+    fn parse_hex_bytes() {
+        assert_eq!(
+            hex_bytes(b"7265736574").unwrap(),
+            (EMPTY, vec![0x72, 0x65, 0x73, 0x65, 0x74])
+        );
+    }
+
+    #[test]
+    fn parse_hex_byte() {
+        assert_eq!(hex_byte(b"72").unwrap(), (EMPTY, 0x72));
+
+        assert_eq!(hex_byte(b"00").unwrap(), (EMPTY, 0x00));
+
+        assert_eq!(hex_byte(b"FF").unwrap(), (EMPTY, 0xff));
+
+        assert_eq!(hex_byte(b"ab").unwrap(), (EMPTY, 0xab));
+
+        assert_eq!(hex_byte(b"853").unwrap(), ("3".as_bytes(), 0x85));
+    }
+
+    #[test]
+    fn parse_hex_u64() {
+        assert_eq!(hex_u64(b"0").unwrap(), (EMPTY, 0x0));
+        assert_eq!(hex_u64(b"00000000").unwrap(), (EMPTY, 0x0));
+        assert_eq!(
+            hex_u64(b"00000000000000000").unwrap(),
+            ("0".as_bytes(), 0x0)
+        );
+
+        assert_eq!(
+            hex_u64(b"1230000000000000").unwrap(),
+            (EMPTY, 0x1230_0000_0000_0000)
+        );
+    }
+}

--- a/gdb-server/src/parser/v_packet.rs
+++ b/gdb-server/src/parser/v_packet.rs
@@ -11,6 +11,7 @@ pub enum VPacket {
     QueryContSupport,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, PartialEq, Clone)]
 pub enum Action {
     Continue,

--- a/gdb-server/src/parser/v_packet.rs
+++ b/gdb-server/src/parser/v_packet.rs
@@ -1,0 +1,100 @@
+use nom::{
+    branch::alt,
+    bytes::complete::tag,
+    character::complete::char,
+    combinator::{map, value},
+    IResult,
+};
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum VPacket {
+    Attach,
+    Continue(Action),
+    Unknown(Vec<u8>),
+    QueryContSupport,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Action {
+    Continue,
+    ContinueSignal(u8),
+    Step,
+    StepSignal,
+    Stop,
+    RangeStep { start: u32, end: u32 },
+}
+
+pub fn v_packet(input: &[u8]) -> IResult<&[u8], VPacket> {
+    let parse_result = alt((v_cont_support, v_cont))(input);
+
+    match parse_result {
+        Ok((input, packet)) => Ok((input, packet)),
+        Err(nom::Err::Error((input, _kind))) => {
+            // For unknown packets, we have to return a valid packet here.
+            // This is requird by the GDB spec.
+            Ok(("".as_bytes(), VPacket::Unknown(input.to_owned())))
+        }
+        Err(other) => Err(other),
+    }
+}
+
+fn v_cont_support(input: &[u8]) -> IResult<&[u8], VPacket> {
+    let (input, _) = tag("Cont?")(input)?;
+
+    Ok((input, VPacket::QueryContSupport))
+}
+
+fn v_cont(input: &[u8]) -> IResult<&[u8], VPacket> {
+    let (input, _) = tag("Cont;")(input)?;
+
+    let (input, action) = v_cont_action(input)?;
+
+    Ok((input, VPacket::Continue(action)))
+}
+
+fn v_cont_action(input: &[u8]) -> IResult<&[u8], Action> {
+    alt((
+        value(Action::Continue, char('c')),
+        value(Action::Step, char('s')),
+        value(Action::Stop, char('t')),
+    ))(input)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const EMPTY: &[u8] = &[];
+
+    #[test]
+    fn parse_v_cont_support() {
+        assert_eq!(
+            v_packet(b"Cont?").unwrap(),
+            (EMPTY, VPacket::QueryContSupport)
+        );
+    }
+
+    #[test]
+    fn parse_v_cont_cont() {
+        assert_eq!(
+            v_packet(b"Cont;c").unwrap(),
+            (EMPTY, VPacket::Continue(Action::Continue))
+        );
+    }
+
+    #[test]
+    fn parse_v_cont_step() {
+        assert_eq!(
+            v_packet(b"Cont;s").unwrap(),
+            (EMPTY, VPacket::Continue(Action::Step))
+        );
+    }
+
+    #[test]
+    fn parse_v_cont_stop() {
+        assert_eq!(
+            v_packet(b"Cont;t").unwrap(),
+            (EMPTY, VPacket::Continue(Action::Stop))
+        );
+    }
+}

--- a/gdb-server/src/worker.rs
+++ b/gdb-server/src/worker.rs
@@ -60,7 +60,7 @@ pub async fn handler(
 
     let response: Option<String> = match parsed_packet {
         HaltReason => handlers::halt_reason(),
-        Query(QueryPacket::Supported) => handlers::q_supported(),
+        Query(QueryPacket::Supported { .. }) => handlers::q_supported(),
         Query(QueryPacket::Attached { .. }) => handlers::q_attached(),
         Query(QueryPacket::Command(cmd)) => {
             if cmd == b"reset" {

--- a/gdb-server/src/worker.rs
+++ b/gdb-server/src/worker.rs
@@ -6,6 +6,7 @@ use futures::select;
 use gdb_protocol::packet::{CheckedPacket, Kind as PacketKind};
 use probe_rs::Core;
 use probe_rs::Session;
+use std::convert::TryFrom;
 use std::time::Duration;
 
 use crate::parser::parse_packet;
@@ -49,7 +50,7 @@ pub async fn handler(
     awaits_halt: &mut bool,
     packet: CheckedPacket,
 ) -> ServerResult<bool> {
-    let parsed_packet = parse_packet(&packet.data)?;
+    let parsed_packet = parse_packet(&packet.data);
     let mut break_due = false;
 
     use crate::parser::v_packet::Action;
@@ -59,74 +60,100 @@ pub async fn handler(
     use crate::parser::VPacket;
 
     let response: Option<String> = match parsed_packet {
-        HaltReason => handlers::halt_reason(),
-        Query(QueryPacket::Supported { .. }) => handlers::q_supported(),
-        Query(QueryPacket::Attached { .. }) => handlers::q_attached(),
-        Query(QueryPacket::Command(cmd)) => {
-            if cmd == b"reset" {
-                handlers::reset_halt(core)
-            } else {
-                log::debug!("Unknown monitor command: '{:?}'", cmd);
-                handlers::reply_empty()
-            }
-        }
-        ReadGeneralRegister => handlers::read_general_registers(),
-        ReadRegisterHex(register) => handlers::read_register(register, core),
-        ReadMemory { address, length } => handlers::read_memory(address, length, core),
-        Detach => handlers::detach(&mut break_due),
-        V(VPacket::Continue(action)) => match action {
-            Action::Continue => handlers::run(core, awaits_halt),
-            Action::Stop => handlers::stop(core, awaits_halt),
-            Action::Step => handlers::step(core, awaits_halt),
-            other => {
-                log::warn!("vCont with action {:?} not supported", other);
-                handlers::reply_empty()
-            }
-        },
-        InsertBreakpoint {
-            breakpoint_type,
-            address,
-            kind,
-        } => match breakpoint_type {
-            BreakpointType::Hardware => handlers::insert_hardware_break(address, kind, core),
-            other => {
-                log::warn!("Breakpoint type {:?} is not supported.", other);
-                handlers::reply_empty()
-            }
-        },
-        RemoveBreakpoint {
-            breakpoint_type,
-            address,
-            kind,
-        } => match breakpoint_type {
-            BreakpointType::Hardware => handlers::remove_hardware_break(address, kind, core),
-            other => {
-                log::warn!("Breakpoint type {:?} is not supported.", other);
-                handlers::reply_empty()
-            }
-        },
-        WriteMemoryBinary { address, data } => handlers::write_memory(address, &data, core),
-        Query(QueryPacket::Transfer { object, operation }) => {
-            use crate::parser::query::TransferOperation;
-
-            if object == b"memory-map" {
-                match operation {
-                    TransferOperation::Read { .. } => handlers::get_memory_map(),
-                    TransferOperation::Write { .. } => {
-                        // not supported
+        Ok(parsed_packet) => {
+            log::debug!("Parsed packet: {:?}", parsed_packet);
+            match parsed_packet {
+                HaltReason => handlers::halt_reason(),
+                Continue => handlers::run(core, awaits_halt),
+                V(VPacket::QueryContSupport) => handlers::vcont_supported(),
+                Query(QueryPacket::Supported { .. }) => handlers::q_supported(),
+                Query(QueryPacket::Attached { .. }) => handlers::q_attached(),
+                Query(QueryPacket::Command(cmd)) => {
+                    if cmd == b"reset" {
+                        handlers::reset_halt(core)
+                    } else {
+                        log::debug!("Unknown monitor command: '{:?}'", cmd);
                         handlers::reply_empty()
                     }
                 }
-            } else {
-                log::warn!("Object '{:?}' not supported for qXfer command", object);
-                handlers::reply_empty()
+                Query(QueryPacket::HostInfo) => handlers::host_info(),
+                ReadGeneralRegister => handlers::read_general_registers(),
+                ReadRegisterHex(register) => handlers::read_register(register, core),
+                ReadMemory { address, length } => {
+                    // LLDB will send 64 bit addresses, which are not supported by probe-rs
+                    // yet.
+
+                    if let Ok(address) = u32::try_from(address) {
+                        handlers::read_memory(address, length, core)
+                    } else {
+                        //
+                        handlers::reply_empty()
+                    }
+                }
+                Detach => handlers::detach(&mut break_due),
+                V(VPacket::Continue(action)) => match action {
+                    Action::Continue => handlers::run(core, awaits_halt),
+                    Action::Stop => handlers::stop(core, awaits_halt),
+                    Action::Step => handlers::step(core, awaits_halt),
+                    other => {
+                        log::warn!("vCont with action {:?} not supported", other);
+                        handlers::reply_empty()
+                    }
+                },
+                InsertBreakpoint {
+                    breakpoint_type,
+                    address,
+                    kind,
+                } => match breakpoint_type {
+                    BreakpointType::Hardware => {
+                        handlers::insert_hardware_break(address, kind, core)
+                    }
+                    other => {
+                        log::warn!("Breakpoint type {:?} is not supported.", other);
+                        handlers::reply_empty()
+                    }
+                },
+                RemoveBreakpoint {
+                    breakpoint_type,
+                    address,
+                    kind,
+                } => match breakpoint_type {
+                    BreakpointType::Hardware => {
+                        handlers::remove_hardware_break(address, kind, core)
+                    }
+                    other => {
+                        log::warn!("Breakpoint type {:?} is not supported.", other);
+                        handlers::reply_empty()
+                    }
+                },
+                WriteMemoryBinary { address, data } => handlers::write_memory(address, &data, core),
+                Query(QueryPacket::Transfer { object, operation }) => {
+                    use crate::parser::query::TransferOperation;
+
+                    if object == b"memory-map" {
+                        match operation {
+                            TransferOperation::Read { .. } => handlers::get_memory_map(),
+                            TransferOperation::Write { .. } => {
+                                // not supported
+                                handlers::reply_empty()
+                            }
+                        }
+                    } else {
+                        log::warn!("Object '{:?}' not supported for qXfer command", object);
+                        handlers::reply_empty()
+                    }
+                }
+                Interrupt => handlers::user_halt(core, awaits_halt),
+                other => {
+                    log::warn!("Unknown command: '{:?}'", other);
+
+                    // respond with an empty response to indicate that we don't suport the command
+                    handlers::reply_empty()
+                }
             }
         }
-        Interrupt => handlers::user_halt(core, awaits_halt),
-        other => {
-            log::warn!("Unknown command: '{:?}'", other);
-
-            // respond with an empty response to indicate that we don't suport the command
+        Err(e) => {
+            log::warn!("Failed to parse packet '{:?}': {}", &packet.data, e);
             handlers::reply_empty()
         }
     };

--- a/gdb-server/src/worker.rs
+++ b/gdb-server/src/worker.rs
@@ -4,7 +4,6 @@ use futures::channel::mpsc;
 use futures::future::FutureExt;
 use futures::select;
 use gdb_protocol::packet::{CheckedPacket, Kind as PacketKind};
-use probe_rs::Core;
 use probe_rs::Session;
 use std::convert::TryFrom;
 use std::time::Duration;

--- a/gdb-server/src/worker.rs
+++ b/gdb-server/src/worker.rs
@@ -78,7 +78,7 @@ pub async fn handler(
                     }
                 }
                 Query(QueryPacket::HostInfo) => handlers::host_info(),
-                ReadGeneralRegister => handlers::read_general_registers(),
+                ReadGeneralRegister => handlers::read_general_registers(session.core(0)?),
                 ReadRegisterHex(register) => handlers::read_register(register, session.core(0)?),
                 ReadMemory { address, length } => {
                     // LLDB will send 64 bit addresses, which are not supported by probe-rs


### PR DESCRIPTION
Use `nom` to parse GDB packets into an Enum, which allows cleaner handling of them. Should make it easier to expand the GDB server to more packets.