### PR TITLE
Split target description schema to its own crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "probe-rs",
+    "probe-rs-target",
     "probe-rs-t2rust",
     "probe-rs-cli-util",
     "cli",

--- a/probe-rs-target/Cargo.toml
+++ b/probe-rs-target/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "probe-rs-target"
+version = "0.1.0"
+edition = "2018"
+description = "Target description schema for probe-rs."
+documentation = "https://docs.rs/probe-rs/"
+homepage = "https://github.com/probe-rs/probe-rs"
+repository = "https://github.com/probe-rs/probe-rs"
+readme = "../README.md"
+categories = ["embedded", "hardware-support", "development-tools::debugging"]
+keywords = ["embedded"]
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+jep106 = "0.2.4"
+serde = { version = "1.0.104", features = ["derive"] }
+base64 = "0.13.0"

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -1,4 +1,5 @@
 use super::memory::MemoryRegion;
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
 /// A single chip variant.
@@ -22,6 +23,6 @@ pub struct Chip {
     /// This can be used to look up the flash algorithm in the
     /// [`ChipFamily::flash_algorithms`] field.
     ///
-    /// [`ChipFamily::flash_algorithms`]: crate::config::ChipFamily::flash_algorithms
+    /// [`ChipFamily::flash_algorithms`]: crate::ChipFamily::flash_algorithms
     pub flash_algorithms: Cow<'static, [Cow<'static, str>]>,
 }

--- a/probe-rs-target/src/chip_family.rs
+++ b/probe-rs-target/src/chip_family.rs
@@ -50,7 +50,7 @@ pub struct ChipFamily {
     pub source: TargetDescriptionSource,
 }
 
-// When deserialization is used, this means that the target is read from an external source.
+/// When deserialization is used, this means that the target is read from an external source.
 fn default_source() -> TargetDescriptionSource {
     TargetDescriptionSource::External
 }

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -1,0 +1,71 @@
+use super::flash_properties::FlashProperties;
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+
+/// The raw flash algorithm is the description of a flash algorithm,
+/// and is usually read from a target description file.
+///
+/// Before it can be used for flashing, it has to be assembled for
+/// a specific chip, using the [RawFlashAlgorithm::assemble] function. This function
+/// will determine the RAM addresses which are used when flashing.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct RawFlashAlgorithm {
+    /// The name of the flash algorithm.
+    pub name: Cow<'static, str>,
+    /// The description of the algorithm.
+    pub description: Cow<'static, str>,
+    /// Whether this flash algorithm is the default one or not.
+    pub default: bool,
+    /// List of 32-bit words containing the position-independent code for the algo.
+    #[serde(deserialize_with = "deserialize")]
+    #[serde(serialize_with = "serialize")]
+    pub instructions: Cow<'static, [u8]>,
+    /// Address of the `Init()` entry point. Optional.
+    pub pc_init: Option<u32>,
+    /// Address of the `UnInit()` entry point. Optional.
+    pub pc_uninit: Option<u32>,
+    /// Address of the `ProgramPage()` entry point.
+    pub pc_program_page: u32,
+    /// Address of the `EraseSector()` entry point.
+    pub pc_erase_sector: u32,
+    /// Address of the `EraseAll()` entry point. Optional.
+    pub pc_erase_all: Option<u32>,
+    /// The offset from the start of RAM to the data section.
+    pub data_section_offset: u32,
+    /// The properties of the flash on the device.
+    pub flash_properties: FlashProperties,
+}
+
+pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&base64::encode(bytes))
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Cow<'static, [u8]>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct Base64Visitor;
+
+    impl<'de> serde::de::Visitor<'de> for Base64Visitor {
+        type Value = Cow<'static, [u8]>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "base64 ASCII text")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            base64::decode(v)
+                .map(Cow::Owned)
+                .map_err(serde::de::Error::custom)
+        }
+    }
+
+    deserializer.deserialize_str(Base64Visitor)
+}

--- a/probe-rs-target/src/flash_properties.rs
+++ b/probe-rs-target/src/flash_properties.rs
@@ -1,4 +1,5 @@
 use super::memory::SectorDescription;
