### PR TITLE
Fix chip erase in multi-region chips.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `--chip` argument now works without specifying the `--elf` argument (fix #517).
 - Fixed: Invalid "Unable to set hardware breakpoint", by removing breakpoint caching, instead querying core directly (#632)
 - Fix crash on unknown AP class. (#662).
+- Fix too many chip erases in chips with multiple NvmRegions. (#670).
 
 
 ## [0.10.1]

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -200,6 +200,10 @@ impl<'session> Flasher<'session> {
         Ok(r)
     }
 
+    pub(super) fn is_chip_erase_supported(&self) -> bool {
+        self.flash_algorithm().pc_erase_all.is_some()
+    }
+
     /// Program the contents of given `FlashBuilder` to the flash.
     ///
     /// If `restore_unwritten_bytes` is `true`, all bytes of a sector,
@@ -209,7 +213,6 @@ impl<'session> Flasher<'session> {
         &mut self,
         region: &NvmRegion,
         flash_builder: &FlashBuilder,
-        mut do_chip_erase: bool,
         restore_unwritten_bytes: bool,
         enable_double_buffering: bool,
         skip_erasing: bool,
@@ -225,14 +228,6 @@ impl<'session> Flasher<'session> {
 
         progress.initialized(flash_layout.clone());
 
-        // If the flash algo doesn't support erase all, disable chip erase.
-        if self.flash_algorithm().pc_erase_all.is_none() {
-            do_chip_erase = false;
-            log::warn!("Chip erase was the selected method to erase the sectors but this chip does not support chip erases (yet).");
-            log::warn!("A manual sector erase will be performed.");
-        }
-
-        log::debug!("Full Chip Erase enabled: {:?}", do_chip_erase);
         log::debug!("Double Buffering enabled: {:?}", enable_double_buffering);
         log::debug!(
             "Restoring unwritten bytes enabled: {:?}",
@@ -265,11 +260,7 @@ impl<'session> Flasher<'session> {
         // Skip erase if necessary
         if !skip_erasing {
             // Erase all necessary sectors
-            if do_chip_erase {
-                self.chip_erase(&flash_layout, progress)?;
-            } else {
-                self.sector_erase(&flash_layout, progress)?;
-            }
+            self.sector_erase(&flash_layout, progress)?;
         }
 
         // Flash all necessary pages.
@@ -300,32 +291,6 @@ impl<'session> Flasher<'session> {
                 .read_8(fill.address(), page_slice)
                 .map_err(FlashError::Core)
         })
-    }
-
-    /// Erase the entire flash of the chip.
-    ///
-    /// This takes the list of available sectors only for progress reporting reasons.
-    /// It does not indeed erase single sectors but erases the entire flash.
-    fn chip_erase(
-        &mut self,
-        flash_layout: &FlashLayout,
-        progress: &FlashProgress,
-    ) -> Result<(), FlashError> {
-        progress.started_erasing();
-
-        let mut t = std::time::Instant::now();
-        let result = self.run_erase(|active| active.erase_all());
-        for sector in flash_layout.sectors() {
-            progress.sector_erased(sector.size(), t.elapsed());
-            t = std::time::Instant::now();
-        }
-
-        if result.is_ok() {
-            progress.finished_erasing();
-        } else {
-            progress.failed_erasing();
-        }
-        result
     }
 
     /// Programs the pages given in `flash_layout` into the flash.

--- a/probe-rs/targets/nRF52 Series.yaml
+++ b/probe-rs/targets/nRF52 Series.yaml
@@ -23,7 +23,6 @@ variants:
           is_boot_memory: false
     flash_algorithms:
       - nrf52
-      - nrf52_uicr
   - name: nRF52810_xxAA
     memory_map:
       - Ram:
@@ -43,7 +42,6 @@ variants:
           is_boot_memory: false
     flash_algorithms:
       - nrf52
-      - nrf52_uicr
   - name: nRF52811_xxAA
     memory_map:
       - Ram:
@@ -63,7 +61,6 @@ variants:
           is_boot_memory: false
     flash_algorithms:
       - nrf52
-      - nrf52_uicr
   - name: nRF52820_xxAA
     memory_map:
       - Ram:
@@ -83,7 +80,6 @@ variants:
           is_boot_memory: false
     flash_algorithms:
       - nrf52
-      - nrf52_uicr
   - name: nRF52832_xxAA
     memory_map:
       - Ram:
@@ -103,7 +99,6 @@ variants:
           is_boot_memory: false
     flash_algorithms:
       - nrf52
-      - nrf52_uicr
   - name: nRF52832_xxAB
     memory_map:
       - Ram:
@@ -123,7 +118,6 @@ variants:
           is_boot_memory: false
     flash_algorithms:
       - nrf52
-      - nrf52_uicr
   - name: nRF52833_xxAA
     memory_map:
       - Ram:
@@ -143,7 +137,6 @@ variants:
           is_boot_memory: false
     flash_algorithms:
       - nrf52
-      - nrf52_uicr
   - name: nRF52840_xxAA
     memory_map:
       - Ram:
@@ -163,7 +156,6 @@ variants:
           is_boot_memory: false
     flash_algorithms:
       - nrf52
-      - nrf52_uicr
 flash_algorithms:
   nrf52:
     name: nrf52
@@ -179,28 +171,6 @@ flash_algorithms:
     flash_properties:
       address_range:
         start: 0
-        end: 0x100000
-      page_size: 0x1000
-      erased_byte_value: 0xFF
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
-      sectors:
-        - size: 0x1000
-          address: 0
-  nrf52_uicr:
-    name: nrf52_uicr
-    description: nrf52_uicr
-    default: false
-    instructions: AL4K4A14LQZoQAgkQAAA01hAZB760UkcUh4AKvLRcEcAIHBHACBwR3C1JkwCIGBgASDgYCRNKGjABwLQACBgYHC9APAs+PbncLUeTAIhYWAeSYhCAtMBIGBhAOCgYBpNAPAd+ChowAf60AAgYGBwvfi1BUaOCBNIASEURkFgEk8BzAHFOGjABwbQdh740Q1IACFBYAhG+L0A8AH48ucMSEBoAAYADgvQCklJaAApB9AJSQpKwwcA0ApgCR1ACPnRcEcAAADlAUAA5AFAABAAEAAEAUAABQFAAAYBQDVGUm4AAAAA
-    pc_init: 0x21
-    pc_uninit: 0x21
-    pc_program_page: 0x71
-    pc_erase_sector: 0x49
-    pc_erase_all: 0x29
-    data_section_offset: 0x170
-    flash_properties:
-      address_range:
-        start: 0x10001000
         end: 0x10002000
       page_size: 0x1000
       erased_byte_value: 0xFF


### PR DESCRIPTION
### The Bug

nrf52 had 2 algorithms: one for the main flash and one for UICR. However, "chip erase" of either erases the entire chip. So probe-rs would do this when flashing:

- chip erase, write flash contents
- chip erase, write uicr contents
- end result is flash is empty

### The Fix

We assume algo X's chiperase erases all NvmRegions controlled by the algo. This seems to hold for all chips (doesn't for nrf52, but does if we merge the algos since they're actually the same one).

First, group all NvmRegions by flash algo. For each flash algo, do chip erase only once (if requested), then flash all its NvmRegions.

This has the nice bonus that all regions of the same algo are flashed together, so the algo is only loaded once. This should make it *ever so slightly* faster.