### PR TITLE
Divide 8-bit reads into chunks of 64 bytes to satisfy ST-Link v2 max length

### DIFF
--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1515,10 +1515,15 @@ impl ArmProbe for StLinkMemoryInterface<'_> {
         self.probe.select_ap(ap)?;
 
         // Read needs to be chunked into chunks of appropriate max length of the probe
-        // Currently fixed to ST-Link v2 max length of 64. However, ST-Link v3 supports 512.
-        for (index, chunk) in data.chunks_mut(64).enumerate() {
+        let chunk_size = if self.probe.probe.hw_version < 3 {
+            64
+        } else {
+            512
+        };
+
+        for (index, chunk) in data.chunks_mut(chunk_size).enumerate() {
             chunk.copy_from_slice(&self.probe.probe.read_mem_8bit(
-                address + (index * 64) as u32,
+                address + (index * chunk_size) as u32,
                 chunk.len() as u16,
                 ap.port_number(),
             )?);


### PR DESCRIPTION
Fix for panic during ST-Link 8-bit memory reads (#425). Split the reads into 64-byte chunks as suggested in the issue.