### PR TITLE
Only check SWO endpoint if it exists

### DIFF
--- a/probe-rs/src/probe/daplink/tools.rs
+++ b/probe-rs/src/probe/daplink/tools.rs
@@ -118,10 +118,13 @@ pub fn open_v2_device(device: Device<rusb::Context>) -> Option<DAPLinkDevice> {
 
             // Detect a third bulk EP which will be for SWO streaming
             let mut swo_ep = None;
-            if eps[2].transfer_type() == rusb::TransferType::Bulk
-                && eps[2].direction() == rusb::Direction::In
-            {
-                swo_ep = Some(eps[2].address());
+
+            if eps.len() > 2 {
+                if eps[2].transfer_type() == rusb::TransferType::Bulk
+                    && eps[2].direction() == rusb::Direction::In
+                {
+                    swo_ep = Some(eps[2].address());
+                }
             }
 
             // Store EP addresses of the in and out EPs


### PR DESCRIPTION
The SWO endpoint on CMSIS-DAP probes is optional, so we shouldn't
panic if it doesn't exist.