### PR TITLE
arm: enable exception trace on setup_swv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Target Support
 
 ### Changed
-- Enabled the generation of global timestamps for ARM targets on `Session::setup_swv`.
+- Enabled the generation of global timestamps and exception traces for ARM targets on `Session::setup_swv`.
 - Changed to `hidraw` for HID access on Linux. This should allow access to HID-based probes without udev rules (#737).
 - Support batching of FTDI commands and use it for RISCV (#717)
 - Include the chip string for `NoRamDefined` in its error message

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -92,6 +92,7 @@ pub fn setup_swv(
     // Configure DWT
     let mut dwt = Dwt::new(core, find_component(components, PeripheralType::Dwt)?);
     dwt.enable()?;
+    dwt.enable_exception_trace()?;
 
     core.flush()
 }


### PR DESCRIPTION
Later down the line some option struct would be helpful for the SWV/ITM API.