### PR TITLE
Release v0.11.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0-alpha.1]
 
+## [0.11.0-alpha.0]
+
 ### Added
 - Support for the `HNONSEC` bit in memory access. This now allows secure access on chips which support TrustZone (#???).
 - Support for RISCV chips which use the System Bus Access method for memory access when debugging (#527).

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "probe-rs-cli"
-version = "0.11.0-alpha.0"
+version = "0.11.0-alpha.1"
 authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Dominik Boehi <dominik.boehi@gmail.ch>"]
 edition = "2018"
 description = "A cli for on chip debugging and flashing of ARM chips."

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "probe-rs-debugger"
-version = "0.11.0-alpha.0"
+version = "0.11.0-alpha.1"
 authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Dominik Boehi <dominik.boehi@gmail.ch>", "Jack Noppe <noppej@hotmail.com>"]
 edition = "2018"
 description = "An interface (CLI or DAP Server) on top of the debug probe capabilities provided by probe-rs."

--- a/gdb-server/Cargo.toml
+++ b/gdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gdb-server"
-version = "0.11.0-alpha.0"
+version = "0.11.0-alpha.1"
 authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Dominik Boehi <dominik.boehi@gmail.ch>"]
 edition = "2018"
 description = "A gdb stub implementation for on chip debugging and flashing of ARM chips."

--- a/probe-rs-cli-util/Cargo.toml
+++ b/probe-rs-cli-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "probe-rs-cli-util"
-version = "0.11.0-alpha.0"
+version = "0.11.0-alpha.1"
 authors = ["Noah Hüsser <yatekii@yatekii.ch", "Dominik Boehi <dominik.boehi@gmail.com>"]
 edition = "2018"
 description = "Helper library for CLI applications based on probe-rs."

--- a/probe-rs-target/Cargo.toml
+++ b/probe-rs-target/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "probe-rs-target"
-version = "0.11.0-alpha.0"
+version = "0.11.0-alpha.1"
 edition = "2018"
 description = "Target description schema for probe-rs."
 documentation = "https://docs.rs/probe-rs/"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "probe-rs"
-version = "0.11.0-alpha.0"
+version = "0.11.0-alpha.1"
 authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Dominik Boehi <dominik.boehi@gmail.ch>"]
 edition = "2018"
 description = "A collection of on chip debugging tools to communicate with microchips."


### PR DESCRIPTION
Bump probe-rs versions in preparation for the v0.11.0-alpha.1 release.