### PR TITLE
Halt RISCV cores on attach

### DIFF
--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -425,6 +425,8 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
             tselect_index += 1;
         }
 
+        log::debug!("Target supports {} breakpoints.", tselect_index);
+
         Ok(tselect_index)
     }
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -117,12 +117,20 @@ impl Session {
                     Core::create_state(0),
                 );
 
-                Session {
+                let mut session = Session {
                     target,
                     probe,
                     interface_state: ArchitectureInterfaceState::Riscv(state),
                     cores: vec![core],
+                };
+
+                {
+                    let mut core = session.core(0)?;
+
+                    core.halt(Duration::from_millis(100))?;
                 }
+
+                session
             }
         };
 


### PR DESCRIPTION
To clean all HW breakpoints on RISCV, core needs to be halted.

This is also more consistent with the behaviour on ARM.

Should fix #352 