### PR TITLE
Move FlashAlgorithm from `config` to `flashing` module.

### DIFF
--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -23,7 +23,6 @@
 //!
 
 mod chip_info;
-mod flash_algorithm;
 mod registry;
 mod target;
 
@@ -32,7 +31,6 @@ pub use probe_rs_target::{
     RamRegion, RawFlashAlgorithm, SectorDescription, SectorInfo, TargetDescriptionSource,
 };
 
-pub use flash_algorithm::FlashAlgorithm;
 pub use registry::{
     add_target_from_yaml, families, get_target_by_name, search_chips, RegistryError,
 };

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Formatter};
 
-use super::{FlashError, FlashVisualizer};
-use crate::config::{FlashAlgorithm, MemoryRange, PageInfo, SectorInfo};
+use super::{FlashAlgorithm, FlashError, FlashVisualizer};
+use crate::config::{MemoryRange, PageInfo, SectorInfo};
 
 /// The description of a page in flash.
 #[derive(Clone, PartialEq, Eq)]
@@ -498,7 +498,7 @@ fn add_fill(address: u32, size: u32, fills: &mut Vec<FlashFill>, page_index: usi
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{FlashAlgorithm, FlashProperties, SectorDescription};
+    use crate::config::{FlashProperties, SectorDescription};
 
     fn assemble_demo_flash1() -> FlashAlgorithm {
         let sd = SectorDescription {

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -1,16 +1,15 @@
-use super::{FlashProperties, PageInfo, RamRegion, SectorInfo};
+use super::FlashError;
+use crate::config::{FlashProperties, PageInfo, RamRegion, RawFlashAlgorithm, SectorInfo};
 use crate::core::Architecture;
-use crate::flashing::FlashError;
 use crate::{architecture::riscv, Target};
 use std::convert::TryInto;
 
 /// A flash algorithm, which has been assembled for a specific
 /// chip.
 ///
-/// To create a [FlashAlgorithm], call the [`assemble`] function
-/// on a [RawFlashAlgorithm].
+/// To create a [FlashAlgorithm], call the [`assemble_from_raw`] function.
 ///
-/// [`assemble`]: RawFlashAlgorithm::assemble
+/// [`assemble_from_raw`]: FlashAlgorithm::assemble_from_raw
 #[derive(Debug, Default, Clone)]
 pub struct FlashAlgorithm {
     /// The name of the flash algorithm.
@@ -128,7 +127,7 @@ impl FlashAlgorithm {
 
     /// Constructs a complete flash algorithm, tailored to the flash and RAM sizes given.
     pub fn assemble_from_raw(
-        raw: &super::RawFlashAlgorithm,
+        raw: &RawFlashAlgorithm,
         ram_region: &RamRegion,
         target: &Target,
     ) -> Result<Self, FlashError> {

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -1,6 +1,7 @@
-use super::FlashProgress;
-use super::{FlashBuilder, FlashError, FlashFill, FlashLayout, FlashPage};
-use crate::config::{FlashAlgorithm, MemoryRange, NvmRegion};
+use super::{
+    FlashAlgorithm, FlashBuilder, FlashError, FlashFill, FlashLayout, FlashPage, FlashProgress,
+};
+use crate::config::{MemoryRange, NvmRegion};
 use crate::memory::MemoryInterface;
 use crate::{
     core::{Architecture, RegisterFile},

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -1,12 +1,10 @@
 use ihex::Record;
 
 use super::{
-    extract_from_elf, BinOptions, ExtractedFlashData, FileDownloadError, FlashBuilder, FlashError,
-    FlashProgress, Flasher,
+    extract_from_elf, BinOptions, ExtractedFlashData, FileDownloadError, FlashAlgorithm,
+    FlashBuilder, FlashError, FlashProgress, Flasher,
 };
-use crate::config::{
-    FlashAlgorithm, MemoryRange, MemoryRegion, NvmRegion, TargetDescriptionSource,
-};
+use crate::config::{MemoryRange, MemoryRegion, NvmRegion, TargetDescriptionSource};
 use crate::memory::MemoryInterface;
 use crate::session::Session;
 use std::{

--- a/probe-rs/src/flashing/mod.rs
+++ b/probe-rs/src/flashing/mod.rs
@@ -10,6 +10,7 @@
 mod builder;
 mod download;
 mod error;
+mod flash_algorithm;
 mod flasher;
 mod loader;
 mod progress;
@@ -18,6 +19,7 @@ mod visualizer;
 use builder::*;
 pub use download::*;
 pub use error::*;
+pub use flash_algorithm::*;
 pub use flasher::*;
 pub use progress::*;
 pub use visualizer::*;


### PR DESCRIPTION
The FlashAlgorithm struct contains actual flashing logic (mostly setting up the algo ASM and stack), rather than just configuration. This PR moves it to the `flashing` module.