### PR TITLE
Add back the missing skip_erase setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Invalid "Unable to set hardware breakpoint", by removing breakpoint caching, instead querying core directly (#632)
 - Fix crash on unknown AP class. (#662).
 - Fix too many chip erases in chips with multiple NvmRegions. (#670).
+- Added missing `skip_erase` setter function introduced in #677 (#679).
 
 
 ## [0.10.1]

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -154,6 +154,13 @@ impl<'progress> DownloadOptions<'progress> {
         self.do_chip_erase = do_chip_erase;
         self
     }
+
+    /// If the chip was pre-erased with external erasers, this flag can set to true to skip erasing
+    /// It may be useful for mass production.
+    pub fn skip_erase(mut self, skip_erase: bool) -> Self {
+        self.skip_erase = skip_erase;
+        self
+    }
 }
 
 /// Downloads a file of given `format` at `path` to the flash of the target given in `session`.

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -155,7 +155,7 @@ impl<'progress> DownloadOptions<'progress> {
         self
     }
 
-    /// If the chip was pre-erased with external erasers, this flag can set to true to skip erasing
+    /// If the chip was pre-erased with external erasers, this flag can be set to true to skip erasing
     /// It may be useful for mass production.
     pub fn skip_erase(mut self, skip_erase: bool) -> Self {
         self.skip_erase = skip_erase;


### PR DESCRIPTION
Hi there, 

As per this pull request https://github.com/probe-rs/probe-rs/pull/677, I think you have forgotten to add the `skip_erase` setter function. So here I add it back.

Jackson