### PR TITLE
Handle Cortex `LOCKUP` status during debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle inlined functions when getting a stack trace (#678).
 - Added 'Statics' (static variables) to the stackframe scopes. These are now visible in VSCode between 'Locals' and 'Registers'. This includes some additional datatypes and DWARF expression evaluation capabilities. (#683)
 - Added a function to mass erase all memory. (#672).
+- Handle Cortex `LOCKUP` status during debugging (#707)
 
 ### Target Support
 

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -1581,11 +1581,10 @@ impl DapStatus for CoreStatus {
         match self {
             CoreStatus::Running => ("continued", "Core is running"),
             CoreStatus::Sleeping => ("sleeping", "Core is in SLEEP mode"),
-            //TODO: Need to implement LockedUp in probe-rs/src/debug
-            // CoreStatus::LockedUp => (
-            //     "lockedup",
-            //     "Core is in LOCKUP status - encountered an unrecoverable error",
-            // ),
+            CoreStatus::LockedUp => (
+                "lockedup",
+                "Core is in LOCKUP status - encountered an unrecoverable exception",
+            ),
             CoreStatus::Halted(halt_reason) => match halt_reason {
                 HaltReason::Breakpoint => (
                     "breakpoint",

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -548,12 +548,6 @@ impl Debugger {
                                     hit_breakpoint_ids: None,
                                 });
                                 debug_adapter.send_event("stopped", event_body);
-                                debug_adapter.send_response::<()>(
-                                    &request,
-                                    Err(DebuggerError::Other(anyhow!(
-                                        "The processor is in LOCKED status, as a result of an unrecoverable exception"
-                                    ))),
-                                );
                                 return false;
                             }
                             CoreStatus::Unknown => {

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -537,16 +537,25 @@ impl Debugger {
                                 });
                                 debug_adapter.send_event("stopped", event_body);
                             }
-                            //TODO: Need to implement LockedUp in probe-rs/src/debug
-                            // CoreStatus::LockedUp => {
-                            //     debug_adapter.send_response::<()>(
-                            //         &request,
-                            //         Err(DebuggerError::Other(anyhow!(
-                            //             "The processor is in LOCKED status, as a result of an unrecoverable error"
-                            //         ))),
-                            //     );
-                            //     return false;
-                            // }
+                            CoreStatus::LockedUp => {
+                                let event_body = Some(StoppedEventBody {
+                                    reason: new_status.short_long_status().0.to_owned(),
+                                    description: Some(new_status.short_long_status().1.to_owned()),
+                                    thread_id: Some(core_data.target_core.id() as i64),
+                                    preserve_focus_hint: Some(false),
+                                    text: None,
+                                    all_threads_stopped: Some(true),
+                                    hit_breakpoint_ids: None,
+                                });
+                                debug_adapter.send_event("stopped", event_body);
+                                debug_adapter.send_response::<()>(
+                                    &request,
+                                    Err(DebuggerError::Other(anyhow!(
+                                        "The processor is in LOCKED status, as a result of an unrecoverable exception"
+                                    ))),
+                                );
+                                return false;
+                            }
                             CoreStatus::Unknown => {
                                 debug_adapter.send_response::<()>(
                                     &request,

--- a/probe-rs/src/architecture/arm/core/m0.rs
+++ b/probe-rs/src/architecture/arm/core/m0.rs
@@ -531,6 +531,14 @@ impl<'probe> CoreInterface for M0<'probe> {
     fn status(&mut self) -> Result<crate::core::CoreStatus, Error> {
         let dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
 
+        if dhcsr.s_lockup() {
+            log::warn!("The core is in locked up status as a result of an unrecoverable exception");
+
+            self.state.current_state = CoreStatus::LockedUp;
+
+            return Ok(CoreStatus::LockedUp);
+        }
+
         if dhcsr.s_sleep() {
             // Check if we assumed the core to be halted
             if self.state.current_state.is_halted() {

--- a/probe-rs/src/architecture/arm/core/m33.rs
+++ b/probe-rs/src/architecture/arm/core/m33.rs
@@ -278,6 +278,14 @@ impl<'probe> CoreInterface for M33<'probe> {
     fn status(&mut self) -> Result<crate::core::CoreStatus, Error> {
         let dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
 
+        if dhcsr.s_lockup() {
+            log::warn!("The core is in locked up status as a result of an unrecoverable exception");
+
+            self.state.current_state = CoreStatus::LockedUp;
+
+            return Ok(CoreStatus::LockedUp);
+        }
+
         if dhcsr.s_sleep() {
             // Check if we assumed the core to be halted
             if self.state.current_state.is_halted() {

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -531,6 +531,7 @@ pub enum Architecture {
 pub enum CoreStatus {
     Running,
     Halted(HaltReason),
+    /// This is a Cortex-M specific status, and will not be set or handled by RISCV code. 
     LockedUp,
     Sleeping,
     Unknown,

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -531,7 +531,7 @@ pub enum Architecture {
 pub enum CoreStatus {
     Running,
     Halted(HaltReason),
-    /// This is a Cortex-M specific status, and will not be set or handled by RISCV code. 
+    /// This is a Cortex-M specific status, and will not be set or handled by RISCV code.
     LockedUp,
     Sleeping,
     Unknown,

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -531,6 +531,7 @@ pub enum Architecture {
 pub enum CoreStatus {
     Running,
     Halted(HaltReason),
+    LockedUp,
     Sleeping,
     Unknown,
 }


### PR DESCRIPTION
Add `CoreStatus::LockedUp` and handle appropriately when read from the core during a `status()` call. This signals that the Cortex core encountered an unrecoverable exception and needs to be reset. For the debugger, this means sending a notification and terminating the debugging session. 