### PR TITLE
Make CHANGELOG changes mandatory in PRs

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -7,5 +7,5 @@ status = [
     "Test Suite (ubuntu-latest)",
     "Test Suite (windows-latest)",
     "Rustfmt",
-    "Changelog",
 ]
+pr_status = ["Changelog"]

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -7,4 +7,5 @@ status = [
     "Test Suite (ubuntu-latest)",
     "Test Suite (windows-latest)",
     "Rustfmt",
+    "Changelog",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,6 @@ jobs:
         with:
           changeLogPath: CHANGELOG.md
           skipLabels: 'needs-changelog, skip-changelog'
-          missingUpdateErrorMessage: 'Please add a changelog entry in the CHANGELOG.md.'
+          missingUpdateErrorMessage: 'Please add a changelog entry in the CHANGELOG.md file.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,9 +170,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Changelog updated
-        uses: Zomzog/changelog-checker@v1.1.0
+      - name: Check that changelog updated
+        uses: dangoslen/changelog-enforcer@v2
         with:
-          fileName: CHANGELOG.md
+          changeLogPath: CHANGELOG.md
+          skipLabels: 'needs-changelog, skip-changelog'
+          missingUpdateErrorMessage: 'Please add a changelog entry in the CHANGELOG.md.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,3 +162,17 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
+
+  changelog:
+    name: Changelog check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Changelog updated
+        uses: Zomzog/changelog-checker@v1.1.0
+        with:
+          fileName: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
           args: --all-features
 
   changelog:
-    name: Changelog check
+    name: Changelog
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources


### PR DESCRIPTION
This PR adds a Github Action that will fail if no entry in the CHANGELOG.md was made.

This will make sure every change will make its way into the changelog and makes releases less nerve wrecking :)