### PR TITLE
Replace goblin crate with object crate

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -35,7 +35,6 @@ bitfield = "0.13.2"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_yaml = "0.8.11"
 ihex = "3.0.0"
-goblin = "0.3.0"
 hexdump = { version = "0.1.0", optional = true }
 thiserror = "1.0.10"
 jaylink = "0.1.4"

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -224,7 +224,7 @@ fn download_elf<'buffer, T: Read + Seek>(
             .data(endian, Bytes(buffer))
             .map_err(|_| FileDownloadError::Object("Failed to access data for an ELF segment."))?;
 
-        if segment_data.len() > 0 {
+        if !segment_data.is_empty() {
             log::info!("Found loadable segment, address: {:#010x}", p_paddr);
 
             let (segment_offset, segment_filesize) = segment.file_range(endian);


### PR DESCRIPTION
Reduce the number of dependencies by replacing the `goblin` crate with `object`, which we're already using anyways.