### PR TITLE
Add EFR32 targets

### DIFF
--- a/probe-rs/targets/EFR32BG21 Series.yaml
+++ b/probe-rs/targets/EFR32BG21 Series.yaml
@@ -1,0 +1,195 @@
+---
+name: EFR32BG21 Series
+variants:
+  - name: EFR32BG21A010F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20018000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG21A010F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG21A010F768
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0xc0000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG21A020F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20018000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG21A020F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG21A020F768
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0xc0000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG21B010F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20018000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG21B010F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG21B010F768
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0xc0000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG21B020F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20018000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG21B020F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG21B020F768
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0xc0000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+flash_algorithms:
+  geckos2:
+    name: geckos2
+    description: EFM32/EFR32 Gecko S2
+    default: true
+    instructions: DUgBaAH0fBGx9bAfBNELSQpoQvQAMgpgCUlB9nEyCmAAIkpggGgHSQHqgCEGSgAgSfgCEHBHAL8EgOAPaIAAQDwAA0AA/P8DBAAAAAVJQfZxMAhgBEgBIgJgACIAIApgcEcAvzwAA0AMIANAsLUJTQAkWfgFAIRCJL8AILC9IEYA8Ar4ACgE9QBUHL8BILC97+cAvwQAAAAPSQJGCMoBMwPRACkB8QQB+NGTsbC1C0wBJQtJJWBIYAIgCGABIAAhAPBe+E/0gFEAKGVQGL8BILC9ACBwRwC/BOD//wwQA0AQAANALenwTQVGyBySRiJKIk8g8AMEASAQYC7gBfUAUIhDoOsFC2keXEWh6wAAb+oEATi/o0bQRohCfWCIvwFGTh3Y+AAAAC64YArQCCAIIQjxBAgA8CT4ACgG8QQG8NAW4AQgOGABIAAhASYA8Bj4eLnaRF1EpOsLBEH2/3EALMzRT/SAUAEhA0oAJhFQAOABJjBGvejwjQwQA0AQAANAcLUQTg1KDkwzHQngBUCNQgS/ACBwvQE0BL9v8AIAcL0VaR1C8tAQaDVCIPABAW/wAQAIv0/w/zARYHC9DAADQIBpZ/8CAAEAAAAAAAAAAAA=
+    pc_init: 1
+    pc_uninit: 77
+    pc_program_page: 229
+    pc_erase_sector: 153
+    pc_erase_all: 109
+    data_section_offset: 456
+    flash_properties:
+      address_range:
+        start: 0
+        end: 0x100000
+      page_size: 12288
+      erased_byte_value: 255
+      program_page_timeout: 260
+      erase_sector_timeout: 200
+      sectors:
+        - size: 8192
+          address: 0
+core: M33

--- a/probe-rs/targets/EFR32BG22 Series.yaml
+++ b/probe-rs/targets/EFR32BG22 Series.yaml
@@ -1,0 +1,69 @@
+---
+name: EFR32BG22 Series
+variants:
+  - name: EFR32BG22C112F352
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20008000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x58000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG22C222F352
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20008000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x58000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32BG22C224F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20008000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+flash_algorithms:
+  geckos2:
+    name: geckos2
+    description: EFM32/EFR32 Gecko S2
+    default: true
+    instructions: DUgBaAH0fBGx9bAfBNELSQpoQvQAMgpgCUlB9nEyCmAAIkpggGgHSQHqgCEGSgAgSfgCEHBHAL8EgOAPaIAAQDwAA0AA/P8DBAAAAAVJQfZxMAhgBEgBIgJgACIAIApgcEcAvzwAA0AMIANAsLUJTQAkWfgFAIRCJL8AILC9IEYA8Ar4ACgE9QBUHL8BILC97+cAvwQAAAAPSQJGCMoBMwPRACkB8QQB+NGTsbC1C0wBJQtJJWBIYAIgCGABIAAhAPBe+E/0gFEAKGVQGL8BILC9ACBwRwC/BOD//wwQA0AQAANALenwTQVGyBySRiJKIk8g8AMEASAQYC7gBfUAUIhDoOsFC2keXEWh6wAAb+oEATi/o0bQRohCfWCIvwFGTh3Y+AAAAC64YArQCCAIIQjxBAgA8CT4ACgG8QQG8NAW4AQgOGABIAAhASYA8Bj4eLnaRF1EpOsLBEH2/3EALMzRT/SAUAEhA0oAJhFQAOABJjBGvejwjQwQA0AQAANAcLUQTg1KDkwzHQngBUCNQgS/ACBwvQE0BL9v8AIAcL0VaR1C8tAQaDVCIPABAW/wAQAIv0/w/zARYHC9DAADQIBpZ/8CAAEAAAAAAAAAAAA=
+    pc_init: 1
+    pc_uninit: 77
+    pc_program_page: 229
+    pc_erase_sector: 153
+    pc_erase_all: 109
+    data_section_offset: 456
+    flash_properties:
+      address_range:
+        start: 0
+        end: 0x100000
+      page_size: 12288
+      erased_byte_value: 255
+      program_page_timeout: 260
+      erase_sector_timeout: 200
+      sectors:
+        - size: 8192
+          address: 0
+core: M33

