### PR TITLE
Remove internal Mutexes

### DIFF
--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -128,7 +128,7 @@ pub trait DAPAccess: DebugProbe + AsRef<dyn DebugProbe> + AsMut<dyn DebugProbe> 
 }
 
 pub trait ArmProbeInterface:
-    SwoAccess + AsRef<dyn DebugProbe> + AsMut<dyn DebugProbe> + Debug + Send + Sync
+    SwoAccess + AsRef<dyn DebugProbe> + AsMut<dyn DebugProbe> + Debug + Send
 {
     fn memory_interface(&mut self, access_port: MemoryAP) -> Result<Memory<'_>, ProbeRsError>;
 

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -439,7 +439,8 @@ impl DebugProbe for FtdiProbe {
             .attach()
             .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
 
-        let taps = selfadapter
+        let taps = self
+            .adapter
             .scan()
             .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
         if taps.is_empty() {

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -7,7 +7,6 @@ use bitvec::{order::Lsb0, slice::BitSlice, vec::BitVec};
 use rusb::UsbContext;
 use std::convert::TryInto;
 use std::io::{self, Read, Write};
-use std::sync::Mutex;
 use std::time::Duration;
 
 mod ftdi_impl;
@@ -386,7 +385,7 @@ impl JtagAdapter {
 
 #[derive(Debug)]
 pub struct FtdiProbe {
-    adapter: Mutex<JtagAdapter>,
+    adapter: JtagAdapter,
     speed_khz: u32,
     idle_cycles: u8,
 }
@@ -411,7 +410,7 @@ impl DebugProbe for FtdiProbe {
             .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
 
         let probe = FtdiProbe {
-            adapter: Mutex::new(adapter),
+            adapter,
             speed_khz: 0,
             idle_cycles: 0,
         };
@@ -435,13 +434,12 @@ impl DebugProbe for FtdiProbe {
 
     fn attach(&mut self) -> Result<(), DebugProbeError> {
         log::debug!("attaching...");
-        let adapter = self.adapter.get_mut().unwrap();
 
-        adapter
+        self.adapter
             .attach()
             .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
 
-        let taps = adapter
+        let taps = selfadapter
             .scan()
             .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
         if taps.is_empty() {
@@ -449,7 +447,7 @@ impl DebugProbe for FtdiProbe {
             return Err(DebugProbeError::TargetNotFound);
         }
         if taps.len() == 1 {
-            adapter
+            self.adapter
                 .select_target(taps[0].idcode)
                 .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
         } else {
@@ -461,7 +459,7 @@ impl DebugProbe for FtdiProbe {
                 .map(|tap| tap.idcode)
                 .find(|idcode| known_idcodes.iter().any(|v| v == idcode));
             if let Some(idcode) = idcode {
-                adapter
+                self.adapter
                     .select_target(idcode)
                     .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
             } else {
@@ -512,14 +510,14 @@ impl DebugProbe for FtdiProbe {
 impl JTAGAccess for FtdiProbe {
     fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {
         log::debug!("read_register({:#x}, {})", address, len);
-        let adapter = self.adapter.get_mut().unwrap();
-        let r = adapter
+        let r = self
+            .adapter
             .target_transfer(address, None, len as usize)
             .map_err(|e| {
                 log::debug!("target_transfer error: {:?}", e);
                 DebugProbeError::ProbeSpecific(Box::new(e))
             })?;
-        adapter
+        self.adapter
             .idle(self.idle_cycles as usize)
             .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
         log::debug!("read_register result: {:?})", r);
@@ -538,14 +536,14 @@ impl JTAGAccess for FtdiProbe {
         len: u32,
     ) -> Result<Vec<u8>, DebugProbeError> {
         log::debug!("write_register({:#x}, {:?}, {})", address, data, len);
-        let adapter = self.adapter.get_mut().unwrap();
-        let r = adapter
+        let r = self
+            .adapter
             .target_transfer(address, Some(data), len as usize)
             .map_err(|e| {
                 log::debug!("target_transfer error: {:?}", e);
                 DebugProbeError::ProbeSpecific(Box::new(e))
             })?;
-        adapter
+        self.adapter
             .idle(self.idle_cycles as usize)
             .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
         log::debug!("write_register result: {:?})", r);

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -396,7 +396,7 @@ impl Probe {
     }
 }
 
-pub trait DebugProbe: Send + Sync + fmt::Debug {
+pub trait DebugProbe: Send + fmt::Debug {
     fn new_from_selector(
         selector: impl Into<DebugProbeSelector>,
     ) -> Result<Box<Self>, DebugProbeError>

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -313,7 +313,7 @@ impl Session {
 }
 
 // This test ensures that [Session] is fully [Send] + [Sync].
-static_assertions::assert_impl_all!(Session: Send, Sync);
+static_assertions::assert_impl_all!(Session: Send);
 
 impl Drop for Session {
     fn drop(&mut self) {


### PR DESCRIPTION
Simplify some probe implementations by not requiring the Session to
be `Sync`.