### PR TITLE
Fix double whitespace in DebugProbeInfo

### DIFF
--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -504,13 +504,13 @@ impl std::fmt::Debug for DebugProbeInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "{} (VID: {:04x}, PID: {:04x}, {} {:?})",
+            "{} (VID: {:04x}, PID: {:04x}, {}{:?})",
             self.identifier,
             self.vendor_id,
             self.product_id,
             self.serial_number
                 .clone()
-                .map_or("".to_owned(), |v| format!("Serial: {},", v)),
+                .map_or("".to_owned(), |v| format!("Serial: {}, ", v)),
             self.probe_type
         )
     }


### PR DESCRIPTION
Before:

    [0]: Dual RS232-HS (VID: 0403, PID: 6010,  FTDI)
    [1]: J-Link (J-Link) (VID: 1366, PID: 0101, Serial: 00026010xxxx, JLink)

After:

    [0]: Dual RS232-HS (VID: 0403, PID: 6010, FTDI)
    [1]: J-Link (J-Link) (VID: 1366, PID: 0101, Serial: 00026010xxxx, JLink)

(Double whitespace in front of "FTDI" is now gone.)