### PR TITLE
Fix inconsistencies in STM32F2 target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated target description for NRF91 (#619).
 - Added a RAM benchmark script (#514).
 - Initial support for batched commands for J-Link (#515).
-- Added support for the STM32F2 family.
+- Added support for the STM32F2 family (#675).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated target description for NRF91 (#619).
 - Added a RAM benchmark script (#514).
 - Initial support for batched commands for J-Link (#515).
-
 - Added support for the STM32F2 family.
 
 ### Changed

--- a/probe-rs/targets/STM32F2 Series.yaml
+++ b/probe-rs/targets/STM32F2 Series.yaml
@@ -8,7 +8,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -24,7 +24,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -40,7 +40,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -56,7 +56,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -72,7 +72,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -88,7 +88,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -104,7 +104,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -120,7 +120,7 @@ variants:
             start: 536870912
             end: 536936448
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134348800
@@ -136,7 +136,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -152,7 +152,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -168,7 +168,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -184,7 +184,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -200,7 +200,7 @@ variants:
             start: 536870912
             end: 536969216
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -216,7 +216,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -232,7 +232,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -248,7 +248,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -264,7 +264,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -280,7 +280,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -296,7 +296,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -312,7 +312,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -328,7 +328,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -344,7 +344,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -360,7 +360,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -376,7 +376,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -392,7 +392,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -408,7 +408,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -424,7 +424,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -440,7 +440,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -456,7 +456,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134479872
@@ -472,7 +472,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -488,7 +488,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135004160
@@ -504,7 +504,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -520,7 +520,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -536,7 +536,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -552,7 +552,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -568,7 +568,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -584,7 +584,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -600,7 +600,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -616,7 +616,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -632,7 +632,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -648,7 +648,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -664,7 +664,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -680,7 +680,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -696,7 +696,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304
@@ -712,7 +712,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 134742016
@@ -728,7 +728,7 @@ variants:
             start: 536870912
             end: 537001984
           is_boot_memory: false
-      - Flash:
+      - Nvm:
           range:
             start: 134217728
             end: 135266304


### PR DESCRIPTION
This is a follow-up to PR #675 regarding @Tiwalun's [comment](https://github.com/probe-rs/probe-rs/pull/675#pullrequestreview-675573651):

> We prefer to use Nvm now in the target description, because it's not always flash but can also be some other kind of non-volatile memory. But Flash is fine as well.

I was not aware of the new name as I based my original PR on tag `v0.10.1`, the last released version. This PR now uses the name `Nvm` as all the other STM32 targets (and others), introduced in commit 7a0b0507beeb42424248ecf9c9e69b0363bb6b5e in December 2020.

The PR also fixes an unintended white line in the changelog that was introduced by the merge.