### PR TITLE
CMSIS-DAP: Fix connecting to EDBG by repeating PacketSize request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).
 - When reading from a HID device, check number of bytes returned to detect USB HID timeouts.
-
-- Fix CMSIS-DAP v1 devices on MacOS using non-64-byte report sizes (#681).
+- Fix connecting to EDBG and similar probes on MacOS (#681, #721)
 
 ## [0.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).
 - When reading from a HID device, check number of bytes returned to detect USB HID timeouts.
 
+- Fix CMSIS-DAP v1 devices on MacOS using non-64-byte report sizes (#681).
+
 ## [0.11.0]
 
 ### Added


### PR DESCRIPTION
This should hopefully resolve #681. I've only been able to test it on Linux so far though, which does not suffer the same problem (but at least continues to work correctly).

The appraoch is number 3 from https://github.com/probe-rs/probe-rs/issues/681#issuecomment-855300380; we attempt to query the device's max packet size over CMSIS-DAP with different HID report sizes until it works. For V2 devices and V1 devices on Linux and Windows, the first query will succeed (so it works the same as before this PR) and we use whatever size it tells us. For V1 devices on MacOS, hopefully _one_ of the queries succeeds, and then we use that size thereafter.

It's possible that making one wrong request will cause MacOS to error on everything afterwards or some other workaround will be needed, I haven't yet been able to test that. @john-terrell, any chance you could test this out on MacOS? 

Previously the report size (and other probe metadata) was queried in `CmsisDap::attach`, but by that point it's already too late to avoid report-size-related errors, because user code (such as cargo-embed) might have already called other methods (like setting probe speed). Instead, I moved the report size checking and other similar metadata (packet count, capabilities, SWO info) into `new_from_device()`, which means it can be the first thing to run and seems a more sensible place anyway. This also means some fields no longer need to be Option, so I've done that too.