### PR TITLE
Improve gdbserver cmdline

### DIFF
--- a/gdb-server/Cargo.toml
+++ b/gdb-server/Cargo.toml
@@ -23,13 +23,14 @@ required-features = ["build-binary"]
 
 [features]
 build-binary = ["pretty_env_logger", "structopt", "failure", "colored"]
+ftdi = ["probe-rs/ftdi"]
 
 [dependencies]
 pretty_env_logger = { version = "0.4.0", optional = true }
 structopt = { version = "0.3.2", optional = true }
 failure = { version = "0.1.5", optional = true }
 colored = { version = "2.0.0", optional = true }
-probe-rs = { path = "../probe-rs", version = "0.10.0", features = ["ftdi"] }
+probe-rs = { path = "../probe-rs", version = "0.10.0" }
 gdb-protocol = { version = "0.1.0" }
 async-std = { version = "1.7.0" }
 futures = "0.3.1"

--- a/gdb-server/Cargo.toml
+++ b/gdb-server/Cargo.toml
@@ -29,7 +29,7 @@ pretty_env_logger = { version = "0.4.0", optional = true }
 structopt = { version = "0.3.2", optional = true }
 failure = { version = "0.1.5", optional = true }
 colored = { version = "2.0.0", optional = true }
-probe-rs = { path = "../probe-rs", version = "0.10.0" }
+probe-rs = { path = "../probe-rs", version = "0.10.0", features = ["ftdi"] }
 gdb-protocol = { version = "0.1.0" }
 async-std = { version = "1.7.0" }
 futures = "0.3.1"

--- a/gdb-server/src/bin.rs
+++ b/gdb-server/src/bin.rs
@@ -30,7 +30,7 @@ struct Opt {
         help = "Use this flag to override the default GDB connection string (localhost:1337)."
     )]
     gdb_connection_string: Option<String>,
-    #[structopt(name = "list", long = "list", help = "list available debug probes")]
+    #[structopt(name = "list-probes", long = "list-probes", help = "list available debug probes")]
     list: bool,
     #[structopt(
         name = "debug probe index",
@@ -59,7 +59,7 @@ pub fn open_probe(
     let device = match index {
         Some(index) => available_probes
             .get(index)
-            .ok_or_else(|| failure::err_msg("Unable to open the specified probe. Use the '--list' flag to see all available probes."))?,
+            .ok_or_else(|| failure::err_msg("Unable to open the specified probe. Use the '--list-probes' flag to see all available probes."))?,
         None => {
             // open the default probe, if only one probe was found
             match available_probes.len() {


### PR DESCRIPTION
I made some improvements to the gdb-server cmdline included in the repository.
The cmdline is not probably not really used that much, because projects like cargo-embed exist.

Anyway, I want to add these improvements, because the gdb-server makes it easy to test other parts of probe-rs, and I intend to do some testing / improving of the riscv target.