### PR TITLE
Refactor ARM Memory code

### DIFF
--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -39,7 +39,7 @@ pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<()> 
     */
 
     let mut state = ArmCommunicationInterfaceState::new();
-    let mut interface = ArmCommunicationInterface::new(&mut probe, &mut state)?;
+    let mut interface = probe.get_arm_interface(&mut state)?;
 
     if let Some(interface) = &mut interface {
         println!("\nAvailable Access Ports:");

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -4,10 +4,10 @@ use probe_rs::{
     architecture::arm::{
         ap::{valid_access_ports, APClass, BaseaddrFormat, MemoryAP, BASE, BASE2, IDR},
         m0::Demcr,
-        memory::{ADIMemoryInterface, Component},
+        memory::Component,
         ArmCommunicationInterface, ArmCommunicationInterfaceState,
     },
-    CoreRegister, Memory,
+    CoreRegister,
 };
 
 use anyhow::Result;
@@ -67,12 +67,7 @@ pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<()> 
                 };
                 baseaddr |= u64::from(base_register.BASEADDR << 12);
 
-                // We assume that only 32bit accesses work here, speed is not really an issue
-                let mut memory = Memory::new(ADIMemoryInterface::<ArmCommunicationInterface>::new(
-                    interface.reborrow(),
-                    access_port,
-                    true,
-                )?);
+                let mut memory = interface.reborrow().memory_interface(access_port)?;
 
                 // Enable
                 // - Data Watchpoint and Trace (DWT)

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -5,7 +5,7 @@ use probe_rs::{
         ap::{valid_access_ports, APClass, BaseaddrFormat, MemoryAP, BASE, BASE2, IDR},
         m0::Demcr,
         memory::Component,
-        ArmCommunicationInterface, ArmCommunicationInterfaceState,
+        ArmCommunicationInterfaceState,
     },
     CoreRegister,
 };

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -2,10 +2,9 @@ use crate::{common::open_probe, SharedOptions};
 
 use probe_rs::{
     architecture::arm::{
-        ap::{valid_access_ports, APClass, BaseaddrFormat, MemoryAP, BASE, BASE2, IDR},
+        ap::{APClass, BaseaddrFormat, MemoryAP, BASE, BASE2, IDR},
         m0::Demcr,
         memory::Component,
-        ArmCommunicationInterfaceState,
     },
     CoreRegister,
 };

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -38,6 +38,8 @@ pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<()> 
 
     */
 
+    /*
+
     let mut state = ArmCommunicationInterfaceState::new();
     let mut interface = probe.get_arm_interface(&mut state)?;
 
@@ -98,6 +100,8 @@ pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<()> 
             "No DAP interface was found on the connected probe. Thus, ARM info cannot be printed."
         )
     }
+
+    */
 
     Ok(())
 }

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -2,9 +2,10 @@ use crate::{common::open_probe, SharedOptions};
 
 use probe_rs::{
     architecture::arm::{
-        ap::{APClass, BaseaddrFormat, MemoryAP, BASE, BASE2, IDR},
+        ap::{GenericAP, MemoryAP},
         m0::Demcr,
         memory::Component,
+        ApInformation,
     },
     CoreRegister,
 };
@@ -37,61 +38,55 @@ pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<()> 
 
     */
 
