### PR TITLE
Add brief build instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,26 @@ Also have a look at [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Please reach out to [@Yatekii](https://github.com/Yatekii)
 
+### Building
+
+Building requires Rust and Cargo which can be installed [using rustup](https://rustup.rs/). probe-rs also depends on libusb and libftdi. On linux these can be installed with your package manager:
+
+```
+# Ubuntu
+> sudo apt install -y libusb-dev libusb-1.0 libftdi1-dev
+```
+
+On Windows you can use [vcpkg](https://github.com/microsoft/vcpkg#quick-start-windows):
+
+```
+# dynamic linking 64-bit
+> vcpkg install libftdi1:x64-windows libusb:x64-windows
+> set VCPKGRS_DYNAMIC=1
+
+# static linking 64-bit
+> vcpkg install libftdi1:x64-windows-static-md libusb:x64-windows-static-md
+```
+
 ## Sponsors
 
 [![Technokrat](https://technokrat.ch/static/img/svg_banner-light.svg)](https://technokrat.ch)

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ On Windows you can use [vcpkg](https://github.com/microsoft/vcpkg#quick-start-wi
 > vcpkg install libftdi1:x64-windows-static-md libusb:x64-windows-static-md
 ```
 
+See [the vcpkg crate documentation](https://docs.rs/vcpkg/) for more information about configuring vcpkg with rust.
+
 ## Sponsors
 
 [![Technokrat](https://technokrat.ch/static/img/svg_banner-light.svg)](https://technokrat.ch)


### PR DESCRIPTION
I think it's worth adding instructions as the dependencies grow. I kept the instructions brief because I think most people reading the readme can figure out how to install the dependencies on their platform of choice once they know what they are. I expanded on the Windows instructions because vcpkg is newer and probably less familiar and it has some nuance with target triplets and env variables. It may not be obvious to look at a build-dependency of a dependency to find the vcpkg crate documentation.