### PR TITLE
Flashing verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new debugger for VS Code, using the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/specification). The debugger can be found in the `probe-rs-debugger` crate (#620).
 - Additional datatype support for the debugger, plus easier to read display values (#631)
 - Added support for raw DAP register reads and writes (#669).
+- Added support for verify after flashing. (#671).
 
 
 ### Target Support

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -887,6 +887,7 @@ impl Debugger {
                     dry_run: false,
                     skip_erase: false,
                     do_chip_erase: self.debugger_options.full_chip_erase,
+                    verify: false,
                 };
                 match download_file_with_options(
                     &mut session_data.session,

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -99,6 +99,8 @@ pub struct DownloadOptions<'progress> {
     /// If the chip was pre-erased with external erasers, this flag can set to true to skip erasing
     /// It may be useful for mass production.
     pub skip_erase: bool,
+    /// After flashing, read back all the flashed data to verify it has been written correctly.
+    pub verify: bool,
 }
 
 /// Downloads a file of given `format` at `path` to the flash of the target given in `session`.

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -55,6 +55,9 @@ pub enum FlashError {
     #[error("Trying to write flash, but no suitable flash loader algorithm is linked to the given target information.")]
     NoFlashLoaderAlgorithmAttached,
 
+    #[error("Verify failed.")]
+    Verify,
+
     // TODO: 1 Add source of target definition
     #[error("No RAM defined for chip.")]
     NoRamDefined { chip: String },

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -355,6 +355,26 @@ impl FlashLoader {
             }
         }
 
+        if options.verify {
+            log::debug!("Verifying!");
+            for (&address, data) in &self.builder.data {
+                log::debug!(
+                    "    data: {:08x}-{:08x} ({} bytes)",
+                    address,
+                    address + data.len() as u32,
+                    data.len()
+                );
+
+                let mut written_data = vec![0; data.len()];
+                core.read(address, &mut written_data)
+                    .map_err(FlashError::Core)?;
+
+                if data != &written_data {
+                    return Err(FlashError::Verify);
+                }
+            }
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Only verifies the actually-written data. Data written by `keep_unwritten` is not verified. 

Doing that would require refactoring how flash building is done (first build for all the algos, then flash all the data keeping around the built pages, then use them to verify). I've opted not to do that for simplicity, and because keep_unwritten is not likely to be used in situations where verify is wanted (for example, factory programming usually does full chip erases). 

Depends on #670 