+use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, ops::Range};
 
 /// Properties of flash memory, which

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -1,0 +1,26 @@
+#![warn(missing_docs)]
+
+//! Target description schema
+//!
+//! For debugging and flashing different chips, called *target* in probe-rs, some
+//! target specific configuration is required. This includes the architecture of
+//! the chip, e.g. RISCV or ARM, and information about the memory map of the target,
+//! which can be used together with a flash algorithm to program the flash memory
+//! of a target.
+//!
+//! This crate contains the schema structs for the YAML target description files.
+//!
+
+mod chip;
+mod chip_family;
+mod flash_algorithm;
+mod flash_properties;
+mod memory;
+
+pub use chip::Chip;
+pub use chip_family::{ChipFamily, TargetDescriptionSource};
+pub use flash_algorithm::RawFlashAlgorithm;
+pub use flash_properties::FlashProperties;
+pub use memory::{
+    MemoryRange, MemoryRegion, NvmRegion, PageInfo, RamRegion, SectorDescription, SectorInfo,
+};

--- a/probe-rs-target/src/memory.rs
+++ b/probe-rs-target/src/memory.rs
@@ -1,4 +1,5 @@
 use core::ops::Range;
+use serde::{Deserialize, Serialize};
 
 /// Represents a region in non-volatile memory (e.g. flash or EEPROM).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -53,7 +54,7 @@ pub struct SectorInfo {
 /// end of the flash, or until another `SectorDescription`
 /// changes the sector size.
 ///
