### PR TITLE
Make DownloadOptions non_exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rework SWD sequence in J-Link (#513).
 - Print ST-Link version in name (#516).
 - Improve argument parsing in debugger, add speed option to probe-rs-cli (#523).
+- `probe_rs::flashing::DownloadOptions` is now marked `non_exhaustive`, to make it easier to add additional flags in the future.
   
 ### Fixed
 

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -881,14 +881,11 @@ impl Debugger {
                     "FLASHING: Starting write of {:?} to device memory",
                     &path_to_elf
                 ));
-                let download_options = DownloadOptions {
-                    progress: None,
-                    keep_unwritten_bytes: self.debugger_options.restore_unwritten_bytes,
-                    dry_run: false,
-                    skip_erase: false,
-                    do_chip_erase: self.debugger_options.full_chip_erase,
-                    verify: false,
-                };
+
+                let download_options = DownloadOptions::new()
+                    .keep_unwritten_bytes(self.debugger_options.restore_unwritten_bytes)
+                    .do_chip_erase(self.debugger_options.full_chip_erase);
+
                 match download_file_with_options(
                     &mut session_data.session,
                     path_to_elf,

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -79,7 +79,20 @@ pub enum FileDownloadError {
 }
 
 /// Options for downloading a file onto a target chip.
+///
+///
+/// This struct should be created using the `new` function, and can be configured either by setting
+/// the fields directly, or using the convenience methods:
+///
+/// ```
+/// use probe_rs::flashing::DownloadOptions;
+///
+/// let mut options = DownloadOptions::new().keep_unwritten_bytes(true);
+///
+/// options.verify = true;
+/// ```
 #[derive(Default)]
+#[non_exhaustive]
 pub struct DownloadOptions<'progress> {
     /// An optional progress reporter which is used if this argument is set to `Some(...)`.
     pub progress: Option<&'progress FlashProgress>,
@@ -101,6 +114,46 @@ pub struct DownloadOptions<'progress> {
     pub skip_erase: bool,
     /// After flashing, read back all the flashed data to verify it has been written correctly.
     pub verify: bool,
+}
+
+impl<'progress> DownloadOptions<'progress> {
+    /// DownloadOptions with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Specify a callback for progress reports.
+    pub fn with_progress_report(mut self, progress: &'progress FlashProgress) -> Self {
+        self.progress = Some(progress);
+        self
+    }
+
+    /// Prepare everything for flashing, but do not perform any actual erase or program operations.
+    pub fn dry_run(mut self, dry_run: bool) -> Self {
+        self.dry_run = dry_run;
+        self
+    }
+
+    /// Restore erased sections of the flash, which do not get overweritten with new data, to their existing values.
+    /// See [`Self::keep_unwritten_bytes`].
+    pub fn keep_unwritten_bytes(mut self, keep_unwritten_bytes: bool) -> Self {
+        self.keep_unwritten_bytes = keep_unwritten_bytes;
+        self
+    }
+
+    /// Verify data after flashing.
+    pub fn verify(mut self, verify: bool) -> Self {
+        self.verify = verify;
+        self
+    }
+
+    /// Perform a full erase of the chip.
+    /// This is often faster than erasing a lot of single sectors.
+    /// So if you do not need the old contents of the flash, this is a good option.
+    pub fn do_chip_erase(mut self, do_chip_erase: bool) -> Self {
+        self.do_chip_erase = do_chip_erase;
+        self
+    }
 }
 
 /// Downloads a file of given `format` at `path` to the flash of the target given in `session`.


### PR DESCRIPTION
This PR marks the flash `DownloadOptions` as `non_exhaustive`. This should make it easier to add additional flags in the future,
without having to update all consumers of the library.
