### PR TITLE
Disable default-features of dep `itm-decode`

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -31,8 +31,8 @@ funty = "=1.1.0" # Temporary fix for https://github.com/bitvecto-rs/bitvec/issue
 gimli = { version = "0.23.0", default-features = false, features = ["endian-reader", "read", "std"] }
 hidapi = "1.2.0"
 ihex = "3.0.0"
-itm-decode = "0.2.0"
-jaylink = {version = "0.1.5", git = "https://github.com/jonas-schievink/jaylink" }
+itm-decode = { version = "0.2.1", default-features = false }
+jaylink = { version = "0.1.5", git = "https://github.com/jonas-schievink/jaylink" }
 jep106 = "0.2.4"
 lazy_static = "1.4.0"
 log = "0.4.8"


### PR DESCRIPTION
Removes `anyhow` and `structopt` from library dependencies and thereby reduces dependency count from 115 to 97 in `release`- and from 101 to 83 in `dev`-mode **!** (see diff below).

Blocker
- [x] `itm-decode` release including https://github.com/tmplt/itm-decode/pull/10

**diff** (produced by `cargo tree -e normal`)
```diff
 probe-rs v0.10.1
 ├── anyhow v1.0.38
 ├── base64 v0.13.0
 ├── bincode v1.3.2
 │   ├── byteorder v1.3.4
 │   └── serde v1.0.124
 │       └── serde_derive v1.0.124 (proc-macro)
 │           ├── proc-macro2 v1.0.24
 │           │   └── unicode-xid v0.2.1
 │           ├── quote v1.0.9
 │           │   └── proc-macro2 v1.0.24 (*)
 │           └── syn v1.0.63
 │               ├── proc-macro2 v1.0.24 (*)
 │               ├── quote v1.0.9 (*)
 │               └── unicode-xid v0.2.1
 ├── bitfield v0.13.2
 ├── bitvec v0.19.5
 │   ├── funty v1.1.0
 │   ├── radium v0.5.3
 │   ├── tap v1.0.1
 │   └── wyz v0.2.0
 ├── enum-primitive-derive v0.2.1 (proc-macro)
 │   ├── num-traits v0.2.14
 │   ├── quote v1.0.9 (*)
 │   └── syn v1.0.63 (*)
 ├── funty v1.1.0
 ├── gimli v0.23.0
 │   ├── fallible-iterator v0.2.0
 │   └── stable_deref_trait v1.2.0
 ├── hidapi v1.2.5
 │   └── libc v0.2.88
 ├── ihex v3.0.0
+├── itm-decode v0.2.1
-├── itm-decode v0.2.0
-│   ├── anyhow v1.0.38
 │   ├── bitmatch v0.1.1 (proc-macro)
 │   │   ├── boolean_expression v0.3.11
 │   │   │   ├── itertools v0.9.0
 │   │   │   │   └── either v1.6.1
 │   │   │   └── smallvec v1.6.1
 │   │   ├── proc-macro2 v1.0.24 (*)
 │   │   ├── quote v1.0.9 (*)
 │   │   └── syn v1.0.63 (*)
 │   ├── bitvec v0.19.5 (*)
 │   ├── funty v1.1.0
-│   └── structopt v0.3.21
-│       ├── clap v2.33.3
-│       │   ├── ansi_term v0.11.0
-│       │   ├── atty v0.2.14
-│       │   │   └── libc v0.2.88
-│       │   ├── bitflags v1.2.1
-│       │   ├── strsim v0.8.0
-│       │   ├── textwrap v0.11.0
-│       │   │   └── unicode-width v0.1.8
-│       │   ├── unicode-width v0.1.8
-│       │   └── vec_map v0.8.2
-│       ├── lazy_static v1.4.0
-│       └── structopt-derive v0.4.14 (proc-macro)
-│           ├── heck v0.3.2
-│           │   └── unicode-segmentation v1.7.1
-│           ├── proc-macro-error v1.0.4
-│           │   ├── proc-macro-error-attr v1.0.4 (proc-macro)
-│           │   │   ├── proc-macro2 v1.0.24 (*)
-│           │   │   └── quote v1.0.9 (*)
-│           │   ├── proc-macro2 v1.0.24 (*)
-│           │   ├── quote v1.0.9 (*)
-│           │   └── syn v1.0.63 (*)
-│           ├── proc-macro2 v1.0.24 (*)
-│           ├── quote v1.0.9 (*)
-│           └── syn v1.0.63 (*)
 ├── jaylink v0.1.5 (https://github.com/jonas-schievink/jaylink#7a0645b2)
 │   ├── bitflags v1.2.1
 │   ├── byteorder v1.3.4
 │   ├── log v0.4.14
 │   │   └── cfg-if v1.0.0
 │   └── rusb v0.8.0
 │       ├── libc v0.2.88
 │       └── libusb1-sys v0.5.0
 │           └── libc v0.2.88
 ├── jep106 v0.2.5
 │   └── serde v1.0.124 (*)
 ├── lazy_static v1.4.0
 ├── log v0.4.14 (*)
 ├── num-traits v0.2.14
 ├── object v0.23.0
 ├── probe-rs-target v0.1.0
 │   ├── base64 v0.13.0
 │   ├── jep106 v0.2.5 (*)
 │   └── serde v1.0.124 (*)
 ├── rusb v0.8.0 (*)
 ├── scroll v0.10.2
 ├── serde v1.0.124 (*)
 ├── serde_yaml v0.8.17
 │   ├── dtoa v0.4.7
 │   ├── linked-hash-map v0.5.4
 │   ├── serde v1.0.124 (*)
 │   └── yaml-rust v0.4.5
 │       └── linked-hash-map v0.5.4
 ├── static_assertions v1.1.0
 ├── svg v0.9.1
 └── thiserror v1.0.24
     └── thiserror-impl v1.0.24 (proc-macro)
         ├── proc-macro2 v1.0.24 (*)
         ├── quote v1.0.9 (*)
         └── syn v1.0.63 (*)
 ```