### PR TITLE
Session auto attach no longer panics when no probes are connected

### DIFF
--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -147,7 +147,10 @@ impl Session {
         let probes = Probe::list_all();
 
         // Use the first probe found.
-        let probe = probes.get(0).ok_or(Error::UnableToOpenProbe("No probe was found"))?.open()?;
+        let probe = probes
+            .get(0)
+            .ok_or(Error::UnableToOpenProbe("No probe was found"))?
+            .open()?;
 
         // Attach to a chip.
         probe.attach(target)

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -147,7 +147,7 @@ impl Session {
         let probes = Probe::list_all();
 
         // Use the first probe found.
-        let probe = probes[0].open()?;
+        let probe = probes.get(0).ok_or(Error::UnableToOpenProbe("No probe was found"))?.open()?;
 
         // Attach to a chip.
         probe.attach(target)


### PR DESCRIPTION
The title says it all. Now an auto attach error can be caught by user code