### PR TITLE
Fix crash on unknown AP class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The breakpoint address is now verified to ensure a breakpoint at the given address is actually possible (#626).
 - riscv: Use correct address for access to `abstractauto`register (#511).
 - The `--chip` argument now works without specifying the `--elf` argument (fix #517).
+- Fix crash on unknown AP class. (#662).
 
 
 

--- a/probe-rs/src/architecture/arm/ap/generic_ap.rs
+++ b/probe-rs/src/architecture/arm/ap/generic_ap.rs
@@ -60,7 +60,7 @@ define_ap_register!(
     IDR {
         REVISION: ((value >> 28) & 0x0F) as u8,
         DESIGNER: ((value >> 17) & 0x7FF) as u16,
-        CLASS: ApClass::from_u8(((value >> 13) & 0x0F) as u8).unwrap(),
+        CLASS: ApClass::from_u8(((value >> 13) & 0x0F) as u8).unwrap_or_default(),
         _RES0: 0,
         VARIANT: ((value >> 4) & 0x0F) as u8,
         TYPE: ApType::from_u8((value & 0x0F) as u8).unwrap()


### PR DESCRIPTION
Locked nrf5840 chips have an AP 0 with IDR=0x47475245, which is a class of 0b1010. This would crash attach.

This PR fixes this by treating unknown ApClass as Undefined.

```
 DEBUG probe_rs::probe::stlink                > Opening AP 0
 TRACE probe_rs::probe::stlink                > JTAG_INIT_AP 0
 TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 4b, 0] to STLink, timeout: 1s
 TRACE probe_rs::probe::stlink::usb_interface > Read 2 bytes, 0 bytes remaining
 TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 45, 0, 0, fc, 0] to STLink, timeout: 1s
 TRACE probe_rs::probe::stlink::usb_interface > Read 8 bytes, 0 bytes remaining
 DEBUG probe_rs::probe::stlink                > Read register    IDR, value=0x47475245
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', probe-rs/probe-rs/src/architecture/arm/ap/generic_ap.rs:63:63
stack backtrace:
   0: rust_begin_unwind
             at /rustc/ff2c947c00f867b9f012e28ba88cecfbe556f904/library/std/src/panicking.rs:515:5
   1: core::panicking::panic_fmt
             at /rustc/ff2c947c00f867b9f012e28ba88cecfbe556f904/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/ff2c947c00f867b9f012e28ba88cecfbe556f904/library/core/src/panicking.rs:50:5
   3: core::option::Option<T>::unwrap
             at /rustc/ff2c947c00f867b9f012e28ba88cecfbe556f904/library/core/src/option.rs:386:21
   4: <probe_rs::architecture::arm::ap::generic_ap::IDR as core::convert::From<u32>>::from
             at ./probe-rs/probe-rs/src/architecture/arm/ap/generic_ap.rs:63:16
   5: <T as core::convert::Into<U>>::into
             at /rustc/ff2c947c00f867b9f012e28ba88cecfbe556f904/library/core/src/convert/mod.rs:538:9
   6: <probe_rs::probe::stlink::StlinkArmDebug as probe_rs::architecture::arm::ap::ApAccess<AP,R>>::read_ap_register
             at ./probe-rs/probe-rs/src/probe/stlink/mod.rs:1399:12
   7: probe_rs::architecture::arm::ap::access_port_is_valid
             at ./probe-rs/probe-rs/src/architecture/arm/ap/mod.rs:146:22
   8: probe_rs::architecture::arm::ap::valid_access_ports::{{closure}}
             at ./probe-rs/probe-rs/src/architecture/arm/ap/mod.rs:161:28
   9: <core::iter::adapters::take_while::TakeWhile<I,P> as core::iter::traits::iterator::Iterator>::next
             at /rustc/ff2c947c00f867b9f012e28ba88cecfbe556f904/library/core/src/iter/adapters/take_while.rs:47:16
  10: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
             at /rustc/ff2c947c00f867b9f012e28ba88cecfbe556f904/library/alloc/src/vec/spec_from_iter_nested.rs:23:32
  11: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
             at /rustc/ff2c947c00f867b9f012e28ba88cecfbe556f904/library/alloc/src/vec/spec_from_iter.rs:36:9
  12: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
             at /rustc/ff2c947c00f867b9f012e28ba88cecfbe556f904/library/alloc/src/vec/mod.rs:2448:9
  13: core::iter::traits::iterator::Iterator::collect
             at /rustc/ff2c947c00f867b9f012e28ba88cecfbe556f904/library/core/src/iter/traits/iterator.rs:1787:9
  14: probe_rs::architecture::arm::ap::valid_access_ports
             at ./probe-rs/probe-rs/src/architecture/arm/ap/mod.rs:159:5
  15: probe_rs::probe::stlink::StlinkArmDebug::new
             at ./probe-rs/probe-rs/src/probe/stlink/mod.rs:1138:19
  16: <probe_rs::probe::stlink::StLink<probe_rs::probe::stlink::usb_interface::StLinkUsbDevice> as probe_rs::probe::DebugProbe>::try_get_arm_interface
             at ./probe-rs/probe-rs/src/probe/stlink/mod.rs:270:15
  17: probe_rs::probe::Probe::try_into_arm_interface
             at ./probe-rs/probe-rs/src/probe/mod.rs:389:13
  18: ak_flasher::recover
             at ./src/main.rs:139:21
  19: ak_flasher::main
             at ./src/main.rs:116:38
  20: core::ops::function::FnOnce::call_once
             at /rustc/ff2c947c00f867b9f012e28ba88cecfbe556f904/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```