### PR TITLE
stlink: remove bank handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix too many chip erases in chips with multiple NvmRegions. (#670).
 - Added missing `skip_erase` setter function introduced in #677 (#679).
 - Fixed incorrect array size calculation  (#683)
-
+- STLink: Removed unnecessary SELECT bank switching  (#692)
 
 ## [0.10.1]
 ### Fixed


### PR DESCRIPTION
    All the commands have the full DP/AP number and register address. The stlink
    firmware switches SELECT on its own to do the requested operration automatically,
    there's no need to handle SELECT manually.

~~Depends on #689 #691~~