### PR TITLE
cargo: bump bitvec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support batching of FTDI commands and use it for RISCV (#717)
 - Include the chip string for `NoRamDefined` in its error message
 - Improved handling of errors in CMSIS-DAP commands (#745).
+- Bumped `bitvec` dependency from 0.19.4 to 0.22.
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = "1.0.31"
 base64 = "0.13.0"
 bincode = "1.3.2"
 bitfield = "0.13.2"
-bitvec = "0.19.4"
+bitvec = "0.22"
 enum-primitive-derive = "0.2.1"
 gimli = { version = "0.25.0", default-features = false, features = ["endian-reader", "read", "std"] }
 hidapi = { version = "1.2.0", default-features = false, features = ["linux-static-hidraw"] }


### PR DESCRIPTION
If a downstream crate depends on bitvec 0.22 and probe-rs 0.19, bitvec
0.19 (and thus probe-rs) will fail to build.