### PR TITLE
flashing: Load flash algo once, not at every reinit.

### DIFF
--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -326,9 +326,10 @@ impl FlashLoader {
         }
 
         // Program the data.
-        let mut flasher = Flasher::new(session, flash_algorithm, region.clone());
+        let mut flasher = Flasher::new(session, flash_algorithm)?;
 
         flasher.program(
+            region,
             &self.builder,
             options.do_chip_erase,
             options.keep_unwritten_bytes,

--- a/probe-rs/src/flashing/mod.rs
+++ b/probe-rs/src/flashing/mod.rs
@@ -55,11 +55,11 @@ mod progress;
 mod visualizer;
 
 use builder::*;
+use flasher::*;
+
 pub use download::*;
 pub use error::*;
 pub use flash_algorithm::*;
-pub use flasher::*;
+pub use loader::*;
 pub use progress::*;
 pub use visualizer::*;
-
-pub use loader::FlashLoader;


### PR DESCRIPTION
- Flasher now no longer takes a Region, allowing reusing it for multiple regions that use the same algo.
- Load algo on `new`, not on `init`, so it's loaded only once. 
- Make Flasher private, remove `flash_block` since it's now unused. There already was no way to create a `Flasher` with the public API. 