### PR TITLE
probe-rs: fix download_hex

### DIFF
--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -172,7 +172,7 @@ fn download_hex<'buffer, T: Read + Seek>(
                 let offset = extended_linear_address | offset as u32;
                 buffer.push((offset, value));
             }
-            EndOfFile => return Ok(()),
+            EndOfFile => (),
             ExtendedSegmentAddress(address) => {
                 _extended_segment_address = address * 16;
             }

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -15,9 +15,9 @@ use thiserror::Error;
 #[derive(Debug)]
 pub struct BinOptions {
     /// The address in memory where the binary will be put at.
-    base_address: Option<u32>,
+    pub base_address: Option<u32>,
     /// The number of bytes to skip at the start of the binary file.
-    skip: u32,
+    pub skip: u32,
 }
 
 /// A finite list of all the available binary formats probe-rs understands.


### PR DESCRIPTION
download_hex was returning before loading the buffer