### PR TITLE
Define better errors for multiple default flash alg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enabled the generation of global timestamps for ARM targets on `Session::setup_swv`.
 - Changed to `hidraw` for HID access on Linux. This should allow access to HID-based probes without udev rules (#737).
 - Support batching of FTDI commands and use it for RISCV (#717)
+- Include the chip string for `NoRamDefined` in its error message
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).
 - When reading from a HID device, check number of bytes returned to detect USB HID timeouts.
 - Fix connecting to EDBG and similar probes on MacOS (#681, #721)
 - Fixed incorrect flash range in `fe310` causing flashing to fail (#732).
+- Multiple default algorithims would silently select the first, now errors intead (#744).
 
 ## [0.11.0]
 

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -49,14 +49,17 @@ pub enum FlashError {
     // TODO: Warn at YAML parsing stage.
     // TODO: 1 Add information about flash (name, address)
     // TODO: 2 Add source of target definition (built-in, yaml)
-    #[error("Trying to write flash, but no suitable flash loader algorithm is linked to the given target information.")]
-    NoFlashLoaderAlgorithmAttached,
+    #[error("Trying to write flash, but no suitable (default) flash loader algorithm is linked to the given target: {name} .")]
+    NoFlashLoaderAlgorithmAttached { name: String },
+
+    #[error("Either more than one flash loader algorithim marked as default or multiple fitting algorithims but no default selected.")]
+    MultipleFlashLoaderAlgorithms,
 
     #[error("Verify failed.")]
     Verify,
 
     // TODO: 1 Add source of target definition
-    #[error("No RAM defined for chip.")]
+    #[error("No RAM defined for chip: {chip}.")]
     NoRamDefined { chip: String },
 
     // Flash algorithm in YAML is broken

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -52,8 +52,10 @@ pub enum FlashError {
     #[error("Trying to write flash, but no suitable (default) flash loader algorithm is linked to the given target: {name} .")]
     NoFlashLoaderAlgorithmAttached { name: String },
 
-    #[error("Either more than one flash loader algorithim marked as default or multiple fitting algorithims but no default selected.")]
-    MultipleFlashLoaderAlgorithms,
+    #[error("Trying to write flash, but found more than one suitable flash loader algorithim marked as default for {region:?}.")]
+    MultipleDefaultFlashLoaderAlgorithms { region: NvmRegion },
+    #[error("Trying to write flash, but found more than one suitable flash algorithims but none marked as default for {region:?}.")]
+    MultipleFlashLoaderAlgorithmsNoDefault { region: NvmRegion },
 
     #[error("Verify failed.")]
     Verify,

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -438,23 +438,28 @@ impl FlashLoader {
             })
             .collect::<Vec<_>>();
 
-        let defaults = algorithms
-            .iter()
-            .filter(|&fa| fa.default)
-            .collect::<Vec<_>>();
+        match algorithms.len() {
+            0 => Err(FlashError::NoFlashLoaderAlgorithmAttached {
+                name: target.name.clone(),
+            }),
+            1 => Ok(algorithms[0]),
+            _ => {
+                // filter for defaults
+                let defaults = algorithms
+                    .iter()
+                    .filter(|&fa| fa.default)
+                    .collect::<Vec<_>>();
 
-        match defaults.len() {
-            0 => {
-                if !algorithms.is_empty() {
-                    Err(FlashError::MultipleFlashLoaderAlgorithms)
-                } else {
-                    Err(FlashError::NoFlashLoaderAlgorithmAttached {
-                        name: target.name.clone(),
-                    })
+                match defaults.len() {
+                    0 => Err(FlashError::MultipleFlashLoaderAlgorithmsNoDefault {
+                        region: region.clone(),
+                    }),
+                    1 => Ok(defaults[0]),
+                    _ => Err(FlashError::MultipleDefaultFlashLoaderAlgorithms {
+                        region: region.clone(),
+                    }),
                 }
             }
-            1 => Ok(defaults[0]),
-            _ => Err(FlashError::MultipleFlashLoaderAlgorithms),
         }
     }
 }

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -1,5 +1,7 @@
 use ihex::Record;
-use probe_rs_target::RawFlashAlgorithm;
+use probe_rs_target::{
+    MemoryRange, MemoryRegion, NvmRegion, RawFlashAlgorithm, TargetDescriptionSource,
+};
 use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom};
 use std::ops::Range;
@@ -11,10 +13,7 @@ use super::{
 };
 use crate::memory::MemoryInterface;
 use crate::session::Session;
-use crate::{
-    config::{MemoryRange, MemoryRegion, NvmRegion, TargetDescriptionSource},
-    Target,
-};
+use crate::Target;
 
 /// `FlashLoader` is a struct which manages the flashing of any chunks of data onto any sections of flash.
 ///
@@ -420,33 +419,42 @@ impl FlashLoader {
     }
 
     /// Try to find a flash algorithm for the given NvmRegion.
-    /// Errors if there's no algo for the region.
-    /// Errors if there's multiple algos for the region and none is marked as default.
+    /// Errors when:
+    /// - there's no algo for the region.
+    /// - there's multiple default algos for the region.
+    /// - there's multiple fitting algos but no default.
     pub(crate) fn get_flash_algorithm_for_region<'a>(
         region: &NvmRegion,
         target: &'a Target,
     ) -> Result<&'a RawFlashAlgorithm, FlashError> {
-        let algorithms = &target
+        let algorithms = target
             .flash_algorithms
             .iter()
-            .filter(|fa| {
+            // filter for algorithims that contiain adress range
+            .filter(|&fa| {
                 fa.flash_properties
                     .address_range
                     .contains_range(&region.range)
             })
             .collect::<Vec<_>>();
 
-        let raw_flash_algorithm = match algorithms.len() {
-            0 => {
-                return Err(FlashError::NoFlashLoaderAlgorithmAttached);
-            }
-            1 => algorithms[0],
-            _ => *algorithms
-                .iter()
-                .find(|a| a.default)
-                .ok_or(FlashError::NoFlashLoaderAlgorithmAttached)?,
-        };
+        let defaults = algorithms
+            .iter()
+            .filter(|&fa| fa.default)
+            .collect::<Vec<_>>();
 
-        Ok(raw_flash_algorithm)
+        match defaults.len() {
+            0 => {
+                if !algorithms.is_empty() {
+                    Err(FlashError::MultipleFlashLoaderAlgorithms)
+                } else {
+                    Err(FlashError::NoFlashLoaderAlgorithmAttached {
+                        name: target.name.clone(),
+                    })
+                }
+            }
+            1 => Ok(defaults[0]),
+            _ => Err(FlashError::MultipleFlashLoaderAlgorithms),
+        }
     }
 }


### PR DESCRIPTION
fixes #741 

Adds a new error type; but it could be seen as too inclusive.
Improves the error message for `NoFlashLoaderAlgorithmAttached` to include the target name

aside: `NoRamDefined` has a chip string that wasn't used in the error message.