### PR TITLE
Add bors

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,0 +1,9 @@
+required_approvals = 1
+block_labels = ["wip"]
+delete_merged_branches = true
+status = [
+    "Check (ubuntu-latest)",
+    "Check (windows-latest)",
+    "Test Suite",
+    "Rustfmt",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, staging, trying ]
   pull_request:
 
 name: CI


### PR DESCRIPTION
This PR sets up bors to help merging PRs. It remains possible to manually merge by clicking the merge button, but if you write 'bors merge' or 'bors r+' after leaving an "approve" review, bors will create a merge commit, check that CI passes on the merge commit, and then update master with it. If multiple PRs are merged at once, it will batch them into tested commits, so at no point will a commit be pushed to master which breaks CI.

Before this PR can be merged, the bors app needs to be added to this repository (I've requested that through github). Once that's done it should be possible to 'bors merge' this PR and have it work.