### PR TITLE
Update target description for STM32WB55 (fix #466)

### DIFF
--- a/probe-rs/targets/STM32WB Series.yaml
+++ b/probe-rs/targets/STM32WB Series.yaml
@@ -4,6 +4,66 @@ manufacturer:
   id: 0x20
   cc: 0x00
 variants:
+  - name: STM32WB30CEUx
+    part: ~
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb3x_512_m4
+  - name: STM32WB35CCUx
+    part: ~
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134479872
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb3x_256_m4
+  - name: STM32WB35CEUx
+    part: ~
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb3x_512_m4
+  - name: STM32WB50CGUx
+    part: ~
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
   - name: STM32WB55CCUx
     part: 0x495
     memory_map:
@@ -90,7 +150,22 @@ variants:
       - Flash:
           range:
             start: 134217728
-            end: 150994944
+            end: 135266304
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
+  - name: STM32WB55VCQx
+    part: ~
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
     flash_algorithms:
       - stm32wb_m4
@@ -109,6 +184,21 @@ variants:
           is_boot_memory: true
     flash_algorithms:
       - stm32wb_m4
+  - name: STM32WB55VEQx
+    part: ~
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
   - name: STM32WB55VEYx
     part: 0x495
     memory_map:
@@ -124,6 +214,21 @@ variants:
           is_boot_memory: true
     flash_algorithms:
       - stm32wb_m4
+  - name: STM32WB55VGQx
+    part: ~
+    memory_map:
+      - Ram:
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+      - Flash:
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+    flash_algorithms:
+      - stm32wb_m4
   - name: STM32WB55VGYx
     part: 0x495
     memory_map:
@@ -135,13 +240,57 @@ variants:
       - Flash:
           range:
             start: 134217728
-            end: 150994944
+            end: 135266304
           is_boot_memory: true
     flash_algorithms:
       - stm32wb_m4
 flash_algorithms:
-  STM32WB_M4:
-    name: STM32WB_M4
+  stm32wb3x_256_m4:
+    name: stm32wb3x_256_m4
+    description: STM32WB3_M4 256 Flash
+    default: true
+    instructions: YUhBaQApA9pgSYFgYEmBYAAgcEdcSEFpQgQRQ0FhACBwRxC1WEhbSVtKAOARYANp2wP71FlKAmEBackD/NQBaQkD/NQBaUkD/NQBaVRLGUMBYUFpBCMZQ0FhQWmcAyFDQWEBackD/NQBaUkD/NQBaQkD/NRBaZlDQWEAIUFhAWkRQgLQAmEBIBC9ACAQvRC1PUlCSgphS2lCTCNAS2FACuNDGEALadsD/NQLaVsD/NQLaRsD/NRMaQIjGEMEQ0xhSGncAyBDSGEAvwC/CGnAA/zUCGlAA/zUCGkAA/zUSGmYQ0hhACBIYQhpEEIC0AphASAQvQEgwAYAaEAcAtEIaCBDCGAAIBC9cLXJHR5LyQgjTckAHWFcaQEmNENcYRpOQDYe4B1hHGnkA/zUHGlkA/zUHGkkA/zUFGgEYFRoRGAcaeQD/NQcaWQD/NQcaSQD/NQ0aggwCDkIMuQHAdABIHC9ACne0VhpQAhAAFhhASDABgBoQBwE0BhoASEJBIhDGGAAIHC9AAAAQABYIwFnRauJ782qqgAAADAAQPpDAAD/AQAAB+D//wAAAAA=
+    pc_init: 1
+    pc_uninit: 21
+    pc_program_page: 265
+    pc_erase_sector: 143
+    pc_erase_all: 35
+    data_section_offset: 424
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 134479872
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 4096
+          address: 0
+  stm32wb3x_512_m4:
+    name: stm32wb3x_512_m4
+    description: STM32WB3_M4 512 Flash
+    default: true
+    instructions: YUhBaQApA9pgSYFgYEmBYAAgcEdcSEFpQgQRQ0FhACBwRxC1WEhbSVtKAOARYANp2wP71FlKAmEBackD/NQBaQkD/NQBaUkD/NQBaVRLGUMBYUFpBCMZQ0FhQWmcAyFDQWEBackD/NQBaUkD/NQBaQkD/NRBaZlDQWEAIUFhAWkRQgLQAmEBIBC9ACAQvRC1PUlCSgphS2lCTCNAS2FACuNDGEALadsD/NQLaVsD/NQLaRsD/NRMaQIjGEMEQ0xhSGncAyBDSGEAvwC/CGnAA/zUCGlAA/zUCGkAA/zUSGmYQ0hhACBIYQhpEEIC0AphASAQvQEgwAYAaEAcAtEIaCBDCGAAIBC9cLXJHR5LyQgjTckAHWFcaQEmNENcYRpOQDYe4B1hHGnkA/zUHGlkA/zUHGkkA/zUFGgEYFRoRGAcaeQD/NQcaWQD/NQcaSQD/NQ0aggwCDkIMuQHAdABIHC9ACne0VhpQAhAAFhhASDABgBoQBwE0BhoASEJBIhDGGAAIHC9AAAAQABYIwFnRauJ782qqgAAADAAQPpDAAD/AQAAB+D//wAAAAA=
+    pc_init: 1
+    pc_uninit: 21
+    pc_program_page: 265
+    pc_erase_sector: 143
+    pc_erase_all: 35
+    data_section_offset: 424
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 134742016
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 4096
+          address: 0
+  stm32wb_m4:
+    name: stm32wb_m4
     description: STM32WB_M4 Flash
     default: true
     instructions: Qfb4cQHqUCBwR0pISEmBYElJgWAAIHBHRkhBaUHwAEFBYQAgcEcBIHBHELVK9qoiQklASADgCmADadsD+9RE8vo0BGFI8gQDQ2FDaUP0gDNDYQDgCmADadsD+9QAIUFhAWkhQgLQBGEBIBC9ACAQvUH2+HEB6lAiELUuSAFpEfRAP/vRAWlJA/zUAWkJA/zURPL6NARhQvACAUFhQWlB9IAxQWFK9qohJEoA4BFgA2nbA/vUACFBYQFpIUIC0ARhASAQvQAgEL0QtRpLyR1A8v8UIfAHARxhASRcYR/gHGkU9EA/+9EcaWQD/NQcaSQD/NQUaARgVGhEYBxpFPRAP/vRHGlkA/zUHGkkA/zUHGmkBwHVASAQvQgwCDkIMgAp3dFYaSDwAQBYYQAgEL0AACMBZ0UAQABYq4nvzQAwAEAAAAAA


### PR DESCRIPTION
The flash address for some chips were wrong, which
meant that probe-rs was unable to find the correct
flash algorithm.