### PR TITLE
flasher: allow skip erasing

### DIFF
--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -885,6 +885,7 @@ impl Debugger {
                     progress: None,
                     keep_unwritten_bytes: self.debugger_options.restore_unwritten_bytes,
                     dry_run: false,
+                    skip_erase: false,
                     do_chip_erase: self.debugger_options.full_chip_erase,
                 };
                 match download_file_with_options(

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -96,6 +96,9 @@ pub struct DownloadOptions<'progress> {
     /// This is often faster than erasing a lot of single sectors.
     /// So if you do not need the old contents of the flash, this is a good option.
     pub do_chip_erase: bool,
+    /// If the chip was pre-erased with external erasers, this flag can set to true to skip erasing
+    /// It may be useful for mass production.
+    pub skip_erase: bool,
 }
 
 /// Downloads a file of given `format` at `path` to the flash of the target given in `session`.

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -211,7 +211,7 @@ impl<'session> Flasher<'session> {
 
         let mut fb = FlashBuilder::new();
         fb.add_data(address, data)?;
-        self.program(&fb, do_chip_erase, true, true, progress)?;
+        self.program(&fb, do_chip_erase, true, true, false, progress)?;
 
         Ok(())
     }
@@ -227,6 +227,7 @@ impl<'session> Flasher<'session> {
         mut do_chip_erase: bool,
         restore_unwritten_bytes: bool,
         enable_double_buffering: bool,
+        skip_erasing: bool,
         progress: &FlashProgress,
     ) -> Result<(), FlashError> {
         log::debug!("Starting program procedure.");
@@ -276,11 +277,14 @@ impl<'session> Flasher<'session> {
         // We successfully finished filling.
         progress.finished_filling();
 
-        // Erase all necessary sectors.
-        if do_chip_erase {
-            self.chip_erase(&flash_layout, progress)?;
-        } else {
-            self.sector_erase(&flash_layout, progress)?;
+        // Skip erase if necessary
+        if !skip_erasing {
+            // Erase all necessary sectors
+            if do_chip_erase {
+                self.chip_erase(&flash_layout, progress)?;
+            } else {
+                self.sector_erase(&flash_layout, progress)?;
+            }
         }
 
         // Flash all necessary pages.

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -333,6 +333,7 @@ impl FlashLoader {
             options.do_chip_erase,
             options.keep_unwritten_bytes,
             true,
+            options.skip_erase,
             options.progress.unwrap_or(&FlashProgress::new(|_| {})),
         )?;
 


### PR DESCRIPTION
Hi there,

This pull request added a flag at `DownloadOption` that allows the user to skip the erasing.  

This flag is helpful for mass production, especially in some cases the chip can be erased with external erasing rigs. To be more specific, CMSIS pack does not provide chip erasing support for some chips like STM32L031K6U6, but the reference manual does indicate that it supports chip erase by toggling RDP bit. So I have made my own chip eraser tool for it. However, probe-rs always re-erase the chip even though the chip is cleared before, as it is impossible to skip the erasing. Therefore here's the PR for adding skip erase support.

Regards,
Jackson