### PR TITLE
Remove Cow in probe-rs-target.

### DIFF
--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -1,6 +1,5 @@
 use super::memory::MemoryRegion;
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 
 /// A single chip variant.
 ///
@@ -11,7 +10,7 @@ use std::borrow::Cow;
 pub struct Chip {
     /// This is the name of the chip in base form.
     /// E.g. `nRF52832`.
-    pub name: Cow<'static, str>,
+    pub name: String,
     /// The `PART` register of the chip.
     /// This value can be determined via the `cli info` command.
     #[cfg_attr(
@@ -20,12 +19,12 @@ pub struct Chip {
     )]
     pub part: Option<u16>,
     /// The memory regions available on the chip.
-    pub memory_map: Cow<'static, [MemoryRegion]>,
+    pub memory_map: Vec<MemoryRegion>,
     /// Names of all flash algorithms available for this chip.
     ///
     /// This can be used to look up the flash algorithm in the
     /// [`ChipFamily::flash_algorithms`] field.
     ///
     /// [`ChipFamily::flash_algorithms`]: crate::ChipFamily::flash_algorithms
-    pub flash_algorithms: Cow<'static, [Cow<'static, str>]>,
+    pub flash_algorithms: Vec<String>,
 }

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -1,5 +1,4 @@
 use super::flash_properties::FlashProperties;
-use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
@@ -12,15 +11,15 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct RawFlashAlgorithm {
     /// The name of the flash algorithm.
-    pub name: Cow<'static, str>,
+    pub name: String,
     /// The description of the algorithm.
-    pub description: Cow<'static, str>,
+    pub description: String,
     /// Whether this flash algorithm is the default one or not.
     pub default: bool,
     /// List of 32-bit words containing the position-independent code for the algo.
     #[serde(deserialize_with = "deserialize")]
     #[serde(serialize_with = "serialize")]
-    pub instructions: Cow<'static, [u8]>,
+    pub instructions: Vec<u8>,
     /// Address of the `Init()` entry point. Optional.
     pub pc_init: Option<u32>,
     /// Address of the `UnInit()` entry point. Optional.
@@ -44,14 +43,14 @@ where
     serializer.serialize_str(&base64::encode(bytes))
 }
 
-pub fn deserialize<'de, D>(deserializer: D) -> Result<Cow<'static, [u8]>, D::Error>
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     struct Base64Visitor;
 
     impl<'de> serde::de::Visitor<'de> for Base64Visitor {
-        type Value = Cow<'static, [u8]>;
+        type Value = Vec<u8>;
 
         fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
             write!(formatter, "base64 ASCII text")
@@ -61,9 +60,7 @@ where
         where
             E: serde::de::Error,
         {
-            base64::decode(v)
-                .map(Cow::Owned)
-                .map_err(serde::de::Error::custom)
+            base64::decode(v).map_err(serde::de::Error::custom)
         }
     }
 

--- a/probe-rs-target/src/flash_properties.rs
+++ b/probe-rs-target/src/flash_properties.rs
@@ -1,6 +1,6 @@
 use super::memory::SectorDescription;
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, ops::Range};
+use std::ops::Range;
 
 /// Properties of flash memory, which
 /// are used when programming Flash memory.
@@ -20,7 +20,7 @@ pub struct FlashProperties {
     /// The approximative time it takes to erase a sector.
     pub erase_sector_timeout: u32,
     /// The available sectors of the device flash.
-    pub sectors: Cow<'static, [SectorDescription]>,
+    pub sectors: Vec<SectorDescription>,
 }
 
 impl Default for FlashProperties {
@@ -32,7 +32,7 @@ impl Default for FlashProperties {
             erased_byte_value: 0,
             program_page_timeout: 0,
             erase_sector_timeout: 0,
-            sectors: Cow::Borrowed(&[]),
+            sectors: vec![],
         }
     }
 }

