### PR TITLE
Export libs from util

### DIFF
--- a/probe-rs-cli-util/Cargo.toml
+++ b/probe-rs-cli-util/Cargo.toml
@@ -16,7 +16,6 @@ license = "MIT OR Apache-2.0"
 default = ["sentry", "anyhow"]
 
 [dependencies]
-structopt = "0.3.16"
 thiserror = "1.0"
 anyhow = { version = "1.0", optional = true }
 indicatif = "0.16.0"

--- a/probe-rs-cli-util/src/lib.rs
+++ b/probe-rs-cli-util/src/lib.rs
@@ -11,6 +11,10 @@ use std::{
     process::{Command, Stdio},
 };
 
+// Re-export crates to avoid version conflicts in the dependent crates.
+pub use indicatif;
+pub use log;
+
 #[derive(Debug, Error)]
 pub enum ArtifactError {
     #[error("Failed to canonicalize path '{work_dir}'.")]


### PR DESCRIPTION
Export the `indicatif` and `log` crates to avoid versioning problems with the `cargo-embed` and `cargo-flash` crates.