-    /*
-
-    let mut state = ArmCommunicationInterfaceState::new();
-    let mut interface = probe.get_arm_interface(&mut state)?;
+    let mut interface = probe.into_arm_interface()?;
 
     if let Some(interface) = &mut interface {
         println!("\nAvailable Access Ports:");
 
-        for access_port in valid_access_ports(interface) {
-            let idr = interface.read_ap_register(access_port, IDR::default())?;
-            println!("{:#x?}", idr);
+        let num_access_ports = interface.num_access_ports();
 
-            if idr.CLASS == APClass::MEMAP {
-                let access_port: MemoryAP = access_port.into();
+        for ap_index in 0..num_access_ports {
+            let access_port = GenericAP::from(ap_index as u8);
 
-                let base_register = interface.read_ap_register(access_port, BASE::default())?;
+            let ap_information = interface.ap_information(access_port).unwrap();
 
-                if !base_register.present {
-                    // No debug entry present
-                    println!("No debug entry present.");
-                    continue;
+            //let idr = interface.read_ap_register(access_port, IDR::default())?;
+            //println!("{:#x?}", idr);
+
+            match ap_information {
+                ApInformation::MemoryAp {
+                    debug_base_address, ..
+                } => {
+                    let access_port: MemoryAP = access_port.into();
+
+                    let base_address = *debug_base_address;
+
+                    let mut memory = interface.memory_interface(access_port)?;
+
+                    // Enable
+                    // - Data Watchpoint and Trace (DWT)
+                    // - Instrumentation Trace Macrocell (ITM)
+                    // - Embedded Trace Macrocell (ETM)
+                    // - Trace Port Interface Unit (TPIU).
+                    let mut demcr = Demcr(memory.read_word_32(Demcr::ADDRESS)?);
+                    demcr.set_dwtena(true);
+                    memory.write_word_32(Demcr::ADDRESS, demcr.into())?;
+
+                    let component_table = Component::try_parse(&mut memory, base_address);
+
+                    component_table
+                        .iter()
+                        .for_each(|entry| println!("{:#08x?}", entry));
+
+                    // let mut reader = crate::memory::romtable::RomTableReader::new(&link_ref, baseaddr as u64);
+
+                    // for e in reader.entries() {
+                    //     if let Ok(e) = e {
+                    //         println!("ROM Table Entry: Component @ 0x{:08x}", e.component_addr());
+                    //     }
+                    // }
                 }
-
-                let mut baseaddr = if BaseaddrFormat::ADIv5 == base_register.Format {
-                    let base2 = interface.read_ap_register(access_port, BASE2::default())?;
-                    u64::from(base2.BASEADDR) << 32
-                } else {
-                    0
-                };
-                baseaddr |= u64::from(base_register.BASEADDR << 12);
-
-                let mut memory = interface.reborrow().memory_interface(access_port)?;
-
-                // Enable
-                // - Data Watchpoint and Trace (DWT)
-                // - Instrumentation Trace Macrocell (ITM)
-                // - Embedded Trace Macrocell (ETM)
-                // - Trace Port Interface Unit (TPIU).
-                let mut demcr = Demcr(memory.read_word_32(Demcr::ADDRESS)?);
-                demcr.set_dwtena(true);
-                memory.write_word_32(Demcr::ADDRESS, demcr.into())?;
-
-                let component_table = Component::try_parse(&mut memory, baseaddr as u64);
-
-                component_table
-                    .iter()
-                    .for_each(|entry| println!("{:#08x?}", entry));
-
-                // let mut reader = crate::memory::romtable::RomTableReader::new(&link_ref, baseaddr as u64);
-
-                // for e in reader.entries() {
-                //     if let Ok(e) = e {
-                //         println!("ROM Table Entry: Component @ 0x{:08x}", e.component_addr());
-                //     }
-                // }
+                ApInformation::Other { .. } => println!("Unknown Type of access port"),
             }
         }
     } else {
@@ -99,8 +94,6 @@ pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<()> 
             "No DAP interface was found on the connected probe. Thus, ARM info cannot be printed."
         )
     }
-
-    */
 
     Ok(())
 }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -21,6 +21,7 @@ pub enum MockMemoryError {
     UnknownRegister,
 }
 
+#[cfg(test)]
 impl MockMemoryAP {
     /// Creates a MockMemoryAP with the memory filled with a pattern where each byte is equal to its
     /// own address plus one (to avoid zeros). The pattern can be used as a canary pattern to ensure

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -150,7 +150,7 @@ where
 }
 
 /// Return a Vec of all valid access ports found that the target connected to the debug_probe
