### PR TITLE
Improve CMSIS-DAP response parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed to `hidraw` for HID access on Linux. This should allow access to HID-based probes without udev rules (#737).
 - Support batching of FTDI commands and use it for RISCV (#717)
 - Include the chip string for `NoRamDefined` in its error message
+- Improved handling of errors in CMSIS-DAP commands (#745).
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).

--- a/probe-rs/src/probe/cmsisdap/commands/general/connect.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/connect.rs
@@ -1,4 +1,4 @@
-use super::super::{Category, Request, SendError};
+use super::super::{CommandId, Request, SendError};
 
 #[derive(Clone, Copy, Debug)]
 pub enum ConnectRequest {
@@ -8,7 +8,7 @@ pub enum ConnectRequest {
 }
 
 impl Request for ConnectRequest {
-    const CATEGORY: Category = Category(0x02);
+    const COMMAND_ID: CommandId = CommandId(0x02);
 
     type Response = ConnectResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/general/connect.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/connect.rs
@@ -12,17 +12,17 @@ impl Request for ConnectRequest {
 
     type Response = ConnectResponse;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = *self as u8;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = *self as u8;
         Ok(1)
     }
 
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        match buffer[offset] {
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        match buffer[0] {
             0 => Ok(ConnectResponse::InitFailed),
             1 => Ok(ConnectResponse::SuccessfulInitForSWD),
             2 => Ok(ConnectResponse::SuccessfulInitForJTAG),
-            _ => Err(SendError::ConnectResponseError(buffer[offset])),
+            other => Err(SendError::ConnectResponseError(other)),
         }
     }
 }

--- a/probe-rs/src/probe/cmsisdap/commands/general/connect.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/connect.rs
@@ -8,7 +8,7 @@ pub enum ConnectRequest {
 }
 
 impl Request for ConnectRequest {
-    const COMMAND_ID: CommandId = CommandId(0x02);
+    const COMMAND_ID: CommandId = CommandId::Connect;
 
     type Response = ConnectResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/general/disconnect.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/disconnect.rs
@@ -1,10 +1,10 @@
-use super::super::{Category, Request, SendError, Status};
+use super::super::{CommandId, Request, SendError, Status};
 
 #[derive(Clone, Copy, Debug)]
 pub struct DisconnectRequest;
 
 impl Request for DisconnectRequest {
-    const CATEGORY: Category = Category(0x03);
+    const COMMAND_ID: CommandId = CommandId(0x03);
 
     type Response = DisconnectResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/general/disconnect.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/disconnect.rs
@@ -8,12 +8,12 @@ impl Request for DisconnectRequest {
 
     type Response = DisconnectResponse;
 
-    fn to_bytes(&self, _buffer: &mut [u8], _offset: usize) -> Result<usize, SendError> {
+    fn to_bytes(&self, _buffer: &mut [u8]) -> Result<usize, SendError> {
         Ok(0)
     }
 
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        Ok(DisconnectResponse(Status::from_byte(buffer[offset])?))
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        Ok(DisconnectResponse(Status::from_byte(buffer[0])?))
     }
 }
 

--- a/probe-rs/src/probe/cmsisdap/commands/general/disconnect.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/disconnect.rs
@@ -4,7 +4,7 @@ use super::super::{CommandId, Request, SendError, Status};
 pub struct DisconnectRequest;
 
 impl Request for DisconnectRequest {
-    const COMMAND_ID: CommandId = CommandId(0x03);
+    const COMMAND_ID: CommandId = CommandId::Disconnect;
 
     type Response = DisconnectResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/general/disconnect.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/disconnect.rs
@@ -1,4 +1,4 @@
-use super::super::{Category, Request, Response, SendError, Status};
+use super::super::{Category, Request, SendError, Status};
 
 #[derive(Clone, Copy, Debug)]
 pub struct DisconnectRequest;
@@ -6,16 +6,16 @@ pub struct DisconnectRequest;
 impl Request for DisconnectRequest {
     const CATEGORY: Category = Category(0x03);
 
+    type Response = DisconnectResponse;
+
     fn to_bytes(&self, _buffer: &mut [u8], _offset: usize) -> Result<usize, SendError> {
         Ok(0)
+    }
+
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
+        Ok(DisconnectResponse(Status::from_byte(buffer[offset])?))
     }
 }
 
 #[derive(Clone, Copy, Debug)]
 pub struct DisconnectResponse(pub(crate) Status);
-
-impl Response for DisconnectResponse {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
-        Ok(DisconnectResponse(Status::from_byte(buffer[offset])?))
-    }
-}

--- a/probe-rs/src/probe/cmsisdap/commands/general/host_status.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/host_status.rs
@@ -1,4 +1,4 @@
-use super::super::{Category, Request, Response, SendError};
+use super::super::{Category, Request, SendError};
 
 #[derive(Clone, Copy, Debug)]
 pub struct HostStatusRequest {
@@ -26,18 +26,18 @@ impl HostStatusRequest {
 impl Request for HostStatusRequest {
     const CATEGORY: Category = Category(0x01);
 
+    type Response = HostStatusResponse;
+
     fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
         buffer[offset] = self.status_type;
         buffer[offset + 1] = self.status;
         Ok(2)
     }
+
+    fn from_bytes(&self, _buffer: &[u8], _offset: usize) -> Result<Self::Response, SendError> {
+        Ok(HostStatusResponse)
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
 pub struct HostStatusResponse;
-
-impl Response for HostStatusResponse {
-    fn from_bytes(_buffer: &[u8], _offset: usize) -> Result<Self, SendError> {
-        Ok(HostStatusResponse)
-    }
-}

--- a/probe-rs/src/probe/cmsisdap/commands/general/host_status.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/host_status.rs
@@ -24,7 +24,7 @@ impl HostStatusRequest {
 }
 
 impl Request for HostStatusRequest {
-    const COMMAND_ID: CommandId = CommandId(0x01);
+    const COMMAND_ID: CommandId = CommandId::HostStatus;
 
     type Response = HostStatusResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/general/host_status.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/host_status.rs
@@ -1,4 +1,4 @@
-use super::super::{Category, Request, SendError};
+use super::super::{CommandId, Request, SendError};
 
 #[derive(Clone, Copy, Debug)]
 pub struct HostStatusRequest {
@@ -24,7 +24,7 @@ impl HostStatusRequest {
 }
 
 impl Request for HostStatusRequest {
-    const CATEGORY: Category = Category(0x01);
+    const COMMAND_ID: CommandId = CommandId(0x01);
 
     type Response = HostStatusResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/general/host_status.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/host_status.rs
@@ -28,13 +28,13 @@ impl Request for HostStatusRequest {
 
     type Response = HostStatusResponse;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = self.status_type;
-        buffer[offset + 1] = self.status;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = self.status_type;
+        buffer[1] = self.status;
         Ok(2)
     }
 
-    fn from_bytes(&self, _buffer: &[u8], _offset: usize) -> Result<Self::Response, SendError> {
+    fn from_bytes(&self, _buffer: &[u8]) -> Result<Self::Response, SendError> {
         Ok(HostStatusResponse)
     }
 }

--- a/probe-rs/src/probe/cmsisdap/commands/general/info.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/info.rs
@@ -8,7 +8,7 @@ macro_rules! info_command {
         pub struct $name {}
 
         impl Request for $name {
-            const COMMAND_ID: CommandId = CommandId(0x00);
+            const COMMAND_ID: CommandId = CommandId::Info;
 
             type Response = $response_type;
 
@@ -46,7 +46,7 @@ info_command!(0xF0, CapabilitiesCommand, Capabilities);
 pub struct TestDomainTimeCommand {}
 
 impl Request for TestDomainTimeCommand {
-    const COMMAND_ID: CommandId = CommandId(0x00);
+    const COMMAND_ID: CommandId = CommandId::Info;
 
     type Response = u32;
 
@@ -56,7 +56,9 @@ impl Request for TestDomainTimeCommand {
     }
     fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
         if buffer[0] == 0x08 {
-            let res = buffer.pread_with::<u32>(1, LE).unwrap();
+            let res = buffer
+                .pread_with::<u32>(1, LE)
+                .map_err(|_| SendError::NotEnoughData)?;
             Ok(res)
         } else {
             Err(SendError::UnexpectedAnswer)

--- a/probe-rs/src/probe/cmsisdap/commands/general/info.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/info.rs
@@ -1,4 +1,4 @@
-use super::super::{Category, Request, SendError};
+use super::super::{CommandId, Request, SendError};
 
 use scroll::{Pread, LE};
 
@@ -8,7 +8,7 @@ macro_rules! info_command {
         pub struct $name {}
 
         impl Request for $name {
-            const CATEGORY: Category = Category(0x00);
+            const COMMAND_ID: CommandId = CommandId(0x00);
 
             type Response = $response_type;
 
@@ -46,7 +46,7 @@ info_command!(0xF0, CapabilitiesCommand, Capabilities);
 pub struct TestDomainTimeCommand {}
 
 impl Request for TestDomainTimeCommand {
-    const CATEGORY: Category = Category(0x00);
+    const COMMAND_ID: CommandId = CommandId(0x00);
 
     type Response = u32;
 

--- a/probe-rs/src/probe/cmsisdap/commands/general/info.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/info.rs
@@ -2,181 +2,53 @@ use super::super::{Category, Request, SendError};
 
 use scroll::{Pread, LE};
 
-#[derive(Clone, Default, Debug)]
-struct VendorCommand {}
+macro_rules! info_command {
+    ($id:expr, $name:ident, $response_type:ty) => {
+        #[derive(Clone, Default, Debug)]
+        pub struct $name {}
 
-impl Request for VendorCommand {
-    const CATEGORY: Category = Category(0x00);
+        impl Request for $name {
+            const CATEGORY: Category = Category(0x00);
 
-    type Response = VendorID;
+            type Response = $response_type;
 
-    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
-        buffer[0] = 0x01;
-        Ok(1)
-    }
+            fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+                buffer[0] = $id;
+                Ok(1)
+            }
 
-    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
-        string_from_bytes(buffer, 0, &VendorID)
-    }
-}
-
-#[derive(Clone, Default, Debug)]
-pub struct VendorID(pub(crate) String);
-
-#[derive(Clone, Default, Debug)]
-struct ProductIdCommand {}
-
-#[derive(Clone, Default, Debug)]
-pub struct ProductID(pub(crate) String);
-
-impl Request for ProductIdCommand {
-    const CATEGORY: Category = Category(0x00);
-
-    type Response = ProductID;
-
-    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
-        buffer[0] = 0x02;
-        Ok(1)
-    }
-    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
-        string_from_bytes(buffer, 0, &ProductID)
-    }
-}
-
-#[derive(Clone, Default, Debug)]
-struct SerialNumberCommand {}
-
-#[derive(Clone, Default, Debug)]
-pub struct SerialNumber(pub(crate) String);
-
-impl Request for SerialNumberCommand {
-    const CATEGORY: Category = Category(0x00);
-
-    type Response = SerialNumber;
-
-    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
-        buffer[0] = 0x03;
-        Ok(1)
-    }
-
-    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
-        string_from_bytes(buffer, 0, &SerialNumber)
-    }
-}
-
-#[derive(Clone, Default, Debug)]
-struct FirmwareVersionCommand {}
-
-#[derive(Clone, Default, Debug)]
-pub struct FirmwareVersion(pub(crate) String);
-
-impl Request for FirmwareVersionCommand {
-    const CATEGORY: Category = Category(0x00);
-
-    type Response = FirmwareVersion;
-
-    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
-        buffer[0] = 0x04;
-        Ok(1)
-    }
-
-    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
-        string_from_bytes(buffer, 0, &FirmwareVersion)
-    }
-}
-
-#[derive(Clone, Default, Debug)]
-struct TargetDeviceVendorCommand {}
-
-#[derive(Clone, Default, Debug)]
-pub struct TargetDeviceVendor(pub(crate) String);
-
-impl Request for TargetDeviceVendorCommand {
-    const CATEGORY: Category = Category(0x00);
-
-    type Response = TargetDeviceVendor;
-
-    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
-        buffer[0] = 0x05;
-        Ok(1)
-    }
-    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
-        string_from_bytes(buffer, 0, &TargetDeviceVendor)
-    }
-}
-
-#[derive(Clone, Default, Debug)]
-struct TargetDeviceNameCommand {}
-
-#[derive(Clone, Default, Debug)]
-pub struct TargetDeviceName(pub(crate) String);
-
-impl Request for TargetDeviceNameCommand {
-    const CATEGORY: Category = Category(0x00);
-
-    type Response = TargetDeviceName;
-
-    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
-        buffer[0] = 0x06;
-        Ok(1)
-    }
-    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
-        string_from_bytes(buffer, 0, &TargetDeviceName)
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct CapabilitiesCommand {}
-
-#[derive(Copy, Clone, Debug)]
-pub struct Capabilities {
-    pub(crate) swd_implemented: bool,
-    pub(crate) jtag_implemented: bool,
-    pub(crate) swo_uart_implemented: bool,
-    pub(crate) swo_manchester_implemented: bool,
-    pub(crate) atomic_commands_implemented: bool,
-    pub(crate) test_domain_timer_implemented: bool,
-    pub(crate) swo_streaming_trace_implemented: bool,
-}
-
-impl Request for CapabilitiesCommand {
-    const CATEGORY: Category = Category(0x00);
-
-    type Response = Capabilities;
-
-    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
-        buffer[0] = 0xF0;
-        Ok(1)
-    }
-    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
-        // This response can contain two info bytes.
-        // In the docs only the first byte is described, so for now we always will only parse that specific byte.
-        if buffer[0] > 0 {
-            Ok(Capabilities {
-                swd_implemented: buffer[1] & 0x01 > 0,
-                jtag_implemented: buffer[1] & 0x02 > 0,
-                swo_uart_implemented: buffer[1] & 0x04 > 0,
-                swo_manchester_implemented: buffer[1] & 0x08 > 0,
-                atomic_commands_implemented: buffer[1] & 0x10 > 0,
-                test_domain_timer_implemented: buffer[1] & 0x20 > 0,
-                swo_streaming_trace_implemented: buffer[1] & 0x40 > 0,
-            })
-        } else {
-            Err(SendError::UnexpectedAnswer)
+            fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+                ParseFromResponse::from_response(buffer)
+            }
         }
-    }
+    };
 }
+
+info_command!(0x01, VendorCommand, Option<String>);
+
+info_command!(0x02, ProductIdCommand, Option<String>);
+
+info_command!(0x03, SerialNumberCommand, Option<String>);
+
+info_command!(0x04, FirmwareVersionCommand, Option<String>);
+
+info_command!(0x05, TargetDeviceVendorCommand, Option<String>);
+
+info_command!(0x06, TargetDeviceNameCommand, Option<String>);
+
+info_command!(0x07, TargetBoardVendorCommand, Option<String>);
+
+info_command!(0x08, TargetBoardNameCommand, Option<String>);
+
+info_command!(0xF0, CapabilitiesCommand, Capabilities);
 
 #[derive(Copy, Clone, Debug)]
 pub struct TestDomainTimeCommand {}
 
-#[derive(Copy, Clone, Debug)]
-pub struct TestDomainTime(pub(crate) u32);
-
 impl Request for TestDomainTimeCommand {
     const CATEGORY: Category = Category(0x00);
 
-    type Response = TestDomainTime;
+    type Response = u32;
 
     fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
         buffer[0] = 0xF1;
@@ -185,103 +57,108 @@ impl Request for TestDomainTimeCommand {
     fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
         if buffer[0] == 0x08 {
             let res = buffer.pread_with::<u32>(1, LE).unwrap();
-            Ok(TestDomainTime(res))
+            Ok(res)
         } else {
             Err(SendError::UnexpectedAnswer)
         }
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct SWOTraceBufferSizeCommand {}
+info_command!(0xFE, UartReceiveBufferSizeCommand, u32);
+info_command!(0xFC, UartTransmitBufferSizeCommand, u32);
+info_command!(0xFD, SWOTraceBufferSizeCommand, u32);
+info_command!(0xFE, PacketCountCommand, u8);
+info_command!(0xFF, PacketSizeCommand, u16);
 
-#[derive(Copy, Clone, Debug)]
-pub struct SWOTraceBufferSize(pub(crate) u32);
+trait ParseFromResponse: Sized {
+    fn from_response(buffer: &[u8]) -> Result<Self, SendError>;
+}
 
-impl Request for SWOTraceBufferSizeCommand {
-    const CATEGORY: Category = Category(0x00);
+impl ParseFromResponse for Option<String> {
+    /// Create a String out of the received buffer.
+    ///
+    /// The length of the buffer is read from the first byte of the buffer.
+    /// If the length is zero, no string is returned.
+    fn from_response(buffer: &[u8]) -> Result<Self, SendError> {
+        let string_len = buffer[0] as usize; // including the zero terminator
 
-    type Response = SWOTraceBufferSize;
-
-    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
-        buffer[0] = 0xFD;
-        Ok(1)
-    }
-    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
-        if buffer[0] == 0x04 {
-            let res = buffer.pread_with::<u32>(1, LE).unwrap();
-            Ok(SWOTraceBufferSize(res))
-        } else {
-            Err(SendError::UnexpectedAnswer)
+        match string_len {
+            0 => Ok(None),
+            n => {
+                let res = std::str::from_utf8(&buffer[1..1 + n])?;
+                Ok(Some(res.to_owned()))
+            }
         }
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct PacketCountCommand {}
-
-#[derive(Copy, Clone, Debug)]
-pub struct PacketCount(pub(crate) u8);
-
-impl Request for PacketCountCommand {
-    const CATEGORY: Category = Category(0x00);
-
-    type Response = PacketCount;
-
-    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
-        buffer[0] = 0xFE;
-        Ok(1)
-    }
-    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
-        if buffer[0] == 0x01 {
-            let res = buffer.pread_with::<u8>(1, LE).unwrap();
-            Ok(PacketCount(res))
-        } else {
+impl ParseFromResponse for u8 {
+    fn from_response(buffer: &[u8]) -> Result<Self, SendError> {
+        if buffer[0] != 1 {
             Err(SendError::UnexpectedAnswer)
+        } else {
+            Ok(buffer.pread_with(1, LE).unwrap())
         }
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct PacketSizeCommand {}
-
-#[derive(Copy, Clone, Debug)]
-pub struct PacketSize(pub(crate) u16);
-
-impl Request for PacketSizeCommand {
-    const CATEGORY: Category = Category(0x00);
-
-    type Response = PacketSize;
-
-    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
-        buffer[0] = 0xFF;
-        Ok(1)
-    }
-    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
-        if buffer[0] == 0x02 {
-            let res = buffer.pread_with::<u16>(1, LE).unwrap();
-            Ok(PacketSize(res))
-        } else {
+impl ParseFromResponse for u16 {
+    fn from_response(buffer: &[u8]) -> Result<Self, SendError> {
+        if buffer[0] != 2 {
             Err(SendError::UnexpectedAnswer)
+        } else {
+            Ok(buffer.pread_with(1, LE).unwrap())
         }
     }
 }
 
-/// Create a String out of the received buffer.
-///
-/// The length of the buffer is read from the buffer, at index offset.
-///
-fn string_from_bytes<R, F: Fn(String) -> R>(
-    buffer: &[u8],
-    offset: usize,
-    constructor: &F,
-) -> Result<R, SendError> {
-    let string_len = buffer[dbg!(offset)] as usize; // including the zero terminator
+impl ParseFromResponse for u32 {
+    fn from_response(buffer: &[u8]) -> Result<Self, SendError> {
+        if buffer[0] != 4 {
+            Err(SendError::UnexpectedAnswer)
+        } else {
+            Ok(buffer.pread_with(1, LE).unwrap())
+        }
+    }
+}
 
-    let string_start = offset + 1;
-    let string_end = string_start + string_len;
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Capabilities {
+    pub(crate) swd_implemented: bool,
+    pub(crate) jtag_implemented: bool,
+    pub(crate) swo_uart_implemented: bool,
+    pub(crate) swo_manchester_implemented: bool,
+    pub(crate) atomic_commands_implemented: bool,
+    pub(crate) test_domain_timer_implemented: bool,
+    pub(crate) swo_streaming_trace_implemented: bool,
+    pub(crate) uart_communication_port_implemented: bool,
+    pub(crate) uart_com_port_implemented: bool,
+}
 
-    let res = std::str::from_utf8(&buffer[string_start..string_end])
-        .expect("Unable to parse received string.");
-    Ok(constructor(res.to_owned()))
+impl ParseFromResponse for Capabilities {
+    fn from_response(buffer: &[u8]) -> Result<Self, SendError> {
+        // This response can contain two info bytes.
+        // In the docs only the first byte is described, so for now we always will only parse that specific byte.
+        if buffer[0] > 0 {
+            let mut capabilites = Capabilities {
+                swd_implemented: buffer[1] & 0x01 > 0,
+                jtag_implemented: buffer[1] & 0x02 > 0,
+                swo_uart_implemented: buffer[1] & 0x04 > 0,
+                swo_manchester_implemented: buffer[1] & 0x08 > 0,
+                atomic_commands_implemented: buffer[1] & 0x10 > 0,
+                test_domain_timer_implemented: buffer[1] & 0x20 > 0,
+                swo_streaming_trace_implemented: buffer[1] & 0x40 > 0,
+                uart_communication_port_implemented: buffer[1] & 0x80 > 0,
+                uart_com_port_implemented: false,
+            };
+
+            if buffer[0] >= 2 {
+                capabilites.uart_com_port_implemented = buffer[2] & (1 << 0) != 0
+            }
+
+            Ok(capabilites)
+        } else {
+            Err(SendError::UnexpectedAnswer)
+        }
+    }
 }

--- a/probe-rs/src/probe/cmsisdap/commands/general/info.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/info.rs
@@ -1,85 +1,132 @@
-use super::super::{Category, Request, Response, SendError};
+use super::super::{Category, Request, SendError};
 
 use scroll::{Pread, LE};
 
-#[allow(unused)]
-#[derive(Copy, Clone, Debug)]
-pub enum Command {
-    VendorID = 0x01,
-    ProductID = 0x02,
-    SerialNumber = 0x03,
-    FirmwareVersion = 0x04,
-    TargetDeviceVendor = 0x05,
-    TargetDeviceName = 0x06,
-    Capabilities = 0xF0,
-    TestDomainTimerParameter = 0xF1,
-    SWOTraceBufferSize = 0xFD,
-    PacketCount = 0xFE,
-    PacketSize = 0xFF,
-}
+#[derive(Clone, Default, Debug)]
+struct VendorCommand {}
 
-impl Request for Command {
+impl Request for VendorCommand {
     const CATEGORY: Category = Category(0x00);
 
+    type Response = VendorID;
+
     fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = *self as u8;
+        buffer[offset] = 0x01;
         Ok(1)
+    }
+
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
+        string_from_bytes(buffer, offset, &VendorID)
     }
 }
 
 #[derive(Clone, Default, Debug)]
 pub struct VendorID(pub(crate) String);
 
-impl Response for VendorID {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
-        string_from_bytes(buffer, offset, &VendorID)
-    }
-}
+#[derive(Clone, Default, Debug)]
+struct ProductIdCommand {}
 
 #[derive(Clone, Default, Debug)]
 pub struct ProductID(pub(crate) String);
 
-impl Response for ProductID {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
+impl Request for ProductIdCommand {
+    const CATEGORY: Category = Category(0x00);
+
+    type Response = ProductID;
+
+    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+        buffer[offset] = 0x02;
+        Ok(1)
+    }
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
         string_from_bytes(buffer, offset, &ProductID)
     }
 }
 
 #[derive(Clone, Default, Debug)]
+struct SerialNumberCommand {}
+
+#[derive(Clone, Default, Debug)]
 pub struct SerialNumber(pub(crate) String);
 
-impl Response for SerialNumber {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
+impl Request for SerialNumberCommand {
+    const CATEGORY: Category = Category(0x00);
+
+    type Response = SerialNumber;
+
+    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+        buffer[offset] = 0x03;
+        Ok(1)
+    }
+
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
         string_from_bytes(buffer, offset, &SerialNumber)
     }
 }
 
 #[derive(Clone, Default, Debug)]
+struct FirmwareVersionCommand {}
+
+#[derive(Clone, Default, Debug)]
 pub struct FirmwareVersion(pub(crate) String);
 
-impl Response for FirmwareVersion {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
+impl Request for FirmwareVersionCommand {
+    const CATEGORY: Category = Category(0x00);
+
+    type Response = FirmwareVersion;
+
+    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+        buffer[offset] = 0x04;
+        Ok(1)
+    }
+
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
         string_from_bytes(buffer, offset, &FirmwareVersion)
     }
 }
 
 #[derive(Clone, Default, Debug)]
+struct TargetDeviceVendorCommand {}
+
+#[derive(Clone, Default, Debug)]
 pub struct TargetDeviceVendor(pub(crate) String);
 
-impl Response for TargetDeviceVendor {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
+impl Request for TargetDeviceVendorCommand {
+    const CATEGORY: Category = Category(0x00);
+
+    type Response = TargetDeviceVendor;
+
+    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+        buffer[offset] = 0x05;
+        Ok(1)
+    }
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
         string_from_bytes(buffer, offset, &TargetDeviceVendor)
     }
 }
 
 #[derive(Clone, Default, Debug)]
+struct TargetDeviceNameCommand {}
+
+#[derive(Clone, Default, Debug)]
 pub struct TargetDeviceName(pub(crate) String);
 
-impl Response for TargetDeviceName {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
+impl Request for TargetDeviceNameCommand {
+    const CATEGORY: Category = Category(0x00);
+
+    type Response = TargetDeviceName;
+
+    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+        buffer[offset] = 0x06;
+        Ok(1)
+    }
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
         string_from_bytes(buffer, offset, &TargetDeviceName)
     }
 }
+
+#[derive(Copy, Clone, Debug)]
+pub struct CapabilitiesCommand {}
 
 #[derive(Copy, Clone, Debug)]
 pub struct Capabilities {
@@ -92,8 +139,16 @@ pub struct Capabilities {
     pub(crate) swo_streaming_trace_implemented: bool,
 }
 
-impl Response for Capabilities {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
+impl Request for CapabilitiesCommand {
+    const CATEGORY: Category = Category(0x00);
+
+    type Response = Capabilities;
+
+    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+        buffer[offset] = 0xF0;
+        Ok(1)
+    }
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
         // This response can contain two info bytes.
         // In the docs only the first byte is described, so for now we always will only parse that specific byte.
         if buffer[offset] > 0 {
@@ -113,14 +168,23 @@ impl Response for Capabilities {
 }
 
 #[derive(Copy, Clone, Debug)]
+pub struct TestDomainTimeCommand {}
+
+#[derive(Copy, Clone, Debug)]
 pub struct TestDomainTime(pub(crate) u32);
 
-impl Response for TestDomainTime {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
+impl Request for TestDomainTimeCommand {
+    const CATEGORY: Category = Category(0x00);
+
+    type Response = TestDomainTime;
+
+    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+        buffer[offset] = 0xF1;
+        Ok(1)
+    }
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
         if buffer[offset] == 0x08 {
-            let res = buffer
-                .pread_with::<u32>(offset + 1, LE)
-                .map_err(|_| SendError::Bug)?;
+            let res = buffer.pread_with::<u32>(offset + 1, LE).unwrap();
             Ok(TestDomainTime(res))
         } else {
             Err(SendError::UnexpectedAnswer)
@@ -129,14 +193,23 @@ impl Response for TestDomainTime {
 }
 
 #[derive(Copy, Clone, Debug)]
+pub struct SWOTraceBufferSizeCommand {}
+
+#[derive(Copy, Clone, Debug)]
 pub struct SWOTraceBufferSize(pub(crate) u32);
 
-impl Response for SWOTraceBufferSize {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
+impl Request for SWOTraceBufferSizeCommand {
+    const CATEGORY: Category = Category(0x00);
+
+    type Response = SWOTraceBufferSize;
+
+    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+        buffer[offset] = 0xFD;
+        Ok(1)
+    }
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
         if buffer[offset] == 0x04 {
-            let res = buffer
-                .pread_with::<u32>(offset + 1, LE)
-                .map_err(|_| SendError::Bug)?;
+            let res = buffer.pread_with::<u32>(offset + 1, LE).unwrap();
             Ok(SWOTraceBufferSize(res))
         } else {
             Err(SendError::UnexpectedAnswer)
@@ -145,14 +218,23 @@ impl Response for SWOTraceBufferSize {
 }
 
 #[derive(Copy, Clone, Debug)]
+pub struct PacketCountCommand {}
+
+#[derive(Copy, Clone, Debug)]
 pub struct PacketCount(pub(crate) u8);
 
-impl Response for PacketCount {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
+impl Request for PacketCountCommand {
+    const CATEGORY: Category = Category(0x00);
+
+    type Response = PacketCount;
+
+    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+        buffer[offset] = 0xFE;
+        Ok(1)
+    }
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
         if buffer[offset] == 0x01 {
-            let res = buffer
-                .pread_with::<u8>(offset + 1, LE)
-                .map_err(|_| SendError::Bug)?;
+            let res = buffer.pread_with::<u8>(offset + 1, LE).unwrap();
             Ok(PacketCount(res))
         } else {
             Err(SendError::UnexpectedAnswer)
@@ -161,14 +243,23 @@ impl Response for PacketCount {
 }
 
 #[derive(Copy, Clone, Debug)]
+pub struct PacketSizeCommand {}
+
+#[derive(Copy, Clone, Debug)]
 pub struct PacketSize(pub(crate) u16);
 
-impl Response for PacketSize {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
+impl Request for PacketSizeCommand {
+    const CATEGORY: Category = Category(0x00);
+
+    type Response = PacketSize;
+
+    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+        buffer[offset] = 0xFF;
+        Ok(1)
+    }
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
         if buffer[offset] == 0x02 {
-            let res = buffer
-                .pread_with::<u16>(offset + 1, LE)
-                .map_err(|_| SendError::Bug)?;
+            let res = buffer.pread_with::<u16>(offset + 1, LE).unwrap();
             Ok(PacketSize(res))
         } else {
             Err(SendError::UnexpectedAnswer)
@@ -190,6 +281,7 @@ fn string_from_bytes<R, F: Fn(String) -> R>(
     let string_start = offset + 1;
     let string_end = string_start + string_len;
 
-    let res = std::str::from_utf8(&buffer[string_start..string_end]).map_err(|_| SendError::Bug)?;
+    let res = std::str::from_utf8(&buffer[string_start..string_end])
+        .expect("Unable to parse received string.");
     Ok(constructor(res.to_owned()))
 }

--- a/probe-rs/src/probe/cmsisdap/commands/general/info.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/info.rs
@@ -10,13 +10,13 @@ impl Request for VendorCommand {
 
     type Response = VendorID;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = 0x01;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = 0x01;
         Ok(1)
     }
 
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        string_from_bytes(buffer, offset, &VendorID)
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        string_from_bytes(buffer, 0, &VendorID)
     }
 }
 
@@ -34,12 +34,12 @@ impl Request for ProductIdCommand {
 
     type Response = ProductID;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = 0x02;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = 0x02;
         Ok(1)
     }
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        string_from_bytes(buffer, offset, &ProductID)
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        string_from_bytes(buffer, 0, &ProductID)
     }
 }
 
@@ -54,13 +54,13 @@ impl Request for SerialNumberCommand {
 
     type Response = SerialNumber;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = 0x03;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = 0x03;
         Ok(1)
     }
 
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        string_from_bytes(buffer, offset, &SerialNumber)
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        string_from_bytes(buffer, 0, &SerialNumber)
     }
 }
 
@@ -75,13 +75,13 @@ impl Request for FirmwareVersionCommand {
 
     type Response = FirmwareVersion;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = 0x04;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = 0x04;
         Ok(1)
     }
 
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        string_from_bytes(buffer, offset, &FirmwareVersion)
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        string_from_bytes(buffer, 0, &FirmwareVersion)
     }
 }
 
@@ -96,12 +96,12 @@ impl Request for TargetDeviceVendorCommand {
 
     type Response = TargetDeviceVendor;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = 0x05;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = 0x05;
         Ok(1)
     }
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        string_from_bytes(buffer, offset, &TargetDeviceVendor)
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        string_from_bytes(buffer, 0, &TargetDeviceVendor)
     }
 }
 
@@ -116,12 +116,12 @@ impl Request for TargetDeviceNameCommand {
 
     type Response = TargetDeviceName;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = 0x06;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = 0x06;
         Ok(1)
     }
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        string_from_bytes(buffer, offset, &TargetDeviceName)
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        string_from_bytes(buffer, 0, &TargetDeviceName)
     }
 }
 
@@ -144,22 +144,22 @@ impl Request for CapabilitiesCommand {
 
     type Response = Capabilities;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = 0xF0;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = 0xF0;
         Ok(1)
     }
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
         // This response can contain two info bytes.
         // In the docs only the first byte is described, so for now we always will only parse that specific byte.
-        if buffer[offset] > 0 {
+        if buffer[0] > 0 {
             Ok(Capabilities {
-                swd_implemented: buffer[offset + 1] & 0x01 > 0,
-                jtag_implemented: buffer[offset + 1] & 0x02 > 0,
-                swo_uart_implemented: buffer[offset + 1] & 0x04 > 0,
-                swo_manchester_implemented: buffer[offset + 1] & 0x08 > 0,
-                atomic_commands_implemented: buffer[offset + 1] & 0x10 > 0,
-                test_domain_timer_implemented: buffer[offset + 1] & 0x20 > 0,
-                swo_streaming_trace_implemented: buffer[offset + 1] & 0x40 > 0,
+                swd_implemented: buffer[1] & 0x01 > 0,
+                jtag_implemented: buffer[1] & 0x02 > 0,
+                swo_uart_implemented: buffer[1] & 0x04 > 0,
+                swo_manchester_implemented: buffer[1] & 0x08 > 0,
+                atomic_commands_implemented: buffer[1] & 0x10 > 0,
+                test_domain_timer_implemented: buffer[1] & 0x20 > 0,
+                swo_streaming_trace_implemented: buffer[1] & 0x40 > 0,
             })
         } else {
             Err(SendError::UnexpectedAnswer)
@@ -178,13 +178,13 @@ impl Request for TestDomainTimeCommand {
 
     type Response = TestDomainTime;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = 0xF1;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = 0xF1;
         Ok(1)
     }
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        if buffer[offset] == 0x08 {
-            let res = buffer.pread_with::<u32>(offset + 1, LE).unwrap();
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        if buffer[0] == 0x08 {
+            let res = buffer.pread_with::<u32>(1, LE).unwrap();
             Ok(TestDomainTime(res))
         } else {
             Err(SendError::UnexpectedAnswer)
@@ -203,13 +203,13 @@ impl Request for SWOTraceBufferSizeCommand {
 
     type Response = SWOTraceBufferSize;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = 0xFD;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = 0xFD;
         Ok(1)
     }
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        if buffer[offset] == 0x04 {
-            let res = buffer.pread_with::<u32>(offset + 1, LE).unwrap();
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        if buffer[0] == 0x04 {
+            let res = buffer.pread_with::<u32>(1, LE).unwrap();
             Ok(SWOTraceBufferSize(res))
         } else {
             Err(SendError::UnexpectedAnswer)
@@ -228,13 +228,13 @@ impl Request for PacketCountCommand {
 
     type Response = PacketCount;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = 0xFE;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = 0xFE;
         Ok(1)
     }
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        if buffer[offset] == 0x01 {
-            let res = buffer.pread_with::<u8>(offset + 1, LE).unwrap();
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        if buffer[0] == 0x01 {
+            let res = buffer.pread_with::<u8>(1, LE).unwrap();
             Ok(PacketCount(res))
         } else {
             Err(SendError::UnexpectedAnswer)
@@ -253,13 +253,13 @@ impl Request for PacketSizeCommand {
 
     type Response = PacketSize;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = 0xFF;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = 0xFF;
         Ok(1)
     }
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        if buffer[offset] == 0x02 {
-            let res = buffer.pread_with::<u16>(offset + 1, LE).unwrap();
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        if buffer[0] == 0x02 {
+            let res = buffer.pread_with::<u16>(1, LE).unwrap();
             Ok(PacketSize(res))
         } else {
             Err(SendError::UnexpectedAnswer)

--- a/probe-rs/src/probe/cmsisdap/commands/general/reset.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/reset.rs
@@ -8,14 +8,14 @@ impl Request for ResetRequest {
 
     type Response = ResetResponse;
 
-    fn to_bytes(&self, _buffer: &mut [u8], _offset: usize) -> Result<usize, SendError> {
+    fn to_bytes(&self, _buffer: &mut [u8]) -> Result<usize, SendError> {
         Ok(0)
     }
 
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
         Ok(ResetResponse {
-            status: Status::from_byte(buffer[offset])?,
-            execute: Execute::from_byte(buffer[offset + 1])?,
+            status: Status::from_byte(buffer[0])?,
+            execute: Execute::from_byte(buffer[1])?,
         })
     }
 }

--- a/probe-rs/src/probe/cmsisdap/commands/general/reset.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/reset.rs
@@ -4,7 +4,7 @@ use super::super::{CommandId, Request, SendError, Status};
 pub struct ResetRequest;
 
 impl Request for ResetRequest {
-    const COMMAND_ID: CommandId = CommandId(0x0A);
+    const COMMAND_ID: CommandId = CommandId::ResetTarget;
 
     type Response = ResetResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/general/reset.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/reset.rs
@@ -1,10 +1,10 @@
-use super::super::{Category, Request, SendError, Status};
+use super::super::{CommandId, Request, SendError, Status};
 
 #[derive(Debug)]
 pub struct ResetRequest;
 
 impl Request for ResetRequest {
-    const CATEGORY: Category = Category(0x0A);
+    const COMMAND_ID: CommandId = CommandId(0x0A);
 
     type Response = ResetResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/general/reset.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/general/reset.rs
@@ -1,4 +1,4 @@
-use super::super::{Category, Request, Response, SendError, Status};
+use super::super::{Category, Request, SendError, Status};
 
 #[derive(Debug)]
 pub struct ResetRequest;
@@ -6,8 +6,17 @@ pub struct ResetRequest;
 impl Request for ResetRequest {
     const CATEGORY: Category = Category(0x0A);
 
+    type Response = ResetResponse;
+
     fn to_bytes(&self, _buffer: &mut [u8], _offset: usize) -> Result<usize, SendError> {
         Ok(0)
+    }
+
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
+        Ok(ResetResponse {
+            status: Status::from_byte(buffer[offset])?,
+            execute: Execute::from_byte(buffer[offset + 1])?,
+        })
     }
 }
 
@@ -32,13 +41,4 @@ impl Execute {
 pub(crate) struct ResetResponse {
     pub status: Status,
     pub execute: Execute,
-}
-
-impl Response for ResetResponse {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
-        Ok(ResetResponse {
-            status: Status::from_byte(buffer[offset])?,
-            execute: Execute::from_byte(buffer[offset + 1])?,
-        })
-    }
 }

--- a/probe-rs/src/probe/cmsisdap/commands/swd/configure.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swd/configure.rs
@@ -1,10 +1,10 @@
-use super::super::{Category, Request, SendError, Status};
+use super::super::{CommandId, Request, SendError, Status};
 
 #[derive(Debug)]
 pub struct ConfigureRequest;
 
 impl Request for ConfigureRequest {
-    const CATEGORY: Category = Category(0x13);
+    const COMMAND_ID: CommandId = CommandId(0x13);
 
     type Response = ConfigureResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/swd/configure.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swd/configure.rs
@@ -8,14 +8,14 @@ impl Request for ConfigureRequest {
 
     type Response = ConfigureResponse;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
         // TODO: Allow configuration
-        buffer[offset] = 0;
+        buffer[0] = 0;
         Ok(1)
     }
 
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        Ok(ConfigureResponse(Status::from_byte(buffer[offset])?))
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        Ok(ConfigureResponse(Status::from_byte(buffer[0])?))
     }
 }
 

--- a/probe-rs/src/probe/cmsisdap/commands/swd/configure.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swd/configure.rs
@@ -4,7 +4,7 @@ use super::super::{CommandId, Request, SendError, Status};
 pub struct ConfigureRequest;
 
 impl Request for ConfigureRequest {
-    const COMMAND_ID: CommandId = CommandId(0x13);
+    const COMMAND_ID: CommandId = CommandId::SwdConfigure;
 
     type Response = ConfigureResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/swd/configure.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swd/configure.rs
@@ -1,4 +1,4 @@
-use super::super::{Category, Request, Response, SendError, Status};
+use super::super::{Category, Request, SendError, Status};
 
 #[derive(Debug)]
 pub struct ConfigureRequest;
@@ -6,18 +6,18 @@ pub struct ConfigureRequest;
 impl Request for ConfigureRequest {
     const CATEGORY: Category = Category(0x13);
 
+    type Response = ConfigureResponse;
+
     fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
         // TODO: Allow configuration
         buffer[offset] = 0;
         Ok(1)
     }
+
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
+        Ok(ConfigureResponse(Status::from_byte(buffer[offset])?))
+    }
 }
 
 #[derive(Debug)]
 pub struct ConfigureResponse(pub(crate) Status);
-
-impl Response for ConfigureResponse {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
-        Ok(ConfigureResponse(Status::from_byte(buffer[offset])?))
-    }
-}

--- a/probe-rs/src/probe/cmsisdap/commands/swj/clock.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/clock.rs
@@ -8,15 +8,15 @@ impl Request for SWJClockRequest {
 
     type Response = SWJClockResponse;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
         use scroll::{Pwrite, LE};
 
-        buffer.pwrite_with(self.0, offset, LE).unwrap();
+        buffer.pwrite_with(self.0, 0, LE).unwrap();
         Ok(4)
     }
 
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        Ok(SWJClockResponse(Status::from_byte(buffer[offset])?))
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        Ok(SWJClockResponse(Status::from_byte(buffer[0])?))
     }
 }
 

--- a/probe-rs/src/probe/cmsisdap/commands/swj/clock.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/clock.rs
@@ -1,10 +1,10 @@
-use super::super::{Category, Request, SendError, Status};
+use super::super::{CommandId, Request, SendError, Status};
 
 #[derive(Debug)]
 pub struct SWJClockRequest(pub(crate) u32);
 
 impl Request for SWJClockRequest {
-    const CATEGORY: Category = Category(0x11);
+    const COMMAND_ID: CommandId = CommandId(0x11);
 
     type Response = SWJClockResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/swj/clock.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/clock.rs
@@ -4,14 +4,16 @@ use super::super::{CommandId, Request, SendError, Status};
 pub struct SWJClockRequest(pub(crate) u32);
 
 impl Request for SWJClockRequest {
-    const COMMAND_ID: CommandId = CommandId(0x11);
+    const COMMAND_ID: CommandId = CommandId::SwjClock;
 
     type Response = SWJClockResponse;
 
     fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
         use scroll::{Pwrite, LE};
 
-        buffer.pwrite_with(self.0, 0, LE).unwrap();
+        buffer
+            .pwrite_with(self.0, 0, LE)
+            .expect("Buffer for CMSIS-DAP command is too small. This is a bug, please report it.");
         Ok(4)
     }
 

--- a/probe-rs/src/probe/cmsisdap/commands/swj/clock.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/clock.rs
@@ -1,4 +1,4 @@
-use super::super::{Category, Request, Response, SendError, Status};
+use super::super::{Category, Request, SendError, Status};
 
 #[derive(Debug)]
 pub struct SWJClockRequest(pub(crate) u32);
@@ -6,21 +6,19 @@ pub struct SWJClockRequest(pub(crate) u32);
 impl Request for SWJClockRequest {
     const CATEGORY: Category = Category(0x11);
 
+    type Response = SWJClockResponse;
+
     fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
         use scroll::{Pwrite, LE};
 
-        buffer
-            .pwrite_with(self.0, offset, LE)
-            .map_err(|_| SendError::Bug)?;
+        buffer.pwrite_with(self.0, offset, LE).unwrap();
         Ok(4)
+    }
+
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
+        Ok(SWJClockResponse(Status::from_byte(buffer[offset])?))
     }
 }
 
 #[derive(Debug)]
 pub(crate) struct SWJClockResponse(pub(crate) Status);
-
-impl Response for SWJClockResponse {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
-        Ok(SWJClockResponse(Status::from_byte(buffer[offset])?))
-    }
-}

--- a/probe-rs/src/probe/cmsisdap/commands/swj/pins.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/pins.rs
@@ -1,4 +1,4 @@
-use super::super::{Category, Request, Response, SendError};
+use super::super::{Category, Request, SendError};
 
 pub struct SWJPinsRequest {
     /// A mask of the values the different pins selected in the selection mask will be set to.
@@ -114,6 +114,8 @@ bitfield::bitfield! {
 impl Request for SWJPinsRequest {
     const CATEGORY: Category = Category(0x10);
 
+    type Response = SWJPinsResponse;
+
     fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
         use scroll::{Pwrite, LE};
 
@@ -128,10 +130,8 @@ impl Request for SWJPinsRequest {
             .expect("This is a bug. Please report it.");
         Ok(6)
     }
-}
 
-impl Response for Pins {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
         Ok(Pins(buffer[offset]))
     }
 }

--- a/probe-rs/src/probe/cmsisdap/commands/swj/pins.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/pins.rs
@@ -112,7 +112,7 @@ bitfield::bitfield! {
 }
 
 impl Request for SWJPinsRequest {
-    const COMMAND_ID: CommandId = CommandId(0x10);
+    const COMMAND_ID: CommandId = CommandId::SwjPins;
 
     type Response = SWJPinsResponse;
 
@@ -121,13 +121,13 @@ impl Request for SWJPinsRequest {
 
         buffer
             .pwrite_with(self.output.0, 0, LE)
-            .expect("This is a bug. Please report it.");
+            .expect("Buffer for CMSIS-DAP command is too small. This is a bug, please report it.");
         buffer
             .pwrite_with(self.select.0, 1, LE)
-            .expect("This is a bug. Please report it.");
+            .expect("Buffer for CMSIS-DAP command is too small. This is a bug, please report it.");
         buffer
             .pwrite_with(self.wait, 2, LE)
-            .expect("This is a bug. Please report it.");
+            .expect("Buffer for CMSIS-DAP command is too small. This is a bug, please report it.");
         Ok(6)
     }
 

--- a/probe-rs/src/probe/cmsisdap/commands/swj/pins.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/pins.rs
@@ -116,23 +116,23 @@ impl Request for SWJPinsRequest {
 
     type Response = SWJPinsResponse;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
         use scroll::{Pwrite, LE};
 
         buffer
-            .pwrite_with(self.output.0, offset, LE)
+            .pwrite_with(self.output.0, 0, LE)
             .expect("This is a bug. Please report it.");
         buffer
-            .pwrite_with(self.select.0, offset + 1, LE)
+            .pwrite_with(self.select.0, 1, LE)
             .expect("This is a bug. Please report it.");
         buffer
-            .pwrite_with(self.wait, offset + 2, LE)
+            .pwrite_with(self.wait, 2, LE)
             .expect("This is a bug. Please report it.");
         Ok(6)
     }
 
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        Ok(Pins(buffer[offset]))
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        Ok(Pins(buffer[0]))
     }
 }
 

--- a/probe-rs/src/probe/cmsisdap/commands/swj/pins.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/pins.rs
@@ -1,4 +1,4 @@
-use super::super::{Category, Request, SendError};
+use super::super::{CommandId, Request, SendError};
 
 pub struct SWJPinsRequest {
     /// A mask of the values the different pins selected in the selection mask will be set to.
@@ -112,7 +112,7 @@ bitfield::bitfield! {
 }
 
 impl Request for SWJPinsRequest {
-    const CATEGORY: Category = Category(0x10);
+    const COMMAND_ID: CommandId = CommandId(0x10);
 
     type Response = SWJPinsResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/swj/sequence.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/sequence.rs
@@ -9,7 +9,7 @@ pub struct SequenceRequest {
 }
 
 impl Request for SequenceRequest {
-    const COMMAND_ID: CommandId = CommandId(0x12);
+    const COMMAND_ID: CommandId = CommandId::SwjSequence;
 
     type Response = SequenceResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/swj/sequence.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/sequence.rs
@@ -1,6 +1,6 @@
 /// Implementation of the DAP_SWJ_SEQUENCE command
 ///
-use super::super::{Category, CmsisDapError, Request, Response, SendError, Status};
+use super::super::{Category, CmsisDapError, Request, SendError, Status};
 
 #[derive(Clone, Copy, Debug)]
 pub struct SequenceRequest {
@@ -10,6 +10,8 @@ pub struct SequenceRequest {
 
 impl Request for SequenceRequest {
     const CATEGORY: Category = Category(0x12);
+
+    type Response = SequenceResponse;
 
     fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
         buffer[offset] = self.bit_count;
@@ -31,6 +33,10 @@ impl Request for SequenceRequest {
 
         // bit_count + data
         Ok(1 + transfer_len_bytes)
+    }
+
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
+        Ok(SequenceResponse(Status::from_byte(buffer[offset])?))
     }
 }
 
@@ -58,9 +64,3 @@ impl SequenceRequest {
 
 #[derive(Debug)]
 pub struct SequenceResponse(pub(crate) Status);
-
-impl Response for SequenceResponse {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
-        Ok(SequenceResponse(Status::from_byte(buffer[offset])?))
-    }
-}

--- a/probe-rs/src/probe/cmsisdap/commands/swj/sequence.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/sequence.rs
@@ -13,8 +13,8 @@ impl Request for SequenceRequest {
 
     type Response = SequenceResponse;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
-        buffer[offset] = self.bit_count;
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
+        buffer[0] = self.bit_count;
 
         // calculate transfer len in bytes
         // A bit_count of zero means that we want to transmit 256 bits
@@ -28,15 +28,14 @@ impl Request for SequenceRequest {
             transfer_len_bytes += 1;
         }
 
-        buffer[(offset + 1)..(offset + 1 + transfer_len_bytes)]
-            .copy_from_slice(&self.data[..transfer_len_bytes]);
+        buffer[1..(1 + transfer_len_bytes)].copy_from_slice(&self.data[..transfer_len_bytes]);
 
         // bit_count + data
         Ok(1 + transfer_len_bytes)
     }
 
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        Ok(SequenceResponse(Status::from_byte(buffer[offset])?))
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        Ok(SequenceResponse(Status::from_byte(buffer[0])?))
     }
 }
 

--- a/probe-rs/src/probe/cmsisdap/commands/swj/sequence.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swj/sequence.rs
@@ -1,6 +1,6 @@
 /// Implementation of the DAP_SWJ_SEQUENCE command
 ///
-use super::super::{Category, CmsisDapError, Request, SendError, Status};
+use super::super::{CmsisDapError, CommandId, Request, SendError, Status};
 
 #[derive(Clone, Copy, Debug)]
 pub struct SequenceRequest {
@@ -9,7 +9,7 @@ pub struct SequenceRequest {
 }
 
 impl Request for SequenceRequest {
-    const CATEGORY: Category = Category(0x12);
+    const COMMAND_ID: CommandId = CommandId(0x12);
 
     type Response = SequenceResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/swo.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swo.rs
@@ -1,6 +1,6 @@
 use scroll::{Pread, LE};
 
-use super::{Category, Request, SendError, Status};
+use super::{CommandId, Request, SendError, Status};
 use std::convert::TryInto;
 
 #[repr(u8)]
@@ -13,7 +13,7 @@ pub enum TransportRequest {
 }
 
 impl Request for TransportRequest {
-    const CATEGORY: Category = Category(0x17);
+    const COMMAND_ID: CommandId = CommandId(0x17);
 
     type Response = TransportResponse;
 
@@ -40,7 +40,7 @@ pub enum ModeRequest {
 }
 
 impl Request for ModeRequest {
-    const CATEGORY: Category = Category(0x18);
+    const COMMAND_ID: CommandId = CommandId(0x18);
 
     type Response = ModeResponse;
 
@@ -61,7 +61,7 @@ pub struct ModeResponse(pub(crate) Status);
 pub struct BaudrateRequest(pub(crate) u32);
 
 impl Request for BaudrateRequest {
-    const CATEGORY: Category = Category(0x19);
+    const COMMAND_ID: CommandId = CommandId(0x19);
 
     type Response = u32;
 
@@ -90,7 +90,7 @@ pub enum ControlRequest {
 }
 
 impl Request for ControlRequest {
-    const CATEGORY: Category = Category(0x1a);
+    const COMMAND_ID: CommandId = CommandId(0x1a);
 
     type Response = ControlResponse;
 
@@ -111,7 +111,7 @@ pub struct ControlResponse(pub(crate) Status);
 pub struct StatusRequest;
 
 impl Request for StatusRequest {
-    const CATEGORY: Category = Category(0x1b);
+    const COMMAND_ID: CommandId = CommandId(0x1b);
 
     type Response = StatusResponse;
 
@@ -161,7 +161,7 @@ pub struct ExtendedStatusRequest {
 }
 
 impl Request for ExtendedStatusRequest {
-    const CATEGORY: Category = Category(0x1e);
+    const COMMAND_ID: CommandId = CommandId(0x1e);
 
     type Response = ExtendedStatusResponse;
 
@@ -217,7 +217,7 @@ pub struct DataRequest {
 }
 
 impl Request for DataRequest {
-    const CATEGORY: Category = Category(0x1c);
+    const COMMAND_ID: CommandId = CommandId(0x1c);
 
     type Response = DataResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/swo.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swo.rs
@@ -187,17 +187,17 @@ impl Request for ExtendedStatusRequest {
         let count = u32::from_le_bytes(
             buffer[1..5]
                 .try_into()
-                .expect("This is a bug. Please report it."),
+                .map_err(|_| SendError::NotEnoughData)?,
         );
         let index = u32::from_le_bytes(
             buffer[5..9]
                 .try_into()
-                .expect("This is a bug. Please report it."),
+                .map_err(|_| SendError::NotEnoughData)?,
         );
         let timestamp = u32::from_le_bytes(
             buffer[9..13]
                 .try_into()
-                .expect("This is a bug. Please report it."),
+                .map_err(|_| SendError::NotEnoughData)?,
         );
         Ok(ExtendedStatusResponse {
             status,

--- a/probe-rs/src/probe/cmsisdap/commands/swo.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/swo.rs
@@ -63,7 +63,7 @@ pub struct BaudrateRequest(pub(crate) u32);
 impl Request for BaudrateRequest {
     const CATEGORY: Category = Category(0x19);
 
-    type Response = BaudrateResponse;
+    type Response = u32;
 
     fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
         assert!(buffer.len() >= 4, "This is a bug. Please report it.");
@@ -78,12 +78,9 @@ impl Request for BaudrateRequest {
 
         let baud: u32 = buffer.pread_with(0, LE).unwrap();
 
-        Ok(BaudrateResponse(baud))
+        Ok(baud)
     }
 }
-
-#[derive(Copy, Clone, Debug)]
-pub struct BaudrateResponse(pub(crate) u32);
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/configure.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/configure.rs
@@ -1,4 +1,4 @@
-use super::super::{Category, Request, Response, SendError, Status};
+use super::super::{Category, Request, SendError, Status};
 
 /// The DAP_TransferConfigure Command sets parameters for DAP_Transfer and DAP_TransferBlock.
 #[derive(Debug)]
@@ -14,25 +14,23 @@ pub struct ConfigureRequest {
 impl Request for ConfigureRequest {
     const CATEGORY: Category = Category(0x04);
 
+    type Response = ConfigureResponse;
+
     fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
         use scroll::{Pwrite, LE};
 
         buffer[offset] = self.idle_cycles;
-        buffer
-            .pwrite_with(self.wait_retry, offset + 1, LE)
-            .map_err(|_| SendError::Bug)?;
+        buffer.pwrite_with(self.wait_retry, offset + 1, LE).unwrap();
         buffer
             .pwrite_with(self.match_retry, offset + 3, LE)
-            .map_err(|_| SendError::Bug)?;
+            .unwrap();
         Ok(5)
+    }
+
+    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
+        Ok(ConfigureResponse(Status::from_byte(buffer[offset])?))
     }
 }
 
 #[derive(Debug)]
 pub struct ConfigureResponse(pub(crate) Status);
-
-impl Response for ConfigureResponse {
-    fn from_bytes(buffer: &[u8], offset: usize) -> Result<Self, SendError> {
-        Ok(ConfigureResponse(Status::from_byte(buffer[offset])?))
-    }
-}

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/configure.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/configure.rs
@@ -12,7 +12,7 @@ pub struct ConfigureRequest {
 }
 
 impl Request for ConfigureRequest {
-    const COMMAND_ID: CommandId = CommandId(0x04);
+    const COMMAND_ID: CommandId = CommandId::TransferConfigure;
 
     type Response = ConfigureResponse;
 
@@ -20,8 +20,12 @@ impl Request for ConfigureRequest {
         use scroll::{Pwrite, LE};
 
         buffer[0] = self.idle_cycles;
-        buffer.pwrite_with(self.wait_retry, 1, LE).unwrap();
-        buffer.pwrite_with(self.match_retry, 3, LE).unwrap();
+        buffer
+            .pwrite_with(self.wait_retry, 1, LE)
+            .expect("This is a bug. Please report it.");
+        buffer
+            .pwrite_with(self.match_retry, 3, LE)
+            .expect("This is a bug. Please report it.");
         Ok(5)
     }
 

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/configure.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/configure.rs
@@ -16,19 +16,17 @@ impl Request for ConfigureRequest {
 
     type Response = ConfigureResponse;
 
-    fn to_bytes(&self, buffer: &mut [u8], offset: usize) -> Result<usize, SendError> {
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, SendError> {
         use scroll::{Pwrite, LE};
 
-        buffer[offset] = self.idle_cycles;
-        buffer.pwrite_with(self.wait_retry, offset + 1, LE).unwrap();
-        buffer
-            .pwrite_with(self.match_retry, offset + 3, LE)
-            .unwrap();
+        buffer[0] = self.idle_cycles;
+        buffer.pwrite_with(self.wait_retry, 1, LE).unwrap();
+        buffer.pwrite_with(self.match_retry, 3, LE).unwrap();
         Ok(5)
     }
 
-    fn from_bytes(&self, buffer: &[u8], offset: usize) -> Result<Self::Response, SendError> {
-        Ok(ConfigureResponse(Status::from_byte(buffer[offset])?))
+    fn from_bytes(&self, buffer: &[u8]) -> Result<Self::Response, SendError> {
+        Ok(ConfigureResponse(Status::from_byte(buffer[0])?))
     }
 }
 

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/configure.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/configure.rs
@@ -1,4 +1,4 @@
-use super::super::{Category, Request, SendError, Status};
+use super::super::{CommandId, Request, SendError, Status};
 
 /// The DAP_TransferConfigure Command sets parameters for DAP_Transfer and DAP_TransferBlock.
 #[derive(Debug)]
@@ -12,7 +12,7 @@ pub struct ConfigureRequest {
 }
 
 impl Request for ConfigureRequest {
-    const CATEGORY: Category = Category(0x04);
+    const COMMAND_ID: CommandId = CommandId(0x04);
 
     type Response = ConfigureResponse;
 

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
@@ -1,6 +1,6 @@
 pub mod configure;
 
-use super::{Category, Request, SendError};
+use super::{CommandId, Request, SendError};
 use crate::architecture::arm::PortType;
 use scroll::{Pread, Pwrite, LE};
 
@@ -104,7 +104,7 @@ impl TransferRequest {
 }
 
 impl Request for TransferRequest {
-    const CATEGORY: Category = Category(0x05);
+    const COMMAND_ID: CommandId = CommandId(0x05);
 
     type Response = TransferResponse;
 
@@ -206,7 +206,7 @@ pub(crate) struct TransferBlockRequest {
 }
 
 impl Request for TransferBlockRequest {
-    const CATEGORY: Category = Category(0x06);
+    const COMMAND_ID: CommandId = CommandId(0x06);
 
     type Response = TransferBlockResponse;
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -39,18 +39,12 @@ use commands::{
         Ack, InnerTransferRequest, TransferBlockRequest, TransferBlockResponse, TransferRequest,
         RW,
     },
-    CmsisDapDevice, SendError, Status,
+    CmsisDapDevice, Status,
 };
 
 use log::{debug, warn};
 
 use std::time::Duration;
-
-impl From<SendError> for DebugProbeError {
-    fn from(e: SendError) -> Self {
-        Self::from(CmsisDapError::from(e))
-    }
-}
 
 pub struct CmsisDap {
     pub device: CmsisDapDevice,


### PR DESCRIPTION
## Bug fixing
 Because the response length is now handled properly, we need to fix parsing the response to transfer requests.
 Only read responses return data, so we need to take this into account, otherwise parsing fails.

## Refactoring
- Remove use of offset in CMSIS-DAP code, use slices instead
- cmsis-dap: Cleanup info command implementation, add info commands and caps for UART
- cmsis-dap: Rename category to command_id to clarify meaning
- Further cleanup, use enum for Command ID
