### PR TITLE
Add support for USB Bus/Port number detection

### DIFF
--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -252,7 +252,7 @@ pub fn open_device_from_selector(
             if device_matches(&device, d_desc, &selector, sn_str)
                 && get_cmsisdap_info(&device).is_some()
             {
-                // If the VID, PID, and potentially SN all match,
+                // If the VID, PID, and potentially SN, bus number and port number are all match,
                 // and the device is a valid CMSIS-DAP probe,
                 // attempt to open the device in v2 mode.
                 if let Some(device) = open_v2_device(device) {
@@ -262,6 +262,11 @@ pub fn open_device_from_selector(
         }
     } else {
         log::debug!("No devices matched using rusb");
+    }
+
+    // Ignore CMSIS-DAP v1 probes as HIDAPI library does not expose
+    if selector.port_number.is_some() && selector.bus_number.is_some() {
+        return Err(ProbeCreationError::NotFound);
     }
 
     // If rusb failed or the device didn't support v2, try using hidapi to open in v1 mode.

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -591,6 +591,8 @@ fn get_device_info(device: &rusb::Device<rusb::Context>) -> Option<DebugProbeInf
         product_id: d_desc.product_id(),
         serial_number: sn_str,
         probe_type: DebugProbeType::Ftdi,
+        bus_id: Some(device.bus_number()),
+        port_id: Some(device.port_number()),
     })
 }
 

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -52,6 +52,8 @@ pub fn list_stlink_devices() -> Vec<DebugProbeInfo> {
                         descriptor.product_id(),
                         sn_str,
                         DebugProbeType::StLink,
+                        Some(device.bus_number()),
+                        Some(device.port_number()),
                     ))
                 })
                 .collect::<Vec<_>>()

--- a/probe-rs/src/probe/stlink/usb_interface.rs
+++ b/probe-rs/src/probe/stlink/usb_interface.rs
@@ -119,7 +119,18 @@ impl StLinkUsbDevice {
                 if selector.vendor_id == descriptor.vendor_id()
                     && selector.product_id == descriptor.product_id()
                 {
-                    // If the VID & PID match, match the serial if one was given.
+                    // If Port ID and Bus ID are given, use them first; otherwise if serial number is given, try serial number;
+                    // or finally, just return with matched the VID and PID.
+                    let port_num = device.port_number();
+                    let bus_num = device.bus_number();
+                    if selector.port_number.is_some()
+                        && selector.bus_number.is_some()
+                        && selector.port_number.unwrap() == port_num
+                        && selector.bus_number.unwrap() == bus_num
+                    {
+                        return Some(device);
+                    }
+
                     if let Some(serial) = &selector.serial_number {
                         let sn_str = read_serial_number(&device, &descriptor).ok();
                         if sn_str.as_ref() == Some(serial) {


### PR DESCRIPTION
Hi @Yatekii @taruti ,

This PR adds support for USB Bus/Port number detection & selection. In short, with this PR, we now can do something like this:

```rust
use std::convert::TryInto;
let selector: probe_rs::DebugProbeSelector = "0d28:0204:3:1".try_into().unwrap();
```

...where it's a DAPLink at Bus 3, Port 1 on a USB Hub. This is mainly used for the mass production tool.

However, I've found a weird issue that, if the port number is set to a wrong one (e.g. an empty USB port), my program may freeze at `probe.attach()` calls, instead of returning `ProbeCreationError::NotFound` error immediately at `Probe::open()`. So far I have no idea why I encounter this issue. Could you please provide any further advice? 

To reproduce the freeze issue, try this code below:

```rust
        let selector: DebugProbeSelector = self.probe_id.clone().try_into().unwrap();
        let mut probe = Probe::open(selector_with_bus_port_number)?;
        
        probe.detach()?;

        let mut session = probe.attach(whatever_target_name)?; // hangs here
        let mut core = session.core(0)?;
```

Regards,
Jackson

