### PR TITLE
Cleanup after fault, fix abort bit layout

### DIFF
--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -138,6 +138,7 @@ where
 }
 
 /// Determine if an AP exists with the given AP number.
+/// Can fail silently under the hood testing an ap that doesnt exist and would require cleanup.
 pub fn access_port_is_valid<AP>(debug_port: &mut AP, access_port: GenericAP) -> bool
 where
     AP: APAccess<GenericAP, IDR>,
@@ -149,7 +150,8 @@ where
     }
 }
 
-/// Return a Vec of all valid access ports found that the target connected to the debug_probe
+/// Return a Vec of all valid access ports found that the target connected to the debug_probe.
+/// Can fail silently under the hood testing an ap that doesnt exist and would require cleanup.
 pub(crate) fn valid_access_ports<AP>(debug_port: &mut AP) -> Vec<GenericAP>
 where
     AP: APAccess<GenericAP, IDR>,

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -47,11 +47,11 @@ bitfield! {
     #[derive(Clone)]
     pub struct Abort(u32);
     impl Debug;
-    pub _, set_orunerrclr: 5;
-    pub _, set_wderrclr: 4;
-    pub _, set_stkerrclr: 3;
-    pub _, set_stkcmpclr: 2;
-    pub _, set_dapabort: 1;
+    pub _, set_orunerrclr: 4;
+    pub _, set_wderrclr: 3;
+    pub _, set_stkerrclr: 2;
+    pub _, set_stkcmpclr: 1;
+    pub _, set_dapabort: 0;
 }
 
 impl Default for Abort {

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -6,6 +6,8 @@ use crate::error;
 /// Describes any error that happened during the or in preparation for the flashing procedure.
 #[derive(Error, Debug)]
 pub enum FlashError {
+    #[error("The execution of '{name}' failed with code {errorcode}. Perhaps your chip has write protected sectors that need to be cleared? Perhaps you need the --nmagic linker arg https://github.com/rust-embedded/cortex-m-quickstart/pull/95")]
+    EraseFailed { name: &'static str, errorcode: u32 },
     #[error("The execution of '{name}' failed with code {errorcode}")]
     RoutineCallFailed { name: &'static str, errorcode: u32 },
     #[error("The '{0}' routine is not supported with the given flash algorithm.")]

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -639,7 +639,7 @@ impl<'probe> ActiveFlasher<'probe, Erase> {
             )?;
 
             if result != 0 {
-                Err(anyhow!(FlashError::RoutineCallFailed {
+                Err(anyhow!(FlashError::EraseFailed {
                     name: "erase_all",
                     errorcode: result,
                 }))
@@ -673,7 +673,7 @@ impl<'probe> ActiveFlasher<'probe, Erase> {
         );
 
         if result != 0 {
-            Err(anyhow!(FlashError::RoutineCallFailed {
+            Err(anyhow!(FlashError::EraseFailed {
                 name: "erase_sector",
                 errorcode: result,
             }))

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -789,6 +789,12 @@ impl DAPAccess for JLink {
                 // To get a clue about the actual fault we read the ctrl register,
                 // which will have the fault status flags set.
 
+                // Reading ctrl directly fails with nack on jlink. A dummy read
+                // of id first seems to clear it up.
+                let dp =
+                    DAPAccess::read_register(self, PortType::DebugPort, DPIDR::ADDRESS as u16)?;
+                log::trace!("Dummy read of DebugPort ID:  {:#x?}", dp);
+
                 let response =
                     DAPAccess::read_register(self, PortType::DebugPort, Ctrl::ADDRESS as u16)?;
                 let ctrl = Ctrl::from(response);
@@ -941,6 +947,12 @@ impl DAPAccess for JLink {
 
                 // To get a clue about the actual fault we read the ctrl register,
                 // which will have the fault status flags set.
+
+                // Reading ctrl directly fails with nack on jlink. A dummy read
+                // of id first seems to clear it up.
+                let dp =
+                    DAPAccess::read_register(self, PortType::DebugPort, DPIDR::ADDRESS as u16)?;
+                log::trace!("Dummy read of DebugPort ID:  {:#x?}", dp);
 
                 let response =
                     DAPAccess::read_register(self, PortType::DebugPort, Ctrl::ADDRESS as u16)?;

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     architecture::arm::{DapError, PortType, Register},
     architecture::{
         arm::{
-            communication_interface::ArmProbeInterface, dp::Ctrl, swo::SwoConfig,
+            communication_interface::ArmProbeInterface, dp::Ctrl, dp::DPIDR, swo::SwoConfig,
             ArmCommunicationInterface, SwoAccess,
         },
         riscv::communication_interface::RiscvCommunicationInterface,
@@ -773,6 +773,10 @@ impl DAPAccess for JLink {
 
             // Get the ack.
             let ack = result_sequence.split_off(3).collect::<Vec<_>>();
+
+            if ack[0] && ack[1] && ack[2] {
+                return Err(DapError::NoAcknowledge.into());
+            }
             if ack[1] {
                 // If ack[1] is set the host must retry the request. So let's do that right away!
                 retries += 1;
@@ -784,11 +788,12 @@ impl DAPAccess for JLink {
 
                 // To get a clue about the actual fault we read the ctrl register,
                 // which will have the fault status flags set.
+
                 let response =
                     DAPAccess::read_register(self, PortType::DebugPort, Ctrl::ADDRESS as u16)?;
                 let ctrl = Ctrl::from(response);
-                log::error!(
-                    "Reading DAP register failed. Ctrl/Stat register value is: {:#?}",
+                log::trace!(
+                    "Writing DAP register failed. Ctrl/Stat register value is: {:#?}",
                     ctrl
                 );
 
@@ -921,6 +926,10 @@ impl DAPAccess for JLink {
 
             // Get the ack.
             let ack = result_sequence.by_ref().take(3).collect::<Vec<_>>();
+
+            if ack[0] && ack[1] && ack[2] {
+                return Err(DapError::NoAcknowledge.into());
+            }
             if ack[1] {
                 // If ack[1] is set the host must retry the request. So let's do that right away!
                 retries += 1;
@@ -932,6 +941,7 @@ impl DAPAccess for JLink {
 
                 // To get a clue about the actual fault we read the ctrl register,
                 // which will have the fault status flags set.
+
                 let response =
                     DAPAccess::read_register(self, PortType::DebugPort, Ctrl::ADDRESS as u16)?;
                 let ctrl = Ctrl::from(response);


### PR DESCRIPTION
In https://github.com/probe-rs/probe-rs/issues/395 we found that when scanning for aps to use, the second ap seemed to make the probe unusable going forward. 

https://developer.arm.com/documentation/ka001433/1-0/?search=5eec6f69e24a5e02d07b2655
> The Stick Error flag, STICKYERR, as defined in the ARM Debug Interface v5 Architecture Specification, can come from either:

>    Error signals returned from the Debug Bus or slave debug component to the Access Port (AP).

>    The Debug Port (DP) trying to access an AP that is not present. For example, it is powered down or is not present at that address, or from protocol errors in Serial Wire. 

In attempting to clear that bit, it seemed to me the abort register was indexed incorrectly. 
https://developer.arm.com/documentation/ddi0413/c/debug-access-port/dap-programmer-s-model/debug-access-port-register-descriptions?lang=en

We could/may someday want to have valid_access_ports not fail silently under the hood, or clear out errors lower when it does..  But it seems like you wouldnt have good aps after invalid accesses so maybe this is just fine.

With these two fixes the probe recovers after the ap scan 