### PR TITLE
Implemented Target Voltage Measurement

### DIFF
--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -488,10 +488,8 @@ impl DebugProbe for JLink {
             Err(_) => log::info!("J-Link: Hardware version: ?"),
         };
 
-        // Verify target voltage (VTref pin). If this is 0, the device is not powered.
-        // We can call .unwrap() here, as errors get propagated by ?, and the J-Link
-        // supports reading the target voltage, so we’re always going to get Some(f32).
-        let target_voltage = self.get_target_voltage()?.unwrap();
+        // Check and report the target voltage.
+        let target_voltage = self.get_target_voltage()?.expect("The J-Link returned None when it should only be able to return Some(f32) or an error. Please report this bug!");
         if target_voltage < crate::probe::LOW_TARGET_VOLTAGE_WARNING_THRESHOLD {
             log::warn!(
                 "J-Link: Target voltage (VTref) is {:2.2} V. Is your target device powered?",
@@ -640,8 +638,8 @@ impl DebugProbe for JLink {
         }
     }
 
-    // self.handle.read_target_voltage() returns the voltage as an integer in mV.
     fn get_target_voltage(&mut self) -> Result<Option<f32>, DebugProbeError> {
+        // Convert the integer millivolts value from self.handle to volts as an f32.
         Ok(Some((self.handle.read_target_voltage()? as f32) / 1000f32))
     }
 }

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -488,14 +488,16 @@ impl DebugProbe for JLink {
             Err(_) => log::info!("J-Link: Hardware version: ?"),
         };
 
