### PR TITLE
Detect correct USB HID interface for CMSIS-DAP v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).
 
 ## [0.11.0]
 

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -544,6 +544,10 @@ pub struct DebugProbeInfo {
     pub product_id: u16,
     pub serial_number: Option<String>,
     pub probe_type: DebugProbeType,
+
+    /// USB HID interface which should be used.
+    /// Necessary for composite HID devices.
+    pub hid_interface: Option<u8>,
 }
 
 impl std::fmt::Debug for DebugProbeInfo {
@@ -570,6 +574,7 @@ impl DebugProbeInfo {
         product_id: u16,
         serial_number: Option<String>,
         probe_type: DebugProbeType,
+        usb_hid_interface: Option<u8>,
     ) -> Self {
         Self {
             identifier: identifier.into(),
@@ -577,6 +582,7 @@ impl DebugProbeInfo {
             product_id,
             serial_number,
             probe_type,
+            hid_interface: usb_hid_interface,
         }
     }
 
@@ -609,6 +615,9 @@ pub struct DebugProbeSelector {
     pub vendor_id: u16,
     pub product_id: u16,
     pub serial_number: Option<String>,
+
+    /// USB HID interface, necessary for composite devices
+    usb_hid_interface: Option<u8>,
 }
 
 impl TryFrom<&str> for DebugProbeSelector {
@@ -620,6 +629,7 @@ impl TryFrom<&str> for DebugProbeSelector {
                 vendor_id: u16::from_str_radix(split[0], 16)?,
                 product_id: u16::from_str_radix(split[1], 16)?,
                 serial_number: None,
+                usb_hid_interface: None,
             }
         } else {
             return Err(DebugProbeSelectorParseError::Format);
@@ -653,6 +663,7 @@ impl From<DebugProbeInfo> for DebugProbeSelector {
             vendor_id: selector.vendor_id,
             product_id: selector.product_id,
             serial_number: selector.serial_number,
+            usb_hid_interface: selector.hid_interface,
         }
     }
 }
@@ -663,6 +674,7 @@ impl From<&DebugProbeInfo> for DebugProbeSelector {
             vendor_id: selector.vendor_id,
             product_id: selector.product_id,
             serial_number: selector.serial_number.clone(),
+            usb_hid_interface: selector.hid_interface,
         }
     }
 }

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -83,7 +83,7 @@ fn get_cmsisdap_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
                     .read_interface_string(language, &descriptor, timeout)
                     .ok()?;
 
-                log::trace!("  Interface {}", interface_desc);
+                log::trace!("  Interface {}: {}", interface.number(), interface_desc);
 
                 if interface_desc.contains("CMSIS-DAP") {
                     cmsis_dap_interface = Some(interface.number());
@@ -99,7 +99,7 @@ fn get_cmsisdap_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
         let cmsis_dap_interface = cmsis_dap_interface.unwrap_or(0);
 
         log::trace!(
-            "Using interface number {} for CMSIS-DAP",
+            "Will use interface number {} for CMSIS-DAPv1",
             cmsis_dap_interface
         );
 

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -92,16 +92,11 @@ fn get_cmsisdap_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
             }
         }
 
-        if cmsis_dap_interface.is_none() {
-            log::debug!("Did not find an USB HID interface for CMSIS-DAP, using interface 0.")
+        if let Some(interface) = cmsis_dap_interface {
+            log::trace!("Will use interface number {} for CMSIS-DAPv1", interface);
+        } else {
+            log::trace!("No HID interface for CMSIS-DAP found.")
         }
-
-        let cmsis_dap_interface = cmsis_dap_interface.unwrap_or(0);
-
-        log::trace!(
-            "Will use interface number {} for CMSIS-DAPv1",
-            cmsis_dap_interface
-        );
 
         Some(DebugProbeInfo {
             identifier: prod_str,
@@ -109,7 +104,7 @@ fn get_cmsisdap_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
             product_id: d_desc.product_id(),
             serial_number: sn_str,
             probe_type: DebugProbeType::CmsisDap,
-            hid_interface: Some(cmsis_dap_interface),
+            hid_interface: cmsis_dap_interface,
         })
     } else {
         None

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -591,6 +591,7 @@ fn get_device_info(device: &rusb::Device<rusb::Context>) -> Option<DebugProbeInf
         product_id: d_desc.product_id(),
         serial_number: sn_str,
         probe_type: DebugProbeType::Ftdi,
+        hid_interface: None,
     })
 }
 

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -783,6 +783,7 @@ pub(crate) fn list_jlink_devices() -> Vec<DebugProbeInfo> {
                     pid,
                     serial,
                     DebugProbeType::JLink,
+                    None,
                 )
             })
             .collect(),

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -53,6 +53,7 @@ pub fn list_stlink_devices() -> Vec<DebugProbeInfo> {
                         descriptor.product_id(),
                         sn_str,
                         DebugProbeType::StLink,
+                        None,
                     ))
                 })
                 .collect::<Vec<_>>()


### PR DESCRIPTION
Some CMSIS-DAP probes have multiple HID interfaces, and the correct interface has to be used to access the CMSIS-DAP functionality. On MacOS, the HID interfaces seem to be returned in a randomized order, so access to the probe will only work sometimes, if the first found interface is the correct one by chance.

With this PR, we look for the correct HID interface while enumerating devices using `rusb`. The correct interface number is then stored in the `DebugProbeInfo` struct, and used when the device is opened with the `hidapi`library to select the correct HID device.

Unfortunately the `hidapi`library does not offer a direct way to access the interface description string, so we have to use `rusb`to detect the correct interface.

This might fix #681, but has only been tested with a MCUlink on MacOS so far.

