### PR TITLE
Add support for flashing nrf52 uicr

### DIFF
--- a/probe-rs/targets/nRF52 Series.yaml
+++ b/probe-rs/targets/nRF52 Series.yaml
@@ -5,178 +5,166 @@ variants:
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
       - Nvm:
           range:
             start: 0
-            end: 196608
+            end: 0x30000
           is_boot_memory: true
+      - Nvm:
+          range:
+            start: 0x10001000
+            end: 0x10002000
+          is_boot_memory: false
     flash_algorithms:
-      - nrf52xxx
-      - nrf52xxx_uicr
-      - nrf52xxx_sde
+      - nrf52
+      - nrf52_uicr
   - name: nRF52810_xxAA
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
       - Nvm:
           range:
             start: 0
-            end: 196608
+            end: 0x30000
           is_boot_memory: true
+      - Nvm:
+          range:
+            start: 0x10001000
+            end: 0x10002000
+          is_boot_memory: false
     flash_algorithms:
-      - nrf52xxx
-      - nrf52xxx_uicr
-      - nrf52xxx_sde
+      - nrf52
+      - nrf52_uicr
   - name: nRF52811_xxAA
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
       - Nvm:
           range:
             start: 0
-            end: 196608
+            end: 0x30000
           is_boot_memory: true
+      - Nvm:
+          range:
+            start: 0x10001000
+            end: 0x10002000
+          is_boot_memory: false
     flash_algorithms:
-      - nrf52xxx
-      - nrf52xxx_uicr
-      - nrf52xxx_sde
+      - nrf52
+      - nrf52_uicr
   - name: nRF52820_xxAA
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
       - Nvm:
           range:
             start: 0
-            end: 262144
+            end: 0x40000
           is_boot_memory: true
+      - Nvm:
+          range:
+            start: 0x10001000
+            end: 0x10002000
+          is_boot_memory: false
     flash_algorithms:
-      - nrf52xxx
-      - nrf52xxx_uicr
-      - nrf52xxx_sde
+      - nrf52
+      - nrf52_uicr
   - name: nRF52832_xxAA
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
       - Nvm:
           range:
             start: 0
-            end: 524288
+            end: 0x80000
           is_boot_memory: true
+      - Nvm:
+          range:
+            start: 0x10001000
+            end: 0x10002000
+          is_boot_memory: false
     flash_algorithms:
-      - nrf52xxx
-      - nrf52xxx_uicr
-      - nrf52xxx_sde
+      - nrf52
+      - nrf52_uicr
   - name: nRF52832_xxAB
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
       - Nvm:
           range:
             start: 0
-            end: 262144
+            end: 0x100000
           is_boot_memory: true
+      - Nvm:
+          range:
+            start: 0x10001000
+            end: 0x10002000
+          is_boot_memory: false
     flash_algorithms:
-      - nrf52xxx
-      - nrf52xxx_uicr
-      - nrf52xxx_sde
+      - nrf52
+      - nrf52_uicr
   - name: nRF52833_xxAA
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
       - Nvm:
           range:
             start: 0
-            end: 524288
+            end: 0x80000
           is_boot_memory: true
+      - Nvm:
+          range:
+            start: 0x10001000
+            end: 0x10002000
+          is_boot_memory: false
     flash_algorithms:
-      - nrf52xxx
-      - nrf52xxx_uicr
-      - nrf52xxx_sde
+      - nrf52
+      - nrf52_uicr
   - name: nRF52840_xxAA
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
       - Nvm:
           range:
             start: 0
-            end: 1048576
+            end: 0x100000
           is_boot_memory: true
+      - Nvm:
+          range:
+            start: 0x10001000
+            end: 0x10002000
+          is_boot_memory: false
     flash_algorithms:
-      - nrf52xxx
-      - nrf52xxx_uicr
-      - nrf52xxx_sde
+      - nrf52
+      - nrf52_uicr
 flash_algorithms:
