### PR TITLE
Rename DapAccess to UntypedDapAccess, combine ApAccess and DpAccess into TypedDapAccess

### DIFF
--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -1,11 +1,11 @@
 use anyhow::anyhow;
 
-use super::super::{ApAccess, Register};
+use super::super::{Register, TypedDapAccess};
 use super::{AddressIncrement, ApRegister, DataSize, CSW, DRW, TAR};
 use crate::architecture::arm::{ap::AccessPort, DpAddress};
 use crate::{
-    architecture::arm::dp::{DebugPortError, DpAccess, DpRegister},
-    CommunicationInterface, DebugProbeError,
+    architecture::arm::dp::{DebugPortError, DpRegister},
+    DebugProbeError,
 };
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -33,13 +33,7 @@ impl MockMemoryAp {
     }
 }
 
-impl CommunicationInterface for MockMemoryAp {
-    fn flush(&mut self) -> Result<(), DebugProbeError> {
-        Ok(())
-    }
-}
-
-impl ApAccess for MockMemoryAp {
+impl TypedDapAccess for MockMemoryAp {
     /// Mocks the read_register method of a AP.
     ///
     /// Returns an Error if any bad instructions or values are chosen.
@@ -223,9 +217,7 @@ impl ApAccess for MockMemoryAp {
 
         Ok(())
     }
-}
 
-impl DpAccess for MockMemoryAp {
     fn read_dp_register<R: DpRegister>(&mut self, _dp: DpAddress) -> Result<R, DebugPortError> {
         // Ignore for Tests
         Ok(0.into())
@@ -236,6 +228,10 @@ impl DpAccess for MockMemoryAp {
         _dp: DpAddress,
         _register: R,
     ) -> Result<(), DebugPortError> {
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), DebugProbeError> {
         Ok(())
     }
 }

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -3,7 +3,7 @@
 #[doc(hidden)]
 pub(crate) mod mock;
 
-use super::{AccessPort, ApAccess, ApRegister, GenericAp, Register};
+use super::{AccessPort, ApRegister, GenericAp, Register, TypedDapAccess};
 use crate::{architecture::arm::ApAddress, DebugProbeError};
 use enum_primitive_derive::Primitive;
 use num_traits::{FromPrimitive, ToPrimitive};
@@ -17,7 +17,7 @@ define_ap!(MemoryAp);
 impl MemoryAp {
     pub fn base_address<A>(&self, interface: &mut A) -> Result<u64, DebugProbeError>
     where
-        A: ApAccess,
+        A: TypedDapAccess,
     {
         let base_register: BASE = interface.read_ap_register(*self)?;
 

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 mod register_generation;
 
-use super::{DapAccess, DpAddress, Register};
+use super::Register;
 use bitfield::bitfield;
 use jep106::JEP106Code;
 
@@ -22,36 +22,6 @@ pub enum DebugPortError {
 impl From<DebugPortError> for DebugProbeError {
     fn from(error: DebugPortError) -> Self {
         DebugProbeError::ArchitectureSpecific(Box::new(error))
-    }
-}
-
-pub trait DpAccess {
-    fn read_dp_register<R: DpRegister>(&mut self, dp: DpAddress) -> Result<R, DebugPortError>;
-
-    fn write_dp_register<R: DpRegister>(
-        &mut self,
-        dp: DpAddress,
-        register: R,
-    ) -> Result<(), DebugPortError>;
-}
-
-impl<T: DapAccess> DpAccess for T {
-    fn read_dp_register<R: DpRegister>(&mut self, dp: DpAddress) -> Result<R, DebugPortError> {
-        log::debug!("Reading DP register {}", R::NAME);
-        let result = self.read_raw_dp_register(dp, R::ADDRESS)?;
-        log::debug!("Read    DP register {}, value=0x{:08x}", R::NAME, result);
-        Ok(result.into())
-    }
-
-    fn write_dp_register<R: DpRegister>(
-        &mut self,
-        dp: DpAddress,
-        register: R,
-    ) -> Result<(), DebugPortError> {
-        let value = register.into();
-        log::debug!("Writing DP register {}, value=0x{:08x}", R::NAME, value);
-        self.write_raw_dp_register(dp, R::ADDRESS, value)?;
-        Ok(())
     }
 }
 

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -1,8 +1,8 @@
 use super::super::ap::{
-    AccessPortError, AddressIncrement, ApAccess, ApRegister, DataSize, MemoryAp, CSW, DRW, TAR,
+    AccessPortError, AddressIncrement, ApRegister, DataSize, MemoryAp, CSW, DRW, TAR,
 };
-use crate::architecture::arm::{dp::DpAccess, MemoryApInformation};
-use crate::{CommunicationInterface, CoreRegister, CoreRegisterAddress, DebugProbeError, Error};
+use crate::architecture::arm::{MemoryApInformation, TypedDapAccess};
+use crate::{CoreRegister, CoreRegisterAddress, DebugProbeError, Error};
 use scroll::{Pread, Pwrite, LE};
 use std::convert::TryInto;
 use std::{
@@ -33,7 +33,7 @@ pub trait ArmProbe {
 /// A struct to give access to a targets memory using a certain DAP.
 pub(crate) struct ADIMemoryInterface<'interface, AP>
 where
-    AP: CommunicationInterface + ApAccess + DpAccess,
+    AP: TypedDapAccess,
 {
     interface: &'interface mut AP,
     only_32bit_data_size: bool,
@@ -53,7 +53,7 @@ where
 
 impl<'interface, AP> ADIMemoryInterface<'interface, AP>
 where
-    AP: CommunicationInterface + ApAccess + DpAccess,
+    AP: TypedDapAccess,
 {
     /// Creates a new MemoryInterface for given AccessPort.
     pub fn new(
@@ -71,7 +71,7 @@ where
 
 impl<AP> ADIMemoryInterface<'_, AP>
 where
-    AP: CommunicationInterface + ApAccess + DpAccess,
+    AP: TypedDapAccess,
 {
     /// Build the correct CSW register for a memory access
     ///
@@ -145,7 +145,7 @@ where
     fn read_ap_register<R>(&mut self, access_port: MemoryAp) -> Result<R, AccessPortError>
     where
         R: ApRegister<MemoryAp>,
-        AP: ApAccess,
+        AP: TypedDapAccess,
     {
         self.interface
             .read_ap_register(access_port)
@@ -162,7 +162,7 @@ where
     ) -> Result<(), AccessPortError>
     where
         R: ApRegister<MemoryAp>,
-        AP: ApAccess,
+        AP: TypedDapAccess,
     {
         self.interface
             .read_ap_register_repeated(access_port, register, values)
@@ -177,7 +177,7 @@ where
     ) -> Result<(), AccessPortError>
     where
         R: ApRegister<MemoryAp>,
-        AP: ApAccess,
+        AP: TypedDapAccess,
     {
         self.interface
             .write_ap_register(access_port, register)
@@ -194,7 +194,7 @@ where
     ) -> Result<(), AccessPortError>
     where
         R: ApRegister<MemoryAp>,
-        AP: ApAccess,
+        AP: TypedDapAccess,
     {
         self.interface
             .write_ap_register_repeated(access_port, register, values)
@@ -586,7 +586,7 @@ where
 
 impl<AP> ArmProbe for ADIMemoryInterface<'_, AP>
 where
-    AP: CommunicationInterface + ApAccess + DpAccess,
+    AP: TypedDapAccess,
 {
     fn read_core_reg(&mut self, ap: MemoryAp, addr: CoreRegisterAddress) -> Result<u32, Error> {
         // Write the DCRSR value to select the register we want to read.

--- a/probe-rs/src/core/communication_interface.rs
+++ b/probe-rs/src/core/communication_interface.rs
@@ -1,5 +1,0 @@
-use crate::DebugProbeError;
-
-pub trait CommunicationInterface {
-    fn flush(&mut self) -> Result<(), DebugProbeError>;
-}

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -1,7 +1,3 @@
-pub(crate) mod communication_interface;
-
-pub use communication_interface::CommunicationInterface;
-
 use crate::architecture::{
     arm::core::CortexState, riscv::communication_interface::RiscvCommunicationInterface,
 };

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -77,9 +77,8 @@ mod session;
 
 pub use crate::config::{CoreType, Target};
 pub use crate::core::{
-    Architecture, Breakpoint, BreakpointId, CommunicationInterface, Core, CoreInformation,
-    CoreInterface, CoreList, CoreRegister, CoreRegisterAddress, CoreState, CoreStatus, HaltReason,
-    SpecificCoreState,
+    Architecture, Breakpoint, BreakpointId, Core, CoreInformation, CoreInterface, CoreList,
+    CoreRegister, CoreRegisterAddress, CoreState, CoreStatus, HaltReason, SpecificCoreState,
 };
 pub use crate::error::Error;
 pub use crate::memory::{Memory, MemoryInterface};

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -9,7 +9,7 @@ use crate::{
     config::{RegistryError, TargetSelector},
 };
 use crate::{
-    architecture::arm::{ap::AccessPort, ApAddress, DapAccess, DpAddress},
+    architecture::arm::{ap::AccessPort, ApAddress, DpAddress, UntypedDapAccess},
     Session,
 };
 use crate::{
@@ -852,7 +852,7 @@ impl ArmProbeInterface for FakeArmInterface {
     }
 }
 
-impl DapAccess for FakeArmInterface {
+impl UntypedDapAccess for FakeArmInterface {
     fn read_raw_dp_register(
         &mut self,
         _dp: DpAddress,
@@ -902,6 +902,10 @@ impl DapAccess for FakeArmInterface {
         _address: u8,
         _values: &[u32],
     ) -> Result<(), DebugProbeError> {
+        todo!()
+    }
+
+    fn flush(&mut self) -> Result<(), DebugProbeError> {
         todo!()
     }
 }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -6,10 +6,11 @@ use self::usb_interface::{StLinkUsb, StLinkUsbDevice};
 use super::{DebugProbe, DebugProbeError, ProbeCreationError, WireProtocol};
 use crate::{
     architecture::arm::{
-        ap::{valid_access_ports, AccessPort, ApAccess, ApClass, MemoryAp, IDR},
+        ap::{valid_access_ports, AccessPort, ApClass, MemoryAp, IDR},
         communication_interface::ArmProbeInterface,
         memory::{adi_v5_memory_interface::ArmProbe, Component},
-        ApAddress, ApInformation, ArmChipInfo, DapAccess, DpAddress, SwoAccess, SwoConfig, SwoMode,
+        ApAddress, ApInformation, ArmChipInfo, DpAddress, SwoAccess, SwoConfig, SwoMode,
+        TypedDapAccess, UntypedDapAccess,
     },
     DebugProbeSelector, Error as ProbeRsError, Memory, Probe,
 };
@@ -1136,7 +1137,7 @@ impl StlinkArmDebug {
     }
 }
 
-impl DapAccess for StlinkArmDebug {
+impl UntypedDapAccess for StlinkArmDebug {
     fn read_raw_dp_register(&mut self, dp: DpAddress, address: u8) -> Result<u32, DebugProbeError> {
         if dp != DpAddress::Default {
             Err(StlinkError::MultidropNotSupported)?;
@@ -1178,6 +1179,10 @@ impl DapAccess for StlinkArmDebug {
         }
 
         self.probe.write_register(ap.ap as u16, address, value)
+    }
+
+    fn flush(&mut self) -> Result<(), DebugProbeError> {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
I don't think having separate traits for `ApAccess` and `DpAccess` makes much sense anymore, so I've combined them nto a single trait. The `flush` method must be available as well, so this can also be on the same trait.