### PR TITLE
Minimize deps

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -21,46 +21,48 @@ builtin-targets = []
 ftdi = ["libftdi1-sys"]
 
 [dependencies]
+anyhow = "1.0.31"
+base64 = "0.13.0"
+bincode = "1.3.2"
+bitfield = "0.13.2"
+bitvec = "0.19.4"
+enum-primitive-derive = "0.2.1"
+funty = "=1.1.0" # Temporary fix for https://github.com/bitvecto-rs/bitvec/issues/105
+gimli = "0.23.0"
+hidapi = "1.2.0"
+ihex = "3.0.0"
+itm-decode = "0.1.5"
+jaylink = "0.1.4"
+jep106 = "0.2.4"
+lazy_static = "1.4.0"
 log = "0.4.8"
 num-traits = "0.2.11"
-enum-primitive-derive = "0.2.1"
-jep106 = "0.2.4"
-scroll = "0.10.1"
-rusb = "0.7.0"
-lazy_static = "1.4.0"
-hidapi = "1.2.0"
-gimli = "0.23.0"
 object = "0.23.0"
-bitfield = "0.13.2"
+rusb = "0.7.0"
+scroll = "0.10.1"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_yaml = "0.8.11"
-ihex = "3.0.0"
-hexdump = { version = "0.1.0", optional = true }
-thiserror = "1.0.10"
-jaylink = "0.1.4"
-base64 = "0.13.0"
-svg = "0.9.0"
-anyhow = "1.0.31"
-bitvec = {version = "0.19.4" }
-funty = "=1.1.0" # Temporary fix for https://github.com/bitvecto-rs/bitvec/issues/105
-itm-decode = "0.1.5"
-bincode = "1.3.2"
-
-libftdi1-sys = { version = "1.0.0-alpha3", optional = true }
 static_assertions = "1.1.0"
+svg = "0.9.0"
+thiserror = "1.0.10"
 
-probe-rs-target  = { path = "../probe-rs-target", version = "0.1.0", features = ["bincode"] }
+# optional
+hexdump = { version = "0.1.0", optional = true }
+libftdi1-sys = { version = "1.0.0-alpha3", optional = true }
+
+# path
+probe-rs-target = { path = "../probe-rs-target", version = "0.1.0", features = ["bincode"] }
 
 [build-dependencies]
-probe-rs-target  = { path = "../probe-rs-target", version = "0.1.0", features = ["bincode"] }
-serde_yaml = "0.8.11"
 bincode = "1.3.2"
+probe-rs-target = { path = "../probe-rs-target", version = "0.1.0", features = ["bincode"] }
+serde_yaml = "0.8.11"
 
 [dev-dependencies]
-rand = "0.8.0"
-structopt = "0.3"
-pretty_env_logger = "0.4.0"
-serde_json = "1.0.47"
-reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 chrono = "0.4.19"
+pretty_env_logger = "0.4.0"
+rand = "0.8.0"
+reqwest = { version = "0.11.0", features = ["blocking", "json"] }
+serde_json = "1.0.47"
 serde = "1.0.118"
+structopt = "0.3"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -37,7 +37,7 @@ jep106 = "0.2.4"
 lazy_static = "1.4.0"
 log = "0.4.8"
 num-traits = "0.2.11"
-object = "0.23.0"
+object = { version = "0.23.0", default-features = false, features = ["elf", "read_core", "std"] }
 rusb = "0.7.0"
 scroll = "0.10.1"
 serde = { version = "1.0.104", features = ["derive"] }

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -28,7 +28,7 @@ bitfield = "0.13.2"
 bitvec = "0.19.4"
 enum-primitive-derive = "0.2.1"
 funty = "=1.1.0" # Temporary fix for https://github.com/bitvecto-rs/bitvec/issues/105
-gimli = "0.23.0"
+gimli = { version = "0.23.0", default-features = false, features = ["endian-reader", "read", "std"] }
 hidapi = "1.2.0"
 ihex = "3.0.0"
 itm-decode = "0.1.5"


### PR DESCRIPTION
This PR removes the sub-dependencies `flate2`, `indexmap`, `wasmparser` by disabling all expect required features for `gimli` and `object`. Also it ~~bumps `rusb` to `0.8.0` and~~ sorts the dependencies.

Fixes #559 

## compile time comparison
The compile time decreases by `~6s` in release mode and `~3s` in dev mode. All of this is only tested on my laptop, but should still give a good enough estimate.
* `master` (17c71ef72a4b1d7635517626af5966a9aeb730e3)
  * `cargo clean && cargo build`
    * 35.45s
    * 36.62s
    * 34.91s
  * `cargo clean && cargo build --release`
    * 1m 02s
    * 57.50s
    * 57.75s
* `minimize-deps` (de68f2582763d59cdbfa987ed4323eb622223ab3)
  * `cargo clean && cargo build`
    * 32.95s
    * 32.48s
    * 32.92s
  * `cargo clean && cargo build --release`
    * 52.01s
    * 53.08s
    * 51.66s

## size comparison
... _(someone knows a good approach for this?)_