### PR TITLE
Multidrop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added initial multicore support. (#565)
+- Added SWDv2 multidrop support for multi-DP chips. (#720)
+- Added RP2040 target (Raspberry Pi Pico). (#720)
 
 ### Target Support
 

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -6,7 +6,7 @@ use probe_rs::{
             ap::{GenericAp, MemoryAp},
             m0::Demcr,
             memory::Component,
-            ApInformation, ArmProbeInterface, MemoryApInformation,
+            ApAddress, ApInformation, ArmProbeInterface, DpAddress, MemoryApInformation,
         },
         riscv::communication_interface::RiscvCommunicationInterface,
     },
@@ -95,10 +95,15 @@ fn try_show_info(mut probe: Probe, protocol: WireProtocol) -> (Probe, Result<()>
 fn show_arm_info(interface: &mut Box<dyn ArmProbeInterface>) -> Result<()> {
     println!("\nAvailable Access Ports:");
 
-    let num_access_ports = interface.num_access_ports();
+    let dp = DpAddress::Default;
+    let num_access_ports = interface.num_access_ports(dp).unwrap();
 
     for ap_index in 0..num_access_ports {
-        let access_port = GenericAp::from(ap_index as u8);
+        let ap = ApAddress {
+            ap: ap_index as u8,
+            dp,
+        };
+        let access_port = GenericAp::new(ap);
 
         let ap_information = interface.ap_information(access_port).unwrap();
 

--- a/debugger/src/info.rs
+++ b/debugger/src/info.rs
@@ -6,7 +6,7 @@ use probe_rs::{
             ap::{GenericAp, MemoryAp},
             m0::Demcr,
             memory::Component,
-            ApInformation, ArmProbeInterface, MemoryApInformation,
+            ApAddress, ApInformation, ArmProbeInterface, DpAddress, MemoryApInformation,
         },
         riscv::communication_interface::RiscvCommunicationInterface,
     },
@@ -123,10 +123,15 @@ fn try_show_info(mut probe: Probe, protocol: WireProtocol) -> (Probe, Result<()>
 fn show_arm_info(interface: &mut Box<dyn ArmProbeInterface>) -> Result<()> {
     println!("\nAvailable Access Ports:");
 
-    let num_access_ports = interface.num_access_ports();
+    let dp = DpAddress::Default;
+    let num_access_ports = interface.num_access_ports(dp).unwrap();
 
     for ap_index in 0..num_access_ports {
-        let access_port = GenericAp::from(ap_index as u8);
+        let ap = ApAddress {
+            ap: ap_index as u8,
+            dp,
+        };
+        let access_port = GenericAp::new(ap);
 
         let ap_information = interface.ap_information(access_port).unwrap();
 

--- a/probe-rs/examples/multidrop_raw.rs
+++ b/probe-rs/examples/multidrop_raw.rs
@@ -1,0 +1,42 @@
+use anyhow::Result;
+use probe_rs::{architecture::arm::DpAddress, Probe};
+
+fn main() -> Result<()> {
+    pretty_env_logger::init();
+
+    // Get a list of all available debug probes.
+    let probes = Probe::list_all();
+
+    // Use the first probe found.
+    let mut probe: Probe = probes[0].open()?;
+
+    probe.set_speed(100)?;
+    probe.attach_to_unspecified()?;
+    let mut iface = probe.try_into_arm_interface().unwrap();
+
+    // This is an example on how to do raw DP register access with multidrop.
+    // This reads DPIDR and TARGETID of both cores in a RP2040. This chip is
+    // unconventional because each core has its own DP.
+
+    let core0 = DpAddress::Multidrop(0x01002927);
+    let core1 = DpAddress::Multidrop(0x11002927);
+
+    println!(
+        "core0 DPIDR:    {:08x}",
+        iface.read_raw_dp_register(core0, 0x00)?
+    );
+    println!(
+        "core0 TARGETID: {:08x}",
+        iface.read_raw_dp_register(core0, 0x24)?
+    );
+    println!(
+        "core1 DPIDR:    {:08x}",
+        iface.read_raw_dp_register(core1, 0x00)?
+    );
+    println!(
+        "core1 TARGETID: {:08x}",
+        iface.read_raw_dp_register(core1, 0x24)?
+    );
+
+    Ok(())
+}

--- a/probe-rs/examples/nrf53_recover.rs
+++ b/probe-rs/examples/nrf53_recover.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use probe_rs::Probe;
+use probe_rs::{
+    architecture::arm::{ApAddress, DpAddress},
+    Probe,
+};
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
@@ -16,17 +19,29 @@ fn main() -> Result<()> {
     // This is an example on how to do a "recover" operation (erase+unlock a locked chip)
     // on an nRF52840 target.
 
-    const APP_MEM: u8 = 0;
-    const NET_MEM: u8 = 1;
-    const APP_CTRL: u8 = 2;
-    const NET_CTRL: u8 = 3;
+    const APP_MEM: ApAddress = ApAddress {
+        ap: 0,
+        dp: DpAddress::Default,
+    };
+    const NET_MEM: ApAddress = ApAddress {
+        ap: 1,
+        dp: DpAddress::Default,
+    };
+    const APP_CTRL: ApAddress = ApAddress {
+        ap: 2,
+        dp: DpAddress::Default,
+    };
+    const NET_CTRL: ApAddress = ApAddress {
+        ap: 3,
+        dp: DpAddress::Default,
+    };
 
     const ERASEALL: u8 = 0x04;
     const ERASEALLSTATUS: u8 = 0x08;
     const IDR: u8 = 0xFC;
 
     for &ap in &[APP_MEM, NET_MEM, APP_CTRL, NET_CTRL] {
-        println!("IDR {} {:x}", ap, iface.read_raw_ap_register(ap, IDR)?);
+        println!("IDR {:?} {:x}", ap, iface.read_raw_ap_register(ap, IDR)?);
     }
 
     for &ap in &[APP_CTRL, NET_CTRL] {

--- a/probe-rs/examples/raw_dap_access.rs
+++ b/probe-rs/examples/raw_dap_access.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use probe_rs::Probe;
+use probe_rs::{
+    architecture::arm::{ApAddress, DpAddress},
+    Probe,
+};
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
@@ -16,7 +19,10 @@ fn main() -> Result<()> {
     // This is an example on how to do a "recover" operation (erase+unlock a locked chip)
     // on an nRF52840 target.
 
-    let port = 1;
+    let port = ApAddress {
+        dp: DpAddress::Default,
+        ap: 1,
+    };
 
     const RESET: u8 = 0;
     const ERASEALL: u8 = 4;

--- a/probe-rs/src/architecture/arm/ap/generic_ap.rs
+++ b/probe-rs/src/architecture/arm/ap/generic_ap.rs
@@ -1,6 +1,7 @@
 //! Generic access port
 
 use super::{AccessPort, ApRegister, Register};
+use crate::architecture::arm::ApAddress;
 use enum_primitive_derive::Primitive;
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -2,7 +2,7 @@ use anyhow::anyhow;
 
 use super::super::{ApAccess, Register};
 use super::{AddressIncrement, ApRegister, DataSize, CSW, DRW, TAR};
-use crate::architecture::arm::ap::AccessPort;
+use crate::architecture::arm::{ap::AccessPort, DpAddress};
 use crate::{
     architecture::arm::dp::{DebugPortError, DpAccess, DpRegister},
     CommunicationInterface, DebugProbeError,
@@ -226,12 +226,16 @@ impl ApAccess for MockMemoryAp {
 }
 
 impl DpAccess for MockMemoryAp {
-    fn read_dp_register<R: DpRegister>(&mut self) -> Result<R, DebugPortError> {
+    fn read_dp_register<R: DpRegister>(&mut self, _dp: DpAddress) -> Result<R, DebugPortError> {
         // Ignore for Tests
         Ok(0.into())
     }
 
-    fn write_dp_register<R: DpRegister>(&mut self, _register: R) -> Result<(), DebugPortError> {
+    fn write_dp_register<R: DpRegister>(
+        &mut self,
+        _dp: DpAddress,
+        _register: R,
+    ) -> Result<(), DebugPortError> {
         Ok(())
     }
 }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -4,7 +4,7 @@
 pub(crate) mod mock;
 
 use super::{AccessPort, ApAccess, ApRegister, GenericAp, Register};
-use crate::DebugProbeError;
+use crate::{architecture::arm::ApAddress, DebugProbeError};
 use enum_primitive_derive::Primitive;
 use num_traits::{FromPrimitive, ToPrimitive};
 
@@ -19,10 +19,10 @@ impl MemoryAp {
     where
         A: ApAccess,
     {
-        let base_register: BASE = interface.read_ap_register(self.port_number())?;
+        let base_register: BASE = interface.read_ap_register(*self)?;
 
         let mut base_address = if BaseaddrFormat::ADIv5 == base_register.Format {
-            let base2: BASE2 = interface.read_ap_register(self.port_number())?;
+            let base2: BASE2 = interface.read_ap_register(*self)?;
 
             u64::from(base2.BASEADDR) << 32
         } else {
@@ -37,7 +37,7 @@ impl MemoryAp {
 impl From<GenericAp> for MemoryAp {
     fn from(other: GenericAp) -> Self {
         MemoryAp {
-            port_number: other.port_number(),
+            address: other.ap_address(),
         }
     }
 }

--- a/probe-rs/src/architecture/arm/ap/register_generation.rs
+++ b/probe-rs/src/architecture/arm/ap/register_generation.rs
@@ -49,24 +49,18 @@ macro_rules! define_ap {
     ($name:ident) => {
         #[derive(Clone, Copy, Debug)]
         pub struct $name {
-            port_number: u8,
+            address: ApAddress,
         }
 
         impl $name {
-            pub fn new(port_number: u8) -> Self {
-                Self { port_number }
-            }
-        }
-
-        impl From<u8> for $name {
-            fn from(value: u8) -> Self {
-                $name { port_number: value }
+            pub const fn new(address: ApAddress) -> Self {
+                Self { address }
             }
         }
 
         impl AccessPort for $name {
-            fn port_number(&self) -> u8 {
-                self.port_number
+            fn ap_address(&self) -> ApAddress {
+                self.address
             }
         }
     };

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -5,18 +5,16 @@ pub(crate) mod jlink;
 pub(crate) mod stlink;
 
 use crate::{
-    architecture::arm::{ap::AccessPort, DapAccess},
+    architecture::arm::memory::adi_v5_memory_interface::ADIMemoryInterface,
+    config::{RegistryError, TargetSelector},
+};
+use crate::{
+    architecture::arm::{ap::AccessPort, ApAddress, DapAccess, DpAddress},
     Session,
 };
 use crate::{
     architecture::arm::{ap::MemoryAp, MemoryApInformation},
     error::Error,
-};
-use crate::{
-    architecture::arm::{
-        dp::DebugPortVersion, memory::adi_v5_memory_interface::ADIMemoryInterface,
-    },
-    config::{RegistryError, TargetSelector},
 };
 use crate::{
     architecture::{
@@ -767,6 +765,10 @@ impl DebugProbe for FakeProbe {
 }
 
 impl RawDapAccess for FakeProbe {
+    fn select_dp(&mut self, _dp: DpAddress) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::CommandNotSupportedByProbe)
+    }
+
     /// Reads the DAP register on the specified port and address
     fn raw_read_register(&mut self, _port: PortType, _addr: u8) -> Result<u32, DebugProbeError> {
         Err(DebugProbeError::CommandNotSupportedByProbe)
@@ -800,7 +802,7 @@ impl FakeArmInterface {
 impl ArmProbeInterface for FakeArmInterface {
     fn memory_interface(&mut self, access_port: MemoryAp) -> Result<Memory<'_>, Error> {
         let ap_information = MemoryApInformation {
-            port_number: access_port.port_number(),
+            address: access_port.ap_address(),
             only_32bit_data_size: false,
             debug_base_address: 0xf000_0000,
             supports_hnonsec: false,
@@ -812,18 +814,19 @@ impl ArmProbeInterface for FakeArmInterface {
     }
 
     fn ap_information(
-        &self,
+        &mut self,
         _access_port: crate::architecture::arm::ap::GenericAp,
-    ) -> Option<&crate::architecture::arm::ApInformation> {
+    ) -> Result<&crate::architecture::arm::ApInformation, Error> {
         todo!()
     }
 
-    fn num_access_ports(&self) -> usize {
-        1
+    fn num_access_ports(&mut self, _dp: DpAddress) -> Result<usize, Error> {
+        Ok(1)
     }
 
     fn read_from_rom_table(
         &mut self,
+        _dp: DpAddress,
     ) -> Result<Option<crate::architecture::arm::ArmChipInfo>, Error> {
         Ok(None)
     }
@@ -838,21 +841,26 @@ impl ArmProbeInterface for FakeArmInterface {
 }
 
 impl DapAccess for FakeArmInterface {
-    fn debug_port_version(&self) -> DebugPortVersion {
-        DebugPortVersion::DPv2
-    }
-
-    fn read_raw_dp_register(&mut self, _address: u8) -> Result<u32, DebugProbeError> {
+    fn read_raw_dp_register(
+        &mut self,
+        _dp: DpAddress,
+        _address: u8,
+    ) -> Result<u32, DebugProbeError> {
         todo!()
     }
 
-    fn write_raw_dp_register(&mut self, _address: u8, _value: u32) -> Result<(), DebugProbeError> {
+    fn write_raw_dp_register(
+        &mut self,
+        _dp: DpAddress,
+        _address: u8,
+        _value: u32,
+    ) -> Result<(), DebugProbeError> {
         todo!()
     }
 
     fn read_raw_ap_register(
         &mut self,
-        _port_number: u8,
+        _ap: ApAddress,
         _address: u8,
     ) -> Result<u32, DebugProbeError> {
         todo!()
@@ -860,7 +868,7 @@ impl DapAccess for FakeArmInterface {
 
     fn read_raw_ap_register_repeated(
         &mut self,
-        _port: u8,
+        _ap: ApAddress,
         _address: u8,
         _values: &mut [u32],
     ) -> Result<(), DebugProbeError> {
@@ -869,7 +877,7 @@ impl DapAccess for FakeArmInterface {
 
     fn write_raw_ap_register(
         &mut self,
-        _port: u8,
+        _ap: ApAddress,
         _address: u8,
         _value: u32,
     ) -> Result<(), DebugProbeError> {
@@ -878,7 +886,7 @@ impl DapAccess for FakeArmInterface {
 
     fn write_raw_ap_register_repeated(
         &mut self,
-        _port: u8,
+        _ap: ApAddress,
         _address: u8,
         _values: &[u32],
     ) -> Result<(), DebugProbeError> {

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -613,7 +613,7 @@ impl RawDapAccess for CmsisDap {
                     ])?)?;
 
                     // TARGETSEL write.
-                    // the TARGETSEL write is not ACKed by design. We can't use a normal register write
+                    // The TARGETSEL write is not ACKed by design. We can't use a normal register write
                     // because many probes don't even send the data phase when NAK.
                     let parity = targetsel.count_ones() % 2;
                     let data = &((parity as u64) << 45 | (targetsel as u64) << 13 | 0x1f99)

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -36,7 +36,7 @@ use commands::{
     CmsisDapDevice, SendError, Status,
 };
 
-use log::debug;
+use log::{debug, warn};
 
 use std::time::Duration;
 
@@ -600,9 +600,41 @@ impl RawDapAccess for CmsisDap {
     fn select_dp(&mut self, dp: DpAddress) -> Result<(), DebugProbeError> {
         match dp {
             DpAddress::Default => Ok(()), // nop
-            DpAddress::Multidrop(_) => Err(DebugProbeError::ProbeSpecific(
-                anyhow::anyhow!("CMSIS-DAP doesn't support multidrop SWD yet").into(),
-            )),
+            DpAddress::Multidrop(targetsel) => {
+                for _i in 0..5 {
+                    // Flush just in case there were writes queued from before.
+                    self.process_batch()?;
+
+                    // dormant-to-swd + line reset
+                    self.send_swj_sequences(SequenceRequest::new(&[
+                        0xff, 0x92, 0xf3, 0x09, 0x62, 0x95, 0x2d, 0x85, 0x86, 0xe9, 0xaf, 0xdd,
+                        0xe3, 0xa2, 0x0e, 0xbc, 0x19, 0xa0, 0xf1, 0xff, 0xff, 0xff, 0xff, 0xff,
+                        0xff, 0xff, 0xff, 0x00,
+                    ])?)?;
+
+                    // TARGETSEL write.
+                    // the TARGETSEL write is not ACKed by design. We can't use a normal register write
+                    // because many probes don't even send the data phase when NAK.
+                    let parity = targetsel.count_ones() % 2;
+                    let data = &((parity as u64) << 45 | (targetsel as u64) << 13 | 0x1f99)
+                        .to_le_bytes()[..6];
+                    self.send_swj_sequences(SequenceRequest::new(data)?)?;
+
+                    // "A write to the TARGETSEL register must always be followed by a read of the DPIDR register or a line reset. If the
+                    // response to the DPIDR read is incorrect, or there is no response, the host must start the sequence again."
+                    match self.raw_read_register(PortType::DebugPort, 0) {
+                        Ok(res) => {
+                            debug!("DPIDR read {:08x}", res);
+                            return Ok(());
+                        }
+                        Err(e) => {
+                            debug!("DPIDR read failed, retrying. Error: {:?}", e);
+                        }
+                    }
+                }
+                warn!("Giving up on TARGETSEL, too many retries.");
+                Err(DapError::NoAcknowledge.into())
+            }
         }
     }
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -6,8 +6,8 @@ use crate::{
         communication_interface::{ArmProbeInterface, DapProbe},
         dp::{Abort, Ctrl},
         swo::poll_interval_from_buf_size,
-        ArmCommunicationInterface, DapError, PortType, RawDapAccess, Register, SwoAccess,
-        SwoConfig, SwoMode,
+        ArmCommunicationInterface, DapError, DpAddress, PortType, RawDapAccess, Register,
+        SwoAccess, SwoConfig, SwoMode,
     },
     probe::{cmsisdap::commands::CmsisDapError, BatchCommand},
     DebugProbe, DebugProbeError, DebugProbeSelector, Error as ProbeRsError, WireProtocol,
@@ -597,6 +597,15 @@ impl DebugProbe for CmsisDap {
 }
 
 impl RawDapAccess for CmsisDap {
+    fn select_dp(&mut self, dp: DpAddress) -> Result<(), DebugProbeError> {
+        match dp {
+            DpAddress::Default => Ok(()), // nop
+            DpAddress::Multidrop(_) => Err(DebugProbeError::ProbeSpecific(
+                anyhow::anyhow!("CMSIS-DAP doesn't support multidrop SWD yet").into(),
+            )),
+        }
+    }
+
     /// Reads the DAP register on the specified port and address.
     fn raw_read_register(&mut self, port: PortType, addr: u8) -> Result<u32, DebugProbeError> {
         self.batch_add(BatchCommand::Read(port, addr as u16))

--- a/probe-rs/src/probe/jlink/swd.rs
+++ b/probe-rs/src/probe/jlink/swd.rs
@@ -3,7 +3,7 @@ use std::iter;
 use crate::{
     architecture::arm::{
         dp::{Abort, Ctrl, RdBuff, DPIDR},
-        DapError, PortType, RawDapAccess, Register,
+        DapError, DpAddress, PortType, RawDapAccess, Register,
     },
     DebugProbeError,
 };
@@ -718,6 +718,15 @@ impl RawSwdIo for JLink {
 }
 
 impl<Probe: RawSwdIo + 'static> RawDapAccess for Probe {
+    fn select_dp(&mut self, dp: DpAddress) -> Result<(), DebugProbeError> {
+        match dp {
+            DpAddress::Default => Ok(()), // nop
+            DpAddress::Multidrop(_) => Err(DebugProbeError::ProbeSpecific(
+                anyhow::anyhow!("JLink doesn't support multidrop SWD yet").into(),
+            )),
+        }
+    }
+
     fn raw_read_register(&mut self, port: PortType, address: u8) -> Result<u32, DebugProbeError> {
         let dap_wait_retries = self.swd_settings().num_retries_after_wait;
         let mut idle_cycles = std::cmp::max(1, self.swd_settings().num_idle_cycles_between_writes);

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -7,13 +7,13 @@ use super::{DebugProbe, DebugProbeError, ProbeCreationError, WireProtocol};
 use crate::{
     architecture::arm::{
         ap::{valid_access_ports, AccessPort, ApAccess, ApClass, MemoryAp, IDR},
-        communication_interface::{ArmCommunicationInterfaceState, ArmProbeInterface},
-        dp::DebugPortVersion,
+        communication_interface::ArmProbeInterface,
         memory::{adi_v5_memory_interface::ArmProbe, Component},
-        ApInformation, ArmChipInfo, DapAccess, SwoAccess, SwoConfig, SwoMode,
+        ApAddress, ApInformation, ArmChipInfo, DapAccess, DpAddress, SwoAccess, SwoConfig, SwoMode,
     },
     DebugProbeSelector, Error as ProbeRsError, Memory, Probe,
 };
+use anyhow::anyhow;
 use constants::{commands, JTagFrequencyToDivider, Mode, Status, SwdFrequencyToDelayCount};
 use scroll::{Pread, Pwrite, BE, LE};
 use std::{cmp::Ordering, convert::TryInto, time::Duration};
@@ -1083,6 +1083,8 @@ pub(crate) enum StlinkError {
     JTAGNotSupportedOnProbe,
     #[error("Manchester-coded SWO mode not supported")]
     ManchesterSwoNotSupported,
+    #[error("Multidrop SWD not supported")]
+    MultidropNotSupported,
     #[error("Unaligned")]
     UnalignedAddress,
 }
@@ -1102,28 +1104,32 @@ impl From<StlinkError> for ProbeCreationError {
 #[derive(Debug)]
 struct StlinkArmDebug {
     probe: Box<StLink<StLinkUsbDevice>>,
-    state: ArmCommunicationInterfaceState,
+
+    /// Information about the APs of the target.
+    /// APs are identified by a number, starting from zero.
+    pub ap_information: Vec<ApInformation>,
 }
 
 impl StlinkArmDebug {
     fn new(
         probe: Box<StLink<StLinkUsbDevice>>,
     ) -> Result<Self, (Box<StLink<StLinkUsbDevice>>, DebugProbeError)> {
-        let state = ArmCommunicationInterfaceState::new();
-
         // Determine the number and type of available APs.
 
-        let mut interface = Self { probe, state };
+        let mut interface = Self {
+            probe,
+            ap_information: Vec::new(),
+        };
 
-        for ap in valid_access_ports(&mut interface) {
+        for ap in valid_access_ports(&mut interface, DpAddress::Default) {
             let ap_state = match ApInformation::read_from_target(&mut interface, ap) {
                 Ok(state) => state,
                 Err(e) => return Err((interface.probe, e)),
             };
 
-            log::debug!("AP {}: {:?}", ap.port_number(), ap_state);
+            log::debug!("AP {:#x?}: {:?}", ap.ap_address(), ap_state);
 
-            interface.state.ap_information.push(ap_state);
+            interface.ap_information.push(ap_state);
         }
 
         Ok(interface)
@@ -1131,31 +1137,47 @@ impl StlinkArmDebug {
 }
 
 impl DapAccess for StlinkArmDebug {
-    fn read_raw_dp_register(&mut self, address: u8) -> Result<u32, DebugProbeError> {
+    fn read_raw_dp_register(&mut self, dp: DpAddress, address: u8) -> Result<u32, DebugProbeError> {
+        if dp != DpAddress::Default {
+            Err(StlinkError::MultidropNotSupported)?;
+        }
         let result = self.probe.read_register(DP_PORT, address)?;
         Ok(result)
     }
 
-    fn write_raw_dp_register(&mut self, address: u8, value: u32) -> Result<(), DebugProbeError> {
+    fn write_raw_dp_register(
+        &mut self,
+        dp: DpAddress,
+        address: u8,
+        value: u32,
+    ) -> Result<(), DebugProbeError> {
+        if dp != DpAddress::Default {
+            Err(StlinkError::MultidropNotSupported)?;
+        }
+
         self.probe.write_register(DP_PORT, address, value)?;
         Ok(())
     }
 
-    fn debug_port_version(&self) -> DebugPortVersion {
-        self.state.debug_port_version
-    }
+    fn read_raw_ap_register(&mut self, ap: ApAddress, address: u8) -> Result<u32, DebugProbeError> {
+        if ap.dp != DpAddress::Default {
+            Err(StlinkError::MultidropNotSupported)?;
+        }
 
-    fn read_raw_ap_register(&mut self, port: u8, address: u8) -> Result<u32, DebugProbeError> {
-        self.probe.read_register(port as u16, address)
+        self.probe.read_register(ap.ap as u16, address)
     }
 
     fn write_raw_ap_register(
         &mut self,
-        port: u8,
+        ap: ApAddress,
         address: u8,
         value: u32,
     ) -> Result<(), DebugProbeError> {
-        self.probe.write_register(port as u16, address, value)
+        if ap.dp != DpAddress::Default {
+            Err(StlinkError::MultidropNotSupported)?;
+        }
+
+        self.probe.write_register(ap.ap as u16, address, value)
     }
 }
 
@@ -1167,18 +1189,30 @@ impl<'probe> ArmProbeInterface for StlinkArmDebug {
     }
 
     fn ap_information(
-        &self,
+        &mut self,
         access_port: crate::architecture::arm::ap::GenericAp,
-    ) -> Option<&crate::architecture::arm::communication_interface::ApInformation> {
-        self.state
-            .ap_information
-            .get(access_port.port_number() as usize)
+    ) -> Result<&crate::architecture::arm::communication_interface::ApInformation, ProbeRsError>
+    {
+        let addr = access_port.ap_address();
+        if addr.dp != DpAddress::Default {
+            Err(DebugProbeError::from(StlinkError::MultidropNotSupported))?;
+        }
+
+        match self.ap_information.get(addr.ap as usize) {
+            Some(res) => Ok(res),
+            None => Err(anyhow!("AP {:#x?} does not exist", addr).into()),
+        }
     }
 
     fn read_from_rom_table(
         &mut self,
+        dp: DpAddress,
     ) -> Result<Option<crate::architecture::arm::ArmChipInfo>, ProbeRsError> {
-        for access_port in valid_access_ports(self) {
+        if dp != DpAddress::Default {
+            Err(DebugProbeError::from(StlinkError::MultidropNotSupported))?;
+        }
+
+        for access_port in valid_access_ports(self, dp) {
             let idr: IDR = self
                 .read_ap_register(access_port)
                 .map_err(ProbeRsError::Probe)?;
@@ -1210,8 +1244,12 @@ impl<'probe> ArmProbeInterface for StlinkArmDebug {
         Ok(None)
     }
 
-    fn num_access_ports(&self) -> usize {
-        self.state.ap_information.len()
+    fn num_access_ports(&mut self, dp: DpAddress) -> Result<usize, ProbeRsError> {
+        if dp != DpAddress::Default {
+            Err(DebugProbeError::from(StlinkError::MultidropNotSupported))?;
+        }
+
+        Ok(self.ap_information.len())
     }
 
     fn target_reset_deassert(&mut self) -> Result<(), ProbeRsError> {
@@ -1258,7 +1296,7 @@ impl ArmProbe for StLinkMemoryInterface<'_> {
             self.probe.probe.read_mem_32bit(
                 address + (index * STLINK_MAX_READ_LEN) as u32,
                 &mut buff,
-                ap.port_number(),
+                ap.ap_address().ap,
             )?;
 
             for (index, word) in buff.chunks_exact(4).enumerate() {
@@ -1285,7 +1323,7 @@ impl ArmProbe for StLinkMemoryInterface<'_> {
             chunk.copy_from_slice(&self.probe.probe.read_mem_8bit(
                 address + (index * chunk_size) as u32,
                 chunk.len() as u16,
-                ap.port_number(),
+                ap.ap_address().ap,
             )?);
         }
 
@@ -1307,7 +1345,7 @@ impl ArmProbe for StLinkMemoryInterface<'_> {
             self.probe.probe.write_mem_32bit(
                 address + (index * STLINK_MAX_WRITE_LEN) as u32,
                 chunk,
-                ap.port_number(),
+                ap.ap_address().ap,
             )?;
         }
 
@@ -1329,7 +1367,7 @@ impl ArmProbe for StLinkMemoryInterface<'_> {
             log::trace!("write_8: small - direct 8 bit write to {:08x}", address);
             self.probe
                 .probe
-                .write_mem_8bit(address, data, ap.port_number())?;
+                .write_mem_8bit(address, data, ap.ap_address().ap)?;
         } else {
             // Handle unaligned data in the beginning.
             let bytes_beginning = if address % 4 == 0 {
@@ -1349,7 +1387,7 @@ impl ArmProbe for StLinkMemoryInterface<'_> {
                 self.probe.probe.write_mem_8bit(
                     current_address,
                     &data[..bytes_beginning],
-                    ap.port_number(),
+                    ap.ap_address().ap,
                 )?;
 
                 current_address += bytes_beginning as u32;
@@ -1373,7 +1411,7 @@ impl ArmProbe for StLinkMemoryInterface<'_> {
                 self.probe.probe.write_mem_32bit(
                     current_address + (index * STLINK_MAX_WRITE_LEN) as u32,
                     chunk,
-                    ap.port_number(),
+                    ap.ap_address().ap,
                 )?;
             }
 
@@ -1390,7 +1428,7 @@ impl ArmProbe for StLinkMemoryInterface<'_> {
                 self.probe.probe.write_mem_8bit(
                     current_address,
                     remaining_bytes,
-                    ap.port_number(),
+                    ap.ap_address().ap,
                 )?;
             }
         }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -278,8 +278,7 @@ impl Session {
         // TODO
         let dp = DpAddress::Default;
 
-        // TODO unwrap
-        for ap_index in 0..(interface.num_access_ports(dp).unwrap() as u8) {
+        for ap_index in 0..(interface.num_access_ports(dp)? as u8) {
             let ap_information = interface
                 .ap_information(GenericAp::new(ApAddress { dp, ap: ap_index }))?
                 .clone();

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -3,13 +3,12 @@
 use crate::architecture::{
     arm::{
         ap::AccessPortError,
-        communication_interface::{
-            ApInformation::{MemoryAp, Other},
-            ArmProbeInterface, MemoryApInformation,
-        },
+        ap::GenericAp,
+        ap::MemoryAp,
+        communication_interface::{ArmProbeInterface, MemoryApInformation},
         core::{debug_core_start, reset_catch_clear, reset_catch_set},
         memory::Component,
-        SwoConfig,
+        ApAddress, ApInformation, DpAddress, SwoConfig,
     },
     riscv::communication_interface::RiscvCommunicationInterface,
 };
@@ -78,7 +77,16 @@ impl ArchitectureInterface {
                     }
                 }?;
 
-                let memory = state.memory_interface(arm_core_access_options.ap.into())?;
+                let dp = match arm_core_access_options.psel {
+                    0 => DpAddress::Default,
+                    x => DpAddress::Multidrop(x),
+                };
+
+                let ap = ApAddress {
+                    dp,
+                    ap: arm_core_access_options.ap,
+                };
+                let memory = state.memory_interface(MemoryAp::new(ap))?;
 
                 core.attach_arm(core_state, memory)
             }
@@ -267,37 +275,35 @@ impl Session {
 
         let mut components = Vec::new();
 
-        for ap_index in 0..(interface.num_access_ports() as u8) {
+        // TODO
+        let dp = DpAddress::Default;
+
+        // TODO unwrap
+        for ap_index in 0..(interface.num_access_ports(dp).unwrap() as u8) {
             let ap_information = interface
-                .ap_information(ap_index.into())
-                .ok_or_else(|| anyhow!("AP {} does not exist on chip.", ap_index))?;
+                .ap_information(GenericAp::new(ApAddress { dp, ap: ap_index }))?
+                .clone();
 
             let component = match ap_information {
-                MemoryAp(MemoryApInformation {
-                    port_number: _,
-                    only_32bit_data_size: _,
+                ApInformation::MemoryAp(MemoryApInformation {
                     debug_base_address: 0,
-                    supports_hnonsec: _,
+                    ..
                 }) => Err(Error::Other(anyhow!("AP has a base address of 0"))),
-                MemoryAp(MemoryApInformation {
-                    port_number,
+                ApInformation::MemoryAp(MemoryApInformation {
+                    address,
                     only_32bit_data_size: _,
                     debug_base_address,
                     supports_hnonsec: _,
                 }) => {
-                    let access_port_number = *port_number;
-                    let base_address = *debug_base_address;
-
-                    let mut memory = interface.memory_interface(access_port_number.into())?;
-
-                    Component::try_parse(&mut memory, base_address)
+                    let mut memory = interface.memory_interface(MemoryAp::new(address))?;
+                    Component::try_parse(&mut memory, debug_base_address)
                         .map_err(Error::architecture_specific)
                 }
-                Other { port_number } => {
+                ApInformation::Other { address } => {
                     // Return an error, only possible to get Component from MemoryAP
                     Err(Error::Other(anyhow!(
-                        "AP {} is not a MemoryAP, unable to get ARM component.",
-                        port_number
+                        "AP {:#x?} is not a MemoryAP, unable to get ARM component.",
+                        address
                     )))
                 }
             };
@@ -430,10 +436,14 @@ fn get_target_from_selector(
                         //let chip_result = try_arm_autodetect(interface);
                         log::debug!("Autodetect: Trying DAP interface...");
 
-                        let found_arm_chip = interface.read_from_rom_table().unwrap_or_else(|e| {
-                            log::info!("Error during auto-detection of ARM chips: {}", e);
-                            None
-                        });
+                        // TODO
+                        let dp = DpAddress::Default;
+
+                        let found_arm_chip =
+                            interface.read_from_rom_table(dp).unwrap_or_else(|e| {
+                                log::info!("Error during auto-detection of ARM chips: {}", e);
+                                None
+                            });
 
                         found_chip = found_arm_chip.map(ChipInfo::from);
 

--- a/probe-rs/targets/RP2040.yaml
+++ b/probe-rs/targets/RP2040.yaml
@@ -1,0 +1,94 @@
+# TODO: Flash XIP has noalloc/nocache aliases, add them?
+# TODO: ROM at 0x00000000 - 0x00004000? probe-rs doesn't seem to have support for ROM regions
+
+name: RP2040
+variants:
+  - name: RP2040
+    cores:
+      - name: core0
+        type: M0
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0x01002927
+      - name: core1
+        type: M0
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0x11002927
+    memory_map:
+      - Ram: # Banks 0-3 striped
+          range:
+            start: 0x20000000
+            end: 0x20040000
+          is_boot_memory: false
+          cores: [core0, core1]
+      - Ram: # Bank 4
+          range:
+            start: 0x20040000
+            end: 0x20041000
+          is_boot_memory: false
+          cores: [core0, core1]
+      - Ram: # Bank 5
+          range:
+            start: 0x20041000
+            end: 0x20042000
+          is_boot_memory: false
+          cores: [core0, core1]
+      - Ram: # Bank 0 non-striped alias
+          range:
+            start: 0x21000000
+            end: 0x21010000
+          is_boot_memory: false
+          cores: [core0, core1]
+      - Ram: # Bank 1 non-striped alias
+          range:
+            start: 0x21010000
+            end: 0x21020000
+          is_boot_memory: false
+          cores: [core0, core1]
+      - Ram: # Bank 2 non-striped alias
+          range:
+            start: 0x21020000
+            end: 0x21030000
+          is_boot_memory: false
+          cores: [core0, core1]
+      - Ram: # Bank 3 non-striped alias
+          range:
+            start: 0x21030000
+            end: 0x21040000
+          is_boot_memory: false
+          cores: [core0, core1]
+      - Nvm: # Flash XIP
+          range:
+            start: 0x10000000
+            end: 0x11000000
+          is_boot_memory: true
+          cores: [core0, core1]
+    flash_algorithms:
+      - algo
+flash_algorithms:
+  algo:
+    name: algo
+    description: algo
+    cores: [core0]
+    default: true
+    instructions: 8LWFsB5MfEQgeAEoAdEA8Dv4ASAEkCBwFU4wRvcwAPCJ+AOUBEYTT7gcAPCD+AVGMEYA8H/4ApAPSADwe/gBkA5IAPB3+AZGOEYA8HP4B0agR6hHC0h4RDDAApkBYAGZBDDCwASYA5kIcAAgBbDwvVJFAABDWAAAUlAAAEZDAABeAQAA9gAAALC1CEx8RCB4ASgI0QZNfUQoaYBHaGmARwAgIHCwvQEgsL3ARtgAAAC2AAAABUh4RAB4ACgB0QEgcEcBSHBHwEbQcAAArgAAABC1Ckl5RAl4ASkM0Q8hCQdAGAdJeUSMaAEiEQMSBNgjoEcAIBC9ASAQvcBGkAAAAGgAAAAQtQtGCEl5RAl4ASkK0Q8hCQdAGAVJeUTMaBFGGkagRwAgEL0BIBC9WgAAADIAAACAshQhCYiJHkqIACoE0AkdgkL50QiIcEf+3tTUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANTU1A==
+    pc_init: 1
+    pc_uninit: 137
+    pc_program_page: 261
+    pc_erase_sector: 209
+    pc_erase_all: 181
+    data_section_offset: 0
+    flash_properties:
+      address_range:
+        start: 0x10000000
+        end: 0x11000000
+      page_size: 0x1000
+      erased_byte_value: 0xFF
+      program_page_timeout: 1000
+      erase_sector_timeout: 3000
+      sectors:
+        - size: 0x1000
+          address: 0


### PR DESCRIPTION
No code for now, just the set of proposed trait changes. Hopefully everything else flows from the traits, so it'd be nice to agree on how to do the traits first.

The main idea is to handle DP switching like AP/bank switching.

The high-level `DapAccess` trait stays stateless. All operations specify the target DP. Implementations will cache the currently selected DP and do the switching when doing an operation to a different DP.

The low-level `RawDapAccess` stays close to the wire. It gains a `select_dp` function which will:
- If None, do regular line reset to talk to the "default" target, assuming there's only one. Will corrupt if there are multiple targets on the bus. This is the current behavior
- If Some, do the multidrop selection stuff (dormant-to-swd, line reset, write to TARGETSEL). Note that the TARGETSEL write looks like a normal DP reg write, but is not: it is not acknowledged. Using `raw_write_register` won't work.