--- a/probe-rs/targets/EFR32FG12P Series.yaml
+++ b/probe-rs/targets/EFR32FG12P Series.yaml
@@ -1,0 +1,125 @@
+---
+name: EFR32FG12P Series
+variants:
+  - name: EFR32FG12P231F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG12P231F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG12P232F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG12P431F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG12P431F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20040000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG12P432F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20040000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG12P433F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20040000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+flash_algorithms:
+  geckos1:
+    name: geckos1
+    description: EFM32/EFR32 Gecko S1
+    default: true
+    instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
+    pc_init: 81
+    pc_uninit: 105
+    pc_program_page: 229
+    pc_erase_sector: 163
+    pc_erase_all: 119
+    data_section_offset: 400
+    flash_properties:
+      address_range:
+        start: 0
+        end: 0x100000
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 260
+      erase_sector_timeout: 200
+      sectors:
+        - size: 2048
+          address: 0
+core: M4

--- a/probe-rs/targets/EFR32FG13P Series.yaml
+++ b/probe-rs/targets/EFR32FG13P Series.yaml
@@ -1,0 +1,69 @@
+---
+name: EFR32FG13P Series
+variants:
+  - name: EFR32FG13P231F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG13P232F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG13P233F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+flash_algorithms:
+  geckos1:
+    name: geckos1
+    description: EFM32/EFR32 Gecko S1
+    default: true
+    instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
+    pc_init: 81
+    pc_uninit: 105
+    pc_program_page: 229
+    pc_erase_sector: 163
+    pc_erase_all: 119
+    data_section_offset: 400
+    flash_properties:
+      address_range:
+        start: 0
+        end: 0x100000
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 260
+      erase_sector_timeout: 200
+      sectors:
+        - size: 2048
+          address: 0
+core: M4

--- a/probe-rs/targets/EFR32FG14P Series.yaml
+++ b/probe-rs/targets/EFR32FG14P Series.yaml
@@ -1,0 +1,111 @@
+---
+name: EFR32FG14P Series
+variants:
+  - name: EFR32FG14P231F128
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20004000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x20000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG14P231F256
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20008000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x40000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG14P232F128
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20004000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x20000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG14P232F256
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20008000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x40000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG14P233F128
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20004000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x20000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32FG14P233F256
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20008000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x40000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+flash_algorithms:
+  geckos1:
+    name: geckos1
+    description: EFM32/EFR32 Gecko S1
+    default: true
+    instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
+    pc_init: 81
+    pc_uninit: 105
+    pc_program_page: 229
+    pc_erase_sector: 163
+    pc_erase_all: 119
+    data_section_offset: 400
+    flash_properties:
+      address_range:
+        start: 0
+        end: 0x100000
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 260
+      erase_sector_timeout: 200
+      sectors:
+        - size: 2048
+          address: 0
+core: M4

--- a/probe-rs/targets/EFR32FG14V Series.yaml
+++ b/probe-rs/targets/EFR32FG14V Series.yaml
@@ -1,0 +1,41 @@
+---
+name: EFR32FG14V Series
+variants:
+  - name: EFR32FG14V132F256
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20008000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x40000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+flash_algorithms:
+  geckos1:
+    name: geckos1
+    description: EFM32/EFR32 Gecko S1
+    default: true
+    instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
+    pc_init: 81
+    pc_uninit: 105
+    pc_program_page: 229
+    pc_erase_sector: 163
+    pc_erase_all: 119
+    data_section_offset: 400
+    flash_properties:
+      address_range:
+        start: 0
+        end: 0x100000
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 260
+      erase_sector_timeout: 200
+      sectors:
+        - size: 2048
+          address: 0
+core: M4

