### PR TITLE
Rename MemoryRegion::Flash to MemoryRegion::Nvm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed `MemoryRegion::Flash` to `MemoryRegion::Nvm`
+- Renamed `FlashInfo` to `NvmInfo`
+- Renamed `FlashRegion` to `NvmRegion` and its `flash_info()` method to `nvm_info()`
+- Renamed `FlashError::NoSuitableFlash` to `FlashError::NoSuitableNvm`
+
 ### Fixed
 
 ## [0.10.1]

--- a/gdb-server/src/handlers.rs
+++ b/gdb-server/src/handlers.rs
@@ -203,7 +203,7 @@ pub(crate) fn get_memory_map(session: &Session) -> Option<String> {
                 region.range.start,
                 region.range.end - region.range.start
             ),
-            MemoryRegion::Flash(region) => {
+            MemoryRegion::Nvm(region) => {
                 // TODO: Use flash with block size
                 format!(
                     r#"<memory type="rom" start="{:#x}" length="{:#x}"/>\n"#,

--- a/probe-rs-t2rust/src/lib.rs
+++ b/probe-rs-t2rust/src/lib.rs
@@ -278,7 +278,7 @@ fn extract_memory_map(chip: &serde_yaml::Value) -> Vec<proc_macro2::TokenStream>
                             region.get("is_boot_memory").unwrap().as_bool().unwrap();
 
                         quote::quote! {
-                            MemoryRegion::Flash(FlashRegion {
+                            MemoryRegion::Nvm(FlashRegion {
                                 range: #start..#end,
                                 is_boot_memory: #is_boot_memory,
                             })

--- a/probe-rs-t2rust/src/lib.rs
+++ b/probe-rs-t2rust/src/lib.rs
@@ -40,7 +40,7 @@ pub fn run(input_dir: impl AsRef<Path>, output_file: impl AsRef<Path>) {
         quote::quote! {
             #[allow(unused_imports)]
             use jep106::JEP106Code;
-            use crate::config::{Chip, RawFlashAlgorithm, FlashRegion, MemoryRegion, RamRegion, SectorDescription, FlashProperties};
+            use crate::config::{Chip, RawFlashAlgorithm, NvmRegion, MemoryRegion, RamRegion, SectorDescription, FlashProperties};
 
             use std::borrow::Cow;
         }
@@ -278,7 +278,7 @@ fn extract_memory_map(chip: &serde_yaml::Value) -> Vec<proc_macro2::TokenStream>
                             region.get("is_boot_memory").unwrap().as_bool().unwrap();
 
                         quote::quote! {
-                            MemoryRegion::Nvm(FlashRegion {
+                            MemoryRegion::Nvm(NvmRegion {
                                 range: #start..#end,
                                 is_boot_memory: #is_boot_memory,
                             })

--- a/probe-rs/src/config/memory.rs
+++ b/probe-rs/src/config/memory.rs
@@ -2,14 +2,14 @@ use core::ops::Range;
 
 /// Represents a region in flash.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct FlashRegion {
+pub struct NvmRegion {
     /// Address range of the region
     pub range: Range<u32>,
     /// True if the chip boots from this memory
     pub is_boot_memory: bool,
 }
 
-impl FlashRegion {
+impl NvmRegion {
     /// Returns the necessary information about the flash.
     pub fn flash_info(&self) -> FlashInfo {
         FlashInfo {
@@ -118,7 +118,7 @@ pub enum MemoryRegion {
     Generic(GenericRegion),
     /// Memory region describing flash, EEPROM or other non-volatile memory.
     #[serde(alias = "Flash")] // Keeping the "Flash" name this for backwards compatibility
-    Nvm(FlashRegion),
+    Nvm(NvmRegion),
 }
 
 #[cfg(test)]

--- a/probe-rs/src/config/memory.rs
+++ b/probe-rs/src/config/memory.rs
@@ -1,6 +1,6 @@
 use core::ops::Range;
 
-/// Represents a region in flash.
+/// Represents a region in non-volatile memory (e.g. flash or EEPROM).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NvmRegion {
     /// Address range of the region
@@ -10,9 +10,9 @@ pub struct NvmRegion {
 }
 
 impl NvmRegion {
-    /// Returns the necessary information about the flash.
-    pub fn flash_info(&self) -> FlashInfo {
-        FlashInfo {
+    /// Returns the necessary information about the NVM.
+    pub fn nvm_info(&self) -> NvmInfo {
+        NvmInfo {
             rom_start: self.range.start,
         }
     }
@@ -74,7 +74,7 @@ pub struct PageInfo {
 
 /// Holds information about the entire flash.
 #[derive(Debug, Copy, Clone)]
-pub struct FlashInfo {
+pub struct NvmInfo {
     pub rom_start: u32,
 }
 

--- a/probe-rs/src/config/memory.rs
+++ b/probe-rs/src/config/memory.rs
@@ -116,8 +116,9 @@ pub enum MemoryRegion {
     /// Generic memory region, which is neither
     /// flash nor RAM.
     Generic(GenericRegion),
-    /// Memory region describing flash.
-    Flash(FlashRegion),
+    /// Memory region describing flash, EEPROM or other non-volatile memory.
+    #[serde(alias = "Flash")] // Keeping the "Flash" name this for backwards compatibility
+    Nvm(FlashRegion),
 }
 
 #[cfg(test)]

--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -35,7 +35,7 @@ pub use chip::Chip;
 pub use chip_family::ChipFamily;
 pub use flash_algorithm::{FlashAlgorithm, RawFlashAlgorithm};
 pub use flash_properties::FlashProperties;
-pub use memory::{FlashRegion, MemoryRegion, PageInfo, RamRegion, SectorDescription, SectorInfo};
+pub use memory::{MemoryRegion, NvmRegion, PageInfo, RamRegion, SectorDescription, SectorInfo};
 pub use registry::{add_target_from_yaml, families, RegistryError};
 pub use target::{Target, TargetParseError, TargetSelector};
 

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -36,10 +36,8 @@ pub enum FlashError {
     DataOverlap(u32),
     #[error("Address {0:#010x} is not a valid address in the flash area.")]
     InvalidFlashAddress(u32),
-    #[error(
-        "No flash memory contains the entire requested memory range {start:#08X}..{end:#08X}."
-    )]
-    NoSuitableFlash { start: u32, end: u32 },
+    #[error("No NVM memory contains the entire requested memory range {start:#08X}..{end:#08X}.")]
+    NoSuitableNvm { start: u32, end: u32 },
     #[error("Trying to write flash, but no suitable flash loader algorithm is linked to the given target information.")]
     NoFlashLoaderAlgorithmAttached,
     #[error(transparent)]

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -2,7 +2,7 @@
 
 use thiserror::Error;
 
-use crate::config::FlashRegion;
+use crate::config::NvmRegion;
 use crate::error;
 
 /// Describes any error that happened during the or in preparation for the flashing procedure.
@@ -21,7 +21,7 @@ pub enum FlashError {
     #[error("Something during the interaction with the core went wrong")]
     Core(#[source] error::Error),
     #[error("{address} is not contained in {region:?}")]
-    AddressNotInRegion { address: u32, region: FlashRegion },
+    AddressNotInRegion { address: u32, region: NvmRegion },
     #[error("Flash algorithm length is not 32 bit aligned.")]
     InvalidFlashAlgorithmLength,
     #[error(

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -92,7 +92,7 @@ impl<'session> Flasher<'session> {
         let algo = &mut self.flash_algorithm;
 
         if address.is_none() {
-            address = Some(self.region.flash_info().rom_start);
+            address = Some(self.region.nvm_info().rom_start);
         }
 
         // Attach to memory and core.

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -1,6 +1,6 @@
 use super::FlashProgress;
 use super::{FlashBuilder, FlashError, FlashFill, FlashLayout, FlashPage};
-use crate::config::{FlashAlgorithm, FlashRegion, MemoryRange};
+use crate::config::{FlashAlgorithm, MemoryRange, NvmRegion};
 use crate::memory::MemoryInterface;
 use crate::{
     core::{Architecture, RegisterFile},
@@ -57,7 +57,7 @@ impl Operation for Verify {
 pub struct Flasher<'session> {
     session: &'session mut Session,
     flash_algorithm: FlashAlgorithm,
-    region: FlashRegion,
+    region: NvmRegion,
     double_buffering_supported: bool,
 }
 
@@ -65,7 +65,7 @@ impl<'session> Flasher<'session> {
     pub(super) fn new(
         session: &'session mut Session,
         flash_algorithm: FlashAlgorithm,
-        region: FlashRegion,
+        region: NvmRegion,
     ) -> Self {
         Self {
             session,

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -79,7 +79,7 @@ impl<'mmap, 'data> FlashLoader<'mmap, 'data> {
                     address += program_length as u32
                 }
                 _ => {
-                    return Err(FlashError::NoSuitableFlash {
+                    return Err(FlashError::NoSuitableNvm {
                         start: address,
                         end: address + data.len() as u32,
                     })

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -46,7 +46,7 @@ impl<'mmap, 'data> FlashLoader<'mmap, 'data> {
             let possible_region = Self::get_region_for_address(self.memory_map, address);
             // If we found a corresponding region, create a builder.
             match possible_region {
-                Some(MemoryRegion::Flash(region)) => {
+                Some(MemoryRegion::Nvm(region)) => {
                     // Get our builder instance.
                     if !self.builders.contains_key(region) {
                         self.builders.insert(region.clone(), FlashBuilder::new());
@@ -96,7 +96,7 @@ impl<'mmap, 'data> FlashLoader<'mmap, 'data> {
         for region in memory_map {
             let r = match region {
                 MemoryRegion::Ram(r) => r.range.clone(),
-                MemoryRegion::Flash(r) => r.range.clone(),
+                MemoryRegion::Nvm(r) => r.range.clone(),
                 MemoryRegion::Generic(r) => r.range.clone(),
             };
             if r.contains(&address) {

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -1,5 +1,5 @@
 use super::{FlashBuilder, FlashError, FlashProgress, Flasher};
-use crate::config::{FlashRegion, MemoryRange, MemoryRegion};
+use crate::config::{MemoryRange, MemoryRegion, NvmRegion};
 use crate::memory::MemoryInterface;
 use crate::session::Session;
 use anyhow::anyhow;
@@ -17,7 +17,7 @@ struct RamWrite<'data> {
 /// Region crossing data chunks are allowed as long as the regions are contiguous.
 pub(super) struct FlashLoader<'mmap, 'data> {
     memory_map: &'mmap [MemoryRegion],
-    builders: HashMap<FlashRegion, FlashBuilder<'data>>,
+    builders: HashMap<NvmRegion, FlashBuilder<'data>>,
     ram_write: Vec<RamWrite<'data>>,
     keep_unwritten: bool,
 }

--- a/probe-rs/targets/EFM32PG12B Series.yaml
+++ b/probe-rs/targets/EFM32PG12B Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 1048576

--- a/probe-rs/targets/HF5032x Series.yaml
+++ b/probe-rs/targets/HF5032x Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768

--- a/probe-rs/targets/HT32F0006 Series.yaml
+++ b/probe-rs/targets/HT32F0006 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560

--- a/probe-rs/targets/HT32F0008 Series.yaml
+++ b/probe-rs/targets/HT32F0008 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512

--- a/probe-rs/targets/HT32F123xx Series.yaml
+++ b/probe-rs/targets/HT32F123xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -83,7 +83,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -98,7 +98,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -113,7 +113,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -128,7 +128,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -143,7 +143,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -158,7 +158,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -173,7 +173,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -188,7 +188,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -203,7 +203,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -218,7 +218,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -233,7 +233,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -248,7 +248,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -263,7 +263,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -278,7 +278,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -293,7 +293,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -308,7 +308,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -323,7 +323,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -338,7 +338,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120

--- a/probe-rs/targets/HT32F12xx Series.yaml
+++ b/probe-rs/targets/HT32F12xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 8192
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 8192
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 31744

--- a/probe-rs/targets/HT32F16xx Series.yaml
+++ b/probe-rs/targets/HT32F16xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -83,7 +83,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -98,7 +98,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -113,7 +113,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -128,7 +128,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -143,7 +143,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -158,7 +158,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -173,7 +173,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -188,7 +188,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -203,7 +203,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120

--- a/probe-rs/targets/HT32F17xx Series.yaml
+++ b/probe-rs/targets/HT32F17xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -83,7 +83,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -98,7 +98,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -113,7 +113,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -128,7 +128,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -143,7 +143,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -158,7 +158,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -173,7 +173,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -188,7 +188,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -203,7 +203,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -218,7 +218,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048

--- a/probe-rs/targets/HT32F502xx Series.yaml
+++ b/probe-rs/targets/HT32F502xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -83,7 +83,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -98,7 +98,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -113,7 +113,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -128,7 +128,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -143,7 +143,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -158,7 +158,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -173,7 +173,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -188,7 +188,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -203,7 +203,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -218,7 +218,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -233,7 +233,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -248,7 +248,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -263,7 +263,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -278,7 +278,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -293,7 +293,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -308,7 +308,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -323,7 +323,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -338,7 +338,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -353,7 +353,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -368,7 +368,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -383,7 +383,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -398,7 +398,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -413,7 +413,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -428,7 +428,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -443,7 +443,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -458,7 +458,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -473,7 +473,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -488,7 +488,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -503,7 +503,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -518,7 +518,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -533,7 +533,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536

--- a/probe-rs/targets/HT32F503xx Series.yaml
+++ b/probe-rs/targets/HT32F503xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536

--- a/probe-rs/targets/HT32F521xx Series.yaml
+++ b/probe-rs/targets/HT32F521xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512

--- a/probe-rs/targets/HT32F522xx Series.yaml
+++ b/probe-rs/targets/HT32F522xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 31744
@@ -83,7 +83,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 31744
@@ -98,7 +98,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 31744
@@ -113,7 +113,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 31744
@@ -128,7 +128,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -143,7 +143,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -158,7 +158,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -173,7 +173,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -188,7 +188,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -203,7 +203,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -218,7 +218,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -233,7 +233,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -248,7 +248,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -263,7 +263,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -278,7 +278,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -293,7 +293,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -308,7 +308,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -323,7 +323,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -338,7 +338,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -353,7 +353,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -368,7 +368,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -383,7 +383,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -398,7 +398,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048
@@ -413,7 +413,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130048

--- a/probe-rs/targets/HT32F523xx Series.yaml
+++ b/probe-rs/targets/HT32F523xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65024
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65024
@@ -83,7 +83,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65024
@@ -98,7 +98,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -113,7 +113,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -128,7 +128,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -143,7 +143,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -158,7 +158,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -173,7 +173,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -188,7 +188,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -203,7 +203,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -218,7 +218,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -233,7 +233,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -248,7 +248,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -263,7 +263,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -278,7 +278,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -293,7 +293,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -308,7 +308,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -323,7 +323,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -338,7 +338,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -353,7 +353,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -368,7 +368,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -383,7 +383,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -398,7 +398,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -413,7 +413,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -428,7 +428,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -443,7 +443,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -458,7 +458,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -473,7 +473,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -488,7 +488,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120
@@ -503,7 +503,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 261120

--- a/probe-rs/targets/HT32F573xx Series.yaml
+++ b/probe-rs/targets/HT32F573xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65024
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65024
@@ -83,7 +83,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65024
@@ -98,7 +98,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -113,7 +113,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -128,7 +128,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -143,7 +143,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -158,7 +158,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -173,7 +173,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -188,7 +188,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -203,7 +203,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560

--- a/probe-rs/targets/HT32F5826 Series.yaml
+++ b/probe-rs/targets/HT32F5826 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560

--- a/probe-rs/targets/HT32F590xx Series.yaml
+++ b/probe-rs/targets/HT32F590xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536

--- a/probe-rs/targets/HT32F597xx Series.yaml
+++ b/probe-rs/targets/HT32F597xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65024
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65024

--- a/probe-rs/targets/HT32F61352 Series.yaml
+++ b/probe-rs/targets/HT32F61352 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560

--- a/probe-rs/targets/HT32F652xx Series.yaml
+++ b/probe-rs/targets/HT32F652xx Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 64512

--- a/probe-rs/targets/HT50F32002 Series.yaml
+++ b/probe-rs/targets/HT50F32002 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -83,7 +83,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -98,7 +98,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -113,7 +113,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -128,7 +128,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768

--- a/probe-rs/targets/HT50F32003 Series.yaml
+++ b/probe-rs/targets/HT50F32003 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 130560

--- a/probe-rs/targets/LPC55S66.yaml
+++ b/probe-rs/targets/LPC55S66.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144

--- a/probe-rs/targets/LPC55S69.yaml
+++ b/probe-rs/targets/LPC55S69.yaml
@@ -10,7 +10,7 @@ variants:
             start: 536870912
             end: 537149440
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 622592
@@ -26,7 +26,7 @@ variants:
             start: 536870912
             end: 537149440
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 622592
@@ -42,7 +42,7 @@ variants:
             start: 536870912
             end: 537149440
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 622592

--- a/probe-rs/targets/LPC800 Series.yaml
+++ b/probe-rs/targets/LPC800 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 268435456
             end: 268437504
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -22,7 +22,7 @@ variants:
             start: 268435456
             end: 268437504
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -36,7 +36,7 @@ variants:
             start: 268435456
             end: 268437504
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -50,7 +50,7 @@ variants:
             start: 268435456
             end: 268437504
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -64,7 +64,7 @@ variants:
             start: 268435456
             end: 268439552
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -78,7 +78,7 @@ variants:
             start: 268435456
             end: 268439552
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -92,7 +92,7 @@ variants:
             start: 268435456
             end: 268439552
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -106,7 +106,7 @@ variants:
             start: 268435456
             end: 268439552
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -120,7 +120,7 @@ variants:
             start: 268435456
             end: 268436480
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 4096
@@ -134,7 +134,7 @@ variants:
             start: 268435456
             end: 268437504
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 8192
@@ -148,7 +148,7 @@ variants:
             start: 268435456
             end: 268439552
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -162,7 +162,7 @@ variants:
             start: 268435456
             end: 268439552
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -176,7 +176,7 @@ variants:
             start: 268435456
             end: 268439552
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -190,7 +190,7 @@ variants:
             start: 268435456
             end: 268439552
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -204,7 +204,7 @@ variants:
             start: 268435456
             end: 268439552
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -218,7 +218,7 @@ variants:
             start: 268435456
             end: 268439552
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -232,7 +232,7 @@ variants:
             start: 268435456
             end: 268443648
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -246,7 +246,7 @@ variants:
             start: 268435456
             end: 268443648
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -260,7 +260,7 @@ variants:
             start: 268435456
             end: 268439552
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -274,7 +274,7 @@ variants:
             start: 268435456
             end: 268439552
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -288,7 +288,7 @@ variants:
             start: 268435456
             end: 268443648
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -302,7 +302,7 @@ variants:
             start: 268435456
             end: 268443648
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -316,7 +316,7 @@ variants:
             start: 268435456
             end: 268443648
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -330,7 +330,7 @@ variants:
             start: 268435456
             end: 268443648
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -344,7 +344,7 @@ variants:
             start: 268435456
             end: 268451840
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -358,7 +358,7 @@ variants:
             start: 268435456
             end: 268451840
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -372,7 +372,7 @@ variants:
             start: 268435456
             end: 268451840
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -386,7 +386,7 @@ variants:
             start: 268435456
             end: 268451840
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -400,7 +400,7 @@ variants:
             start: 268435456
             end: 268443648
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 30720

--- a/probe-rs/targets/MAX32665-66.yaml
+++ b/probe-rs/targets/MAX32665-66.yaml
@@ -10,7 +10,7 @@ variants:
             start: 0x20000000
             end: 0x2008C000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x10000000
             end: 0x10100000
@@ -25,7 +25,7 @@ variants:
             start: 0x20000000
             end: 0x2008C000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x10000000
             end: 0x10100000

--- a/probe-rs/targets/SAM D Series.yaml
+++ b/probe-rs/targets/SAM D Series.yaml
@@ -10,7 +10,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -25,7 +25,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -41,7 +41,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -57,7 +57,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -73,7 +73,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -88,7 +88,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -104,7 +104,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -120,7 +120,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -136,7 +136,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -151,7 +151,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -166,7 +166,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -181,7 +181,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -197,7 +197,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -213,7 +213,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -228,7 +228,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -244,7 +244,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -260,7 +260,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -275,7 +275,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -290,7 +290,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -305,7 +305,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -320,7 +320,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -335,7 +335,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 32768
@@ -351,7 +351,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -366,7 +366,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 65536
@@ -382,7 +382,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -397,7 +397,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144

--- a/probe-rs/targets/SAMD11.yaml
+++ b/probe-rs/targets/SAMD11.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -22,7 +22,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -36,7 +36,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384
@@ -50,7 +50,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 16384

--- a/probe-rs/targets/SAMD51.yaml
+++ b/probe-rs/targets/SAMD51.yaml
@@ -10,7 +10,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -25,7 +25,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 524288
@@ -40,7 +40,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -55,7 +55,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 524288
@@ -70,7 +70,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 1048576
@@ -85,7 +85,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 524288
@@ -100,7 +100,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 1048576
@@ -115,7 +115,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 524288
@@ -130,7 +130,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 1048576

--- a/probe-rs/targets/STM32F0 Series.yaml
+++ b/probe-rs/targets/STM32F0 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -83,7 +83,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -98,7 +98,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -113,7 +113,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -128,7 +128,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -143,7 +143,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -158,7 +158,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -173,7 +173,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -188,7 +188,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -203,7 +203,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -218,7 +218,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -233,7 +233,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -248,7 +248,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -263,7 +263,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -278,7 +278,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -293,7 +293,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -308,7 +308,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -323,7 +323,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -338,7 +338,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -353,7 +353,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -368,7 +368,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -383,7 +383,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -398,7 +398,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -413,7 +413,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -428,7 +428,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -443,7 +443,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -458,7 +458,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -473,7 +473,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -488,7 +488,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -503,7 +503,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -518,7 +518,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -533,7 +533,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -548,7 +548,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -563,7 +563,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -578,7 +578,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -593,7 +593,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -608,7 +608,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -623,7 +623,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -638,7 +638,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -653,7 +653,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -668,7 +668,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -683,7 +683,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -698,7 +698,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -713,7 +713,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -728,7 +728,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -743,7 +743,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -758,7 +758,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -773,7 +773,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -788,7 +788,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -803,7 +803,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -818,7 +818,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -833,7 +833,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -848,7 +848,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -863,7 +863,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -878,7 +878,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -893,7 +893,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -908,7 +908,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -923,7 +923,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -938,7 +938,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -953,7 +953,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -968,7 +968,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -983,7 +983,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -998,7 +998,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1013,7 +1013,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1028,7 +1028,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1043,7 +1043,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1058,7 +1058,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1073,7 +1073,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1088,7 +1088,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1103,7 +1103,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1118,7 +1118,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1133,7 +1133,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1148,7 +1148,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1163,7 +1163,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1178,7 +1178,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1193,7 +1193,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1208,7 +1208,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1223,7 +1223,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1238,7 +1238,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1253,7 +1253,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1268,7 +1268,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1283,7 +1283,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1298,7 +1298,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1313,7 +1313,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1328,7 +1328,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1343,7 +1343,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1358,7 +1358,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1373,7 +1373,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1388,7 +1388,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1403,7 +1403,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1418,7 +1418,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1433,7 +1433,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1448,7 +1448,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1463,7 +1463,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1478,7 +1478,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1493,7 +1493,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1508,7 +1508,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1523,7 +1523,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1538,7 +1538,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1553,7 +1553,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1568,7 +1568,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1583,7 +1583,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1598,7 +1598,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1613,7 +1613,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1628,7 +1628,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1643,7 +1643,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1658,7 +1658,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872

--- a/probe-rs/targets/STM32F1 Series.yaml
+++ b/probe-rs/targets/STM32F1 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -83,7 +83,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -98,7 +98,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -113,7 +113,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -128,7 +128,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -143,7 +143,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -158,7 +158,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -173,7 +173,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -188,7 +188,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -203,7 +203,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -218,7 +218,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -233,7 +233,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -248,7 +248,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -263,7 +263,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -278,7 +278,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -293,7 +293,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -308,7 +308,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -323,7 +323,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -338,7 +338,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -353,7 +353,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -368,7 +368,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -383,7 +383,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -398,7 +398,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -413,7 +413,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -428,7 +428,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -443,7 +443,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -458,7 +458,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -473,7 +473,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -488,7 +488,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -503,7 +503,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -518,7 +518,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -533,7 +533,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -548,7 +548,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -563,7 +563,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -578,7 +578,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -593,7 +593,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -608,7 +608,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -623,7 +623,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -638,7 +638,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -653,7 +653,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -668,7 +668,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -683,7 +683,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -698,7 +698,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -713,7 +713,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -728,7 +728,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -743,7 +743,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -758,7 +758,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -773,7 +773,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -788,7 +788,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -803,7 +803,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -818,7 +818,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -833,7 +833,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -848,7 +848,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -863,7 +863,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -878,7 +878,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -893,7 +893,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -908,7 +908,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -923,7 +923,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -938,7 +938,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -953,7 +953,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -968,7 +968,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -983,7 +983,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -998,7 +998,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1013,7 +1013,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -1028,7 +1028,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1043,7 +1043,7 @@ variants:
             start: 536870912
             end: 536877056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -1058,7 +1058,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -1073,7 +1073,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1088,7 +1088,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1103,7 +1103,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1118,7 +1118,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1133,7 +1133,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1148,7 +1148,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -1163,7 +1163,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1178,7 +1178,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -1193,7 +1193,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1208,7 +1208,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1223,7 +1223,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -1238,7 +1238,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1253,7 +1253,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -1268,7 +1268,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1283,7 +1283,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1298,7 +1298,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1313,7 +1313,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1328,7 +1328,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1343,7 +1343,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1358,7 +1358,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1373,7 +1373,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1388,7 +1388,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1403,7 +1403,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1418,7 +1418,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872

--- a/probe-rs/targets/STM32F3 Series.yaml
+++ b/probe-rs/targets/STM32F3 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -23,7 +23,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -38,7 +38,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -53,7 +53,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -68,7 +68,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -83,7 +83,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -98,7 +98,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -113,7 +113,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -128,7 +128,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -143,7 +143,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -158,7 +158,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -173,7 +173,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -188,7 +188,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -203,7 +203,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -218,7 +218,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -233,7 +233,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -248,7 +248,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -263,7 +263,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -278,7 +278,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -293,7 +293,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -308,7 +308,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -323,7 +323,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -338,7 +338,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -353,7 +353,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -368,7 +368,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -383,7 +383,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -398,7 +398,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -413,7 +413,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -428,7 +428,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -443,7 +443,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -458,7 +458,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -473,7 +473,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -488,7 +488,7 @@ variants:
             start: 268435456
             end: 268443648
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -503,7 +503,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -518,7 +518,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -533,7 +533,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -548,7 +548,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -563,7 +563,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -578,7 +578,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -593,7 +593,7 @@ variants:
             start: 536870912
             end: 536883200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -608,7 +608,7 @@ variants:
             start: 268435456
             end: 268443648
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -623,7 +623,7 @@ variants:
             start: 268435456
             end: 268443648
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -638,7 +638,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -653,7 +653,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -668,7 +668,7 @@ variants:
             start: 268435456
             end: 268443648
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -683,7 +683,7 @@ variants:
             start: 268435456
             end: 268443648
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -698,7 +698,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -713,7 +713,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -728,7 +728,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -743,7 +743,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -758,7 +758,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -773,7 +773,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -788,7 +788,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -803,7 +803,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -818,7 +818,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -833,7 +833,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -848,7 +848,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -863,7 +863,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -878,7 +878,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -893,7 +893,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -908,7 +908,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -923,7 +923,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -933,7 +933,7 @@ variants:
       - stm32f3xx_opt
   - name: STM32F334K4Tx
     memory_map:
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -943,7 +943,7 @@ variants:
       - stm32f3xx_opt
   - name: STM32F334K4Ux
     memory_map:
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -958,7 +958,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -973,7 +973,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -988,7 +988,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1003,7 +1003,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1018,7 +1018,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -1033,7 +1033,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1048,7 +1048,7 @@ variants:
             start: 536870912
             end: 536911872
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1063,7 +1063,7 @@ variants:
             start: 536870912
             end: 536911872
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1078,7 +1078,7 @@ variants:
             start: 536870912
             end: 536911872
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1093,7 +1093,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1108,7 +1108,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1123,7 +1123,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1138,7 +1138,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1153,7 +1153,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1168,7 +1168,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1183,7 +1183,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1198,7 +1198,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1213,7 +1213,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1228,7 +1228,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1243,7 +1243,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1258,7 +1258,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1273,7 +1273,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1288,7 +1288,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1303,7 +1303,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1318,7 +1318,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1333,7 +1333,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016

--- a/probe-rs/targets/STM32F4 Series.yaml
+++ b/probe-rs/targets/STM32F4 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -24,7 +24,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -40,7 +40,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -56,7 +56,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -72,7 +72,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -88,7 +88,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -104,7 +104,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -120,7 +120,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -136,7 +136,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -152,7 +152,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -168,7 +168,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -184,7 +184,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -200,7 +200,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -216,7 +216,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -232,7 +232,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -248,7 +248,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -264,7 +264,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -280,7 +280,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -296,7 +296,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -312,7 +312,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -328,7 +328,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -344,7 +344,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -360,7 +360,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -376,7 +376,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -392,7 +392,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -408,7 +408,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -424,7 +424,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -440,7 +440,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -456,7 +456,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -472,7 +472,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -488,7 +488,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -504,7 +504,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -520,7 +520,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -536,7 +536,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -551,7 +551,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -566,7 +566,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -581,7 +581,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -596,7 +596,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -611,7 +611,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -626,7 +626,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -641,7 +641,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -656,7 +656,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -671,7 +671,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -686,7 +686,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -702,7 +702,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -718,7 +718,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -734,7 +734,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -750,7 +750,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -766,7 +766,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -782,7 +782,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -798,7 +798,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -814,7 +814,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -830,7 +830,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -846,7 +846,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -862,7 +862,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -878,7 +878,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -894,7 +894,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -910,7 +910,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -926,7 +926,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -942,7 +942,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -958,7 +958,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -974,7 +974,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -990,7 +990,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1006,7 +1006,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1022,7 +1022,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1038,7 +1038,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1054,7 +1054,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1070,7 +1070,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1085,7 +1085,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1100,7 +1100,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1115,7 +1115,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1130,7 +1130,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1145,7 +1145,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1160,7 +1160,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1175,7 +1175,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1190,7 +1190,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1205,7 +1205,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1220,7 +1220,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1235,7 +1235,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1250,7 +1250,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1265,7 +1265,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1280,7 +1280,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1296,7 +1296,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1312,7 +1312,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1328,7 +1328,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1344,7 +1344,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1360,7 +1360,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1376,7 +1376,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1392,7 +1392,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1408,7 +1408,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1424,7 +1424,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1440,7 +1440,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1456,7 +1456,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1472,7 +1472,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1487,7 +1487,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1502,7 +1502,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1517,7 +1517,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1532,7 +1532,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1547,7 +1547,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1562,7 +1562,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135790592
@@ -1577,7 +1577,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1594,7 +1594,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1610,7 +1610,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1627,7 +1627,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1644,7 +1644,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1660,7 +1660,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1676,7 +1676,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1693,7 +1693,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1709,7 +1709,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1726,7 +1726,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1742,7 +1742,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1759,7 +1759,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1775,7 +1775,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1791,7 +1791,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1808,7 +1808,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1824,7 +1824,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1840,7 +1840,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1856,7 +1856,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1873,7 +1873,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1890,7 +1890,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1906,7 +1906,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1922,7 +1922,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1938,7 +1938,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1955,7 +1955,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1971,7 +1971,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1987,7 +1987,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2004,7 +2004,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2020,7 +2020,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2036,7 +2036,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2053,7 +2053,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2069,7 +2069,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2085,7 +2085,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2101,7 +2101,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2118,7 +2118,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2135,7 +2135,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2151,7 +2151,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2167,7 +2167,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2184,7 +2184,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2200,7 +2200,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2217,7 +2217,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2233,7 +2233,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2249,7 +2249,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2266,7 +2266,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2282,7 +2282,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2299,7 +2299,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2316,7 +2316,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2332,7 +2332,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2348,7 +2348,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2365,7 +2365,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2381,7 +2381,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2398,7 +2398,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2414,7 +2414,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2431,7 +2431,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2447,7 +2447,7 @@ variants:
             start: 536870912
             end: 537067520
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2463,7 +2463,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -2479,7 +2479,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2495,7 +2495,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -2511,7 +2511,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2527,7 +2527,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -2543,7 +2543,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2559,7 +2559,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -2575,7 +2575,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -2591,7 +2591,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2607,7 +2607,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2623,7 +2623,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2639,7 +2639,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2655,7 +2655,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2671,7 +2671,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2688,7 +2688,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2705,7 +2705,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2721,7 +2721,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2737,7 +2737,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2753,7 +2753,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2770,7 +2770,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2786,7 +2786,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2802,7 +2802,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2818,7 +2818,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2835,7 +2835,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2852,7 +2852,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2868,7 +2868,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2884,7 +2884,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2900,7 +2900,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2917,7 +2917,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2933,7 +2933,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2949,7 +2949,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2966,7 +2966,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2982,7 +2982,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2998,7 +2998,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3015,7 +3015,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3031,7 +3031,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3048,7 +3048,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3065,7 +3065,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3081,7 +3081,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3097,7 +3097,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3114,7 +3114,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3130,7 +3130,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3147,7 +3147,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3164,7 +3164,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3180,7 +3180,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3196,7 +3196,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3213,7 +3213,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3229,7 +3229,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3246,7 +3246,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3262,7 +3262,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3279,7 +3279,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880

--- a/probe-rs/targets/STM32F7 Series.yaml
+++ b/probe-rs/targets/STM32F7 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -31,7 +31,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -54,7 +54,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -77,7 +77,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -100,7 +100,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -123,7 +123,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -146,7 +146,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -169,7 +169,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -192,7 +192,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -215,7 +215,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -238,7 +238,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -261,7 +261,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -284,7 +284,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -307,7 +307,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -330,7 +330,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -353,7 +353,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -376,7 +376,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -399,7 +399,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -422,7 +422,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -445,7 +445,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -468,7 +468,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -491,7 +491,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -514,7 +514,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -537,7 +537,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -560,7 +560,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -583,7 +583,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -606,7 +606,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -629,7 +629,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -652,7 +652,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -675,7 +675,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -698,7 +698,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -721,7 +721,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -744,7 +744,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -767,7 +767,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -790,7 +790,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -813,7 +813,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -836,7 +836,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -859,7 +859,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -882,7 +882,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -905,7 +905,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -928,7 +928,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -951,7 +951,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -974,7 +974,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -997,7 +997,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1020,7 +1020,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1043,7 +1043,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1066,7 +1066,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1089,7 +1089,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1112,7 +1112,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1135,7 +1135,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1158,7 +1158,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1181,7 +1181,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1204,7 +1204,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1227,7 +1227,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1250,7 +1250,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1273,7 +1273,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1296,7 +1296,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1319,7 +1319,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1342,7 +1342,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1365,7 +1365,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1388,7 +1388,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1411,7 +1411,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1434,7 +1434,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1457,7 +1457,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1480,7 +1480,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1503,7 +1503,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1526,7 +1526,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1549,7 +1549,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1572,7 +1572,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1595,7 +1595,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1618,7 +1618,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1641,7 +1641,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1666,7 +1666,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1691,7 +1691,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1716,7 +1716,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1741,7 +1741,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1766,7 +1766,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1791,7 +1791,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1816,7 +1816,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1841,7 +1841,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1866,7 +1866,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1891,7 +1891,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1916,7 +1916,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1941,7 +1941,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1966,7 +1966,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -1991,7 +1991,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2016,7 +2016,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2041,7 +2041,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2066,7 +2066,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2091,7 +2091,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2116,7 +2116,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2141,7 +2141,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2166,7 +2166,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2191,7 +2191,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2216,7 +2216,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2241,7 +2241,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2266,7 +2266,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2291,7 +2291,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2316,7 +2316,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2341,7 +2341,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2366,7 +2366,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2391,7 +2391,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2416,7 +2416,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2441,7 +2441,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2466,7 +2466,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2491,7 +2491,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2516,7 +2516,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2541,7 +2541,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2566,7 +2566,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2591,7 +2591,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2616,7 +2616,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2641,7 +2641,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2666,7 +2666,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2691,7 +2691,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -2716,7 +2716,7 @@ variants:
             start: 536870912
             end: 537395200
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880

--- a/probe-rs/targets/STM32G0 Series.yaml
+++ b/probe-rs/targets/STM32G0 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -24,7 +24,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -40,7 +40,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -56,7 +56,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -72,7 +72,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -88,7 +88,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -104,7 +104,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -120,7 +120,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -136,7 +136,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -152,7 +152,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -168,7 +168,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -184,7 +184,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -200,7 +200,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -216,7 +216,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -232,7 +232,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -248,7 +248,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -264,7 +264,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -280,7 +280,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -296,7 +296,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -312,7 +312,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -328,7 +328,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -344,7 +344,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -360,7 +360,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -376,7 +376,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -392,7 +392,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -408,7 +408,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -424,7 +424,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -440,7 +440,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -456,7 +456,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -472,7 +472,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -488,7 +488,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -504,7 +504,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -520,7 +520,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -536,7 +536,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -552,7 +552,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -568,7 +568,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -584,7 +584,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -600,7 +600,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -616,7 +616,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -632,7 +632,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -648,7 +648,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -664,7 +664,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -680,7 +680,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -696,7 +696,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -712,7 +712,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -728,7 +728,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -744,7 +744,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -760,7 +760,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -776,7 +776,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -792,7 +792,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -808,7 +808,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -824,7 +824,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -840,7 +840,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -856,7 +856,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -872,7 +872,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -888,7 +888,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -904,7 +904,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -920,7 +920,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -936,7 +936,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -952,7 +952,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -968,7 +968,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -984,7 +984,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1000,7 +1000,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1016,7 +1016,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1032,7 +1032,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1048,7 +1048,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1064,7 +1064,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -1080,7 +1080,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1096,7 +1096,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1112,7 +1112,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1128,7 +1128,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1144,7 +1144,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1160,7 +1160,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1176,7 +1176,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1192,7 +1192,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1208,7 +1208,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1224,7 +1224,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1240,7 +1240,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1256,7 +1256,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1272,7 +1272,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1288,7 +1288,7 @@ variants:
             start: 536870912
             end: 536907776
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800

--- a/probe-rs/targets/STM32G4 Series.yaml
+++ b/probe-rs/targets/STM32G4 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -22,7 +22,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -36,7 +36,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -50,7 +50,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -64,7 +64,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -78,7 +78,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -92,7 +92,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -106,7 +106,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -120,7 +120,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -134,7 +134,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -148,7 +148,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -162,7 +162,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -176,7 +176,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -190,7 +190,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -204,7 +204,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -218,7 +218,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -232,7 +232,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -246,7 +246,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -260,7 +260,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -274,7 +274,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -288,7 +288,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -302,7 +302,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -316,7 +316,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -330,7 +330,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -344,7 +344,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -358,7 +358,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -372,7 +372,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -386,7 +386,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -400,7 +400,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -414,7 +414,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -428,7 +428,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -442,7 +442,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -456,7 +456,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -470,7 +470,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -484,7 +484,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -499,7 +499,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -514,7 +514,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -528,7 +528,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -543,7 +543,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -558,7 +558,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -572,7 +572,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -587,7 +587,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -601,7 +601,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -616,7 +616,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -630,7 +630,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -644,7 +644,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -658,7 +658,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -673,7 +673,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -688,7 +688,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -703,7 +703,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -717,7 +717,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -731,7 +731,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -745,7 +745,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -759,7 +759,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -774,7 +774,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -789,7 +789,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -803,7 +803,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -817,7 +817,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -832,7 +832,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -847,7 +847,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -861,7 +861,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -875,7 +875,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -890,7 +890,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -904,7 +904,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -918,7 +918,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -933,7 +933,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -947,7 +947,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -961,7 +961,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -975,7 +975,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -989,7 +989,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1003,7 +1003,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1017,7 +1017,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1032,7 +1032,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1047,7 +1047,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1062,7 +1062,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1076,7 +1076,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1090,7 +1090,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1104,7 +1104,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1118,7 +1118,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1133,7 +1133,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1148,7 +1148,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1162,7 +1162,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1176,7 +1176,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1191,7 +1191,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1206,7 +1206,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1220,7 +1220,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1234,7 +1234,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1249,7 +1249,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1263,7 +1263,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1277,7 +1277,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1292,7 +1292,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1306,7 +1306,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1320,7 +1320,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1334,7 +1334,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1348,7 +1348,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1362,7 +1362,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1376,7 +1376,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1391,7 +1391,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1406,7 +1406,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1421,7 +1421,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1436,7 +1436,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1451,7 +1451,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1466,7 +1466,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1481,7 +1481,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1496,7 +1496,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1511,7 +1511,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1526,7 +1526,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1541,7 +1541,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1556,7 +1556,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1571,7 +1571,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1586,7 +1586,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1601,7 +1601,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1616,7 +1616,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1631,7 +1631,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1646,7 +1646,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1661,7 +1661,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1676,7 +1676,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1691,7 +1691,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800

--- a/probe-rs/targets/STM32H7 Series.yaml
+++ b/probe-rs/targets/STM32H7 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -22,7 +22,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -36,7 +36,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -50,7 +50,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -64,7 +64,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -78,7 +78,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -92,7 +92,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -106,7 +106,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -120,7 +120,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -134,7 +134,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -148,7 +148,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -162,7 +162,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -176,7 +176,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -190,7 +190,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -204,7 +204,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -218,7 +218,7 @@ variants:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -232,7 +232,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -246,7 +246,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -260,7 +260,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -274,7 +274,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -288,7 +288,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -302,7 +302,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -316,7 +316,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -330,7 +330,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -344,7 +344,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -358,7 +358,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -372,7 +372,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -386,7 +386,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -400,7 +400,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -414,7 +414,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -428,7 +428,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -442,7 +442,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -456,7 +456,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -471,7 +471,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -486,7 +486,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -501,7 +501,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -516,7 +516,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -531,7 +531,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -546,7 +546,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -561,7 +561,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -576,7 +576,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -591,7 +591,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -606,7 +606,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -621,7 +621,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -636,7 +636,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -651,7 +651,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -666,7 +666,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -681,7 +681,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -696,7 +696,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -711,7 +711,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -726,7 +726,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -741,7 +741,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08020000
@@ -755,7 +755,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08020000
@@ -769,7 +769,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08020000
@@ -783,7 +783,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08020000
@@ -797,7 +797,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08020000
@@ -811,7 +811,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -825,7 +825,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -839,7 +839,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -853,7 +853,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -867,7 +867,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -881,7 +881,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -895,7 +895,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -909,7 +909,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -923,7 +923,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -938,7 +938,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -953,7 +953,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -968,7 +968,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -983,7 +983,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -998,7 +998,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1013,7 +1013,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1028,7 +1028,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1043,7 +1043,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1058,7 +1058,7 @@ variants:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1073,7 +1073,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1087,7 +1087,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1101,7 +1101,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1115,7 +1115,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1129,7 +1129,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1143,7 +1143,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1157,7 +1157,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1171,7 +1171,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1185,7 +1185,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1199,7 +1199,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1213,7 +1213,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1227,7 +1227,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1241,7 +1241,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1255,7 +1255,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1269,7 +1269,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1283,7 +1283,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1297,7 +1297,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1311,7 +1311,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1325,7 +1325,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1339,7 +1339,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1353,7 +1353,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1367,7 +1367,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1381,7 +1381,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1395,7 +1395,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1409,7 +1409,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1423,7 +1423,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1437,7 +1437,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08100000
@@ -1451,7 +1451,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1465,7 +1465,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1479,7 +1479,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08020000
@@ -1493,7 +1493,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08020000
@@ -1507,7 +1507,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08020000
@@ -1521,7 +1521,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08020000
@@ -1535,7 +1535,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08020000
@@ -1549,7 +1549,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08020000
@@ -1563,7 +1563,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1577,7 +1577,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1591,7 +1591,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1605,7 +1605,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1619,7 +1619,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1633,7 +1633,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1647,7 +1647,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1661,7 +1661,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1675,7 +1675,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1689,7 +1689,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1703,7 +1703,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1717,7 +1717,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1731,7 +1731,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1745,7 +1745,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000
@@ -1759,7 +1759,7 @@ variants:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0x08000000
             end: 0x08200000

--- a/probe-rs/targets/STM32L0 Series.yaml
+++ b/probe-rs/targets/STM32L0 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -24,7 +24,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -40,7 +40,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -56,7 +56,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -72,7 +72,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -88,7 +88,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -104,7 +104,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134225920
@@ -120,7 +120,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -136,7 +136,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -152,7 +152,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134225920
@@ -168,7 +168,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134225920
@@ -184,7 +184,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -200,7 +200,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -216,7 +216,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134225920
@@ -232,7 +232,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -248,7 +248,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134225920
@@ -264,7 +264,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134225920
@@ -280,7 +280,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -296,7 +296,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -312,7 +312,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -328,7 +328,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -344,7 +344,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -360,7 +360,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -376,7 +376,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -392,7 +392,7 @@ variants:
             start: 536870912
             end: 536872960
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -408,7 +408,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -424,7 +424,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -440,7 +440,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -456,7 +456,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -472,7 +472,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -488,7 +488,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -504,7 +504,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -520,7 +520,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -536,7 +536,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -552,7 +552,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -568,7 +568,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -584,7 +584,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -600,7 +600,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -616,7 +616,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134234112
@@ -632,7 +632,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -648,7 +648,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -664,7 +664,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -680,7 +680,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -696,7 +696,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -712,7 +712,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -728,7 +728,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -744,7 +744,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -760,7 +760,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -776,7 +776,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -792,7 +792,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -808,7 +808,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -824,7 +824,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -840,7 +840,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -856,7 +856,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -872,7 +872,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -888,7 +888,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -904,7 +904,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -920,7 +920,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -936,7 +936,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -952,7 +952,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -968,7 +968,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -984,7 +984,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1000,7 +1000,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1016,7 +1016,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -1032,7 +1032,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -1048,7 +1048,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1064,7 +1064,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1080,7 +1080,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -1096,7 +1096,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1112,7 +1112,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -1128,7 +1128,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1144,7 +1144,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -1160,7 +1160,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -1176,7 +1176,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1192,7 +1192,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1208,7 +1208,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1224,7 +1224,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1240,7 +1240,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1256,7 +1256,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1272,7 +1272,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1288,7 +1288,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1304,7 +1304,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1320,7 +1320,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1336,7 +1336,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1352,7 +1352,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1368,7 +1368,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1384,7 +1384,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1400,7 +1400,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1416,7 +1416,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1432,7 +1432,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1448,7 +1448,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1464,7 +1464,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1480,7 +1480,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1496,7 +1496,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1512,7 +1512,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1528,7 +1528,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1544,7 +1544,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1560,7 +1560,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1576,7 +1576,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1592,7 +1592,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1608,7 +1608,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1624,7 +1624,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1640,7 +1640,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1656,7 +1656,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1672,7 +1672,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1688,7 +1688,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1704,7 +1704,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1720,7 +1720,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1736,7 +1736,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1752,7 +1752,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1768,7 +1768,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1784,7 +1784,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1800,7 +1800,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1816,7 +1816,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1832,7 +1832,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1848,7 +1848,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1864,7 +1864,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1880,7 +1880,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1896,7 +1896,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1912,7 +1912,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1928,7 +1928,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1944,7 +1944,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -1960,7 +1960,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1976,7 +1976,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1992,7 +1992,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2008,7 +2008,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2024,7 +2024,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -2040,7 +2040,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -2056,7 +2056,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -2072,7 +2072,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -2088,7 +2088,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2104,7 +2104,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2120,7 +2120,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2136,7 +2136,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2152,7 +2152,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2168,7 +2168,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2184,7 +2184,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -2200,7 +2200,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -2216,7 +2216,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2232,7 +2232,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2248,7 +2248,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -2264,7 +2264,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2280,7 +2280,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -2296,7 +2296,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -2312,7 +2312,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2328,7 +2328,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2344,7 +2344,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -2360,7 +2360,7 @@ variants:
             start: 536870912
             end: 537198592
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -2376,7 +2376,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -2392,7 +2392,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -2408,7 +2408,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336
@@ -2424,7 +2424,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134414336

--- a/probe-rs/targets/STM32L1 Series.yaml
+++ b/probe-rs/targets/STM32L1 Series.yaml
@@ -10,7 +10,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -27,7 +27,7 @@ variants:
             start: 536870912
             end: 536875008
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -44,7 +44,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -61,7 +61,7 @@ variants:
             start: 536870912
             end: 536879104
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -78,7 +78,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -95,7 +95,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -112,7 +112,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -129,7 +129,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -146,7 +146,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -163,7 +163,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -180,7 +180,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -197,7 +197,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -214,7 +214,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -231,7 +231,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -248,7 +248,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -265,7 +265,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -282,7 +282,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -299,7 +299,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -316,7 +316,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -333,7 +333,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -350,7 +350,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -367,7 +367,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -384,7 +384,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -401,7 +401,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -418,7 +418,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -435,7 +435,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -452,7 +452,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -469,7 +469,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -486,7 +486,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -503,7 +503,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -520,7 +520,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -537,7 +537,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -554,7 +554,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -571,7 +571,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -588,7 +588,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -605,7 +605,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -622,7 +622,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -639,7 +639,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -656,7 +656,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -673,7 +673,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -690,7 +690,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -707,7 +707,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -724,7 +724,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -741,7 +741,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -758,7 +758,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -775,7 +775,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -792,7 +792,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -809,7 +809,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -826,7 +826,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -843,7 +843,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -860,7 +860,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134250496
@@ -877,7 +877,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -894,7 +894,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -911,7 +911,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -928,7 +928,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -945,7 +945,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -962,7 +962,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -979,7 +979,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -996,7 +996,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1013,7 +1013,7 @@ variants:
             start: 536870912
             end: 536881152
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1030,7 +1030,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -1047,7 +1047,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1064,7 +1064,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -1081,7 +1081,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1098,7 +1098,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1115,7 +1115,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -1132,7 +1132,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1149,7 +1149,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1166,7 +1166,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -1183,7 +1183,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1200,7 +1200,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -1217,7 +1217,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1234,7 +1234,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1251,7 +1251,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -1268,7 +1268,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1285,7 +1285,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1302,7 +1302,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1319,7 +1319,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -1336,7 +1336,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1353,7 +1353,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134610944
@@ -1370,7 +1370,7 @@ variants:
             start: 536870912
             end: 536952832
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016

--- a/probe-rs/targets/STM32L4 Series.yaml
+++ b/probe-rs/targets/STM32L4 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -29,7 +29,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -48,7 +48,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -67,7 +67,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -86,7 +86,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -105,7 +105,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -124,7 +124,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -143,7 +143,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -162,7 +162,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -181,7 +181,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -200,7 +200,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -219,7 +219,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -238,7 +238,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -257,7 +257,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -276,7 +276,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -295,7 +295,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -314,7 +314,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -333,7 +333,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -352,7 +352,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -371,7 +371,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -390,7 +390,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -409,7 +409,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -428,7 +428,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -447,7 +447,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -466,7 +466,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -485,7 +485,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -504,7 +504,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -523,7 +523,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -542,7 +542,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -561,7 +561,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -580,7 +580,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -599,7 +599,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -618,7 +618,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -637,7 +637,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -656,7 +656,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -675,7 +675,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -694,7 +694,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -713,7 +713,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -732,7 +732,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -751,7 +751,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -770,7 +770,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -789,7 +789,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -808,7 +808,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -827,7 +827,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -846,7 +846,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -865,7 +865,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -884,7 +884,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -903,7 +903,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -922,7 +922,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -941,7 +941,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -960,7 +960,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -979,7 +979,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -998,7 +998,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1017,7 +1017,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1036,7 +1036,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1055,7 +1055,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1074,7 +1074,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1093,7 +1093,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1112,7 +1112,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1131,7 +1131,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1150,7 +1150,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1169,7 +1169,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1188,7 +1188,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1207,7 +1207,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1226,7 +1226,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1245,7 +1245,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1264,7 +1264,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1283,7 +1283,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1302,7 +1302,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1321,7 +1321,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1340,7 +1340,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1359,7 +1359,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1378,7 +1378,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1397,7 +1397,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1416,7 +1416,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1435,7 +1435,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1454,7 +1454,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1473,7 +1473,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1492,7 +1492,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1511,7 +1511,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1530,7 +1530,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1549,7 +1549,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1568,7 +1568,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1587,7 +1587,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1606,7 +1606,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1625,7 +1625,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1644,7 +1644,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1663,7 +1663,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1682,7 +1682,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1701,7 +1701,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1720,7 +1720,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1739,7 +1739,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1758,7 +1758,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1777,7 +1777,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1796,7 +1796,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1815,7 +1815,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1834,7 +1834,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1853,7 +1853,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -1872,7 +1872,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1891,7 +1891,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1910,7 +1910,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1929,7 +1929,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1948,7 +1948,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -1967,7 +1967,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -1986,7 +1986,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2005,7 +2005,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2024,7 +2024,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -2043,7 +2043,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2062,7 +2062,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2081,7 +2081,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -2100,7 +2100,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2119,7 +2119,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2138,7 +2138,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2157,7 +2157,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2176,7 +2176,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2195,7 +2195,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2214,7 +2214,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2233,7 +2233,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2252,7 +2252,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2271,7 +2271,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2290,7 +2290,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -2309,7 +2309,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2328,7 +2328,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2347,7 +2347,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -2366,7 +2366,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2385,7 +2385,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2404,7 +2404,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2423,7 +2423,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2442,7 +2442,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2461,7 +2461,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2480,7 +2480,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2499,7 +2499,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2518,7 +2518,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2537,7 +2537,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2556,7 +2556,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2575,7 +2575,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2594,7 +2594,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2613,7 +2613,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2632,7 +2632,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -2651,7 +2651,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2670,7 +2670,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2689,7 +2689,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2708,7 +2708,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2727,7 +2727,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2746,7 +2746,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2765,7 +2765,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2784,7 +2784,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2803,7 +2803,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2822,7 +2822,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2841,7 +2841,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2860,7 +2860,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2878,7 +2878,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2896,7 +2896,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2914,7 +2914,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2932,7 +2932,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2950,7 +2950,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2968,7 +2968,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -2986,7 +2986,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3004,7 +3004,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3022,7 +3022,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3040,7 +3040,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3058,7 +3058,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3076,7 +3076,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3096,7 +3096,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3116,7 +3116,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3136,7 +3136,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3156,7 +3156,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3176,7 +3176,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3196,7 +3196,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3216,7 +3216,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3236,7 +3236,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3256,7 +3256,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3276,7 +3276,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3296,7 +3296,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3316,7 +3316,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3336,7 +3336,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3356,7 +3356,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3376,7 +3376,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3396,7 +3396,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3416,7 +3416,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3436,7 +3436,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3456,7 +3456,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -3476,7 +3476,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3496,7 +3496,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3516,7 +3516,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3536,7 +3536,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3556,7 +3556,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3576,7 +3576,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3596,7 +3596,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3616,7 +3616,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3636,7 +3636,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3657,7 +3657,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3678,7 +3678,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3699,7 +3699,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3720,7 +3720,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3741,7 +3741,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880
@@ -3762,7 +3762,7 @@ variants:
             start: 536870912
             end: 537526272
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 136314880

--- a/probe-rs/targets/STM32L5 Series.yaml
+++ b/probe-rs/targets/STM32L5 Series.yaml
@@ -9,7 +9,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -27,7 +27,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -45,7 +45,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -63,7 +63,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -81,7 +81,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -99,7 +99,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -117,7 +117,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -135,7 +135,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -153,7 +153,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -171,7 +171,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -189,7 +189,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -207,7 +207,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -225,7 +225,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -243,7 +243,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -261,7 +261,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -279,7 +279,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -297,7 +297,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -315,7 +315,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -333,7 +333,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -351,7 +351,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -369,7 +369,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -387,7 +387,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -405,7 +405,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -423,7 +423,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -441,7 +441,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -459,7 +459,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -477,7 +477,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -495,7 +495,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -513,7 +513,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -531,7 +531,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -549,7 +549,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -567,7 +567,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -585,7 +585,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -603,7 +603,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -621,7 +621,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -639,7 +639,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016

--- a/probe-rs/targets/STM32WB Series.yaml
+++ b/probe-rs/targets/STM32WB Series.yaml
@@ -12,7 +12,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -27,7 +27,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -42,7 +42,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -57,7 +57,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -72,7 +72,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -87,7 +87,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -102,7 +102,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -117,7 +117,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -132,7 +132,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -147,7 +147,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -162,7 +162,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -177,7 +177,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -192,7 +192,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -207,7 +207,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -222,7 +222,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -237,7 +237,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304

--- a/probe-rs/targets/STM32WL Series.yaml
+++ b/probe-rs/targets/STM32WL Series.yaml
@@ -10,7 +10,7 @@ variants:
             start: 536870912
             end: 536891392
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134283264
@@ -25,7 +25,7 @@ variants:
             start: 536870912
             end: 536920064
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -40,7 +40,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872

--- a/probe-rs/targets/nRF51 Series.yaml
+++ b/probe-rs/targets/nRF51 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -24,7 +24,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -40,7 +40,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -56,7 +56,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 196608
@@ -72,7 +72,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -88,7 +88,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -104,7 +104,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 131072
@@ -120,7 +120,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -136,7 +136,7 @@ variants:
             start: 536870912
             end: 536887296
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144

--- a/probe-rs/targets/nRF52 Series.yaml
+++ b/probe-rs/targets/nRF52 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 196608
@@ -24,7 +24,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 196608
@@ -40,7 +40,7 @@ variants:
             start: 536870912
             end: 536895488
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 196608
@@ -56,7 +56,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -72,7 +72,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 524288
@@ -88,7 +88,7 @@ variants:
             start: 536870912
             end: 536903680
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 262144
@@ -104,7 +104,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 524288
@@ -120,7 +120,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 1048576

--- a/probe-rs/targets/nRF91 Series.yaml
+++ b/probe-rs/targets/nRF91 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 537133056
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 0
             end: 1048576


### PR DESCRIPTION
Flash is a bit misleading, because EEPROM or option bytes are covered by this as well.

Note that this change affects target files. I'll update target-gen in a separate PR.