### PR TITLE
Improved protocol error handling for JLink

### DIFF
--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -682,14 +682,14 @@ impl JTAGAccess for JLink {
 }
 
 impl JLink {
-    // Try to perform a line reset, followed by a read of the DPIDR register.
-    //
-    // Returns true if the read of the DPIDR register was succesful, and false
-    // otherwise. In case of JLink Errors, the actual error is returned.
-    //
-    // If the first line reset fails, it is tried once again, as the target
-    // might be in the middle of a transfer the first time we try the reset.
-    // See
+    /// Try to perform a line reset, followed by a read of the DPIDR register.
+    ///
+    /// Returns true if the read of the DPIDR register was succesful, and false
+    /// otherwise. In case of JLink Errors, the actual error is returned.
+    ///
+    /// If the first line reset fails, it is tried once again, as the target
+    /// might be in the middle of a transfer the first time we try the reset.
+    /// See
     fn line_reset(&mut self) -> Result<bool, DebugProbeError> {
         log::debug!("Performing line reset!");
 


### PR DESCRIPTION
Improvements to the SWD protocol handling for JLInk:

- Add idle cycles after a register write, to ensure it is actually performed.
  This is only necessary when no other command is performed afterwards, but
  is now done everytime, for increased stability. It also helps with avoiding
  WAIT responses for the next requests, after the writes.

- When we don't receive a response from the target, perform a line reset to
  try and recover.
  