### PR TITLE
arm/itm: doc fields, enable global timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Target Support
 
 ### Changed
+- Enabled the generation of global timestamps for ARM targets on `Session::setup_swv`.
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).

--- a/probe-rs/src/architecture/arm/component/itm.rs
+++ b/probe-rs/src/architecture/arm/component/itm.rs
@@ -34,10 +34,11 @@ impl<'probe: 'core, 'core> Itm<'probe, 'core> {
             .component
             .read_reg(self.core, REGISTER_OFFSET_ITM_TCR)?;
 
-        value |= 1; // itm enable
-        value |= 1 << 1; // timestamp enable
-        value |= 1 << 2; // Enable sync pulses, note DWT_CTRL.SYNCTAP must be configured.
-        value |= 1 << 3; // tx enable (for DWT)
+        value |= 1 << 0; // ITMENA: enable ITM (master switch)
+        value |= 1 << 1; // TSENA: enable local timestamps
+        value |= 1 << 2; // SYNENA: Enable sync pulses, note DWT_CTRL.SYNCTAP must be configured.
+        value |= 1 << 3; // TXENA: forward DWT packets to ITM
+        value |= 1 << 11; // GTSFREQ: generate global timestamp every 8192 cycles
         value |= 13 << 16; // 7 bits trace bus ID
         self.component
             .write_reg(self.core, REGISTER_OFFSET_ITM_TCR, value)?;


### PR DESCRIPTION
This enables generation of global timestamps every 8192 or after every
packet, depending on read register value. Preferably, [0] (which binds
into #727) would be used here instead.

[0] https://github.com/rust-embedded/cortex-m/pull/342/files#diff-4a52d1ab15248eae14ea79bf2efcaf399b0cb20abd65e5be7d05654ddf252835R177