### PR TITLE
Fix HW breakpoints and remove caching of breakpoints in CoreStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The breakpoint address is now verified to ensure a breakpoint at the given address is actually possible (#626).
 - riscv: Use correct address for access to `abstractauto`register (#511).
 - The `--chip` argument now works without specifying the `--elf` argument (fix #517).
+- Fixed: Invalid "Unable to set hardware breakpoint", by removing breakpoint caching (#632)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The breakpoint address is now verified to ensure a breakpoint at the given address is actually possible (#626).
 - riscv: Use correct address for access to `abstractauto`register (#511).
 - The `--chip` argument now works without specifying the `--elf` argument (fix #517).
-- Fixed: Invalid "Unable to set hardware breakpoint", by removing breakpoint caching (#632)
+- Fixed: Invalid "Unable to set hardware breakpoint", by removing breakpoint caching, instead querying core directly (#632)
 
 
 

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -517,7 +517,7 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
                 if let Some(location) = source_location {
                     let (verified, reason_msg) =
                         match core_data.target_core.set_hw_breakpoint(location as u32) {
-                            Ok(_) => (true, None),
+                            Ok(_) => (true, Some(format!("Breakpoint at memory address: 0x{:08x}", location))),
                             Err(err) => (false, Some(err.to_string())),
                         };
 

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -483,13 +483,11 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
             }
         };
 
-        let mut created_breakpoints: Vec<Breakpoint> = Vec::new(); //For returning in the Response
+        let mut created_breakpoints: Vec<Breakpoint> = Vec::new(); // For returning in the Response
 
         let source_path = args.source.path.as_ref().map(Path::new);
 
-        //Always clear existing breakpoints before setting new ones.
-        //TODO: Consider if it would be more or less efficient to compare VSCode's requested breakpoints against Probe-rs and only clear/set the old/new ones.
-        //TODO: It appears as if the clear_all_hw_breakpoints doesn't always do that. Investigate and fix.
+        // Always clear existing breakpoints before setting new ones. The DAP Specification doesn't make allowances for deleting and setting individual breakpoints.
         match core_data.target_core.clear_all_hw_breakpoints() {
             Ok(_) => {}
             Err(error) => {
@@ -1077,7 +1075,7 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
 
             let mut command_arguments: Vec<&str> = line.split_whitespace().collect();
             let command_name = command_arguments.remove(0);
-            let arguments = if command_arguments.is_empty() {
+            let arguments = if !command_arguments.is_empty() {
                 Some(json!(command_arguments))
             } else {
                 None

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -521,7 +521,11 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
                                 true,
                                 Some(format!("Breakpoint at memory address: 0x{:08x}", location)),
                             ),
-                            Err(err) => (false, Some(err.to_string())),
+                            Err(err) => {
+                                //In addition to sending the error to the 'Hover' message, also write it to the Debug Console Log
+                                self.log_to_console(format!("ERROR: Could not set breakpoint at memory address: 0x{:08x}: {}", location, err));
+                                (false, Some(err.to_string()))
+                            },
                         };
 
                     created_breakpoints.push(Breakpoint {

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -515,23 +515,21 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
                 });
 
                 if let Some(location) = source_location {
-                    let (verified, reason_msg) = match core_data
-                        .target_core
-                        .set_hw_breakpoint(location as u32)
-                    {
-                        Ok(_) => (
-                            true,
-                            Some(format!("Breakpoint at memory address: 0x{:08x}", location)),
-                        ),
-                        Err(err) => {
-                            //In addition to sending the error to the 'Hover' message, also write it to the Debug Console Log
-                            self.log_to_console(format!(
+                    let (verified, reason_msg) =
+                        match core_data.target_core.set_hw_breakpoint(location as u32) {
+                            Ok(_) => (
+                                true,
+                                Some(format!("Breakpoint at memory address: 0x{:08x}", location)),
+                            ),
+                            Err(err) => {
+                                //In addition to sending the error to the 'Hover' message, also write it to the Debug Console Log
+                                self.log_to_console(format!(
                                 "ERROR: Could not set breakpoint at memory address: 0x{:08x}: {}",
                                 location, err
                             ));
-                            (false, Some(err.to_string()))
-                        }
-                    };
+                                (false, Some(err.to_string()))
+                            }
+                        };
 
                     created_breakpoints.push(Breakpoint {
                         column: bp.column,

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -517,7 +517,10 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
                 if let Some(location) = source_location {
                     let (verified, reason_msg) =
                         match core_data.target_core.set_hw_breakpoint(location as u32) {
-                            Ok(_) => (true, Some(format!("Breakpoint at memory address: 0x{:08x}", location))),
+                            Ok(_) => (
+                                true,
+                                Some(format!("Breakpoint at memory address: 0x{:08x}", location)),
+                            ),
                             Err(err) => (false, Some(err.to_string())),
                         };
 

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -515,18 +515,23 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
                 });
 
                 if let Some(location) = source_location {
-                    let (verified, reason_msg) =
-                        match core_data.target_core.set_hw_breakpoint(location as u32) {
-                            Ok(_) => (
-                                true,
-                                Some(format!("Breakpoint at memory address: 0x{:08x}", location)),
-                            ),
-                            Err(err) => {
-                                //In addition to sending the error to the 'Hover' message, also write it to the Debug Console Log
-                                self.log_to_console(format!("ERROR: Could not set breakpoint at memory address: 0x{:08x}: {}", location, err));
-                                (false, Some(err.to_string()))
-                            },
-                        };
+                    let (verified, reason_msg) = match core_data
+                        .target_core
+                        .set_hw_breakpoint(location as u32)
+                    {
+                        Ok(_) => (
+                            true,
+                            Some(format!("Breakpoint at memory address: 0x{:08x}", location)),
+                        ),
+                        Err(err) => {
+                            //In addition to sending the error to the 'Hover' message, also write it to the Debug Console Log
+                            self.log_to_console(format!(
+                                "ERROR: Could not set breakpoint at memory address: 0x{:08x}: {}",
+                                location, err
+                            ));
+                            (false, Some(err.to_string()))
+                        }
+                    };
 
                     created_breakpoints.push(Breakpoint {
                         column: bp.column,

--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -462,7 +462,7 @@ impl<'probe> CoreInterface for M0<'probe> {
         Ok(())
     }
 
-    fn set_breakpoint(&mut self, bp_register_index: usize, addr: u32) -> Result<(), Error> {
+    fn set_hw_breakpoint(&mut self, bp_register_index: usize, addr: u32) -> Result<(), Error> {
         debug!("Setting breakpoint on address 0x{:08x}", addr);
 
         // The highest 3 bits of the address have to be zero, otherwise the breakpoint cannot
@@ -493,7 +493,7 @@ impl<'probe> CoreInterface for M0<'probe> {
         &ARM_REGISTER_FILE
     }
 
-    fn clear_breakpoint(&mut self, bp_unit_index: usize) -> Result<(), Error> {
+    fn clear_hw_breakpoint(&mut self, bp_unit_index: usize) -> Result<(), Error> {
         let register_addr = BpCompx::ADDRESS + (bp_unit_index * size_of::<u32>()) as u32;
 
         let mut value = BpCompx::from(0);
@@ -579,7 +579,7 @@ impl<'probe> CoreInterface for M0<'probe> {
         Ok(())
     }
 
-    fn get_hw_breakpoints(&mut self) -> Result<Vec<u32>, Error> {
+    fn get_hw_breakpoints(&mut self) -> Result<Vec<Option<u32>>, Error> {
         todo!()
     }
 }

--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -578,6 +578,10 @@ impl<'probe> CoreInterface for M0<'probe> {
         self.memory.write_core_reg(address, value)?;
         Ok(())
     }
+
+    fn get_hw_breakpoints(&mut self) -> Result<Vec<u32>, Error> {
+        todo!()
+    }
 }
 
 impl<'probe> MemoryInterface for M0<'probe> {

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -332,6 +332,10 @@ impl<'probe> CoreInterface for M33<'probe> {
 
         Ok(CoreStatus::Running)
     }
+
+    fn get_hw_breakpoints(&mut self) -> Result<Vec<u32>, Error> {
+        todo!()
+    }
 }
 
 impl<'probe> MemoryInterface for M33<'probe> {

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -235,7 +235,7 @@ impl<'probe> CoreInterface for M33<'probe> {
         Ok(())
     }
 
-    fn set_breakpoint(&mut self, bp_unit_index: usize, addr: u32) -> Result<(), Error> {
+    fn set_hw_breakpoint(&mut self, bp_unit_index: usize, addr: u32) -> Result<(), Error> {
         let mut val = FpCompX::from(0);
 
         // clear bits which cannot be set and shift into position
@@ -255,7 +255,7 @@ impl<'probe> CoreInterface for M33<'probe> {
         &ARM_REGISTER_FILE
     }
 
-    fn clear_breakpoint(&mut self, bp_unit_index: usize) -> Result<(), Error> {
+    fn clear_hw_breakpoint(&mut self, bp_unit_index: usize) -> Result<(), Error> {
         let mut val = FpCompX::from(0);
         val.set_enable(false);
         val.set_bp_addr(0);
@@ -333,7 +333,7 @@ impl<'probe> CoreInterface for M33<'probe> {
         Ok(CoreStatus::Running)
     }
 
-    fn get_hw_breakpoints(&mut self) -> Result<Vec<u32>, Error> {
+    fn get_hw_breakpoints(&mut self) -> Result<Vec<Option<u32>>, Error> {
         todo!()
     }
 }

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -10,7 +10,7 @@ use crate::{
     core::{Architecture, CoreStatus, HaltReason},
     MemoryInterface,
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 use bitfield::bitfield;
 use std::mem::size_of;
@@ -600,7 +600,7 @@ impl<'probe> CoreInterface for M4<'probe> {
             val = FpRev2CompX::breakpoint_configuration(addr).into();
         } else {
             log::warn!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", ctrl_reg.rev());
-            return Err(Error::Probe(DebugProbeError::CommandNotSupportedByProbe));
+            return Err(Error::Other(anyhow!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", ctrl_reg.rev())));
         }
 
         // This is fine as FpRev1CompX and Rev2CompX are just two different
@@ -655,7 +655,7 @@ impl<'probe> CoreInterface for M4<'probe> {
                 breakpoint = register_value & 0xff_ff_ff_fe;
             } else {
                 log::warn!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", ctrl_reg.rev());
-                return Err(Error::Probe(DebugProbeError::CommandNotSupportedByProbe));
+                return Err(Error::Other(anyhow!("This chip uses FPBU revision {}, which is not yet supported. HW breakpoints are not available.", ctrl_reg.rev())));
             }
             breakpoints.push(breakpoint);
             Ok(())

--- a/probe-rs/src/architecture/arm/core/m4.rs
+++ b/probe-rs/src/architecture/arm/core/m4.rs
@@ -668,7 +668,7 @@ impl<'probe> CoreInterface for M4<'probe> {
             // FpRev1 and FpRev2 needs different decoding of the register value, but the location where we read from is the same ...
             let reg_addr = FpRev1CompX::ADDRESS + (bp_unit_index * size_of::<u32>()) as u32;
             // The raw breakpoint address as read from memory
-           let register_value = self.memory.read_word_32(reg_addr)?;
+            let register_value = self.memory.read_word_32(reg_addr)?;
             // The breakpoint address after it has been adjusted for FpRev 1 or 2
             let breakpoint:u32;
             if register_value & 0b1 == 0b1 { // We only care about `enabled` breakpoints

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -371,7 +371,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         Ok(())
     }
 
-    fn set_breakpoint(&mut self, bp_unit_index: usize, addr: u32) -> Result<(), crate::Error> {
+    fn set_hw_breakpoint(&mut self, bp_unit_index: usize, addr: u32) -> Result<(), crate::Error> {
         // select requested trigger
         let tselect = 0x7a0;
         let tdata1 = 0x7a1;
@@ -409,7 +409,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         Ok(())
     }
 
-    fn clear_breakpoint(&mut self, unit_index: usize) -> Result<(), crate::Error> {
+    fn clear_hw_breakpoint(&mut self, unit_index: usize) -> Result<(), crate::Error> {
         let tselect = 0x7a0;
         let tdata1 = 0x7a1;
         let tdata2 = 0x7a2;
@@ -471,7 +471,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         }
     }
 
-    fn get_hw_breakpoints(&mut self) -> Result<Vec<u32>, Error> {
+    fn get_hw_breakpoints(&mut self) -> Result<Vec<Option<u32>>, Error> {
         todo!()
     }
 }

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -470,6 +470,10 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
             )
         }
     }
+
+    fn get_hw_breakpoints(&mut self) -> Result<Vec<u32>, Error> {
+        todo!()
+    }
 }
 
 impl<'probe> MemoryInterface for Riscv32<'probe> {

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -431,7 +431,7 @@ impl<'probe> Core<'probe> {
             .inner
             .get_hw_breakpoints()?
             .iter()
-            .position(|bp| bp.is_some() && bp.unwrap() == address)
+            .position(|&bp| bp == Some(address))
         {
             Some(breakpoint_comparator_index) => breakpoint_comparator_index,
             None => self.find_free_breakpoint_comparator_index()?,

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -403,7 +403,7 @@ impl<'probe> Core<'probe> {
     fn next_available_hw_breakpoint_id(&mut self) -> Result<usize, error::Error> {
         let mut next_available_hw_breakpoint = 0;
         for breakpoint in self.inner.get_hw_breakpoints()? {
-            if breakpoint == 0 {
+            if breakpoint.is_zero() {
                 return Ok(next_available_hw_breakpoint);
             } else {
                 next_available_hw_breakpoint += 1;

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod communication_interface;
 
 pub use communication_interface::CommunicationInterface;
+use num_traits::Zero;
 
 use crate::architecture::{
     arm::core::CortexState, riscv::communication_interface::RiscvCommunicationInterface,
@@ -467,7 +468,7 @@ impl<'probe> Core<'probe> {
     /// Also used as a helper function in [`Session::drop`].
     pub fn clear_all_hw_breakpoints(&mut self) -> Result<(), error::Error> {
         for breakpoint in self.inner.get_hw_breakpoints()? {
-            if breakpoint != 0 {
+            if !breakpoint.is_zero() {
                 self.clear_hw_breakpoint(breakpoint)?;
             }
         }

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -398,7 +398,7 @@ impl<'probe> Core<'probe> {
         self.inner.registers()
     }
 
-    //Find the id of the next available hw breakpoint
+    /// Find the ID of the next available HW breakpoint.
     fn next_available_hw_breakpoint_id(&mut self) -> Result<usize, error::Error> {
         let mut next_available_hw_breakpoint = 0;
         for breakpoint in self.inner.get_hw_breakpoints()? {

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -379,7 +379,7 @@ impl Drop for Session {
     fn drop(&mut self) {
         let result = { 0..self.cores.len() }.try_for_each(|i| {
             self.core(i)
-                .and_then(|mut core| core.clear_all_set_hw_breakpoints())
+                .and_then(|mut core| core.clear_all_hw_breakpoints())
         });
 
         if let Err(err) = result {


### PR DESCRIPTION
I've removed breakpoint caching from `CoreStatus`, and added a new trait `CoreInterface::get_hw_breakpoints`

The new trait has an implementation for `m4.rs`, and a default `todo!()` implementation for the other architectures.

If you are OK with this new implementation, then we should extend implementation and testing to the other architectures.