### PR TITLE
M0: Use correct mask when setting breakpoint

### DIFF
--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -442,7 +442,7 @@ impl<'probe> CoreInterface for M0<'probe> {
             // match higher halfword
             value.set_bp_match(0b10);
         }
-        value.set_comp((addr >> 2) & 0x00FF_FFFF);
+        value.set_comp((addr >> 2) & 0x07FF_FFFF);
         value.set_enable(true);
 
         let register_addr = BpCompx::ADDRESS + (bp_register_index * size_of::<u32>()) as u32;


### PR DESCRIPTION
The address mask used when setting the breakpoint comparator register on Cortex-M0(+) devices does not match the specification in the declaration of the BpCompx register ([m0.rs#L126](https://github.com/probe-rs/probe-rs/blob/master/probe-rs/src/architecture/arm/core/m0.rs#L126)). Bits 26-28 of the address are cleared when they should not be, causing breakpoints set at addresses higher than 0x03ffffff to end up at the wrong location.

This PR sets the correct mask according to the specification.