--- a/probe-rs/targets/EFR32FG1P Series.yaml
+++ b/probe-rs/targets/EFR32FG1P Series.yaml
@@ -1,0 +1,153 @@
+---
+name: EFR32FG1P Series
+variants:
+  - name: EFR32FG1P131F64
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20004000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x10000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckop2
+  - name: EFR32FG1P131F128
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20007c00
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x20000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckop2
+  - name: EFR32FG1P131F256
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20007c00
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x40000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckop2
+  - name: EFR32FG1P132F64
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20004000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x10000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckop2
+  - name: EFR32FG1P132F128
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20007c00
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x20000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckop2
+  - name: EFR32FG1P132F256
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20007c00
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x40000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckop2
+  - name: EFR32FG1P133F64
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20004000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x10000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckop2
+  - name: EFR32FG1P133F128
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20007c00
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x20000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckop2
+  - name: EFR32FG1P133F256
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20007c00
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x40000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckop2
+flash_algorithms:
+  geckop2:
+    name: geckop2
+    description: EFM32/EFR32 Gecko P2
+    default: true
+    instructions: QLpwR8C6cEdP6jAAcEcAAHC1WUtZTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1KSUH2cTAIZAAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3cf9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/92P/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgTOcAAICWmAAAAA5AAAAAAA==
+    pc_init: 81
+    pc_uninit: 93
+    pc_program_page: 217
+    pc_erase_sector: 151
+    pc_erase_all: 107
+    data_section_offset: 384
+    flash_properties:
+      address_range:
+        start: 0
+        end: 0x40000
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 260
+      erase_sector_timeout: 200
+      sectors:
+        - size: 2048
+          address: 0
+core: M4

--- a/probe-rs/targets/EFR32FG22 Series.yaml
+++ b/probe-rs/targets/EFR32FG22 Series.yaml
@@ -1,0 +1,55 @@
+---
+name: EFR32FG22 Series
+variants:
+  - name: EFR32FG22C121F256
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20008000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x40000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+  - name: EFR32FG22C121F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20008000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos2
+flash_algorithms:
+  geckos2:
+    name: geckos2
+    description: EFM32/EFR32 Gecko S2
+    default: true
+    instructions: DUgBaAH0fBGx9bAfBNELSQpoQvQAMgpgCUlB9nEyCmAAIkpggGgHSQHqgCEGSgAgSfgCEHBHAL8EgOAPaIAAQDwAA0AA/P8DBAAAAAVJQfZxMAhgBEgBIgJgACIAIApgcEcAvzwAA0AMIANAsLUJTQAkWfgFAIRCJL8AILC9IEYA8Ar4ACgE9QBUHL8BILC97+cAvwQAAAAPSQJGCMoBMwPRACkB8QQB+NGTsbC1C0wBJQtJJWBIYAIgCGABIAAhAPBe+E/0gFEAKGVQGL8BILC9ACBwRwC/BOD//wwQA0AQAANALenwTQVGyBySRiJKIk8g8AMEASAQYC7gBfUAUIhDoOsFC2keXEWh6wAAb+oEATi/o0bQRohCfWCIvwFGTh3Y+AAAAC64YArQCCAIIQjxBAgA8CT4ACgG8QQG8NAW4AQgOGABIAAhASYA8Bj4eLnaRF1EpOsLBEH2/3EALMzRT/SAUAEhA0oAJhFQAOABJjBGvejwjQwQA0AQAANAcLUQTg1KDkwzHQngBUCNQgS/ACBwvQE0BL9v8AIAcL0VaR1C8tAQaDVCIPABAW/wAQAIv0/w/zARYHC9DAADQIBpZ/8CAAEAAAAAAAAAAAA=
+    pc_init: 1
+    pc_uninit: 77
+    pc_program_page: 229
+    pc_erase_sector: 153
+    pc_erase_all: 109
+    data_section_offset: 456
+    flash_properties:
+      address_range:
+        start: 0
+        end: 0x100000
+      page_size: 12288
+      erased_byte_value: 255
+      program_page_timeout: 260
+      erase_sector_timeout: 200
+      sectors:
+        - size: 8192
+          address: 0
+core: M33

--- a/probe-rs/targets/EFR32MG12P Series.yaml
+++ b/probe-rs/targets/EFR32MG12P Series.yaml
@@ -1,0 +1,153 @@
+---
+name: EFR32MG12P Series
+variants:
+  - name: EFR32MG12P132F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32MG12P132F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32MG12P231F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32MG12P232F512
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x80000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32MG12P232F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32MG12P332F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20040000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32MG12P431F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20040000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32MG12P432F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20040000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+  - name: EFR32MG12P433F1024
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20040000
+          is_boot_memory: false
+      - Nvm:
+          range:
+            start: 0
+            end: 0x100000
+          is_boot_memory: true
+    flash_algorithms:
+      - geckos1
+flash_algorithms:
+  geckos1:
+    name: geckos1
+    description: EFM32/EFR32 Gecko S1
+    default: true
+    instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
+    pc_init: 81
+    pc_uninit: 105
+    pc_program_page: 229
+    pc_erase_sector: 163
+    pc_erase_all: 119
+    data_section_offset: 400
+    flash_properties:
+      address_range:
+        start: 0
+        end: 0x100000
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 260
+      erase_sector_timeout: 200
+      sectors:
+        - size: 2048
+          address: 0
+core: M4


### PR DESCRIPTION
Adds support for various SiLabs EFR32 targets, generated using `target-gen`, while removing duplicates.