### PR TITLE
Fix build without built-in targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,19 @@ jobs:
         with:
           toolchain: stable
           override: true
-          
+
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1.2.0
+
+      - name: cargo check for probe-rs, --no-default-features
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check -p probe-rs --no-default-features
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1.0.3
         with:
-          command: check
+          command: check --all-features
 
   test:
     name: Test Suite
@@ -106,7 +111,7 @@ jobs:
           toolchain: stable
           override: true
           target: thumbv7m-none-eabi
-      
+
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1.2.0
 
@@ -163,7 +168,7 @@ jobs:
 
       - name: Install clippy
         run: rustup component add clippy
-        
+
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1.2.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,14 @@ jobs:
       - name: cargo check for probe-rs, --no-default-features
         uses: actions-rs/cargo@v1.0.3
         with:
-          command: check -p probe-rs --no-default-features
+          command: check
+          args: -p probe-rs --no-default-features
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1.0.3
         with:
-          command: check --all-features
+          command: check
+          args: --all-features
 
   test:
     name: Test Suite

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -135,6 +135,7 @@ struct Registry {
 }
 
 impl Registry {
+    #[cfg(feature = "builtin-targets")]
     fn from_builtin_families() -> Self {
         const BUILTIN_TARGETS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/targets.bincode"));
 
@@ -150,7 +151,7 @@ impl Registry {
     fn from_builtin_families() -> Self {
         let mut families = vec![];
         add_generic_targets(&mut families);
-        families
+        Self { families }
     }
 
     fn families(&self) -> &Vec<ChipFamily> {


### PR DESCRIPTION
This fixes the probe-rs build without built-in targets, which is necessary for the `target-gen` tool.

It also adds a check to CI, to ensure it doesn't break again.