### PR TITLE
Fix a bus congestion when polling the chip too often.

### DIFF
--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -306,15 +306,13 @@ impl<'probe> CoreInterface for M0<'probe> {
         // Wait until halted state is active again.
         let start = Instant::now();
 
-        let mut n = 0;
         while start.elapsed() < timeout {
             let dhcsr_val = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
 
             if dhcsr_val.s_halt() {
                 return Ok(());
             }
-            std::thread::sleep(Duration::from_millis(1 << n));
-            n += 1;
+            std::thread::sleep(Duration::from_millis(1));
         }
         Err(Error::Probe(DebugProbeError::Timeout))
     }

--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -306,12 +306,15 @@ impl<'probe> CoreInterface for M0<'probe> {
         // Wait until halted state is active again.
         let start = Instant::now();
 
+        let mut n = 0;
         while start.elapsed() < timeout {
             let dhcsr_val = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
 
             if dhcsr_val.s_halt() {
                 return Ok(());
             }
+            std::thread::sleep(Duration::from_millis(1 << n));
+            n += 1;
         }
         Err(Error::Probe(DebugProbeError::Timeout))
     }

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -70,11 +70,14 @@ impl<'probe> CoreInterface for M33<'probe> {
         // Wait until halted state is active again.
         let start = Instant::now();
 
+        let mut n = 0;
         while start.elapsed() < timeout {
             let dhcsr_val = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
             if dhcsr_val.s_halt() {
                 return Ok(());
             }
+            std::thread::sleep(Duration::from_millis(1 << n));
+            n += 1;
         }
         Err(Error::Probe(DebugProbeError::Timeout))
     }

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -70,14 +70,12 @@ impl<'probe> CoreInterface for M33<'probe> {
         // Wait until halted state is active again.
         let start = Instant::now();
 
-        let mut n = 0;
         while start.elapsed() < timeout {
             let dhcsr_val = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
             if dhcsr_val.s_halt() {
                 return Ok(());
             }
-            std::thread::sleep(Duration::from_millis(1 << n));
-            n += 1;
+            std::thread::sleep(Duration::from_millis(1));
         }
         Err(Error::Probe(DebugProbeError::Timeout))
     }

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -361,7 +361,7 @@ impl<'probe> CoreInterface for M4<'probe> {
 
                 return Ok(());
             }
-            std::thread::sleep(Duration::from_millis(10 + n * 10));
+            std::thread::sleep(Duration::from_millis(1 << n));
             n += 1;
         }
         Err(Error::Probe(DebugProbeError::Timeout))

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -352,6 +352,7 @@ impl<'probe> CoreInterface for M4<'probe> {
         // Wait until halted state is active again.
         let start = Instant::now();
 
+        let mut n = 0;
         while start.elapsed() < timeout {
             let dhcsr_val = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
             if dhcsr_val.s_halt() {
@@ -360,6 +361,8 @@ impl<'probe> CoreInterface for M4<'probe> {
 
                 return Ok(());
             }
+            std::thread::sleep(Duration::from_millis(10 + n * 10));
+            n += 1;
         }
         Err(Error::Probe(DebugProbeError::Timeout))
     }

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -352,7 +352,6 @@ impl<'probe> CoreInterface for M4<'probe> {
         // Wait until halted state is active again.
         let start = Instant::now();
 
-        let mut n = 0;
         while start.elapsed() < timeout {
             let dhcsr_val = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
             if dhcsr_val.s_halt() {
@@ -361,8 +360,7 @@ impl<'probe> CoreInterface for M4<'probe> {
 
                 return Ok(());
             }
-            std::thread::sleep(Duration::from_millis(1 << n));
-            n += 1;
+            std::thread::sleep(Duration::from_millis(1));
         }
         Err(Error::Probe(DebugProbeError::Timeout))
     }

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -712,7 +712,9 @@ impl<'probe> ActiveFlasher<'probe, Erase> {
                     r3: None,
                 },
                 false,
-                Duration::from_secs(5),
+                Duration::from_millis(
+                    self.flash_algorithm.flash_properties.erase_sector_timeout as u64,
+                ),
             )
             .map_err(|error| FlashError::EraseFailed {
                 sector_address: address,
@@ -760,7 +762,9 @@ impl<'p> ActiveFlasher<'p, Program> {
                     r3: None,
                 },
                 false,
-                Duration::from_secs(2),
+                Duration::from_millis(
+                    self.flash_algorithm.flash_properties.program_page_timeout as u64,
+                ),
             )
             .map_err(|error| FlashError::PageWrite {
                 page_address: address,


### PR DESCRIPTION
Previously, when waiting for a flash algorithm routine to complete, the algorithm on the host side would poll the core state relentlessly, leading to frequent timeouts when polling longer operations, such as sector erase, for completion. Now we do two things: a) we honor the timeouts given to us with the flash algorithm description files properly, and b) we poll the core at maximum once per 10ms with increasing delays each time. This results in significantly less traffic and as a nice byproduct way less log traffic.