-pub fn valid_access_ports<AP>(debug_port: &mut AP) -> Vec<GenericAP>
+pub(crate) fn valid_access_ports<AP>(debug_port: &mut AP) -> Vec<GenericAP>
 where
     AP: APAccess<GenericAP, IDR>,
 {

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -7,7 +7,6 @@ use crate::architecture::arm::dp::DebugPortError;
 use crate::DebugProbeError;
 
 pub use generic_ap::{APClass, APType, GenericAP, IDR};
-pub(crate) use memory_ap::mock;
 pub use memory_ap::{
     AddressIncrement, BaseaddrFormat, DataSize, MemoryAP, BASE, BASE2, CSW, DRW, TAR,
 };

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -206,7 +206,7 @@ fn get_debug_port_version(probe: &mut Probe) -> Result<DebugPortVersion, DebugPr
 }
 
 impl<'probe> ArmCommunicationInterface<'probe> {
-    pub fn new(
+    pub(crate) fn new(
         probe: &'probe mut Probe,
         state: &'probe mut ArmCommunicationInterfaceState,
     ) -> Result<Option<Self>, DebugProbeError> {

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -21,16 +21,13 @@ where
     only_32bit_data_size: bool,
 }
 
-impl<'probe: 'interface, 'interface>
-    ADIMemoryInterface<'interface, ArmCommunicationInterface<'probe>>
-{
+impl<'interface> ADIMemoryInterface<'interface, ArmCommunicationInterface> {
     /// Creates a new MemoryInterface for given AccessPort.
     pub fn new(
-        interface: &'interface mut ArmCommunicationInterface<'probe>,
+        interface: &'interface mut ArmCommunicationInterface,
         access_port_number: impl Into<MemoryAP>,
         only_32bit_data_size: bool,
-    ) -> Result<ADIMemoryInterface<'interface, ArmCommunicationInterface<'probe>>, AccessPortError>
-    {
+    ) -> Result<ADIMemoryInterface<'interface, ArmCommunicationInterface>, AccessPortError> {
         Ok(Self {
             interface,
             access_port: access_port_number.into(),

--- a/probe-rs/src/architecture/arm/memory/mod.rs
+++ b/probe-rs/src/architecture/arm/memory/mod.rs
@@ -2,7 +2,6 @@ pub(crate) mod adi_v5_memory_interface;
 pub(crate) mod romtable;
 
 use super::ap::AccessPortError;
-pub use adi_v5_memory_interface::ADIMemoryInterface;
 pub use romtable::Component;
 
 pub trait ToMemoryReadSize: Into<u32> + Copy {

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -8,6 +8,7 @@ pub mod swo;
 
 pub use communication_interface::{
     ArmChipInfo, ArmCommunicationInterface, ArmCommunicationInterfaceState, DAPAccess, DapError,
+    ApInformation,
 };
 pub use communication_interface::{PortType, Register};
 pub use swo::{SwoAccess, SwoConfig, SwoMode};

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -7,8 +7,7 @@ pub mod memory;
 pub mod swo;
 
 pub use communication_interface::{
-    ArmChipInfo, ArmCommunicationInterface, ArmCommunicationInterfaceState, DAPAccess, DapError,
-    ApInformation,
+    ApInformation, ArmChipInfo, ArmCommunicationInterface, DAPAccess, DapError,
 };
 pub use communication_interface::{PortType, Register};
 pub use swo::{SwoAccess, SwoConfig, SwoMode};

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -9,7 +9,7 @@ use crate::architecture::riscv::*;
 use crate::DebugProbeError;
 use crate::{MemoryInterface, Probe};
 
-use crate::{probe::JTAGAccess, CoreRegisterAddress, Error as ProbeRsError};
+use crate::{probe::JTAGAccess, CoreRegisterAddress, DebugProbe, Error as ProbeRsError};
 
 use std::{
     convert::TryInto,
@@ -624,7 +624,19 @@ impl<'probe> RiscvCommunicationInterface {
     }
 
     pub fn close(self) -> Probe {
-        Probe::from_attached_probe(self.probe.as_probe())
+        Probe::from_attached_probe(self.probe.into_probe())
+    }
+}
+
+impl<'a> AsRef<dyn DebugProbe + 'a> for RiscvCommunicationInterface {
+    fn as_ref(&self) -> &(dyn DebugProbe + 'a) {
+        self.probe.as_ref().as_ref()
+    }
+}
+
+impl<'a> AsMut<dyn DebugProbe + 'a> for RiscvCommunicationInterface {
+    fn as_mut(&mut self) -> &mut (dyn DebugProbe + 'a) {
+        self.probe.as_mut().as_mut()
     }
 }
 

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -9,7 +9,7 @@ use crate::architecture::riscv::*;
 use crate::DebugProbeError;
 use crate::{MemoryInterface, Probe};
 
-use crate::{CoreRegisterAddress, Error as ProbeRsError};
+use crate::{probe::JTAGAccess, CoreRegisterAddress, Error as ProbeRsError};
 
 use std::{
     convert::TryInto,
@@ -102,7 +102,6 @@ enum DebugModuleVersion {
 
 #[derive(Debug)]
 pub struct RiscvCommunicationInterfaceState {
-    initialized: bool,
     abits: u32,
 
     /// Size of the program buffer, in 32-bit words
@@ -125,8 +124,6 @@ const RISCV_TIMEOUT: Duration = Duration::from_secs(5);
 impl RiscvCommunicationInterfaceState {
     pub fn new() -> Self {
         RiscvCommunicationInterfaceState {
-            initialized: false,
-
             abits: 0,
             // Set to the minimum here, will be set to the correct value below
             progbuf_size: 0,
@@ -139,50 +136,23 @@ impl RiscvCommunicationInterfaceState {
             supports_autoexec: false,
         }
     }
-
-    pub(crate) fn initialize(&mut self) {
-        self.initialized = true;
-    }
-
-    pub(crate) fn initialized(&self) -> bool {
-        self.initialized
-    }
 }
 
-pub struct RiscvCommunicationInterface<'probe> {
-    probe: &'probe mut Probe,
-    state: &'probe mut RiscvCommunicationInterfaceState,
+#[derive(Debug)]
+pub struct RiscvCommunicationInterface {
+    probe: Box<dyn JTAGAccess>,
+    state: RiscvCommunicationInterfaceState,
 }
 
-impl<'probe> RiscvCommunicationInterface<'probe> {
-    pub fn new(
-        probe: &'probe mut Probe,
-        state: &'probe mut RiscvCommunicationInterfaceState,
-    ) -> Result<Option<Self>, ProbeRsError> {
-        if probe.has_jtag_interface() {
-            let mut s = Self { probe, state };
+impl<'probe> RiscvCommunicationInterface {
+    pub fn new(probe: Box<dyn JTAGAccess>) -> Result<Self, DebugProbeError> {
+        let state = RiscvCommunicationInterfaceState::new();
+        let mut s = Self { probe, state };
 
-            if !s.state.initialized() {
-                s.enter_debug_mode()?;
-                s.state.initialize();
-            }
+        s.enter_debug_mode()
+            .map_err(|e| DebugProbeError::Other(anyhow!(e)))?;
 
-            Ok(Some(s))
-        } else {
-            log::debug!("No JTAG interface available on probe");
-
-            Ok(None)
-        }
-    }
-
-    /// Reborrows the `RiscvCommunicationInterface` at hand.
-    /// This borrows the references inside the interface and hands them out with a new interface.
-    /// This method replaces the normally called `::clone()` method which consumes the object,
-    /// which is not what we want.
-    pub fn reborrow(&mut self) -> RiscvCommunicationInterface<'_> {
-        RiscvCommunicationInterface::new(self.probe, self.state)
-            .unwrap()
-            .unwrap()
+        Ok(s)
     }
 
     fn enter_debug_mode(&mut self) -> Result<(), RiscvError> {
@@ -190,12 +160,7 @@ impl<'probe> RiscvCommunicationInterface<'probe> {
 
         log::debug!("Building RISCV interface");
 
-        let jtag_interface = self
-            .probe
-            .get_interface_jtag_mut()?
-            .ok_or(DebugProbeError::InterfaceNotAvailable("JTAG"))?;
-
-        let dtmcs_raw = jtag_interface.read_register(DTMCS_ADDRESS, DTMCS_WIDTH)?;
+        let dtmcs_raw = self.probe.read_register(DTMCS_ADDRESS, DTMCS_WIDTH)?;
 
         let dtmcs = Dtmcs(u32::from_le_bytes((&dtmcs_raw[..]).try_into().unwrap()));
 
@@ -206,7 +171,7 @@ impl<'probe> RiscvCommunicationInterface<'probe> {
         let idle_cycles = dtmcs.idle();
 
         // Setup the number of idle cycles between JTAG accesses
-        jtag_interface.set_idle_cycles(idle_cycles as u8);
+        self.probe.set_idle_cycles(idle_cycles as u8);
 
         // Reset error bits from previous connections
         self.dmi_reset()?;
@@ -272,23 +237,14 @@ impl<'probe> RiscvCommunicationInterface<'probe> {
 
         let bytes = reg_value.to_le_bytes();
 
-        let jtag_interface = self
-            .probe
-            .get_interface_jtag_mut()?
-            .ok_or(DebugProbeError::InterfaceNotAvailable("JTAG"))?;
-
-        jtag_interface.write_register(DTMCS_ADDRESS, &bytes, DTMCS_WIDTH)?;
+        self.probe
+            .write_register(DTMCS_ADDRESS, &bytes, DTMCS_WIDTH)?;
 
         Ok(())
     }
 
     pub(crate) fn read_idcode(&mut self) -> Result<u32, DebugProbeError> {
-        let jtag_interface = self
-            .probe
-            .get_interface_jtag_mut()?
-            .ok_or(DebugProbeError::InterfaceNotAvailable("JTAG"))?;
-
-        let value = jtag_interface.read_register(0x1, 32)?;
+        let value = self.probe.read_register(0x1, 32)?;
 
         Ok(u32::from_le_bytes((&value[..]).try_into().unwrap()))
     }
@@ -311,12 +267,7 @@ impl<'probe> RiscvCommunicationInterface<'probe> {
 
         let bit_size = self.state.abits + DMI_ADDRESS_BIT_OFFSET;
 
-        let jtag_interface = self
-            .probe
-            .get_interface_jtag_mut()?
-            .ok_or(DebugProbeError::InterfaceNotAvailable("JTAG"))?;
-
-        let response_bytes = jtag_interface.write_register(DMI_ADDRESS, &bytes, bit_size)?;
+        let response_bytes = self.probe.write_register(DMI_ADDRESS, &bytes, bit_size)?;
 
         let response_value: u128 = response_bytes.iter().enumerate().fold(0, |acc, elem| {
             let (byte_offset, value) = elem;
@@ -671,9 +622,13 @@ impl<'probe> RiscvCommunicationInterface<'probe> {
 
         Ok(())
     }
+
+    pub fn close(self) -> Probe {
+        Probe::from_attached_probe(self.probe.as_probe())
+    }
 }
 
-impl<'probe> MemoryInterface for RiscvCommunicationInterface<'probe> {
+impl MemoryInterface for RiscvCommunicationInterface {
     fn read_word_32(&mut self, address: u32) -> Result<u32, crate::Error> {
         let result = self.perform_memory_read(address, RiscvBusAccess::A32)?;
 

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -24,11 +24,11 @@ pub(crate) mod assembly;
 pub mod communication_interface;
 
 pub struct Riscv32<'probe> {
-    interface: RiscvCommunicationInterface<'probe>,
+    interface: &'probe mut RiscvCommunicationInterface,
 }
 
 impl<'probe> Riscv32<'probe> {
-    pub fn new(interface: RiscvCommunicationInterface<'probe>) -> Self {
+    pub fn new(interface: &'probe mut RiscvCommunicationInterface) -> Self {
         Self { interface }
     }
 

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -6,8 +6,7 @@ use crate::error;
 use crate::DebugProbeError;
 use crate::{
     architecture::{
-        arm::{ap::MemoryAP, core::CortexState, ArmCommunicationInterface},
-        riscv::communication_interface::RiscvCommunicationInterface,
+        arm::core::CortexState, riscv::communication_interface::RiscvCommunicationInterface,
     },
     Error, Memory, MemoryInterface,
 };
@@ -324,7 +323,7 @@ impl SpecificCoreState {
     pub(crate) fn attach_riscv<'probe>(
         &self,
         state: &'probe mut CoreState,
-        interface: RiscvCommunicationInterface<'probe>,
+        interface: &'probe mut RiscvCommunicationInterface,
     ) -> Result<Core<'probe>, Error> {
         Ok(match self {
             SpecificCoreState::Riscv => {

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         arm::{ap::MemoryAP, core::CortexState, ArmCommunicationInterface},
         riscv::communication_interface::RiscvCommunicationInterface,
     },
-    Error, MemoryInterface,
+    Error, Memory, MemoryInterface,
 };
 use anyhow::{anyhow, Result};
 use std::time::Duration;
@@ -298,13 +298,8 @@ impl SpecificCoreState {
     pub(crate) fn attach_arm<'probe>(
         &'probe mut self,
         state: &'probe mut CoreState,
-        interface: ArmCommunicationInterface<'probe>,
+        memory: Memory<'probe>,
     ) -> Result<Core<'probe>, Error> {
-        // TODO: This should support multiple APs
-        let ap = MemoryAP::new(0);
-
-        let memory = interface.memory_interface(ap)?;
-
         Ok(match self {
             // TODO: Change this once the new archtecture structure for ARM hits.
             // Cortex-M3, M4 and M7 use the Armv7[E]-M architecture and are

--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -10,9 +10,7 @@ use crate::architecture::{
     },
 };
 use crate::probe::{daplink::commands::CmsisDapError, BatchCommand};
-use crate::{
-    DebugProbe, DebugProbeError, DebugProbeSelector, Error as ProbeRsError, Memory, WireProtocol,
-};
+use crate::{DebugProbe, DebugProbeError, DebugProbeSelector, Error as ProbeRsError, WireProtocol};
 use commands::{
     general::{
         connect::{ConnectRequest, ConnectResponse},
@@ -37,14 +35,13 @@ use commands::{
 };
 use log::debug;
 
-use super::JTAGAccess;
 use std::sync::Mutex;
 use std::time::Duration;
 
 use anyhow::anyhow;
-use architecture::arm::{
-    communication_interface::ArmProbeInterface, ArmCommunicationInterface,
-    ArmCommunicationInterfaceState,
+use architecture::{
+    arm::{communication_interface::ArmProbeInterface, ArmCommunicationInterface},
+    riscv::communication_interface::RiscvCommunicationInterface,
 };
 use commands::DAPLinkDevice;
 
@@ -532,12 +529,10 @@ impl DebugProbe for DAPLink {
         Ok(())
     }
 
-    fn get_interface_jtag(&self) -> Option<&dyn JTAGAccess> {
-        None
-    }
-
-    fn get_interface_jtag_mut(&mut self) -> Option<&mut dyn JTAGAccess> {
-        None
+    fn get_interface_jtag(
+        self: Box<Self>,
+    ) -> Result<Option<RiscvCommunicationInterface>, DebugProbeError> {
+        Ok(None)
     }
 
     fn get_interface_swo(&self) -> Option<&dyn SwoAccess> {
@@ -550,11 +545,18 @@ impl DebugProbe for DAPLink {
 
     fn get_arm_interface<'probe>(
         self: Box<Self>,
-        state: ArmCommunicationInterfaceState,
     ) -> Result<Option<Box<dyn ArmProbeInterface + 'probe>>, DebugProbeError> {
-        let interface = ArmCommunicationInterface::new(self, state)?;
+        let interface = ArmCommunicationInterface::new(self)?;
 
         Ok(Some(Box::new(interface)))
+    }
+
+    fn has_arm_interface(&self) -> bool {
+        true
+    }
+
+    fn has_jtag_interface(&self) -> bool {
+        false
     }
 }
 

--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -549,8 +549,8 @@ impl DebugProbe for DAPLink {
     }
 
     fn get_arm_interface<'probe>(
-        &'probe mut self,
-        state: &'probe mut ArmCommunicationInterfaceState,
+        self: Box<Self>,
+        state: ArmCommunicationInterfaceState,
     ) -> Result<Option<Box<dyn ArmProbeInterface + 'probe>>, DebugProbeError> {
         let interface = ArmCommunicationInterface::new(self, state)?;
 
@@ -664,6 +664,10 @@ impl DAPAccess for DAPLink {
     fn flush(&mut self) -> Result<(), DebugProbeError> {
         self.process_batch()?;
         Ok(())
+    }
+
+    fn as_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
     }
 }
 

--- a/probe-rs/src/probe/daplink/mod.rs
+++ b/probe-rs/src/probe/daplink/mod.rs
@@ -555,8 +555,20 @@ impl DebugProbe for DAPLink {
         true
     }
 
-    fn has_jtag_interface(&self) -> bool {
+    fn has_riscv_interface(&self) -> bool {
         false
+    }
+}
+
+impl<'a> AsRef<dyn DebugProbe + 'a> for DAPLink {
+    fn as_ref(&self) -> &(dyn DebugProbe + 'a) {
+        self
+    }
+}
+
+impl<'a> AsMut<dyn DebugProbe + 'a> for DAPLink {
+    fn as_mut(&mut self) -> &mut (dyn DebugProbe + 'a) {
+        self
     }
 }
 
@@ -668,7 +680,7 @@ impl DAPAccess for DAPLink {
         Ok(())
     }
 
-    fn as_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
         self
     }
 }

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -1,11 +1,9 @@
 use crate::architecture::{
-    arm::{DAPAccess, SwoAccess},
-    riscv::communication_interface::RiscvCommunicationInterface,
+    arm::SwoAccess, riscv::communication_interface::RiscvCommunicationInterface,
 };
 use crate::probe::{JTAGAccess, ProbeCreationError};
 use crate::{
-    DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType, Memory,
-    WireProtocol,
+    DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType, WireProtocol,
 };
 use bitvec::order::Lsb0;
 use bitvec::vec::BitVec;
@@ -527,7 +525,7 @@ impl DebugProbe for FtdiProbe {
         Ok(None)
     }
 
-    fn has_jtag_interface(&self) -> bool {
+    fn has_riscv_interface(&self) -> bool {
         true
     }
 }
@@ -575,7 +573,19 @@ impl JTAGAccess for FtdiProbe {
         Ok(r)
     }
 
-    fn as_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
+    }
+}
+
+impl AsRef<dyn DebugProbe> for FtdiProbe {
+    fn as_ref(&self) -> &(dyn DebugProbe + 'static) {
+        self
+    }
+}
+
+impl AsMut<dyn DebugProbe> for FtdiProbe {
+    fn as_mut(&mut self) -> &mut (dyn DebugProbe + 'static) {
         self
     }
 }

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -621,7 +621,7 @@ impl DebugProbe for JLink {
         self.supported_protocols.contains(&WireProtocol::Swd)
     }
 
-    fn has_jtag_interface(&self) -> bool {
+    fn has_riscv_interface(&self) -> bool {
         self.supported_protocols.contains(&WireProtocol::Jtag)
     }
 }
@@ -676,7 +676,19 @@ impl JTAGAccess for JLink {
         self.jtag_idle_cycles = idle_cycles;
     }
 
-    fn as_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
+    }
+}
+
+impl<'a> AsRef<dyn DebugProbe + 'a> for JLink {
+    fn as_ref(&self) -> &(dyn DebugProbe + 'a) {
+        self
+    }
+}
+
+impl<'a> AsMut<dyn DebugProbe + 'a> for JLink {
+    fn as_mut(&mut self) -> &mut (dyn DebugProbe + 'a) {
         self
     }
 }
@@ -944,7 +956,7 @@ impl DAPAccess for JLink {
         Err(DebugProbeError::Timeout)
     }
 
-    fn as_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
         self
     }
 }

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -609,8 +609,8 @@ impl DebugProbe for JLink {
     }
 
     fn get_arm_interface<'probe>(
-        &'probe mut self,
-        state: &'probe mut ArmCommunicationInterfaceState,
+        self: Box<Self>,
+        state: ArmCommunicationInterfaceState,
     ) -> Result<Option<Box<dyn ArmProbeInterface + 'probe>>, DebugProbeError> {
         if self.supported_protocols.contains(&WireProtocol::Swd) {
             let interface = ArmCommunicationInterface::new(self, state)?;
@@ -934,6 +934,10 @@ impl DAPAccess for JLink {
         // If we land here, the DAP operation timed out.
         log::error!("DAP write timeout.");
         Err(DebugProbeError::Timeout)
+    }
+
+    fn as_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
     }
 }
 

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -348,7 +348,10 @@ impl Probe {
         if !self.attached {
             Err(DebugProbeError::NotAttached)
         } else {
-            ArmCommunicationInterface::new(self, state)
+            match self.inner.get_interface_dap_mut() {
+                Some(interface) => ArmCommunicationInterface::new(interface, state),
+                None => Ok(None),
+            }
         }
     }
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -242,8 +242,8 @@ impl DebugProbe for STLink<STLinkUSBDevice> {
     }
 
     fn get_arm_interface<'probe>(
-        &'probe mut self,
-        state: &'probe mut ArmCommunicationInterfaceState,
+        self: Box<Self>,
+        state: ArmCommunicationInterfaceState,
     ) -> Result<Option<Box<dyn ArmProbeInterface + 'probe>>, DebugProbeError> {
         let interface = ArmCommunicationInterface::new(self, state)?;
 
@@ -310,6 +310,10 @@ impl DAPAccess for STLink<STLinkUSBDevice> {
         } else {
             Err(StlinkError::BlanksNotAllowedOnDPRegister.into())
         }
+    }
+
+    fn as_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
     }
 }
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -252,7 +252,7 @@ impl DebugProbe for STLink<STLinkUSBDevice> {
         true
     }
 
-    fn has_jtag_interface(&self) -> bool {
+    fn has_riscv_interface(&self) -> bool {
         false
     }
 }
@@ -318,7 +318,19 @@ impl DAPAccess for STLink<STLinkUSBDevice> {
         }
     }
 
-    fn as_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
+    }
+}
+
+impl<'a> AsRef<dyn DebugProbe + 'a> for STLink<STLinkUSBDevice> {
+    fn as_ref(&self) -> &(dyn DebugProbe + 'a) {
+        self
+    }
+}
+
+impl<'a> AsMut<dyn DebugProbe + 'a> for STLink<STLinkUSBDevice> {
+    fn as_mut(&mut self) -> &mut (dyn DebugProbe + 'a) {
         self
     }
 }
@@ -908,7 +920,7 @@ mod test {
             _read_data: &mut [u8],
             _timeout: std::time::Duration,
         ) -> Result<usize, DebugProbeError> {
-            todo!()
+            unimplemented!("Not implemented for MockUSB")
         }
     }
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -54,7 +54,7 @@ impl ArchitectureInterfaceState {
     ) -> Result<Core<'probe>, Error> {
         match self {
             ArchitectureInterfaceState::Arm(state) => {
-                let interface = probe
+                let mut interface = probe
                     .get_arm_interface(state)?
                     .ok_or_else(|| anyhow!("No DAP interface available on probe"))?;
 
@@ -201,7 +201,7 @@ impl Session {
     }
 
     pub fn get_arm_component(&mut self) -> Result<Component, Error> {
-        let interface = self.get_arm_interface()?;
+        let mut interface = self.get_arm_interface()?;
 
         let ap_index = 0;
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -52,7 +52,8 @@ impl ArchitectureInterfaceState {
         match self {
             ArchitectureInterfaceState::Arm(state) => core.attach_arm(
                 core_state,
-                ArmCommunicationInterface::new(probe, state)?
+                probe
+                    .get_arm_interface(state)?
                     .ok_or_else(|| anyhow!("No DAP interface available on probe"))?,
             ),
             ArchitectureInterfaceState::Riscv(state) => core.attach_riscv(
@@ -187,7 +188,8 @@ impl Session {
             ArchitectureInterfaceState::Arm(state) => state,
             _ => return Err(Error::ArchitectureRequired(&["ARMv7", "ARMv8"])),
         };
-        Ok(ArmCommunicationInterface::new(&mut self.probe, state)?.unwrap())
+
+        Ok(self.probe.get_arm_interface(state)?.unwrap())
     }
 
     pub fn get_arm_component(&mut self) -> Result<Component, Error> {
@@ -329,7 +331,7 @@ fn get_target_from_selector(
             let mut found_chip = None;
 
             let mut state = ArmCommunicationInterfaceState::new();
-            let interface = ArmCommunicationInterface::new(probe, &mut state)?;
+            let interface = probe.get_arm_interface(&mut state)?;
             if let Some(mut interface) = interface {
                 let chip_result = try_arm_autodetect(&mut interface);
 


### PR DESCRIPTION
Proposal for a refactor of the code responsible for ARM cores. The goal is to move the creation of the actual interface to the probe,
to make it easier to support different probes.

The ideas is that a Probe is responsible for creating the `ArmCommunicationInterface`, or a similar struct. The ST-Link for example could then create another implementation of this, which supports the ST-Link API better.