### PR TITLE
Allow flashing IHex file with probe-rs-cli

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,7 @@ probe-rs = { path = "../probe-rs", version = "0.10.0" }
 pretty_env_logger = "0.4.0"
 log = "0.4.6"
 structopt = "0.3.7"
+clap = "2.33"
 scroll = "0.10.1"
 rustyline = "8.0.0"
 capstone = "0.8.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,6 +12,7 @@ use probe_rs::{
 };
 
 use capstone::{arch::arm::ArchMode, prelude::*, Capstone, Endian};
+use clap::arg_enum;
 use rustyline::Editor;
 use structopt::StructOpt;
 
@@ -23,6 +24,23 @@ use std::time::Instant;
 
 fn parse_hex(src: &str) -> Result<u32, ParseIntError> {
     u32::from_str_radix(src, 16)
+}
+
+arg_enum! {
+    #[derive(Debug, Clone, Copy)]
+    enum DownloadFileType {
+        Elf,
+        Hex,
+    }
+}
+
+impl From<DownloadFileType> for Format {
+    fn from(this: DownloadFileType) -> Format {
+        match this {
+            DownloadFileType::Elf => Format::Elf,
+            DownloadFileType::Hex => Format::Hex,
+        }
+    }
 }
 
 #[derive(StructOpt)]
@@ -77,6 +95,15 @@ enum Cli {
         #[structopt(flatten)]
         shared: SharedOptions,
 
+        /// Format of the file to be downloaded to the flash
+        #[structopt(
+            possible_values = &DownloadFileType::variants(),
+            case_insensitive = true,
+            default_value = "elf",
+            long
+        )]
+        format: DownloadFileType,
+
         /// The path to the file to be downloaded to the flash
         path: String,
     },
@@ -126,7 +153,11 @@ fn main() -> Result<()> {
         Cli::Reset { shared, assert } => reset_target_of_device(&shared, assert),
         Cli::Debug { shared, exe } => debug(&shared, exe),
         Cli::Dump { shared, loc, words } => dump_memory(&shared, loc, words),
-        Cli::Download { shared, path } => download_program_fast(&shared, &path),
+        Cli::Download {
+            shared,
+            format,
+            path,
+        } => download_program_fast(&shared, format.into(), &path),
         Cli::Trace { shared, loc } => trace_u32_on_target(&shared, loc),
     }
 }
@@ -177,9 +208,9 @@ fn dump_memory(shared_options: &SharedOptions, loc: u32, words: u32) -> Result<(
     })
 }
 
-fn download_program_fast(shared_options: &SharedOptions, path: &str) -> Result<()> {
+fn download_program_fast(shared_options: &SharedOptions, format: Format, path: &str) -> Result<()> {
     with_device(shared_options, |mut session| {
-        download_file(&mut session, &path, Format::Elf)?;
+        download_file(&mut session, &path, format)?;
 
         Ok(())
     })


### PR DESCRIPTION
Allows running `probe-rs-cli download --format hex path/to/file.hex`