### PR TITLE
Use dedicated ST-Link API for CPU Register Read / Write

### DIFF
--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -18,14 +18,14 @@ use thiserror::Error;
 pub enum AccessPortError {
     #[error("Failed to access address 0x{address:08x} as it is not aligned to the requirement of {alignment} bytes.")]
     MemoryNotAligned { address: u32, alignment: usize },
-    #[error("Failed to read register {name} at address 0x{address:08x} because: {source}")]
+    #[error("Failed to read register {name} at address 0x{address:08x}")]
     RegisterReadError {
         address: u8,
         name: &'static str,
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
-    #[error("Failed to write register {name} at address 0x{address:08x} because: {source}")]
+    #[error("Failed to write register {name} at address 0x{address:08x}")]
     RegisterWriteError {
         address: u8,
         name: &'static str,

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -273,12 +273,10 @@ impl<'interface> ArmCommunicationInterface {
                 let adi_v5_memory_interface = ADIMemoryInterface::<
                     'interface,
                     ArmCommunicationInterface,
-                >::new(
-                    self, access_port, only_32bit_data_size
-                )
+                >::new(self, only_32bit_data_size)
                 .map_err(ProbeRsError::architecture_specific)?;
 
-                Ok(Memory::new(adi_v5_memory_interface))
+                Ok(Memory::new(adi_v5_memory_interface, access_port))
             }
             ApInformation::Other { port_number } => Err(ProbeRsError::Other(anyhow!(format!(
                 "AP {} is not a memory AP",

--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -6,7 +6,7 @@ use crate::core::{
 use crate::error::Error;
 use crate::memory::Memory;
 use crate::{CoreStatus, DebugProbeError, HaltReason, MemoryInterface};
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use bitfield::bitfield;
 use log::debug;
 use std::{
@@ -58,31 +58,6 @@ impl From<Dhcsr> for u32 {
 impl CoreRegister for Dhcsr {
     const ADDRESS: u32 = 0xE000_EDF0;
     const NAME: &'static str = "DHCSR";
-}
-
-bitfield! {
-    #[derive(Copy, Clone)]
-    pub struct Dcrsr(u32);
-    impl Debug;
-    pub _, set_regwnr: 16;
-    pub _, set_regsel: 4,0;
-}
-
-impl From<u32> for Dcrsr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dcrsr> for u32 {
-    fn from(value: Dcrsr) -> Self {
-        value.0
-    }
-}
-
-impl CoreRegister for Dcrsr {
-    const ADDRESS: u32 = 0xE000_EDF4;
-    const NAME: &'static str = "DCRSR";
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -324,19 +299,6 @@ impl<'probe> M0<'probe> {
 
         Ok(Self { memory, state })
     }
-
-    fn wait_for_core_register_transfer(&mut self) -> Result<()> {
-        // now we have to poll the dhcsr register, until the dhcsr.s_regrdy bit is set
-        // (see C1-292, cortex m0 arm)
-        for _ in 0..100 {
-            let dhcsr_val = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
-
-            if dhcsr_val.s_regrdy() {
-                return Ok(());
-            }
-        }
-        Err(anyhow!(Error::Probe(DebugProbeError::Timeout)))
-    }
 }
 
 impl<'probe> CoreInterface for M0<'probe> {
@@ -363,38 +325,6 @@ impl<'probe> CoreInterface for M0<'probe> {
         } else {
             Ok(false)
         }
-    }
-
-    fn read_core_reg(&mut self, addr: CoreRegisterAddress) -> Result<u32, Error> {
-        // Write the DCRSR value to select the register we want to read.
-        let mut dcrsr_val = Dcrsr(0);
-        dcrsr_val.set_regwnr(false); // Perform a read.
-        dcrsr_val.set_regsel(addr.into()); // The address of the register to read.
-
-        self.memory
-            .write_word_32(Dcrsr::ADDRESS, dcrsr_val.into())?;
-
-        self.wait_for_core_register_transfer()?;
-
-        self.memory.read_word_32(Dcrdr::ADDRESS).map_err(From::from)
-    }
-
-    fn write_core_reg(&mut self, addr: CoreRegisterAddress, value: u32) -> Result<()> {
-        let result: Result<(), Error> = self
-            .memory
-            .write_word_32(Dcrdr::ADDRESS, value)
-            .map_err(From::from);
-        result?;
-
-        // write the DCRSR value to select the register we want to write.
-        let mut dcrsr_val = Dcrsr(0);
-        dcrsr_val.set_regwnr(true); // Perform a write.
-        dcrsr_val.set_regsel(addr.into()); // The address of the register to write.
-
-        self.memory
-            .write_word_32(Dcrsr::ADDRESS, dcrsr_val.into())?;
-
-        self.wait_for_core_register_transfer()
     }
 
     fn halt(&mut self, timeout: Duration) -> Result<CoreInformation, Error> {
@@ -599,6 +529,15 @@ impl<'probe> CoreInterface for M0<'probe> {
         self.state.current_state = CoreStatus::Running;
 
         Ok(CoreStatus::Running)
+    }
+
+    fn read_core_reg(&mut self, address: CoreRegisterAddress) -> Result<u32, Error> {
+        self.memory.read_core_reg(address)
+    }
+
+    fn write_core_reg(&mut self, address: CoreRegisterAddress, value: u32) -> Result<()> {
+        self.memory.write_core_reg(address, value)?;
+        Ok(())
     }
 }
 

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -10,7 +10,7 @@ use crate::{
     core::{Architecture, CoreStatus, HaltReason},
     MemoryInterface,
 };
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 use bitfield::bitfield;
 use std::mem::size_of;
@@ -61,31 +61,6 @@ impl From<Dhcsr> for u32 {
 impl CoreRegister for Dhcsr {
     const ADDRESS: u32 = 0xE000_EDF0;
     const NAME: &'static str = "DHCSR";
-}
-
-bitfield! {
-    #[derive(Copy, Clone)]
-    pub struct Dcrsr(u32);
-    impl Debug;
-    pub _, set_regwnr: 16;
-    pub _, set_regsel: 6,0;
-}
-
-impl From<u32> for Dcrsr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dcrsr> for u32 {
-    fn from(value: Dcrsr) -> Self {
-        value.0
-    }
-}
-
-impl CoreRegister for Dcrsr {
-    const ADDRESS: u32 = 0xE000_EDF4;
-    const NAME: &'static str = "DCRSR";
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -370,21 +345,6 @@ impl<'probe> M4<'probe> {
 
         Ok(Self { memory, state })
     }
-
-    fn wait_for_core_register_transfer(&mut self, timeout: Duration) -> Result<(), Error> {
-        // now we have to poll the dhcsr register, until the dhcsr.s_regrdy bit is set
-        // (see C1-292, cortex m0 arm)
-        let start = Instant::now();
-
-        while start.elapsed() < timeout {
-            let dhcsr_val = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
-
-            if dhcsr_val.s_regrdy() {
-                return Ok(());
-            }
-        }
-        Err(Error::Probe(DebugProbeError::Timeout))
-    }
 }
 
 impl<'probe> CoreInterface for M4<'probe> {
@@ -472,37 +432,14 @@ impl<'probe> CoreInterface for M4<'probe> {
         Ok(CoreStatus::Running)
     }
 
-    fn read_core_reg(&mut self, addr: CoreRegisterAddress) -> Result<u32, Error> {
-        // Write the DCRSR value to select the register we want to read.
-        let mut dcrsr_val = Dcrsr(0);
-        dcrsr_val.set_regwnr(false); // Perform a read.
-        dcrsr_val.set_regsel(addr.into()); // The address of the register to read.
-
-        self.memory
-            .write_word_32(Dcrsr::ADDRESS, dcrsr_val.into())?;
-
-        self.wait_for_core_register_transfer(Duration::from_millis(100))?;
-
-        self.memory.read_word_32(Dcrdr::ADDRESS).map_err(From::from)
+    fn read_core_reg(&mut self, address: CoreRegisterAddress) -> Result<u32, Error> {
+        self.memory.read_core_reg(address)
     }
 
-    fn write_core_reg(&mut self, addr: CoreRegisterAddress, value: u32) -> Result<()> {
-        let result: Result<(), Error> = self
-            .memory
-            .write_word_32(Dcrdr::ADDRESS, value)
-            .map_err(From::from);
-        result?;
+    fn write_core_reg(&mut self, address: CoreRegisterAddress, value: u32) -> Result<()> {
+        self.memory.write_core_reg(address, value)?;
 
-        // write the DCRSR value to select the register we want to write.
-        let mut dcrsr_val = Dcrsr(0);
-        dcrsr_val.set_regwnr(true); // Perform a write.
-        dcrsr_val.set_regsel(addr.into()); // The address of the register to write.
-
-        self.memory
-            .write_word_32(Dcrsr::ADDRESS, dcrsr_val.into())?;
-
-        self.wait_for_core_register_transfer(Duration::from_millis(100))
-            .context("Waiting for core register transfer")
+        Ok(())
     }
 
     fn halt(&mut self, timeout: Duration) -> Result<CoreInformation, Error> {

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -662,7 +662,7 @@ bitfield! {
     pub s_sleep, _: 18;
     pub s_halt, _: 17;
     pub s_regrdy, _: 16;
-    pub c_maskings, set_c_maskints: 3;
+    pub c_maskints, set_c_maskints: 3;
     pub c_step, set_c_step: 2;
     pub c_halt, set_c_halt: 1;
     pub c_debugen, set_c_debugen: 0;

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -2,10 +2,33 @@ use super::super::ap::{
     APAccess, APRegister, AccessPortError, AddressIncrement, DataSize, MemoryAP, CSW, DRW, TAR,
 };
 use crate::architecture::arm::{dp::DPAccess, ArmCommunicationInterface};
-use crate::{CommunicationInterface, Error, MemoryInterface};
+use crate::{CommunicationInterface, CoreRegister, CoreRegisterAddress, DebugProbeError, Error};
 use scroll::{Pread, Pwrite, LE};
 use std::convert::TryInto;
-use std::ops::Range;
+use std::{
+    ops::Range,
+    time::{Duration, Instant},
+};
+
+use bitfield::bitfield;
+
+pub trait ArmProbe {
+    fn read_core_reg(&mut self, ap: MemoryAP, addr: CoreRegisterAddress) -> Result<u32, Error>;
+    fn write_core_reg(
+        &mut self,
+        ap: MemoryAP,
+        addr: CoreRegisterAddress,
+        value: u32,
+    ) -> Result<(), Error>;
+
+    fn read_8(&mut self, ap: MemoryAP, address: u32, data: &mut [u8]) -> Result<(), Error>;
+    fn read_32(&mut self, ap: MemoryAP, address: u32, data: &mut [u32]) -> Result<(), Error>;
+
+    fn write_8(&mut self, ap: MemoryAP, address: u32, data: &[u8]) -> Result<(), Error>;
+    fn write_32(&mut self, ap: MemoryAP, address: u32, data: &[u32]) -> Result<(), Error>;
+
+    fn flush(&mut self) -> Result<(), Error>;
+}
 
 /// A struct to give access to a targets memory using a certain DAP.
 pub(in crate::architecture::arm) struct ADIMemoryInterface<'interface, AP>
@@ -17,7 +40,6 @@ where
         + DPAccess,
 {
     interface: &'interface mut AP,
-    access_port: MemoryAP,
     only_32bit_data_size: bool,
 }
 
@@ -25,12 +47,10 @@ impl<'interface> ADIMemoryInterface<'interface, ArmCommunicationInterface> {
     /// Creates a new MemoryInterface for given AccessPort.
     pub fn new(
         interface: &'interface mut ArmCommunicationInterface,
-        access_port_number: impl Into<MemoryAP>,
         only_32bit_data_size: bool,
     ) -> Result<ADIMemoryInterface<'interface, ArmCommunicationInterface>, AccessPortError> {
         Ok(Self {
             interface,
-            access_port: access_port_number.into(),
             only_32bit_data_size,
         })
     }
@@ -71,14 +91,37 @@ where
         }
     }
 
+    fn wait_for_core_register_transfer(
+        &mut self,
+        access_port: MemoryAP,
+        timeout: Duration,
+    ) -> Result<(), Error> {
+        // now we have to poll the dhcsr register, until the dhcsr.s_regrdy bit is set
+        // (see C1-292, cortex m0 arm)
+        let start = Instant::now();
+
+        while start.elapsed() < timeout {
+            let dhcsr_val = Dhcsr(self.read_word_32(access_port, Dhcsr::ADDRESS).unwrap());
+
+            if dhcsr_val.s_regrdy() {
+                return Ok(());
+            }
+        }
+        Err(Error::Probe(DebugProbeError::Timeout))
+    }
+
     /// Read a 32 bit register on the given AP.
-    fn read_ap_register<R>(&mut self, register: R) -> Result<R, AccessPortError>
+    fn read_ap_register<R>(
+        &mut self,
+        access_port: MemoryAP,
+        register: R,
+    ) -> Result<R, AccessPortError>
     where
         R: APRegister<MemoryAP>,
         AP: APAccess<MemoryAP, R>,
     {
         self.interface
-            .read_ap_register(self.access_port, register)
+            .read_ap_register(access_port, register)
             .map_err(AccessPortError::register_read_error::<R, _>)
     }
 
@@ -86,6 +129,7 @@ where
     /// register on the given AP.
     fn read_ap_register_repeated<R>(
         &mut self,
+        access_port: MemoryAP,
         register: R,
         values: &mut [u32],
     ) -> Result<(), AccessPortError>
@@ -94,18 +138,22 @@ where
         AP: APAccess<MemoryAP, R>,
     {
         self.interface
-            .read_ap_register_repeated(self.access_port, register, values)
+            .read_ap_register_repeated(access_port, register, values)
             .map_err(AccessPortError::register_read_error::<R, _>)
     }
 
     /// Write a 32 bit register on the given AP.
-    fn write_ap_register<R>(&mut self, register: R) -> Result<(), AccessPortError>
+    fn write_ap_register<R>(
+        &mut self,
+        access_port: MemoryAP,
+        register: R,
+    ) -> Result<(), AccessPortError>
     where
         R: APRegister<MemoryAP>,
         AP: APAccess<MemoryAP, R>,
     {
         self.interface
-            .write_ap_register(self.access_port, register)
+            .write_ap_register(access_port, register)
             .map_err(AccessPortError::register_write_error::<R, _>)
     }
 
@@ -113,6 +161,7 @@ where
     /// register on the given AP.
     fn write_ap_register_repeated<R>(
         &mut self,
+        access_port: MemoryAP,
         register: R,
         values: &[u32],
     ) -> Result<(), AccessPortError>
@@ -121,7 +170,7 @@ where
         AP: APAccess<MemoryAP, R>,
     {
         self.interface
-            .write_ap_register_repeated(self.access_port, register, values)
+            .write_ap_register_repeated(access_port, register, values)
             .map_err(AccessPortError::register_write_error::<R, _>)
     }
 
@@ -129,7 +178,11 @@ where
     ///
     /// The address where the read should be performed at has to be word aligned.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    pub fn read_word_32(&mut self, address: u32) -> Result<u32, AccessPortError> {
+    pub fn read_word_32(
+        &mut self,
+        access_port: MemoryAP,
+        address: u32,
+    ) -> Result<u32, AccessPortError> {
         if (address % 4) != 0 {
             return Err(AccessPortError::alignment_error(address, 4));
         }
@@ -137,15 +190,19 @@ where
         let csw = Self::build_csw_register(DataSize::U32);
 
         let tar = TAR { address };
-        self.write_ap_register(csw)?;
-        self.write_ap_register(tar)?;
-        let result = self.read_ap_register(DRW::default())?;
+        self.write_ap_register(access_port, csw)?;
+        self.write_ap_register(access_port, tar)?;
+        let result = self.read_ap_register(access_port, DRW::default())?;
 
         Ok(result.data)
     }
 
     /// Read an 8bit word at `addr`.
-    pub fn read_word_8(&mut self, address: u32) -> Result<u8, AccessPortError> {
+    pub fn read_word_8(
+        &mut self,
+        access_port: MemoryAP,
+        address: u32,
+    ) -> Result<u8, AccessPortError> {
         let aligned = aligned_range(address, 1)?;
 
         // Offset of byte in word (little endian)
@@ -153,13 +210,13 @@ where
 
         let result = if self.only_32bit_data_size {
             // Read 32-bit word and extract the correct byte
-            ((self.read_word_32(aligned.start)? >> bit_offset) & 0xFF) as u8
+            ((self.read_word_32(access_port, aligned.start)? >> bit_offset) & 0xFF) as u8
         } else {
             let csw = Self::build_csw_register(DataSize::U8);
             let tar = TAR { address };
-            self.write_ap_register(csw)?;
-            self.write_ap_register(tar)?;
-            let result = self.read_ap_register(DRW::default())?;
+            self.write_ap_register(access_port, csw)?;
+            self.write_ap_register(access_port, tar)?;
+            let result = self.read_ap_register(access_port, DRW::default())?;
 
             // Extract the correct byte
             // See "Arm Debug Interface Architecture Specification ADIv5.0 to ADIv5.2", C2.2.6
@@ -174,7 +231,12 @@ where
     /// The number of words read is `data.len()`.
     /// The address where the read should be performed at has to be word aligned.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    pub fn read_32(&mut self, start_address: u32, data: &mut [u32]) -> Result<(), AccessPortError> {
+    pub fn read_32(
+        &mut self,
+        access_port: MemoryAP,
+        start_address: u32,
+        data: &mut [u32],
+    ) -> Result<(), AccessPortError> {
         if data.is_empty() {
             return Ok(());
         }
@@ -185,11 +247,11 @@ where
 
         // Second we read in 32 bit reads until we have less than 32 bits left to read.
         let csw = Self::build_csw_register(DataSize::U32);
-        self.write_ap_register(csw)?;
+        self.write_ap_register(access_port, csw)?;
 
         let mut address = start_address;
         let tar = TAR { address };
-        self.write_ap_register(tar)?;
+        self.write_ap_register(access_port, tar)?;
 
         // figure out how many words we can write before the
         // data overflows
@@ -215,6 +277,7 @@ where
         let first_chunk_size_words = first_chunk_size_bytes / 4;
 
         self.read_ap_register_repeated(
+            access_port,
             DRW { data: 0 },
             &mut data[data_offset..first_chunk_size_words],
         )?;
@@ -227,7 +290,7 @@ where
             // the autoincrement is limited to the 10 lowest bits so we need to write the address
             // every time it overflows
             let tar = TAR { address };
-            self.write_ap_register(tar)?;
+            self.write_ap_register(access_port, tar)?;
 
             let next_chunk_size_bytes = std::cmp::min(max_chunk_size_bytes, remaining_data_len * 4);
 
@@ -240,6 +303,7 @@ where
             let next_chunk_size_words = next_chunk_size_bytes / 4;
 
             self.read_ap_register_repeated(
+                access_port,
                 DRW { data: 0 },
                 &mut data[data_offset..(data_offset + next_chunk_size_words)],
             )?;
@@ -254,7 +318,12 @@ where
         Ok(())
     }
 
-    pub fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), AccessPortError> {
+    pub fn read_8(
+        &mut self,
+        access_port: MemoryAP,
+        address: u32,
+        data: &mut [u8],
+    ) -> Result<(), AccessPortError> {
         if data.is_empty() {
             return Ok(());
         }
@@ -263,7 +332,7 @@ where
 
         // Read aligned block of 32-bit words
         let mut buf32 = vec![0u32; aligned.len() / 4];
-        self.read_32(aligned.start, &mut buf32)?;
+        self.read_32(access_port, aligned.start, &mut buf32)?;
 
         // Convert 32-bit words to bytes
         let mut buf8 = vec![0u8; aligned.len()];
@@ -282,7 +351,12 @@ where
     ///
     /// The address where the write should be performed at has to be word aligned.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    pub fn write_word_32(&mut self, address: u32, data: u32) -> Result<(), AccessPortError> {
+    pub fn write_word_32(
+        &mut self,
+        access_port: MemoryAP,
+        address: u32,
+        data: u32,
+    ) -> Result<(), AccessPortError> {
         if (address % 4) != 0 {
             return Err(AccessPortError::alignment_error(address, 4));
         }
@@ -290,18 +364,23 @@ where
         let csw = Self::build_csw_register(DataSize::U32);
         let drw = DRW { data };
         let tar = TAR { address };
-        self.write_ap_register(csw)?;
-        self.write_ap_register(tar)?;
-        self.write_ap_register(drw)?;
+        self.write_ap_register(access_port, csw)?;
+        self.write_ap_register(access_port, tar)?;
+        self.write_ap_register(access_port, drw)?;
 
         // Ensure the write is actually performed.
-        let _ = self.write_ap_register(csw);
+        let _ = self.write_ap_register(access_port, csw);
 
         Ok(())
     }
 
     /// Write an 8bit word at `addr`.
-    pub fn write_word_8(&mut self, address: u32, data: u8) -> Result<(), AccessPortError> {
+    pub fn write_word_8(
+        &mut self,
+        access_port: MemoryAP,
+        address: u32,
+        data: u8,
+    ) -> Result<(), AccessPortError> {
         let aligned = aligned_range(address, 1)?;
 
         // Offset of byte in word (little endian)
@@ -310,19 +389,19 @@ where
         if self.only_32bit_data_size {
             // Read the existing 32-bit word and insert the byte at the correct bit offset
             // See "Arm Debug Interface Architecture Specification ADIv5.0 to ADIv5.2", C2.2.6
-            let word = self.read_word_32(aligned.start)?;
+            let word = self.read_word_32(access_port, aligned.start)?;
             let word = word & !(0xFF << bit_offset) | (u32::from(data) << bit_offset);
 
-            self.write_word_32(aligned.start, word)?;
+            self.write_word_32(access_port, aligned.start, word)?;
         } else {
             let csw = Self::build_csw_register(DataSize::U8);
             let drw = DRW {
                 data: u32::from(data) << bit_offset,
             };
             let tar = TAR { address };
-            self.write_ap_register(csw)?;
-            self.write_ap_register(tar)?;
-            self.write_ap_register(drw)?;
+            self.write_ap_register(access_port, csw)?;
+            self.write_ap_register(access_port, tar)?;
+            self.write_ap_register(access_port, drw)?;
         }
 
         Ok(())
@@ -333,7 +412,12 @@ where
     /// The number of words written is `data.len()`.
     /// The address where the write should be performed at has to be word aligned.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    pub fn write_32(&mut self, start_address: u32, data: &[u32]) -> Result<(), AccessPortError> {
+    pub fn write_32(
+        &mut self,
+        access_port: MemoryAP,
+        start_address: u32,
+        data: &[u32],
+    ) -> Result<(), AccessPortError> {
         if data.is_empty() {
             return Ok(());
         }
@@ -351,11 +435,11 @@ where
         // Second we write in 32 bit reads until we have less than 32 bits left to write.
         let csw = Self::build_csw_register(DataSize::U32);
 
-        self.write_ap_register(csw)?;
+        self.write_ap_register(access_port, csw)?;
 
         let mut address = start_address;
         let tar = TAR { address };
-        self.write_ap_register(tar)?;
+        self.write_ap_register(access_port, tar)?;
 
         // figure out how many words we can write before the
         // data overflows
@@ -381,6 +465,7 @@ where
         let first_chunk_size_words = first_chunk_size_bytes / 4;
 
         self.write_ap_register_repeated(
+            access_port,
             DRW { data: 0 },
             &data[data_offset..first_chunk_size_words],
         )?;
@@ -393,7 +478,7 @@ where
             // the autoincrement is limited to the 10 lowest bits so we need to write the address
             // every time it overflows
             let tar = TAR { address };
-            self.write_ap_register(tar)?;
+            self.write_ap_register(access_port, tar)?;
 
             let next_chunk_size_bytes = std::cmp::min(max_chunk_size_bytes, remaining_data_len * 4);
 
@@ -406,6 +491,7 @@ where
             let next_chunk_size_words = next_chunk_size_bytes / 4;
 
             self.write_ap_register_repeated(
+                access_port,
                 DRW { data: 0 },
                 &data[data_offset..(data_offset + next_chunk_size_words)],
             )?;
@@ -416,7 +502,7 @@ where
         }
 
         // Ensure the last write is actually performed
-        self.write_ap_register(csw)?;
+        self.write_ap_register(access_port, csw)?;
 
         log::debug!("Finished writing block");
 
@@ -426,7 +512,12 @@ where
     /// Write a block of 8bit words at `addr`.
     ///
     /// The number of words written is `data.len()`.
-    pub fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), AccessPortError> {
+    pub fn write_8(
+        &mut self,
+        access_port: MemoryAP,
+        address: u32,
+        data: &[u8],
+    ) -> Result<(), AccessPortError> {
         if data.is_empty() {
             return Ok(());
         }
@@ -438,14 +529,18 @@ where
 
         // If the start of the range isn't aligned, read the first word in to avoid clobbering
         if address != aligned.start {
-            buf8.pwrite_with(self.read_word_32(aligned.start)?, 0, LE)
+            buf8.pwrite_with(self.read_word_32(access_port, aligned.start)?, 0, LE)
                 .unwrap();
         }
 
         // If the end of the range isn't aligned, read the last word in to avoid clobbering
         if address + data.len() as u32 != aligned.end {
-            buf8.pwrite_with(self.read_word_32(aligned.end - 4)?, aligned.len() - 4, LE)
-                .unwrap();
+            buf8.pwrite_with(
+                self.read_word_32(access_port, aligned.end - 4)?,
+                aligned.len() - 4,
+                LE,
+            )
+            .unwrap();
         }
 
         // Copy input data into buffer at the correct location
@@ -459,17 +554,193 @@ where
         }
 
         // Write aligned block into memory
-        self.write_32(aligned.start, &buf32)?;
+        self.write_32(access_port, aligned.start, &buf32)?;
+
+        Ok(())
+    }
+}
+
+impl<AP> ArmProbe for ADIMemoryInterface<'_, AP>
+where
+    AP: CommunicationInterface
+        + APAccess<MemoryAP, CSW>
+        + APAccess<MemoryAP, TAR>
+        + APAccess<MemoryAP, DRW>
+        + DPAccess,
+{
+    fn read_core_reg(&mut self, ap: MemoryAP, addr: CoreRegisterAddress) -> Result<u32, Error> {
+        // Write the DCRSR value to select the register we want to read.
+        let mut dcrsr_val = Dcrsr(0);
+        dcrsr_val.set_regwnr(false); // Perform a read.
+        dcrsr_val.set_regsel(addr.into()); // The address of the register to read.
+
+        self.write_word_32(ap, Dcrsr::ADDRESS, dcrsr_val.into())
+            .unwrap();
+
+        self.wait_for_core_register_transfer(ap, Duration::from_millis(100))?;
+
+        let value = self.read_word_32(ap, Dcrdr::ADDRESS).unwrap();
+
+        Ok(value)
+    }
+
+    fn write_core_reg(
+        &mut self,
+        ap: MemoryAP,
+        addr: CoreRegisterAddress,
+        value: u32,
+    ) -> Result<(), Error> {
+        self.write_word_32(ap, Dcrdr::ADDRESS, value).unwrap();
+
+        // write the DCRSR value to select the register we want to write.
+        let mut dcrsr_val = Dcrsr(0);
+        dcrsr_val.set_regwnr(true); // Perform a write.
+        dcrsr_val.set_regsel(addr.into()); // The address of the register to write.
+
+        self.write_word_32(ap, Dcrsr::ADDRESS, dcrsr_val.into())
+            .unwrap();
+
+        self.wait_for_core_register_transfer(ap, Duration::from_millis(100))?;
 
         Ok(())
     }
 
-    pub fn flush(&mut self) -> Result<(), AccessPortError> {
-        match self.interface.flush() {
-            Ok(_) => Ok(()),
-            Err(e) => Err(AccessPortError::FlushError(e)),
+    fn read_8(&mut self, ap: MemoryAP, address: u32, data: &mut [u8]) -> Result<(), Error> {
+        if data.len() == 1 {
+            data[0] = self.read_word_8(ap, address).unwrap();
+        } else {
+            self.read_8(ap, address, data).unwrap();
         }
+
+        Ok(())
     }
+
+    fn read_32(&mut self, ap: MemoryAP, address: u32, data: &mut [u32]) -> Result<(), Error> {
+        if data.len() == 1 {
+            data[0] = self.read_word_32(ap, address).unwrap();
+        } else {
+            self.read_32(ap, address, data).unwrap();
+        }
+
+        Ok(())
+    }
+
+    fn write_8(&mut self, ap: MemoryAP, address: u32, data: &[u8]) -> Result<(), Error> {
+        if data.len() == 1 {
+            self.write_word_8(ap, address, data[0]).unwrap();
+        } else {
+            self.write_8(ap, address, data).unwrap();
+        }
+
+        Ok(())
+    }
+
+    fn write_32(&mut self, ap: MemoryAP, address: u32, data: &[u32]) -> Result<(), Error> {
+        if data.len() == 1 {
+            self.write_word_32(ap, address, data[0]).unwrap();
+        } else {
+            self.write_32(ap, address, data).unwrap();
+        }
+
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), Error> {
+        self.interface.flush()?;
+
+        Ok(())
+    }
+}
+
+bitfield! {
+    #[derive(Copy, Clone)]
+    pub struct Dhcsr(u32);
+    impl Debug;
+    pub s_reset_st, _: 25;
+    pub s_retire_st, _: 24;
+    pub s_lockup, _: 19;
+    pub s_sleep, _: 18;
+    pub s_halt, _: 17;
+    pub s_regrdy, _: 16;
+    pub c_maskings, set_c_maskints: 3;
+    pub c_step, set_c_step: 2;
+    pub c_halt, set_c_halt: 1;
+    pub c_debugen, set_c_debugen: 0;
+}
+
+impl Dhcsr {
+    /// This function sets the bit to enable writes to this register.
+    ///
+    /// C1.6.3 Debug Halting Control and Status Register, DHCSR:
+    /// Debug key:
+    /// Software must write 0xA05F to this field to enable write accesses to bits
+    /// [15:0], otherwise the processor ignores the write access.
+    pub fn enable_write(&mut self) {
+        self.0 &= !(0xffff << 16);
+        self.0 |= 0xa05f << 16;
+    }
+}
+
+impl From<u32> for Dhcsr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dhcsr> for u32 {
+    fn from(value: Dhcsr) -> Self {
+        value.0
+    }
+}
+
+impl CoreRegister for Dhcsr {
+    const ADDRESS: u32 = 0xE000_EDF0;
+    const NAME: &'static str = "DHCSR";
+}
+
+bitfield! {
+    #[derive(Copy, Clone)]
+    pub struct Dcrsr(u32);
+    impl Debug;
+    pub _, set_regwnr: 16;
+    pub _, set_regsel: 4,0;
+}
+
+impl From<u32> for Dcrsr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dcrsr> for u32 {
+    fn from(value: Dcrsr) -> Self {
+        value.0
+    }
+}
+
+impl CoreRegister for Dcrsr {
+    const ADDRESS: u32 = 0xE000_EDF4;
+    const NAME: &'static str = "DCRSR";
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct Dcrdr(u32);
+
+impl From<u32> for Dcrdr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dcrdr> for u32 {
+    fn from(value: Dcrdr) -> Self {
+        value.0
+    }
+}
+
+impl CoreRegister for Dcrdr {
+    const ADDRESS: u32 = 0xE000_EDF8;
+    const NAME: &'static str = "DCRDR";
 }
 
 /// Calculates a 32-bit word aligned range from an address/length pair.
@@ -491,65 +762,16 @@ fn aligned_range(address: u32, len: usize) -> Result<Range<u32>, AccessPortError
     Ok(Range { start, end })
 }
 
-impl<AP> MemoryInterface for ADIMemoryInterface<'_, AP>
-where
-    AP: CommunicationInterface
-        + APAccess<MemoryAP, CSW>
-        + APAccess<MemoryAP, TAR>
-        + APAccess<MemoryAP, DRW>
-        + DPAccess,
-{
-    fn read_word_32(&mut self, address: u32) -> Result<u32, Error> {
-        ADIMemoryInterface::read_word_32(self, address).map_err(Error::architecture_specific)
-    }
-
-    fn read_word_8(&mut self, address: u32) -> Result<u8, Error> {
-        ADIMemoryInterface::read_word_8(self, address).map_err(Error::architecture_specific)
-    }
-
-    fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), Error> {
-        ADIMemoryInterface::read_32(self, address, data).map_err(Error::architecture_specific)
-    }
-
-    fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), Error> {
-        ADIMemoryInterface::read_8(self, address, data).map_err(Error::architecture_specific)
-    }
-
-    fn write_word_32(&mut self, address: u32, data: u32) -> Result<(), Error> {
-        ADIMemoryInterface::write_word_32(self, address, data).map_err(Error::architecture_specific)
-    }
-
-    fn write_word_8(&mut self, address: u32, data: u8) -> Result<(), Error> {
-        ADIMemoryInterface::write_word_8(self, address, data).map_err(Error::architecture_specific)
-    }
-
-    fn write_32(&mut self, address: u32, data: &[u32]) -> Result<(), Error> {
-        ADIMemoryInterface::write_32(self, address, data).map_err(Error::architecture_specific)
-    }
-
-    fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), Error> {
-        ADIMemoryInterface::write_8(self, address, data).map_err(Error::architecture_specific)
-    }
-
-    fn flush(&mut self) -> Result<(), Error> {
-        ADIMemoryInterface::flush(self).map_err(Error::architecture_specific)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::super::super::ap::{memory_ap::mock::MockMemoryAP, MemoryAP};
+    use super::super::super::ap::memory_ap::mock::MockMemoryAP;
     use super::ADIMemoryInterface;
 
     impl<'interface> ADIMemoryInterface<'interface, MockMemoryAP> {
         /// Creates a new MemoryInterface for given AccessPort.
-        fn new(
-            mock: &'interface mut MockMemoryAP,
-            access_port_number: impl Into<MemoryAP>,
-        ) -> ADIMemoryInterface<'interface, MockMemoryAP> {
+        fn new(mock: &'interface mut MockMemoryAP) -> ADIMemoryInterface<'interface, MockMemoryAP> {
             Self {
                 interface: mock,
-                access_port: access_port_number.into(),
                 only_32bit_data_size: false,
             }
         }
@@ -571,10 +793,12 @@ mod tests {
     fn read_word_32() {
         let mut mock = MockMemoryAP::with_pattern();
         mock.memory[..8].copy_from_slice(&DATA8[..8]);
-        let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock, 0x0);
+        let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock);
 
         for &address in &[0, 4] {
-            let value = mi.read_word_32(address).expect("read_word_32 failed");
+            let value = mi
+                .read_word_32(0.into(), address)
+                .expect("read_word_32 failed");
             assert_eq!(value, DATA32[address as usize / 4]);
         }
     }
@@ -583,11 +807,11 @@ mod tests {
     fn read_word_8() {
         let mut mock = MockMemoryAP::with_pattern();
         mock.memory[..8].copy_from_slice(&DATA8[..8]);
-        let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock, 0x0);
+        let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock);
 
         for address in 0..8 {
             let value = mi
-                .read_word_8(address)
+                .read_word_8(0.into(), address)
                 .unwrap_or_else(|_| panic!("read_word_8 failed, address = {}", address));
             assert_eq!(value, DATA8[address as usize], "address = {}", address);
         }
@@ -597,12 +821,12 @@ mod tests {
     fn write_word_32() {
         for &address in &[0, 4] {
             let mut mock = MockMemoryAP::with_pattern();
-            let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock, 0x0);
+            let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock);
 
             let mut expected = Vec::from(mi.mock_memory());
             expected[(address as usize)..(address as usize) + 4].copy_from_slice(&DATA8[..4]);
 
-            mi.write_word_32(address, DATA32[0])
+            mi.write_word_32(0.into(), address, DATA32[0])
                 .unwrap_or_else(|_| panic!("write_word_32 failed, address = {}", address));
             assert_eq!(
                 mi.mock_memory(),
@@ -617,12 +841,12 @@ mod tests {
     fn write_word_8() {
         for address in 0..8 {
             let mut mock = MockMemoryAP::with_pattern();
-            let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock, 0x0);
+            let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock);
 
             let mut expected = Vec::from(mi.mock_memory());
             expected[address] = DATA8[0];
 
-            mi.write_word_8(address as u32, DATA8[0])
+            mi.write_word_8(0.into(), address as u32, DATA8[0])
                 .unwrap_or_else(|_| panic!("write_word_8 failed, address = {}", address));
             assert_eq!(
                 mi.mock_memory(),
@@ -637,14 +861,15 @@ mod tests {
     fn read_32() {
         let mut mock = MockMemoryAP::with_pattern();
         mock.memory[..DATA8.len()].copy_from_slice(DATA8);
-        let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock, 0x0);
+        let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock);
 
         for &address in &[0, 4] {
             for len in 0..3 {
                 let mut data = vec![0u32; len];
-                mi.read_32(address, &mut data).unwrap_or_else(|_| {
-                    panic!("read_32 failed, address = {}, len = {}", address, len)
-                });
+                mi.read_32(0.into(), address, &mut data)
+                    .unwrap_or_else(|_| {
+                        panic!("read_32 failed, address = {}, len = {}", address, len)
+                    });
 
                 assert_eq!(
                     data.as_slice(),
@@ -660,10 +885,10 @@ mod tests {
     #[test]
     fn read_32_unaligned_should_error() {
         let mut mock = MockMemoryAP::with_pattern();
-        let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock, 0x0);
+        let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock);
 
         for &address in &[1, 3, 127] {
-            assert!(mi.read_32(address, &mut [0u32; 4]).is_err());
+            assert!(mi.read_32(0.into(), address, &mut [0u32; 4]).is_err());
         }
     }
 
@@ -671,12 +896,12 @@ mod tests {
     fn read_8() {
         let mut mock = MockMemoryAP::with_pattern();
         mock.memory[..DATA8.len()].copy_from_slice(DATA8);
-        let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock, 0x0);
+        let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock);
 
         for address in 0..4 {
             for len in 0..12 {
                 let mut data = vec![0u8; len];
-                mi.read_8(address, &mut data).unwrap_or_else(|_| {
+                mi.read_8(0.into(), address, &mut data).unwrap_or_else(|_| {
                     panic!("read_8 failed, address = {}, len = {}", address, len)
                 });
 
@@ -696,14 +921,14 @@ mod tests {
         for &address in &[0, 4] {
             for len in 0..3 {
                 let mut mock = MockMemoryAP::with_pattern();
-                let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock, 0x0);
+                let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock);
 
                 let mut expected = Vec::from(mi.mock_memory());
                 expected[address as usize..(address as usize) + len * 4]
                     .copy_from_slice(&DATA8[..len * 4]);
 
                 let data = &DATA32[..len];
-                mi.write_32(address, data).unwrap_or_else(|_| {
+                mi.write_32(0.into(), address, data).unwrap_or_else(|_| {
                     panic!("write_32 failed, address = {}, len = {}", address, len)
                 });
 
@@ -721,10 +946,12 @@ mod tests {
     #[test]
     fn write_block_u32_unaligned_should_error() {
         let mut mock = MockMemoryAP::with_pattern();
-        let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock, 0x0);
+        let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock);
 
         for &address in &[1, 3, 127] {
-            assert!(mi.write_32(address, &[0xDEAD_BEEF, 0xABBA_BABE]).is_err());
+            assert!(mi
+                .write_32(0.into(), address, &[0xDEAD_BEEF, 0xABBA_BABE])
+                .is_err());
         }
     }
 
@@ -733,13 +960,13 @@ mod tests {
         for address in 0..4 {
             for len in 0..12 {
                 let mut mock = MockMemoryAP::with_pattern();
-                let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock, 0x0);
+                let mut mi = ADIMemoryInterface::<MockMemoryAP>::new(&mut mock);
 
                 let mut expected = Vec::from(mi.mock_memory());
                 expected[address as usize..(address as usize) + len].copy_from_slice(&DATA8[..len]);
 
                 let data = &DATA8[..len];
-                mi.write_8(address, data).unwrap_or_else(|_| {
+                mi.write_8(0.into(), address, data).unwrap_or_else(|_| {
                     panic!("write_8 failed, address = {}, len = {}", address, len)
                 });
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -12,16 +12,19 @@ use crate::{
         },
         communication_interface::{ArmCommunicationInterfaceState, ArmProbeInterface},
         dp::{DPAccess, DPBankSel, DPRegister, DebugPortError, Select},
-        memory::Component,
+        memory::{adi_v5_memory_interface::ArmProbe, Component},
         ApInformation, ArmChipInfo, SwoAccess, SwoConfig, SwoMode,
     },
-    DebugProbeSelector, Error as ProbeRsError, Memory, MemoryInterface, Probe,
+    DebugProbeSelector, Error as ProbeRsError, Memory, Probe,
 };
 use constants::{commands, JTagFrequencyToDivider, Mode, Status, SwdFrequencyToDelayCount};
 use scroll::{Pread, Pwrite, BE, LE};
 use std::{cmp::Ordering, convert::TryInto, time::Duration};
 use thiserror::Error;
 use usb_interface::TIMEOUT;
+
+const STLINK_MAX_READ_LEN: usize = 6144;
+const STLINK_MAX_WRITE_LEN: usize = 16384;
 
 #[derive(Debug)]
 pub struct STLink<D: StLinkUsb> {
@@ -298,20 +301,10 @@ impl DAPAccess for STLink<STLinkUSBDevice> {
             ];
             let mut buf = [0; 2];
             self.send_jtag_command(cmd, &[], &mut buf, TIMEOUT)?;
-
-            // Ensure the write is actually performed.
-            self.flush()?;
-
             Ok(())
         } else {
             Err(StlinkError::BlanksNotAllowedOnDPRegister.into())
         }
-    }
-
-    fn flush(&mut self) -> Result<(), DebugProbeError> {
-        self.read_register(PortType::DebugPort, 0xc)?;
-
-        Ok(())
     }
 
     fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
@@ -786,27 +779,25 @@ impl<D: StLinkUsb> STLink<D> {
     fn read_mem_32bit(
         &mut self,
         address: u32,
-        length: u16,
+        data: &mut [u8],
         apsel: u8,
-    ) -> Result<Vec<u32>, DebugProbeError> {
+    ) -> Result<(), DebugProbeError> {
         log::debug!(
             "Read mem 32 bit, address={:08x}, length={}",
             address,
-            length
+            data.len()
         );
         // Maximum supported read length is 2^16 bytes.
         assert!(
-            length < (u16::MAX / 4),
-            "Maximum read length for STLink is 16'384 words"
+            data.len() <= 6144,
+            "Maximum read length for STLink is 6144 bytes"
         );
 
         if address % 4 != 0 {
             todo!("Should return an error here");
         }
 
-        let byte_length = length * 4;
-
-        let mut receive_buffer = vec![0u8; byte_length as usize];
+        let data_length = data.len();
 
         self.device.write(
             &[
@@ -816,23 +807,18 @@ impl<D: StLinkUsb> STLink<D> {
                 (address >> 8) as u8,
                 (address >> 16) as u8,
                 (address >> 24) as u8,
-                byte_length as u8,
-                (byte_length >> 8) as u8,
+                data_length as u8,
+                (data_length >> 8) as u8,
                 apsel,
             ],
             &[],
-            &mut receive_buffer,
+            data,
             TIMEOUT,
         )?;
 
         self.get_last_rw_status()?;
 
-        let words: Vec<u32> = receive_buffer
-            .chunks_exact(4)
-            .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
-            .collect();
-
-        Ok(words)
+        Ok(())
     }
 
     fn read_mem_8bit(
@@ -1020,7 +1006,7 @@ impl<D: StLinkUsb> STLink<D> {
         self.send_jtag_command(&cmd, &[], &mut buff, TIMEOUT)
     }
 
-    fn _read_core_reg(&mut self, index: u32) -> Result<u32, DebugProbeError> {
+    fn read_core_reg(&mut self, index: u32) -> Result<u32, DebugProbeError> {
         log::trace!("Read core reg {:08x}", index);
         let mut buff = [0u8; 8];
 
@@ -1039,7 +1025,7 @@ impl<D: StLinkUsb> STLink<D> {
         Ok(response)
     }
 
-    fn _write_core_reg(&mut self, index: u32, value: u32) -> Result<(), DebugProbeError> {
+    fn write_core_reg(&mut self, index: u32, value: u32) -> Result<(), DebugProbeError> {
         log::trace!("Write core reg {:08x}", index);
         let mut buff = [0u8; 2];
 
@@ -1193,30 +1179,6 @@ impl StlinkArmDebug {
         }
     }
 
-    /// Read the given register `R` of the given `AP`, where the read register value is wrapped in
-    /// the given `register` parameter.
-    pub fn read_ap_register<AP, R>(
-        &mut self,
-        port: impl Into<AP>,
-        _register: R,
-    ) -> Result<R, DebugProbeError>
-    where
-        AP: AccessPort,
-        R: APRegister<AP>,
-    {
-        log::debug!("Reading register {}", R::NAME);
-        self.select_ap_and_ap_bank(port.into().port_number(), R::APBANKSEL)?;
-
-        let result = self.probe.read_register(
-            PortType::AccessPort(u16::from(self.state.current_apsel)),
-            u16::from(R::ADDRESS),
-        )?;
-
-        log::debug!("Read register    {}, value=0x{:08x}", R::NAME, result);
-
-        Ok(R::from(result))
-    }
-
     fn select_dp_bank(&mut self, dp_bank: DPBankSel) -> Result<(), DebugPortError> {
         match dp_bank {
             DPBankSel::Bank(new_bank) => {
@@ -1278,97 +1240,6 @@ impl StlinkArmDebug {
 
         Ok(())
     }
-
-    /// Write the given register `R` of the given `AP`, where the to be written register value
-    /// is wrapped in the given `register` parameter.
-    pub fn write_ap_register<AP, R>(
-        &mut self,
-        port: impl Into<AP>,
-        register: R,
-    ) -> Result<(), DebugProbeError>
-    where
-        AP: AccessPort,
-        R: APRegister<AP>,
-    {
-        let register_value = register.into();
-
-        log::debug!(
-            "Writing register {}, value=0x{:08X}",
-            R::NAME,
-            register_value
-        );
-
-        self.select_ap_and_ap_bank(port.into().port_number(), R::APBANKSEL)?;
-
-        self.probe.write_register(
-            PortType::AccessPort(u16::from(self.state.current_apsel)),
-            u16::from(R::ADDRESS),
-            register_value,
-        )?;
-
-        // Read from AP register
-        Ok(())
-    }
-
-    // TODO: Fix this ugly: _register: R, values: &[u32]
-    /// Write the given register `R` of the given `AP` repeatedly, where the to be written register
-    /// values are stored in the `values` array. The values are written in the exact order they are
-    /// stored in the array.
-    pub fn write_ap_register_repeated<AP, R>(
-        &mut self,
-        port: impl Into<AP>,
-        _register: R,
-        values: &[u32],
-    ) -> Result<(), DebugProbeError>
-    where
-        AP: AccessPort,
-        R: APRegister<AP>,
-    {
-        log::debug!(
-            "Writing register {}, block with len={} words",
-            R::NAME,
-            values.len(),
-        );
-
-        self.select_ap_and_ap_bank(port.into().port_number(), R::APBANKSEL)?;
-
-        self.probe.write_block(
-            PortType::AccessPort(u16::from(self.state.current_apsel)),
-            u16::from(R::ADDRESS),
-            values,
-        )?;
-        Ok(())
-    }
-
-    // TODO: fix types, see above!
-    /// Read the given register `R` of the given `AP` repeatedly, where the read register values
-    /// are stored in the `values` array. The values are read in the exact order they are stored in
-    /// the array.
-    pub fn read_ap_register_repeated<AP, R>(
-        &mut self,
-        port: impl Into<AP>,
-        _register: R,
-        values: &mut [u32],
-    ) -> Result<(), DebugProbeError>
-    where
-        AP: AccessPort,
-        R: APRegister<AP>,
-    {
-        log::debug!(
-            "Reading register {}, block with len={} words",
-            R::NAME,
-            values.len(),
-        );
-
-        self.select_ap_and_ap_bank(port.into().port_number(), R::APBANKSEL)?;
-
-        self.probe.read_block(
-            PortType::AccessPort(u16::from(self.state.current_apsel)),
-            u16::from(R::ADDRESS),
-            values,
-        )?;
-        Ok(())
-    }
 }
 
 impl DPAccess for StlinkArmDebug {
@@ -1414,12 +1285,9 @@ impl DPAccess for StlinkArmDebug {
 
 impl<'probe> ArmProbeInterface for StlinkArmDebug {
     fn memory_interface(&mut self, access_port: MemoryAP) -> Result<Memory<'_>, ProbeRsError> {
-        let interface = StLinkMemoryInterface {
-            probe: self,
-            access_port,
-        };
+        let interface = StLinkMemoryInterface { probe: self };
 
-        Ok(Memory::new(interface))
+        Ok(Memory::new(interface, access_port))
     }
 
     fn ap_information(
@@ -1482,30 +1350,95 @@ where
 {
     type Error = DebugProbeError;
 
-    fn read_ap_register(&mut self, port: impl Into<AP>, register: R) -> Result<R, Self::Error> {
-        self.read_ap_register(port, register)
+    /// Read the given register `R` of the given `AP`, where the read register value is wrapped in
+    /// the given `register` parameter.
+    fn read_ap_register(&mut self, port: impl Into<AP>, _register: R) -> Result<R, Self::Error> {
+        log::debug!("Reading register {}", R::NAME);
+        self.select_ap_and_ap_bank(port.into().port_number(), R::APBANKSEL)?;
+
+        let result = self.probe.read_register(
+            PortType::AccessPort(u16::from(self.state.current_apsel)),
+            u16::from(R::ADDRESS),
+        )?;
+
+        log::debug!("Read register    {}, value=0x{:08x}", R::NAME, result);
+
+        Ok(result.into())
     }
 
+    /// Write the given register `R` of the given `AP`, where the to be written register value
+    /// is wrapped in the given `register` parameter.
     fn write_ap_register(&mut self, port: impl Into<AP>, register: R) -> Result<(), Self::Error> {
-        self.write_ap_register(port, register)
+        let register_value = register.into();
+
+        log::debug!(
+            "Writing register {}, value=0x{:08X}",
+            R::NAME,
+            register_value
+        );
+
+        self.select_ap_and_ap_bank(port.into().port_number(), R::APBANKSEL)?;
+
+        self.probe.write_register(
+            PortType::AccessPort(u16::from(self.state.current_apsel)),
+            u16::from(R::ADDRESS),
+            register_value,
+        )?;
+
+        // Read from AP register
+        Ok(())
     }
 
+    // TODO: Fix this ugly: _register: R, values: &[u32]
+    /// Write the given register `R` of the given `AP` repeatedly, where the to be written register
+    /// values are stored in the `values` array. The values are written in the exact order they are
+    /// stored in the array.
     fn write_ap_register_repeated(
         &mut self,
         port: impl Into<AP> + Clone,
-        register: R,
+        _register: R,
         values: &[u32],
     ) -> Result<(), Self::Error> {
-        self.write_ap_register_repeated(port, register, values)
+        log::debug!(
+            "Writing register {}, block with len={} words",
+            R::NAME,
+            values.len(),
+        );
+
+        self.select_ap_and_ap_bank(port.into().port_number(), R::APBANKSEL)?;
+
+        self.probe.write_block(
+            PortType::AccessPort(u16::from(self.state.current_apsel)),
+            u16::from(R::ADDRESS),
+            values,
+        )?;
+        Ok(())
     }
 
+    // TODO: fix types, see above!
+    /// Read the given register `R` of the given `AP` repeatedly, where the read register values
+    /// are stored in the `values` array. The values are read in the exact order they are stored in
+    /// the array.
     fn read_ap_register_repeated(
         &mut self,
         port: impl Into<AP> + Clone,
-        register: R,
+        _register: R,
         values: &mut [u32],
     ) -> Result<(), Self::Error> {
-        self.read_ap_register_repeated(port, register, values)
+        log::debug!(
+            "Reading register {}, block with len={} words",
+            R::NAME,
+            values.len(),
+        );
+
+        self.select_ap_and_ap_bank(port.into().port_number(), R::APBANKSEL)?;
+
+        self.probe.read_block(
+            PortType::AccessPort(u16::from(self.state.current_apsel)),
+            u16::from(R::ADDRESS),
+            values,
+        )?;
+        Ok(())
     }
 }
 
@@ -1538,160 +1471,64 @@ impl SwoAccess for StlinkArmDebug {
 #[derive(Debug)]
 struct StLinkMemoryInterface<'probe> {
     probe: &'probe mut StlinkArmDebug,
-    access_port: MemoryAP,
 }
 
-impl MemoryInterface for StLinkMemoryInterface<'_> {
-    fn read_word_32(&mut self, address: u32) -> Result<u32, ProbeRsError> {
-        self.probe.select_ap(self.access_port)?;
+impl ArmProbe for StLinkMemoryInterface<'_> {
+    fn read_32(
+        &mut self,
+        ap: MemoryAP,
+        address: u32,
+        data: &mut [u32],
+    ) -> Result<(), ProbeRsError> {
+        self.probe.select_ap(ap)?;
 
-        let mut buff = [0];
-        self.read_32(address, &mut buff)?;
+        // Read needs to be chunked into chunks with max length 6144 bytes
+        for (index, chunk) in data.chunks_mut(STLINK_MAX_READ_LEN / 4).enumerate() {
+            let mut buff = vec![0u8; 4 * chunk.len()];
 
-        Ok(buff[0])
-    }
-
-    fn read_word_8(&mut self, address: u32) -> Result<u8, ProbeRsError> {
-        self.probe.select_ap(self.access_port)?;
-
-        let mut buff = [0u8];
-        self.read_8(address, &mut buff)?;
-
-        Ok(buff[0])
-    }
-
-    fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), ProbeRsError> {
-        self.probe.select_ap(self.access_port)?;
-
-        let received_words = self.probe.probe.read_mem_32bit(
-            address,
-            data.len() as u16,
-            self.access_port.port_number(),
-        )?;
-
-        data.copy_from_slice(&received_words);
-
-        Ok(())
-    }
-
-    fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), ProbeRsError> {
-        self.probe.select_ap(self.access_port)?;
-
-        // The underlying STLink command is limited to a single USB frame at a time
-        // so we must manually chunk it into multiple commands if it exceeds
-        // that size.
-        let chunk_size = if self.probe.probe.hw_version < 3 {
-            64
-        } else {
-            512
-        };
-
-        // If we read less than chunk_size bytes, just read it directly.
-        if data.len() < chunk_size {
-            log::trace!("read_8: small - direct 8 bit read from {:08x}", address);
-            let received_words = self.probe.probe.read_mem_8bit(
-                address,
-                data.len() as u16,
-                self.access_port.port_number(),
-            )?;
-            data.copy_from_slice(&received_words);
-        } else {
-            // Handle unaligned data in the beginning.
-            let bytes_beginning = if address % 4 == 0 {
-                0
-            } else {
-                (4 - address % 4) as usize
-            };
-
-            let mut current_address = address;
-
-            if bytes_beginning > 0 {
-                log::trace!(
-                    "read_8: at_begin - unaligned read of {} bytes from address {:08x}",
-                    bytes_beginning,
-                    current_address,
-                );
-                let received_words = self.probe.probe.read_mem_8bit(
-                    current_address,
-                    bytes_beginning as u16,
-                    self.access_port.port_number(),
-                )?;
-                data[0..bytes_beginning].copy_from_slice(&received_words);
-
-                current_address += bytes_beginning as u32;
-            }
-
-            // Address has to be aligned here.
-            assert!(current_address % 4 == 0);
-            let bytes_remaining = data.len() - bytes_beginning;
-            let word_count = bytes_remaining / 4;
-
-            log::trace!(
-                "read_8: aligned read of {} bytes from address {:08x}",
-                bytes_remaining,
-                current_address,
-            );
-
-            let received_words = self.probe.probe.read_mem_32bit(
-                current_address,
-                word_count as u16,
-                self.access_port.port_number(),
+            self.probe.probe.read_mem_32bit(
+                address + (index * STLINK_MAX_READ_LEN) as u32,
+                &mut buff,
+                ap.port_number(),
             )?;
 
-            let data_chunks = (&mut data[bytes_beginning..]).chunks_exact_mut(4);
-            received_words
-                .into_iter()
-                .zip(data_chunks)
-                .for_each(|(word, chunk)| chunk.copy_from_slice(&word.to_le_bytes()));
-
-            let word_bytes = word_count * 4;
-            current_address += word_bytes as u32;
-
-            let remaining_bytes = &mut data[bytes_beginning + word_bytes..];
-
-            if !remaining_bytes.is_empty() {
-                log::trace!(
-                    "read_8: at_end -unaligned read of {} bytes from address {:08x}",
-                    remaining_bytes.len(),
-                    current_address,
-                );
-                let received_words = self.probe.probe.read_mem_8bit(
-                    current_address,
-                    remaining_bytes.len() as u16,
-                    self.access_port.port_number(),
-                )?;
-                remaining_bytes.copy_from_slice(&received_words);
+            for (index, word) in buff.chunks_exact(4).enumerate() {
+                chunk[index] = u32::from_le_bytes(word.try_into().unwrap());
             }
         }
 
         Ok(())
     }
 
-    fn write_word_32(&mut self, address: u32, data: u32) -> Result<(), ProbeRsError> {
-        self.probe.select_ap(self.access_port)?;
+    fn read_8(&mut self, ap: MemoryAP, address: u32, data: &mut [u8]) -> Result<(), ProbeRsError> {
+        self.probe.select_ap(ap)?;
 
-        self.write_32(address, &[data])?;
+        let received_data =
+            self.probe
+                .probe
+                .read_mem_8bit(address, data.len() as u16, ap.port_number())?;
+
+        data.copy_from_slice(&received_data);
 
         Ok(())
     }
 
-    fn write_word_8(&mut self, address: u32, data: u8) -> Result<(), ProbeRsError> {
-        self.probe.select_ap(self.access_port)?;
+    fn write_32(&mut self, ap: MemoryAP, address: u32, data: &[u32]) -> Result<(), ProbeRsError> {
+        self.probe.select_ap(ap)?;
 
-        self.write_8(address, &[data])
-    }
+        for (index, chunk) in data.chunks(16384 / 4).enumerate() {
+            self.probe.probe.write_mem_32bit(
+                address + (index * STLINK_MAX_WRITE_LEN) as u32,
+                chunk,
+                ap.port_number(),
+            )?;
+        }
 
-    fn write_32(&mut self, address: u32, data: &[u32]) -> Result<(), ProbeRsError> {
-        self.probe.select_ap(self.access_port)?;
-
-        self.probe
-            .probe
-            .write_mem_32bit(address, data, self.access_port.port_number())?;
         Ok(())
     }
 
-    fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), ProbeRsError> {
-        self.probe.select_ap(self.access_port)?;
+    fn write_8(&mut self, ap: MemoryAP, address: u32, data: &[u8]) -> Result<(), ProbeRsError> {
+        self.probe.select_ap(ap)?;
 
         // The underlying STLink command is limited to a single USB frame at a time
         // so we must manually chunk it into multiple command if it exceeds
@@ -1707,7 +1544,7 @@ impl MemoryInterface for StLinkMemoryInterface<'_> {
             log::trace!("write_8: small - direct 8 bit write to {:08x}", address);
             self.probe
                 .probe
-                .write_mem_8bit(address, data, self.access_port.port_number())?;
+                .write_mem_8bit(address, data, ap.port_number())?;
         } else {
             // Handle unaligned data in the beginning.
             let bytes_beginning = if address % 4 == 0 {
@@ -1727,7 +1564,7 @@ impl MemoryInterface for StLinkMemoryInterface<'_> {
                 self.probe.probe.write_mem_8bit(
                     current_address,
                     &data[..bytes_beginning],
-                    self.access_port.port_number(),
+                    ap.port_number(),
                 )?;
 
                 current_address += bytes_beginning as u32;
@@ -1749,11 +1586,9 @@ impl MemoryInterface for StLinkMemoryInterface<'_> {
                 current_address,
             );
 
-            self.probe.probe.write_mem_32bit(
-                current_address,
-                &words,
-                self.access_port.port_number(),
-            )?;
+            self.probe
+                .probe
+                .write_mem_32bit(current_address, &words, ap.port_number())?;
 
             current_address += (words.len() * 4) as u32;
 
@@ -1768,7 +1603,7 @@ impl MemoryInterface for StLinkMemoryInterface<'_> {
                 self.probe.probe.write_mem_8bit(
                     current_address,
                     remaining_bytes,
-                    self.access_port.port_number(),
+                    ap.port_number(),
                 )?;
             }
         }
@@ -1777,6 +1612,31 @@ impl MemoryInterface for StLinkMemoryInterface<'_> {
 
     fn flush(&mut self) -> Result<(), ProbeRsError> {
         self.probe.probe.flush()?;
+
+        Ok(())
+    }
+
+    fn read_core_reg(
+        &mut self,
+        _ap: MemoryAP,
+        addr: crate::CoreRegisterAddress,
+    ) -> Result<u32, ProbeRsError> {
+        // Unclear how this works with multiple APs
+
+        let value = self.probe.probe.read_core_reg(addr.0 as u32)?;
+
+        Ok(value)
+    }
+
+    fn write_core_reg(
+        &mut self,
+        _ap: MemoryAP,
+        addr: crate::CoreRegisterAddress,
+        value: u32,
+    ) -> Result<(), ProbeRsError> {
+        // Unclear how this works with multiple APs
+
+        self.probe.probe.write_core_reg(addr.0 as u32, value)?;
 
         Ok(())
     }

--- a/probe-rs/src/probe/stlink/usb_interface.rs
+++ b/probe-rs/src/probe/stlink/usb_interface.rs
@@ -256,14 +256,14 @@ impl StLinkUsb for STLinkUSBDevice {
                 remaining_bytes -= written_bytes;
                 write_index += written_bytes;
 
-                log::debug!(
+                log::trace!(
                     "Wrote {} bytes, {} bytes remaining",
                     written_bytes,
                     remaining_bytes
                 );
             }
 
-            log::debug!("USB write done!");
+            log::trace!("USB write done!");
         }
 
         // Optional data in phase.
@@ -280,7 +280,7 @@ impl StLinkUsb for STLinkUSBDevice {
                 read_index += read_bytes;
                 remaining_bytes -= read_bytes;
 
-                log::debug!(
+                log::trace!(
                     "Read {} bytes, {} bytes remaining",
                     read_bytes,
                     remaining_bytes

--- a/probe-rs/src/probe/stlink/usb_interface.rs
+++ b/probe-rs/src/probe/stlink/usb_interface.rs
@@ -234,38 +234,57 @@ impl StLinkUsb for STLinkUSBDevice {
             .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
 
         if written_bytes != CMD_LEN {
-            return Err(StlinkError::NotEnoughBytesRead {
+            return Err(StlinkError::NotEnoughBytesWritten {
                 is: written_bytes,
                 should: CMD_LEN,
             }
             .into());
         }
+
         // Optional data out phase.
         if !write_data.is_empty() {
-            let written_bytes = self
-                .device_handle
-                .write_bulk(ep_out, write_data, timeout)
-                .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
-            if written_bytes != write_data.len() {
-                return Err(StlinkError::NotEnoughBytesRead {
-                    is: written_bytes,
-                    should: write_data.len(),
-                }
-                .into());
+            let mut remaining_bytes = write_data.len();
+
+            let mut write_index = 0;
+
+            while remaining_bytes > 0 {
+                let written_bytes = self
+                    .device_handle
+                    .write_bulk(ep_out, &write_data[write_index..], timeout)
+                    .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
+
+                remaining_bytes -= written_bytes;
+                write_index += written_bytes;
+
+                log::debug!(
+                    "Wrote {} bytes, {} bytes remaining",
+                    written_bytes,
+                    remaining_bytes
+                );
             }
+
+            log::debug!("USB write done!");
         }
+
         // Optional data in phase.
         if !read_data.is_empty() {
-            let read_bytes = self
-                .device_handle
-                .read_bulk(ep_in, read_data, timeout)
-                .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
-            if read_bytes != read_data.len() {
-                return Err(StlinkError::NotEnoughBytesRead {
-                    is: read_bytes,
-                    should: read_data.len(),
-                }
-                .into());
+            let mut remaining_bytes = read_data.len();
+            let mut read_index = 0;
+
+            while remaining_bytes > 0 {
+                let read_bytes = self
+                    .device_handle
+                    .read_bulk(ep_in, &mut read_data[read_index..], timeout)
+                    .map_err(|e| DebugProbeError::USB(Some(Box::new(e))))?;
+
+                read_index += read_bytes;
+                remaining_bytes -= read_bytes;
+
+                log::debug!(
+                    "Read {} bytes, {} bytes remaining",
+                    read_bytes,
+                    remaining_bytes
+                );
             }
         }
         Ok(())


### PR DESCRIPTION
With this PR, the dedicated ST-Link APIs for register read / write are used.

This complicates the whole API a bit, by creating an additional `ArmProbe` trait, which offers both memory access,
as well as register access.

@mvirkkunen  The API for the debug sequences is probably also influenced by this. From what I've seen, the debug sequences need access to memory read write, AP/DP read write, as well as direct access to the individual pins. Would it make sense to extend the new `ArmProbe` trait, so that this can be handled, or do you have other ideas already?

(This is split-off from #369)