### PR TITLE
Improve tracking of core status

### DIFF
--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -276,11 +276,11 @@ impl<'probe> M0<'probe> {
             let core_state = if dhcsr.s_sleep() {
                 CoreStatus::Sleeping
             } else if dhcsr.s_halt() {
-                log::debug!("Core was halted when connecting");
-
                 let dfsr = Dfsr(memory.read_word_32(Dfsr::ADDRESS)?);
 
                 let reason = dfsr.halt_reason();
+
+                log::debug!("Core was halted when connecting, reason: {:?}", reason);
 
                 CoreStatus::Halted(reason)
             } else {
@@ -340,6 +340,9 @@ impl<'probe> CoreInterface for M0<'probe> {
 
         self.wait_for_core_halted(timeout)?;
 
+        // Update core status
+        let _ = self.status()?;
+
         // try to read the program counter
         let pc_value = self.read_core_reg(PC.address)?;
 
@@ -348,16 +351,34 @@ impl<'probe> CoreInterface for M0<'probe> {
     }
 
     fn run(&mut self) -> Result<(), Error> {
+        //before we run, we always perform a single instruction step, to account for possible breakpoints that might get us stuck on the current instruction
+        self.step()?;
+
         let mut value = Dhcsr(0);
         value.set_c_halt(false);
         value.set_c_debugen(true);
         value.enable_write();
 
         self.memory.write_word_32(Dhcsr::ADDRESS, value.into())?;
-        self.memory.flush()
+        self.memory.flush()?;
+
+        // We assume that the core is running now
+        self.state.current_state = CoreStatus::Running;
+
+        Ok(())
     }
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
+        //First check if we stopped on a breakpoint, because this requires special handling before we can continue
+        let was_breakpoint =
+            if self.state.current_state == CoreStatus::Halted(HaltReason::Breakpoint) {
+                log::debug!("Core was halted on breakpoint, disabling breakpoints");
+                self.enable_breakpoints(false)?;
+                true
+            } else {
+                false
+            };
+
         let mut value = Dhcsr(0);
         // Leave halted state.
         // Step one instruction.
@@ -368,9 +389,13 @@ impl<'probe> CoreInterface for M0<'probe> {
         value.enable_write();
 
         self.memory.write_word_32(Dhcsr::ADDRESS, value.into())?;
-
+        self.memory.flush()?;
         self.wait_for_core_halted(Duration::from_millis(100))?;
 
+        //Re-enable breakpoints before we continue
+        if was_breakpoint {
+            self.enable_breakpoints(true)?;
+        }
         // try to read the program counter
         let pc_value = self.read_core_reg(PC.address)?;
 
@@ -396,6 +421,9 @@ impl<'probe> CoreInterface for M0<'probe> {
         self.reset()?;
 
         self.wait_for_core_halted(timeout)?;
+
+        // Update core status
+        let _ = self.status()?;
 
         const XPSR_THUMB: u32 = 1 << 24;
         let xpsr_value = self.read_core_reg(XPSR.address)?;
@@ -427,8 +455,9 @@ impl<'probe> CoreInterface for M0<'probe> {
         value.set_enable(state);
 
         self.memory.write_word_32(BpCtrl::ADDRESS, value.into())?;
+        self.memory.flush()?;
 
-        self.state.hw_breakpoints_enabled = true;
+        self.state.hw_breakpoints_enabled = state;
 
         Ok(())
     }
@@ -515,6 +544,7 @@ impl<'probe> CoreInterface for M0<'probe> {
                 // that the reason for the halt has changed. No bits set
                 // means that we have an unkown HaltReason.
                 if reason == HaltReason::Unknown {
+                    log::debug!("Cached halt reason: {:?}", self.state.current_state);
                     return Ok(self.state.current_state);
                 }
 

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -563,6 +563,12 @@ impl CoreStatus {
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum HaltReason {
+    /// Multiple reasons for a halt.
+    ///
+    /// This can happen for example when a single instruction
+    /// step ends up on a breakpoint, after which both brekpoint and step / request
+    /// are set.
+    Multiple,
     /// Core halted due to a breakpoint, either
     /// a *soft* or a *hard* breakpoint.
     Breakpoint,
@@ -577,7 +583,8 @@ pub enum HaltReason {
     Request,
     /// External halt request
     External,
-    /// Unknown reason for halt. This can happen for
-    /// example when the core is already halted when we connect.
+    /// Unknown reason for halt.
+    ///
+    /// This can happen for example when the core is already halted when we connect.
     Unknown,
 }

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -566,7 +566,7 @@ pub enum HaltReason {
     /// Multiple reasons for a halt.
     ///
     /// This can happen for example when a single instruction
-    /// step ends up on a breakpoint, after which both brekpoint and step / request
+    /// step ends up on a breakpoint, after which both breakpoint and step / request
     /// are set.
     Multiple,
     /// Core halted due to a breakpoint, either


### PR DESCRIPTION
The status bits used for the core status are sticky, so we need to ensure
that we read the status register when it's expected to change.

If we don't read it, multiple bits will be set which means it's not
possible anymore to find out why the core is halted.