-  nrf52xxx:
-    name: nrf52xxx
-    description: nRF52xxx
-    default: false
-    instructions: sLUURkDyBAXA8gAFACBJ+AUACesFAcHpAQDIYNCyAPBV+gAoHr8J6wUBwekCBLC9CesFAAEhQWAA8B76ACCwvRC1BEYAIADwQfo4sUDyBAHA8gABSUTB6QIEEL1A8gQAwPIAAAnrAAGJaAApBL8AIBC9RPIAAcLyAAEBIgpgWfgAIEpgSERCaIpggmjKYMBoCGEAIBC9AL9A8gQAwPIAAAEhSfgAEEhEACHA6QERwWAA8Ey6sLUERkDyBAXA8gAFAiBJ+AUACesFAAAhwOkBEcFgAPCf+bT78PEB+xBAMLEJ6wUAAyHA6QIUZSCwvQnrBQABIUFgAPCj+aBCE9gA8KH5oEIP2QnrBQACIUFgIEYA8Mj5Aygcv2cgsL0gRgDw//kAILC9CesFAAQhwOkCFGYgsL0t6fBBFUYORgRGQPIEB8DyAAcDIEn4BwAJ6wcBACLB6QEiymChBwbQCesHAcHpAgRlIL3o8IEJ6wcAASFBYADwZfmgQhXYAPBj+aBCEdkJ6wcAAyFBYAbrBAgA8Fn5gEUP2QnrBwAEIcDpAhhmIL3o8IEJ6wcABCHA6QIUZiC96PCBCesHAAQhQWAA8G/5MLEJ6wcAAiGBYGcgvejwgQnrBwAFIUFgIEYA8GL5AigH0gnrBwACIcDpAhRnIL3o8IEP0SBGMUb/IgDwNPhIsQMgSfgHAAnrBwAFIUFgZyC96PCBAyBJ+AcACesHAAYhQWAAILDrlg8Iv73o8IFP6pYIACZU+CYAATAL0VX4JgBE+CYAAPBb+QE2ACBGRfHTvejwgQnrBwChGQUiwOkCIWggvejwgS3p8EEWRg1GBEZA8gQHwPIABwUgSfgHAAnrBwAAIcDpARHBYKgHB9AJ6wcAAyHA6QIVZSC96PCBCesHAAIhQWAA8Mr4oEIV2ADwyPigQhHZCesHAAMhQWAF6wQIAPC++IBFD9kJ6wcABCHA6QIYZiC96PCBCesHAAQhwOkCFGYgvejwgQnrBwAEIUFgAC0EvwAgvejwgQAhBuAAvwExACCpQii/vejwgWBcsEL20AnrBwAhRAUiwOkCIQEgvejwgS3p8EGQRg9GBEZA8gQFwPIABQQgSfgFAAnrBQAAIcDpARHBYKAHCNAJ6wUAAyHA6QIUZSYwRr3o8IEJ6wUAASFBYADwafigQhLYAPBn+KBCDtkJ6wUAAyFBYD4ZAPBe+IZCDtkJ6wUABCHA6QIWBOAJ6wUABCHA6QIUZiYwRr3o8IEJ6wUABCFBYAAgsOuXDwvQuAgAIQC/WPghICNok0IK0QExBDSBQvbTCesFAAUhQWAwRr3o8IEJ6wUABiHA6QIUIEa96PCBQPIwEMHyAAABaAExHL8AaHBHQPbgcM/yAABBaAB4YfMLIHBHECDB8gAAAWgBMRS/AGhP9IBQcEcUIMHyAAABaAExFL8AaE/0AHBwRwAgcEcAIHBHELX/9+X/BEb/9+z/YEMQvQFEgUKcvwEgcEcD4IhCJL8BIHBHUPgEKwEyHL8AIHBH9OcAv4C1//e5/w8oiL+AvQEhAfoA8EzyQEIQQh6/QPIIYMTyAAABYIC9AL8AIHBHQ/IEAQloTvLbUsXysRKRQhy/AyBwR0PyCAEKaAMhgkKIvwIhCEZwRwMohL9pIHBHgLVAsgWhUfggAE7yBFHE8gEBCGAA8Ar4ACCAvQAAAAACAAAAAQAAAAAAAABO8gBAxPIBAAFoACn80HBHTvIMUMTyAQABIQFg8OcAv4GwAJAAmE7yCFHE8gEBCGABsOXngLVO8hRQxPIBAAEhAWD/993/ACCAvQC/cLX/93n/BEYAJQAg//ek/wIoBdA4uQEmACWlQgbTDeBD8ggABWgAJqVCB9IoRv/30f//90n/BUSlQvfTAC4Yv//30v8AIHC9AAAAAAAAAAAAAAAAAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 65
-    pc_program_page: 309
-    pc_erase_sector: 181
-    pc_erase_all: 153
-    data_section_offset: 1428
-    flash_properties:
-      address_range:
-        start: 0
-        end: 2097152
-      page_size: 4096
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
-      sectors:
-        - size: 4096
-          address: 0
-  nrf52xxx_uicr:
-    name: nrf52xxx_uicr
-    description: nRF52xxx UICR Erase
-    default: true
-    instructions: cLUURkDyBAbA8gAGACVJ+AZQCesGAMDpAVXFYNCyAPD7+QAoHr8J6wYBwekCBAVGKEZwvRC1BEYAIADw7flA8gQBwPIAAUlEELHB6QIEA+CJaAApCL8QvUTyAAHC8gABASIKYEDyBALA8gACWfgCMEtgSkRTaItgk2jLYNJoCmEQvQC/QPIEAMDyAAABIUn4ABBIRAAhwOkBEcFgAPDwuRC1QPIEAMDyAAACIUn4ABBIRAAkwOkBRMRgAPBR+QFGT/AQIP8iAPAP+DixAPDY+QRGaSgE0AAsCL8AJCBGEL0AJCBGEL0Av7C1QPIEDMDyAAwFI0n4DDAJ6wwDT/AADsPpAe7D+AzggwcF0AnrDAEDIsHpAiAL4AnrDA4BI874BDCLBwjQCesMAAMiwOkCIU/wZQ5wRrC9CesMDgIjzvgEMEH2/3XB8gAFqEIF2QnrDAEEIsHpAiAN4AnrDAMDJFxgAesADmscnkUI2QnrDAAEIcDpAh5P8GYOcEawvVGxACNP8AAOAL/FXJVCB9EBM4tC+dML4E/wAA5wRrC9CesMARhEBSLB6QIgT/ABDnBGsL0Avy3p8EEVRgRGQPIEBsDyAAYDIEn4BgAJ6wYCACPC6QEz02CKBwbQCesGAsLpAgFlIL3o8IEJ6wYAAiJCYEH2/3LB8gAClEIH2QnrBgAEIcDpAhRmIL3o8IEJ6wYAAyNDYAgZATKQQgfZCesGAQQiwekCIGYgvejwgQAgsOuRDxrQT+qRCAAnC+BV+CcARPgnAADwAvkBNwAgR0Uov73o8IFU+CcAATDv0AnrBgDhGQUiwOkCIWggvejwgQC/sLVA8gQFwPIABQQjSfgFMAnrBQMAJMPpAUTcYIMHBtAJ6wUBAyLB6QIgZSCwvQnrBQMBJFxgiwcG0AnrBQADIsDpAiFlILC9CesFAwIkXGBB9v9+wfIADnBFBtkJ6wUBBCLB6QIgZiCwvQnrBQMDJFxgAesADA7xAQOcRQbZCesFAAQhwOkCHGYgsL0J6wUDBCRcYAAjs+uRDwS/YEawvU/qkQ4AIQXgATEEMHFFJL9gRrC9UvghMARonEL00AnrBQEGIsHpAiCwvQAAQPIwEMHyAAABaAExHL8AaHBHQPbgcM/yAABBaAB4YfMLIHBHECDB8gAAAWgBMRS/AGhP9IBQcEcUIMHyAAABaAExFL8AaE/0AHBwRwAgcEcAIHBHELX/9+X/BEb/9+z/YEMQvQFEgUKcvwEgcEcD4IhCJL8BIHBHUPgEKwEyHL8AIHBH9OcAv4C1//e5/w8oiL+AvQEhAfoA8EzyQEIQQh6/QPIIYMTyAAABYIC9AL8AIHBHQ/IEAQloTvLbUsXysRKRQhy/AyBwR0PyCAEKaAMhgkKIvwIhCEZwRwMohL9pIHBHgLVAsgWhUfggAE7yBFHE8gEBCGAA8Ar4ACCAvQAAAAACAAAAAQAAAAAAAABO8gBAxPIBAAFoACn80HBHTvIMUMTyAQABIQFg8OcAv4GwAJAAmE7yCFHE8gEBCGABsOXngLVO8hRQxPIBAAEhAWD/993/ACCAvQC/cLX/93n/BEYAJQAg//ek/wIoBdA4uQEmACWlQgbTDeBD8ggABWgAJqVCB9IoRv/30f//90n/BUSlQvfTAC4Yv//30v8AIHC9AAAAAAAAAAAAAAAAAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 53
-    pc_program_page: 437
-    pc_erase_sector: 161
-    pc_erase_all: 133
-    data_section_offset: 1248
-    flash_properties:
-      address_range:
-        start: 268439552
-        end: 268443648
-      page_size: 4096
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
-      sectors:
-        - size: 4096
-          address: 0
-  nrf52xxx_sde:
-    name: nrf52xxx_sde
-    description: nRF52xxx SoftDevice Erase
+  nrf52:
+    name: nrf52
+    description: nrf52
     default: true
     instructions: AL4K4A14LQZoQAgkQAAA01hAZB760UkcUh4AKvLRcEcAIHBHACBwR3C1JkwCIGBgASDgYCRNKGjABwLQACBgYHC9APAs+PbncLUeTAIhYWAeSYhCAtMBIGBhAOCgYBpNAPAd+ChowAf60AAgYGBwvfi1BUaOCBNIASEURkFgEk8BzAHFOGjABwbQdh740Q1IACFBYAhG+L0A8AH48ucMSEBoAAYADgvQCklJaAApB9AJSQpKwwcA0ApgCR1ACPnRcEcAAADlAUAA5AFAABAAEAAEAUAABQFAAAYBQDVGUm4AAAAA
     pc_init: 0x21
