### PR TITLE
Return plain Vec<DebugProbeInfo> from list_jlink_devices()

### DIFF
--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -1023,39 +1023,43 @@ fn bits_to_byte(bits: impl IntoIterator<Item = bool>) -> u32 {
     bit_val
 }
 
-pub(crate) fn list_jlink_devices() -> Result<impl Iterator<Item = DebugProbeInfo>, DebugProbeError>
-{
-    Ok(jaylink::scan_usb()?.map(|device_info| {
-        let vid = device_info.vid();
-        let pid = device_info.pid();
-        let (serial, product) = if let Ok(device) = device_info.open() {
-            let serial = device.serial_string();
-            let serial = if serial.is_empty() {
-                None
-            } else {
-                Some(serial.to_owned())
-            };
-            let product = device.product_string();
-            let product = if product.is_empty() {
-                None
-            } else {
-                Some(product.to_owned())
-            };
-            (serial, product)
-        } else {
-            (None, None)
-        };
-        DebugProbeInfo::new(
-            format!(
-                "J-Link{}",
-                product.map(|p| format!(" ({})", p)).unwrap_or_default()
-            ),
-            vid,
-            pid,
-            serial,
-            DebugProbeType::JLink,
-        )
-    }))
+pub(crate) fn list_jlink_devices() -> Vec<DebugProbeInfo> {
+    match jaylink::scan_usb() {
+        Ok(devices) => devices
+            .map(|device_info| {
+                let vid = device_info.vid();
+                let pid = device_info.pid();
+                let (serial, product) = if let Ok(device) = device_info.open() {
+                    let serial = device.serial_string();
+                    let serial = if serial.is_empty() {
+                        None
+                    } else {
+                        Some(serial.to_owned())
+                    };
+                    let product = device.product_string();
+                    let product = if product.is_empty() {
+                        None
+                    } else {
+                        Some(product.to_owned())
+                    };
+                    (serial, product)
+                } else {
+                    (None, None)
+                };
+                DebugProbeInfo::new(
+                    format!(
+                        "J-Link{}",
+                        product.map(|p| format!(" ({})", p)).unwrap_or_default()
+                    ),
+                    vid,
+                    pid,
+                    serial,
+                    DebugProbeType::JLink,
+                )
+            })
+            .collect(),
+        Err(_) => Vec::new(),
+    }
 }
 
 impl From<jaylink::Error> for DebugProbeError {

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -182,7 +182,7 @@ impl Probe {
         }
         list.extend(stlink::tools::list_stlink_devices());
 
-        list.extend(list_jlink_devices().expect("Failed to list J-Link devices."));
+        list.extend(list_jlink_devices());
 
         list
     }


### PR DESCRIPTION
Change to return `Vec<DebugProbeInfo>` instead of `Result<impl Iterator>` to match the other `list_x_devices()` methods and prevent a jlink error from stopping other drivers operating. The original patch was only a two-line change but sadly rustfmt had other ideas!

Closes #399.

I don't have any j-link probes, so this is untested beyond checking it builds.