### PR TITLE
apply some clippy hints to remove them from showing up in code review

### DIFF
--- a/gdb-server/src/parser/v_packet.rs
+++ b/gdb-server/src/parser/v_packet.rs
@@ -30,7 +30,7 @@ pub fn v_packet(input: &[u8]) -> IResult<&[u8], VPacket> {
         Err(nom::Err::Error((input, _kind))) => {
             // For unknown packets, we have to return a valid packet here.
             // This is requird by the GDB spec.
-            Ok(("".as_bytes(), VPacket::Unknown(input.to_owned())))
+            Ok((b"", VPacket::Unknown(input.to_owned())))
         }
         Err(other) => Err(other),
     }

--- a/probe-rs/examples/tcp_itm.rs
+++ b/probe-rs/examples/tcp_itm.rs
@@ -154,7 +154,7 @@ impl SwoPublisher for TcpPublisher {
                 loop {
                     // If a halt was requested, cease operations.
                     if halt_rx.try_recv().is_ok() {
-                        return ();
+                        return;
                     }
 
                     // Handle new incomming connections.
@@ -180,19 +180,16 @@ impl SwoPublisher for TcpPublisher {
                         }
                         None => {
                             log::error!("The TCP listener iterator was exhausted. Shutting down websocket listener.");
-                            return ();
+                            return;
                         }
                     }
 
                     // Send at max one pending message to each socket.
-                    match inbound.try_recv() {
-                        Ok(update) => {
-                            Self::write_to_all_sockets(
-                                &mut sockets,
-                                serde_json::to_string(&update).unwrap(),
-                            );
-                        }
-                        _ => (),
+                    if let Ok(update) = inbound.try_recv() {
+                        Self::write_to_all_sockets(
+                            &mut sockets,
+                            serde_json::to_string(&update).unwrap(),
+                        );
                     }
 
                     // Pause the current thread to not use CPU for no reason.

--- a/probe-rs/src/architecture/arm/swo/decoder.rs
+++ b/probe-rs/src/architecture/arm/swo/decoder.rs
@@ -453,6 +453,12 @@ impl Decoder {
     }
 }
 
+impl Default for Decoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn extract_size(c: u8) -> Result<usize, String> {
     match c & 0b11 {
         0b01 => Ok(1),

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -138,6 +138,12 @@ impl RiscvCommunicationInterfaceState {
     }
 }
 
+impl Default for RiscvCommunicationInterfaceState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug)]
 pub struct RiscvCommunicationInterface {
     probe: Box<dyn JTAGAccess>,

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -521,7 +521,7 @@ impl<'probe> Core<'probe> {
             .iter()
             .map(|bp| bp.register_hw)
             .collect();
-        used_bp.sort();
+        used_bp.sort_unstable();
 
         let mut free_bp = 0;
 
@@ -583,10 +583,7 @@ pub enum CoreStatus {
 
 impl CoreStatus {
     pub fn is_halted(&self) -> bool {
-        match self {
-            CoreStatus::Halted(_) => true,
-            _ => false,
-        }
+        matches!(self, CoreStatus::Halted(_))
     }
 }
 

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -800,8 +800,8 @@ mod tests {
                         address: 0x000000,
                         data: {
                             let mut data = vec![42; 1024];
-                            for i in 0..42 {
-                                data[i] = 0;
+                            for d in &mut data[..42] {
+                                *d = 0;
                             }
                             data
                         },
@@ -810,8 +810,8 @@ mod tests {
                         address: 0x000400,
                         data: {
                             let mut data = vec![0; 1024];
-                            for i in 0..42 {
-                                data[i] = 42;
+                            for d in &mut data[..42] {
+                                *d = 42;
                             }
                             data
                         },
@@ -898,8 +898,8 @@ mod tests {
                         address: 0x001000,
                         data: {
                             let mut data = vec![0; 1024];
-                            for i in 0..928 {
-                                data[i] = 42;
+                            for d in &mut data[..928] {
+                                *d = 42;
                             }
                             data
                         },
@@ -999,8 +999,8 @@ mod tests {
                         address: 0x001000,
                         data: {
                             let mut data = vec![42; 1024];
-                            for i in 928..1024 {
-                                data[i] = 0;
+                            for d in &mut data[928..1024] {
+                                *d = 0;
                             }
                             data
                         },
@@ -1009,8 +1009,8 @@ mod tests {
                         address: 0x001C00,
                         data: {
                             let mut data = vec![42; 1024];
-                            for i in 0..692 {
-                                data[i] = 0;
+                            for d in &mut data[..692] {
+                                *d = 0;
                             }
                             data
                         },
@@ -1043,8 +1043,8 @@ mod tests {
                         address: 0x003000,
                         data: {
                             let mut data = vec![42; 1024];
-                            for i in 596..1024 {
-                                data[i] = 0;
+                            for d in &mut data[596..1024] {
+                                *d = 0;
                             }
                             data
                         },
@@ -1170,8 +1170,8 @@ mod tests {
                         address: 0x001000,
                         data: {
                             let mut data = vec![42; 1024];
-                            for i in 928..1024 {
-                                data[i] = 0;
+                            for d in &mut data[928..1024] {
+                                *d = 0;
                             }
                             data
                         },
@@ -1180,8 +1180,8 @@ mod tests {
                         address: 0x001C00,
                         data: {
                             let mut data = vec![42; 1024];
-                            for i in 0..692 {
-                                data[i] = 0;
+                            for d in &mut data[..692] {
+                                *d = 0;
                             }
                             data
                         },
@@ -1206,8 +1206,8 @@ mod tests {
                         address: 0x003000,
                         data: {
                             let mut data = vec![42; 1024];
-                            for i in 596..1024 {
-                                data[i] = 0;
+                            for d in &mut data[596..1024] {
+                                *d = 0;
                             }
                             data
                         },

--- a/probe-rs/src/probe/daplink/tools.rs
+++ b/probe-rs/src/probe/daplink/tools.rs
@@ -119,12 +119,11 @@ pub fn open_v2_device(device: Device<rusb::Context>) -> Option<DAPLinkDevice> {
             // Detect a third bulk EP which will be for SWO streaming
             let mut swo_ep = None;
 
-            if eps.len() > 2 {
-                if eps[2].transfer_type() == rusb::TransferType::Bulk
-                    && eps[2].direction() == rusb::Direction::In
-                {
-                    swo_ep = Some(eps[2].address());
-                }
+            if eps.len() > 2
+                && eps[2].transfer_type() == rusb::TransferType::Bulk
+                && eps[2].direction() == rusb::Direction::In
+            {
+                swo_ep = Some(eps[2].address());
             }
 
             // Store EP addresses of the in and out EPs

--- a/probe-rs/src/probe/ftdi/ftdi_impl.rs
+++ b/probe-rs/src/probe/ftdi/ftdi_impl.rs
@@ -293,6 +293,7 @@ impl Write for Device {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("failed to enumerate devices to open the correct one")]
@@ -316,10 +317,6 @@ pub enum Error {
 
     #[error("unknown or unexpected libftdi error")]
     Unknown { source: LibFtdiError },
-
-    #[error("INTERNAL, DO NOT USE")]
-    #[doc(hidden)]
-    __NonExhaustive,
 }
 
 impl Error {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -532,7 +532,7 @@ impl DebugProbe for JLink {
 
                 // Construct the entire init sequence.
                 let swd_io_sequence =
-                    // Send the reset sequence (> 50 0-bits).    
+                    // Send the reset sequence (> 50 0-bits).
                     iter::repeat(true).take(64)
                     // Send the JTAG to SWD sequence.
                     .chain(jtag_to_swd_sequence.iter().copied())
@@ -543,7 +543,7 @@ impl DebugProbe for JLink {
 
                 // Construct the direction sequence for reset sequence.
                 let direction =
-                    // Send the reset sequence (> 50 0-bits).    
+                    // Send the reset sequence (> 50 0-bits).
                     iter::repeat(true).take(64)
                     // Send the JTAG to SWD sequence.
                     .chain(iter::repeat(true).take(16))
@@ -736,9 +736,7 @@ impl DAPAccess for JLink {
         ];
 
         // Add the data bits to the SWDIO sequence.
-        for _ in 0..32 {
-            swd_io_sequence.push(false);
-        }
+        swd_io_sequence.extend_from_slice(&[false; 32]);
 
         // Add the parity bit to the sequence.
         swd_io_sequence.push(false);

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -715,7 +715,7 @@ impl<D: StLinkUsb> STLink<D> {
 
         // Return the last error (will be SwdDpWait or SwdApWait)
         let status = Status::from(read_data[0]);
-        return Err(From::from(StlinkError::CommandFailed(status)));
+        Err(From::from(StlinkError::CommandFailed(status)))
     }
 
     pub fn start_trace_reception(&mut self, config: &SwoConfig) -> Result<(), DebugProbeError> {
@@ -1835,7 +1835,7 @@ mod test {
 
                     let version: u16 = ((self.hw_version as u16) << 12)
                         | ((self.jtag_version as u16) << 6)
-                        | ((self.swim_version as u16) << 0);
+                        | (self.swim_version as u16);
 
                     read_data[0] = (version >> 8) as u8;
                     read_data[1] = version as u8;

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -164,10 +164,7 @@ impl Session {
 
     /// Attaches to the core with the given number.
     pub fn core(&mut self, n: usize) -> Result<Core<'_>, Error> {
-        let (core, core_state) = self
-            .cores
-            .get_mut(n)
-            .ok_or_else(|| Error::CoreNotFound(n))?;
+        let (core, core_state) = self.cores.get_mut(n).ok_or(Error::CoreNotFound(n))?;
 
         self.interface.attach(core, core_state)
     }
@@ -182,9 +179,7 @@ impl Session {
         interface.read_swo()
     }
 
-    pub fn get_arm_interface<'session>(
-        &'session mut self,
-    ) -> Result<&'session mut Box<dyn ArmProbeInterface>, Error> {
+    pub fn get_arm_interface(&mut self) -> Result<&mut Box<dyn ArmProbeInterface>, Error> {
         let interface = match &mut self.interface {
             ArchitectureInterface::Arm(state) => state,
             _ => return Err(Error::ArchitectureRequired(&["ARMv7", "ARMv8"])),


### PR DESCRIPTION
I did this some time ago and thought this might as well be of some use.

The nested `if` and `<< 0` are arguably worse now, not sure if you just
want to have the clippy warning on, want an ignore or want the lint
applied. The `default` is also a bit useless...idk

I don't see a way to fix the two remaining `.collect` and `Box<Self>` warnings.