### PR TITLE
Determine flashable memory regions based on flash algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Support for the `HNONSEC` bit in memory access. This now allows secure access on chips which support TrustZone (#???).
+- The flash loader now supports EEPROM and RAM memory types as well (#???).
 
 ### Changed
 
-- Renamed `MemoryRegion::Flash` to `MemoryRegion::Nvm`
-- Renamed `FlashInfo` to `NvmInfo`
-- Renamed `FlashRegion` to `NvmRegion` and its `flash_info()` method to `nvm_info()`
-- Renamed `FlashError::NoSuitableFlash` to `FlashError::NoSuitableNvm`
+- Renamed `MemoryRegion::Flash` to `MemoryRegion::Nvm`.
+- Renamed `FlashRegion` to `NvmRegion` and its `flash_info()` method to `nvm_info()`.
+- Renamed `FlashError::NoSuitableFlash` to `FlashError::NoSuitableMemoryRegion`.
 
 ### Fixed
 

--- a/probe-rs-t2rust/src/lib.rs
+++ b/probe-rs-t2rust/src/lib.rs
@@ -40,7 +40,7 @@ pub fn run(input_dir: impl AsRef<Path>, output_file: impl AsRef<Path>) {
         quote::quote! {
             #[allow(unused_imports)]
             use jep106::JEP106Code;
-            use crate::config::{Chip, RawFlashAlgorithm, NvmRegion, MemoryRegion, RamRegion, SectorDescription, FlashProperties};
+            use crate::config::{Chip, RawFlashAlgorithm, MemoryRegion, RamRegion, SectorDescription, FlashProperties};
 
             use std::borrow::Cow;
         }

--- a/probe-rs/examples/eeprom_download.rs
+++ b/probe-rs/examples/eeprom_download.rs
@@ -1,0 +1,118 @@
+//! This example accepts a path to a binary file on the command line, and
+//! flashes it to the specified base address.
+
+use std::{num::ParseIntError, path::PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use structopt::StructOpt;
+
+use probe_rs::{
+    config::TargetSelector,
+    flashing::{self, BinOptions, DownloadOptions, Format},
+    Probe, WireProtocol,
+};
+
+#[derive(StructOpt)]
+struct CLI {
+    /// Path to a binary file that will be written to the EEPROM.
+    #[structopt(long = "binfile")]
+    binfile: PathBuf,
+    /// The base address. File contents will be written here.
+    #[structopt(long = "address", parse(try_from_str = parse_hex))]
+    base_address: u32,
+    /// If this is set, then the `keep_unwritten_bytes` option is not set when flashing.
+    #[structopt(long = "no-keep-unwritten-bytes")]
+    no_keep_unwritten_bytes: bool,
+    #[structopt(long = "chip")]
+    chip: Option<String>,
+    #[structopt(long = "speed")]
+    speed: Option<u32>,
+    #[structopt(long = "protocol")]
+    protocol: Option<String>,
+}
+
+fn parse_hex(src: &str) -> Result<u32, ParseIntError> {
+    u32::from_str_radix(src.trim_start_matches("0x"), 16)
+}
+
+fn main() -> Result<()> {
+    pretty_env_logger::init();
+
+    // Parse args
+    let matches = CLI::from_args();
+
+    // Open probe
+    let mut probe = open_probe(None)?;
+
+    // Select target
+    let target_selector = match matches.chip {
+        Some(identifier) => identifier.into(),
+        None => TargetSelector::Auto,
+    };
+
+    // Set protocol
+    let protocol = match matches.protocol {
+        Some(protocol) => protocol
+            .parse()
+            .map_err(|e| anyhow!("Unknown protocol: '{}'", e))?,
+        None => WireProtocol::Swd,
+    };
+    probe
+        .select_protocol(protocol)
+        .context("Failed to select SWD as the transport protocol")?;
+
+    // Set speed
+    if let Some(speed) = matches.speed {
+        probe
+            .set_speed(speed)
+            .context("Failed to set probe speed")?;
+    }
+
+    // Attach to target
+    let mut session = probe
+        .attach(target_selector)
+        .context("Failed to attach probe to target")?;
+
+    // Download file
+    flashing::download_file_with_options(
+        &mut session,
+        &matches.binfile,
+        Format::Bin(BinOptions {
+            base_address: Some(matches.base_address),
+            skip: 0,
+        }),
+        DownloadOptions {
+            progress: None,
+            keep_unwritten_bytes: !matches.no_keep_unwritten_bytes,
+        },
+    )
+    .unwrap();
+
+    // Reset core
+    let mut core = session.core(0).context("Failed to attach to core")?;
+    core.reset()?;
+
+    Ok(())
+}
+
+fn open_probe(index: Option<usize>) -> Result<Probe> {
+    let list = Probe::list_all();
+
+    let device = match index {
+        Some(index) => list
+            .get(index)
+            .ok_or(anyhow!("Probe with specified index not found"))?,
+        None => {
+            // open the default probe, if only one probe was found
+            if list.len() == 1 {
+                &list[0]
+            } else {
+                return Err(anyhow!("No probe found."));
+            }
+        }
+    };
+
+    let probe = device.open().context("Failed to open probe")?;
+
+    Ok(probe)
+}

--- a/probe-rs/examples/eeprom_download.rs
+++ b/probe-rs/examples/eeprom_download.rs
@@ -85,8 +85,7 @@ fn main() -> Result<()> {
             progress: None,
             keep_unwritten_bytes: !matches.no_keep_unwritten_bytes,
         },
-    )
-    .unwrap();
+    )?;
 
     // Reset core
     let mut core = session.core(0).context("Failed to attach to core")?;

--- a/probe-rs/src/config/flash_properties.rs
+++ b/probe-rs/src/config/flash_properties.rs
@@ -1,11 +1,12 @@
 use super::memory::SectorDescription;
 use std::{borrow::Cow, ops::Range};
 
-/// Properties of flash memory, which
-/// are used when programming Flash memory.
+/// Properties of flash memory, which are used when programming Flash memory.
 ///
-/// These values are read from the
-/// YAML target description files.
+/// These values are read from the YAML target description files,
+/// and are part of the [`FlashAlgorithm`] struct.
+///
+/// [`FlashAlgorithm`]: crate::config::FlashAlgorithm
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FlashProperties {
     /// The range of the device flash.

--- a/probe-rs/src/config/memory.rs
+++ b/probe-rs/src/config/memory.rs
@@ -9,15 +9,6 @@ pub struct NvmRegion {
     pub is_boot_memory: bool,
 }
 
-impl NvmRegion {
-    /// Returns the necessary information about the NVM.
-    pub fn nvm_info(&self) -> NvmInfo {
-        NvmInfo {
-            rom_start: self.range.start,
-        }
-    }
-}
-
 /// Represents a region in RAM.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RamRegion {
@@ -70,12 +61,6 @@ pub struct PageInfo {
     pub base_address: u32,
     /// Size of the page
     pub size: u32,
-}
-
-/// Holds information about the entire flash.
-#[derive(Debug, Copy, Clone)]
-pub struct NvmInfo {
-    pub rom_start: u32,
 }
 
 /// Enables the user to do range intersection testing.

--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -35,7 +35,9 @@ pub use chip::Chip;
 pub use chip_family::ChipFamily;
 pub use flash_algorithm::{FlashAlgorithm, RawFlashAlgorithm};
 pub use flash_properties::FlashProperties;
-pub use memory::{MemoryRegion, NvmRegion, PageInfo, RamRegion, SectorDescription, SectorInfo};
+pub use memory::{
+    GenericRegion, MemoryRegion, NvmRegion, PageInfo, RamRegion, SectorDescription, SectorInfo,
+};
 pub use registry::{add_target_from_yaml, families, RegistryError};
 pub use target::{Target, TargetParseError, TargetSelector};
 

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -110,11 +110,7 @@ pub fn download_file_with_options(
 
     let memory_map = session.memory_map().to_vec();
     let flash_algorithms = session.flash_algorithms().to_vec();
-    let mut loader = FlashLoader::new(
-        &memory_map,
-        &flash_algorithms,
-        options.keep_unwritten_bytes,
-    );
+    let mut loader = FlashLoader::new(&memory_map, &flash_algorithms, options.keep_unwritten_bytes);
 
     match format {
         Format::Bin(options) => download_bin(&mut buffer, &mut file, &mut loader, options),

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -107,9 +107,14 @@ pub fn download_file_with_options(
     };
     let mut buffer = vec![];
     let mut buffer_vec = vec![];
-    // IMPORTANT: Change this to an actual memory map of a real chip
+
     let memory_map = session.memory_map().to_vec();
-    let mut loader = FlashLoader::new(&memory_map, options.keep_unwritten_bytes);
+    let flash_algorithms = session.flash_algorithms().to_vec();
+    let mut loader = FlashLoader::new(
+        &memory_map,
+        &flash_algorithms,
+        options.keep_unwritten_bytes,
+    );
 
     match format {
         Format::Bin(options) => download_bin(&mut buffer, &mut file, &mut loader, options),
@@ -131,7 +136,7 @@ pub fn download_file_with_options(
 fn download_bin<'buffer, T: Read + Seek>(
     buffer: &'buffer mut Vec<u8>,
     file: &'buffer mut T,
-    loader: &mut FlashLoader<'_, 'buffer>,
+    loader: &mut FlashLoader<'_, '_, 'buffer>,
     options: BinOptions,
 ) -> Result<(), FileDownloadError> {
     // Skip the specified bytes.
@@ -157,7 +162,7 @@ fn download_bin<'buffer, T: Read + Seek>(
 fn download_hex<'buffer, T: Read + Seek>(
     buffer: &'buffer mut Vec<(u32, Vec<u8>)>,
     file: &mut T,
-    loader: &mut FlashLoader<'_, 'buffer>,
+    loader: &mut FlashLoader<'_, '_, 'buffer>,
 ) -> Result<(), FileDownloadError> {
     let mut _extended_segment_address = 0;
     let mut extended_linear_address = 0;
@@ -193,7 +198,7 @@ fn download_hex<'buffer, T: Read + Seek>(
 fn download_elf<'buffer, T: Read + Seek>(
     buffer: &'buffer mut Vec<u8>,
     file: &'buffer mut T,
-    loader: &mut FlashLoader<'_, 'buffer>,
+    loader: &mut FlashLoader<'_, '_, 'buffer>,
 ) -> Result<(), FileDownloadError> {
     use goblin::elf::program_header::*;
 

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -2,8 +2,9 @@
 
 use thiserror::Error;
 
-use crate::config::NvmRegion;
 use crate::error;
+
+use std::ops::Range;
 
 /// Describes any error that happened during the or in preparation for the flashing procedure.
 #[derive(Error, Debug)]
@@ -20,8 +21,8 @@ pub enum FlashError {
     Memory(#[source] error::Error),
     #[error("Something during the interaction with the core went wrong")]
     Core(#[source] error::Error),
-    #[error("{address} is not contained in {region:?}")]
-    AddressNotInRegion { address: u32, region: NvmRegion },
+    #[error("{address} is not contained in region {region:?}")]
+    AddressNotInRegion { address: u32, region: Range<u32> },
     #[error("Flash algorithm length is not 32 bit aligned.")]
     InvalidFlashAlgorithmLength,
     #[error(
@@ -36,8 +37,8 @@ pub enum FlashError {
     DataOverlap(u32),
     #[error("Address {0:#010x} is not a valid address in the flash area.")]
     InvalidFlashAddress(u32),
-    #[error("No NVM memory contains the entire requested memory range {start:#08X}..{end:#08X}.")]
-    NoSuitableNvm { start: u32, end: u32 },
+    #[error("No memory region contains the entire requested memory range {start:#08X}..{end:#08X}.")]
+    NoSuitableMemoryRegion { start: u32, end: u32 },
     #[error("Trying to write flash, but no suitable flash loader algorithm is linked to the given target information.")]
     NoFlashLoaderAlgorithmAttached,
     #[error(transparent)]

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -37,7 +37,9 @@ pub enum FlashError {
     DataOverlap(u32),
     #[error("Address {0:#010x} is not a valid address in the flash area.")]
     InvalidFlashAddress(u32),
-    #[error("No memory region contains the entire requested memory range {start:#08X}..{end:#08X}.")]
+    #[error(
+        "No memory region contains the entire requested memory range {start:#08X}..{end:#08X}."
+    )]
     NoSuitableMemoryRegion { start: u32, end: u32 },
     #[error("Trying to write flash, but no suitable flash loader algorithm is linked to the given target information.")]
     NoFlashLoaderAlgorithmAttached,

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -1,39 +1,56 @@
 use super::{FlashBuilder, FlashError, FlashProgress, Flasher};
-use crate::config::{MemoryRange, MemoryRegion, NvmRegion};
+use crate::config::{MemoryRange, MemoryRegion, RawFlashAlgorithm};
 use crate::memory::MemoryInterface;
 use crate::session::Session;
 use anyhow::anyhow;
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Range};
 
 struct RamWrite<'data> {
     address: u32,
     data: &'data [u8],
 }
 
+/// Flashable memory types.
+pub(super) enum MemoryType {
+    /// Non-volatile memory, e.g. flash or EEPROM.
+    Nvm,
+    /// RAM.
+    Ram,
+}
+
 /// `FlashLoader` is a struct which manages the flashing of any chunks of data onto any sections of flash.
 /// Use `add_data()` to add a chunks of data.
 /// Once you are done adding all your data, use `commit()` to flash the data.
 /// The flash loader will make sure to select the appropriate flash region for the right data chunks.
-/// Region crossing data chunks are allowed as long as the regions are contiguous.
-pub(super) struct FlashLoader<'mmap, 'data> {
+/// Region crossing data chunks are allowed as long as the regions are
+/// contiguous and the same flash algorithm can be used for all of them.
+pub(super) struct FlashLoader<'mmap, 'algos, 'data> {
     memory_map: &'mmap [MemoryRegion],
-    builders: HashMap<NvmRegion, FlashBuilder<'data>>,
+    flash_algorithms: &'algos [RawFlashAlgorithm],
+    builders: HashMap<Range<u32>, FlashBuilder<'data>>,
     ram_write: Vec<RamWrite<'data>>,
     keep_unwritten: bool,
 }
 
-impl<'mmap, 'data> FlashLoader<'mmap, 'data> {
-    pub(super) fn new(memory_map: &'mmap [MemoryRegion], keep_unwritten: bool) -> Self {
+impl<'mmap, 'algos, 'data> FlashLoader<'mmap, 'algos, 'data> {
+    pub(super) fn new(
+        memory_map: &'mmap [MemoryRegion],
+        flash_algorithms: &'algos [RawFlashAlgorithm],
+        keep_unwritten: bool,
+    ) -> Self {
         Self {
             memory_map,
+            flash_algorithms,
             builders: HashMap::new(),
             ram_write: Vec::new(),
             keep_unwritten,
         }
     }
+
     /// Stages a chunk of data to be programmed.
     ///
-    /// The chunk can cross flash boundaries as long as one flash region connects to another flash region.
+    /// Region crossing data chunks are allowed as long as the regions are
+    /// contiguous and the same flash algorithm can be used for all of them.
     pub(super) fn add_data(
         &mut self,
         mut address: u32,
@@ -42,68 +59,68 @@ impl<'mmap, 'data> FlashLoader<'mmap, 'data> {
         let size = data.len();
         let mut remaining = size;
         while remaining > 0 {
-            // Get the flash region in with this chunk of data starts.
-            let possible_region = Self::get_region_for_address(self.memory_map, address);
+            // Get the flash region in which this chunk of data starts.
+            let (range, memory_type) = self.get_region_for_address(address).ok_or_else(|| {
+                FlashError::NoSuitableMemoryRegion {
+                    start: address,
+                    end: address + data.len() as u32,
+                }
+            })?;
+
+            // Determine how much more data can be contained by this region.
+            let program_length = usize::min(remaining, (range.end - address + 1) as usize);
+
             // If we found a corresponding region, create a builder.
-            match possible_region {
-                Some(MemoryRegion::Nvm(region)) => {
-                    // Get our builder instance.
-                    if !self.builders.contains_key(region) {
-                        self.builders.insert(region.clone(), FlashBuilder::new());
-                    };
-
-                    // Determine how much more data can be contained by this region.
-                    let program_length =
-                        usize::min(remaining, (region.range.end - address + 1) as usize);
-
+            match memory_type {
+                MemoryType::Nvm => {
                     // Add as much data to the builder as can be contained by this region.
                     self.builders
-                        .get_mut(&region)
-                        .map(|r| r.add_data(address, &data[size - remaining..program_length]));
-
-                    // Advance the cursors.
-                    remaining -= program_length;
-                    address += program_length as u32
+                        .entry(range)
+                        .or_insert_with(FlashBuilder::new)
+                        .add_data(address, &data[size - remaining..program_length])?;
                 }
-                Some(MemoryRegion::Ram(region)) => {
-                    // Determine how much more data can be contained by this region.
-                    let program_length =
-                        usize::min(remaining, (region.range.end - address + 1) as usize);
-
+                MemoryType::Ram => {
                     // Add data to be written to the vector.
                     let data = &data[size - remaining..program_length];
                     self.ram_write.push(RamWrite { address, data });
-
-                    // Advance the cursors.
-                    remaining -= program_length;
-                    address += program_length as u32
-                }
-                _ => {
-                    return Err(FlashError::NoSuitableNvm {
-                        start: address,
-                        end: address + data.len() as u32,
-                    })
                 }
             }
+
+            // Advance the cursors.
+            remaining -= program_length;
+            address += program_length as u32
         }
         Ok(())
     }
 
-    pub(super) fn get_region_for_address(
-        memory_map: &[MemoryRegion],
-        address: u32,
-    ) -> Option<&MemoryRegion> {
-        for region in memory_map {
-            let r = match region {
-                MemoryRegion::Ram(r) => r.range.clone(),
-                MemoryRegion::Nvm(r) => r.range.clone(),
-                MemoryRegion::Generic(r) => r.range.clone(),
-            };
-            if r.contains(&address) {
-                return Some(region);
-            }
+    /// Find the appropriate memory region for that address.
+    pub(super) fn get_region_for_address(&self, address: u32) -> Option<(Range<u32>, MemoryType)> {
+        // Look through the flash algorithms, check whether we know of a flash
+        // algorithm that can flash the specified address.
+        let flashable_range = self
+            .flash_algorithms
+            .iter()
+            .map(|algo| &algo.flash_properties.address_range)
+            .filter(|range| range.contains(&address))
+            .next();
+        if let Some(range) = flashable_range {
+            return Some((range.clone(), MemoryType::Nvm));
         }
-        None
+
+        // If no flash algorithm could be found for that range, check whether a
+        // RAM memory region could match (since that's supported as well by the
+        // flash loader).
+        self.memory_map
+            .iter()
+            .filter_map(|mmap| {
+                if let MemoryRegion::Ram(region) = mmap {
+                    Some(region.range.clone())
+                } else {
+                    None
+                }
+            })
+            .map(|range| (range, MemoryType::Ram))
+            .next()
     }
 
     /// Writes all the stored data chunks to flash.
@@ -118,11 +135,11 @@ impl<'mmap, 'data> FlashLoader<'mmap, 'data> {
         do_chip_erase: bool,
     ) -> Result<(), FlashError> {
         // Iterate over builders we've created and program the data.
-        for (region, builder) in &self.builders {
+        for (range, builder) in &self.builders {
             log::debug!(
                 "Using builder for region (0x{:08x}..0x{:08x})",
-                region.range.start,
-                region.range.end
+                range.start,
+                range.end
             );
 
             // Try to find a flash algorithm for the range of the current builder
@@ -139,11 +156,7 @@ impl<'mmap, 'data> FlashLoader<'mmap, 'data> {
             let algorithms = session.flash_algorithms();
             let algorithms = algorithms
                 .iter()
-                .filter(|fa| {
-                    fa.flash_properties
-                        .address_range
-                        .contains_range(&region.range)
-                })
+                .filter(|fa| fa.flash_properties.address_range.contains_range(range))
                 .collect::<Vec<_>>();
 
             log::debug!("Algorithms: {:?}", &algorithms);
@@ -171,7 +184,7 @@ impl<'mmap, 'data> FlashLoader<'mmap, 'data> {
             let flash_algorithm = raw_flash_algorithm.assemble(ram, session.architecture())?;
 
             // Program the data.
-            let mut flasher = Flasher::new(session, flash_algorithm, region.clone());
+            let mut flasher = Flasher::new(session, flash_algorithm, range.clone());
             flasher.program(builder, do_chip_erase, self.keep_unwritten, false, progress)?
         }
 


### PR DESCRIPTION
Previously, we used the `memory_map` entries in the target description
file to determine whether an NVM address was flashable or not. However,
some target CMSIS-Packs did not include ranges for all flashable areas
(e.g. EEPROM), even though a corresponding flash algorithm exists.

However, if we have a flash algorithm, then we can flash this memory
region, even if no corresponding entry in the `memory_map` exists.

This commit updates the flash loader to use only the flash algorithms to
determine whether an NVM address is flashable or not.

Based on #482, merge that first!