### PR TITLE
use `dunce` crate for path conanicalized paths

### DIFF
--- a/probe-rs-cli-util/Cargo.toml
+++ b/probe-rs-cli-util/Cargo.toml
@@ -22,3 +22,4 @@ probe-rs = { version = "0.9.0", path = "../probe-rs" }
 cargo_toml = "0.8.1"
 serde = { version = "1.0.115", features = [ "derive" ] }
 cargo_metadata = "0.12.0"
+dunce = "1.0.1"

--- a/probe-rs-cli-util/src/lib.rs
+++ b/probe-rs-cli-util/src/lib.rs
@@ -42,7 +42,7 @@ pub fn read_metadata(work_dir: &Path) -> Result<Metadata> {
 /// The output of `cargo build` is parsed to detect the path to the generated binary artifact.
 /// If either no artifact, or more than a single artifact are created, an error is returned.
 pub fn build_artifact(work_dir: &Path, args: &[String]) -> Result<PathBuf> {
-    let work_dir = work_dir.canonicalize()?;
+    let work_dir = dunce::canonicalize(work_dir)?;
 
     let cargo_executable = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
 

--- a/probe-rs-cli-util/tests/cargo_integration.rs
+++ b/probe-rs-cli-util/tests/cargo_integration.rs
@@ -35,18 +35,14 @@ fn get_binary_artifact_with_cargo_config() {
     expected_path.push("thumbv7m-none-eabi");
     expected_path.push("debug");
     expected_path.push("binary_cargo_config");
+    expected_path = dunce::canonicalize(expected_path).expect("Failed to canonicalize path");
 
     let args = [];
 
     let binary_path =
         probe_rs_cli_util::build_artifact(&work_dir, &args).expect("Failed to read artifact path.");
 
-    assert_eq!(
-        binary_path,
-        expected_path
-            .canonicalize()
-            .expect("Failed to canonicalize path")
-    );
+    assert_eq!(binary_path, expected_path);
 }
 
 #[test]
@@ -56,18 +52,14 @@ fn get_binary_artifact_with_cargo_config_toml() {
     expected_path.push("thumbv7m-none-eabi");
     expected_path.push("debug");
     expected_path.push("binary_cargo_config_toml");
+    expected_path = dunce::canonicalize(expected_path).expect("Failed to canonicalize path");
 
     let args = [];
 
     let binary_path =
         probe_rs_cli_util::build_artifact(&work_dir, &args).expect("Failed to read artifact path.");
 
-    assert_eq!(
-        binary_path,
-        expected_path
-            .canonicalize()
-            .expect("Failed to canonicalize path")
-    );
+    assert_eq!(binary_path, expected_path);
 }
 
 #[test]
@@ -216,9 +208,7 @@ fn test_project_dir(test_name: &str) -> PathBuf {
 
     manifest_dir.push(test_name);
 
-    manifest_dir
-        .canonicalize()
-        .expect("Failed to build canonicalized test_project_dir")
+    dunce::canonicalize(manifest_dir).expect("Failed to build canonicalized test_project_dir")
 }
 
 fn owned_args(args: &[&str]) -> Vec<String> {

--- a/probe-rs-cli-util/tests/cargo_integration.rs
+++ b/probe-rs-cli-util/tests/cargo_integration.rs
@@ -35,14 +35,16 @@ fn get_binary_artifact_with_cargo_config() {
     expected_path.push("thumbv7m-none-eabi");
     expected_path.push("debug");
     expected_path.push("binary_cargo_config");
-    expected_path = dunce::canonicalize(expected_path).expect("Failed to canonicalize path");
 
     let args = [];
 
     let binary_path =
         probe_rs_cli_util::build_artifact(&work_dir, &args).expect("Failed to read artifact path.");
 
-    assert_eq!(binary_path, expected_path);
+    assert_eq!(
+        binary_path,
+        dunce::canonicalize(expected_path).expect("Failed to canonicalize path")
+    );
 }
 
 #[test]
@@ -52,14 +54,16 @@ fn get_binary_artifact_with_cargo_config_toml() {
     expected_path.push("thumbv7m-none-eabi");
     expected_path.push("debug");
     expected_path.push("binary_cargo_config_toml");
-    expected_path = dunce::canonicalize(expected_path).expect("Failed to canonicalize path");
 
     let args = [];
 
     let binary_path =
         probe_rs_cli_util::build_artifact(&work_dir, &args).expect("Failed to read artifact path.");
 
-    assert_eq!(binary_path, expected_path);
+    assert_eq!(
+        binary_path,
+        dunce::canonicalize(expected_path).expect("Failed to canonicalize path")
+    );
 }
 
 #[test]


### PR DESCRIPTION
fixes [probe-rs/cargo-embed#119]

switch from `fs::canonicalize` to `dunce::canonicalize` to canonicalize file paths for better path-handling on windows.  On all other targets `dunce::canonicalize` drops to the standard `fs::canonicalize`.

Tested with [cargo-embed-workspace](https://github.com/berkowski/cargo-embed-workspace) on windows and was able to compile the virtual workspace with `cargo embed`