### PR TITLE
Add EFM32PG12 target

### DIFF
--- a/probe-rs/targets/EFM32PG12B Series.yaml
+++ b/probe-rs/targets/EFM32PG12B Series.yaml
@@ -1,0 +1,41 @@
+---
+name: EFM32PG12B Series
+variants:
+  - name: EFM32PG12B500F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 0
+            end: 1048576
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+flash_algorithms:
+  geckos1:
+    name: geckos1
+    description: EFM32/EFR32 Gecko S1
+    default: true
+    instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
+    pc_init: 81
+    pc_uninit: 105
+    pc_program_page: 229
+    pc_erase_sector: 163
+    pc_erase_all: 119
+    data_section_offset: 400
+    flash_properties:
+      address_range:
+        start: 0
+        end: 1048576
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 260
+      erase_sector_timeout: 200
+      sectors:
+        - size: 2048
+          address: 0
+core: M4


### PR DESCRIPTION
Extracted from `SiliconLabs.GeckoPlatform_EFM32PG12B_DFP.3.0.0.pack`
Removed duplicates. Differences between the contained chips is only the temperature range.