### PR TITLE
Fix errors introduced into the debugger by new flashing algorithms and error improvements

### DIFF
--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -55,7 +55,7 @@ pub enum FileDownloadError {
     /// An error with the actual flashing procedure has occured.
     ///
     /// This is mostly an error in the communication with the target inflicted by a bad hardware connection or a probe-rs bug.
-    #[error("Error while flashing")]
+    #[error(transparent)]
     Flash(#[from] FlashError),
     /// Reading and decoding the IHEX file has failed due to the given error.
     #[error("Could not read ihex format")]

--- a/probe-rs/targets/STM32H7_Series.yaml
+++ b/probe-rs/targets/STM32H7_Series.yaml
@@ -760,7 +760,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H745BITx
     cores:
       - name: main
@@ -783,7 +782,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H745IGKx
     cores:
@@ -808,7 +806,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H745IGTx
     cores:
       - name: main
@@ -831,7 +828,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H745IIKx
     cores:
@@ -856,7 +852,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H745IITx
     cores:
       - name: main
@@ -879,7 +874,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H745XGHx
     cores:
@@ -904,7 +898,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H745XIHx
     cores:
       - name: main
@@ -927,7 +920,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H745ZGTx
     cores:
@@ -952,7 +944,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H745ZITx
     cores:
       - name: main
@@ -975,7 +966,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H747AGIx
     cores:
@@ -1000,7 +990,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H747AIIx
     cores:
       - name: main
@@ -1023,7 +1012,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H747BGTx
     cores:
@@ -1048,7 +1036,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H747BITx
     cores:
       - name: main
@@ -1071,7 +1058,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H747IGTx
     cores:
@@ -1096,7 +1082,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H747IITx
     cores:
       - name: main
@@ -1119,7 +1104,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H747XGHx
     cores:
@@ -1144,7 +1128,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H747XIHx
     cores:
       - name: main
@@ -1168,7 +1151,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H747ZIYx
     cores:
       - name: main
@@ -1191,7 +1173,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H750IBKx
     cores:
@@ -1515,7 +1496,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H755IIKx
     cores:
       - name: main
@@ -1538,7 +1518,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H755IITx
     cores:
@@ -1563,7 +1542,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H755XIHx
     cores:
       - name: main
@@ -1586,7 +1564,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H755ZITx
     cores:
@@ -1611,7 +1588,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H757AIIx
     cores:
       - name: main
@@ -1634,7 +1610,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H757BITx
     cores:
@@ -1659,7 +1634,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H757IITx
     cores:
       - name: main
@@ -1682,7 +1656,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H757XIHx
     cores:
@@ -1707,7 +1680,6 @@ variants:
           cores: [main]
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
   - name: STM32H757ZIYx
     cores:
       - name: main
@@ -1730,7 +1702,6 @@ variants:
           is_boot_memory: true
           cores: [main]
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
   - name: STM32H7A3AGIxQ
     cores:


### PR DESCRIPTION
Since the latest rebase from master, the `probe-rs-debugger` fails for me with an error: 
```
Trying to write flash, but found more than one suitable flash loader algorithim marked as default for NvmRegion { range: 134217728..136314880, is_boot_memory: true, cores: ["main"] }.
```
The RUST_LOG=debug shows that it finds two identical flash algorithms. 
```
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::download] Found loadable segment, physical address: 0x08000000, virtual address: 0x08000000, flags: 0x4
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::download] Matching section: ".vector_table"
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::download] Found loadable segment, physical address: 0x08000298, virtual address: 0x08000298, flags: 0x5
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::download] Matching section: ".text"
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::download] Found loadable segment, physical address: 0x0800f9b4, virtual address: 0x0800f9b4, flags: 0x4
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::download] Matching section: ".rodata"
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::download] Found loadable segment, physical address: 0x0801145c, virtual address: 0x20000000, flags: 0x6
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::download] Matching section: ".data"
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::loader] Found 4 loadable sections:
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::loader]     .vector_table at 08000000 (664 bytes)
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::loader]     .text at 08000298 (63260 bytes)
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::loader]     .rodata at 0800F9B4 (6824 bytes)
[2021-07-29T18:50:16Z INFO  probe_rs::flashing::loader]     .data at 0801145C (64 bytes)
[2021-07-29T18:50:16Z DEBUG probe_rs::flashing::loader] committing FlashLoader!
[2021-07-29T18:50:16Z DEBUG probe_rs::flashing::loader] Contents of builder:
[2021-07-29T18:50:16Z DEBUG probe_rs::flashing::loader]     data: 08000000-0801149c (70812 bytes)
[2021-07-29T18:50:16Z DEBUG probe_rs::flashing::loader] Flash algorithms:
[2021-07-29T18:50:16Z DEBUG probe_rs::flashing::loader]     algo stm32h7x_2048: 08000000-08200000 (2097152 bytes)
[2021-07-29T18:50:16Z DEBUG probe_rs::flashing::loader]     algo stm32h7x_2048: 08000000-08200000 (2097152 bytes)
[2021-07-29T18:50:16Z DEBUG probe_rs::flashing::loader] Regions:
[2021-07-29T18:50:16Z DEBUG probe_rs::flashing::loader]     region: 08000000-08200000 (2097152 bytes)
```
 