### PR TITLE
Fix newly introduced clippy lints.

### DIFF
--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -3,7 +3,7 @@ use crate::{common::open_probe, SharedOptions};
 use probe_rs::{
     architecture::{
         arm::{
-            ap::{GenericAP, MemoryAP},
+            ap::{GenericAp, MemoryAp},
             m0::Demcr,
             memory::Component,
             ApInformation, ArmProbeInterface, MemoryApInformation,
@@ -98,7 +98,7 @@ fn show_arm_info(interface: &mut Box<dyn ArmProbeInterface>) -> Result<()> {
     let num_access_ports = interface.num_access_ports();
 
     for ap_index in 0..num_access_ports {
-        let access_port = GenericAP::from(ap_index as u8);
+        let access_port = GenericAp::from(ap_index as u8);
 
         let ap_information = interface.ap_information(access_port).unwrap();
 
@@ -109,7 +109,7 @@ fn show_arm_info(interface: &mut Box<dyn ArmProbeInterface>) -> Result<()> {
             ApInformation::MemoryAp(MemoryApInformation {
                 debug_base_address, ..
             }) => {
-                let access_port: MemoryAP = access_port.into();
+                let access_port: MemoryAp = access_port.into();
 
                 let base_address = *debug_base_address;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,7 +31,7 @@ fn parse_hex(src: &str) -> Result<u32, ParseIntError> {
     about = "A CLI for on top of the debug probe capabilities provided by probe-rs",
     author = "Noah Hüsser <yatekii@yatekii.ch> / Dominik Böhi <dominik.boehi@gmail.ch>"
 )]
-enum CLI {
+enum Cli {
     /// List all connected debug probes
     #[structopt(name = "list")]
     List {},
@@ -118,16 +118,16 @@ fn main() -> Result<()> {
     // Initialize the logging backend.
     pretty_env_logger::init();
 
-    let matches = CLI::from_args();
+    let matches = Cli::from_args();
 
     match matches {
-        CLI::List {} => list_connected_devices(),
-        CLI::Info { shared } => crate::info::show_info_of_device(&shared),
-        CLI::Reset { shared, assert } => reset_target_of_device(&shared, assert),
-        CLI::Debug { shared, exe } => debug(&shared, exe),
-        CLI::Dump { shared, loc, words } => dump_memory(&shared, loc, words),
-        CLI::Download { shared, path } => download_program_fast(&shared, &path),
-        CLI::Trace { shared, loc } => trace_u32_on_target(&shared, loc),
+        Cli::List {} => list_connected_devices(),
+        Cli::Info { shared } => crate::info::show_info_of_device(&shared),
+        Cli::Reset { shared, assert } => reset_target_of_device(&shared, assert),
+        Cli::Debug { shared, exe } => debug(&shared, exe),
+        Cli::Dump { shared, loc, words } => dump_memory(&shared, loc, words),
+        Cli::Download { shared, path } => download_program_fast(&shared, &path),
+        Cli::Trace { shared, loc } => trace_u32_on_target(&shared, loc),
     }
 }
 

--- a/probe-rs/src/architecture/arm/ap/generic_ap.rs
+++ b/probe-rs/src/architecture/arm/ap/generic_ap.rs
@@ -1,43 +1,42 @@
 //! Generic access port
 
-use super::{APRegister, AccessPort, Register};
+use super::{AccessPort, ApRegister, Register};
 use enum_primitive_derive::Primitive;
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 
-#[allow(non_camel_case_types)]
 #[derive(Debug, Primitive, Clone, Copy, PartialEq)]
-pub enum APClass {
+pub enum ApClass {
     Undefined = 0b0000,
-    COMAP = 0b0001,
-    MEMAP = 0b1000,
+    ComAp = 0b0001,
+    MemAp = 0b1000,
 }
 
-impl Default for APClass {
+impl Default for ApClass {
     fn default() -> Self {
-        APClass::Undefined
+        ApClass::Undefined
     }
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Primitive, Clone, Copy, PartialEq)]
-pub enum APType {
-    JTAG_COM_AP = 0x0,
-    AMBA_AHB3 = 0x1,
-    AMBA_APB2_APB3 = 0x2,
-    AMBA_AXI3_AXI4 = 0x4,
-    AMBA_AHB5 = 0x5,
-    AMBA_AHB4 = 0x6,
-    AMBA_AXI5 = 0x7,
-    AMBA_AHB5_HPROT = 0x8,
+pub enum ApType {
+    JtagComAp = 0x0,
+    AmbaAhb3 = 0x1,
+    AmbaAhb2Ahb3 = 0x2,
+    AmbaAxi3Axi4 = 0x4,
+    AmbaAhb5 = 0x5,
+    AmbaAhb4 = 0x6,
+    AmbaAxi5 = 0x7,
+    AmbaAhb5Hprot = 0x8,
 }
 
-impl Default for APType {
+impl Default for ApType {
     fn default() -> Self {
-        APType::JTAG_COM_AP
+        ApType::JtagComAp
     }
 }
 
-define_ap!(GenericAP);
+define_ap!(GenericAp);
 
 define_ap_register!(
     /// Identification Register
@@ -46,25 +45,25 @@ define_ap_register!(
     /// an AP.
     ///
     /// It has to be present on every AP.
-    GenericAP,
+    GenericAp,
     IDR,
     0x0FC,
     [
         (REVISION: u8),
         (DESIGNER: u16),
-        (CLASS: APClass),
+        (CLASS: ApClass),
         (_RES0: u8),
         (VARIANT: u8),
-        (TYPE: APType),
+        (TYPE: ApType),
     ],
     value,
     IDR {
         REVISION: ((value >> 28) & 0x0F) as u8,
         DESIGNER: ((value >> 17) & 0x7FF) as u16,
-        CLASS: APClass::from_u8(((value >> 13) & 0x0F) as u8).unwrap(),
+        CLASS: ApClass::from_u8(((value >> 13) & 0x0F) as u8).unwrap(),
         _RES0: 0,
         VARIANT: ((value >> 4) & 0x0F) as u8,
-        TYPE: APType::from_u8((value & 0x0F) as u8).unwrap()
+        TYPE: ApType::from_u8((value & 0x0F) as u8).unwrap()
     },
     (u32::from(value.REVISION) << 28)
         | (u32::from(value.DESIGNER) << 17)

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -1,7 +1,7 @@
-use super::super::{APAccess, Register};
-use super::{APRegister, AddressIncrement, DataSize, MemoryAP, CSW, DRW, TAR};
+use super::super::{ApAccess, Register};
+use super::{AddressIncrement, ApRegister, DataSize, MemoryAp, CSW, DRW, TAR};
 use crate::{
-    architecture::arm::dp::{DPAccess, DPRegister, DebugPortError},
+    architecture::arm::dp::{DebugPortError, DpAccess, DpRegister},
     CommunicationInterface, DebugProbeError,
 };
 use std::collections::HashMap;
@@ -9,7 +9,7 @@ use std::convert::TryInto;
 use thiserror::Error;
 
 #[derive(Debug)]
-pub struct MockMemoryAP {
+pub struct MockMemoryAp {
     pub memory: Vec<u8>,
     store: HashMap<(u8, u8), u32>,
 }
@@ -22,8 +22,8 @@ pub enum MockMemoryError {
     UnknownRegister,
 }
 
-impl MockMemoryAP {
-    /// Creates a MockMemoryAP with the memory filled with a pattern where each byte is equal to its
+impl MockMemoryAp {
+    /// Creates a MockMemoryAp with the memory filled with a pattern where each byte is equal to its
     /// own address plus one (to avoid zeros). The pattern can be used as a canary pattern to ensure
     /// writes do not clobber adjacent memory. The memory is also quite small so it can be feasibly
     /// printed out for debugging.
@@ -39,15 +39,15 @@ impl MockMemoryAP {
     }
 }
 
-impl CommunicationInterface for MockMemoryAP {
+impl CommunicationInterface for MockMemoryAp {
     fn flush(&mut self) -> Result<(), DebugProbeError> {
         Ok(())
     }
 }
 
-impl<R> APAccess<MemoryAP, R> for MockMemoryAP
+impl<R> ApAccess<MemoryAp, R> for MockMemoryAp
 where
-    R: APRegister<MemoryAP>,
+    R: ApRegister<MemoryAp>,
 {
     type Error = MockMemoryError;
 
@@ -56,7 +56,7 @@ where
     /// Returns an Error if any bad instructions or values are chosen.
     fn read_ap_register(
         &mut self,
-        _port: impl Into<MemoryAP>,
+        _port: impl Into<MemoryAp>,
         _register: R,
     ) -> Result<R, Self::Error> {
         let csw = self.store[&(CSW::ADDRESS, CSW::APBANKSEL)];
@@ -128,7 +128,7 @@ where
     /// Returns an Error if any bad instructions or values are chosen.
     fn write_ap_register(
         &mut self,
-        _port: impl Into<MemoryAP>,
+        _port: impl Into<MemoryAp>,
         register: R,
     ) -> Result<(), Self::Error> {
         log::debug!("Mock: Write to register {:x?}", &register);
@@ -214,7 +214,7 @@ where
 
     fn write_ap_register_repeated(
         &mut self,
-        port: impl Into<MemoryAP> + Clone,
+        port: impl Into<MemoryAp> + Clone,
         _register: R,
         values: &[u32],
     ) -> Result<(), Self::Error> {
@@ -226,7 +226,7 @@ where
     }
     fn read_ap_register_repeated(
         &mut self,
-        port: impl Into<MemoryAP> + Clone,
+        port: impl Into<MemoryAp> + Clone,
         register: R,
         values: &mut [u32],
     ) -> Result<(), Self::Error> {
@@ -240,13 +240,13 @@ where
     }
 }
 
-impl DPAccess for MockMemoryAP {
-    fn read_dp_register<R: DPRegister>(&mut self) -> Result<R, DebugPortError> {
+impl DpAccess for MockMemoryAp {
+    fn read_dp_register<R: DpRegister>(&mut self) -> Result<R, DebugPortError> {
         // Ignore for Tests
         Ok(0.into())
     }
 
-    fn write_dp_register<R: DPRegister>(&mut self, _register: R) -> Result<(), DebugPortError> {
+    fn write_dp_register<R: DpRegister>(&mut self, _register: R) -> Result<(), DebugPortError> {
         Ok(())
     }
 }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -3,7 +3,7 @@
 #[doc(hidden)]
 pub(crate) mod mock;
 
-use super::{APAccess, APRegister, AccessPort, GenericAP, Register};
+use super::{AccessPort, ApAccess, ApRegister, GenericAp, Register};
 use crate::DebugProbeError;
 use enum_primitive_derive::Primitive;
 use num_traits::{FromPrimitive, ToPrimitive};
@@ -12,13 +12,13 @@ use num_traits::{FromPrimitive, ToPrimitive};
 //
 // The memory AP can be used to access a memory-mapped
 // set of debug resouces of the attached system.
-define_ap!(MemoryAP);
+define_ap!(MemoryAp);
 
-impl MemoryAP {
+impl MemoryAp {
     pub fn base_address<A>(&self, interface: &mut A) -> Result<u64, DebugProbeError>
     where
-        A: APAccess<MemoryAP, BASE, Error = DebugProbeError>
-            + APAccess<MemoryAP, BASE2, Error = DebugProbeError>,
+        A: ApAccess<MemoryAp, BASE, Error = DebugProbeError>
+            + ApAccess<MemoryAp, BASE2, Error = DebugProbeError>,
     {
         let base_register = interface.read_ap_register(self.port_number(), BASE::default())?;
 
@@ -35,9 +35,9 @@ impl MemoryAP {
     }
 }
 
-impl From<GenericAP> for MemoryAP {
-    fn from(other: GenericAP) -> Self {
-        MemoryAP {
+impl From<GenericAp> for MemoryAp {
+    fn from(other: GenericAp) -> Self {
+        MemoryAp {
             port_number: other.port_number(),
         }
     }
@@ -118,7 +118,7 @@ impl Default for DebugEntryState {
 
 define_ap_register!(
     /// Base register
-    MemoryAP,
+    MemoryAp,
     BASE,
     0xF8,
     [
@@ -150,7 +150,7 @@ define_ap_register!(
 
 define_ap_register!(
     /// Base register
-    MemoryAP,
+    MemoryAp,
     BASE2,
     0xF0,
     [(BASEADDR: u32),],
@@ -161,7 +161,7 @@ define_ap_register!(
 
 define_ap_register!(
     /// Banked Data 0 register
-    MemoryAP,
+    MemoryAp,
     BD0,
     0x10,
     [(data: u32),],
@@ -172,7 +172,7 @@ define_ap_register!(
 
 define_ap_register!(
     /// Banked Data 1 register
-    MemoryAP,
+    MemoryAp,
     BD1,
     0x14,
     [(data: u32),],
@@ -183,7 +183,7 @@ define_ap_register!(
 
 define_ap_register!(
     /// Banked Data 2 register
-    MemoryAP,
+    MemoryAp,
     BD2,
     0x18,
     [(data: u32),],
@@ -194,7 +194,7 @@ define_ap_register!(
 
 define_ap_register!(
     /// Banked Data 3 register
-    MemoryAP,
+    MemoryAp,
     BD3,
     0x1C,
     [(data: u32),],
@@ -208,7 +208,7 @@ define_ap_register!(
     ///
     /// The configuration register (CFG) is used to determine
     /// which extensions are included in the memory AP.
-    MemoryAP,
+    MemoryAp,
     CFG,
     0xF4,
     [(LD: u8), (LA: u8), (BE: u8),],
@@ -226,7 +226,7 @@ define_ap_register!(
     ///
     /// The control and status word register (CSW) is used
     /// to configure memory access through the memory AP.
-    MemoryAP,
+    MemoryAp,
     CSW,
     0x00,
     [
@@ -319,7 +319,7 @@ define_ap_register!(
     ///
     /// A read from the *DRW* register is translated to a memory read
     /// from the address specified in the TAR register.
-    MemoryAP,
+    MemoryAp,
     DRW,
     0x0C,
     [(data: u32),],
@@ -338,7 +338,7 @@ define_ap_register!(
     /// Writes to this register only have an effect if
     /// the *Barrier Operations Extension* is implemented
     /// by the AP.
-    MemoryAP,
+    MemoryAp,
     MBT,
     0x20,
     [(data: u32)],
@@ -353,7 +353,7 @@ define_ap_register!(
     /// The transfer address register (TAR) holds the memory
     /// address which will be accessed through a read or
     /// write of the DRW register.
-    MemoryAP,
+    MemoryAp,
     TAR,
     0x04,
     [(address: u32),],

--- a/probe-rs/src/architecture/arm/ap/register_generation.rs
+++ b/probe-rs/src/architecture/arm/ap/register_generation.rs
@@ -16,6 +16,7 @@ macro_rules! define_ap_register {
     => {
         $(#[$outer])*
         #[allow(non_snake_case)]
+        #[allow(clippy::upper_case_acronyms)]
         #[derive(Debug, Default, Clone, Copy, PartialEq)]
         pub struct $name {
             $(pub $field: $type,)*
@@ -39,7 +40,7 @@ macro_rules! define_ap_register {
             }
         }
 
-        impl APRegister<$port_type> for $name {
+        impl ApRegister<$port_type> for $name {
             // APBANKSEL is always the upper 4 bits of the register address.
             const APBANKSEL: u8 = $address >> 4;
         }

--- a/probe-rs/src/architecture/arm/component/dwt.rs
+++ b/probe-rs/src/architecture/arm/component/dwt.rs
@@ -21,7 +21,7 @@ pub struct Dwt<'probe: 'core, 'core> {
 impl<'probe: 'core, 'core> Dwt<'probe, 'core> {
     /// Creates a new DWT component representation.
     pub fn new(core: &'core mut Core<'probe>, component: &'core Component) -> Self {
-        Dwt { core, component }
+        Dwt { component, core }
     }
 
     /// Logs some info about the DWT component.

--- a/probe-rs/src/architecture/arm/component/itm.rs
+++ b/probe-rs/src/architecture/arm/component/itm.rs
@@ -19,7 +19,7 @@ const REGISTER_OFFSET_ACCESS: u32 = 0xFB0;
 
 impl<'probe: 'core, 'core> Itm<'probe, 'core> {
     pub fn new(core: &'core mut Core<'probe>, component: &'core Component) -> Self {
-        Itm { core, component }
+        Itm { component, core }
     }
 
     pub fn unlock(&mut self) -> Result<(), Error> {

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -74,7 +74,7 @@ pub fn setup_swv(
     tpiu.set_prescaler(prescaler)?;
     match config.mode() {
         SwoMode::Manchester => tpiu.set_pin_protocol(1)?,
-        SwoMode::UART => tpiu.set_pin_protocol(2)?,
+        SwoMode::Uart => tpiu.set_pin_protocol(2)?,
     }
 
     // Formatter: TrigIn enabled, bypass optional

--- a/probe-rs/src/architecture/arm/component/tpiu.rs
+++ b/probe-rs/src/architecture/arm/component/tpiu.rs
@@ -19,7 +19,7 @@ pub struct Tpiu<'probe: 'core, 'core> {
 
 impl<'probe: 'core, 'core> Tpiu<'probe, 'core> {
     pub fn new(core: &'core mut Core<'probe>, component: &'core Component) -> Self {
-        Tpiu { core, component }
+        Tpiu { component, core }
     }
 
     pub fn set_port_size(&mut self, value: u32) -> Result<(), Error> {

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -26,20 +26,20 @@ impl From<DebugPortError> for DebugProbeError {
     }
 }
 
-pub trait DPAccess {
-    fn read_dp_register<R: DPRegister>(&mut self) -> Result<R, DebugPortError>;
+pub trait DpAccess {
+    fn read_dp_register<R: DpRegister>(&mut self) -> Result<R, DebugPortError>;
 
-    fn write_dp_register<R: DPRegister>(&mut self, register: R) -> Result<(), DebugPortError>;
+    fn write_dp_register<R: DpRegister>(&mut self, register: R) -> Result<(), DebugPortError>;
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub enum DPBankSel {
+pub enum DpBankSel {
     DontCare,
     Bank(u8),
 }
 
-pub trait DPRegister: Register {
-    const DP_BANK: DPBankSel;
+pub trait DpRegister: Register {
+    const DP_BANK: DpBankSel;
     const VERSION: DebugPortVersion;
 }
 
@@ -72,8 +72,8 @@ impl From<Abort> for u32 {
     }
 }
 
-impl DPRegister for Abort {
-    const DP_BANK: DPBankSel = DPBankSel::DontCare;
+impl DpRegister for Abort {
+    const DP_BANK: DpBankSel = DpBankSel::DontCare;
     const VERSION: DebugPortVersion = DebugPortVersion::DPv1;
 }
 
@@ -121,8 +121,8 @@ impl From<Ctrl> for u32 {
     }
 }
 
-impl DPRegister for Ctrl {
-    const DP_BANK: DPBankSel = DPBankSel::Bank(0);
+impl DpRegister for Ctrl {
+    const DP_BANK: DpBankSel = DpBankSel::Bank(0);
     const VERSION: DebugPortVersion = DebugPortVersion::DPv1;
 }
 
@@ -152,8 +152,8 @@ impl From<Select> for u32 {
     }
 }
 
-impl DPRegister for Select {
-    const DP_BANK: DPBankSel = DPBankSel::DontCare;
+impl DpRegister for Select {
+    const DP_BANK: DpBankSel = DpBankSel::DontCare;
     const VERSION: DebugPortVersion = DebugPortVersion::DPv1;
 }
 
@@ -187,8 +187,8 @@ impl From<DPIDR> for u32 {
     }
 }
 
-impl DPRegister for DPIDR {
-    const DP_BANK: DPBankSel = DPBankSel::DontCare;
+impl DpRegister for DPIDR {
+    const DP_BANK: DpBankSel = DpBankSel::DontCare;
     const VERSION: DebugPortVersion = DebugPortVersion::DPv1;
 }
 
@@ -218,8 +218,8 @@ impl From<TARGETID> for u32 {
     }
 }
 
-impl DPRegister for TARGETID {
-    const DP_BANK: DPBankSel = DPBankSel::Bank(2);
+impl DpRegister for TARGETID {
+    const DP_BANK: DpBankSel = DpBankSel::Bank(2);
     const VERSION: DebugPortVersion = DebugPortVersion::DPv2;
 }
 
@@ -270,8 +270,8 @@ impl From<RdBuff> for u32 {
     }
 }
 
-impl DPRegister for RdBuff {
-    const DP_BANK: DPBankSel = DPBankSel::DontCare;
+impl DpRegister for RdBuff {
+    const DP_BANK: DpBankSel = DpBankSel::DontCare;
     const VERSION: DebugPortVersion = DebugPortVersion::DPv1;
 }
 

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -1,7 +1,7 @@
 use super::super::ap::{
-    APAccess, APRegister, AccessPortError, AddressIncrement, DataSize, MemoryAP, CSW, DRW, TAR,
+    AccessPortError, AddressIncrement, ApAccess, ApRegister, DataSize, MemoryAp, CSW, DRW, TAR,
 };
-use crate::architecture::arm::{dp::DPAccess, MemoryApInformation};
+use crate::architecture::arm::{dp::DpAccess, MemoryApInformation};
 use crate::{CommunicationInterface, CoreRegister, CoreRegisterAddress, DebugProbeError, Error};
 use scroll::{Pread, Pwrite, LE};
 use std::convert::TryInto;
@@ -13,19 +13,19 @@ use std::{
 use bitfield::bitfield;
 
 pub trait ArmProbe {
-    fn read_core_reg(&mut self, ap: MemoryAP, addr: CoreRegisterAddress) -> Result<u32, Error>;
+    fn read_core_reg(&mut self, ap: MemoryAp, addr: CoreRegisterAddress) -> Result<u32, Error>;
     fn write_core_reg(
         &mut self,
-        ap: MemoryAP,
+        ap: MemoryAp,
         addr: CoreRegisterAddress,
         value: u32,
     ) -> Result<(), Error>;
 
-    fn read_8(&mut self, ap: MemoryAP, address: u32, data: &mut [u8]) -> Result<(), Error>;
-    fn read_32(&mut self, ap: MemoryAP, address: u32, data: &mut [u32]) -> Result<(), Error>;
+    fn read_8(&mut self, ap: MemoryAp, address: u32, data: &mut [u8]) -> Result<(), Error>;
+    fn read_32(&mut self, ap: MemoryAp, address: u32, data: &mut [u32]) -> Result<(), Error>;
 
-    fn write_8(&mut self, ap: MemoryAP, address: u32, data: &[u8]) -> Result<(), Error>;
-    fn write_32(&mut self, ap: MemoryAP, address: u32, data: &[u32]) -> Result<(), Error>;
+    fn write_8(&mut self, ap: MemoryAp, address: u32, data: &[u8]) -> Result<(), Error>;
+    fn write_32(&mut self, ap: MemoryAp, address: u32, data: &[u32]) -> Result<(), Error>;
 
     fn flush(&mut self) -> Result<(), Error>;
 }
@@ -34,10 +34,10 @@ pub trait ArmProbe {
 pub(crate) struct ADIMemoryInterface<'interface, AP>
 where
     AP: CommunicationInterface
-        + APAccess<MemoryAP, CSW>
-        + APAccess<MemoryAP, TAR>
-        + APAccess<MemoryAP, DRW>
-        + DPAccess,
+        + ApAccess<MemoryAp, CSW>
+        + ApAccess<MemoryAp, TAR>
+        + ApAccess<MemoryAp, DRW>
+        + DpAccess,
 {
     interface: &'interface mut AP,
     only_32bit_data_size: bool,
@@ -58,10 +58,10 @@ where
 impl<'interface, AP> ADIMemoryInterface<'interface, AP>
 where
     AP: CommunicationInterface
-        + APAccess<MemoryAP, CSW>
-        + APAccess<MemoryAP, TAR>
-        + APAccess<MemoryAP, DRW>
-        + DPAccess,
+        + ApAccess<MemoryAp, CSW>
+        + ApAccess<MemoryAp, TAR>
+        + ApAccess<MemoryAp, DRW>
+        + DpAccess,
 {
     /// Creates a new MemoryInterface for given AccessPort.
     pub fn new(
@@ -80,10 +80,10 @@ where
 impl<AP> ADIMemoryInterface<'_, AP>
 where
     AP: CommunicationInterface
-        + APAccess<MemoryAP, CSW>
-        + APAccess<MemoryAP, TAR>
-        + APAccess<MemoryAP, DRW>
-        + DPAccess,
+        + ApAccess<MemoryAp, CSW>
+        + ApAccess<MemoryAp, TAR>
+        + ApAccess<MemoryAp, DRW>
+        + DpAccess,
 {
     /// Build the correct CSW register for a memory access
     ///
@@ -118,7 +118,7 @@ where
 
     fn write_csw_register(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         value: CSW,
     ) -> Result<(), AccessPortError> {
         // Check if the write is necessary
@@ -136,7 +136,7 @@ where
 
     fn wait_for_core_register_transfer(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         timeout: Duration,
     ) -> Result<(), Error> {
         // now we have to poll the dhcsr register, until the dhcsr.s_regrdy bit is set
@@ -156,12 +156,12 @@ where
     /// Read a 32 bit register on the given AP.
     fn read_ap_register<R>(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         register: R,
     ) -> Result<R, AccessPortError>
     where
-        R: APRegister<MemoryAP>,
-        AP: APAccess<MemoryAP, R>,
+        R: ApRegister<MemoryAp>,
+        AP: ApAccess<MemoryAp, R>,
     {
         self.interface
             .read_ap_register(access_port, register)
@@ -172,13 +172,13 @@ where
     /// register on the given AP.
     fn read_ap_register_repeated<R>(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         register: R,
         values: &mut [u32],
     ) -> Result<(), AccessPortError>
     where
-        R: APRegister<MemoryAP>,
-        AP: APAccess<MemoryAP, R>,
+        R: ApRegister<MemoryAp>,
+        AP: ApAccess<MemoryAp, R>,
     {
         self.interface
             .read_ap_register_repeated(access_port, register, values)
@@ -188,12 +188,12 @@ where
     /// Write a 32 bit register on the given AP.
     fn write_ap_register<R>(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         register: R,
     ) -> Result<(), AccessPortError>
     where
-        R: APRegister<MemoryAP>,
-        AP: APAccess<MemoryAP, R>,
+        R: ApRegister<MemoryAp>,
+        AP: ApAccess<MemoryAp, R>,
     {
         self.interface
             .write_ap_register(access_port, register)
@@ -204,13 +204,13 @@ where
     /// register on the given AP.
     fn write_ap_register_repeated<R>(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         register: R,
         values: &[u32],
     ) -> Result<(), AccessPortError>
     where
-        R: APRegister<MemoryAP>,
-        AP: APAccess<MemoryAP, R>,
+        R: ApRegister<MemoryAp>,
+        AP: ApAccess<MemoryAp, R>,
     {
         self.interface
             .write_ap_register_repeated(access_port, register, values)
@@ -223,7 +223,7 @@ where
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
     pub fn read_word_32(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         address: u32,
     ) -> Result<u32, AccessPortError> {
         if (address % 4) != 0 {
@@ -244,7 +244,7 @@ where
     /// Read an 8bit word at `addr`.
     pub fn read_word_8(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         address: u32,
     ) -> Result<u8, AccessPortError> {
         let aligned = aligned_range(address, 1)?;
@@ -277,7 +277,7 @@ where
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
     pub fn read_32(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         start_address: u32,
         data: &mut [u32],
     ) -> Result<(), AccessPortError> {
@@ -364,7 +364,7 @@ where
 
     pub fn read_8(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         address: u32,
         data: &mut [u8],
     ) -> Result<(), AccessPortError> {
@@ -397,7 +397,7 @@ where
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
     pub fn write_word_32(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         address: u32,
         data: u32,
     ) -> Result<(), AccessPortError> {
@@ -419,7 +419,7 @@ where
     /// Write an 8bit word at `addr`.
     pub fn write_word_8(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         address: u32,
         data: u8,
     ) -> Result<(), AccessPortError> {
@@ -457,7 +457,7 @@ where
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
     pub fn write_32(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         start_address: u32,
         data: &[u32],
     ) -> Result<(), AccessPortError> {
@@ -554,7 +554,7 @@ where
     /// The number of words written is `data.len()`.
     pub fn write_8(
         &mut self,
-        access_port: MemoryAP,
+        access_port: MemoryAp,
         address: u32,
         data: &[u8],
     ) -> Result<(), AccessPortError> {
@@ -603,12 +603,12 @@ where
 impl<AP> ArmProbe for ADIMemoryInterface<'_, AP>
 where
     AP: CommunicationInterface
-        + APAccess<MemoryAP, CSW>
-        + APAccess<MemoryAP, TAR>
-        + APAccess<MemoryAP, DRW>
-        + DPAccess,
+        + ApAccess<MemoryAp, CSW>
+        + ApAccess<MemoryAp, TAR>
+        + ApAccess<MemoryAp, DRW>
+        + DpAccess,
 {
-    fn read_core_reg(&mut self, ap: MemoryAP, addr: CoreRegisterAddress) -> Result<u32, Error> {
+    fn read_core_reg(&mut self, ap: MemoryAp, addr: CoreRegisterAddress) -> Result<u32, Error> {
         // Write the DCRSR value to select the register we want to read.
         let mut dcrsr_val = Dcrsr(0);
         dcrsr_val.set_regwnr(false); // Perform a read.
@@ -625,7 +625,7 @@ where
 
     fn write_core_reg(
         &mut self,
-        ap: MemoryAP,
+        ap: MemoryAp,
         addr: CoreRegisterAddress,
         value: u32,
     ) -> Result<(), Error> {
@@ -643,7 +643,7 @@ where
         Ok(())
     }
 
-    fn read_8(&mut self, ap: MemoryAP, address: u32, data: &mut [u8]) -> Result<(), Error> {
+    fn read_8(&mut self, ap: MemoryAp, address: u32, data: &mut [u8]) -> Result<(), Error> {
         if data.len() == 1 {
             data[0] = self.read_word_8(ap, address)?;
         } else {
@@ -653,7 +653,7 @@ where
         Ok(())
     }
 
-    fn read_32(&mut self, ap: MemoryAP, address: u32, data: &mut [u32]) -> Result<(), Error> {
+    fn read_32(&mut self, ap: MemoryAp, address: u32, data: &mut [u32]) -> Result<(), Error> {
         if data.len() == 1 {
             data[0] = self.read_word_32(ap, address)?;
         } else {
@@ -663,7 +663,7 @@ where
         Ok(())
     }
 
-    fn write_8(&mut self, ap: MemoryAP, address: u32, data: &[u8]) -> Result<(), Error> {
+    fn write_8(&mut self, ap: MemoryAp, address: u32, data: &[u8]) -> Result<(), Error> {
         if data.len() == 1 {
             self.write_word_8(ap, address, data[0])?;
         } else {
@@ -673,7 +673,7 @@ where
         Ok(())
     }
 
-    fn write_32(&mut self, ap: MemoryAP, address: u32, data: &[u32]) -> Result<(), Error> {
+    fn write_32(&mut self, ap: MemoryAp, address: u32, data: &[u32]) -> Result<(), Error> {
         if data.len() == 1 {
             self.write_word_32(ap, address, data[0])?;
         } else {
@@ -804,14 +804,14 @@ fn aligned_range(address: u32, len: usize) -> Result<Range<u32>, AccessPortError
 mod tests {
     use crate::architecture::arm::MemoryApInformation;
 
-    use super::super::super::ap::memory_ap::mock::MockMemoryAP;
+    use super::super::super::ap::memory_ap::mock::MockMemoryAp;
     use super::ADIMemoryInterface;
 
-    impl<'interface> ADIMemoryInterface<'interface, MockMemoryAP> {
+    impl<'interface> ADIMemoryInterface<'interface, MockMemoryAp> {
         /// Creates a new MemoryInterface for given AccessPort.
         fn new_mock(
-            mock: &'interface mut MockMemoryAP,
-        ) -> ADIMemoryInterface<'interface, MockMemoryAP> {
+            mock: &'interface mut MockMemoryAp,
+        ) -> ADIMemoryInterface<'interface, MockMemoryAp> {
             let ap_information = MemoryApInformation {
                 port_number: 0,
                 only_32bit_data_size: false,
@@ -836,7 +836,7 @@ mod tests {
 
     #[test]
     fn read_word_32() {
-        let mut mock = MockMemoryAP::with_pattern();
+        let mut mock = MockMemoryAp::with_pattern();
         mock.memory[..8].copy_from_slice(&DATA8[..8]);
         let mut mi = ADIMemoryInterface::new_mock(&mut mock);
 
@@ -850,7 +850,7 @@ mod tests {
 
     #[test]
     fn read_word_8() {
-        let mut mock = MockMemoryAP::with_pattern();
+        let mut mock = MockMemoryAp::with_pattern();
         mock.memory[..8].copy_from_slice(&DATA8[..8]);
         let mut mi = ADIMemoryInterface::new_mock(&mut mock);
 
@@ -865,7 +865,7 @@ mod tests {
     #[test]
     fn write_word_32() {
         for &address in &[0, 4] {
-            let mut mock = MockMemoryAP::with_pattern();
+            let mut mock = MockMemoryAp::with_pattern();
             let mut mi = ADIMemoryInterface::new_mock(&mut mock);
 
             let mut expected = Vec::from(mi.mock_memory());
@@ -885,7 +885,7 @@ mod tests {
     #[test]
     fn write_word_8() {
         for address in 0..8 {
-            let mut mock = MockMemoryAP::with_pattern();
+            let mut mock = MockMemoryAp::with_pattern();
             let mut mi = ADIMemoryInterface::new_mock(&mut mock);
 
             let mut expected = Vec::from(mi.mock_memory());
@@ -904,7 +904,7 @@ mod tests {
 
     #[test]
     fn read_32() {
-        let mut mock = MockMemoryAP::with_pattern();
+        let mut mock = MockMemoryAp::with_pattern();
         mock.memory[..DATA8.len()].copy_from_slice(DATA8);
         let mut mi = ADIMemoryInterface::new_mock(&mut mock);
 
@@ -929,7 +929,7 @@ mod tests {
 
     #[test]
     fn read_32_unaligned_should_error() {
-        let mut mock = MockMemoryAP::with_pattern();
+        let mut mock = MockMemoryAp::with_pattern();
         let mut mi = ADIMemoryInterface::new_mock(&mut mock);
 
         for &address in &[1, 3, 127] {
@@ -939,7 +939,7 @@ mod tests {
 
     #[test]
     fn read_8() {
-        let mut mock = MockMemoryAP::with_pattern();
+        let mut mock = MockMemoryAp::with_pattern();
         mock.memory[..DATA8.len()].copy_from_slice(DATA8);
         let mut mi = ADIMemoryInterface::new_mock(&mut mock);
 
@@ -965,7 +965,7 @@ mod tests {
     fn write_32() {
         for &address in &[0, 4] {
             for len in 0..3 {
-                let mut mock = MockMemoryAP::with_pattern();
+                let mut mock = MockMemoryAp::with_pattern();
                 let mut mi = ADIMemoryInterface::new_mock(&mut mock);
 
                 let mut expected = Vec::from(mi.mock_memory());
@@ -990,7 +990,7 @@ mod tests {
 
     #[test]
     fn write_block_u32_unaligned_should_error() {
-        let mut mock = MockMemoryAP::with_pattern();
+        let mut mock = MockMemoryAp::with_pattern();
         let mut mi = ADIMemoryInterface::new_mock(&mut mock);
 
         for &address in &[1, 3, 127] {
@@ -1004,7 +1004,7 @@ mod tests {
     fn write_8() {
         for address in 0..4 {
             for len in 0..12 {
-                let mut mock = MockMemoryAP::with_pattern();
+                let mut mock = MockMemoryAp::with_pattern();
                 let mut mi = ADIMemoryInterface::new_mock(&mut mock);
 
                 let mut expected = Vec::from(mi.mock_memory());

--- a/probe-rs/src/architecture/arm/memory/mod.rs
+++ b/probe-rs/src/architecture/arm/memory/mod.rs
@@ -10,15 +10,15 @@ pub trait ToMemoryReadSize: Into<u32> + Copy {
     /// The transfer size expressed in bytes.
     const MEMORY_TRANSFER_SIZE: u8;
     /// Transform a generic 32 bit sized value to a transfer size sized one.
-    fn to_result(value: u32) -> Self;
+    fn into_result(self) -> Self;
 }
 
 impl ToMemoryReadSize for u32 {
     const ALIGNMENT_MASK: u32 = 0x3;
     const MEMORY_TRANSFER_SIZE: u8 = 4;
 
-    fn to_result(value: u32) -> Self {
-        value
+    fn into_result(self) -> Self {
+        self
     }
 }
 
@@ -26,8 +26,8 @@ impl ToMemoryReadSize for u16 {
     const ALIGNMENT_MASK: u32 = 0x1;
     const MEMORY_TRANSFER_SIZE: u8 = 2;
 
-    fn to_result(value: u32) -> Self {
-        value as u16
+    fn into_result(self) -> Self {
+        self as u16
     }
 }
 
@@ -35,8 +35,8 @@ impl ToMemoryReadSize for u8 {
     const ALIGNMENT_MASK: u32 = 0x0;
     const MEMORY_TRANSFER_SIZE: u8 = 1;
 
-    fn to_result(value: u32) -> Self {
-        value as u8
+    fn into_result(self) -> Self {
+        self as u8
     }
 }
 

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -7,7 +7,7 @@ pub mod memory;
 pub mod swo;
 
 pub use communication_interface::{
-    ApInformation, ArmChipInfo, ArmCommunicationInterface, DAPAccess, DapError, MemoryApInformation,
+    ApInformation, ArmChipInfo, ArmCommunicationInterface, DapAccess, DapError, MemoryApInformation,
 };
 pub use communication_interface::{PortType, Register};
 pub use swo::{SwoAccess, SwoConfig, SwoMode};

--- a/probe-rs/src/architecture/arm/swo/mod.rs
+++ b/probe-rs/src/architecture/arm/swo/mod.rs
@@ -4,7 +4,7 @@ use crate::Error;
 
 #[derive(Debug, Copy, Clone)]
 pub enum SwoMode {
-    UART,
+    Uart,
     Manchester,
 }
 
@@ -36,7 +36,7 @@ impl SwoConfig {
     /// TPIU continuous formatting is disabled (DWT/ITM only).
     pub fn new(tpiu_clk: u32) -> Self {
         SwoConfig {
-            mode: SwoMode::UART,
+            mode: SwoMode::Uart,
             baud: 1_000_000,
             tpiu_clk,
             tpiu_continuous_formatting: false,
@@ -57,7 +57,7 @@ impl SwoConfig {
 
     /// Set the mode to UART
     pub fn set_mode_uart(mut self) -> Self {
-        self.mode = SwoMode::UART;
+        self.mode = SwoMode::Uart;
         self
     }
 
@@ -140,7 +140,7 @@ pub(crate) fn poll_interval_from_buf_size(
 ) -> Option<std::time::Duration> {
     let time_to_full_ms = match config.mode() {
         // In UART, the output data is at the baud rate with 10 clocks per byte.
-        SwoMode::UART => (1000 * buf_size as u32) / (config.baud() / 10),
+        SwoMode::Uart => (1000 * buf_size as u32) / (config.baud() / 10),
 
         // In Manchester, the output data is at half the baud rate with
         // between 8.25 and 10 clocks per byte, so use a conservative 8 clocks/byte.

--- a/probe-rs/src/architecture/riscv/dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm.rs
@@ -47,7 +47,7 @@ impl Dtm {
         // Setup the number of idle cycles between JTAG accesses
         probe.set_idle_cycles(idle_cycles as u8);
 
-        Ok(Self { abits, probe })
+        Ok(Self { probe, abits })
     }
 
     pub fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -186,7 +186,7 @@ impl FlashLoader {
 
         let mut extracted_data = Vec::new();
 
-        let num_sections = extract_from_elf(&mut extracted_data, &mut elf_buffer)?;
+        let num_sections = extract_from_elf(&mut extracted_data, &elf_buffer)?;
 
         if num_sections == 0 {
             log::warn!("No loadable segments were found in the ELF file.");

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -1,6 +1,6 @@
 use crate::error;
 use crate::{
-    architecture::arm::{ap::MemoryAP, memory::adi_v5_memory_interface::ArmProbe},
+    architecture::arm::{ap::MemoryAp, memory::adi_v5_memory_interface::ArmProbe},
     CoreRegisterAddress,
 };
 
@@ -97,11 +97,11 @@ where
 
 pub struct Memory<'probe> {
     inner: Box<dyn ArmProbe + 'probe>,
-    ap_sel: MemoryAP,
+    ap_sel: MemoryAp,
 }
 
 impl<'probe> Memory<'probe> {
-    pub fn new(memory: impl ArmProbe + 'probe + Sized, ap_sel: MemoryAP) -> Memory<'probe> {
+    pub fn new(memory: impl ArmProbe + 'probe + Sized, ap_sel: MemoryAp) -> Memory<'probe> {
         Self {
             inner: Box::new(memory),
             ap_sel,

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -1,4 +1,4 @@
-use super::CMSISDAPDevice;
+use super::CmsisDapDevice;
 use crate::{
     probe::{DebugProbeInfo, DebugProbeType, ProbeCreationError},
     DebugProbeSelector,
@@ -67,7 +67,7 @@ fn get_cmsisdap_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
             vendor_id: d_desc.vendor_id(),
             product_id: d_desc.product_id(),
             serial_number: sn_str,
-            probe_type: DebugProbeType::CMSISDAP,
+            probe_type: DebugProbeType::CmsisDap,
         })
     } else {
         None
@@ -83,7 +83,7 @@ fn get_cmsisdap_hid_info(device: &hidapi::DeviceInfo) -> Option<DebugProbeInfo> 
                 vendor_id: device.vendor_id(),
                 product_id: device.product_id(),
                 serial_number: device.serial_number().map(|s| s.to_owned()),
-                probe_type: DebugProbeType::CMSISDAP,
+                probe_type: DebugProbeType::CmsisDap,
             });
         }
     }
@@ -91,7 +91,7 @@ fn get_cmsisdap_hid_info(device: &hidapi::DeviceInfo) -> Option<DebugProbeInfo> 
 }
 
 /// Attempt to open the given device in CMSIS-DAP v2 mode
-pub fn open_v2_device(device: Device<rusb::Context>) -> Option<CMSISDAPDevice> {
+pub fn open_v2_device(device: Device<rusb::Context>) -> Option<CmsisDapDevice> {
     // Open device handle and read basic information
     let timeout = Duration::from_millis(100);
     let d_desc = device.device_descriptor().ok()?;
@@ -152,7 +152,7 @@ pub fn open_v2_device(device: Device<rusb::Context>) -> Option<CMSISDAPDevice> {
             match handle.claim_interface(interface.number()) {
                 Ok(()) => {
                     log::debug!("Opening {:04x}:{:04x} in CMSIS-DAPv2 mode", vid, pid);
-                    return Some(CMSISDAPDevice::V2 {
+                    return Some(CmsisDapDevice::V2 {
                         handle,
                         out_ep: eps[0].address(),
                         in_ep: eps[1].address(),
@@ -196,7 +196,7 @@ fn device_matches(
 /// otherwise in v1 mode.
 pub fn open_device_from_selector(
     selector: impl Into<DebugProbeSelector>,
-) -> Result<CMSISDAPDevice, ProbeCreationError> {
+) -> Result<CmsisDapDevice, ProbeCreationError> {
     let selector = selector.into();
 
     log::trace!("Attempting to open device matching {}", selector);
@@ -274,7 +274,7 @@ pub fn open_device_from_selector(
     match hid_device {
         Ok(device) => {
             match device.get_product_string() {
-                Ok(Some(s)) if s.contains("CMSIS-DAP") => Ok(CMSISDAPDevice::V1 {
+                Ok(Some(s)) if s.contains("CMSIS-DAP") => Ok(CmsisDapDevice::V1 {
                     handle: device,
                     // Start with a default 64-byte report size, which is the most
                     // common size for CMSIS-DAPv1 HID devices. We'll request the

--- a/probe-rs/src/probe/ftdi/ftdi_impl.rs
+++ b/probe-rs/src/probe/ftdi/ftdi_impl.rs
@@ -19,9 +19,9 @@ pub enum Interface {
     Any,
 }
 
-impl Into<ffi::ftdi_interface> for Interface {
-    fn into(self) -> ffi::ftdi_interface {
-        match self {
+impl From<Interface> for ffi::ftdi_interface {
+    fn from(value: Interface) -> Self {
+        match value {
             Interface::A => ffi::ftdi_interface::INTERFACE_A,
             Interface::B => ffi::ftdi_interface::INTERFACE_B,
             Interface::C => ffi::ftdi_interface::INTERFACE_C,
@@ -43,9 +43,9 @@ pub enum BitMode {
     Ft1284,
 }
 
-impl Into<ffi::ftdi_mpsse_mode> for BitMode {
-    fn into(self) -> ffi::ftdi_mpsse_mode {
-        match self {
+impl From<BitMode> for ffi::ftdi_mpsse_mode {
+    fn from(value: BitMode) -> Self {
+        match value {
             BitMode::Reset => ffi::ftdi_mpsse_mode::BITMODE_RESET,
             BitMode::Bitbang => ffi::ftdi_mpsse_mode::BITMODE_BITBANG,
             BitMode::Mpsse => ffi::ftdi_mpsse_mode::BITMODE_MPSSE,

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -590,7 +590,7 @@ fn get_device_info(device: &rusb::Device<rusb::Context>) -> Option<DebugProbeInf
         vendor_id: d_desc.vendor_id(),
         product_id: d_desc.product_id(),
         serial_number: sn_str,
-        probe_type: DebugProbeType::FTDI,
+        probe_type: DebugProbeType::Ftdi,
     })
 }
 

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -9,7 +9,7 @@ use std::iter;
 use crate::{
     architecture::{
         arm::{
-            communication_interface::{ArmProbeInterface, DAPProbe},
+            communication_interface::{ArmProbeInterface, DapProbe},
             swo::SwoConfig,
             ArmCommunicationInterface, SwoAccess,
         },
@@ -696,7 +696,7 @@ impl JTAGAccess for JLink {
     }
 }
 
-impl DAPProbe for JLink {}
+impl DapProbe for JLink {}
 
 impl SwoAccess for JLink {
     fn enable_swo(&mut self, config: &SwoConfig) -> Result<(), ProbeRsError> {

--- a/probe-rs/src/probe/jlink/swd.rs
+++ b/probe-rs/src/probe/jlink/swd.rs
@@ -3,7 +3,7 @@ use std::iter;
 use crate::{
     architecture::arm::{
         dp::{Abort, Ctrl, RdBuff, DPIDR},
-        DAPAccess, DapError, PortType, Register,
+        DapAccess, DapError, PortType, Register,
     },
     DebugProbeError,
 };
@@ -700,7 +700,7 @@ impl RawSwdIo for JLink {
     }
 }
 
-impl<Probe: RawSwdIo + 'static> DAPAccess for Probe {
+impl<Probe: RawSwdIo + 'static> DapAccess for Probe {
     fn read_register(&mut self, port: PortType, address: u16) -> Result<u32, DebugProbeError> {
         let dap_wait_retries = self.swd_settings().num_retries_after_wait;
         let mut idle_cycles = std::cmp::max(1, self.swd_settings().num_idle_cycles_between_writes);
@@ -731,7 +731,7 @@ impl<Probe: RawSwdIo + 'static> DAPAccess for Probe {
 
                     abort.set_orunerrclr(true);
 
-                    DAPAccess::write_register(
+                    DapAccess::write_register(
                         self,
                         PortType::DebugPort,
                         Abort::ADDRESS as u16,
@@ -752,7 +752,7 @@ impl<Probe: RawSwdIo + 'static> DAPAccess for Probe {
                     // To get a clue about the actual fault we read the ctrl register,
                     // which will have the fault status flags set.
                     let response =
-                        DAPAccess::read_register(self, PortType::DebugPort, Ctrl::ADDRESS as u16)?;
+                        DapAccess::read_register(self, PortType::DebugPort, Ctrl::ADDRESS as u16)?;
                     let ctrl = Ctrl::from(response);
                     log::debug!(
                         "Reading DAP register failed. Ctrl/Stat register value is: {:#?}",
@@ -771,7 +771,7 @@ impl<Probe: RawSwdIo + 'static> DAPAccess for Probe {
                         abort.set_orunerrclr(ctrl.sticky_orun());
                         abort.set_stkerrclr(ctrl.sticky_err());
 
-                        DAPAccess::write_register(
+                        DapAccess::write_register(
                             self,
                             PortType::DebugPort,
                             Abort::ADDRESS as u16,
@@ -842,7 +842,7 @@ impl<Probe: RawSwdIo + 'static> DAPAccess for Probe {
 
                             abort.set_orunerrclr(true);
 
-                            DAPAccess::write_register(
+                            DapAccess::write_register(
                                 self,
                                 PortType::DebugPort,
                                 Abort::ADDRESS as u16,
@@ -903,7 +903,7 @@ impl<Probe: RawSwdIo + 'static> DAPAccess for Probe {
                     abort.set_orunerrclr(true);
 
                     // Because we use overrun detection, we now have to clear the overrun error
-                    DAPAccess::write_register(
+                    DapAccess::write_register(
                         self,
                         PortType::DebugPort,
                         Abort::ADDRESS as u16,
@@ -924,7 +924,7 @@ impl<Probe: RawSwdIo + 'static> DAPAccess for Probe {
                     // which will have the fault status flags set.
 
                     let response =
-                        DAPAccess::read_register(self, PortType::DebugPort, Ctrl::ADDRESS as u16)?;
+                        DapAccess::read_register(self, PortType::DebugPort, Ctrl::ADDRESS as u16)?;
 
                     let ctrl = Ctrl::from(response);
                     log::trace!(
@@ -944,7 +944,7 @@ impl<Probe: RawSwdIo + 'static> DAPAccess for Probe {
                         abort.set_orunerrclr(ctrl.sticky_orun());
                         abort.set_stkerrclr(ctrl.sticky_err());
 
-                        DAPAccess::write_register(
+                        DapAccess::write_register(
                             self,
                             PortType::DebugPort,
                             Abort::ADDRESS as u16,
@@ -1017,7 +1017,7 @@ impl<Probe: RawSwdIo + 'static> DAPAccess for Probe {
 
                             abort.set_orunerrclr(true);
 
-                            DAPAccess::write_register(
+                            DapAccess::write_register(
                                 self,
                                 PortType::DebugPort,
                                 Abort::ADDRESS as u16,
@@ -1052,7 +1052,7 @@ mod test {
 
     use std::iter;
 
-    use crate::architecture::arm::{DAPAccess, PortType};
+    use crate::architecture::arm::{DapAccess, PortType};
 
     use super::{RawSwdIo, SwdSettings, SwdStatistics};
 

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -51,7 +51,7 @@ pub fn list_stlink_devices() -> Vec<DebugProbeInfo> {
                         descriptor.vendor_id(),
                         descriptor.product_id(),
                         sn_str,
-                        DebugProbeType::STLink,
+                        DebugProbeType::StLink,
                     ))
                 })
                 .collect::<Vec<_>>()


### PR DESCRIPTION
This changes a lot of naming to be more in line with Rust's conventions.