### PR TITLE
Add RawApAccess trait, cleanup ApAccess trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an option to skip erasing the flash before programming (#628).
 - Added a new debugger for VS Code, using the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/specification). The debugger can be found in the `probe-rs-debugger` crate (#620).
 - Additional datatype support for the debugger, plus easier to read display values (#631)
-- Added support for raw DAP register reads and writes (#669).
+- Added support for raw DAP register reads and writes, using the `RawApAccess` trait (#669, #689).
 - Added support for verify after flashing. (#671).
 - Handle inlined functions when getting a stack trace (#678).
 - Added 'Statics' (static variables) to the stackframe scopes. These are now visible in VSCode between 'Locals' and 'Registers'. This includes some additional datatypes and DWARF expression evaluation capabilities. (#683)

--- a/probe-rs/examples/raw_dap_access.rs
+++ b/probe-rs/examples/raw_dap_access.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use probe_rs::{architecture::arm::PortType, Probe};
+use probe_rs::Probe;
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
@@ -16,25 +16,25 @@ fn main() -> Result<()> {
     // This is an example on how to do a "recover" operation (erase+unlock a locked chip)
     // on an nRF52840 target.
 
-    let port = PortType::AccessPort(1);
+    let port = 1;
 
-    const RESET: u16 = 0;
-    const ERASEALL: u16 = 4;
-    const ERASEALLSTATUS: u16 = 8;
+    const RESET: u8 = 0;
+    const ERASEALL: u8 = 4;
+    const ERASEALLSTATUS: u8 = 8;
 
     // Reset
-    iface.write_register(port, RESET, 1)?;
-    iface.write_register(port, RESET, 0)?;
+    iface.write_raw_ap_register(port, RESET, 1)?;
+    iface.write_raw_ap_register(port, RESET, 0)?;
 
     // Start erase
-    iface.write_register(port, ERASEALL, 1)?;
+    iface.write_raw_ap_register(port, ERASEALL, 1)?;
 
     // Wait for erase done
-    while iface.read_register(port, ERASEALLSTATUS)? != 0 {}
+    while iface.read_raw_ap_register(port, ERASEALLSTATUS)? != 0 {}
 
     // Reset again
-    iface.write_register(port, RESET, 1)?;
-    iface.write_register(port, RESET, 0)?;
+    iface.write_raw_ap_register(port, RESET, 1)?;
+    iface.write_raw_ap_register(port, RESET, 0)?;
 
     Ok(())
 }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -1,5 +1,6 @@
 use super::super::{ApAccess, Register};
-use super::{AddressIncrement, ApRegister, DataSize, MemoryAp, CSW, DRW, TAR};
+use super::{AddressIncrement, ApRegister, DataSize, CSW, DRW, TAR};
+use crate::architecture::arm::ap::AccessPort;
 use crate::{
     architecture::arm::dp::{DebugPortError, DpAccess, DpRegister},
     CommunicationInterface, DebugProbeError,
@@ -10,7 +11,7 @@ use std::convert::TryInto;
 #[derive(Debug)]
 pub struct MockMemoryAp {
     pub memory: Vec<u8>,
-    store: HashMap<(u8, u8), u32>,
+    store: HashMap<u8, u32>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -28,9 +29,9 @@ impl MockMemoryAp {
     /// printed out for debugging.
     pub fn with_pattern() -> Self {
         let mut store = HashMap::new();
-        store.insert((CSW::ADDRESS, CSW::APBANKSEL), 0);
-        store.insert((TAR::ADDRESS, TAR::APBANKSEL), 0);
-        store.insert((DRW::ADDRESS, DRW::APBANKSEL), 0);
+        store.insert(CSW::ADDRESS, 0);
+        store.insert(TAR::ADDRESS, 0);
+        store.insert(DRW::ADDRESS, 0);
         Self {
             memory: (1..=16).collect(),
             store,
@@ -44,26 +45,23 @@ impl CommunicationInterface for MockMemoryAp {
     }
 }
 
-impl<R> ApAccess<MemoryAp, R> for MockMemoryAp
-where
-    R: ApRegister<MemoryAp>,
-{
+impl ApAccess for MockMemoryAp {
     type Error = MockMemoryError;
 
     /// Mocks the read_register method of a AP.
     ///
     /// Returns an Error if any bad instructions or values are chosen.
-    fn read_ap_register(
-        &mut self,
-        _port: impl Into<MemoryAp>,
-        _register: R,
-    ) -> Result<R, Self::Error> {
-        let csw = self.store[&(CSW::ADDRESS, CSW::APBANKSEL)];
-        let address = self.store[&(TAR::ADDRESS, TAR::APBANKSEL)];
+    fn read_ap_register<PORT, R>(&mut self, _port: impl Into<PORT>) -> Result<R, Self::Error>
+    where
+        PORT: AccessPort,
+        R: ApRegister<PORT>,
+    {
+        let csw = self.store[&CSW::ADDRESS];
+        let address = self.store[&TAR::ADDRESS];
 
-        match (R::ADDRESS, R::APBANKSEL) {
-            (DRW::ADDRESS, DRW::APBANKSEL) => {
-                let drw = self.store[&(DRW::ADDRESS, DRW::APBANKSEL)];
+        match R::ADDRESS {
+            DRW::ADDRESS => {
+                let drw = self.store[&DRW::ADDRESS];
                 let bit_offset = (address % 4) * 8;
                 let offset = address as usize;
                 let csw = CSW::from(csw);
@@ -100,12 +98,11 @@ where
                     _ => return Err(MockMemoryError::UnknownWidth),
                 };
 
-                self.store.insert((DRW::ADDRESS, DRW::APBANKSEL), new_drw);
+                self.store.insert(DRW::ADDRESS, new_drw);
 
                 match csw.AddrInc {
                     AddressIncrement::Single => {
-                        self.store
-                            .insert((TAR::ADDRESS, TAR::APBANKSEL), address + offset);
+                        self.store.insert(TAR::ADDRESS, address + offset);
                     }
                     AddressIncrement::Off => (),
                     AddressIncrement::Packed => {
@@ -115,8 +112,8 @@ where
 
                 Ok(R::from(new_drw))
             }
-            (CSW::ADDRESS, CSW::APBANKSEL) => Ok(R::from(self.store[&(R::ADDRESS, R::APBANKSEL)])),
-            (TAR::ADDRESS, TAR::APBANKSEL) => Ok(R::from(self.store[&(R::ADDRESS, R::APBANKSEL)])),
+            CSW::ADDRESS => Ok(R::from(self.store[&R::ADDRESS])),
+            TAR::ADDRESS => Ok(R::from(self.store[&R::ADDRESS])),
             _ => Err(MockMemoryError::UnknownRegister),
         }
     }
@@ -124,20 +121,24 @@ where
     /// Mocks the write_register method of a AP.
     ///
     /// Returns an Error if any bad instructions or values are chosen.
-    fn write_ap_register(
+    fn write_ap_register<PORT, R>(
         &mut self,
-        _port: impl Into<MemoryAp>,
+        _port: impl Into<PORT>,
         register: R,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Self::Error>
+    where
+        PORT: AccessPort,
+        R: ApRegister<PORT>,
+    {
         log::debug!("Mock: Write to register {:x?}", &register);
 
         let value: u32 = register.into();
-        self.store.insert((R::ADDRESS, R::APBANKSEL), value);
-        let csw = self.store[&(CSW::ADDRESS, CSW::APBANKSEL)];
-        let address = self.store[&(TAR::ADDRESS, TAR::APBANKSEL)];
+        self.store.insert(R::ADDRESS, value);
+        let csw = self.store[&CSW::ADDRESS];
+        let address = self.store[&TAR::ADDRESS];
 
-        match (R::ADDRESS, R::APBANKSEL) {
-            (DRW::ADDRESS, DRW::APBANKSEL) => {
+        match R::ADDRESS {
+            DRW::ADDRESS => {
                 let csw = CSW::from(csw);
 
                 let access_width = match csw.SIZE {
@@ -176,8 +177,7 @@ where
                 }
                 .map(|offset| match csw.AddrInc {
                     AddressIncrement::Single => {
-                        self.store
-                            .insert((TAR::ADDRESS, TAR::APBANKSEL), address + offset);
+                        self.store.insert(TAR::ADDRESS, address + offset);
                     }
                     AddressIncrement::Off => (),
                     AddressIncrement::Packed => {
@@ -185,40 +185,48 @@ where
                     }
                 })
             }
-            (CSW::ADDRESS, CSW::APBANKSEL) => {
-                self.store.insert((CSW::ADDRESS, CSW::APBANKSEL), value);
+            CSW::ADDRESS => {
+                self.store.insert(CSW::ADDRESS, value);
                 Ok(())
             }
-            (TAR::ADDRESS, TAR::APBANKSEL) => {
-                self.store.insert((TAR::ADDRESS, TAR::APBANKSEL), value);
+            TAR::ADDRESS => {
+                self.store.insert(TAR::ADDRESS, value);
                 Ok(())
             }
             _ => Err(MockMemoryError::UnknownRegister),
         }
     }
 
-    fn write_ap_register_repeated(
+    fn write_ap_register_repeated<PORT, R>(
         &mut self,
-        port: impl Into<MemoryAp> + Clone,
+        port: impl Into<PORT> + Clone,
         _register: R,
         values: &[u32],
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Self::Error>
+    where
+        PORT: AccessPort,
+        R: ApRegister<PORT>,
+    {
         for value in values {
             self.write_ap_register(port.clone(), R::from(*value))?
         }
 
         Ok(())
     }
-    fn read_ap_register_repeated(
+
+    fn read_ap_register_repeated<PORT, R>(
         &mut self,
-        port: impl Into<MemoryAp> + Clone,
-        register: R,
+        port: impl Into<PORT> + Clone,
+        _register: R,
         values: &mut [u32],
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Self::Error>
+    where
+        PORT: AccessPort,
+        R: ApRegister<PORT>,
+    {
         for value in values {
-            *value = self
-                .read_ap_register(port.clone(), register.clone())?
-                .into()
+            let register_value: R = self.read_ap_register(port.clone())?;
+            *value = register_value.into()
         }
 
         Ok(())

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -17,13 +17,12 @@ define_ap!(MemoryAp);
 impl MemoryAp {
     pub fn base_address<A>(&self, interface: &mut A) -> Result<u64, DebugProbeError>
     where
-        A: ApAccess<MemoryAp, BASE, Error = DebugProbeError>
-            + ApAccess<MemoryAp, BASE2, Error = DebugProbeError>,
+        A: ApAccess<Error = DebugProbeError>,
     {
-        let base_register = interface.read_ap_register(self.port_number(), BASE::default())?;
+        let base_register: BASE = interface.read_ap_register(self.port_number())?;
 
         let mut base_address = if BaseaddrFormat::ADIv5 == base_register.Format {
-            let base2 = interface.read_ap_register(self.port_number(), BASE2::default())?;
+            let base2: BASE2 = interface.read_ap_register(self.port_number())?;
 
             u64::from(base2.BASEADDR) << 32
         } else {

--- a/probe-rs/src/architecture/arm/ap/register_generation.rs
+++ b/probe-rs/src/architecture/arm/ap/register_generation.rs
@@ -41,8 +41,6 @@ macro_rules! define_ap_register {
         }
 
         impl ApRegister<$port_type> for $name {
-            // APBANKSEL is always the upper 4 bits of the register address.
-            const APBANKSEL: u8 = $address >> 4;
         }
     }
 }

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -1,7 +1,7 @@
 use super::{
     ap::{
-        valid_access_ports, AccessPort, ApAccess, ApClass, ApRegister, BaseaddrFormat, DataSize,
-        GenericAp, MemoryAp, BASE, BASE2, CSW, IDR,
+        valid_access_ports, AccessPort, ApAccess, ApClass, ApRegister, BaseaddrFormat, GenericAp,
+        MemoryAp, RawApAccess, BASE, BASE2, CSW, IDR,
     },
     dp::{
         Abort, Ctrl, DebugPortError, DebugPortId, DebugPortVersion, DpAccess, DpBankSel,
@@ -11,7 +11,8 @@ use super::{
     SwoAccess, SwoConfig,
 };
 use crate::{
-    CommunicationInterface, DebugProbe, DebugProbeError, Error as ProbeRsError, Memory, Probe,
+    architecture::arm::ap::DataSize, CommunicationInterface, DebugProbe, DebugProbeError,
+    Error as ProbeRsError, Memory, Probe,
 };
 use anyhow::anyhow;
 use jep106::JEP106Code;
@@ -71,7 +72,7 @@ pub trait Register: Clone + From<u32> + Into<u32> + Sized + Debug {
 
 pub trait DapAccess {
     /// Reads the DAP register on the specified port and address
-    fn read_register(&mut self, port: PortType, addr: u16) -> Result<u32, DebugProbeError>;
+    fn read_register(&mut self, port: PortType, addr: u8) -> Result<u32, DebugProbeError>;
 
     /// Read multiple values from the same DAP register.
     ///
@@ -80,7 +81,7 @@ pub trait DapAccess {
     fn read_block(
         &mut self,
         port: PortType,
-        addr: u16,
+        addr: u8,
         values: &mut [u32],
     ) -> Result<(), DebugProbeError> {
         for val in values {
@@ -94,7 +95,7 @@ pub trait DapAccess {
     fn write_register(
         &mut self,
         port: PortType,
-        addr: u16,
+        addr: u8,
         value: u32,
     ) -> Result<(), DebugProbeError>;
 
@@ -105,7 +106,7 @@ pub trait DapAccess {
     fn write_block(
         &mut self,
         port: PortType,
-        addr: u16,
+        addr: u8,
         values: &[u32],
     ) -> Result<(), DebugProbeError> {
         for val in values {
@@ -124,7 +125,9 @@ pub trait DapAccess {
     }
 }
 
-pub trait ArmProbeInterface: DapAccess + SwoAccess + Debug + Send {
+pub trait ArmProbeInterface:
+    RawApAccess<Error = DebugProbeError> + SwoAccess + Debug + Send
+{
     fn memory_interface(&mut self, access_port: MemoryAp) -> Result<Memory<'_>, ProbeRsError>;
 
     fn ap_information(&self, access_port: GenericAp) -> Option<&ApInformation>;
@@ -181,6 +184,62 @@ impl ArmCommunicationInterfaceState {
             current_apsel: 0,
             current_apbanksel: 0,
             ap_information: Vec::new(),
+        }
+    }
+}
+
+impl ApInformation {
+    /// Read information about an AP from its registers.
+    ///
+    /// This reads the IDR register of the AP, and parses
+    /// further AP specific information based on its class.
+    ///
+    /// Currently, AP specific information is read for Memory APs.
+    pub(crate) fn read_from_target<P>(
+        probe: &mut P,
+        access_port: GenericAp,
+    ) -> Result<Self, DebugProbeError>
+    where
+        P: ApAccess<Error = DebugProbeError>,
+    {
+        let idr: IDR = probe.read_ap_register(access_port)?;
+
+        if idr.CLASS == ApClass::MemAp {
+            let access_port: MemoryAp = access_port.into();
+
+            let base_register: BASE = probe.read_ap_register(access_port)?;
+
+            let mut base_address = if BaseaddrFormat::ADIv5 == base_register.Format {
+                let base2: BASE2 = probe.read_ap_register(access_port)?;
+
+                u64::from(base2.BASEADDR) << 32
+            } else {
+                0
+            };
+            base_address |= u64::from(base_register.BASEADDR << 12);
+
+            // Read information about HNONSEC support and supported access widths
+            let csw = CSW::new(DataSize::U8);
+
+            probe.write_ap_register(access_port, csw)?;
+            let csw: CSW = probe.read_ap_register(access_port)?;
+
+            let only_32bit_data_size = csw.SIZE != DataSize::U8;
+
+            let supports_hnonsec = csw.HNONSEC == 1;
+
+            log::debug!("HNONSEC supported: {}", supports_hnonsec);
+
+            Ok(ApInformation::MemoryAp(MemoryApInformation {
+                port_number: access_port.port_number(),
+                only_32bit_data_size,
+                debug_base_address: base_address,
+                supports_hnonsec: false,
+            }))
+        } else {
+            Ok(ApInformation::Other {
+                port_number: access_port.port_number(),
+            })
         }
     }
 }
@@ -248,36 +307,6 @@ impl ArmProbeInterface for ArmCommunicationInterface {
     }
 }
 
-impl DapAccess for ArmCommunicationInterface {
-    fn read_register(&mut self, port: PortType, addr: u16) -> Result<u32, DebugProbeError> {
-        self.probe.read_register(port, addr)
-    }
-    fn write_register(
-        &mut self,
-        port: PortType,
-        addr: u16,
-        value: u32,
-    ) -> Result<(), DebugProbeError> {
-        self.probe.write_register(port, addr, value)
-    }
-    fn read_block(
-        &mut self,
-        port: PortType,
-        addr: u16,
-        values: &mut [u32],
-    ) -> Result<(), DebugProbeError> {
-        self.probe.read_block(port, addr, values)
-    }
-    fn write_block(
-        &mut self,
-        port: PortType,
-        addr: u16,
-        values: &[u32],
-    ) -> Result<(), DebugProbeError> {
-        self.probe.write_block(port, addr, values)
-    }
-}
-
 impl<'interface> ArmCommunicationInterface {
     pub(crate) fn new(
         probe: Box<dyn DapProbe>,
@@ -295,7 +324,7 @@ impl<'interface> ArmCommunicationInterface {
         log::trace!("Searching valid APs");
 
         for ap in valid_access_ports(&mut interface) {
-            let ap_state = match interface.read_ap_information(ap) {
+            let ap_state = match ApInformation::read_from_target(&mut interface, ap) {
                 Ok(state) => state,
                 Err(e) => return Err((interface.probe, e)),
             };
@@ -383,7 +412,13 @@ impl<'interface> ArmCommunicationInterface {
         Ok(())
     }
 
-    fn select_ap_and_ap_bank(&mut self, port: u8, ap_bank: u8) -> Result<(), DebugProbeError> {
+    fn select_ap_and_ap_bank(
+        &mut self,
+        port: u8,
+        ap_register_address: u8,
+    ) -> Result<(), DebugProbeError> {
+        let ap_bank = ap_register_address >> 4;
+
         let mut cache_changed = if self.state.current_apsel != port {
             self.state.current_apsel = port;
             true
@@ -438,174 +473,11 @@ impl<'interface> ArmCommunicationInterface {
         Ok(())
     }
 
-    /// Write the given register `R` of the given `AP`, where the to be written register value
-    /// is wrapped in the given `register` parameter.
-    pub fn write_ap_register<AP, R>(
-        &mut self,
-        port: impl Into<AP>,
-        register: R,
-    ) -> Result<(), DebugProbeError>
-    where
-        AP: AccessPort,
-        R: ApRegister<AP>,
-    {
-        log::debug!("Writing register {}, value={:x?}", R::NAME, register);
-
-        let register_value = register.into();
-
-        self.select_ap_and_ap_bank(port.into().port_number(), R::APBANKSEL)?;
-
-        self.probe.write_register(
-            PortType::AccessPort(u16::from(self.state.current_apsel)),
-            u16::from(R::ADDRESS),
-            register_value,
-        )?;
-        Ok(())
-    }
-
-    // TODO: Fix this ugly: _register: R, values: &[u32]
-    /// Write the given register `R` of the given `AP` repeatedly, where the to be written register
-    /// values are stored in the `values` array. The values are written in the exact order they are
-    /// stored in the array.
-    pub fn write_ap_register_repeated<AP, R>(
-        &mut self,
-        port: impl Into<AP>,
-        _register: R,
-        values: &[u32],
-    ) -> Result<(), DebugProbeError>
-    where
-        AP: AccessPort,
-        R: ApRegister<AP>,
-    {
-        log::debug!(
-            "Writing register {}, block with len={} words",
-            R::NAME,
-            values.len(),
-        );
-
-        self.select_ap_and_ap_bank(port.into().port_number(), R::APBANKSEL)?;
-
-        self.probe.write_block(
-            PortType::AccessPort(u16::from(self.state.current_apsel)),
-            u16::from(R::ADDRESS),
-            values,
-        )?;
-        Ok(())
-    }
-
-    /// Read the given register `R` of the given `AP`, where the read register value is wrapped in
-    /// the given `register` parameter.
-    pub fn read_ap_register<AP, R>(
-        &mut self,
-        port: impl Into<AP>,
-        _register: R,
-    ) -> Result<R, DebugProbeError>
-    where
-        AP: AccessPort,
-        R: ApRegister<AP>,
-    {
-        log::debug!("Reading register {}", R::NAME);
-        self.select_ap_and_ap_bank(port.into().port_number(), R::APBANKSEL)?;
-
-        let result: R = self
-            .probe
-            .read_register(
-                PortType::AccessPort(u16::from(self.state.current_apsel)),
-                u16::from(R::ADDRESS),
-            )?
-            .into();
-
-        log::debug!("Read register    {}, value=0x{:x?}", R::NAME, result);
-
-        Ok(result)
-    }
-
-    // TODO: fix types, see above!
-    /// Read the given register `R` of the given `AP` repeatedly, where the read register values
-    /// are stored in the `values` array. The values are read in the exact order they are stored in
-    /// the array.
-    pub fn read_ap_register_repeated<AP, R>(
-        &mut self,
-        port: impl Into<AP>,
-        _register: R,
-        values: &mut [u32],
-    ) -> Result<(), DebugProbeError>
-    where
-        AP: AccessPort,
-        R: ApRegister<AP>,
-    {
-        log::debug!(
-            "Reading register {}, block with len={} words",
-            R::NAME,
-            values.len(),
-        );
-
-        self.select_ap_and_ap_bank(port.into().port_number(), R::APBANKSEL)?;
-
-        self.probe.read_block(
-            PortType::AccessPort(u16::from(self.state.current_apsel)),
-            u16::from(R::ADDRESS),
-            values,
-        )?;
-        Ok(())
-    }
-
     /// Determine the type and additional information about a AP
     pub(crate) fn ap_information(&self, access_port: impl AccessPort) -> Option<&ApInformation> {
         self.state
             .ap_information
             .get(access_port.port_number() as usize)
-    }
-
-    /// Read information about an AP from its registers.
-    ///
-    /// This reads the IDR register of the AP, and parses
-    /// further AP specific information based on its class.
-    ///
-    /// Currently, AP specific information is read for Memory APs.
-    fn read_ap_information(
-        &mut self,
-        access_port: GenericAp,
-    ) -> Result<ApInformation, DebugProbeError> {
-        let idr = self.read_ap_register(access_port, IDR::default())?;
-
-        if idr.CLASS == ApClass::MemAp {
-            let access_port: MemoryAp = access_port.into();
-
-            let base_register = self.read_ap_register(access_port, BASE::default())?;
-
-            let mut base_address = if BaseaddrFormat::ADIv5 == base_register.Format {
-                let base2 = self.read_ap_register(access_port, BASE2::default())?;
-
-                u64::from(base2.BASEADDR) << 32
-            } else {
-                0
-            };
-            base_address |= u64::from(base_register.BASEADDR << 12);
-
-            // Read information about HNONSEC support and supported access widths
-            let csw = CSW::new(DataSize::U8);
-
-            self.write_ap_register(access_port, csw)?;
-            let csw = self.read_ap_register(access_port, CSW::default())?;
-
-            let only_32bit_data_size = csw.SIZE != DataSize::U8;
-
-            let supports_hnonsec = csw.HNONSEC == 1;
-
-            log::debug!("HNONSEC supported: {}", supports_hnonsec);
-
-            Ok(ApInformation::MemoryAp(MemoryApInformation {
-                port_number: access_port.port_number(),
-                only_32bit_data_size,
-                debug_base_address: base_address,
-                supports_hnonsec,
-            }))
-        } else {
-            Ok(ApInformation::Other {
-                port_number: access_port.port_number(),
-            })
-        }
     }
 
     fn get_debug_port_version(&mut self) -> Result<DebugPortVersion, DebugProbeError> {
@@ -635,7 +507,7 @@ impl DpAccess for ArmCommunicationInterface {
         log::debug!("Reading DP register {}", R::NAME);
         let result = self
             .probe
-            .read_register(PortType::DebugPort, u16::from(R::ADDRESS))?
+            .read_register(PortType::DebugPort, R::ADDRESS)?
             .into();
 
         log::debug!("Read    DP register {}, value=0x{:x?}", R::NAME, result);
@@ -655,7 +527,7 @@ impl DpAccess for ArmCommunicationInterface {
 
         log::debug!("Writing DP register {}, value=0x{:x?}", R::NAME, register);
         self.probe
-            .write_register(PortType::DebugPort, R::ADDRESS as u16, register.into())?;
+            .write_register(PortType::DebugPort, R::ADDRESS, register.into())?;
 
         Ok(())
     }
@@ -684,85 +556,133 @@ impl SwoAccess for ArmCommunicationInterface {
     }
 }
 
-impl<R> ApAccess<MemoryAp, R> for ArmCommunicationInterface
-where
-    R: ApRegister<MemoryAp>,
-{
+impl RawApAccess for ArmCommunicationInterface {
     type Error = DebugProbeError;
 
-    fn read_ap_register(
-        &mut self,
-        port: impl Into<MemoryAp>,
-        register: R,
-    ) -> Result<R, Self::Error> {
-        self.read_ap_register(port, register)
+    fn read_raw_ap_register(&mut self, port_number: u8, address: u8) -> Result<u32, Self::Error> {
+        self.select_ap_and_ap_bank(port_number, address)?;
+
+        let result = self.probe.read_register(
+            PortType::AccessPort(u16::from(self.state.current_apsel)),
+            address,
+        )?;
+
+        Ok(result)
     }
 
-    fn write_ap_register(
+    fn read_raw_ap_register_repeated(
         &mut self,
-        port: impl Into<MemoryAp>,
-        register: R,
-    ) -> Result<(), Self::Error> {
-        self.write_ap_register(port, register)
-    }
-
-    fn write_ap_register_repeated(
-        &mut self,
-        port: impl Into<MemoryAp>,
-        register: R,
-        values: &[u32],
-    ) -> Result<(), Self::Error> {
-        self.write_ap_register_repeated(port, register, values)
-    }
-
-    fn read_ap_register_repeated(
-        &mut self,
-        port: impl Into<MemoryAp>,
-        register: R,
+        port: u8,
+        address: u8,
         values: &mut [u32],
     ) -> Result<(), Self::Error> {
-        self.read_ap_register_repeated(port, register, values)
+        self.select_ap_and_ap_bank(port, address)?;
+
+        self.probe.read_block(
+            PortType::AccessPort(u16::from(self.state.current_apsel)),
+            address,
+            values,
+        )?;
+        Ok(())
+    }
+
+    fn write_raw_ap_register(
+        &mut self,
+        port: u8,
+        address: u8,
+        value: u32,
+    ) -> Result<(), Self::Error> {
+        self.select_ap_and_ap_bank(port, address)?;
+
+        self.probe.write_register(
+            PortType::AccessPort(u16::from(self.state.current_apsel)),
+            address,
+            value,
+        )
+    }
+
+    fn write_raw_ap_register_repeated(
+        &mut self,
+        port: u8,
+        address: u8,
+        values: &[u32],
+    ) -> Result<(), Self::Error> {
+        self.select_ap_and_ap_bank(port, address)?;
+
+        self.probe.write_block(
+            PortType::AccessPort(u16::from(self.state.current_apsel)),
+            address,
+            values,
+        )?;
+        Ok(())
     }
 }
 
-impl<R> ApAccess<GenericAp, R> for ArmCommunicationInterface
-where
-    R: ApRegister<GenericAp>,
-{
-    type Error = DebugProbeError;
+impl<T: RawApAccess> ApAccess for T {
+    type Error = T::Error;
 
-    fn read_ap_register(
-        &mut self,
-        port: impl Into<GenericAp>,
-        register: R,
-    ) -> Result<R, Self::Error> {
-        self.read_ap_register(port, register)
+    fn read_ap_register<PORT, R>(&mut self, port: impl Into<PORT>) -> Result<R, Self::Error>
+    where
+        PORT: AccessPort,
+        R: ApRegister<PORT>,
+    {
+        log::debug!("Reading register {}", R::NAME);
+        let raw_value =
+            RawApAccess::read_raw_ap_register(self, port.into().port_number(), R::ADDRESS)?;
+
+        log::debug!("Read register    {}, value=0x{:x?}", R::NAME, raw_value);
+
+        Ok(raw_value.into())
     }
 
-    fn write_ap_register(
+    fn write_ap_register<PORT, R>(
         &mut self,
-        port: impl Into<GenericAp>,
+        port: impl Into<PORT>,
         register: R,
-    ) -> Result<(), Self::Error> {
-        self.write_ap_register(port, register)
+    ) -> Result<(), Self::Error>
+    where
+        PORT: AccessPort,
+        R: ApRegister<PORT>,
+    {
+        log::debug!("Writing register {}, value={:x?}", R::NAME, register);
+        self.write_raw_ap_register(port.into().port_number(), R::ADDRESS, register.into())
     }
 
-    fn write_ap_register_repeated(
+    fn write_ap_register_repeated<PORT, R>(
         &mut self,
-        port: impl Into<GenericAp>,
-        register: R,
+        port: impl Into<PORT>,
+        _register: R,
         values: &[u32],
-    ) -> Result<(), Self::Error> {
-        self.write_ap_register_repeated(port, register, values)
+    ) -> Result<(), Self::Error>
+    where
+        PORT: AccessPort,
+        R: ApRegister<PORT>,
+    {
+        log::debug!(
+            "Writing register {}, block with len={} words",
+            R::NAME,
+            values.len(),
+        );
+        self.write_raw_ap_register_repeated(port.into().port_number(), R::ADDRESS, values)
     }
 
-    fn read_ap_register_repeated(
+    fn read_ap_register_repeated<PORT, R>(
         &mut self,
-        port: impl Into<GenericAp>,
-        register: R,
+        port: impl Into<PORT>,
+        _register: R,
         values: &mut [u32],
-    ) -> Result<(), Self::Error> {
-        self.read_ap_register_repeated(port, register, values)
+    ) -> Result<(), Self::Error>
+    where
+        PORT: AccessPort,
+        R: ApRegister<PORT>,
+    {
+        log::debug!(
+            "Reading register {}, block with len={} words",
+            R::NAME,
+            values.len(),
+        );
+
+        self.read_raw_ap_register_repeated(port.into().port_number(), R::ADDRESS, values)
     }
 }
 
@@ -790,8 +710,8 @@ impl ArmCommunicationInterface {
                 .map_err(ProbeRsError::architecture_specific)?;
         }
         for access_port in aps {
-            let idr = self
-                .read_ap_register(access_port, IDR::default())
+            let idr: IDR = self
+                .read_ap_register(access_port)
                 .map_err(ProbeRsError::Probe)?;
             log::debug!("{:#x?}", idr);
 

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -218,11 +218,17 @@ impl ApInformation {
             };
             base_address |= u64::from(base_register.BASEADDR << 12);
 
+            // Save old CSW value. STLink firmare caches it, which breaks things
+            // if we change it behind its back.
+            let old_csw: CSW = probe.read_ap_register(access_port)?;
+
             // Read information about HNONSEC support and supported access widths
             let csw = CSW::new(DataSize::U8);
 
             probe.write_ap_register(access_port, csw)?;
             let csw: CSW = probe.read_ap_register(access_port)?;
+
+            probe.write_ap_register(access_port, old_csw)?;
 
             let only_32bit_data_size = csw.SIZE != DataSize::U8;
 

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -33,11 +33,7 @@ pub trait ArmProbe {
 /// A struct to give access to a targets memory using a certain DAP.
 pub(crate) struct ADIMemoryInterface<'interface, AP>
 where
-    AP: CommunicationInterface
-        + ApAccess<MemoryAp, CSW>
-        + ApAccess<MemoryAp, TAR>
-        + ApAccess<MemoryAp, DRW>
-        + DpAccess,
+    AP: CommunicationInterface + ApAccess + DpAccess,
 {
     interface: &'interface mut AP,
     only_32bit_data_size: bool,
@@ -57,11 +53,7 @@ where
 
 impl<'interface, AP> ADIMemoryInterface<'interface, AP>
 where
-    AP: CommunicationInterface
-        + ApAccess<MemoryAp, CSW>
-        + ApAccess<MemoryAp, TAR>
-        + ApAccess<MemoryAp, DRW>
-        + DpAccess,
+    AP: CommunicationInterface + ApAccess + DpAccess,
 {
     /// Creates a new MemoryInterface for given AccessPort.
     pub fn new(
@@ -79,11 +71,7 @@ where
 
 impl<AP> ADIMemoryInterface<'_, AP>
 where
-    AP: CommunicationInterface
-        + ApAccess<MemoryAp, CSW>
-        + ApAccess<MemoryAp, TAR>
-        + ApAccess<MemoryAp, DRW>
-        + DpAccess,
+    AP: CommunicationInterface + ApAccess + DpAccess,
 {
     /// Build the correct CSW register for a memory access
     ///
@@ -154,17 +142,13 @@ where
     }
 
     /// Read a 32 bit register on the given AP.
-    fn read_ap_register<R>(
-        &mut self,
-        access_port: MemoryAp,
-        register: R,
-    ) -> Result<R, AccessPortError>
+    fn read_ap_register<R>(&mut self, access_port: MemoryAp) -> Result<R, AccessPortError>
     where
         R: ApRegister<MemoryAp>,
-        AP: ApAccess<MemoryAp, R>,
+        AP: ApAccess,
     {
         self.interface
-            .read_ap_register(access_port, register)
+            .read_ap_register(access_port)
             .map_err(AccessPortError::register_read_error::<R, _>)
     }
 
@@ -178,7 +162,7 @@ where
     ) -> Result<(), AccessPortError>
     where
         R: ApRegister<MemoryAp>,
-        AP: ApAccess<MemoryAp, R>,
+        AP: ApAccess,
     {
         self.interface
             .read_ap_register_repeated(access_port, register, values)
@@ -193,7 +177,7 @@ where
     ) -> Result<(), AccessPortError>
     where
         R: ApRegister<MemoryAp>,
-        AP: ApAccess<MemoryAp, R>,
+        AP: ApAccess,
     {
         self.interface
             .write_ap_register(access_port, register)
@@ -210,7 +194,7 @@ where
     ) -> Result<(), AccessPortError>
     where
         R: ApRegister<MemoryAp>,
-        AP: ApAccess<MemoryAp, R>,
+        AP: ApAccess,
     {
         self.interface
             .write_ap_register_repeated(access_port, register, values)
@@ -236,7 +220,7 @@ where
 
         self.write_csw_register(access_port, csw)?;
         self.write_ap_register(access_port, tar)?;
-        let result = self.read_ap_register(access_port, DRW::default())?;
+        let result: DRW = self.read_ap_register(access_port)?;
 
         Ok(result.data)
     }
@@ -260,7 +244,7 @@ where
             let tar = TAR { address };
             self.write_csw_register(access_port, csw)?;
             self.write_ap_register(access_port, tar)?;
-            let result = self.read_ap_register(access_port, DRW::default())?;
+            let result: DRW = self.read_ap_register(access_port)?;
 
             // Extract the correct byte
             // See "Arm Debug Interface Architecture Specification ADIv5.0 to ADIv5.2", C2.2.6
@@ -602,11 +586,7 @@ where
 
 impl<AP> ArmProbe for ADIMemoryInterface<'_, AP>
 where
-    AP: CommunicationInterface
-        + ApAccess<MemoryAp, CSW>
-        + ApAccess<MemoryAp, TAR>
-        + ApAccess<MemoryAp, DRW>
-        + DpAccess,
+    AP: CommunicationInterface + ApAccess + DpAccess,
 {
     fn read_core_reg(&mut self, ap: MemoryAp, addr: CoreRegisterAddress) -> Result<u32, Error> {
         // Write the DCRSR value to select the register we want to read.

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -82,7 +82,7 @@ pub use crate::core::{
     SpecificCoreState,
 };
 pub use crate::error::Error;
-pub use crate::memory::{Memory, MemoryInterface, MemoryList};
+pub use crate::memory::{Memory, MemoryInterface};
 pub use crate::probe::{
     AttachMethod, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType,
     Probe, ProbeCreationError, WireProtocol,

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -199,18 +199,3 @@ impl<'probe> Memory<'probe> {
         self.inner.write_core_reg(self.ap_sel, addr, value)
     }
 }
-
-pub struct MemoryList<'probe>(Vec<Memory<'probe>>);
-
-impl<'probe> MemoryList<'probe> {
-    pub fn new(memories: Vec<Memory<'probe>>) -> Self {
-        Self(memories)
-    }
-}
-
-impl<'probe> std::ops::Deref for MemoryList<'probe> {
-    type Target = Vec<Memory<'probe>>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -4,6 +4,7 @@ pub(crate) mod ftdi;
 pub(crate) mod jlink;
 pub(crate) mod stlink;
 
+use crate::architecture::arm::ap::RawApAccess;
 use crate::{architecture::arm::ap::AccessPort, Session};
 use crate::{
     architecture::arm::memory::adi_v5_memory_interface::ADIMemoryInterface,
@@ -759,7 +760,7 @@ impl DebugProbe for FakeProbe {
 
 impl DapAccess for FakeProbe {
     /// Reads the DAP register on the specified port and address
-    fn read_register(&mut self, _port: PortType, _addr: u16) -> Result<u32, DebugProbeError> {
+    fn read_register(&mut self, _port: PortType, _addr: u8) -> Result<u32, DebugProbeError> {
         Err(DebugProbeError::CommandNotSupportedByProbe)
     }
 
@@ -767,7 +768,7 @@ impl DapAccess for FakeProbe {
     fn write_register(
         &mut self,
         _port: PortType,
-        _addr: u16,
+        _addr: u8,
         _value: u32,
     ) -> Result<(), DebugProbeError> {
         Err(DebugProbeError::CommandNotSupportedByProbe)
@@ -828,45 +829,38 @@ impl ArmProbeInterface for FakeArmInterface {
     }
 }
 
-impl DapAccess for FakeArmInterface {
-    fn read_register(&mut self, port: PortType, addr: u16) -> Result<u32, DebugProbeError> {
-        self.probe.read_register(port, addr)
-    }
-    fn write_register(
-        &mut self,
-        port: PortType,
-        addr: u16,
-        value: u32,
-    ) -> Result<(), DebugProbeError> {
-        self.probe.write_register(port, addr, value)
-    }
-    fn read_block(
-        &mut self,
-        port: PortType,
-        addr: u16,
-        values: &mut [u32],
-    ) -> Result<(), DebugProbeError> {
-        self.probe.read_block(port, addr, values)
-    }
-    fn write_block(
-        &mut self,
-        port: PortType,
-        addr: u16,
-        values: &[u32],
-    ) -> Result<(), DebugProbeError> {
-        self.probe.write_block(port, addr, values)
-    }
-}
+impl RawApAccess for FakeArmInterface {
+    type Error = DebugProbeError;
 
-impl AsMut<(dyn DebugProbe + 'static)> for FakeArmInterface {
-    fn as_mut(&mut self) -> &mut (dyn DebugProbe + 'static) {
-        self.probe.as_mut()
+    fn read_raw_ap_register(&mut self, _port_number: u8, _address: u8) -> Result<u32, Self::Error> {
+        todo!()
     }
-}
 
-impl AsRef<(dyn DebugProbe + 'static)> for FakeArmInterface {
-    fn as_ref(&self) -> &(dyn DebugProbe + 'static) {
-        self.probe.as_ref()
+    fn read_raw_ap_register_repeated(
+        &mut self,
+        _port: u8,
+        _address: u8,
+        _values: &mut [u32],
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn write_raw_ap_register(
+        &mut self,
+        _port: u8,
+        _address: u8,
+        _value: u32,
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn write_raw_ap_register_repeated(
+        &mut self,
+        _port: u8,
+        _address: u8,
+        _values: &[u32],
+    ) -> Result<(), Self::Error> {
+        todo!()
     }
 }
 


### PR DESCRIPTION
Exposing the `DAPAccess` trait directly can be problematic, since it bypasses the handling of the `APBANKSEL` field. The new `RawApAccess` exposes the same functionality, but handles the AP bank selection as well.

@Dirbaio Can you check if the nRF unlock still works with these changes?

There is also some further cleanup of the ApAccess traits.