### PR TITLE
Use dedicated ST-Link APIs

### DIFF
--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -145,17 +145,17 @@ pub trait ArmProbeInterface:
 }
 
 #[derive(Debug)]
-struct ArmCommunicationInterfaceState {
-    debug_port_version: DebugPortVersion,
+pub(crate) struct ArmCommunicationInterfaceState {
+    pub debug_port_version: DebugPortVersion,
 
-    current_dpbanksel: u8,
+    pub current_dpbanksel: u8,
 
-    current_apsel: u8,
-    current_apbanksel: u8,
+    pub current_apsel: u8,
+    pub current_apbanksel: u8,
 
     /// Information about the APs of the target.
     /// APs are identified by a number, starting from zero.
-    ap_information: Vec<ApInformation>,
+    pub ap_information: Vec<ApInformation>,
 }
 
 #[derive(Debug)]

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -130,10 +130,7 @@ pub trait DAPAccess: DebugProbe + AsRef<dyn DebugProbe> + AsMut<dyn DebugProbe> 
 pub trait ArmProbeInterface:
     SwoAccess + AsRef<dyn DebugProbe> + AsMut<dyn DebugProbe> + Debug
 {
-    fn memory_interface<'interface>(
-        &'interface mut self,
-        access_port: MemoryAP,
-    ) -> Result<Memory<'interface>, ProbeRsError>;
+    fn memory_interface(&mut self, access_port: MemoryAP) -> Result<Memory<'_>, ProbeRsError>;
 
     fn ap_information(&self, access_port: GenericAP) -> Option<&ApInformation>;
 
@@ -204,10 +201,7 @@ pub struct ArmCommunicationInterface {
 }
 
 impl ArmProbeInterface for ArmCommunicationInterface {
-    fn memory_interface<'interface>(
-        &'interface mut self,
-        access_port: MemoryAP,
-    ) -> Result<Memory<'interface>, ProbeRsError> {
+    fn memory_interface(&mut self, access_port: MemoryAP) -> Result<Memory<'_>, ProbeRsError> {
         ArmCommunicationInterface::memory_interface(self, access_port)
     }
 

