### PR TITLE
m0/set_breakpoint: match a single halfword

### DIFF
--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -505,7 +505,13 @@ impl<'probe> CoreInterface for M0<'probe> {
     fn set_breakpoint(&mut self, bp_register_index: usize, addr: u32) -> Result<(), Error> {
         debug!("Setting breakpoint on address 0x{:08x}", addr);
         let mut value = BpCompx(0);
-        value.set_bp_match(0b11);
+        if addr % 4 < 2 {
+            // match lower halfword
+            value.set_bp_match(0b01);
+        } else {
+            // match higher halfword
+            value.set_bp_match(0b10);
+        }
         value.set_comp((addr >> 2) & 0x00FF_FFFF);
         value.set_enable(true);
 


### PR DESCRIPTION
the current logic matches both halfwords, meaning that given the following machine code:
``` text
000003e0 DefaultPreInit:
     3e0: 70 47                         bx      lr

000003e2 HardFaultTrampoline:
     3e2: 70 46                         mov     r0, lr
```
if you place a breakpoint at `HardFaultTrampoline` (address = `0x3e2`) then that breakpoint also triggers when `DefaultPreInit` is invoked
with this PR the breakpoint only fires when `HardFaultTrampoline` is called
