### PR TITLE
fix riscv abstract command handling (register writes failing)

### DIFF
--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -382,6 +382,10 @@ impl<'probe> RiscvCommunicationInterface {
 
         let abstractauto_readback: Abstractauto = self.read_dm_register()?;
 
+        // clear abstractauto
+        abstractauto = Abstractauto(0);
+        self.write_dm_register(abstractauto)?;
+
         self.state.supports_autoexec = abstractauto_readback == abstractauto;
         log::debug!("Support for autoexec: {}", self.state.supports_autoexec);
 


### PR DESCRIPTION
I bisected the codebase, and found, that the following commit introduced the regression: 63eb1379b47f1353239b287bd665d5ab983962df

Turns out, this is not the real bug, but it made the bug manifest itself.
enter_debug_mode() probes for autoexec capability, but forgets to reset the register in the dm. This causes spuriously executed abstract commands on hardware implementations, that support autoexec.

To fix the issue, clear the register after probing.