--- a/probe-rs/src/config/flash_algorithm.rs
+++ b/probe-rs/src/config/flash_algorithm.rs
@@ -188,7 +188,7 @@ impl FlashAlgorithm {
 
         let code_start = addr_load + (header.len() * size_of::<u32>()) as u32;
 
-        let name = raw.name.clone().into_owned();
+        let name = raw.name.clone();
 
         Ok(FlashAlgorithm {
             name,
@@ -212,14 +212,13 @@ impl FlashAlgorithm {
 #[test]
 fn flash_sector_single_size() {
     use crate::config::SectorDescription;
-    use std::borrow::Cow;
 
     let config = FlashAlgorithm {
         flash_properties: FlashProperties {
-            sectors: Cow::Borrowed(&[SectorDescription {
+            sectors: vec![SectorDescription {
                 size: 0x100,
                 address: 0x0,
-            }]),
+            }],
             address_range: 0x1000..0x1000 + 0x1000,
             page_size: 0x10,
             ..Default::default()
@@ -244,14 +243,13 @@ fn flash_sector_single_size() {
 #[test]
 fn flash_sector_single_size_weird_sector_size() {
     use crate::config::SectorDescription;
-    use std::borrow::Cow;
 
     let config = FlashAlgorithm {
         flash_properties: FlashProperties {
-            sectors: Cow::Borrowed(&[SectorDescription {
+            sectors: vec![SectorDescription {
                 size: 258,
                 address: 0x0,
-            }]),
+            }],
             address_range: 0x800_0000..0x800_0000 + 258 * 10,
             page_size: 0x10,
             ..Default::default()
@@ -276,11 +274,10 @@ fn flash_sector_single_size_weird_sector_size() {
 #[test]
 fn flash_sector_multiple_sizes() {
     use crate::config::SectorDescription;
-    use std::borrow::Cow;
 
     let config = FlashAlgorithm {
         flash_properties: FlashProperties {
-            sectors: Cow::Borrowed(&[
+            sectors: vec![
                 SectorDescription {
                     size: 0x4000,
                     address: 0x0,
@@ -293,7 +290,7 @@ fn flash_sector_multiple_sizes() {
                     size: 0x2_0000,
                     address: 0x2_0000,
                 },
-            ]),
+            ],
             address_range: 0x800_0000..0x800_0000 + 0x10_0000,
             page_size: 0x10,
             ..Default::default()

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -5,10 +5,7 @@ use crate::core::CoreType;
 use lazy_static::lazy_static;
 use std::fs::File;
 use std::path::Path;
-use std::{
-    borrow::Cow,
-    sync::{Arc, Mutex, TryLockError},
-};
+use std::sync::{Arc, Mutex, TryLockError};
 use thiserror::Error;
 
 lazy_static! {
@@ -48,86 +45,88 @@ impl<R> From<TryLockError<R>> for RegistryError {
     }
 }
 
-const GENERIC_TARGETS: [ChipFamily; 6] = [
-    ChipFamily {
-        name: Cow::Borrowed("Generic Cortex-M0"),
-        manufacturer: None,
-        variants: Cow::Borrowed(&[Chip {
-            name: Cow::Borrowed("cortex-m0"),
-            part: None,
-            memory_map: Cow::Borrowed(&[]),
-            flash_algorithms: Cow::Borrowed(&[]),
-        }]),
-        flash_algorithms: Cow::Borrowed(&[]),
-        core: Cow::Borrowed("M0"),
-        source: TargetDescriptionSource::Generic,
-    },
-    ChipFamily {
-        name: Cow::Borrowed("Generic Cortex-M4"),
-        manufacturer: None,
-        variants: Cow::Borrowed(&[Chip {
-            name: Cow::Borrowed("cortex-m4"),
-            part: None,
-            memory_map: Cow::Borrowed(&[]),
-            flash_algorithms: Cow::Borrowed(&[]),
-        }]),
-        flash_algorithms: Cow::Borrowed(&[]),
-        core: Cow::Borrowed("M4"),
-        source: TargetDescriptionSource::Generic,
-    },
-    ChipFamily {
-        name: Cow::Borrowed("Generic Cortex-M3"),
-        manufacturer: None,
-        variants: Cow::Borrowed(&[Chip {
-            name: Cow::Borrowed("cortex-m3"),
-            part: None,
-            memory_map: Cow::Borrowed(&[]),
-            flash_algorithms: Cow::Borrowed(&[]),
-        }]),
-        flash_algorithms: Cow::Borrowed(&[]),
-        core: Cow::Borrowed("M3"),
-        source: TargetDescriptionSource::Generic,
-    },
-    ChipFamily {
-        name: Cow::Borrowed("Generic Cortex-M33"),
-        manufacturer: None,
-        variants: Cow::Borrowed(&[Chip {
-            name: Cow::Borrowed("cortex-m33"),
-            part: None,
-            memory_map: Cow::Borrowed(&[]),
-            flash_algorithms: Cow::Borrowed(&[]),
-        }]),
-        flash_algorithms: Cow::Borrowed(&[]),
-        core: Cow::Borrowed("M33"),
-        source: TargetDescriptionSource::Generic,
-    },
-    ChipFamily {
-        name: Cow::Borrowed("Generic Cortex-M7"),
-        manufacturer: None,
-        variants: Cow::Borrowed(&[Chip {
-            name: Cow::Borrowed("cortex-m7"),
-            part: None,
-            memory_map: Cow::Borrowed(&[]),
-            flash_algorithms: Cow::Borrowed(&[]),
-        }]),
-        flash_algorithms: Cow::Borrowed(&[]),
-        core: Cow::Borrowed("M7"),
-        source: TargetDescriptionSource::Generic,
-    },
-    ChipFamily {
-        name: Cow::Borrowed("Generic Riscv"),
-        manufacturer: None,
-        variants: Cow::Borrowed(&[Chip {
-            name: Cow::Borrowed("riscv"),
-            part: None,
-            memory_map: Cow::Borrowed(&[]),
-            flash_algorithms: Cow::Borrowed(&[]),
-        }]),
-        flash_algorithms: Cow::Borrowed(&[]),
-        core: Cow::Borrowed("riscv"),
-        source: TargetDescriptionSource::Generic,
-    },
-];
+fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
+    vec.extend_from_slice(&[
+        ChipFamily {
+            name: "Generic Cortex-M0".to_owned(),
+            manufacturer: None,
+            variants: vec![Chip {
+                name: "cortex-m0".to_owned(),
+                part: None,
+                memory_map: vec![],
+                flash_algorithms: vec![],
+            }],
+            flash_algorithms: vec![],
+            core: "M0".to_owned(),
+            source: TargetDescriptionSource::Generic,
+        },
+        ChipFamily {
+            name: "Generic Cortex-M4".to_owned(),
+            manufacturer: None,
+            variants: vec![Chip {
+                name: "cortex-m4".to_owned(),
+                part: None,
+                memory_map: vec![],
+                flash_algorithms: vec![],
+            }],
+            flash_algorithms: vec![],
+            core: "M4".to_owned(),
+            source: TargetDescriptionSource::Generic,
+        },
+        ChipFamily {
+            name: "Generic Cortex-M3".to_owned(),
+            manufacturer: None,
+            variants: vec![Chip {
+                name: "cortex-m3".to_owned(),
+                part: None,
+                memory_map: vec![],
+                flash_algorithms: vec![],
+            }],
+            flash_algorithms: vec![],
+            core: "M3".to_owned(),
+            source: TargetDescriptionSource::Generic,
+        },
+        ChipFamily {
+            name: "Generic Cortex-M33".to_owned(),
+            manufacturer: None,
+            variants: vec![Chip {
+                name: "cortex-m33".to_owned(),
+                part: None,
+                memory_map: vec![],
+                flash_algorithms: vec![],
+            }],
+            flash_algorithms: vec![],
+            core: "M33".to_owned(),
+            source: TargetDescriptionSource::Generic,
+        },
+        ChipFamily {
+            name: "Generic Cortex-M7".to_owned(),
+            manufacturer: None,
+            variants: vec![Chip {
+                name: "cortex-m7".to_owned(),
+                part: None,
+                memory_map: vec![],
+                flash_algorithms: vec![],
+            }],
+            flash_algorithms: vec![],
+            core: "M7".to_owned(),
+            source: TargetDescriptionSource::Generic,
+        },
+        ChipFamily {
+            name: "Generic Riscv".to_owned(),
+            manufacturer: None,
+            variants: vec![Chip {
+                name: "riscv".to_owned(),
+                part: None,
+                memory_map: vec![],
+                flash_algorithms: vec![],
+            }],
+            flash_algorithms: vec![],
+            core: "riscv".to_owned(),
+            source: TargetDescriptionSource::Generic,
+        },
+    ]);
+}
 
 /// Registry of all available targets.
 struct Registry {
@@ -136,23 +135,22 @@ struct Registry {
 }
 
 impl Registry {
-    #[cfg(feature = "builtin-targets")]
     fn from_builtin_families() -> Self {
         const BUILTIN_TARGETS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/targets.bincode"));
 
         let mut families: Vec<ChipFamily> = bincode::deserialize(BUILTIN_TARGETS)
             .expect("Failed to deserialize builtin targets. This is a bug.");
 
-        families.extend(GENERIC_TARGETS.iter().cloned());
+        add_generic_targets(&mut families);
 
         Self { families }
     }
 
     #[cfg(not(feature = "builtin-targets"))]
     fn from_builtin_families() -> Self {
-        Self {
-            families: GENERIC_TARGETS.iter().cloned().collect(),
-        }
+        let mut families = vec![];
+        add_generic_targets(&mut families);
+        families
     }
 
     fn families(&self) -> &Vec<ChipFamily> {
@@ -261,9 +259,7 @@ impl Registry {
         let core = if let Some(core) = CoreType::from_string(&family.core) {
             core
         } else {
-            return Err(RegistryError::UnknownCoreType(
-                family.core.clone().into_owned(),
-            ));
+            return Err(RegistryError::UnknownCoreType(family.core.clone()));
         };
 
         // find relevant algorithms

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -43,10 +43,10 @@ impl Target {
         source: TargetDescriptionSource,
     ) -> Target {
         Target {
-            name: chip.name.clone().into_owned(),
+            name: chip.name.clone(),
             flash_algorithms,
             core_type,
-            memory_map: chip.memory_map.clone().into_owned(),
+            memory_map: chip.memory_map.clone(),
             source,
         }
     }

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -513,7 +513,7 @@ mod tests {
             erased_byte_value: 255,
             program_page_timeout: 200,
             erase_sector_timeout: 200,
-            sectors: std::borrow::Cow::Owned(vec![sd]),
+            sectors: vec![sd],
         };
 
         flash_algorithm
@@ -532,7 +532,7 @@ mod tests {
             erased_byte_value: 255,
             program_page_timeout: 200,
             erase_sector_timeout: 200,
-            sectors: std::borrow::Cow::Owned(vec![sd]),
+            sectors: vec![sd],
         };
 
         flash_algorithm


### PR DESCRIPTION
The reason for Cow was to be able to use Borrowed in t2rust-generated code, but that no longer applies. IMO it is more readable without Cow, and I can't think of any downside.

:no_entry_sign: :cow: 