### PR TITLE
CMSIS-DAP: Match only on VID/PID if no SN is specified

### DIFF
--- a/probe-rs/src/probe/daplink/tools.rs
+++ b/probe-rs/src/probe/daplink/tools.rs
@@ -164,7 +164,11 @@ fn device_matches(
     if device_descriptor.vendor_id() == selector.vendor_id
         && device_descriptor.product_id() == selector.product_id
     {
-        serial_str == selector.serial_number
+        if selector.serial_number.is_some() {
+            serial_str == selector.serial_number
+        } else {
+            true
+        }
     } else {
         false
     }


### PR DESCRIPTION
This resolves an issue where specifying `--probe vid:pid` meant a CMSIS-DAP device was only ever opened in V1 mode, even if it was V2 capable, because it always tried to match using the SN too.