--- a/probe-rs/src/probe/stlink/constants.rs
+++ b/probe-rs/src/probe/stlink/constants.rs
@@ -27,6 +27,13 @@ pub mod commands {
     // The following commands are from Version 2 of the API,
     // supported
     pub const JTAG_ENTER2: u8 = 0x30;
+
+    pub const JTAG_READ_CORE_REG: u8 = 0x33;
+    pub const JTAG_WRITE_CORE_REG: u8 = 0x34;
+
+    pub const JTAG_WRITE_DEBUG_REG: u8 = 0x35;
+    pub const JTAG_READ_DEBUG_REG: u8 = 0x36;
+
     pub const JTAG_GETLASTRWSTATUS2: u8 = 0x3e; // From V2J15
     pub const JTAG_DRIVE_NRST: u8 = 0x3c;
     pub const SWO_START_TRACE_RECEPTION: u8 = 0x40;

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -313,7 +313,7 @@ impl DAPAccess for STLink<STLinkUSBDevice> {
             let mut buf = [0; 2];
             self.send_jtag_command(cmd, &[], &mut buf, TIMEOUT)?;
 
-            // Ensure the write is actually performed
+            // Ensure the write is actually performed.
             self.flush()?;
 
             Ok(())
@@ -808,7 +808,7 @@ impl<D: StLinkUsb> STLink<D> {
             address,
             length
         );
-        // Maximum supported read length is 2^16 bytes
+        // Maximum supported read length is 2^16 bytes.
         assert!(
             length < (u16::MAX / 4),
             "Maximum read length for STLink is 16'384 words"
@@ -839,7 +839,6 @@ impl<D: StLinkUsb> STLink<D> {
             TIMEOUT,
         )?;
 
-        // get last RW status
         self.get_last_rw_status()?;
 
         let words: Vec<u32> = receive_buffer
@@ -876,7 +875,6 @@ impl<D: StLinkUsb> STLink<D> {
             TIMEOUT,
         )?;
 
-        // get last RW status
         self.get_last_rw_status()?;
 
         Ok(receive_buffer)
@@ -891,7 +889,7 @@ impl<D: StLinkUsb> STLink<D> {
         log::trace!("write_mem_32bit");
         let length = data.len();
 
-        // Maximum supported read length is 2^16 bytes
+        // Maximum supported read length is 2^16 bytes.
         assert!(
             length < (u16::MAX / 4) as usize,
             "Maximum write length for STLink is 16'384 words"
@@ -930,7 +928,6 @@ impl<D: StLinkUsb> STLink<D> {
             TIMEOUT,
         )?;
 
-        // get last RW status
         self.get_last_rw_status()?;
 
         Ok(())
@@ -964,7 +961,6 @@ impl<D: StLinkUsb> STLink<D> {
             TIMEOUT,
         )?;
 
-        // get last RW status
         self.get_last_rw_status()?;
 
         Ok(())
@@ -1111,7 +1107,7 @@ impl StlinkArmDebug {
     fn new(probe: Box<STLink<STLinkUSBDevice>>) -> Result<Self, DebugProbeError> {
         let state = ArmCommunicationInterfaceState::new();
 
-        /* determine the number and type of available APs */
+        // Determine the number and type of available APs.
 
         let mut interface = Self { probe, state };
 
@@ -1158,7 +1154,7 @@ impl StlinkArmDebug {
                 base_address
             );
 
-            // Ensure if we can access this AP
+            // Ensure that we can access this AP.
             let status = self.read_ap_register(access_port, CSW::default())?;
 
             log::debug!("AP {} - {:?}", access_port.port_number(), status);
@@ -1260,7 +1256,7 @@ impl StlinkArmDebug {
     }
 
     fn select_ap(&mut self, port: impl AccessPort) -> Result<(), DebugProbeError> {
-        // Change AP, leave ap_bank_sel the same
+        // Change AP, leave ap_bank_sel the same.
         self.probe.select_ap(port.port_number())?;
 
         // if self.state.current_apsel != port.port_number() {
@@ -1467,13 +1463,6 @@ impl<'probe> ArmProbeInterface for StlinkArmDebug {
                 }
             }
         }
-        // log::info!(
-        //     "{}\n{}\n{}\n{}",
-        //     "If you are using a Nordic chip, it might be locked to debug access".yellow(),
-        //     "Run cargo flash with --nrf-recover to unlock".yellow(),
-        //     "WARNING: --nrf-recover will erase the entire code".yellow(),
-        //     "flash and UICR area of the device, in addition to the entire RAM".yellow()
-        // );
 
         Ok(None)
     }
@@ -1557,7 +1546,6 @@ impl MemoryInterface for StLinkMemoryInterface<'_> {
     fn read_word_32(&mut self, address: u32) -> Result<u32, ProbeRsError> {
         self.probe.select_ap(self.access_port)?;
 
-        //let value = self.probe.probe.read_debug_reg(address)?;
         let mut buff = [0];
         self.read_32(address, &mut buff)?;
 
@@ -1636,7 +1624,7 @@ impl MemoryInterface for StLinkMemoryInterface<'_> {
                 .probe
                 .write_mem_8bit(address, data, self.access_port.port_number())?;
         } else {
-            // Handle unaligned data in the beginning
+            // Handle unaligned data in the beginning.
             let bytes_beginning = if address % 4 == 0 {
                 0
             } else {
@@ -1660,7 +1648,7 @@ impl MemoryInterface for StLinkMemoryInterface<'_> {
                 current_address += bytes_beginning as u32;
             }
 
-            // Address has to be aligned here
+            // Address has to be aligned here.
             assert!(current_address % 4 == 0);
 
             // Convert bytes to u32
@@ -1698,7 +1686,6 @@ impl MemoryInterface for StLinkMemoryInterface<'_> {
                     self.access_port.port_number(),
                 )?;
 
-                // current_address += bytes_beginning as u32;
             }
         }
         Ok(())
@@ -1710,21 +1697,6 @@ impl MemoryInterface for StLinkMemoryInterface<'_> {
         Ok(())
     }
 
-    /*
-
-    fn read_core_reg(&mut self, index: u32) -> Result<u32, ProbeRsError> {
-        let val = self.probe.probe.read_core_reg(index)?;
-
-        Ok(val)
-    }
-
-    fn write_core_reg(&mut self, index: u32, value: u32) -> Result<(), ProbeRsError> {
-        self.probe.probe.write_core_reg(index, value)?;
-
-        Ok(())
-    }
-
-    */
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This uses the dedicated APIs for memory read / write and core register read / write on ST-Links.

This improves the flash speed from about 121 kB/s Erase and 15 kB Write to about 145 kB/s Erase and 30 kB/s Write :rocket:,
measured with a ST-Link v2 with a SWD Frequency of 4.6 MHz.

The API is still a bit of a mess now, but I assume that with the support for debug sequences, this will have to be adapted anyway.
