### PR TITLE
Allow accessing DapAccess from the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a generic `read` function, which can be used for memory access with maximum speed, regardless of access width (#633).
 - Added an option to skip erasing the flash before programming (#628).
 - Added a new debugger for VS Code, using the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/specification). The debugger can be found in the `probe-rs-debugger` crate (#620).
+- Added support for raw DAP register reads and writes (#669).
 
 
 ### Target Support

--- a/probe-rs/examples/raw_dap_access.rs
+++ b/probe-rs/examples/raw_dap_access.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use probe_rs::{architecture::arm::PortType, Probe};
+
+fn main() -> Result<()> {
+    pretty_env_logger::init();
+
+    // Get a list of all available debug probes.
+    let probes = Probe::list_all();
+
+    // Use the first probe found.
+    let mut probe = probes[0].open()?;
+
+    probe.attach_to_unspecified()?;
+    let mut iface = probe.try_into_arm_interface().unwrap();
+
+    // This is an example on how to do a "recover" operation (erase+unlock a locked chip)
+    // on an nRF52840 target.
+
+    let port = PortType::AccessPort(1);
+
+    const RESET: u16 = 0;
+    const ERASEALL: u16 = 4;
+    const ERASEALLSTATUS: u16 = 8;
+
+    // Reset
+    iface.write_register(port, RESET, 1)?;
+    iface.write_register(port, RESET, 0)?;
+
+    // Start erase
+    iface.write_register(port, ERASEALL, 1)?;
+
+    // Wait for erase done
+    while iface.read_register(port, ERASEALLSTATUS)? != 0 {}
+
+    // Reset again
+    iface.write_register(port, RESET, 1)?;
+    iface.write_register(port, RESET, 0)?;
+
+    Ok(())
+}

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -125,7 +125,7 @@ pub trait DapAccess {
     }
 }
 
-pub trait ArmProbeInterface: SwoAccess + Debug + Send {
+pub trait ArmProbeInterface: DapAccess + SwoAccess + Debug + Send {
     fn memory_interface(&mut self, access_port: MemoryAp) -> Result<Memory<'_>, ProbeRsError>;
 
     fn ap_information(&self, access_port: GenericAp) -> Option<&ApInformation>;
@@ -246,6 +246,36 @@ impl ArmProbeInterface for ArmCommunicationInterface {
 
     fn close(self: Box<Self>) -> Probe {
         Probe::from_attached_probe(self.probe.into_probe())
+    }
+}
+
+impl DapAccess for ArmCommunicationInterface {
+    fn read_register(&mut self, port: PortType, addr: u16) -> Result<u32, DebugProbeError> {
+        self.probe.read_register(port, addr)
+    }
+    fn write_register(
+        &mut self,
+        port: PortType,
+        addr: u16,
+        value: u32,
+    ) -> Result<(), DebugProbeError> {
+        self.probe.write_register(port, addr, value)
+    }
+    fn read_block(
+        &mut self,
+        port: PortType,
+        addr: u16,
+        values: &mut [u32],
+    ) -> Result<(), DebugProbeError> {
+        self.probe.read_block(port, addr, values)
+    }
+    fn write_block(
+        &mut self,
+        port: PortType,
+        addr: u16,
+        values: &[u32],
+    ) -> Result<(), DebugProbeError> {
+        self.probe.write_block(port, addr, values)
     }
 }
 

--- a/probe-rs/src/probe/mod.rs
+++ b/probe-rs/src/probe/mod.rs
@@ -829,6 +829,36 @@ impl ArmProbeInterface for FakeArmInterface {
     }
 }
 
+impl DapAccess for FakeArmInterface {
+    fn read_register(&mut self, port: PortType, addr: u16) -> Result<u32, DebugProbeError> {
+        self.probe.read_register(port, addr)
+    }
+    fn write_register(
+        &mut self,
+        port: PortType,
+        addr: u16,
+        value: u32,
+    ) -> Result<(), DebugProbeError> {
+        self.probe.write_register(port, addr, value)
+    }
+    fn read_block(
+        &mut self,
+        port: PortType,
+        addr: u16,
+        values: &mut [u32],
+    ) -> Result<(), DebugProbeError> {
+        self.probe.read_block(port, addr, values)
+    }
+    fn write_block(
+        &mut self,
+        port: PortType,
+        addr: u16,
+        values: &[u32],
+    ) -> Result<(), DebugProbeError> {
+        self.probe.write_block(port, addr, values)
+    }
+}
+
 impl AsMut<(dyn DebugProbe + 'static)> for FakeArmInterface {
     fn as_mut(&mut self) -> &mut (dyn DebugProbe + 'static) {
         self.probe.as_mut()

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1378,6 +1378,36 @@ impl<'probe> ArmProbeInterface for StlinkArmDebug {
     }
 }
 
+impl DapAccess for StlinkArmDebug {
+    fn read_register(&mut self, port: PortType, addr: u16) -> Result<u32, DebugProbeError> {
+        self.probe.read_register(port, addr)
+    }
+    fn write_register(
+        &mut self,
+        port: PortType,
+        addr: u16,
+        value: u32,
+    ) -> Result<(), DebugProbeError> {
+        self.probe.write_register(port, addr, value)
+    }
+    fn read_block(
+        &mut self,
+        port: PortType,
+        addr: u16,
+        values: &mut [u32],
+    ) -> Result<(), DebugProbeError> {
+        self.probe.read_block(port, addr, values)
+    }
+    fn write_block(
+        &mut self,
+        port: PortType,
+        addr: u16,
+        values: &[u32],
+    ) -> Result<(), DebugProbeError> {
+        self.probe.write_block(port, addr, values)
+    }
+}
+
 impl<AP, R> ApAccess<AP, R> for StlinkArmDebug
 where
     R: ApRegister<AP> + Clone,


### PR DESCRIPTION
Allow using DapAccess from the public API, by adding it to ArmProbeInterface. 

Example nrf52840 recover operation:

```rust
    let mut probe: Probe = open_probe(opts)?;

    probe.attach_to_unspecified()?;
    let mut iface = probe.try_into_arm_interface().unwrap();

    let port = PortType::AccessPort(1);

    const RESET: u16 = 0;
    const ERASEALL: u16 = 4;
    const ERASEALLSTATUS: u16 = 8;
    const APPROTECTSTATUS: u16 = 12;

    // Reset
    iface.write_register(port, RESET, 1)?;
    iface.write_register(port, RESET, 0)?;

    // Start erase
    iface.write_register(port, ERASEALL, 1)?;

    // Wait for erase done
    while iface.read_register(port, ERASEALLSTATUS)? != 0 {}

    // Reset again
    iface.write_register(port, RESET, 1)?;
    iface.write_register(port, RESET, 0)?;
