### PR TITLE
Fix jaylink dependency by temporarily using upstream

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -32,13 +32,13 @@ gimli = { version = "0.23.0", default-features = false, features = ["endian-read
 hidapi = "1.2.0"
 ihex = "3.0.0"
 itm-decode = "0.2.0"
-jaylink = {version = "0.1.5", git = "https://github.com/jschievink/jaylink" }
+jaylink = {version = "0.1.5", git = "https://github.com/jonas-schievink/jaylink" }
 jep106 = "0.2.4"
 lazy_static = "1.4.0"
 log = "0.4.8"
 num-traits = "0.2.11"
 object = { version = "0.23.0", default-features = false, features = ["elf", "read_core", "std"] }
-rusb = "0.7.0"
+rusb = "0.8.0"
 scroll = "0.10.1"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_yaml = "0.8.11"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -32,7 +32,7 @@ gimli = { version = "0.23.0", default-features = false, features = ["endian-read
 hidapi = "1.2.0"
 ihex = "3.0.0"
 itm-decode = "0.2.0"
-jaylink = "0.1.4"
+jaylink = {version = "0.1.5", git = "https://github.com/jschievink/jaylink" }
 jep106 = "0.2.4"
 lazy_static = "1.4.0"
 log = "0.4.8"

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -59,7 +59,7 @@ impl JLink {
         &mut self,
         protocol: Option<WireProtocol>,
     ) -> Result<WireProtocol, DebugProbeError> {
-        let capabilities = self.handle.read_capabilities()?;
+        let capabilities = self.handle.capabilities();
 
         if capabilities.contains(jaylink::Capabilities::SELECT_IF) {
             if let Some(protocol) = protocol {
@@ -68,11 +68,7 @@ impl JLink {
                     WireProtocol::Jtag => jaylink::Interface::Jtag,
                 };
 
-                if self
-                    .handle
-                    .read_available_interfaces()?
-                    .any(|interface| interface == jlink_interface)
-                {
+                if self.handle.available_interfaces().contains(jlink_interface) {
                     // We can select the desired interface
                     self.handle.select_interface(jlink_interface)?;
                     Ok(protocol)
@@ -81,7 +77,7 @@ impl JLink {
                 }
             } else {
                 // No special protocol request
-                let current_protocol = self.handle.read_current_interface()?;
+                let current_protocol = self.handle.current_interface();
 
                 match current_protocol {
                     jaylink::Interface::Swd => Ok(WireProtocol::Swd),
@@ -361,12 +357,12 @@ impl DebugProbe for JLink {
         // not be able to change protocols.
 
         let supported_protocols: Vec<WireProtocol> = if jlink_handle
-            .read_capabilities()?
+            .capabilities()
             .contains(jaylink::Capabilities::SELECT_IF)
         {
-            let interfaces = jlink_handle.read_available_interfaces()?;
+            let interfaces = jlink_handle.available_interfaces();
 
-            let protocols: Vec<_> = interfaces.map(WireProtocol::try_from).collect();
+            let protocols: Vec<_> = interfaces.into_iter().map(WireProtocol::try_from).collect();
 
             protocols
                 .iter()
@@ -477,7 +473,7 @@ impl DebugProbe for JLink {
         log::debug!("Attaching with protocol '{}'", actual_protocol);
 
         // Get reference to JayLink instance
-        let capabilities = self.handle.read_capabilities()?;
+        let capabilities = self.handle.capabilities();
 
         // Log some information about the probe
         let serial = self.handle.serial_string().trim_start_matches('0');


### PR DESCRIPTION
Released `jaylink` currently uses 0.6.3 of `rusb`.
Upstream uses `0.8.0` which matches our used version.

This is required because it will lead to segfaults on macOS otherwise.