### PR TITLE
Use shared options in cli

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ ftdi = ["probe-rs/ftdi"]
 
 [dependencies]
 probe-rs = { path = "../probe-rs", version = "0.11.0" }
+probe-rs-cli-util = { path = "../probe-rs-cli-util", version = "0.11.0" }
 
 pretty_env_logger = "0.4.0"
 log = "0.4.6"

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -1,11 +1,6 @@
-use crate::SharedOptions;
-
 use probe_rs::{
-    architecture::arm::ap::AccessPortError, config::TargetSelector, flashing::FileDownloadError,
-    DebugProbeError, Error, Probe, Session,
+    architecture::arm::ap::AccessPortError, flashing::FileDownloadError, DebugProbeError, Error,
 };
-
-use anyhow::Result;
 
 #[derive(Debug, thiserror::Error)]
 pub enum CliError {
@@ -25,68 +20,6 @@ pub enum CliError {
         argument: String,
         source: anyhow::Error,
     },
-    #[error("Unable to open probe{}", .0.map(|s| format!(": {}", s)).as_deref().unwrap_or("."))]
-    UnableToOpenProbe(Option<&'static str>),
     #[error(transparent)]
     ProbeRs(#[from] Error),
-}
-
-pub(crate) fn open_probe(index: Option<usize>) -> Result<Probe, CliError> {
-    let available_probes = Probe::list_all();
-
-    let device = match index {
-        Some(index) => available_probes
-            .get(index)
-            .ok_or(CliError::UnableToOpenProbe(Some("Unable to open the specified probe. Use the 'list' subcommand to see all available probes.")))?,
-        None => {
-            // open the default probe, if only one probe was found
-            match available_probes.len() {
-                0 => return Err(CliError::UnableToOpenProbe(Some("No probe detected."))),
-                1 => &available_probes[0],
-                _ => return Err(CliError::UnableToOpenProbe(Some("Multiple probes found. Please specify which probe to use using the -n parameter."))),
-            }
-        }
-    };
-
-    let probe = device.open()?;
-    Ok(probe)
-}
-
-/// Takes a closure that is handed an `DAPLink` instance and then executed.
-/// After the closure is done, the USB device is always closed,
-/// even in an error case inside the closure!
-pub(crate) fn with_device<F>(shared_options: &SharedOptions, f: F) -> Result<()>
-where
-    F: FnOnce(Session) -> Result<()>,
-{
-    let mut probe = open_probe(shared_options.n)?;
-
-    let target_selector = match &shared_options.chip {
-        Some(identifier) => identifier.into(),
-        None => TargetSelector::Auto,
-    };
-
-    if let Some(protocol) = shared_options.protocol {
-        probe.select_protocol(protocol)?;
-    }
-
-    if let Some(speed) = shared_options.speed {
-        let actual_speed = probe.set_speed(speed)?;
-
-        if actual_speed != speed {
-            log::warn!(
-                "Protocol speed {} kHz not supported, actual speed is {} kHz",
-                speed,
-                actual_speed
-            );
-        }
-    }
-
-    let session = if shared_options.connect_under_reset {
-        probe.attach_under_reset(target_selector)?
-    } else {
-        probe.attach(target_selector)?
-    };
-
-    f(session)
 }

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -1,5 +1,3 @@
-use crate::{common::open_probe, SharedOptions};
-
 use probe_rs::{
     architecture::{
         arm::{
@@ -14,11 +12,12 @@ use probe_rs::{
 };
 
 use anyhow::Result;
+use probe_rs_cli_util::common_options::ProbeOptions;
 
-pub(crate) fn show_info_of_device(shared_options: &SharedOptions) -> Result<()> {
-    let mut probe = open_probe(shared_options.n)?;
+pub(crate) fn show_info_of_device(common: &ProbeOptions) -> Result<()> {
+    let mut probe = common.attach_probe()?;
 
-    let protocols = if let Some(protocol) = shared_options.protocol {
+    let protocols = if let Some(protocol) = common.protocol {
         vec![protocol]
     } else {
         vec![WireProtocol::Jtag, WireProtocol::Swd]

--- a/probe-rs-cli-util/src/common_options.rs
+++ b/probe-rs-cli-util/src/common_options.rs
@@ -142,8 +142,8 @@ pub struct ProbeOptions {
     pub chip: Option<String>,
     #[structopt(name = "chip description file path", long = "chip-description-path")]
     pub chip_description_path: Option<PathBuf>,
-    #[structopt(name = "protocol", long = "protocol", default_value = "swd")]
-    pub protocol: WireProtocol,
+    #[structopt(name = "protocol", long = "protocol")]
+    pub protocol: Option<WireProtocol>,
     #[structopt(
         long = "probe",
         help = "Use this flag to select a specific probe in the list.\n\
@@ -237,13 +237,16 @@ impl ProbeOptions {
             }
         }?;
 
-        // Select protocol and speed
-        probe.select_protocol(self.protocol).map_err(|error| {
-            OperationError::FailedToSelectProtocol {
-                source: error,
-                protocol: self.protocol,
-            }
-        })?;
+        if let Some(protocol) = self.protocol {
+            // Select protocol and speed
+            probe.select_protocol(protocol).map_err(|error| {
+                OperationError::FailedToSelectProtocol {
+                    source: error,
+                    protocol,
+                }
+            })?;
+        }
+
         if let Some(speed) = self.speed {
             let _actual_speed = probe.set_speed(speed).map_err(|error| {
                 OperationError::FailedToSelectProtocolSpeed {


### PR DESCRIPTION
Use the new shared options in the `probe-rs-cli`.

@tmplt: I would like to change `ProbeOptions::protocol` into an `Option`, instead of using `SWD` as the default value. There are probes which only support JTAG, so it's better to not choose any protocol if nothing is specified. Otherwise users of these probes are forced to always specify `--protocol=jtag`. Is that OK for you?