-/// [`FlashProperties`]: crate::config::FlashProperties
+/// [`FlashProperties`]: crate::FlashProperties
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SectorDescription {
     /// Size of each individual flash sector

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -48,6 +48,8 @@ itm-decode = "0.1.5"
 libftdi1-sys = { version = "1.0.0-alpha3", optional = true }
 static_assertions = "1.1.0"
 
+probe-rs-target  = { path = "../probe-rs-target", version ="0.1.0" }
+
 [build-dependencies]
 probe-rs-t2rust  = { path = "../probe-rs-t2rust", version ="0.7.0" }
 

--- a/probe-rs/src/config/flash_algorithm.rs
+++ b/probe-rs/src/config/flash_algorithm.rs
@@ -2,7 +2,6 @@ use super::{FlashProperties, PageInfo, RamRegion, SectorInfo};
 use crate::core::Architecture;
 use crate::flashing::FlashError;
 use crate::{architecture::riscv, Target};
-use std::borrow::Cow;
 use std::convert::TryInto;
 
 /// A flash algorithm, which has been assembled for a specific
@@ -213,6 +212,8 @@ impl FlashAlgorithm {
 #[test]
 fn flash_sector_single_size() {
     use crate::config::SectorDescription;
+    use std::borrow::Cow;
+
     let config = FlashAlgorithm {
         flash_properties: FlashProperties {
             sectors: Cow::Borrowed(&[SectorDescription {
@@ -243,6 +244,8 @@ fn flash_sector_single_size() {
 #[test]
 fn flash_sector_single_size_weird_sector_size() {
     use crate::config::SectorDescription;
+    use std::borrow::Cow;
+
     let config = FlashAlgorithm {
         flash_properties: FlashProperties {
             sectors: Cow::Borrowed(&[SectorDescription {
@@ -273,6 +276,8 @@ fn flash_sector_single_size_weird_sector_size() {
 #[test]
 fn flash_sector_multiple_sizes() {
     use crate::config::SectorDescription;
+    use std::borrow::Cow;
+
     let config = FlashAlgorithm {
         flash_properties: FlashProperties {
             sectors: Cow::Borrowed(&[

--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -22,26 +22,21 @@
 //! be used to read targets from a YAML file.
 //!
 
-mod chip;
-mod chip_family;
 mod chip_info;
 mod flash_algorithm;
-mod flash_properties;
-mod memory;
 mod registry;
 mod target;
 
-pub use chip::Chip;
-pub use chip_family::ChipFamily;
-pub use flash_algorithm::{FlashAlgorithm, RawFlashAlgorithm};
-pub use flash_properties::FlashProperties;
-pub use memory::{
-    MemoryRange, MemoryRegion, NvmRegion, PageInfo, RamRegion, SectorDescription, SectorInfo,
+pub use probe_rs_target::{
+    Chip, ChipFamily, FlashProperties, MemoryRange, MemoryRegion, NvmRegion, PageInfo, RamRegion,
+    RawFlashAlgorithm, SectorDescription, SectorInfo, TargetDescriptionSource,
 };
+
+pub use flash_algorithm::FlashAlgorithm;
 pub use registry::{
     add_target_from_yaml, families, get_target_by_name, search_chips, RegistryError,
 };
-pub use target::{Target, TargetDescriptionSource, TargetParseError, TargetSelector};
+pub use target::{Target, TargetParseError, TargetSelector};
 
 // Crate-internal API
 pub(crate) use chip_info::ChipInfo;

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -1,7 +1,6 @@
 //! Internal target registry
 
-use super::target::{Target, TargetDescriptionSource};
-use crate::config::{Chip, ChipFamily, ChipInfo};
+use super::{Chip, ChipFamily, ChipInfo, Target, TargetDescriptionSource};
 use crate::core::CoreType;
 use lazy_static::lazy_static;
 use std::fs::File;
@@ -287,7 +286,7 @@ impl Registry {
 
     fn add_target_from_yaml(&mut self, path_to_yaml: &Path) -> Result<(), RegistryError> {
         let file = File::open(path_to_yaml)?;
-        let chip = ChipFamily::from_yaml_reader(file)?;
+        let chip: ChipFamily = serde_yaml::from_reader(file)?;
 
         let index = self
             .families

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -1,6 +1,4 @@
-use super::chip::Chip;
-use super::flash_algorithm::RawFlashAlgorithm;
-use super::memory::MemoryRegion;
+use super::{Chip, MemoryRegion, RawFlashAlgorithm, TargetDescriptionSource};
 use crate::core::{Architecture, CoreType};
 
 /// This describes a complete target with a fixed chip model and variant.
@@ -31,24 +29,6 @@ impl std::fmt::Debug for Target {
             self.name, self.flash_algorithms, self.memory_map
         )
     }
-}
-
-/// Source of a target description.
-///
-/// This is used for diagnostics, when
-/// an error related to a target description occurs.
-#[derive(Clone, Debug, PartialEq)]
-pub enum TargetDescriptionSource {
-    /// The target description is a generic target description,
-    /// which just describes a core type (e.g. M4), without any
-    /// flash algorithm or memory description.
-    Generic,
-    /// The target description is a built-in target description,
-    /// which was included into probe-rs at compile time.
-    BuiltIn,
-    /// The target description was from an external source
-    /// during runtime.
-    External,
 }
 
 /// An error occured while parsing the target description.

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -4,7 +4,9 @@ use super::{
     extract_from_elf, BinOptions, ExtractedFlashData, FileDownloadError, FlashBuilder, FlashError,
     FlashProgress, Flasher,
 };
-use crate::config::{MemoryRange, MemoryRegion, NvmRegion, TargetDescriptionSource};
+use crate::config::{
+    FlashAlgorithm, MemoryRange, MemoryRegion, NvmRegion, TargetDescriptionSource,
+};
 use crate::memory::MemoryInterface;
 use crate::session::Session;
 use std::{
@@ -307,8 +309,8 @@ impl<'data> FlashLoader<'data> {
                 0 => {
                     return Err(FlashError::NoFlashLoaderAlgorithmAttached);
                 }
-                1 => &algorithms[0],
-                _ => algorithms
+                1 => algorithms[0],
+                _ => *algorithms
                     .iter()
                     .find(|a| a.default)
                     .ok_or(FlashError::NoFlashLoaderAlgorithmAttached)?,
@@ -325,7 +327,8 @@ impl<'data> FlashLoader<'data> {
                     chip: session.target().name.clone(),
                 })?;
 
-            let flash_algorithm = raw_flash_algorithm.assemble(ram, session.target())?;
+            let flash_algorithm =
+                FlashAlgorithm::assemble_from_raw(raw_flash_algorithm, ram, session.target())?;
 
             if dry_run {
                 println!("Skipping programming, dry run!");


### PR DESCRIPTION
As discussed in Matrix, it would be nice to replace `t2rust` with embedding the YAMLs in the binary. The advantage is that we don't have to maintain two parsers for the YAML format.

This is a previous step to achieve that: separate all the structs defining the YAML schema into its own crate, so it can be used from build.rs and other crates.