-        // Verify target voltage (VTref pin, mV). If this is 0, the device is not powered.
-        let target_voltage = self.handle.read_target_voltage()?;
-        if target_voltage == 0 {
+        // Verify target voltage (VTref pin). If this is 0, the device is not powered.
+        // We can call .unwrap() here, as errors get propagated by ?, and the J-Link
+        // supports reading the target voltage, so we’re always going to get Some(f32).
+        let target_voltage = self.get_target_voltage()?.unwrap();
+        if target_voltage == crate::probe::LOW_TARGET_VOLTAGE_WARNING_THRESHOLD {
             log::warn!("J-Link: Target voltage (VTref) is 0 V. Is your target device powered?");
         } else {
             log::info!(
                 "J-Link: Target voltage: {:2.2} V",
-                target_voltage as f32 / 1000f32
+                target_voltage
             );
         }
 
@@ -636,6 +638,11 @@ impl DebugProbe for JLink {
         } else {
             Err((self, DebugProbeError::InterfaceNotAvailable("SWD/ARM")))
         }
+    }
+
+    // self.handle.read_target_voltage() returns the voltage as an integer in mV.
+    fn get_target_voltage(&mut self) -> Result<Option<f32>, DebugProbeError> {
+        Ok(Some((self.handle.read_target_voltage()? as f32) / 1000f32))
     }
 }
 

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -492,8 +492,11 @@ impl DebugProbe for JLink {
         // We can call .unwrap() here, as errors get propagated by ?, and the J-Link
         // supports reading the target voltage, so we’re always going to get Some(f32).
         let target_voltage = self.get_target_voltage()?.unwrap();
-        if target_voltage == crate::probe::LOW_TARGET_VOLTAGE_WARNING_THRESHOLD {
-            log::warn!("J-Link: Target voltage (VTref) is 0 V. Is your target device powered?");
+        if target_voltage < crate::probe::LOW_TARGET_VOLTAGE_WARNING_THRESHOLD {
+            log::warn!(
+                "J-Link: Target voltage (VTref) is {:2.2} V. Is your target device powered?",
+                target_voltage
+            );
         } else {
             log::info!("J-Link: Target voltage: {:2.2} V", target_voltage);
         }

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -495,10 +495,7 @@ impl DebugProbe for JLink {
         if target_voltage == crate::probe::LOW_TARGET_VOLTAGE_WARNING_THRESHOLD {
             log::warn!("J-Link: Target voltage (VTref) is 0 V. Is your target device powered?");
         } else {
-            log::info!(
-                "J-Link: Target voltage: {:2.2} V",
-                target_voltage
-            );
+            log::info!("J-Link: Target voltage: {:2.2} V", target_voltage);
         }
 
         match actual_protocol {

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -15,6 +15,10 @@ use jlink::list_jlink_devices;
 use std::{convert::TryFrom, fmt};
 use thiserror::Error;
 
+/// Log warnings when the measured target voltage is
+/// lower than 1.4V, if at all measureable.
+const LOW_TARGET_VOLTAGE_WARNING_THRESHOLD: f32 = 1.4;
+
 #[derive(Copy, Clone, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 pub enum WireProtocol {
     Swd,
@@ -501,6 +505,12 @@ pub trait DebugProbe: Send + fmt::Debug {
     }
 
     fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe>;
+
+    /// Reads the target voltage, if possible. Returns `Ok(None)` if the
+    /// probe doesn’t support reading the target voltage.
+    fn get_target_voltage(&mut self) -> Result<Option<f32>, DebugProbeError> {
+        Ok(None)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -15,7 +15,7 @@ use jlink::list_jlink_devices;
 use std::{convert::TryFrom, fmt};
 use thiserror::Error;
 
-/// Log warnings when the measured target voltage is
+/// Used to log warnings when the measured target voltage is
 /// lower than 1.4V, if at all measureable.
 const LOW_TARGET_VOLTAGE_WARNING_THRESHOLD: f32 = 1.4;
 
@@ -506,8 +506,8 @@ pub trait DebugProbe: Send + fmt::Debug {
 
     fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe>;
 
-    /// Reads the target voltage, if possible. Returns `Ok(None)` if the
-    /// probe doesn’t support reading the target voltage.
+    /// Reads the target voltage in Volts, if possible. Returns `Ok(None)`
+    /// if the probe doesn’t support reading the target voltage.
     fn get_target_voltage(&mut self) -> Result<Option<f32>, DebugProbeError> {
         Ok(None)
     }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -151,10 +151,8 @@ impl DebugProbe for STLink<STLinkUSBDevice> {
             }
         };
 
-        // Check and report the target voltage. We can call
-        // ?.unwrap() as the ST-Link supports reading the target
-        // voltage and will always return Some(f32).
-        let target_voltage = self.get_target_voltage()?.unwrap();
+        // Check and report the target voltage.
+        let target_voltage = self.get_target_voltage()?.expect("The ST-Link returned None when it should only be able to return Some(f32) or an error. Please report this bug!");
         if target_voltage < crate::probe::LOW_TARGET_VOLTAGE_WARNING_THRESHOLD {
             log::warn!(
                 "Target voltage (VAPP) is {:2.2} V. Is your target device powered?",

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -161,10 +161,7 @@ impl DebugProbe for STLink<STLinkUSBDevice> {
                 target_voltage
             );
         } else {
-            log::info!(
-                "Target voltage (VAPP): {:2.2} V",
-                target_voltage
-            );
+            log::info!("Target voltage (VAPP): {:2.2} V", target_voltage);
         }
 
         let mut buf = [0; 2];

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -151,6 +151,22 @@ impl DebugProbe for STLink<STLinkUSBDevice> {
             }
         };
 
+        // Check and report the target voltage. We can call
+        // ?.unwrap() as the ST-Link supports reading the target
+        // voltage and will always return Some(f32).
+        let target_voltage = self.get_target_voltage()?.unwrap();
+        if target_voltage < crate::probe::LOW_TARGET_VOLTAGE_WARNING_THRESHOLD {
+            log::warn!(
+                "Target voltage (VAPP) is {:2.2} V. Is your target device powered?",
+                target_voltage
+            );
+        } else {
+            log::info!(
+                "Target voltage (VAPP): {:2.2} V",
+                target_voltage
+            );
+        }
+
         let mut buf = [0; 2];
         self.send_jtag_command(
             &[commands::JTAG_COMMAND, commands::JTAG_ENTER2, param, 0],
@@ -261,6 +277,27 @@ impl DebugProbe for STLink<STLinkUSBDevice> {
             Err((probe, err)) => Err((probe.into_probe(), err)),
         }
     }
+
+    fn get_target_voltage(&mut self) -> Result<Option<f32>, DebugProbeError> {
+        let mut buf = [0; 8];
+        match self
+            .device
+            .write(&[commands::GET_TARGET_VOLTAGE], &[], &mut buf, TIMEOUT)
+        {
+            Ok(_) => {
+                // The next two unwraps are safe!
+                let a0 = (&buf[0..4]).pread_with::<u32>(0, LE).unwrap() as f32;
+                let a1 = (&buf[4..8]).pread_with::<u32>(0, LE).unwrap() as f32;
+                if a0 != 0.0 {
+                    Ok(Some((2.0 * a1 * 1.2 / a0) as f32))
+                } else {
+                    // Should never happen
+                    Err(StlinkError::VoltageDivisionByZero.into())
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
 }
 
 impl DAPAccess for STLink<STLinkUSBDevice> {
@@ -363,29 +400,6 @@ impl<D: StLinkUsb> STLink<D> {
 
     /// Firmware version that adds multiple AP support.
     const MIN_JTAG_VERSION_MULTI_AP: u8 = 28;
-
-    /// Reads the target voltage.
-    /// For the china fake variants this will always read a nonzero value!
-    pub fn get_target_voltage(&mut self) -> Result<f32, DebugProbeError> {
-        let mut buf = [0; 8];
-        match self
-            .device
-            .write(&[commands::GET_TARGET_VOLTAGE], &[], &mut buf, TIMEOUT)
-        {
-            Ok(_) => {
-                // The next two unwraps are safe!
-                let a0 = (&buf[0..4]).pread_with::<u32>(0, LE).unwrap() as f32;
-                let a1 = (&buf[4..8]).pread_with::<u32>(0, LE).unwrap() as f32;
-                if a0 != 0.0 {
-                    Ok((2.0 * a1 * 1.2 / a0) as f32)
-                } else {
-                    // Should never happen
-                    Err(StlinkError::VoltageDivisionByZero.into())
-                }
-            }
-            Err(e) => Err(e),
-        }
-    }
 
     /// Get the current mode of the ST-Link
     fn get_current_mode(&mut self) -> Result<Mode, DebugProbeError> {
@@ -526,7 +540,7 @@ impl<D: StLinkUsb> STLink<D> {
             self.jtag_speed_khz = current;
         }
 
-        self.get_target_voltage().map(|_| ())
+        Ok(())
     }
 
     /// sets the SWD frequency.


### PR DESCRIPTION
Added `get_target_voltage()` to `DebugProbe`, based off the original implementation of it
on `STLink`, but generalised to return `Result<Option<f32>, DebugProbeError>` to allow for
probes which don’t support reading target voltage. Added a default implementation on the
trait which returns `Ok(None)`.

Added a `LOW_TARGET_VOLTAGE_WARNING_THRESHOLD` constant to the `probe` module, currently
set to 1.4V as an initial guideline.

Implemented `get_target_voltage()` on `STLink` and `JLink`, based off existing code which
did a similar thing.

Altered `STLink::attach()` and `JLink::attach()` to use `get_target_voltage()` and
`LOW_TARGET_VOLTAGE_WARNING_THRESHOLD` for consistent target voltage reporting.