### PR TITLE
Do not store HID interface in DebugProbeSelector, retrieve interface when opening Probe

### DIFF
--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -613,9 +613,6 @@ pub struct DebugProbeSelector {
     pub vendor_id: u16,
     pub product_id: u16,
     pub serial_number: Option<String>,
-
-    /// USB HID interface, necessary for composite devices
-    usb_hid_interface: Option<u8>,
 }
 
 impl TryFrom<&str> for DebugProbeSelector {
@@ -627,7 +624,6 @@ impl TryFrom<&str> for DebugProbeSelector {
                 vendor_id: u16::from_str_radix(split[0], 16)?,
                 product_id: u16::from_str_radix(split[1], 16)?,
                 serial_number: None,
-                usb_hid_interface: None,
             }
         } else {
             return Err(DebugProbeSelectorParseError::Format);
@@ -661,7 +657,6 @@ impl From<DebugProbeInfo> for DebugProbeSelector {
             vendor_id: selector.vendor_id,
             product_id: selector.product_id,
             serial_number: selector.serial_number,
-            usb_hid_interface: selector.hid_interface,
         }
     }
 }
@@ -672,7 +667,6 @@ impl From<&DebugProbeInfo> for DebugProbeSelector {
             vendor_id: selector.vendor_id,
             product_id: selector.product_id,
             serial_number: selector.serial_number.clone(),
-            usb_hid_interface: selector.hid_interface,
         }
     }
 }

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -246,6 +246,15 @@ pub fn open_device_from_selector(
 
     log::trace!("Attempting to open device matching {}", selector);
 
+    // We need to use rusb to detect the proper HID interface to use
+    // if a probe has multiple HID interfaces. The hidapi lib unfortunately
+    // offers no method to get the interface description string directly,
+    // so we retrieve the device information using rusb and store it here.
+    //
+    // If rusb cannot be used, we will just use the first HID interface and
+    // try to open that.
+    let mut hid_device_info: Option<DebugProbeInfo> = None;
+
     // Try using rusb to open a v2 device. This might fail if
     // the device does not support v2 operation or due to driver
     // or permission issues with opening bulk devices.
@@ -286,12 +295,16 @@ pub fn open_device_from_selector(
             // multiple open handles are not allowed on Windows.
             drop(handle);
 
-            if device_matches(d_desc, &selector, sn_str) && get_cmsisdap_info(&device).is_some() {
-                // If the VID, PID, and potentially SN all match,
-                // and the device is a valid CMSIS-DAP probe,
-                // attempt to open the device in v2 mode.
-                if let Some(device) = open_v2_device(device) {
-                    return Ok(device);
+            if device_matches(d_desc, &selector, sn_str) {
+                hid_device_info = get_cmsisdap_info(&device);
+
+                if hid_device_info.is_some() {
+                    // If the VID, PID, and potentially SN all match,
+                    // and the device is a valid CMSIS-DAP probe,
+                    // attempt to open the device in v2 mode.
+                    if let Some(device) = open_v2_device(device) {
+                        return Ok(device);
+                    }
                 }
             }
         }
@@ -327,7 +340,9 @@ pub fn open_device_from_selector(
                 device_match &= Some(sn.as_ref()) == info.serial_number();
             }
 
-            if let Some(hid_interface) = selector.usb_hid_interface {
+            if let Some(hid_interface) =
+                hid_device_info.as_ref().and_then(|info| info.hid_interface)
+            {
                 device_match &= info.interface_number() == hid_interface as i32;
             }
 


### PR DESCRIPTION
Storing the HID interface in the DebugProbeSelector does not work well together with cargo-embed.

With this PR, the interface is found when the probe is opened, not when listing probes. This
fixes #726.﻿
