### PR TITLE
Use hidraw backend for hidapi on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2.3.4
 
-      - name: Install libusb and libftdi (linux)
+      - name: Install libusb, libudev and libftdi (linux)
         run: |
           sudo apt update
-          sudo apt install -y libusb-1.0-0-dev libftdi1-dev
+          sudo apt install -y libusb-1.0-0-dev libftdi1-dev libudev-dev
         # Only install on Ubuntu
         if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'ubuntu-20.04')
 
@@ -94,7 +94,7 @@ jobs:
       - name: Install libusb and libftdi (linux)
         run: |
           sudo apt update
-          sudo apt install -y libusb-1.0-0-dev libftdi1-dev
+          sudo apt install -y libusb-1.0-0-dev libftdi1-dev libudev-dev
         # Only install on Ubuntu
         if: matrix.os == 'ubuntu-latest'
 
@@ -160,7 +160,7 @@ jobs:
       - name: Install libusb
         run: |
           sudo apt update
-          sudo apt install -y libusb-1.0-0-dev libftdi1-dev
+          sudo apt install -y libusb-1.0-0-dev libftdi1-dev libudev-dev
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Enabled the generation of global timestamps for ARM targets on `Session::setup_swv`.
+- Changed to `hidraw` for HID access on Linux. This should allow access to HID-based probes without udev rules (#737).
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ Building requires Rust and Cargo which can be installed [using rustup](https://r
 
 ```console
 # Ubuntu
-> sudo apt install -y libusb-1.0-0-dev libftdi1-dev
+> sudo apt install -y libusb-1.0-0-dev libftdi1-dev libudev-dev
 
 # Fedora
-> sudo dnf install -y libusbx-devel libftdi-devel
+> sudo dnf install -y libusbx-devel libftdi-devel libudev-devel
 ```
 
 On Windows you can use [vcpkg](https://github.com/microsoft/vcpkg#quick-start-windows):

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -28,7 +28,7 @@ bitfield = "0.13.2"
 bitvec = "0.19.4"
 enum-primitive-derive = "0.2.1"
 gimli = { version = "0.24.0", default-features = false, features = ["endian-reader", "read", "std"] }
-hidapi = "1.2.0"
+hidapi = { version = "1.2.0", default-features = false, features = ["linux-static-hidraw"] }
 ihex = "3.0.0"
 jaylink = "0.2.0"
 jep106 = "0.2.4"


### PR DESCRIPTION
`hidapi` has two possible backends on Linux, `libusb` and `hidraw`. `hidraw` seems to require less permissions, so I think we should use it. This might help with #357.