### PR TITLE
Fix riscv backend hart scanning

### DIFF
--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -336,7 +336,7 @@ impl<'probe> RiscvCommunicationInterface {
             // Check if the current hart exists
             let status: Dmstatus = self.read_dm_register()?;
 
-            if status.anyunavail() {
+            if status.anynonexistent() {
                 break;
             }
 


### PR DESCRIPTION
It looks like the hart scanning code for riscv uses the wrong status bit in the dmstatus register.
On my chip (GD32V), this causes the debugger to scan through 2^10 harts, which takes quite a while.

Use anynonexistent flag instead, for determining a non-existing hart index.

https://raw.githubusercontent.com/riscv/riscv-debug-spec/master/riscv-debug-stable.pdf section 3.3 describes the recommended procedure for scanning harts.