### PR TITLE
Implement chunking of large 8-bit reads for stlinkv2/v3

### DIFF
--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1644,7 +1644,7 @@ impl MemoryInterface for StLinkMemoryInterface<'_> {
             let word_bytes = word_count * 4;
             current_address += word_bytes as u32;
 
-            let remaining_bytes = &mut data[bytes_beginning+word_bytes..];
+            let remaining_bytes = &mut data[bytes_beginning + word_bytes..];
 
             if !remaining_bytes.is_empty() {
                 log::trace!(


### PR DESCRIPTION
This follows the pattern already implemented for 8-bit writes; small reads go in one 8-bit read, while large reads are split into three phases with the bulk of the transfer done with aligned 32-bit reads.

There is an extra restriction on reads, which is that they must read at least 2 bytes. When 1 is requested, 2 are read and then the returned buffer is truncated to the requested length of 1 before it is returned.

I've exercised (on a stlinkv2 clone) both the small 8-bit read and the large 3-phase read, including when one of the 8-bit reads is only 1 byte, and it seems to be working properly in all cases I've seen so far.