### PR TITLE
Detect timeout when reading from USB HID device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).
+- When reading from a HID device, check number of bytes returned to detect USB HID timeouts.
 
 ## [0.11.0]
 


### PR DESCRIPTION
The return value from `HidDevice::read_timeout`was not checked, so we did not detect when a timeout occured.

With the changes in this PR, it should be possible to try multiple reports when connecting to a CMSIS-DAP probe, as is planned in #721.