### PR TITLE
Only load segments with type PT_LOAD

### DIFF
--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -1,6 +1,6 @@
 use object::{
-    elf::FileHeader32, read::elf::FileHeader, read::elf::ProgramHeader, Bytes, Endianness, Object,
-    ObjectSection,
+    elf::FileHeader32, elf::PT_LOAD, read::elf::FileHeader, read::elf::ProgramHeader, Bytes,
+    Endianness, Object, ObjectSection,
 };
 
 use std::{cmp::Ordering, fs::File, path::Path, str::FromStr};
@@ -272,7 +272,7 @@ pub(super) fn extract_from_elf<'data>(
 
         let mut elf_section = Vec::new();
 
-        if !segment_data.is_empty() {
+        if !segment_data.is_empty() && segment.p_type(endian) == PT_LOAD {
             log::info!(
                 "Found loadable segment, physical address: {:#010x}, virtual address: {:#010x}, flags: {:#x}",
                 p_paddr,


### PR DESCRIPTION
We need to make sure that the only loadable sections are actually
downloaded to the core. This check seems to be missing currently.

Fixes #581