### PR TITLE
make registry pub again

### DIFF
--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -28,7 +28,7 @@ mod chip_info;
 mod flash_algorithm;
 mod flash_properties;
 mod memory;
-mod registry;
+pub mod registry;
 mod target;
 
 pub use chip::Chip;


### PR DESCRIPTION
Recent cleanup removed pub
https://github.com/probe-rs/probe-rs/commit/b16bf3a96d52795b526bdf6f7df1040fdeb64f2b#diff-96bd23d0dcb571a6a74e591dace70607d2d11570d52f9c2dd620d72f30535574L7

But we need it, or to refactor cargo flash
https://github.com/probe-rs/cargo-flash/blob/56106057485eb4e502cc033af4a9c30209c165dc/src/main.rs#L483
https://github.com/probe-rs/cargo-flash/blob/56106057485eb4e502cc033af4a9c30209c165dc/src/main.rs#L217