### PR TITLE
Avoid panic when AP doesn't exist, clean-up log

### DIFF
--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -272,9 +272,12 @@ impl<'interface> ArmCommunicationInterface {
         &'interface mut self,
         access_port: MemoryAP,
     ) -> Result<Memory<'interface>, ProbeRsError> {
-        let info = self
-            .ap_information(access_port)
-            .expect("Failed to get information for AP");
+        let info = self.ap_information(access_port).ok_or_else(|| {
+            anyhow!(
+                "Failed to get information for AP {}",
+                access_port.port_number()
+            )
+        })?;
 
         match info {
             ApInformation::MemoryAp(ap_information) => {

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -490,10 +490,25 @@ impl<'probe> Core<'probe> {
         }
     }
 
+    /// Clear all hardware breakpoints
+    ///
+    /// This function will clear all HW breakpoints which are configured on the target,
+    /// regardless if they are set by probe-rs or not.
     pub fn clear_all_hw_breakpoints(&mut self) -> Result<(), error::Error> {
         let num_hw_breakpoints = self.get_available_breakpoint_units()? as usize;
 
         { 0..num_hw_breakpoints }.try_for_each(|unit_index| self.inner.clear_breakpoint(unit_index))
+    }
+
+    /// Clear all HW breakpoints which were set by probe-rs.
+    ///
+    /// Currently used as a helper function in [Session::drop].
+    pub(crate) fn clear_all_set_hw_breakpoints(&mut self) -> Result<(), error::Error> {
+        for bp in self.state.breakpoints.drain(..) {
+            self.inner.clear_breakpoint(bp.register_hw)?;
+        }
+
+        Ok(())
     }
 
     pub fn architecture(&self) -> Architecture {

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -308,8 +308,7 @@ impl Session {
                 self.core(n)
                     .and_then(|mut core| core.clear_all_hw_breakpoints())
             })
-            .collect::<Result<Vec<_>, _>>()
-            .map(|_| ())
+            .collect()
     }
 }
 
@@ -318,7 +317,14 @@ static_assertions::assert_impl_all!(Session: Send, Sync);
 
 impl Drop for Session {
     fn drop(&mut self) {
-        if let Err(err) = self.clear_all_hw_breakpoints() {
+        let result: Result<(), crate::Error> = { 0..self.cores.len() }
+            .map(|i| {
+                self.core(i)
+                    .and_then(|mut core| core.clear_all_set_hw_breakpoints())
+            })
+            .collect();
+
+        if let Err(err) = result {
             log::warn!("Could not clear all hardware breakpoints: {:?}", err);
         }
     }


### PR DESCRIPTION
Two small changes:

## Only clear HW breakpoint when necessary

Currently we try to clean all HW breakpoints when dropping,
which can make the log output very confusing when some error 
occurs. It should be sufficient to just clean the breakpoints
we actually configured ourselves.

## Avoid panic when AP information is missing
When the information for an AP is missing, we currently panic.
As a first step, this is replaced by an error with this PR.

In the future, this should probably be handled better, especially
when multiple cores are used.
