### PR TITLE
Add macOS test to bors

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -4,6 +4,7 @@ delete_merged_branches = true
 status = [
     "Check (ubuntu-latest)",
     "Check (windows-latest)",
+    "Check (macos-latest)",
     "Test Suite (ubuntu-latest)",
     "Test Suite (windows-latest)",
     "Rustfmt",


### PR DESCRIPTION
Avoid problems when bors wants to merge but macOS CI has not completed yet.