### PR TITLE
riscv: fix abstractauto register address

### DIFF
--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -1167,7 +1167,7 @@ bitfield! {
 }
 
 impl DebugRegister for Abstractauto {
-    const ADDRESS: u8 = 0x38;
+    const ADDRESS: u8 = 0x18;
     const NAME: &'static str = "abstractauto";
 }
 


### PR DESCRIPTION
`abstractauto` was incorrectly specified as being at 0x38, which is actually the address of `sbcs` (which is specified correctly).

![Table 3.8: Debug Module Debug Bus Registers, RISC-V External Debug Support Version 0.13.2](https://user-images.githubusercontent.com/691552/103267642-d2204c00-4a16-11eb-879f-d84322a805b1.png)

Implementations may choose not to implement `abstractauto` -- in this case writes to the register are ignored, and reads produce all zeros. The following code attempts to detect it, by writing a 1 and seeing if is read back:

https://github.com/probe-rs/probe-rs/blob/205a8088aa8f9f303ba1a162fc7417b9517bad58/probe-rs/src/architecture/riscv/communication_interface.rs#L255-L265

Here's what that looks like in practice:
```
 DEBUG > Write DM register 'abstractauto' at 0x00000038 = 0x00000001
 DEBUG > Reading DM register 'abstractauto' at 0x00000038
 DEBUG > Read DM register 'abstractauto' at 0x00000038 = 0x20040407
 DEBUG > Support for autoexec: false
```

`0x20040407` (the contents of `sbcs`) is a nonsensical result, so it assumed to not exist, regardless of whether it really does

Thanks!