### PR TITLE
Improve target generation

### DIFF
--- a/probe-rs/build.rs
+++ b/probe-rs/build.rs
@@ -16,7 +16,16 @@ fn main() {
 
     let mut rustfmt = Command::new("rustfmt");
 
-    rustfmt.arg("--emit").arg("files").arg(dest_path);
+    rustfmt.arg("--emit").arg("files").arg(&dest_path);
 
-    rustfmt.status().expect("Failed to run rustfmt");
+    let fmt_result = rustfmt.status().expect("Failed to run rustfmt");
+
+    if !fmt_result.success() {
+        println!("cargo:warning=Failed to formated generated target file.",);
+        println!(
+            "cargo:warning='rustfmt --emit files {}' failed with {}",
+            dest_path.display(),
+            fmt_result
+        );
+    }
 }


### PR DESCRIPTION
* Show an error message when the build script is unable to run
  rustfmt.

* Don't generate a struct without values for the JEP106 code in the
  target generation. The whole struct should be `None` in that case.