### PR TITLE
Rename flash to Nvm in probe-rs-t2rust

### DIFF
--- a/probe-rs-t2rust/src/lib.rs
+++ b/probe-rs-t2rust/src/lib.rs
@@ -270,7 +270,7 @@ fn extract_memory_map(chip: &serde_yaml::Value) -> Vec<proc_macro2::TokenStream>
                     }
                 })
                 .or_else(|| {
-                    memory_region.get("Flash").map(|region| {
+                    memory_region.get("Nvm").map(|region| {
                         let range = region.get("range").unwrap();
                         let start = range.get("start").unwrap().as_u64().unwrap() as u32;
                         let end = range.get("end").unwrap().as_u64().unwrap() as u32;


### PR DESCRIPTION
Rename `Flash` to `Nvm` in probe-rs-t2rust, otherwise the flash ranges are not included in the built-in targets.