@@ -188,12 +176,34 @@ flash_algorithms:
     flash_properties:
       address_range:
         start: 0
-        end: 2097152
-      page_size: 4096
-      erased_byte_value: 255
+        end: 0x100000
+      page_size: 0x1000
+      erased_byte_value: 0xFF
       program_page_timeout: 1000
       erase_sector_timeout: 3000
       sectors:
-        - size: 4096
+        - size: 0x1000
+          address: 0
+  nrf52_uicr:
+    name: nrf52_uicr
+    description: nrf52_uicr
+    default: false
+    instructions: AL4K4A14LQZoQAgkQAAA01hAZB760UkcUh4AKvLRcEcAIHBHACBwR3C1JkwCIGBgASDgYCRNKGjABwLQACBgYHC9APAs+PbncLUeTAIhYWAeSYhCAtMBIGBhAOCgYBpNAPAd+ChowAf60AAgYGBwvfi1BUaOCBNIASEURkFgEk8BzAHFOGjABwbQdh740Q1IACFBYAhG+L0A8AH48ucMSEBoAAYADgvQCklJaAApB9AJSQpKwwcA0ApgCR1ACPnRcEcAAADlAUAA5AFAABAAEAAEAUAABQFAAAYBQDVGUm4AAAAA
+    pc_init: 0x21
+    pc_uninit: 0x21
+    pc_program_page: 0x71
+    pc_erase_sector: 0x49
+    pc_erase_all: 0x29
+    data_section_offset: 0x170
+    flash_properties:
+      address_range:
+        start: 0x10001000
+        end: 0x10002000
+      page_size: 0x1000
+      erased_byte_value: 0xFF
+      program_page_timeout: 1000
+      erase_sector_timeout: 3000
+      sectors:
+        - size: 0x1000
           address: 0
 core: M4


### PR DESCRIPTION
- Changed all addresses to hex (much more readable!)
- Removed unused old flash algos
- Added nrf52_uicr flash algo, which is identical to the main one (the algo checks the address and does the right thing)
- Added uicr NVM region to all chips.