### PR TITLE
Remove itm-decode dependency, don't build sentry by default

### DIFF
--- a/probe-rs-cli-util/Cargo.toml
+++ b/probe-rs-cli-util/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["embedded"]
 license = "MIT OR Apache-2.0"
 
 [features]
-default = ["sentry", "anyhow"]
+default = ["anyhow"]
 
 [dependencies]
 thiserror = "1.0"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -27,11 +27,9 @@ bincode = "1.3.2"
 bitfield = "0.13.2"
 bitvec = "0.19.4"
 enum-primitive-derive = "0.2.1"
-funty = "=1.1.0" # Temporary fix for https://github.com/bitvecto-rs/bitvec/issues/105
 gimli = { version = "0.24.0", default-features = false, features = ["endian-reader", "read", "std"] }
 hidapi = "1.2.0"
 ihex = "3.0.0"
-itm-decode = { version = "0.2.1", default-features = false }
 jaylink = "0.2.0"
 jep106 = "0.2.4"
 once_cell = "1.7.2"
@@ -67,3 +65,4 @@ reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 serde_json = "1.0.47"
 serde = "1.0.118"
 structopt = "0.3"
+itm-decode = { version = "0.3.0", default-features = false }

--- a/probe-rs/examples/tcp_itm.rs
+++ b/probe-rs/examples/tcp_itm.rs
@@ -1,5 +1,8 @@
-use probe_rs::architecture::arm::swo::{Decoder, SwoConfig, TracePacket};
+use probe_rs::architecture::arm::swo::SwoConfig;
 use probe_rs::Error;
+
+use itm_decode::{Decoder, TracePacket};
+
 use serde::{Deserialize, Serialize};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -38,7 +41,7 @@ fn main() -> Result<(), Error> {
     loop {
         let bytes = session.read_swo()?;
 
-        decoder.feed(bytes);
+        decoder.push(bytes);
         while let Ok(Some(packet)) = decoder.pull() {
             match packet {
                 TracePacket::LocalTimestamp1 { ts, data_relation } => {

--- a/probe-rs/src/architecture/arm/swo/mod.rs
+++ b/probe-rs/src/architecture/arm/swo/mod.rs
@@ -1,5 +1,3 @@
-pub use itm_decode::*;
-
 use crate::Error;
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
- Remove itm-decode dependency, seems unused
- Remove sentry from default features, improve workspace build time
