### PR TITLE
Rename ARM CoreTypes from CortexMxx to ArmvXm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include the chip string for `NoRamDefined` in its error message
 - Improved handling of errors in CMSIS-DAP commands (#745).
 - Bumped dependencies `bitvec 0.19.4`to `bitvec 0.22`, `nom 6.0.0` to `nom 7.0.0-alpha1`. (#756)
-
 - `DebugProbeError::CommandNotSupportedByProbe` now holds a name string of the unsupported command.
+- Target YAMLs: Renamed `core.type` values from `M0, M4, etc` to `armv6m`, `armv7m`, `armv8m`.
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -2,7 +2,7 @@ use crate::common::CliError;
 
 use capstone::Capstone;
 use num_traits::Num;
-use probe_rs::architecture::arm::CortexDump;
+use probe_rs::architecture::arm::Dump;
 use probe_rs::debug::DebugInfo;
 use probe_rs::{Core, CoreRegisterAddress, MemoryInterface};
 
@@ -319,7 +319,7 @@ impl DebugCli {
 
                 cli_data.core.read_8(stack_bot, &mut stack[..])?;
 
-                let mut dump = CortexDump::new(stack_bot, stack);
+                let mut dump = Dump::new(stack_bot, stack);
 
                 for i in 0..12 {
                     dump.regs[i as usize] =

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -2,7 +2,7 @@ use probe_rs::{
     architecture::{
         arm::{
             ap::{GenericAp, MemoryAp},
-            m0::Demcr,
+            armv6m::Demcr,
             memory::Component,
             sequences::DefaultArmSequence,
             ApAddress, ApInformation, ArmProbeInterface, DpAddress, MemoryApInformation,

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -293,7 +293,7 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
 
         // core_data.target_core.read_8(stack_bot, &mut stack[..])?;
 
-        // let mut dump = CortexDump::new(stack_bot, stack);
+        // let mut dump = Dump::new(stack_bot, stack);
 
         // for i in 0..12 {
         //     dump.regs[i as usize] = core_data

--- a/debugger/src/info.rs
+++ b/debugger/src/info.rs
@@ -4,7 +4,7 @@ use probe_rs::{
     architecture::{
         arm::{
             ap::{GenericAp, MemoryAp},
-            m0::Demcr,
+            armv6m::Demcr,
             memory::Component,
             sequences::DefaultArmSequence,
             ApAddress, ApInformation, ArmProbeInterface, DpAddress, MemoryApInformation,

--- a/gdb-server/src/architecture.rs
+++ b/gdb-server/src/architecture.rs
@@ -143,11 +143,10 @@ impl GdbTargetExt for probe_rs::Target {
 
         // TODO: what if they're not all equal?
         let architecture = match self.cores[0].core_type {
-            CoreType::M0 => "armv6-m",
-            CoreType::M3 => "armv7-m",
-            CoreType::M4 | CoreType::M7 => "armv7e-m",
-            CoreType::M33 => "armv8-m.main",
-            //CoreType::M23 => "armv8-m.base",
+            CoreType::Armv6m => "armv6-m",
+            CoreType::Armv7m => "armv7-m",
+            CoreType::Armv7em => "armv7e-m",
+            CoreType::Armv8m => "armv8-m.main",
             CoreType::Riscv => "riscv:rv32",
         };
 

--- a/probe-rs-target/src/chip_family.rs
+++ b/probe-rs-target/src/chip_family.rs
@@ -24,17 +24,16 @@ pub enum TargetDescriptionSource {
 
 /// Type of a supported core
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CoreType {
-    /// ARM Cortex M0
-    M0,
-    /// ARM Cortex M3
-    M3,
-    /// ARM Cortex M4
-    M4,
-    /// ARM Cortex M33
-    M33,
-    /// ARM Cortex M7
-    M7,
+    /// ARMv6-M: Cortex M0, M0+, M1
+    Armv6m,
+    /// ARMv7-M: Cortex M3
+    Armv7m,
+    /// ARMv7e-M: Cortex M4, M7
+    Armv7em,
+    /// ARMv8-M: Cortex M23, M33
+    Armv8m,
     /// RISC-V
     Riscv,
 }

--- a/probe-rs-target/src/memory.rs
+++ b/probe-rs-target/src/memory.rs
@@ -12,15 +12,6 @@ pub struct NvmRegion {
     pub cores: Vec<String>,
 }
 
-impl NvmRegion {
-    /// Returns the necessary information about the NVM.
-    pub fn nvm_info(&self) -> NvmInfo {
-        NvmInfo {
-            rom_start: self.range.start,
-        }
-    }
-}
-
 /// Represents a region in RAM.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RamRegion {
@@ -77,12 +68,6 @@ pub struct PageInfo {
     pub base_address: u32,
     /// Size of the page
     pub size: u32,
-}
-
-/// Holds information about the entire flash.
-#[derive(Debug, Copy, Clone)]
-pub struct NvmInfo {
-    pub rom_start: u32,
 }
 
 /// Enables the user to do range intersection testing.

--- a/probe-rs-target/src/memory.rs
+++ b/probe-rs-target/src/memory.rs
@@ -12,6 +12,15 @@ pub struct NvmRegion {
     pub cores: Vec<String>,
 }
 
+impl NvmRegion {
+    /// Returns the necessary information about the NVM.
+    pub fn nvm_info(&self) -> NvmInfo {
+        NvmInfo {
+            rom_start: self.range.start,
+        }
+    }
+}
+
 /// Represents a region in RAM.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RamRegion {
@@ -68,6 +77,12 @@ pub struct PageInfo {
     pub base_address: u32,
     /// Size of the page
     pub size: u32,
+}
+
+/// Holds information about the entire flash.
+#[derive(Debug, Copy, Clone)]
+pub struct NvmInfo {
+    pub rom_start: u32,
 }
 
 /// Enables the user to do range intersection testing.

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -3,7 +3,7 @@ mod itm;
 mod tpiu;
 
 use super::memory::romtable::{Component, PeripheralType, RomTableError};
-use crate::architecture::arm::core::m0::Demcr;
+use crate::architecture::arm::core::armv6m::Demcr;
 use crate::architecture::arm::{SwoConfig, SwoMode};
 use crate::{Core, CoreRegister, Error, MemoryInterface};
 pub use dwt::Dwt;

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -1,4 +1,4 @@
-use super::{CortexState, Dfsr, ARM_REGISTER_FILE};
+use super::{Dfsr, State, ARM_REGISTER_FILE};
 
 use crate::architecture::arm::sequences::ArmDebugSequence;
 use crate::core::{RegisterDescription, RegisterFile, RegisterKind};
@@ -277,18 +277,18 @@ const XPSR: RegisterDescription = RegisterDescription {
     address: CoreRegisterAddress(0b1_0000),
 };
 
-pub struct M0<'probe> {
+pub struct Armv6m<'probe> {
     memory: Memory<'probe>,
 
-    state: &'probe mut CortexState,
+    state: &'probe mut State,
 
     sequence: Arc<dyn ArmDebugSequence>,
 }
 
-impl<'probe> M0<'probe> {
+impl<'probe> Armv6m<'probe> {
     pub(crate) fn new(
         mut memory: Memory<'probe>,
-        state: &'probe mut CortexState,
+        state: &'probe mut State,
         sequence: Arc<dyn ArmDebugSequence>,
     ) -> Result<Self, Error> {
         if !state.initialized() {
@@ -327,7 +327,7 @@ impl<'probe> M0<'probe> {
     }
 }
 
-impl<'probe> CoreInterface for M0<'probe> {
+impl<'probe> CoreInterface for Armv6m<'probe> {
     fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
         // Wait until halted state is active again.
         let start = Instant::now();
@@ -621,7 +621,7 @@ impl<'probe> CoreInterface for M0<'probe> {
     }
 }
 
-impl<'probe> MemoryInterface for M0<'probe> {
+impl<'probe> MemoryInterface for Armv6m<'probe> {
     fn read_word_32(&mut self, address: u32) -> Result<u32, Error> {
         self.memory.read_word_32(address)
     }

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -6,7 +6,7 @@ use crate::error::Error;
 use crate::memory::Memory;
 use crate::DebugProbeError;
 
-use super::{register, CortexState, Dfsr, ARM_REGISTER_FILE};
+use super::{register, Dfsr, State, ARM_REGISTER_FILE};
 use crate::{
     core::{Architecture, CoreStatus, HaltReason},
     MemoryInterface,
@@ -326,18 +326,18 @@ impl FpRev2CompX {
 pub const MSP: CoreRegisterAddress = CoreRegisterAddress(0b000_1001);
 pub const PSP: CoreRegisterAddress = CoreRegisterAddress(0b000_1010);
 
-pub struct M4<'probe> {
+pub struct Armv7m<'probe> {
     memory: Memory<'probe>,
 
-    state: &'probe mut CortexState,
+    state: &'probe mut State,
 
     sequence: Arc<dyn ArmDebugSequence>,
 }
 
-impl<'probe> M4<'probe> {
+impl<'probe> Armv7m<'probe> {
     pub(crate) fn new(
         mut memory: Memory<'probe>,
-        state: &'probe mut CortexState,
+        state: &'probe mut State,
         sequence: Arc<dyn ArmDebugSequence>,
     ) -> Result<Self, Error> {
         if !state.initialized() {
@@ -376,7 +376,7 @@ impl<'probe> M4<'probe> {
     }
 }
 
-impl<'probe> CoreInterface for M4<'probe> {
+impl<'probe> CoreInterface for Armv7m<'probe> {
     fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
         // Wait until halted state is active again.
         let start = Instant::now();
@@ -698,7 +698,7 @@ impl<'probe> CoreInterface for M4<'probe> {
     }
 }
 
-impl<'probe> MemoryInterface for M4<'probe> {
+impl<'probe> MemoryInterface for Armv7m<'probe> {
     fn read_word_32(&mut self, address: u32) -> Result<u32, Error> {
         self.memory.read_word_32(address)
     }

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -15,25 +15,25 @@ use anyhow::Result;
 
 use bitfield::bitfield;
 
-use super::{CortexState, Dfsr, ARM_REGISTER_FILE};
+use super::{Dfsr, State, ARM_REGISTER_FILE};
 use std::sync::Arc;
 use std::{
     mem::size_of,
     time::{Duration, Instant},
 };
 
-pub struct M33<'probe> {
+pub struct Armv8m<'probe> {
     memory: Memory<'probe>,
 
-    state: &'probe mut CortexState,
+    state: &'probe mut State,
 
     sequence: Arc<dyn ArmDebugSequence>,
 }
 
-impl<'probe> M33<'probe> {
+impl<'probe> Armv8m<'probe> {
     pub(crate) fn new(
         mut memory: Memory<'probe>,
-        state: &'probe mut CortexState,
+        state: &'probe mut State,
         sequence: Arc<dyn ArmDebugSequence>,
     ) -> Result<Self, Error> {
         if !state.initialized() {
@@ -74,7 +74,7 @@ impl<'probe> M33<'probe> {
     }
 }
 
-impl<'probe> CoreInterface for M33<'probe> {
+impl<'probe> CoreInterface for Armv8m<'probe> {
     fn wait_for_core_halted(&mut self, timeout: Duration) -> Result<(), Error> {
         // Wait until halted state is active again.
         let start = Instant::now();
@@ -360,7 +360,7 @@ impl<'probe> CoreInterface for M33<'probe> {
     }
 }
 
-impl<'probe> MemoryInterface for M33<'probe> {
+impl<'probe> MemoryInterface for Armv8m<'probe> {
     fn read_word_32(&mut self, address: u32) -> Result<u32, Error> {
         self.memory.read_word_32(address)
     }

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -5,20 +5,20 @@ use crate::{
 
 use bitfield::bitfield;
 
-pub mod m0;
-pub mod m33;
-pub mod m4;
+pub mod armv6m;
+pub mod armv7m;
+pub mod armv8m;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CortexDump {
+pub struct Dump {
     pub regs: [u32; 16],
     stack_addr: u32,
     stack: Vec<u8>,
 }
 
-impl CortexDump {
-    pub fn new(stack_addr: u32, stack: Vec<u8>) -> CortexDump {
-        CortexDump {
+impl Dump {
+    pub fn new(stack_addr: u32, stack: Vec<u8>) -> Dump {
+        Dump {
             regs: [0u32; 16],
             stack_addr,
             stack,
@@ -255,7 +255,7 @@ impl CoreRegister for Dfsr {
 }
 
 #[derive(Debug)]
-pub struct CortexState {
+pub struct State {
     initialized: bool,
 
     hw_breakpoints_enabled: bool,
@@ -263,7 +263,7 @@ pub struct CortexState {
     current_state: CoreStatus,
 }
 
-impl CortexState {
+impl State {
     pub(crate) fn new() -> Self {
         Self {
             initialized: false,

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -14,9 +14,9 @@ pub use communication_interface::{
 pub use swo::{SwoAccess, SwoConfig, SwoMode};
 pub use traits::*;
 
-pub use self::core::m0;
-pub use self::core::m33;
-pub use self::core::m4;
-pub use self::core::CortexDump;
+pub use self::core::armv6m;
+pub use self::core::armv7m;
+pub use self::core::armv8m;
+pub use self::core::Dump;
 
 pub use communication_interface::ArmProbeInterface;

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -179,7 +179,7 @@ pub trait ArmDebugSequence: Send + Sync {
     /// [ARM SVD Debug Description]: http://www.keil.com/pack/doc/cmsis/Pack/html/debug_description.html#debugCoreStart
     #[doc(alias = "DebugCoreStart")]
     fn debug_core_start(&self, core: &mut Memory) -> Result<(), crate::Error> {
-        use crate::architecture::arm::core::m4::Dhcsr;
+        use crate::architecture::arm::core::armv7m::Dhcsr;
 
         let current_dhcsr = Dhcsr(core.read_word_32(Dhcsr::ADDRESS)?);
 
@@ -206,7 +206,7 @@ pub trait ArmDebugSequence: Send + Sync {
     /// [ARM SVD Debug Description]: http://www.keil.com/pack/doc/cmsis/Pack/html/debug_description.html#resetCatchSet
     #[doc(alias = "ResetCatchSet")]
     fn reset_catch_set(&self, core: &mut Memory) -> Result<(), crate::Error> {
-        use crate::architecture::arm::core::m4::{Demcr, Dhcsr};
+        use crate::architecture::arm::core::armv7m::{Demcr, Dhcsr};
 
         // Request halt after reset
         let mut demcr = Demcr(core.read_word_32(Demcr::ADDRESS)?);
@@ -227,7 +227,7 @@ pub trait ArmDebugSequence: Send + Sync {
     /// [ARM SVD Debug Description]: http://www.keil.com/pack/doc/cmsis/Pack/html/debug_description.html#resetCatchClear
     #[doc(alias = "ResetCatchClear")]
     fn reset_catch_clear(&self, core: &mut Memory) -> Result<(), crate::Error> {
-        use crate::architecture::arm::core::m4::Demcr;
+        use crate::architecture::arm::core::armv7m::Demcr;
 
         // Clear reset catch bit
         let mut demcr = Demcr(core.read_word_32(Demcr::ADDRESS)?);
@@ -244,7 +244,7 @@ pub trait ArmDebugSequence: Send + Sync {
     /// [ARM SVD Debug Description]: http://www.keil.com/pack/doc/cmsis/Pack/html/debug_description.html#resetSystem
     #[doc(alias = "ResetSystem")]
     fn reset_system(&self, interface: &mut Memory) -> Result<(), crate::Error> {
-        use crate::architecture::arm::core::m4::{Aircr, Dhcsr};
+        use crate::architecture::arm::core::armv7m::{Aircr, Dhcsr};
 
         let mut aircr = Aircr(0);
         aircr.vectkey();

--- a/probe-rs/src/architecture/arm/sequences/nxp.rs
+++ b/probe-rs/src/architecture/arm/sequences/nxp.rs
@@ -95,7 +95,7 @@ impl ArmDebugSequence for LPC55S69 {
     }
 
     fn reset_catch_set(&self, interface: &mut crate::Memory) -> Result<(), crate::Error> {
-        use crate::architecture::arm::core::m4::{Demcr, Dhcsr};
+        use crate::architecture::arm::core::armv7m::{Demcr, Dhcsr};
 
         let mut reset_vector = 0xffff_ffff;
         let mut demcr = Demcr(interface.read_word_32(Demcr::ADDRESS)?);
@@ -169,7 +169,7 @@ impl ArmDebugSequence for LPC55S69 {
     }
 
     fn reset_catch_clear(&self, interface: &mut crate::Memory) -> Result<(), crate::Error> {
-        use crate::architecture::arm::core::m4::Demcr;
+        use crate::architecture::arm::core::armv7m::Demcr;
 
         interface.write_word_32(0xE000_2008, 0x0)?;
         interface.write_word_32(0xE000_2000, 0x2)?;
@@ -182,7 +182,7 @@ impl ArmDebugSequence for LPC55S69 {
     }
 
     fn reset_system(&self, interface: &mut crate::Memory) -> Result<(), crate::Error> {
-        use crate::architecture::arm::core::m4::Aircr;
+        use crate::architecture::arm::core::armv7m::Aircr;
 
         let mut aircr = Aircr(0);
         aircr.vectkey();
@@ -206,7 +206,7 @@ impl ArmDebugSequence for LPC55S69 {
 }
 
 fn wait_for_stop_after_reset(memory: &mut crate::Memory) -> Result<(), crate::Error> {
-    use crate::architecture::arm::core::m4::Dhcsr;
+    use crate::architecture::arm::core::armv7m::Dhcsr;
     log::info!("Wait for stop after reset");
 
     thread::sleep(Duration::from_millis(10));

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -46,14 +46,14 @@ impl<R> From<TryLockError<R>> for RegistryError {
 fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
     vec.extend_from_slice(&[
         ChipFamily {
-            name: "Generic Cortex-M0".to_owned(),
+            name: "Generic ARMv6-M".to_owned(),
             manufacturer: None,
             variants: vec![Chip {
-                name: "cortex-m0".to_owned(),
+                name: "armv6m".to_owned(),
                 part: None,
                 cores: vec![Core {
                     name: "core".to_owned(),
-                    core_type: CoreType::M0,
+                    core_type: CoreType::Armv6m,
                     core_access_options: CoreAccessOptions::Arm(ArmCoreAccessOptions {
                         ap: 0,
                         psel: 0,
@@ -66,14 +66,14 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
             source: TargetDescriptionSource::Generic,
         },
         ChipFamily {
-            name: "Generic Cortex-M4".to_owned(),
+            name: "Generic ARMv7-M".to_owned(),
             manufacturer: None,
             variants: vec![Chip {
-                name: "cortex-m4".to_owned(),
+                name: "armv7m".to_owned(),
                 part: None,
                 cores: vec![Core {
                     name: "core".to_owned(),
-                    core_type: CoreType::M4,
+                    core_type: CoreType::Armv7m,
                     core_access_options: CoreAccessOptions::Arm(ArmCoreAccessOptions {
                         ap: 0,
                         psel: 0,
@@ -86,14 +86,14 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
             source: TargetDescriptionSource::Generic,
         },
         ChipFamily {
-            name: "Generic Cortex-M3".to_owned(),
+            name: "Generic ARMv8-M".to_owned(),
             manufacturer: None,
             variants: vec![Chip {
-                name: "cortex-m3".to_owned(),
+                name: "armv8m".to_owned(),
                 part: None,
                 cores: vec![Core {
                     name: "core".to_owned(),
-                    core_type: CoreType::M3,
+                    core_type: CoreType::Armv8m,
                     core_access_options: CoreAccessOptions::Arm(ArmCoreAccessOptions {
                         ap: 0,
                         psel: 0,
@@ -106,47 +106,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
             source: TargetDescriptionSource::Generic,
         },
         ChipFamily {
-            name: "Generic Cortex-M33".to_owned(),
-            manufacturer: None,
-            variants: vec![Chip {
-                name: "cortex-m33".to_owned(),
-                part: None,
-                cores: vec![Core {
-                    name: "core".to_owned(),
-                    core_type: CoreType::M33,
-                    core_access_options: CoreAccessOptions::Arm(ArmCoreAccessOptions {
-                        ap: 0,
-                        psel: 0,
-                    }),
-                }],
-                memory_map: vec![],
-                flash_algorithms: vec![],
-            }],
-            flash_algorithms: vec![],
-            source: TargetDescriptionSource::Generic,
-        },
-        ChipFamily {
-            name: "Generic Cortex-M7".to_owned(),
-            manufacturer: None,
-            variants: vec![Chip {
-                name: "cortex-m7".to_owned(),
-                part: None,
-                cores: vec![Core {
-                    name: "core".to_owned(),
-                    core_type: CoreType::M7,
-                    core_access_options: CoreAccessOptions::Arm(ArmCoreAccessOptions {
-                        ap: 0,
-                        psel: 0,
-                    }),
-                }],
-                memory_map: vec![],
-                flash_algorithms: vec![],
-            }],
-            flash_algorithms: vec![],
-            source: TargetDescriptionSource::Generic,
-        },
-        ChipFamily {
-            name: "Generic Riscv".to_owned(),
+            name: "Generic RISC-V".to_owned(),
             manufacturer: None,
             variants: vec![Chip {
                 name: "riscv".to_owned(),

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -4,7 +4,7 @@ pub use communication_interface::CommunicationInterface;
 use probe_rs_target::CoreType;
 
 use crate::architecture::{
-    arm::core::CortexState, riscv::communication_interface::RiscvCommunicationInterface,
+    arm::core::State, riscv::communication_interface::RiscvCommunicationInterface,
 };
 use crate::error;
 use crate::Target;
@@ -237,33 +237,30 @@ impl CoreState {
 
 #[derive(Debug)]
 pub enum SpecificCoreState {
-    M3(CortexState),
-    M4(CortexState),
-    M33(CortexState),
-    M0(CortexState),
-    M7(CortexState),
+    Armv6m(State),
+    Armv7m(State),
+    Armv7em(State),
+    Armv8m(State),
     Riscv,
 }
 
 impl SpecificCoreState {
     pub(crate) fn from_core_type(typ: CoreType) -> Self {
         match typ {
-            CoreType::M0 => SpecificCoreState::M0(CortexState::new()),
-            CoreType::M3 => SpecificCoreState::M3(CortexState::new()),
-            CoreType::M33 => SpecificCoreState::M33(CortexState::new()),
-            CoreType::M4 => SpecificCoreState::M4(CortexState::new()),
-            CoreType::M7 => SpecificCoreState::M7(CortexState::new()),
+            CoreType::Armv6m => SpecificCoreState::Armv6m(State::new()),
+            CoreType::Armv7m => SpecificCoreState::Armv7m(State::new()),
+            CoreType::Armv7em => SpecificCoreState::Armv7m(State::new()),
+            CoreType::Armv8m => SpecificCoreState::Armv8m(State::new()),
             CoreType::Riscv => SpecificCoreState::Riscv,
         }
     }
 
     pub(crate) fn core_type(&self) -> CoreType {
         match self {
-            SpecificCoreState::M0(_) => CoreType::M0,
-            SpecificCoreState::M3(_) => CoreType::M3,
-            SpecificCoreState::M33(_) => CoreType::M33,
-            SpecificCoreState::M4(_) => CoreType::M4,
-            SpecificCoreState::M7(_) => CoreType::M7,
+            SpecificCoreState::Armv6m(_) => CoreType::Armv6m,
+            SpecificCoreState::Armv7m(_) => CoreType::Armv7m,
+            SpecificCoreState::Armv7em(_) => CoreType::Armv7em,
+            SpecificCoreState::Armv8m(_) => CoreType::Armv8m,
             SpecificCoreState::Riscv => CoreType::Riscv,
         }
     }
@@ -284,21 +281,16 @@ impl SpecificCoreState {
         };
 
         Ok(match self {
-            // TODO: Change this once the new archtecture structure for ARM hits.
-            // Cortex-M3, M4 and M7 use the Armv7[E]-M architecture and are
-            // identical for our purposes.
-            SpecificCoreState::M3(s) | SpecificCoreState::M4(s) | SpecificCoreState::M7(s) => {
-                Core::new(
-                    crate::architecture::arm::m4::M4::new(memory, s, debug_sequence)?,
-                    state,
-                )
-            }
-            SpecificCoreState::M33(s) => Core::new(
-                crate::architecture::arm::m33::M33::new(memory, s, debug_sequence)?,
+            SpecificCoreState::Armv6m(s) => Core::new(
+                crate::architecture::arm::armv6m::Armv6m::new(memory, s, debug_sequence)?,
                 state,
             ),
-            SpecificCoreState::M0(s) => Core::new(
-                crate::architecture::arm::m0::M0::new(memory, s, debug_sequence)?,
+            SpecificCoreState::Armv7m(s) | SpecificCoreState::Armv7em(s) => Core::new(
+                crate::architecture::arm::armv7m::Armv7m::new(memory, s, debug_sequence)?,
+                state,
+            ),
+            SpecificCoreState::Armv8m(s) => Core::new(
+                crate::architecture::arm::armv8m::Armv8m::new(memory, s, debug_sequence)?,
                 state,
             ),
             _ => {

--- a/probe-rs/targets/EFM32PG12B_Series.yaml
+++ b/probe-rs/targets/EFM32PG12B_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFM32PG12B500F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32BG12P_Series.yaml
+++ b/probe-rs/targets/EFR32BG12P_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32BG12P132F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32BG12P232F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32BG12P232F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32BG12P332F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: EFR32BG12P432F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: EFR32BG12P433F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32BG13P_Series.yaml
+++ b/probe-rs/targets/EFR32BG13P_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32BG13P532F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32BG13P632F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32BG13P732F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32BG13P733F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32BG14P_Series.yaml
+++ b/probe-rs/targets/EFR32BG14P_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32BG14P532F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32BG14P632F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32BG14P732F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32BG14P733F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32BG1P_Series.yaml
+++ b/probe-rs/targets/EFR32BG1P_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32BG1P232F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32BG1P233F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32BG1P332F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32BG1P333F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32BG21_Series.yaml
+++ b/probe-rs/targets/EFR32BG21_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32BG21A010F1024
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32BG21A010F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32BG21A010F768
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32BG21A020F1024
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: EFR32BG21A020F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: EFR32BG21A020F768
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: EFR32BG21B010F1024
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -165,7 +165,7 @@ variants:
   - name: EFR32BG21B010F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -188,7 +188,7 @@ variants:
   - name: EFR32BG21B010F768
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -211,7 +211,7 @@ variants:
   - name: EFR32BG21B020F1024
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -234,7 +234,7 @@ variants:
   - name: EFR32BG21B020F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -257,7 +257,7 @@ variants:
   - name: EFR32BG21B020F768
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32BG22_Series.yaml
+++ b/probe-rs/targets/EFR32BG22_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32BG22C112F352
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32BG22C222F352
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32BG22C224F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32FG12P_Series.yaml
+++ b/probe-rs/targets/EFR32FG12P_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32FG12P231F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32FG12P231F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32FG12P232F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32FG12P431F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: EFR32FG12P431F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: EFR32FG12P432F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: EFR32FG12P433F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32FG13P_Series.yaml
+++ b/probe-rs/targets/EFR32FG13P_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32FG13P231F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32FG13P232F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32FG13P233F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32FG14P_Series.yaml
+++ b/probe-rs/targets/EFR32FG14P_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32FG14P231F128
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32FG14P231F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32FG14P232F128
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32FG14P232F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: EFR32FG14P233F128
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: EFR32FG14P233F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32FG14V_Series.yaml
+++ b/probe-rs/targets/EFR32FG14V_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32FG14V132F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32FG1P_Series.yaml
+++ b/probe-rs/targets/EFR32FG1P_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32FG1P131F64
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32FG1P131F128
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32FG1P131F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32FG1P132F64
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: EFR32FG1P132F128
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: EFR32FG1P132F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: EFR32FG1P133F64
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -165,7 +165,7 @@ variants:
   - name: EFR32FG1P133F128
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -188,7 +188,7 @@ variants:
   - name: EFR32FG1P133F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32FG22_Series.yaml
+++ b/probe-rs/targets/EFR32FG22_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32FG22C121F256
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32FG22C121F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32FG23_Series.yaml
+++ b/probe-rs/targets/EFR32FG23_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32FG23A010F256
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32FG23A010F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32FG23A011F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32FG23A020F256
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: EFR32FG23A020F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: EFR32FG23A021F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: EFR32FG23B010F256
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -165,7 +165,7 @@ variants:
   - name: EFR32FG23B010F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -188,7 +188,7 @@ variants:
   - name: EFR32FG23B020F256
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -211,7 +211,7 @@ variants:
   - name: EFR32FG23B020F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32MG12P_Series.yaml
+++ b/probe-rs/targets/EFR32MG12P_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32MG12P132F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32MG12P132F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32MG12P231F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32MG12P232F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: EFR32MG12P232F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: EFR32MG12P332F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: EFR32MG12P431F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -165,7 +165,7 @@ variants:
   - name: EFR32MG12P432F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -188,7 +188,7 @@ variants:
   - name: EFR32MG12P433F1024
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32MG13P_Series.yaml
+++ b/probe-rs/targets/EFR32MG13P_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32MG13P632F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32MG13P731F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32MG13P732F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32MG13P733F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: EFR32MG13P832F512
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32MG14P_Series.yaml
+++ b/probe-rs/targets/EFR32MG14P_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32MG14P632F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32MG14P632F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32MG14P731F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32MG14P732F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: EFR32MG14P732F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: EFR32MG14P732F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: EFR32MG14P732F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -165,7 +165,7 @@ variants:
   - name: EFR32MG14P733F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -188,7 +188,7 @@ variants:
   - name: EFR32MG14P733F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32MG1P_Series.yaml
+++ b/probe-rs/targets/EFR32MG1P_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32MG1P131F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32MG1P132F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32MG1P133F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32MG1P231F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: EFR32MG1P232F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: EFR32MG1P233F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: EFR32MG1P632F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -165,7 +165,7 @@ variants:
   - name: EFR32MG1P732F256
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32MG21_Series.yaml
+++ b/probe-rs/targets/EFR32MG21_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32MG21A010F1024
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32MG21A010F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: EFR32MG21A010F768
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: EFR32MG21A020F1024
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: EFR32MG21A020F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: EFR32MG21A020F768
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: EFR32MG21B010F1024
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -165,7 +165,7 @@ variants:
   - name: EFR32MG21B010F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -188,7 +188,7 @@ variants:
   - name: EFR32MG21B010F768
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -211,7 +211,7 @@ variants:
   - name: EFR32MG21B020F1024
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -234,7 +234,7 @@ variants:
   - name: EFR32MG21B020F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -257,7 +257,7 @@ variants:
   - name: EFR32MG21B020F768
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -280,7 +280,7 @@ variants:
   - name: RM21Z000F1024
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/EFR32MG22_Series.yaml
+++ b/probe-rs/targets/EFR32MG22_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: EFR32MG22A224F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: EFR32MG22C224F512
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/GD32VF1_Series.yaml
+++ b/probe-rs/targets/GD32VF1_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: GD32VF103CBT6
     cores:
       - name: main
-        type: Riscv
+        type: riscv
         core_access_options:
           Riscv: {}
     memory_map:

--- a/probe-rs/targets/HF5032x_Series.yaml
+++ b/probe-rs/targets/HF5032x_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HF5032
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HF5032L_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HF5032Q_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HF5032S_28SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F0006_Series.yaml
+++ b/probe-rs/targets/HT32F0006_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F0006
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F0006_48LQFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F0006_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F0008_Series.yaml
+++ b/probe-rs/targets/HT32F0008_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F0008
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F0008_24QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F0008_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT32F0008_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: HT32F0008_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F123xx_Series.yaml
+++ b/probe-rs/targets/HT32F123xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F12345
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F12345_46QFN
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F12345_48LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT32F12345_64LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: HT32F12364
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: HT32F12364_46QFN
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: HT32F12364_48LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: HT32F12364_64LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: HT32F12365
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
   - name: HT32F12365_100LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -244,7 +244,7 @@ variants:
   - name: HT32F12365_46QFN
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -268,7 +268,7 @@ variants:
   - name: HT32F12365_48LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: HT32F12365_64LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: HT32F12366
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -340,7 +340,7 @@ variants:
   - name: HT32F12366_100LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -364,7 +364,7 @@ variants:
   - name: HT32F12366_46QFN
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -388,7 +388,7 @@ variants:
   - name: HT32F12366_48LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -412,7 +412,7 @@ variants:
   - name: HT32F12366_64LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -436,7 +436,7 @@ variants:
   - name: HT32F22366
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -460,7 +460,7 @@ variants:
   - name: HT32F22366_100LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -484,7 +484,7 @@ variants:
   - name: HT32F22366_46QFN
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -508,7 +508,7 @@ variants:
   - name: HT32F22366_48LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -532,7 +532,7 @@ variants:
   - name: HT32F22366_64LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F12xx_Series.yaml
+++ b/probe-rs/targets/HT32F12xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F1251
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F1251B
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F1252
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT32F1253
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F16xx_Series.yaml
+++ b/probe-rs/targets/HT32F16xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F1653
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F1653_48LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F1653_64LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT32F1654
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: HT32F1654_48LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: HT32F1654_64LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: HT32F1655
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: HT32F1655_100LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: HT32F1655_48LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
   - name: HT32F1655_64LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -244,7 +244,7 @@ variants:
   - name: HT32F1656
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -268,7 +268,7 @@ variants:
   - name: HT32F1656_100LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: HT32F1656_48LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: HT32F1656_64LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F17xx_Series.yaml
+++ b/probe-rs/targets/HT32F17xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F1755
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F1755_100LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F1755_48LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT32F1755_48QFN
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: HT32F1755_64LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: HT32F1765
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: HT32F1765_100LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: HT32F1765_48LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: HT32F1765_48QFN
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
   - name: HT32F1765_64LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -244,7 +244,7 @@ variants:
   - name: HT32F2755
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -268,7 +268,7 @@ variants:
   - name: HT32F2755_100LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: HT32F2755_48LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: HT32F2755_48QFN
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -340,7 +340,7 @@ variants:
   - name: HT32F2755_64LQFP
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F502xx_Series.yaml
+++ b/probe-rs/targets/HT32F502xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F50220
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F50220_24QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F50220_24SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT32F50220_28SOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: HT32F50220_28SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: HT32F50220_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: HT32F50220_44LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: HT32F50220_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: HT32F50220_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
   - name: HT32F50230
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -244,7 +244,7 @@ variants:
   - name: HT32F50230_24QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -268,7 +268,7 @@ variants:
   - name: HT32F50230_24SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: HT32F50230_28SOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: HT32F50230_28SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -340,7 +340,7 @@ variants:
   - name: HT32F50230_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -364,7 +364,7 @@ variants:
   - name: HT32F50230_44LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -388,7 +388,7 @@ variants:
   - name: HT32F50230_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -412,7 +412,7 @@ variants:
   - name: HT32F50230_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -436,7 +436,7 @@ variants:
   - name: HT32F50231
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -460,7 +460,7 @@ variants:
   - name: HT32F50231_24QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -484,7 +484,7 @@ variants:
   - name: HT32F50231_24SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -508,7 +508,7 @@ variants:
   - name: HT32F50231_28SOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -532,7 +532,7 @@ variants:
   - name: HT32F50231_28SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -556,7 +556,7 @@ variants:
   - name: HT32F50231_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -580,7 +580,7 @@ variants:
   - name: HT32F50231_44LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -604,7 +604,7 @@ variants:
   - name: HT32F50231_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -628,7 +628,7 @@ variants:
   - name: HT32F50231_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -652,7 +652,7 @@ variants:
   - name: HT32F50241
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -676,7 +676,7 @@ variants:
   - name: HT32F50241_24QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -700,7 +700,7 @@ variants:
   - name: HT32F50241_24SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -724,7 +724,7 @@ variants:
   - name: HT32F50241_28SOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -748,7 +748,7 @@ variants:
   - name: HT32F50241_28SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -772,7 +772,7 @@ variants:
   - name: HT32F50241_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -796,7 +796,7 @@ variants:
   - name: HT32F50241_44LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -820,7 +820,7 @@ variants:
   - name: HT32F50241_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -844,7 +844,7 @@ variants:
   - name: HT32F50241_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F503xx_Series.yaml
+++ b/probe-rs/targets/HT32F503xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F50343
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F50343_32QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F50343_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT32F50343_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: HT32F50343_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F521xx_Series.yaml
+++ b/probe-rs/targets/HT32F521xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F52142
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F52142_24QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F52142_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT32F52142_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: HT32F52142_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F522xx_Series.yaml
+++ b/probe-rs/targets/HT32F522xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F52220
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F52220_24SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F52220_28SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT32F52220_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: HT32F52230
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: HT32F52230_24SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: HT32F52230_28SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: HT32F52230_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: HT32F52231
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
   - name: HT32F52231_24SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -244,7 +244,7 @@ variants:
   - name: HT32F52231_28SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -268,7 +268,7 @@ variants:
   - name: HT32F52231_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: HT32F52231_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: HT32F52241
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -340,7 +340,7 @@ variants:
   - name: HT32F52241_24SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -364,7 +364,7 @@ variants:
   - name: HT32F52241_28SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -388,7 +388,7 @@ variants:
   - name: HT32F52241_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -412,7 +412,7 @@ variants:
   - name: HT32F52241_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -436,7 +436,7 @@ variants:
   - name: HT32F52243
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -460,7 +460,7 @@ variants:
   - name: HT32F52243_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -484,7 +484,7 @@ variants:
   - name: HT32F52243_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -508,7 +508,7 @@ variants:
   - name: HT32F52243_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -532,7 +532,7 @@ variants:
   - name: HT32F52243_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -556,7 +556,7 @@ variants:
   - name: HT32F52253
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -580,7 +580,7 @@ variants:
   - name: HT32F52253_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -604,7 +604,7 @@ variants:
   - name: HT32F52253_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -628,7 +628,7 @@ variants:
   - name: HT32F52253_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -652,7 +652,7 @@ variants:
   - name: HT32F52253_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F523xx_Series.yaml
+++ b/probe-rs/targets/HT32F523xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F52331
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F52331_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F52331_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT32F52341
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: HT32F52341_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: HT32F52341_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: HT32F52342
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: HT32F52342_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: HT32F52342_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
   - name: HT32F52342_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -244,7 +244,7 @@ variants:
   - name: HT32F52344
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -268,7 +268,7 @@ variants:
   - name: HT32F52344_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: HT32F52344_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: HT32F52344_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -340,7 +340,7 @@ variants:
   - name: HT32F52344_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -364,7 +364,7 @@ variants:
   - name: HT32F52352
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -388,7 +388,7 @@ variants:
   - name: HT32F52352_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -412,7 +412,7 @@ variants:
   - name: HT32F52352_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -436,7 +436,7 @@ variants:
   - name: HT32F52352_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -460,7 +460,7 @@ variants:
   - name: HT32F52354
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -484,7 +484,7 @@ variants:
   - name: HT32F52354_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -508,7 +508,7 @@ variants:
   - name: HT32F52354_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -532,7 +532,7 @@ variants:
   - name: HT32F52354_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -556,7 +556,7 @@ variants:
   - name: HT32F52354_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -580,7 +580,7 @@ variants:
   - name: HT32F52357
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -604,7 +604,7 @@ variants:
   - name: HT32F52357_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -628,7 +628,7 @@ variants:
   - name: HT32F52357_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -652,7 +652,7 @@ variants:
   - name: HT32F52357_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -676,7 +676,7 @@ variants:
   - name: HT32F52357_80LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -700,7 +700,7 @@ variants:
   - name: HT32F52367
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -724,7 +724,7 @@ variants:
   - name: HT32F52367_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -748,7 +748,7 @@ variants:
   - name: HT32F52367_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -772,7 +772,7 @@ variants:
   - name: HT32F52367_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -796,7 +796,7 @@ variants:
   - name: HT32F52367_80LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F573xx_Series.yaml
+++ b/probe-rs/targets/HT32F573xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F57331
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F57331_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F57331_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT32F57341
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: HT32F57341_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: HT32F57341_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: HT32F57342
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: HT32F57342_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: HT32F57342_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
   - name: HT32F57342_80LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -244,7 +244,7 @@ variants:
   - name: HT32F57352
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -268,7 +268,7 @@ variants:
   - name: HT32F57352_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: HT32F57352_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: HT32F57352_80LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F5826_Series.yaml
+++ b/probe-rs/targets/HT32F5826_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F5826
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F590xx_Series.yaml
+++ b/probe-rs/targets/HT32F590xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F59041
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F59041_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F597xx_Series.yaml
+++ b/probe-rs/targets/HT32F597xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F59741
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F59741_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F61352_Series.yaml
+++ b/probe-rs/targets/HT32F61352_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F61352
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F61352_48LQFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F61352_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT32F652xx_Series.yaml
+++ b/probe-rs/targets/HT32F652xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT32F65230
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT32F65230_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT32F65240
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT32F65240_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT50F32002_Series.yaml
+++ b/probe-rs/targets/HT50F32002_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT50F32002
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT50F32002_24QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT50F32002_24SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT50F32002_28SOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: HT50F32002_28SSOP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: HT50F32002_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: HT50F32002_44LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: HT50F32002_46QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: HT50F32002_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/HT50F32003_Series.yaml
+++ b/probe-rs/targets/HT50F32003_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: HT50F32003
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: HT50F32003_33QFN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: HT50F32003_48LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: HT50F32003_64LQFP
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/LPC546xx_Series.yaml
+++ b/probe-rs/targets/LPC546xx_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: LPC54605J256BD100
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: LPC54605J256ET100
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: LPC54605J256ET180
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: LPC54605J512BD100
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: LPC54605J512ET100
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: LPC54605J512ET180
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: LPC54606J256BD100
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: LPC54606J256ET100
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: LPC54606J256ET180
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
   - name: LPC54606J512BD100
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -244,7 +244,7 @@ variants:
   - name: LPC54606J512BD208
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -268,7 +268,7 @@ variants:
   - name: LPC54606J512ET100
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: LPC54607J256BD208
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: LPC54607J256ET180
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -340,7 +340,7 @@ variants:
   - name: LPC54607J512ET180
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -364,7 +364,7 @@ variants:
   - name: LPC54608J512BD208
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -388,7 +388,7 @@ variants:
   - name: LPC54608J512ET180
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -412,7 +412,7 @@ variants:
   - name: LPC54616J256ET180
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -436,7 +436,7 @@ variants:
   - name: LPC54616J512BD100
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -460,7 +460,7 @@ variants:
   - name: LPC54616J512BD208
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -484,7 +484,7 @@ variants:
   - name: LPC54616J512ET100
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -508,7 +508,7 @@ variants:
   - name: LPC54618J512BD208
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -532,7 +532,7 @@ variants:
   - name: LPC54618J512ET180
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -556,7 +556,7 @@ variants:
   - name: LPC54628J512ET180
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/LPC5526.yaml
+++ b/probe-rs/targets/LPC5526.yaml
@@ -5,7 +5,7 @@ variants:
   - name: LPC5526JBD100
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: LPC5526JBD64
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -51,7 +51,7 @@ variants:
   - name: LPC5526JEV98
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/LPC5528.yaml
+++ b/probe-rs/targets/LPC5528.yaml
@@ -5,7 +5,7 @@ variants:
   - name: LPC5528JBD100
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: LPC5528JBD64
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -51,7 +51,7 @@ variants:
   - name: LPC5528JEV98
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/LPC55S26.yaml
+++ b/probe-rs/targets/LPC55S26.yaml
@@ -5,7 +5,7 @@ variants:
   - name: LPC55S26JBD100
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: LPC55S26JBD64
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -51,7 +51,7 @@ variants:
   - name: LPC55S26JEV98
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/LPC55S28.yaml
+++ b/probe-rs/targets/LPC55S28.yaml
@@ -5,7 +5,7 @@ variants:
   - name: LPC55S28JBD100
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: LPC55S28JBD64
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -51,7 +51,7 @@ variants:
   - name: LPC55S28JEV98
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/LPC55S66.yaml
+++ b/probe-rs/targets/LPC55S66.yaml
@@ -4,7 +4,7 @@ variants:
   - name: LPC55S66JBD100
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: LPC55S66JBD64
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: LPC55S66JEV98
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/LPC55S69.yaml
+++ b/probe-rs/targets/LPC55S69.yaml
@@ -5,7 +5,7 @@ variants:
   - name: LPC55S69JBD100
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -29,7 +29,7 @@ variants:
   - name: LPC55S69JBD64
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -53,7 +53,7 @@ variants:
   - name: LPC55S69JEV98
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/LPC800_Series.yaml
+++ b/probe-rs/targets/LPC800_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: LPC802M001JDH16
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: LPC802M001JDH20
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: LPC802M001JHI33
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: LPC802M011JDH20
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: LPC804M101JDH20
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: LPC804M101JDH24
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: LPC804M101JHI33
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -165,7 +165,7 @@ variants:
   - name: LPC804M111JDH24
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -188,7 +188,7 @@ variants:
   - name: LPC810M021FN8
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -211,7 +211,7 @@ variants:
   - name: LPC811M001JDH16
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -234,7 +234,7 @@ variants:
   - name: LPC812M101JD20
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -257,7 +257,7 @@ variants:
   - name: LPC812M101JDH16
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -280,7 +280,7 @@ variants:
   - name: LPC812M101JDH20
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -303,7 +303,7 @@ variants:
   - name: LPC812M101JTB16
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -326,7 +326,7 @@ variants:
   - name: LPC822M101JDH20
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -349,7 +349,7 @@ variants:
   - name: LPC822M101JHI33
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -372,7 +372,7 @@ variants:
   - name: LPC824M201JDH20
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -395,7 +395,7 @@ variants:
   - name: LPC824M201JHI33
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -418,7 +418,7 @@ variants:
   - name: LPC832M101FDH20
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -441,7 +441,7 @@ variants:
   - name: LPC834M101FHI33
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -464,7 +464,7 @@ variants:
   - name: LPC844M201JBD48
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -487,7 +487,7 @@ variants:
   - name: LPC844M201JBD64
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -510,7 +510,7 @@ variants:
   - name: LPC844M201JHI33
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -533,7 +533,7 @@ variants:
   - name: LPC844M201JHI48
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -556,7 +556,7 @@ variants:
   - name: LPC845M301JBD48
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -579,7 +579,7 @@ variants:
   - name: LPC845M301JBD64
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -602,7 +602,7 @@ variants:
   - name: LPC845M301JHI33
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -625,7 +625,7 @@ variants:
   - name: LPC845M301JHI48
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -648,7 +648,7 @@ variants:
   - name: LPC8N04FHI24
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/MAX32665-66.yaml
+++ b/probe-rs/targets/MAX32665-66.yaml
@@ -5,7 +5,7 @@ variants:
   - name: MAX32665
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: MAX32666
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/RP2040.yaml
+++ b/probe-rs/targets/RP2040.yaml
@@ -6,13 +6,13 @@ variants:
   - name: RP2040
     cores:
       - name: core0
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
             psel: 0x01002927
       - name: core1
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/SAM4_Dualcore_Series.yaml
+++ b/probe-rs/targets/SAM4_Dualcore_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: ATSAM4C16C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: ATSAM4C32C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -51,7 +51,7 @@ variants:
   - name: ATSAM4C32E
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -74,7 +74,7 @@ variants:
   - name: ATSAM4C4C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -98,7 +98,7 @@ variants:
   - name: ATSAM4C8C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -122,7 +122,7 @@ variants:
   - name: ATSAM4CMP16C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -145,7 +145,7 @@ variants:
   - name: ATSAM4CMP32C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -168,7 +168,7 @@ variants:
   - name: ATSAM4CMP8C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -191,7 +191,7 @@ variants:
   - name: ATSAM4CMS16C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -214,7 +214,7 @@ variants:
   - name: ATSAM4CMS32C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -237,7 +237,7 @@ variants:
   - name: ATSAM4CMS4C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -260,7 +260,7 @@ variants:
   - name: ATSAM4CMS8C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -283,7 +283,7 @@ variants:
   - name: ATSAM4CP16B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -306,7 +306,7 @@ variants:
   - name: ATSAM4CP16C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/SAM4_Series.yaml
+++ b/probe-rs/targets/SAM4_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: ATSAM4E16C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: ATSAM4E16E
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: ATSAM4E8C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: ATSAM4E8E
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: ATSAM4LC2A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: ATSAM4LC2B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: ATSAM4LC2C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -165,7 +165,7 @@ variants:
   - name: ATSAM4LC4A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -188,7 +188,7 @@ variants:
   - name: ATSAM4LC4B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -211,7 +211,7 @@ variants:
   - name: ATSAM4LC4C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -234,7 +234,7 @@ variants:
   - name: ATSAM4LC8A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -257,7 +257,7 @@ variants:
   - name: ATSAM4LC8B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -280,7 +280,7 @@ variants:
   - name: ATSAM4LC8C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -303,7 +303,7 @@ variants:
   - name: ATSAM4LS2A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -326,7 +326,7 @@ variants:
   - name: ATSAM4LS2B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -349,7 +349,7 @@ variants:
   - name: ATSAM4LS2C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -372,7 +372,7 @@ variants:
   - name: ATSAM4LS4A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -395,7 +395,7 @@ variants:
   - name: ATSAM4LS4B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -418,7 +418,7 @@ variants:
   - name: ATSAM4LS4C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -441,7 +441,7 @@ variants:
   - name: ATSAM4LS8A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -464,7 +464,7 @@ variants:
   - name: ATSAM4LS8B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -487,7 +487,7 @@ variants:
   - name: ATSAM4LS8C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -510,7 +510,7 @@ variants:
   - name: ATSAM4N16B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -533,7 +533,7 @@ variants:
   - name: ATSAM4N16C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -556,7 +556,7 @@ variants:
   - name: ATSAM4N8A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -579,7 +579,7 @@ variants:
   - name: ATSAM4N8B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -602,7 +602,7 @@ variants:
   - name: ATSAM4N8C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -625,7 +625,7 @@ variants:
   - name: ATSAM4S16B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -649,7 +649,7 @@ variants:
   - name: ATSAM4S16C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -673,7 +673,7 @@ variants:
   - name: ATSAM4S2A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -697,7 +697,7 @@ variants:
   - name: ATSAM4S2B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -721,7 +721,7 @@ variants:
   - name: ATSAM4S2C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -745,7 +745,7 @@ variants:
   - name: ATSAM4S4A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -769,7 +769,7 @@ variants:
   - name: ATSAM4S4B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -793,7 +793,7 @@ variants:
   - name: ATSAM4S4C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -817,7 +817,7 @@ variants:
   - name: ATSAM4S8B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -841,7 +841,7 @@ variants:
   - name: ATSAM4S8C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -865,7 +865,7 @@ variants:
   - name: ATSAM4SA16B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -889,7 +889,7 @@ variants:
   - name: ATSAM4SA16C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -913,7 +913,7 @@ variants:
   - name: ATSAM4SD16B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -937,7 +937,7 @@ variants:
   - name: ATSAM4SD16C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -961,7 +961,7 @@ variants:
   - name: ATSAM4SD32B
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -985,7 +985,7 @@ variants:
   - name: ATSAM4SD32C
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1009,7 +1009,7 @@ variants:
   - name: ATSAM4SP32A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/SAMD10.yaml
+++ b/probe-rs/targets/SAMD10.yaml
@@ -4,7 +4,7 @@ variants:
   - name: ATSAMD10C13A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: ATSAMD10C14A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: ATSAMD10D13AM
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: ATSAMD10D13AS
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: ATSAMD10D14AM
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: ATSAMD10D14AS
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: ATSAMD10D14AU
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/SAMD11.yaml
+++ b/probe-rs/targets/SAMD11.yaml
@@ -4,7 +4,7 @@ variants:
   - name: ATSAMD11C14A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: ATSAMD11D14AM
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: ATSAMD11D14AS
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: ATSAMD11D14AU
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/SAMD21.yaml
+++ b/probe-rs/targets/SAMD21.yaml
@@ -4,7 +4,7 @@ variants:
   - name: ATSAMD21E15A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: ATSAMD21E15B
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: ATSAMD21E15BU
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -74,7 +74,7 @@ variants:
   - name: ATSAMD21E15CU
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -98,7 +98,7 @@ variants:
   - name: ATSAMD21E15L
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -122,7 +122,7 @@ variants:
   - name: ATSAMD21E16A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -146,7 +146,7 @@ variants:
   - name: ATSAMD21E16B
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -170,7 +170,7 @@ variants:
   - name: ATSAMD21E16BU
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -194,7 +194,7 @@ variants:
   - name: ATSAMD21E16CU
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -218,7 +218,7 @@ variants:
   - name: ATSAMD21E16L
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -242,7 +242,7 @@ variants:
   - name: ATSAMD21E17A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -265,7 +265,7 @@ variants:
   - name: ATSAMD21E17D
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -289,7 +289,7 @@ variants:
   - name: ATSAMD21E17DU
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -313,7 +313,7 @@ variants:
   - name: ATSAMD21E17L
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -337,7 +337,7 @@ variants:
   - name: ATSAMD21E18A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -360,7 +360,7 @@ variants:
   - name: ATSAMD21G15A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -383,7 +383,7 @@ variants:
   - name: ATSAMD21G15B
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -407,7 +407,7 @@ variants:
   - name: ATSAMD21G15L
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -431,7 +431,7 @@ variants:
   - name: ATSAMD21G16A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -454,7 +454,7 @@ variants:
   - name: ATSAMD21G16B
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -478,7 +478,7 @@ variants:
   - name: ATSAMD21G16L
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -502,7 +502,7 @@ variants:
   - name: ATSAMD21G17A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -525,7 +525,7 @@ variants:
   - name: ATSAMD21G17AU
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -548,7 +548,7 @@ variants:
   - name: ATSAMD21G17D
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -572,7 +572,7 @@ variants:
   - name: ATSAMD21G17L
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -596,7 +596,7 @@ variants:
   - name: ATSAMD21G18A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -619,7 +619,7 @@ variants:
   - name: ATSAMD21G18AU
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -642,7 +642,7 @@ variants:
   - name: ATSAMD21J15A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -665,7 +665,7 @@ variants:
   - name: ATSAMD21J15B
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -689,7 +689,7 @@ variants:
   - name: ATSAMD21J16A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -712,7 +712,7 @@ variants:
   - name: ATSAMD21J16B
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -736,7 +736,7 @@ variants:
   - name: ATSAMD21J17A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -759,7 +759,7 @@ variants:
   - name: ATSAMD21J17D
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -783,7 +783,7 @@ variants:
   - name: ATSAMD21J18A
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/SAMD51.yaml
+++ b/probe-rs/targets/SAMD51.yaml
@@ -5,7 +5,7 @@ variants:
   - name: ATSAMD51G18A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: ATSAMD51G19A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -51,7 +51,7 @@ variants:
   - name: ATSAMD51J18A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -74,7 +74,7 @@ variants:
   - name: ATSAMD51J19A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -97,7 +97,7 @@ variants:
   - name: ATSAMD51J20A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -120,7 +120,7 @@ variants:
   - name: ATSAMD51N19A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -143,7 +143,7 @@ variants:
   - name: ATSAMD51N20A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -166,7 +166,7 @@ variants:
   - name: ATSAMD51P19A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -189,7 +189,7 @@ variants:
   - name: ATSAMD51P20A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/SAME51.yaml
+++ b/probe-rs/targets/SAME51.yaml
@@ -4,7 +4,7 @@ variants:
   - name: ATSAME51G18A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -26,7 +26,7 @@ variants:
   - name: ATSAME51G19A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -48,7 +48,7 @@ variants:
   - name: ATSAME51J18A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -71,7 +71,7 @@ variants:
   - name: ATSAME51J19A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -94,7 +94,7 @@ variants:
   - name: ATSAME51J20A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -117,7 +117,7 @@ variants:
   - name: ATSAME51N19A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -140,7 +140,7 @@ variants:
   - name: ATSAME51N20A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/SAME53.yaml
+++ b/probe-rs/targets/SAME53.yaml
@@ -4,7 +4,7 @@ variants:
   - name: ATSAME53J18A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: ATSAME53J19A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: ATSAME53J20A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: ATSAME53N19A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: ATSAME53N20A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/SAME54.yaml
+++ b/probe-rs/targets/SAME54.yaml
@@ -4,7 +4,7 @@ variants:
   - name: ATSAME54N19A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: ATSAME54N20A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: ATSAME54P19A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: ATSAME54P20A
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/SAME70.yaml
+++ b/probe-rs/targets/SAME70.yaml
@@ -4,7 +4,7 @@ variants:
   - name: ATSAME70J19
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: ATSAME70J19B
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: ATSAME70J20
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: ATSAME70J20B
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: ATSAME70J21
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: ATSAME70J21B
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: ATSAME70N19
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: ATSAME70N19B
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: ATSAME70N20
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
   - name: ATSAME70N20B
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -244,7 +244,7 @@ variants:
   - name: ATSAME70N21
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -268,7 +268,7 @@ variants:
   - name: ATSAME70N21B
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: ATSAME70Q19
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: ATSAME70Q19B
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -340,7 +340,7 @@ variants:
   - name: ATSAME70Q20
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -364,7 +364,7 @@ variants:
   - name: ATSAME70Q20B
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -388,7 +388,7 @@ variants:
   - name: ATSAME70Q21
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -412,7 +412,7 @@ variants:
   - name: ATSAME70Q21B
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32F0_Series.yaml
+++ b/probe-rs/targets/STM32F0_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: STM32F030C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: STM32F030C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: STM32F030CCTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: STM32F030F4Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: STM32F030K6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: STM32F030R8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: STM32F030RCTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: STM32F031C4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: STM32F031C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
   - name: STM32F031E6Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -244,7 +244,7 @@ variants:
   - name: STM32F031F4Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -268,7 +268,7 @@ variants:
   - name: STM32F031F6Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: STM32F031G4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: STM32F031G6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -340,7 +340,7 @@ variants:
   - name: STM32F031K4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -364,7 +364,7 @@ variants:
   - name: STM32F031K6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -388,7 +388,7 @@ variants:
   - name: STM32F031K6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -412,7 +412,7 @@ variants:
   - name: STM32F038C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -436,7 +436,7 @@ variants:
   - name: STM32F038E6Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -460,7 +460,7 @@ variants:
   - name: STM32F038F6Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -484,7 +484,7 @@ variants:
   - name: STM32F038G6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -508,7 +508,7 @@ variants:
   - name: STM32F038K6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -532,7 +532,7 @@ variants:
   - name: STM32F042C4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -556,7 +556,7 @@ variants:
   - name: STM32F042C4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -580,7 +580,7 @@ variants:
   - name: STM32F042C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -604,7 +604,7 @@ variants:
   - name: STM32F042C6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -628,7 +628,7 @@ variants:
   - name: STM32F042F4Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -652,7 +652,7 @@ variants:
   - name: STM32F042F6Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -676,7 +676,7 @@ variants:
   - name: STM32F042G4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -700,7 +700,7 @@ variants:
   - name: STM32F042G6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -724,7 +724,7 @@ variants:
   - name: STM32F042K4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -748,7 +748,7 @@ variants:
   - name: STM32F042K4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -772,7 +772,7 @@ variants:
   - name: STM32F042K6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -796,7 +796,7 @@ variants:
   - name: STM32F042K6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -820,7 +820,7 @@ variants:
   - name: STM32F042T6Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -844,7 +844,7 @@ variants:
   - name: STM32F048C6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -868,7 +868,7 @@ variants:
   - name: STM32F048G6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -892,7 +892,7 @@ variants:
   - name: STM32F048T6Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -916,7 +916,7 @@ variants:
   - name: STM32F051C4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -940,7 +940,7 @@ variants:
   - name: STM32F051C4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -964,7 +964,7 @@ variants:
   - name: STM32F051C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -988,7 +988,7 @@ variants:
   - name: STM32F051C6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1012,7 +1012,7 @@ variants:
   - name: STM32F051C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1036,7 +1036,7 @@ variants:
   - name: STM32F051C8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1060,7 +1060,7 @@ variants:
   - name: STM32F051K4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1084,7 +1084,7 @@ variants:
   - name: STM32F051K4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1108,7 +1108,7 @@ variants:
   - name: STM32F051K6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1132,7 +1132,7 @@ variants:
   - name: STM32F051K6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1156,7 +1156,7 @@ variants:
   - name: STM32F051K8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1180,7 +1180,7 @@ variants:
   - name: STM32F051K8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1204,7 +1204,7 @@ variants:
   - name: STM32F051R4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1228,7 +1228,7 @@ variants:
   - name: STM32F051R6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1252,7 +1252,7 @@ variants:
   - name: STM32F051R8Hx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1276,7 +1276,7 @@ variants:
   - name: STM32F051R8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1300,7 +1300,7 @@ variants:
   - name: STM32F051T8Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1324,7 +1324,7 @@ variants:
   - name: STM32F058C8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1348,7 +1348,7 @@ variants:
   - name: STM32F058R8Hx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1372,7 +1372,7 @@ variants:
   - name: STM32F058R8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1396,7 +1396,7 @@ variants:
   - name: STM32F058T8Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1420,7 +1420,7 @@ variants:
   - name: STM32F070C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1444,7 +1444,7 @@ variants:
   - name: STM32F070CBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1468,7 +1468,7 @@ variants:
   - name: STM32F070F6Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1492,7 +1492,7 @@ variants:
   - name: STM32F070RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1516,7 +1516,7 @@ variants:
   - name: STM32F071C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1540,7 +1540,7 @@ variants:
   - name: STM32F071C8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1564,7 +1564,7 @@ variants:
   - name: STM32F071CBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1588,7 +1588,7 @@ variants:
   - name: STM32F071CBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1612,7 +1612,7 @@ variants:
   - name: STM32F071CBYx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1636,7 +1636,7 @@ variants:
   - name: STM32F071RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1660,7 +1660,7 @@ variants:
   - name: STM32F071V8Hx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1684,7 +1684,7 @@ variants:
   - name: STM32F071V8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1708,7 +1708,7 @@ variants:
   - name: STM32F071VBHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1732,7 +1732,7 @@ variants:
   - name: STM32F071VBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1756,7 +1756,7 @@ variants:
   - name: STM32F072C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1780,7 +1780,7 @@ variants:
   - name: STM32F072C8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1804,7 +1804,7 @@ variants:
   - name: STM32F072CBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1828,7 +1828,7 @@ variants:
   - name: STM32F072CBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1852,7 +1852,7 @@ variants:
   - name: STM32F072CBYx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1876,7 +1876,7 @@ variants:
   - name: STM32F072R8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1900,7 +1900,7 @@ variants:
   - name: STM32F072RBHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1924,7 +1924,7 @@ variants:
   - name: STM32F072RBIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1948,7 +1948,7 @@ variants:
   - name: STM32F072RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1972,7 +1972,7 @@ variants:
   - name: STM32F072V8Hx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1996,7 +1996,7 @@ variants:
   - name: STM32F072V8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2020,7 +2020,7 @@ variants:
   - name: STM32F072VBHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2044,7 +2044,7 @@ variants:
   - name: STM32F072VBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2068,7 +2068,7 @@ variants:
   - name: STM32F078CBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2092,7 +2092,7 @@ variants:
   - name: STM32F078CBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2116,7 +2116,7 @@ variants:
   - name: STM32F078CBYx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2140,7 +2140,7 @@ variants:
   - name: STM32F078RBHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2164,7 +2164,7 @@ variants:
   - name: STM32F078RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2188,7 +2188,7 @@ variants:
   - name: STM32F078VBHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2212,7 +2212,7 @@ variants:
   - name: STM32F078VBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2236,7 +2236,7 @@ variants:
   - name: STM32F091CBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2260,7 +2260,7 @@ variants:
   - name: STM32F091CBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2284,7 +2284,7 @@ variants:
   - name: STM32F091CCTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2308,7 +2308,7 @@ variants:
   - name: STM32F091CCUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2332,7 +2332,7 @@ variants:
   - name: STM32F091RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2356,7 +2356,7 @@ variants:
   - name: STM32F091RCHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2380,7 +2380,7 @@ variants:
   - name: STM32F091RCTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2404,7 +2404,7 @@ variants:
   - name: STM32F091RCYx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2428,7 +2428,7 @@ variants:
   - name: STM32F091VBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2452,7 +2452,7 @@ variants:
   - name: STM32F091VCHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2476,7 +2476,7 @@ variants:
   - name: STM32F091VCTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2500,7 +2500,7 @@ variants:
   - name: STM32F098CCTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2524,7 +2524,7 @@ variants:
   - name: STM32F098CCUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2548,7 +2548,7 @@ variants:
   - name: STM32F098RCHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2572,7 +2572,7 @@ variants:
   - name: STM32F098RCTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2596,7 +2596,7 @@ variants:
   - name: STM32F098RCYx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2620,7 +2620,7 @@ variants:
   - name: STM32F098VCHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2644,7 +2644,7 @@ variants:
   - name: STM32F098VCTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32F1_Series.yaml
+++ b/probe-rs/targets/STM32F1_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: STM32F100C4
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: STM32F100C6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: STM32F100C8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: STM32F100CB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: STM32F100R4
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: STM32F100R6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: STM32F100R8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: STM32F100RB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: STM32F100RC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
   - name: STM32F100RD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -244,7 +244,7 @@ variants:
   - name: STM32F100RE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -268,7 +268,7 @@ variants:
   - name: STM32F100V8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: STM32F100VB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: STM32F100VC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -340,7 +340,7 @@ variants:
   - name: STM32F100VD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -364,7 +364,7 @@ variants:
   - name: STM32F100VE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -388,7 +388,7 @@ variants:
   - name: STM32F100ZC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -412,7 +412,7 @@ variants:
   - name: STM32F100ZD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -436,7 +436,7 @@ variants:
   - name: STM32F100ZE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -460,7 +460,7 @@ variants:
   - name: STM32F101C4
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -484,7 +484,7 @@ variants:
   - name: STM32F101C6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -508,7 +508,7 @@ variants:
   - name: STM32F101C8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -532,7 +532,7 @@ variants:
   - name: STM32F101CB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -556,7 +556,7 @@ variants:
   - name: STM32F101R4
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -580,7 +580,7 @@ variants:
   - name: STM32F101R6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -604,7 +604,7 @@ variants:
   - name: STM32F101R8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -628,7 +628,7 @@ variants:
   - name: STM32F101RB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -652,7 +652,7 @@ variants:
   - name: STM32F101RC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -676,7 +676,7 @@ variants:
   - name: STM32F101RD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -700,7 +700,7 @@ variants:
   - name: STM32F101RE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -724,7 +724,7 @@ variants:
   - name: STM32F101RF
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -748,7 +748,7 @@ variants:
   - name: STM32F101RG
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -772,7 +772,7 @@ variants:
   - name: STM32F101T4
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -796,7 +796,7 @@ variants:
   - name: STM32F101T6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -820,7 +820,7 @@ variants:
   - name: STM32F101T8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -844,7 +844,7 @@ variants:
   - name: STM32F101TB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -868,7 +868,7 @@ variants:
   - name: STM32F101V8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -892,7 +892,7 @@ variants:
   - name: STM32F101VB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -916,7 +916,7 @@ variants:
   - name: STM32F101VC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -940,7 +940,7 @@ variants:
   - name: STM32F101VD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -964,7 +964,7 @@ variants:
   - name: STM32F101VE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -988,7 +988,7 @@ variants:
   - name: STM32F101VF
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1012,7 +1012,7 @@ variants:
   - name: STM32F101VG
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1036,7 +1036,7 @@ variants:
   - name: STM32F101ZC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1060,7 +1060,7 @@ variants:
   - name: STM32F101ZD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1084,7 +1084,7 @@ variants:
   - name: STM32F101ZE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1108,7 +1108,7 @@ variants:
   - name: STM32F101ZF
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1132,7 +1132,7 @@ variants:
   - name: STM32F101ZG
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1156,7 +1156,7 @@ variants:
   - name: STM32F102C4
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1180,7 +1180,7 @@ variants:
   - name: STM32F102C6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1204,7 +1204,7 @@ variants:
   - name: STM32F102C8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1228,7 +1228,7 @@ variants:
   - name: STM32F102CB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1252,7 +1252,7 @@ variants:
   - name: STM32F102R4
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1276,7 +1276,7 @@ variants:
   - name: STM32F102R6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1300,7 +1300,7 @@ variants:
   - name: STM32F102R8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1324,7 +1324,7 @@ variants:
   - name: STM32F102RB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1348,7 +1348,7 @@ variants:
   - name: STM32F103C4
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1372,7 +1372,7 @@ variants:
   - name: STM32F103C6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1396,7 +1396,7 @@ variants:
   - name: STM32F103C8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1420,7 +1420,7 @@ variants:
   - name: STM32F103CB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1444,7 +1444,7 @@ variants:
   - name: STM32F103R4
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1468,7 +1468,7 @@ variants:
   - name: STM32F103R6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1492,7 +1492,7 @@ variants:
   - name: STM32F103R8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1516,7 +1516,7 @@ variants:
   - name: STM32F103RB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1540,7 +1540,7 @@ variants:
   - name: STM32F103RC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1564,7 +1564,7 @@ variants:
   - name: STM32F103RD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1588,7 +1588,7 @@ variants:
   - name: STM32F103RE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1612,7 +1612,7 @@ variants:
   - name: STM32F103RF
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1636,7 +1636,7 @@ variants:
   - name: STM32F103RG
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1660,7 +1660,7 @@ variants:
   - name: STM32F103T4
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1684,7 +1684,7 @@ variants:
   - name: STM32F103T6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1708,7 +1708,7 @@ variants:
   - name: STM32F103T8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1732,7 +1732,7 @@ variants:
   - name: STM32F103TB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1756,7 +1756,7 @@ variants:
   - name: STM32F103V8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1780,7 +1780,7 @@ variants:
   - name: STM32F103VB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1804,7 +1804,7 @@ variants:
   - name: STM32F103VC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1828,7 +1828,7 @@ variants:
   - name: STM32F103VD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1852,7 +1852,7 @@ variants:
   - name: STM32F103VE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1876,7 +1876,7 @@ variants:
   - name: STM32F103VF
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1900,7 +1900,7 @@ variants:
   - name: STM32F103VG
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1924,7 +1924,7 @@ variants:
   - name: STM32F103ZC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1948,7 +1948,7 @@ variants:
   - name: STM32F103ZD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1972,7 +1972,7 @@ variants:
   - name: STM32F103ZE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1996,7 +1996,7 @@ variants:
   - name: STM32F103ZF
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -2020,7 +2020,7 @@ variants:
   - name: STM32F103ZG
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -2044,7 +2044,7 @@ variants:
   - name: STM32F105R8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -2068,7 +2068,7 @@ variants:
   - name: STM32F105RB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -2092,7 +2092,7 @@ variants:
   - name: STM32F105RC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -2116,7 +2116,7 @@ variants:
   - name: STM32F105V8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -2140,7 +2140,7 @@ variants:
   - name: STM32F105VB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -2164,7 +2164,7 @@ variants:
   - name: STM32F105VC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -2188,7 +2188,7 @@ variants:
   - name: STM32F107RB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -2212,7 +2212,7 @@ variants:
   - name: STM32F107RC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -2236,7 +2236,7 @@ variants:
   - name: STM32F107VB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -2260,7 +2260,7 @@ variants:
   - name: STM32F107VC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32F2_Series.yaml
+++ b/probe-rs/targets/STM32F2_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: STM32F205RBTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -29,7 +29,7 @@ variants:
   - name: STM32F205RCTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -54,7 +54,7 @@ variants:
   - name: STM32F205RETx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -79,7 +79,7 @@ variants:
   - name: STM32F205REYx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -104,7 +104,7 @@ variants:
   - name: STM32F205RFTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -129,7 +129,7 @@ variants:
   - name: STM32F205RGTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -154,7 +154,7 @@ variants:
   - name: STM32F205RGYx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -179,7 +179,7 @@ variants:
   - name: STM32F205VBTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -204,7 +204,7 @@ variants:
   - name: STM32F205VCTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -229,7 +229,7 @@ variants:
   - name: STM32F205VETx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -254,7 +254,7 @@ variants:
   - name: STM32F205VFTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -279,7 +279,7 @@ variants:
   - name: STM32F205VGTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -304,7 +304,7 @@ variants:
   - name: STM32F205ZCTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -329,7 +329,7 @@ variants:
   - name: STM32F205ZETx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -354,7 +354,7 @@ variants:
   - name: STM32F205ZFTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -379,7 +379,7 @@ variants:
   - name: STM32F205ZGTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -404,7 +404,7 @@ variants:
   - name: STM32F207ICHx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -429,7 +429,7 @@ variants:
   - name: STM32F207ICTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -454,7 +454,7 @@ variants:
   - name: STM32F207IEHx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -479,7 +479,7 @@ variants:
   - name: STM32F207IETx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -504,7 +504,7 @@ variants:
   - name: STM32F207IFHx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -529,7 +529,7 @@ variants:
   - name: STM32F207IFTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -554,7 +554,7 @@ variants:
   - name: STM32F207IGHx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -579,7 +579,7 @@ variants:
   - name: STM32F207IGTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -604,7 +604,7 @@ variants:
   - name: STM32F207VCTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -629,7 +629,7 @@ variants:
   - name: STM32F207VETx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -654,7 +654,7 @@ variants:
   - name: STM32F207VFTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -679,7 +679,7 @@ variants:
   - name: STM32F207VGTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -704,7 +704,7 @@ variants:
   - name: STM32F207ZCTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -729,7 +729,7 @@ variants:
   - name: STM32F207ZETx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -754,7 +754,7 @@ variants:
   - name: STM32F207ZFTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -779,7 +779,7 @@ variants:
   - name: STM32F207ZGTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -804,7 +804,7 @@ variants:
   - name: STM32F215RETx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -829,7 +829,7 @@ variants:
   - name: STM32F215RGTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -854,7 +854,7 @@ variants:
   - name: STM32F215VETx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -879,7 +879,7 @@ variants:
   - name: STM32F215VGTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -904,7 +904,7 @@ variants:
   - name: STM32F215ZETx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -929,7 +929,7 @@ variants:
   - name: STM32F215ZGTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -954,7 +954,7 @@ variants:
   - name: STM32F217IEHx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -979,7 +979,7 @@ variants:
   - name: STM32F217IETx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1004,7 +1004,7 @@ variants:
   - name: STM32F217IGHx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1029,7 +1029,7 @@ variants:
   - name: STM32F217IGTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1054,7 +1054,7 @@ variants:
   - name: STM32F217VETx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1079,7 +1079,7 @@ variants:
   - name: STM32F217VGTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1104,7 +1104,7 @@ variants:
   - name: STM32F217ZETx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1129,7 +1129,7 @@ variants:
   - name: STM32F217ZGTx
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32F3_Series.yaml
+++ b/probe-rs/targets/STM32F3_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: STM32F301C6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: STM32F301C8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -52,7 +52,7 @@ variants:
   - name: STM32F301C8Yx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: STM32F301K6Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: STM32F301K8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
   - name: STM32F301K8Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
   - name: STM32F301R6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
   - name: STM32F301R8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: STM32F302C6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
   - name: STM32F302C8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -244,7 +244,7 @@ variants:
   - name: STM32F302C8Yx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -268,7 +268,7 @@ variants:
   - name: STM32F302CBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: STM32F302CCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: STM32F302K6Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -340,7 +340,7 @@ variants:
   - name: STM32F302K8Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -364,7 +364,7 @@ variants:
   - name: STM32F302R6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -388,7 +388,7 @@ variants:
   - name: STM32F302R8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -412,7 +412,7 @@ variants:
   - name: STM32F302RBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -436,7 +436,7 @@ variants:
   - name: STM32F302RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -460,7 +460,7 @@ variants:
   - name: STM32F302RDTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -484,7 +484,7 @@ variants:
   - name: STM32F302RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -508,7 +508,7 @@ variants:
   - name: STM32F302VBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -532,7 +532,7 @@ variants:
   - name: STM32F302VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -556,7 +556,7 @@ variants:
   - name: STM32F302VCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -580,7 +580,7 @@ variants:
   - name: STM32F302VDHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -604,7 +604,7 @@ variants:
   - name: STM32F302VDTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -628,7 +628,7 @@ variants:
   - name: STM32F302VEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -652,7 +652,7 @@ variants:
   - name: STM32F302VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -676,7 +676,7 @@ variants:
   - name: STM32F302ZDTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -700,7 +700,7 @@ variants:
   - name: STM32F302ZETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -724,7 +724,7 @@ variants:
   - name: STM32F303C6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -748,7 +748,7 @@ variants:
   - name: STM32F303C8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -772,7 +772,7 @@ variants:
   - name: STM32F303CBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -796,7 +796,7 @@ variants:
   - name: STM32F303CCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -820,7 +820,7 @@ variants:
   - name: STM32F303K6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -844,7 +844,7 @@ variants:
   - name: STM32F303K6Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -868,7 +868,7 @@ variants:
   - name: STM32F303K8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -892,7 +892,7 @@ variants:
   - name: STM32F303K8Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -916,7 +916,7 @@ variants:
   - name: STM32F303R6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -940,7 +940,7 @@ variants:
   - name: STM32F303R8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -964,7 +964,7 @@ variants:
   - name: STM32F303RBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -988,7 +988,7 @@ variants:
   - name: STM32F303RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1012,7 +1012,7 @@ variants:
   - name: STM32F303RDTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1036,7 +1036,7 @@ variants:
   - name: STM32F303RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1060,7 +1060,7 @@ variants:
   - name: STM32F303VBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1084,7 +1084,7 @@ variants:
   - name: STM32F303VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1108,7 +1108,7 @@ variants:
   - name: STM32F303VCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1132,7 +1132,7 @@ variants:
   - name: STM32F303VDHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1156,7 +1156,7 @@ variants:
   - name: STM32F303VDTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1180,7 +1180,7 @@ variants:
   - name: STM32F303VEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1204,7 +1204,7 @@ variants:
   - name: STM32F303VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1228,7 +1228,7 @@ variants:
   - name: STM32F303VEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1252,7 +1252,7 @@ variants:
   - name: STM32F303ZDTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1276,7 +1276,7 @@ variants:
   - name: STM32F303ZETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1300,7 +1300,7 @@ variants:
   - name: STM32F318C8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1324,7 +1324,7 @@ variants:
   - name: STM32F318C8Yx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1348,7 +1348,7 @@ variants:
   - name: STM32F318K8Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1372,7 +1372,7 @@ variants:
   - name: STM32F328C8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1396,7 +1396,7 @@ variants:
   - name: STM32F334C4Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1420,7 +1420,7 @@ variants:
   - name: STM32F334C6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1444,7 +1444,7 @@ variants:
   - name: STM32F334C8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1468,7 +1468,7 @@ variants:
   - name: STM32F334C8Yx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1492,7 +1492,7 @@ variants:
   - name: STM32F334K4Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1510,7 +1510,7 @@ variants:
   - name: STM32F334K4Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1528,7 +1528,7 @@ variants:
   - name: STM32F334K6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1552,7 +1552,7 @@ variants:
   - name: STM32F334K6Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1576,7 +1576,7 @@ variants:
   - name: STM32F334K8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1600,7 +1600,7 @@ variants:
   - name: STM32F334K8Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1624,7 +1624,7 @@ variants:
   - name: STM32F334R6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1648,7 +1648,7 @@ variants:
   - name: STM32F334R8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1672,7 +1672,7 @@ variants:
   - name: STM32F358CCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1696,7 +1696,7 @@ variants:
   - name: STM32F358RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1720,7 +1720,7 @@ variants:
   - name: STM32F358VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1744,7 +1744,7 @@ variants:
   - name: STM32F373C8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1768,7 +1768,7 @@ variants:
   - name: STM32F373CBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1792,7 +1792,7 @@ variants:
   - name: STM32F373CCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1816,7 +1816,7 @@ variants:
   - name: STM32F373R8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1840,7 +1840,7 @@ variants:
   - name: STM32F373RBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1864,7 +1864,7 @@ variants:
   - name: STM32F373RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1888,7 +1888,7 @@ variants:
   - name: STM32F373V8Hx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1912,7 +1912,7 @@ variants:
   - name: STM32F373V8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1936,7 +1936,7 @@ variants:
   - name: STM32F373VBHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1960,7 +1960,7 @@ variants:
   - name: STM32F373VBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1984,7 +1984,7 @@ variants:
   - name: STM32F373VCHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2008,7 +2008,7 @@ variants:
   - name: STM32F373VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2032,7 +2032,7 @@ variants:
   - name: STM32F378CCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2056,7 +2056,7 @@ variants:
   - name: STM32F378RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2080,7 +2080,7 @@ variants:
   - name: STM32F378RCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2104,7 +2104,7 @@ variants:
   - name: STM32F378VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2128,7 +2128,7 @@ variants:
   - name: STM32F398VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32F4_Series.yaml
+++ b/probe-rs/targets/STM32F4_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: STM32F401CBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -29,7 +29,7 @@ variants:
   - name: STM32F401CBYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -54,7 +54,7 @@ variants:
   - name: STM32F401CCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -79,7 +79,7 @@ variants:
   - name: STM32F401CCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -104,7 +104,7 @@ variants:
   - name: STM32F401CDUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -129,7 +129,7 @@ variants:
   - name: STM32F401CDYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -154,7 +154,7 @@ variants:
   - name: STM32F401CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -179,7 +179,7 @@ variants:
   - name: STM32F401CEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -204,7 +204,7 @@ variants:
   - name: STM32F401RBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -229,7 +229,7 @@ variants:
   - name: STM32F401RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -254,7 +254,7 @@ variants:
   - name: STM32F401RDTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -279,7 +279,7 @@ variants:
   - name: STM32F401RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -304,7 +304,7 @@ variants:
   - name: STM32F401VBHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -329,7 +329,7 @@ variants:
   - name: STM32F401VBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -354,7 +354,7 @@ variants:
   - name: STM32F401VCHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -379,7 +379,7 @@ variants:
   - name: STM32F401VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -404,7 +404,7 @@ variants:
   - name: STM32F401VDHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -429,7 +429,7 @@ variants:
   - name: STM32F401VDTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -454,7 +454,7 @@ variants:
   - name: STM32F401VEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -479,7 +479,7 @@ variants:
   - name: STM32F401VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -504,7 +504,7 @@ variants:
   - name: STM32F405OEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -529,7 +529,7 @@ variants:
   - name: STM32F405OGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -554,7 +554,7 @@ variants:
   - name: STM32F405RGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -579,7 +579,7 @@ variants:
   - name: STM32F405VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -604,7 +604,7 @@ variants:
   - name: STM32F405ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -629,7 +629,7 @@ variants:
   - name: STM32F407IEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -654,7 +654,7 @@ variants:
   - name: STM32F407IETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -679,7 +679,7 @@ variants:
   - name: STM32F407IGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -704,7 +704,7 @@ variants:
   - name: STM32F407IGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -729,7 +729,7 @@ variants:
   - name: STM32F407VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -754,7 +754,7 @@ variants:
   - name: STM32F407VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -779,7 +779,7 @@ variants:
   - name: STM32F407ZETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -804,7 +804,7 @@ variants:
   - name: STM32F407ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -829,7 +829,7 @@ variants:
   - name: STM32F410C8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -853,7 +853,7 @@ variants:
   - name: STM32F410C8Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -877,7 +877,7 @@ variants:
   - name: STM32F410CBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -901,7 +901,7 @@ variants:
   - name: STM32F410CBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -925,7 +925,7 @@ variants:
   - name: STM32F410R8Ix
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -949,7 +949,7 @@ variants:
   - name: STM32F410R8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -973,7 +973,7 @@ variants:
   - name: STM32F410RBIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -997,7 +997,7 @@ variants:
   - name: STM32F410RBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1021,7 +1021,7 @@ variants:
   - name: STM32F410T8Yx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1045,7 +1045,7 @@ variants:
   - name: STM32F410TBYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1069,7 +1069,7 @@ variants:
   - name: STM32F411CCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1094,7 +1094,7 @@ variants:
   - name: STM32F411CCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1119,7 +1119,7 @@ variants:
   - name: STM32F411CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1144,7 +1144,7 @@ variants:
   - name: STM32F411CEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1169,7 +1169,7 @@ variants:
   - name: STM32F411RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1194,7 +1194,7 @@ variants:
   - name: STM32F411RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1219,7 +1219,7 @@ variants:
   - name: STM32F411VCHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1244,7 +1244,7 @@ variants:
   - name: STM32F411VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1269,7 +1269,7 @@ variants:
   - name: STM32F411VEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1294,7 +1294,7 @@ variants:
   - name: STM32F411VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1319,7 +1319,7 @@ variants:
   - name: STM32F412CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1344,7 +1344,7 @@ variants:
   - name: STM32F412CGUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1369,7 +1369,7 @@ variants:
   - name: STM32F412RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1394,7 +1394,7 @@ variants:
   - name: STM32F412REYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1419,7 +1419,7 @@ variants:
   - name: STM32F412RGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1444,7 +1444,7 @@ variants:
   - name: STM32F412RGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1469,7 +1469,7 @@ variants:
   - name: STM32F412VEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1494,7 +1494,7 @@ variants:
   - name: STM32F412VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1519,7 +1519,7 @@ variants:
   - name: STM32F412VGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1544,7 +1544,7 @@ variants:
   - name: STM32F412VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1569,7 +1569,7 @@ variants:
   - name: STM32F412ZEJx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1594,7 +1594,7 @@ variants:
   - name: STM32F412ZETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1619,7 +1619,7 @@ variants:
   - name: STM32F412ZGJx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1644,7 +1644,7 @@ variants:
   - name: STM32F412ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1669,7 +1669,7 @@ variants:
   - name: STM32F413CGUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1693,7 +1693,7 @@ variants:
   - name: STM32F413CHUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1717,7 +1717,7 @@ variants:
   - name: STM32F413MGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1741,7 +1741,7 @@ variants:
   - name: STM32F413MHYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1765,7 +1765,7 @@ variants:
   - name: STM32F413RGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1789,7 +1789,7 @@ variants:
   - name: STM32F413RHTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1813,7 +1813,7 @@ variants:
   - name: STM32F413VGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1837,7 +1837,7 @@ variants:
   - name: STM32F413VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1861,7 +1861,7 @@ variants:
   - name: STM32F413VHHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1885,7 +1885,7 @@ variants:
   - name: STM32F413VHTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1909,7 +1909,7 @@ variants:
   - name: STM32F413ZGJx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1933,7 +1933,7 @@ variants:
   - name: STM32F413ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1957,7 +1957,7 @@ variants:
   - name: STM32F413ZHJx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1981,7 +1981,7 @@ variants:
   - name: STM32F413ZHTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2005,7 +2005,7 @@ variants:
   - name: STM32F415OGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2030,7 +2030,7 @@ variants:
   - name: STM32F415RGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2055,7 +2055,7 @@ variants:
   - name: STM32F415VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2080,7 +2080,7 @@ variants:
   - name: STM32F415ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2105,7 +2105,7 @@ variants:
   - name: STM32F417IEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2130,7 +2130,7 @@ variants:
   - name: STM32F417IETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2155,7 +2155,7 @@ variants:
   - name: STM32F417IGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2180,7 +2180,7 @@ variants:
   - name: STM32F417IGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2205,7 +2205,7 @@ variants:
   - name: STM32F417VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2230,7 +2230,7 @@ variants:
   - name: STM32F417VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2255,7 +2255,7 @@ variants:
   - name: STM32F417ZETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2280,7 +2280,7 @@ variants:
   - name: STM32F417ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2305,7 +2305,7 @@ variants:
   - name: STM32F423CHUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2329,7 +2329,7 @@ variants:
   - name: STM32F423MHYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2353,7 +2353,7 @@ variants:
   - name: STM32F423RHTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2377,7 +2377,7 @@ variants:
   - name: STM32F423VHHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2401,7 +2401,7 @@ variants:
   - name: STM32F423VHTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2425,7 +2425,7 @@ variants:
   - name: STM32F423ZHJx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2449,7 +2449,7 @@ variants:
   - name: STM32F423ZHTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2473,7 +2473,7 @@ variants:
   - name: STM32F427AGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2499,7 +2499,7 @@ variants:
   - name: STM32F427AIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2524,7 +2524,7 @@ variants:
   - name: STM32F427IGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2550,7 +2550,7 @@ variants:
   - name: STM32F427IGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2576,7 +2576,7 @@ variants:
   - name: STM32F427IIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2601,7 +2601,7 @@ variants:
   - name: STM32F427IITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2626,7 +2626,7 @@ variants:
   - name: STM32F427VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2652,7 +2652,7 @@ variants:
   - name: STM32F427VITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2677,7 +2677,7 @@ variants:
   - name: STM32F427ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2703,7 +2703,7 @@ variants:
   - name: STM32F427ZITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2728,7 +2728,7 @@ variants:
   - name: STM32F429AGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2754,7 +2754,7 @@ variants:
   - name: STM32F429AIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2779,7 +2779,7 @@ variants:
   - name: STM32F429BETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2804,7 +2804,7 @@ variants:
   - name: STM32F429BGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2830,7 +2830,7 @@ variants:
   - name: STM32F429BITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2855,7 +2855,7 @@ variants:
   - name: STM32F429IEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2880,7 +2880,7 @@ variants:
   - name: STM32F429IETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2905,7 +2905,7 @@ variants:
   - name: STM32F429IGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2931,7 +2931,7 @@ variants:
   - name: STM32F429IGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2957,7 +2957,7 @@ variants:
   - name: STM32F429IIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2982,7 +2982,7 @@ variants:
   - name: STM32F429IITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3007,7 +3007,7 @@ variants:
   - name: STM32F429NEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3032,7 +3032,7 @@ variants:
   - name: STM32F429NGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3058,7 +3058,7 @@ variants:
   - name: STM32F429NIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3083,7 +3083,7 @@ variants:
   - name: STM32F429VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3108,7 +3108,7 @@ variants:
   - name: STM32F429VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3134,7 +3134,7 @@ variants:
   - name: STM32F429VITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3159,7 +3159,7 @@ variants:
   - name: STM32F429ZETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3184,7 +3184,7 @@ variants:
   - name: STM32F429ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3210,7 +3210,7 @@ variants:
   - name: STM32F429ZITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3235,7 +3235,7 @@ variants:
   - name: STM32F429ZIYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3260,7 +3260,7 @@ variants:
   - name: STM32F437AIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3285,7 +3285,7 @@ variants:
   - name: STM32F437IGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3311,7 +3311,7 @@ variants:
   - name: STM32F437IGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3337,7 +3337,7 @@ variants:
   - name: STM32F437IIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3362,7 +3362,7 @@ variants:
   - name: STM32F437IITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3387,7 +3387,7 @@ variants:
   - name: STM32F437VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3413,7 +3413,7 @@ variants:
   - name: STM32F437VITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3438,7 +3438,7 @@ variants:
   - name: STM32F437ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3464,7 +3464,7 @@ variants:
   - name: STM32F437ZITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3489,7 +3489,7 @@ variants:
   - name: STM32F439AIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3514,7 +3514,7 @@ variants:
   - name: STM32F439BGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3540,7 +3540,7 @@ variants:
   - name: STM32F439BITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3565,7 +3565,7 @@ variants:
   - name: STM32F439IGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3591,7 +3591,7 @@ variants:
   - name: STM32F439IGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3617,7 +3617,7 @@ variants:
   - name: STM32F439IIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3642,7 +3642,7 @@ variants:
   - name: STM32F439IITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3667,7 +3667,7 @@ variants:
   - name: STM32F439NGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3693,7 +3693,7 @@ variants:
   - name: STM32F439NIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3718,7 +3718,7 @@ variants:
   - name: STM32F439VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3744,7 +3744,7 @@ variants:
   - name: STM32F439VITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3769,7 +3769,7 @@ variants:
   - name: STM32F439ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3795,7 +3795,7 @@ variants:
   - name: STM32F439ZITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3820,7 +3820,7 @@ variants:
   - name: STM32F439ZIYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3845,7 +3845,7 @@ variants:
   - name: STM32F446MCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3870,7 +3870,7 @@ variants:
   - name: STM32F446MEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3895,7 +3895,7 @@ variants:
   - name: STM32F446RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3920,7 +3920,7 @@ variants:
   - name: STM32F446RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3945,7 +3945,7 @@ variants:
   - name: STM32F446VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3970,7 +3970,7 @@ variants:
   - name: STM32F446VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3995,7 +3995,7 @@ variants:
   - name: STM32F446ZCHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4020,7 +4020,7 @@ variants:
   - name: STM32F446ZCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4045,7 +4045,7 @@ variants:
   - name: STM32F446ZEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4070,7 +4070,7 @@ variants:
   - name: STM32F446ZEJx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4095,7 +4095,7 @@ variants:
   - name: STM32F446ZETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4120,7 +4120,7 @@ variants:
   - name: STM32F469AEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4145,7 +4145,7 @@ variants:
   - name: STM32F469AEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4170,7 +4170,7 @@ variants:
   - name: STM32F469AGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4196,7 +4196,7 @@ variants:
   - name: STM32F469AGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4222,7 +4222,7 @@ variants:
   - name: STM32F469AIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4247,7 +4247,7 @@ variants:
   - name: STM32F469AIYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4272,7 +4272,7 @@ variants:
   - name: STM32F469BETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4297,7 +4297,7 @@ variants:
   - name: STM32F469BGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4323,7 +4323,7 @@ variants:
   - name: STM32F469BITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4348,7 +4348,7 @@ variants:
   - name: STM32F469IEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4373,7 +4373,7 @@ variants:
   - name: STM32F469IETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4398,7 +4398,7 @@ variants:
   - name: STM32F469IGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4424,7 +4424,7 @@ variants:
   - name: STM32F469IGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4450,7 +4450,7 @@ variants:
   - name: STM32F469IIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4475,7 +4475,7 @@ variants:
   - name: STM32F469IITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4500,7 +4500,7 @@ variants:
   - name: STM32F469NEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4525,7 +4525,7 @@ variants:
   - name: STM32F469NGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4551,7 +4551,7 @@ variants:
   - name: STM32F469NIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4576,7 +4576,7 @@ variants:
   - name: STM32F469VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4601,7 +4601,7 @@ variants:
   - name: STM32F469VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4627,7 +4627,7 @@ variants:
   - name: STM32F469VITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4652,7 +4652,7 @@ variants:
   - name: STM32F469ZETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4677,7 +4677,7 @@ variants:
   - name: STM32F469ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4703,7 +4703,7 @@ variants:
   - name: STM32F469ZITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4728,7 +4728,7 @@ variants:
   - name: STM32F479AGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4754,7 +4754,7 @@ variants:
   - name: STM32F479AGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4780,7 +4780,7 @@ variants:
   - name: STM32F479AIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4805,7 +4805,7 @@ variants:
   - name: STM32F479AIYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4830,7 +4830,7 @@ variants:
   - name: STM32F479BGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4856,7 +4856,7 @@ variants:
   - name: STM32F479BITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4881,7 +4881,7 @@ variants:
   - name: STM32F479IGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4907,7 +4907,7 @@ variants:
   - name: STM32F479IGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4933,7 +4933,7 @@ variants:
   - name: STM32F479IIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4958,7 +4958,7 @@ variants:
   - name: STM32F479IITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4983,7 +4983,7 @@ variants:
   - name: STM32F479NGHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5009,7 +5009,7 @@ variants:
   - name: STM32F479NIHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5034,7 +5034,7 @@ variants:
   - name: STM32F479VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5060,7 +5060,7 @@ variants:
   - name: STM32F479VITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5085,7 +5085,7 @@ variants:
   - name: STM32F479ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5111,7 +5111,7 @@ variants:
   - name: STM32F479ZITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32F7_Series.yaml
+++ b/probe-rs/targets/STM32F7_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: STM32F722ICKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -36,7 +36,7 @@ variants:
   - name: STM32F722ICTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -68,7 +68,7 @@ variants:
   - name: STM32F722IEKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
   - name: STM32F722IETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -132,7 +132,7 @@ variants:
   - name: STM32F722RCTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -164,7 +164,7 @@ variants:
   - name: STM32F722RETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
   - name: STM32F722VCTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -228,7 +228,7 @@ variants:
   - name: STM32F722VETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -260,7 +260,7 @@ variants:
   - name: STM32F722ZCTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -292,7 +292,7 @@ variants:
   - name: STM32F722ZETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -324,7 +324,7 @@ variants:
   - name: STM32F723ICKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -356,7 +356,7 @@ variants:
   - name: STM32F723ICTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -388,7 +388,7 @@ variants:
   - name: STM32F723IEKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -420,7 +420,7 @@ variants:
   - name: STM32F723IETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -452,7 +452,7 @@ variants:
   - name: STM32F723VEYx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -484,7 +484,7 @@ variants:
   - name: STM32F723ZCIx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -516,7 +516,7 @@ variants:
   - name: STM32F723ZCTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -548,7 +548,7 @@ variants:
   - name: STM32F723ZEIx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -580,7 +580,7 @@ variants:
   - name: STM32F723ZETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -612,7 +612,7 @@ variants:
   - name: STM32F730I8Kx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -644,7 +644,7 @@ variants:
   - name: STM32F730R8Tx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -676,7 +676,7 @@ variants:
   - name: STM32F730V8Tx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -708,7 +708,7 @@ variants:
   - name: STM32F730Z8Tx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -740,7 +740,7 @@ variants:
   - name: STM32F732IEKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -772,7 +772,7 @@ variants:
   - name: STM32F732IETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -804,7 +804,7 @@ variants:
   - name: STM32F732RETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -836,7 +836,7 @@ variants:
   - name: STM32F732VETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -868,7 +868,7 @@ variants:
   - name: STM32F732ZETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -900,7 +900,7 @@ variants:
   - name: STM32F733IEKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -932,7 +932,7 @@ variants:
   - name: STM32F733IETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -964,7 +964,7 @@ variants:
   - name: STM32F733VETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -996,7 +996,7 @@ variants:
   - name: STM32F733VEYx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1028,7 +1028,7 @@ variants:
   - name: STM32F733ZEKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1060,7 +1060,7 @@ variants:
   - name: STM32F733ZETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1092,7 +1092,7 @@ variants:
   - name: STM32F745IEKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1124,7 +1124,7 @@ variants:
   - name: STM32F745IETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1156,7 +1156,7 @@ variants:
   - name: STM32F745IGKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1188,7 +1188,7 @@ variants:
   - name: STM32F745IGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1220,7 +1220,7 @@ variants:
   - name: STM32F745VEHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1252,7 +1252,7 @@ variants:
   - name: STM32F745VETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1284,7 +1284,7 @@ variants:
   - name: STM32F745VGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1316,7 +1316,7 @@ variants:
   - name: STM32F745VGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1348,7 +1348,7 @@ variants:
   - name: STM32F745ZETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1380,7 +1380,7 @@ variants:
   - name: STM32F745ZGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1412,7 +1412,7 @@ variants:
   - name: STM32F746BETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1444,7 +1444,7 @@ variants:
   - name: STM32F746BGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1476,7 +1476,7 @@ variants:
   - name: STM32F746IEKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1508,7 +1508,7 @@ variants:
   - name: STM32F746IETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1540,7 +1540,7 @@ variants:
   - name: STM32F746IGKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1572,7 +1572,7 @@ variants:
   - name: STM32F746IGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1604,7 +1604,7 @@ variants:
   - name: STM32F746NEHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1636,7 +1636,7 @@ variants:
   - name: STM32F746NGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1668,7 +1668,7 @@ variants:
   - name: STM32F746VEHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1700,7 +1700,7 @@ variants:
   - name: STM32F746VETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1732,7 +1732,7 @@ variants:
   - name: STM32F746VGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1764,7 +1764,7 @@ variants:
   - name: STM32F746VGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1796,7 +1796,7 @@ variants:
   - name: STM32F746ZETx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1828,7 +1828,7 @@ variants:
   - name: STM32F746ZEYx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1860,7 +1860,7 @@ variants:
   - name: STM32F746ZGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1892,7 +1892,7 @@ variants:
   - name: STM32F746ZGYx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1924,7 +1924,7 @@ variants:
   - name: STM32F750N8Hx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1956,7 +1956,7 @@ variants:
   - name: STM32F750V8Tx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1988,7 +1988,7 @@ variants:
   - name: STM32F750Z8Tx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2020,7 +2020,7 @@ variants:
   - name: STM32F756BGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2052,7 +2052,7 @@ variants:
   - name: STM32F756IGKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2084,7 +2084,7 @@ variants:
   - name: STM32F756IGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2116,7 +2116,7 @@ variants:
   - name: STM32F756NGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2148,7 +2148,7 @@ variants:
   - name: STM32F756VGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2180,7 +2180,7 @@ variants:
   - name: STM32F756VGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2212,7 +2212,7 @@ variants:
   - name: STM32F756ZGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2244,7 +2244,7 @@ variants:
   - name: STM32F756ZGYx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2276,7 +2276,7 @@ variants:
   - name: STM32F765BGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2310,7 +2310,7 @@ variants:
   - name: STM32F765BITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2344,7 +2344,7 @@ variants:
   - name: STM32F765IGKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2378,7 +2378,7 @@ variants:
   - name: STM32F765IGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2412,7 +2412,7 @@ variants:
   - name: STM32F765IIKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2446,7 +2446,7 @@ variants:
   - name: STM32F765IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2480,7 +2480,7 @@ variants:
   - name: STM32F765NGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2514,7 +2514,7 @@ variants:
   - name: STM32F765NIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2548,7 +2548,7 @@ variants:
   - name: STM32F765VGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2582,7 +2582,7 @@ variants:
   - name: STM32F765VITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2616,7 +2616,7 @@ variants:
   - name: STM32F765ZGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2650,7 +2650,7 @@ variants:
   - name: STM32F765ZITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2684,7 +2684,7 @@ variants:
   - name: STM32F767BGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2718,7 +2718,7 @@ variants:
   - name: STM32F767BITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2752,7 +2752,7 @@ variants:
   - name: STM32F767IGKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2786,7 +2786,7 @@ variants:
   - name: STM32F767IGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2820,7 +2820,7 @@ variants:
   - name: STM32F767IIKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2854,7 +2854,7 @@ variants:
   - name: STM32F767IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2888,7 +2888,7 @@ variants:
   - name: STM32F767NGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2922,7 +2922,7 @@ variants:
   - name: STM32F767NIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2956,7 +2956,7 @@ variants:
   - name: STM32F767VGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2990,7 +2990,7 @@ variants:
   - name: STM32F767VITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3024,7 +3024,7 @@ variants:
   - name: STM32F767ZGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3058,7 +3058,7 @@ variants:
   - name: STM32F767ZITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3092,7 +3092,7 @@ variants:
   - name: STM32F768AIYx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3126,7 +3126,7 @@ variants:
   - name: STM32F769AGYx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3160,7 +3160,7 @@ variants:
   - name: STM32F769AIYx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3194,7 +3194,7 @@ variants:
   - name: STM32F769BGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3228,7 +3228,7 @@ variants:
   - name: STM32F769BITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3262,7 +3262,7 @@ variants:
   - name: STM32F769IGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3296,7 +3296,7 @@ variants:
   - name: STM32F769IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3330,7 +3330,7 @@ variants:
   - name: STM32F769NGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3364,7 +3364,7 @@ variants:
   - name: STM32F769NIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3398,7 +3398,7 @@ variants:
   - name: STM32F777BITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3432,7 +3432,7 @@ variants:
   - name: STM32F777IIKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3466,7 +3466,7 @@ variants:
   - name: STM32F777IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3500,7 +3500,7 @@ variants:
   - name: STM32F777NIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3534,7 +3534,7 @@ variants:
   - name: STM32F777VITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3568,7 +3568,7 @@ variants:
   - name: STM32F777ZITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3602,7 +3602,7 @@ variants:
   - name: STM32F778AIYx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3636,7 +3636,7 @@ variants:
   - name: STM32F779AIYx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3670,7 +3670,7 @@ variants:
   - name: STM32F779BITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3704,7 +3704,7 @@ variants:
   - name: STM32F779IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3738,7 +3738,7 @@ variants:
   - name: STM32F779NIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32G0_Series.yaml
+++ b/probe-rs/targets/STM32G0_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: STM32G030C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -29,7 +29,7 @@ variants:
   - name: STM32G030C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -54,7 +54,7 @@ variants:
   - name: STM32G030F6Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -79,7 +79,7 @@ variants:
   - name: STM32G030J6Mx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -104,7 +104,7 @@ variants:
   - name: STM32G030K6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -129,7 +129,7 @@ variants:
   - name: STM32G030K8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -154,7 +154,7 @@ variants:
   - name: STM32G031C4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -179,7 +179,7 @@ variants:
   - name: STM32G031C4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -204,7 +204,7 @@ variants:
   - name: STM32G031C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -229,7 +229,7 @@ variants:
   - name: STM32G031C6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -254,7 +254,7 @@ variants:
   - name: STM32G031C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -279,7 +279,7 @@ variants:
   - name: STM32G031C8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -304,7 +304,7 @@ variants:
   - name: STM32G031F4Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -329,7 +329,7 @@ variants:
   - name: STM32G031F6Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -354,7 +354,7 @@ variants:
   - name: STM32G031F8Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -379,7 +379,7 @@ variants:
   - name: STM32G031G4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -404,7 +404,7 @@ variants:
   - name: STM32G031G6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -429,7 +429,7 @@ variants:
   - name: STM32G031G8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -454,7 +454,7 @@ variants:
   - name: STM32G031J4Mx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -479,7 +479,7 @@ variants:
   - name: STM32G031J6Mx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -504,7 +504,7 @@ variants:
   - name: STM32G031K4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -529,7 +529,7 @@ variants:
   - name: STM32G031K4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -554,7 +554,7 @@ variants:
   - name: STM32G031K6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -579,7 +579,7 @@ variants:
   - name: STM32G031K6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -604,7 +604,7 @@ variants:
   - name: STM32G031K8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -629,7 +629,7 @@ variants:
   - name: STM32G031K8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -654,7 +654,7 @@ variants:
   - name: STM32G031Y8Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -679,7 +679,7 @@ variants:
   - name: STM32G041C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -704,7 +704,7 @@ variants:
   - name: STM32G041C6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -729,7 +729,7 @@ variants:
   - name: STM32G041C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -754,7 +754,7 @@ variants:
   - name: STM32G041C8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -779,7 +779,7 @@ variants:
   - name: STM32G041F6Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -804,7 +804,7 @@ variants:
   - name: STM32G041F8Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -829,7 +829,7 @@ variants:
   - name: STM32G041G6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -854,7 +854,7 @@ variants:
   - name: STM32G041G8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -879,7 +879,7 @@ variants:
   - name: STM32G041J6Mx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -904,7 +904,7 @@ variants:
   - name: STM32G041K6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -929,7 +929,7 @@ variants:
   - name: STM32G041K6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -954,7 +954,7 @@ variants:
   - name: STM32G041K8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -979,7 +979,7 @@ variants:
   - name: STM32G041K8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1004,7 +1004,7 @@ variants:
   - name: STM32G041Y8Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1029,7 +1029,7 @@ variants:
   - name: STM32G070CBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1054,7 +1054,7 @@ variants:
   - name: STM32G070KBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1079,7 +1079,7 @@ variants:
   - name: STM32G070RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1104,7 +1104,7 @@ variants:
   - name: STM32G071C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1129,7 +1129,7 @@ variants:
   - name: STM32G071C6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1154,7 +1154,7 @@ variants:
   - name: STM32G071C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1179,7 +1179,7 @@ variants:
   - name: STM32G071C8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1204,7 +1204,7 @@ variants:
   - name: STM32G071CBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1229,7 +1229,7 @@ variants:
   - name: STM32G071CBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1254,7 +1254,7 @@ variants:
   - name: STM32G071EBYx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1279,7 +1279,7 @@ variants:
   - name: STM32G071G6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1304,7 +1304,7 @@ variants:
   - name: STM32G071G8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1329,7 +1329,7 @@ variants:
   - name: STM32G071G8UxN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1354,7 +1354,7 @@ variants:
   - name: STM32G071GBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1379,7 +1379,7 @@ variants:
   - name: STM32G071GBUxN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1404,7 +1404,7 @@ variants:
   - name: STM32G071K6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1429,7 +1429,7 @@ variants:
   - name: STM32G071K6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1454,7 +1454,7 @@ variants:
   - name: STM32G071K8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1479,7 +1479,7 @@ variants:
   - name: STM32G071K8TxN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1504,7 +1504,7 @@ variants:
   - name: STM32G071K8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1529,7 +1529,7 @@ variants:
   - name: STM32G071K8UxN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1554,7 +1554,7 @@ variants:
   - name: STM32G071KBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1579,7 +1579,7 @@ variants:
   - name: STM32G071KBTxN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1604,7 +1604,7 @@ variants:
   - name: STM32G071KBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1629,7 +1629,7 @@ variants:
   - name: STM32G071KBUxN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1654,7 +1654,7 @@ variants:
   - name: STM32G071R6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1679,7 +1679,7 @@ variants:
   - name: STM32G071R8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1704,7 +1704,7 @@ variants:
   - name: STM32G071RBIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1729,7 +1729,7 @@ variants:
   - name: STM32G071RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1754,7 +1754,7 @@ variants:
   - name: STM32G081CBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1779,7 +1779,7 @@ variants:
   - name: STM32G081CBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1804,7 +1804,7 @@ variants:
   - name: STM32G081EBYx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1829,7 +1829,7 @@ variants:
   - name: STM32G081GBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1854,7 +1854,7 @@ variants:
   - name: STM32G081GBUxN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1879,7 +1879,7 @@ variants:
   - name: STM32G081KBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1904,7 +1904,7 @@ variants:
   - name: STM32G081KBTxN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1929,7 +1929,7 @@ variants:
   - name: STM32G081KBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1954,7 +1954,7 @@ variants:
   - name: STM32G081KBUxN
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1979,7 +1979,7 @@ variants:
   - name: STM32G081RBIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2004,7 +2004,7 @@ variants:
   - name: STM32G081RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32G4_Series.yaml
+++ b/probe-rs/targets/STM32G4_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: STM32G431C6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: STM32G431C6Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: STM32G431C8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: STM32G431C8Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: STM32G431CBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: STM32G431CBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: STM32G431CBYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -165,7 +165,7 @@ variants:
   - name: STM32G431K6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -188,7 +188,7 @@ variants:
   - name: STM32G431K6Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -211,7 +211,7 @@ variants:
   - name: STM32G431K8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -234,7 +234,7 @@ variants:
   - name: STM32G431K8Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -257,7 +257,7 @@ variants:
   - name: STM32G431KBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -280,7 +280,7 @@ variants:
   - name: STM32G431KBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -303,7 +303,7 @@ variants:
   - name: STM32G431M6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -326,7 +326,7 @@ variants:
   - name: STM32G431M8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -349,7 +349,7 @@ variants:
   - name: STM32G431R6Ix
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -372,7 +372,7 @@ variants:
   - name: STM32G431R6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -395,7 +395,7 @@ variants:
   - name: STM32G431R8Ix
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -418,7 +418,7 @@ variants:
   - name: STM32G431R8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -441,7 +441,7 @@ variants:
   - name: STM32G431RBIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -464,7 +464,7 @@ variants:
   - name: STM32G431RBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -487,7 +487,7 @@ variants:
   - name: STM32G431V6Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -510,7 +510,7 @@ variants:
   - name: STM32G431V8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -533,7 +533,7 @@ variants:
   - name: STM32G431VBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -556,7 +556,7 @@ variants:
   - name: STM32G441CBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -579,7 +579,7 @@ variants:
   - name: STM32G441CBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -602,7 +602,7 @@ variants:
   - name: STM32G441CBYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -625,7 +625,7 @@ variants:
   - name: STM32G441KBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -648,7 +648,7 @@ variants:
   - name: STM32G441KBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -671,7 +671,7 @@ variants:
   - name: STM32G441RBIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -694,7 +694,7 @@ variants:
   - name: STM32G441RBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -717,7 +717,7 @@ variants:
   - name: STM32G441VBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -740,7 +740,7 @@ variants:
   - name: STM32G471CCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -763,7 +763,7 @@ variants:
   - name: STM32G471CCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -786,7 +786,7 @@ variants:
   - name: STM32G471CETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -810,7 +810,7 @@ variants:
   - name: STM32G471CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -834,7 +834,7 @@ variants:
   - name: STM32G471MCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -857,7 +857,7 @@ variants:
   - name: STM32G471METx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -881,7 +881,7 @@ variants:
   - name: STM32G471MEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -905,7 +905,7 @@ variants:
   - name: STM32G471QCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -928,7 +928,7 @@ variants:
   - name: STM32G471QETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -952,7 +952,7 @@ variants:
   - name: STM32G471RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -975,7 +975,7 @@ variants:
   - name: STM32G471RE
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -999,7 +999,7 @@ variants:
   - name: STM32G471VCHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1022,7 +1022,7 @@ variants:
   - name: STM32G471VCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1045,7 +1045,7 @@ variants:
   - name: STM32G471VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1068,7 +1068,7 @@ variants:
   - name: STM32G471VEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1092,7 +1092,7 @@ variants:
   - name: STM32G471VEIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1116,7 +1116,7 @@ variants:
   - name: STM32G471VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1140,7 +1140,7 @@ variants:
   - name: STM32G473CBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1163,7 +1163,7 @@ variants:
   - name: STM32G473CBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1186,7 +1186,7 @@ variants:
   - name: STM32G473CCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1209,7 +1209,7 @@ variants:
   - name: STM32G473CCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1232,7 +1232,7 @@ variants:
   - name: STM32G473CETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1256,7 +1256,7 @@ variants:
   - name: STM32G473CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1280,7 +1280,7 @@ variants:
   - name: STM32G473MBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1303,7 +1303,7 @@ variants:
   - name: STM32G473MCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1326,7 +1326,7 @@ variants:
   - name: STM32G473METx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1350,7 +1350,7 @@ variants:
   - name: STM32G473MEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1374,7 +1374,7 @@ variants:
   - name: STM32G473QBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1397,7 +1397,7 @@ variants:
   - name: STM32G473QCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1420,7 +1420,7 @@ variants:
   - name: STM32G473QETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1444,7 +1444,7 @@ variants:
   - name: STM32G473RBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1467,7 +1467,7 @@ variants:
   - name: STM32G473RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1490,7 +1490,7 @@ variants:
   - name: STM32G473RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1514,7 +1514,7 @@ variants:
   - name: STM32G473VBHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1537,7 +1537,7 @@ variants:
   - name: STM32G473VBIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1560,7 +1560,7 @@ variants:
   - name: STM32G473VBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1583,7 +1583,7 @@ variants:
   - name: STM32G473VCHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1606,7 +1606,7 @@ variants:
   - name: STM32G473VCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1629,7 +1629,7 @@ variants:
   - name: STM32G473VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1652,7 +1652,7 @@ variants:
   - name: STM32G473VEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1676,7 +1676,7 @@ variants:
   - name: STM32G473VEIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1700,7 +1700,7 @@ variants:
   - name: STM32G473VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1724,7 +1724,7 @@ variants:
   - name: STM32G474CBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1747,7 +1747,7 @@ variants:
   - name: STM32G474CBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1770,7 +1770,7 @@ variants:
   - name: STM32G474CCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1793,7 +1793,7 @@ variants:
   - name: STM32G474CCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1816,7 +1816,7 @@ variants:
   - name: STM32G474CETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1840,7 +1840,7 @@ variants:
   - name: STM32G474CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1864,7 +1864,7 @@ variants:
   - name: STM32G474MBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1887,7 +1887,7 @@ variants:
   - name: STM32G474MCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1910,7 +1910,7 @@ variants:
   - name: STM32G474METx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1934,7 +1934,7 @@ variants:
   - name: STM32G474MEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1958,7 +1958,7 @@ variants:
   - name: STM32G474QBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1981,7 +1981,7 @@ variants:
   - name: STM32G474QCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2004,7 +2004,7 @@ variants:
   - name: STM32G474QETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2028,7 +2028,7 @@ variants:
   - name: STM32G474RBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2051,7 +2051,7 @@ variants:
   - name: STM32G474RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2074,7 +2074,7 @@ variants:
   - name: STM32G474RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2098,7 +2098,7 @@ variants:
   - name: STM32G474VBHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2121,7 +2121,7 @@ variants:
   - name: STM32G474VBIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2144,7 +2144,7 @@ variants:
   - name: STM32G474VBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2167,7 +2167,7 @@ variants:
   - name: STM32G474VCHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2190,7 +2190,7 @@ variants:
   - name: STM32G474VCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2213,7 +2213,7 @@ variants:
   - name: STM32G474VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2236,7 +2236,7 @@ variants:
   - name: STM32G474VEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2260,7 +2260,7 @@ variants:
   - name: STM32G474VEIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2284,7 +2284,7 @@ variants:
   - name: STM32G474VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2308,7 +2308,7 @@ variants:
   - name: STM32G483CETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2332,7 +2332,7 @@ variants:
   - name: STM32G483CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2356,7 +2356,7 @@ variants:
   - name: STM32G483METx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2380,7 +2380,7 @@ variants:
   - name: STM32G483MEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2404,7 +2404,7 @@ variants:
   - name: STM32G483QETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2428,7 +2428,7 @@ variants:
   - name: STM32G483RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2452,7 +2452,7 @@ variants:
   - name: STM32G483VEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2476,7 +2476,7 @@ variants:
   - name: STM32G483VEIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2500,7 +2500,7 @@ variants:
   - name: STM32G483VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2524,7 +2524,7 @@ variants:
   - name: STM32G484CETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2548,7 +2548,7 @@ variants:
   - name: STM32G484CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2572,7 +2572,7 @@ variants:
   - name: STM32G484METx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2596,7 +2596,7 @@ variants:
   - name: STM32G484MEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2620,7 +2620,7 @@ variants:
   - name: STM32G484QETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2644,7 +2644,7 @@ variants:
   - name: STM32G484RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2668,7 +2668,7 @@ variants:
   - name: STM32G484VEHx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2692,7 +2692,7 @@ variants:
   - name: STM32G484VEIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2716,7 +2716,7 @@ variants:
   - name: STM32G484VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2740,7 +2740,7 @@ variants:
   - name: STM32GBK1CB
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32H7_Series.yaml
+++ b/probe-rs/targets/STM32H7_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: STM32H742AGIx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -27,7 +27,7 @@ variants:
   - name: STM32H742AIIx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -50,7 +50,7 @@ variants:
   - name: STM32H742BGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -73,7 +73,7 @@ variants:
   - name: STM32H742BITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -96,7 +96,7 @@ variants:
   - name: STM32H742IGKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -119,7 +119,7 @@ variants:
   - name: STM32H742IGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -142,7 +142,7 @@ variants:
   - name: STM32H742IIKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -165,7 +165,7 @@ variants:
   - name: STM32H742IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -188,7 +188,7 @@ variants:
   - name: STM32H742VGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -211,7 +211,7 @@ variants:
   - name: STM32H742VGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -234,7 +234,7 @@ variants:
   - name: STM32H742VIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -257,7 +257,7 @@ variants:
   - name: STM32H742VITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -280,7 +280,7 @@ variants:
   - name: STM32H742XGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -303,7 +303,7 @@ variants:
   - name: STM32H742XIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -326,7 +326,7 @@ variants:
   - name: STM32H742ZGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -349,7 +349,7 @@ variants:
   - name: STM32H742ZITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -372,7 +372,7 @@ variants:
   - name: STM32H743AGIx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -395,7 +395,7 @@ variants:
   - name: STM32H743AIIx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -418,7 +418,7 @@ variants:
   - name: STM32H743BGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -441,7 +441,7 @@ variants:
   - name: STM32H743BITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -464,7 +464,7 @@ variants:
   - name: STM32H743IGKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -487,7 +487,7 @@ variants:
   - name: STM32H743IGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -510,7 +510,7 @@ variants:
   - name: STM32H743IIKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -533,7 +533,7 @@ variants:
   - name: STM32H743IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -556,7 +556,7 @@ variants:
   - name: STM32H743VGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -579,7 +579,7 @@ variants:
   - name: STM32H743VGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -602,7 +602,7 @@ variants:
   - name: STM32H743VIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -625,7 +625,7 @@ variants:
   - name: STM32H743VITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -648,7 +648,7 @@ variants:
   - name: STM32H743XGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -671,7 +671,7 @@ variants:
   - name: STM32H743XIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -694,7 +694,7 @@ variants:
   - name: STM32H743ZGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -717,7 +717,7 @@ variants:
   - name: STM32H743ZITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -740,7 +740,7 @@ variants:
   - name: STM32H745BGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -763,7 +763,7 @@ variants:
   - name: STM32H745BITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -786,7 +786,7 @@ variants:
   - name: STM32H745IGKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -809,7 +809,7 @@ variants:
   - name: STM32H745IGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -832,7 +832,7 @@ variants:
   - name: STM32H745IIKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -855,7 +855,7 @@ variants:
   - name: STM32H745IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -878,7 +878,7 @@ variants:
   - name: STM32H745XGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -901,7 +901,7 @@ variants:
   - name: STM32H745XIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -924,7 +924,7 @@ variants:
   - name: STM32H745ZGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -947,7 +947,7 @@ variants:
   - name: STM32H745ZITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -970,7 +970,7 @@ variants:
   - name: STM32H747AGIx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -993,7 +993,7 @@ variants:
   - name: STM32H747AIIx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1016,7 +1016,7 @@ variants:
   - name: STM32H747BGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1039,7 +1039,7 @@ variants:
   - name: STM32H747BITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1062,7 +1062,7 @@ variants:
   - name: STM32H747IGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1085,7 +1085,7 @@ variants:
   - name: STM32H747IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1108,7 +1108,7 @@ variants:
   - name: STM32H747XGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1131,7 +1131,7 @@ variants:
   - name: STM32H747XIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1154,7 +1154,7 @@ variants:
   - name: STM32H747ZIYx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1177,7 +1177,7 @@ variants:
   - name: STM32H750IBKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1200,7 +1200,7 @@ variants:
   - name: STM32H750IBTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1223,7 +1223,7 @@ variants:
   - name: STM32H750VBTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1246,7 +1246,7 @@ variants:
   - name: STM32H750XBHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1269,7 +1269,7 @@ variants:
   - name: STM32H750ZBTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1292,7 +1292,7 @@ variants:
   - name: STM32H753AIIx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1315,7 +1315,7 @@ variants:
   - name: STM32H753BITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1338,7 +1338,7 @@ variants:
   - name: STM32H753IIKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1361,7 +1361,7 @@ variants:
   - name: STM32H753IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1384,7 +1384,7 @@ variants:
   - name: STM32H753VIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1407,7 +1407,7 @@ variants:
   - name: STM32H753VITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1430,7 +1430,7 @@ variants:
   - name: STM32H753XIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1453,7 +1453,7 @@ variants:
   - name: STM32H753ZITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1476,7 +1476,7 @@ variants:
   - name: STM32H755BITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1499,7 +1499,7 @@ variants:
   - name: STM32H755IIKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1522,7 +1522,7 @@ variants:
   - name: STM32H755IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1545,7 +1545,7 @@ variants:
   - name: STM32H755XIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1568,7 +1568,7 @@ variants:
   - name: STM32H755ZITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1591,7 +1591,7 @@ variants:
   - name: STM32H757AIIx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1614,7 +1614,7 @@ variants:
   - name: STM32H757BITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1637,7 +1637,7 @@ variants:
   - name: STM32H757IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1660,7 +1660,7 @@ variants:
   - name: STM32H757XIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1683,7 +1683,7 @@ variants:
   - name: STM32H757ZIYx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1706,7 +1706,7 @@ variants:
   - name: STM32H7A3AGIxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1729,7 +1729,7 @@ variants:
   - name: STM32H7A3AIIxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1752,7 +1752,7 @@ variants:
   - name: STM32H7A3IGKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1775,7 +1775,7 @@ variants:
   - name: STM32H7A3IGKxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1798,7 +1798,7 @@ variants:
   - name: STM32H7A3IGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1821,7 +1821,7 @@ variants:
   - name: STM32H7A3IGTxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1844,7 +1844,7 @@ variants:
   - name: STM32H7A3IIKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1867,7 +1867,7 @@ variants:
   - name: STM32H7A3IIKxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1890,7 +1890,7 @@ variants:
   - name: STM32H7A3IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1913,7 +1913,7 @@ variants:
   - name: STM32H7A3IITxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1936,7 +1936,7 @@ variants:
   - name: STM32H7A3LGHxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1959,7 +1959,7 @@ variants:
   - name: STM32H7A3LIHxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1982,7 +1982,7 @@ variants:
   - name: STM32H7A3NGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2005,7 +2005,7 @@ variants:
   - name: STM32H7A3NIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2028,7 +2028,7 @@ variants:
   - name: STM32H7A3QIYxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2051,7 +2051,7 @@ variants:
   - name: STM32H7A3RGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2074,7 +2074,7 @@ variants:
   - name: STM32H7A3RITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2097,7 +2097,7 @@ variants:
   - name: STM32H7A3VGHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2120,7 +2120,7 @@ variants:
   - name: STM32H7A3VGHxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2143,7 +2143,7 @@ variants:
   - name: STM32H7A3VGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2166,7 +2166,7 @@ variants:
   - name: STM32H7A3VGTxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2189,7 +2189,7 @@ variants:
   - name: STM32H7A3VIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2212,7 +2212,7 @@ variants:
   - name: STM32H7A3VIHxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2235,7 +2235,7 @@ variants:
   - name: STM32H7A3VITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2258,7 +2258,7 @@ variants:
   - name: STM32H7A3VITxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2281,7 +2281,7 @@ variants:
   - name: STM32H7A3ZGTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2304,7 +2304,7 @@ variants:
   - name: STM32H7A3ZGTxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2327,7 +2327,7 @@ variants:
   - name: STM32H7A3ZITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2350,7 +2350,7 @@ variants:
   - name: STM32H7A3ZITxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2373,7 +2373,7 @@ variants:
   - name: STM32H7B0ABIxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2396,7 +2396,7 @@ variants:
   - name: STM32H7B0IBKxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2419,7 +2419,7 @@ variants:
   - name: STM32H7B0IBTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2442,7 +2442,7 @@ variants:
   - name: STM32H7B0RBTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2465,7 +2465,7 @@ variants:
   - name: STM32H7B0VBTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2488,7 +2488,7 @@ variants:
   - name: STM32H7B0ZBTx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2511,7 +2511,7 @@ variants:
   - name: STM32H7B3AIIxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2534,7 +2534,7 @@ variants:
   - name: STM32H7B3IIKx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2557,7 +2557,7 @@ variants:
   - name: STM32H7B3IIKxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2580,7 +2580,7 @@ variants:
   - name: STM32H7B3IITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2603,7 +2603,7 @@ variants:
   - name: STM32H7B3IITxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2626,7 +2626,7 @@ variants:
   - name: STM32H7B3LIHxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2649,7 +2649,7 @@ variants:
   - name: STM32H7B3NIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2672,7 +2672,7 @@ variants:
   - name: STM32H7B3QIYxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2695,7 +2695,7 @@ variants:
   - name: STM32H7B3RITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2718,7 +2718,7 @@ variants:
   - name: STM32H7B3VIHx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2741,7 +2741,7 @@ variants:
   - name: STM32H7B3VIHxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2764,7 +2764,7 @@ variants:
   - name: STM32H7B3VITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2787,7 +2787,7 @@ variants:
   - name: STM32H7B3VITxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2810,7 +2810,7 @@ variants:
   - name: STM32H7B3ZITx
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2833,7 +2833,7 @@ variants:
   - name: STM32H7B3ZITxQ
     cores:
       - name: main
-        type: M7
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32L0_Series.yaml
+++ b/probe-rs/targets/STM32L0_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: STM32L010C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -29,7 +29,7 @@ variants:
   - name: STM32L010F4Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -54,7 +54,7 @@ variants:
   - name: STM32L010K4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -79,7 +79,7 @@ variants:
   - name: STM32L010K8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -104,7 +104,7 @@ variants:
   - name: STM32L010R8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -129,7 +129,7 @@ variants:
   - name: STM32L010RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -154,7 +154,7 @@ variants:
   - name: STM32L011D3Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -179,7 +179,7 @@ variants:
   - name: STM32L011D4Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -204,7 +204,7 @@ variants:
   - name: STM32L011E4Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -229,7 +229,7 @@ variants:
   - name: STM32L011F3Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -254,7 +254,7 @@ variants:
   - name: STM32L011F3Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -279,7 +279,7 @@ variants:
   - name: STM32L011F4Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -304,7 +304,7 @@ variants:
   - name: STM32L011F4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -329,7 +329,7 @@ variants:
   - name: STM32L011G3Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -354,7 +354,7 @@ variants:
   - name: STM32L011G4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -379,7 +379,7 @@ variants:
   - name: STM32L011K3Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -404,7 +404,7 @@ variants:
   - name: STM32L011K3Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -429,7 +429,7 @@ variants:
   - name: STM32L011K4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -454,7 +454,7 @@ variants:
   - name: STM32L011K4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -479,7 +479,7 @@ variants:
   - name: STM32L021D4Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -504,7 +504,7 @@ variants:
   - name: STM32L021F4Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -529,7 +529,7 @@ variants:
   - name: STM32L021F4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -554,7 +554,7 @@ variants:
   - name: STM32L021G4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -579,7 +579,7 @@ variants:
   - name: STM32L021K4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -604,7 +604,7 @@ variants:
   - name: STM32L021K4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -629,7 +629,7 @@ variants:
   - name: STM32L031C4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -654,7 +654,7 @@ variants:
   - name: STM32L031C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -679,7 +679,7 @@ variants:
   - name: STM32L031E4Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -704,7 +704,7 @@ variants:
   - name: STM32L031E6Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -729,7 +729,7 @@ variants:
   - name: STM32L031F4Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -754,7 +754,7 @@ variants:
   - name: STM32L031F6Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -779,7 +779,7 @@ variants:
   - name: STM32L031G4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -804,7 +804,7 @@ variants:
   - name: STM32L031G6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -829,7 +829,7 @@ variants:
   - name: STM32L031G6UxS
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -854,7 +854,7 @@ variants:
   - name: STM32L031K4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -879,7 +879,7 @@ variants:
   - name: STM32L031K4Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -904,7 +904,7 @@ variants:
   - name: STM32L031K6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -929,7 +929,7 @@ variants:
   - name: STM32L031K6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -954,7 +954,7 @@ variants:
   - name: STM32L041C4Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -979,7 +979,7 @@ variants:
   - name: STM32L041C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1004,7 +1004,7 @@ variants:
   - name: STM32L041E6Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1029,7 +1029,7 @@ variants:
   - name: STM32L041F6Px
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1054,7 +1054,7 @@ variants:
   - name: STM32L041G6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1079,7 +1079,7 @@ variants:
   - name: STM32L041K6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1104,7 +1104,7 @@ variants:
   - name: STM32L041K6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1129,7 +1129,7 @@ variants:
   - name: STM32L051C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1154,7 +1154,7 @@ variants:
   - name: STM32L051C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1179,7 +1179,7 @@ variants:
   - name: STM32L051K6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1204,7 +1204,7 @@ variants:
   - name: STM32L051K6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1229,7 +1229,7 @@ variants:
   - name: STM32L051K8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1254,7 +1254,7 @@ variants:
   - name: STM32L051K8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1279,7 +1279,7 @@ variants:
   - name: STM32L051R6Hx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1304,7 +1304,7 @@ variants:
   - name: STM32L051R6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1329,7 +1329,7 @@ variants:
   - name: STM32L051R8Hx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1354,7 +1354,7 @@ variants:
   - name: STM32L051R8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1379,7 +1379,7 @@ variants:
   - name: STM32L051T6Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1404,7 +1404,7 @@ variants:
   - name: STM32L051T8Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1429,7 +1429,7 @@ variants:
   - name: STM32L052C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1454,7 +1454,7 @@ variants:
   - name: STM32L052C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1479,7 +1479,7 @@ variants:
   - name: STM32L052K6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1504,7 +1504,7 @@ variants:
   - name: STM32L052K6Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1529,7 +1529,7 @@ variants:
   - name: STM32L052K8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1554,7 +1554,7 @@ variants:
   - name: STM32L052K8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1579,7 +1579,7 @@ variants:
   - name: STM32L052R6Hx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1604,7 +1604,7 @@ variants:
   - name: STM32L052R6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1629,7 +1629,7 @@ variants:
   - name: STM32L052R8Hx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1654,7 +1654,7 @@ variants:
   - name: STM32L052R8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1679,7 +1679,7 @@ variants:
   - name: STM32L052T6Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1704,7 +1704,7 @@ variants:
   - name: STM32L052T8Yx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1729,7 +1729,7 @@ variants:
   - name: STM32L053C6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1754,7 +1754,7 @@ variants:
   - name: STM32L053C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1779,7 +1779,7 @@ variants:
   - name: STM32L053R6Hx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1804,7 +1804,7 @@ variants:
   - name: STM32L053R6Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1829,7 +1829,7 @@ variants:
   - name: STM32L053R8Hx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1854,7 +1854,7 @@ variants:
   - name: STM32L053R8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1879,7 +1879,7 @@ variants:
   - name: STM32L062K8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1904,7 +1904,7 @@ variants:
   - name: STM32L062K8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1929,7 +1929,7 @@ variants:
   - name: STM32L063C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1954,7 +1954,7 @@ variants:
   - name: STM32L063R8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -1979,7 +1979,7 @@ variants:
   - name: STM32L071C8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2004,7 +2004,7 @@ variants:
   - name: STM32L071CBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2029,7 +2029,7 @@ variants:
   - name: STM32L071CBYx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2054,7 +2054,7 @@ variants:
   - name: STM32L071CZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2079,7 +2079,7 @@ variants:
   - name: STM32L071CZYx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2104,7 +2104,7 @@ variants:
   - name: STM32L071K8Ux
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2129,7 +2129,7 @@ variants:
   - name: STM32L071KBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2160,7 +2160,7 @@ variants:
   - name: STM32L071KBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2185,7 +2185,7 @@ variants:
   - name: STM32L071KZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2210,7 +2210,7 @@ variants:
   - name: STM32L071KZUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2235,7 +2235,7 @@ variants:
   - name: STM32L071RBHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2260,7 +2260,7 @@ variants:
   - name: STM32L071RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2285,7 +2285,7 @@ variants:
   - name: STM32L071RZHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2310,7 +2310,7 @@ variants:
   - name: STM32L071RZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2335,7 +2335,7 @@ variants:
   - name: STM32L071V8Ix
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2360,7 +2360,7 @@ variants:
   - name: STM32L071V8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2385,7 +2385,7 @@ variants:
   - name: STM32L071VBIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2410,7 +2410,7 @@ variants:
   - name: STM32L071VBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2435,7 +2435,7 @@ variants:
   - name: STM32L071VZIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2460,7 +2460,7 @@ variants:
   - name: STM32L071VZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2485,7 +2485,7 @@ variants:
   - name: STM32L072CBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2510,7 +2510,7 @@ variants:
   - name: STM32L072CBYx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2535,7 +2535,7 @@ variants:
   - name: STM32L072CZEx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2560,7 +2560,7 @@ variants:
   - name: STM32L072CZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2585,7 +2585,7 @@ variants:
   - name: STM32L072CZYx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2610,7 +2610,7 @@ variants:
   - name: STM32L072KBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2635,7 +2635,7 @@ variants:
   - name: STM32L072KBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2660,7 +2660,7 @@ variants:
   - name: STM32L072KZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2685,7 +2685,7 @@ variants:
   - name: STM32L072KZUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2710,7 +2710,7 @@ variants:
   - name: STM32L072RBHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2735,7 +2735,7 @@ variants:
   - name: STM32L072RBIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2760,7 +2760,7 @@ variants:
   - name: STM32L072RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2785,7 +2785,7 @@ variants:
   - name: STM32L072RZHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2810,7 +2810,7 @@ variants:
   - name: STM32L072RZIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2835,7 +2835,7 @@ variants:
   - name: STM32L072RZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2860,7 +2860,7 @@ variants:
   - name: STM32L072V8Ix
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2885,7 +2885,7 @@ variants:
   - name: STM32L072V8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2910,7 +2910,7 @@ variants:
   - name: STM32L072VBIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2935,7 +2935,7 @@ variants:
   - name: STM32L072VBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2960,7 +2960,7 @@ variants:
   - name: STM32L072VZIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -2985,7 +2985,7 @@ variants:
   - name: STM32L072VZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3010,7 +3010,7 @@ variants:
   - name: STM32L073CBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3035,7 +3035,7 @@ variants:
   - name: STM32L073CZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3060,7 +3060,7 @@ variants:
   - name: STM32L073RBHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3085,7 +3085,7 @@ variants:
   - name: STM32L073RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3110,7 +3110,7 @@ variants:
   - name: STM32L073RZHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3135,7 +3135,7 @@ variants:
   - name: STM32L073RZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3160,7 +3160,7 @@ variants:
   - name: STM32L073V8Ix
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3185,7 +3185,7 @@ variants:
   - name: STM32L073V8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3210,7 +3210,7 @@ variants:
   - name: STM32L073VBIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3235,7 +3235,7 @@ variants:
   - name: STM32L073VBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3260,7 +3260,7 @@ variants:
   - name: STM32L073VZIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3285,7 +3285,7 @@ variants:
   - name: STM32L073VZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3310,7 +3310,7 @@ variants:
   - name: STM32L081CZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3335,7 +3335,7 @@ variants:
   - name: STM32L081KZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3360,7 +3360,7 @@ variants:
   - name: STM32L081KZUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3385,7 +3385,7 @@ variants:
   - name: STM32L082CZYx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3410,7 +3410,7 @@ variants:
   - name: STM32L082KBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3435,7 +3435,7 @@ variants:
   - name: STM32L082KBUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3460,7 +3460,7 @@ variants:
   - name: STM32L082KZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3485,7 +3485,7 @@ variants:
   - name: STM32L082KZUx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3510,7 +3510,7 @@ variants:
   - name: STM32L083CBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3535,7 +3535,7 @@ variants:
   - name: STM32L083CZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3560,7 +3560,7 @@ variants:
   - name: STM32L083RBHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3585,7 +3585,7 @@ variants:
   - name: STM32L083RBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3610,7 +3610,7 @@ variants:
   - name: STM32L083RZHx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3635,7 +3635,7 @@ variants:
   - name: STM32L083RZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3660,7 +3660,7 @@ variants:
   - name: STM32L083V8Ix
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3685,7 +3685,7 @@ variants:
   - name: STM32L083V8Tx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3710,7 +3710,7 @@ variants:
   - name: STM32L083VBIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3735,7 +3735,7 @@ variants:
   - name: STM32L083VBTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3760,7 +3760,7 @@ variants:
   - name: STM32L083VZIx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -3785,7 +3785,7 @@ variants:
   - name: STM32L083VZTx
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32L1_Series.yaml
+++ b/probe-rs/targets/STM32L1_Series.yaml
@@ -5,7 +5,7 @@ variants:
   - name: STM32L100C6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -30,7 +30,7 @@ variants:
   - name: STM32L100C6xxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -55,7 +55,7 @@ variants:
   - name: STM32L100R8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -80,7 +80,7 @@ variants:
   - name: STM32L100R8xxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -105,7 +105,7 @@ variants:
   - name: STM32L100RB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -130,7 +130,7 @@ variants:
   - name: STM32L100RBxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -155,7 +155,7 @@ variants:
   - name: STM32L100RC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -180,7 +180,7 @@ variants:
   - name: STM32L151C6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -205,7 +205,7 @@ variants:
   - name: STM32L151C6xxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -230,7 +230,7 @@ variants:
   - name: STM32L151C8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -255,7 +255,7 @@ variants:
   - name: STM32L151C8xxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -280,7 +280,7 @@ variants:
   - name: STM32L151CB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -305,7 +305,7 @@ variants:
   - name: STM32L151CBxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -330,7 +330,7 @@ variants:
   - name: STM32L151CC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -355,7 +355,7 @@ variants:
   - name: STM32L151QC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -380,7 +380,7 @@ variants:
   - name: STM32L151QD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -405,7 +405,7 @@ variants:
   - name: STM32L151QE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -430,7 +430,7 @@ variants:
   - name: STM32L151R6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -455,7 +455,7 @@ variants:
   - name: STM32L151R6xxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -480,7 +480,7 @@ variants:
   - name: STM32L151R8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -505,7 +505,7 @@ variants:
   - name: STM32L151R8xxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -530,7 +530,7 @@ variants:
   - name: STM32L151RB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -555,7 +555,7 @@ variants:
   - name: STM32L151RBxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -580,7 +580,7 @@ variants:
   - name: STM32L151RC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -605,7 +605,7 @@ variants:
   - name: STM32L151RCxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -630,7 +630,7 @@ variants:
   - name: STM32L151RD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -655,7 +655,7 @@ variants:
   - name: STM32L151RE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -680,7 +680,7 @@ variants:
   - name: STM32L151UC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -705,7 +705,7 @@ variants:
   - name: STM32L151V8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -730,7 +730,7 @@ variants:
   - name: STM32L151V8xxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -755,7 +755,7 @@ variants:
   - name: STM32L151VB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -780,7 +780,7 @@ variants:
   - name: STM32L151VBxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -805,7 +805,7 @@ variants:
   - name: STM32L151VC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -830,7 +830,7 @@ variants:
   - name: STM32L151VCxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -855,7 +855,7 @@ variants:
   - name: STM32L151VD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -880,7 +880,7 @@ variants:
   - name: STM32L151VE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -905,7 +905,7 @@ variants:
   - name: STM32L151ZC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -930,7 +930,7 @@ variants:
   - name: STM32L151ZD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -955,7 +955,7 @@ variants:
   - name: STM32L151ZE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -980,7 +980,7 @@ variants:
   - name: STM32L152C6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1005,7 +1005,7 @@ variants:
   - name: STM32L152C6xxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1030,7 +1030,7 @@ variants:
   - name: STM32L152C8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1055,7 +1055,7 @@ variants:
   - name: STM32L152C8xxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1080,7 +1080,7 @@ variants:
   - name: STM32L152CB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1105,7 +1105,7 @@ variants:
   - name: STM32L152CBxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1130,7 +1130,7 @@ variants:
   - name: STM32L152CC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1155,7 +1155,7 @@ variants:
   - name: STM32L152QC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1180,7 +1180,7 @@ variants:
   - name: STM32L152QD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1205,7 +1205,7 @@ variants:
   - name: STM32L152QE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1230,7 +1230,7 @@ variants:
   - name: STM32L152R6
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1255,7 +1255,7 @@ variants:
   - name: STM32L152R6xxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1280,7 +1280,7 @@ variants:
   - name: STM32L152R8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1305,7 +1305,7 @@ variants:
   - name: STM32L152R8xxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1330,7 +1330,7 @@ variants:
   - name: STM32L152RB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1355,7 +1355,7 @@ variants:
   - name: STM32L152RBxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1380,7 +1380,7 @@ variants:
   - name: STM32L152RC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1405,7 +1405,7 @@ variants:
   - name: STM32L152RCxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1430,7 +1430,7 @@ variants:
   - name: STM32L152RD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1455,7 +1455,7 @@ variants:
   - name: STM32L152RE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1480,7 +1480,7 @@ variants:
   - name: STM32L152V8
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1505,7 +1505,7 @@ variants:
   - name: STM32L152V8xxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1530,7 +1530,7 @@ variants:
   - name: STM32L152VB
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1555,7 +1555,7 @@ variants:
   - name: STM32L152VBxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1580,7 +1580,7 @@ variants:
   - name: STM32L152VC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1605,7 +1605,7 @@ variants:
   - name: STM32L152VCxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1630,7 +1630,7 @@ variants:
   - name: STM32L152VD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1655,7 +1655,7 @@ variants:
   - name: STM32L152VE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1680,7 +1680,7 @@ variants:
   - name: STM32L152ZC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1705,7 +1705,7 @@ variants:
   - name: STM32L152ZD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1730,7 +1730,7 @@ variants:
   - name: STM32L152ZE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1755,7 +1755,7 @@ variants:
   - name: STM32L162QD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1780,7 +1780,7 @@ variants:
   - name: STM32L162RC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1805,7 +1805,7 @@ variants:
   - name: STM32L162RCxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1830,7 +1830,7 @@ variants:
   - name: STM32L162RD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1855,7 +1855,7 @@ variants:
   - name: STM32L162RE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1880,7 +1880,7 @@ variants:
   - name: STM32L162VC
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1905,7 +1905,7 @@ variants:
   - name: STM32L162VCxxA
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1930,7 +1930,7 @@ variants:
   - name: STM32L162VD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1955,7 +1955,7 @@ variants:
   - name: STM32L162VE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -1980,7 +1980,7 @@ variants:
   - name: STM32L162ZD
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0
@@ -2005,7 +2005,7 @@ variants:
   - name: STM32L162ZE
     cores:
       - name: main
-        type: M3
+        type: armv7m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32L4_Series.yaml
+++ b/probe-rs/targets/STM32L4_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: Flash
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -34,7 +34,7 @@ variants:
   - name: STM32L412C8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -62,7 +62,7 @@ variants:
   - name: STM32L412C8Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -90,7 +90,7 @@ variants:
   - name: STM32L412CBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -118,7 +118,7 @@ variants:
   - name: STM32L412CBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -146,7 +146,7 @@ variants:
   - name: STM32L412K8Ix
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -174,7 +174,7 @@ variants:
   - name: STM32L412K8Tx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -202,7 +202,7 @@ variants:
   - name: STM32L412K8Ux
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -230,7 +230,7 @@ variants:
   - name: STM32L412KBIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -258,7 +258,7 @@ variants:
   - name: STM32L412KBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -286,7 +286,7 @@ variants:
   - name: STM32L412KBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -314,7 +314,7 @@ variants:
   - name: STM32L412T8Yx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -342,7 +342,7 @@ variants:
   - name: STM32L412TBYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -370,7 +370,7 @@ variants:
   - name: STM32L422CBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -398,7 +398,7 @@ variants:
   - name: STM32L422CBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -426,7 +426,7 @@ variants:
   - name: STM32L422KBIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -454,7 +454,7 @@ variants:
   - name: STM32L422KBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -482,7 +482,7 @@ variants:
   - name: STM32L422KBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -510,7 +510,7 @@ variants:
   - name: STM32L422TBYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -538,7 +538,7 @@ variants:
   - name: STM32L431CBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -566,7 +566,7 @@ variants:
   - name: STM32L431CBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -594,7 +594,7 @@ variants:
   - name: STM32L431CBYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -622,7 +622,7 @@ variants:
   - name: STM32L431CCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -650,7 +650,7 @@ variants:
   - name: STM32L431CCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -678,7 +678,7 @@ variants:
   - name: STM32L431CCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -706,7 +706,7 @@ variants:
   - name: STM32L431KBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -734,7 +734,7 @@ variants:
   - name: STM32L431KCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -762,7 +762,7 @@ variants:
   - name: STM32L431RBIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -790,7 +790,7 @@ variants:
   - name: STM32L431RBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -818,7 +818,7 @@ variants:
   - name: STM32L431RBYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -846,7 +846,7 @@ variants:
   - name: STM32L431RCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -874,7 +874,7 @@ variants:
   - name: STM32L431RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -902,7 +902,7 @@ variants:
   - name: STM32L431RCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -930,7 +930,7 @@ variants:
   - name: STM32L431VCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -958,7 +958,7 @@ variants:
   - name: STM32L431VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -986,7 +986,7 @@ variants:
   - name: STM32L432KBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1014,7 +1014,7 @@ variants:
   - name: STM32L432KCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1042,7 +1042,7 @@ variants:
   - name: STM32L433CBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1070,7 +1070,7 @@ variants:
   - name: STM32L433CBUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1098,7 +1098,7 @@ variants:
   - name: STM32L433CBYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1126,7 +1126,7 @@ variants:
   - name: STM32L433CCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1154,7 +1154,7 @@ variants:
   - name: STM32L433CCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1182,7 +1182,7 @@ variants:
   - name: STM32L433CCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1210,7 +1210,7 @@ variants:
   - name: STM32L433RBIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1238,7 +1238,7 @@ variants:
   - name: STM32L433RBTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1266,7 +1266,7 @@ variants:
   - name: STM32L433RBYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1294,7 +1294,7 @@ variants:
   - name: STM32L433RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1322,7 +1322,7 @@ variants:
   - name: STM32L433VCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1350,7 +1350,7 @@ variants:
   - name: STM32L433VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1378,7 +1378,7 @@ variants:
   - name: STM32L442KCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1406,7 +1406,7 @@ variants:
   - name: STM32L443CCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1434,7 +1434,7 @@ variants:
   - name: STM32L443CCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1462,7 +1462,7 @@ variants:
   - name: STM32L443CCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1490,7 +1490,7 @@ variants:
   - name: STM32L443RCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1518,7 +1518,7 @@ variants:
   - name: STM32L443RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1546,7 +1546,7 @@ variants:
   - name: STM32L443RCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1574,7 +1574,7 @@ variants:
   - name: STM32L443VCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1602,7 +1602,7 @@ variants:
   - name: STM32L443VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1630,7 +1630,7 @@ variants:
   - name: STM32L451CCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1658,7 +1658,7 @@ variants:
   - name: STM32L451CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1686,7 +1686,7 @@ variants:
   - name: STM32L451RCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1714,7 +1714,7 @@ variants:
   - name: STM32L451RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1742,7 +1742,7 @@ variants:
   - name: STM32L451RCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1770,7 +1770,7 @@ variants:
   - name: STM32L451REIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1798,7 +1798,7 @@ variants:
   - name: STM32L451RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1826,7 +1826,7 @@ variants:
   - name: STM32L451REYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1854,7 +1854,7 @@ variants:
   - name: STM32L451VCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1882,7 +1882,7 @@ variants:
   - name: STM32L451VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1910,7 +1910,7 @@ variants:
   - name: STM32L451VEIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1938,7 +1938,7 @@ variants:
   - name: STM32L451VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1966,7 +1966,7 @@ variants:
   - name: STM32L452CCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -1994,7 +1994,7 @@ variants:
   - name: STM32L452CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2022,7 +2022,7 @@ variants:
   - name: STM32L452RCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2050,7 +2050,7 @@ variants:
   - name: STM32L452RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2078,7 +2078,7 @@ variants:
   - name: STM32L452RCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2106,7 +2106,7 @@ variants:
   - name: STM32L452REIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2134,7 +2134,7 @@ variants:
   - name: STM32L452RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2162,7 +2162,7 @@ variants:
   - name: STM32L452REYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2190,7 +2190,7 @@ variants:
   - name: STM32L452VCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2218,7 +2218,7 @@ variants:
   - name: STM32L452VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2246,7 +2246,7 @@ variants:
   - name: STM32L452VEIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2274,7 +2274,7 @@ variants:
   - name: STM32L452VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2302,7 +2302,7 @@ variants:
   - name: STM32L462CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2330,7 +2330,7 @@ variants:
   - name: STM32L462REIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2358,7 +2358,7 @@ variants:
   - name: STM32L462RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2386,7 +2386,7 @@ variants:
   - name: STM32L462REYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2414,7 +2414,7 @@ variants:
   - name: STM32L462VEIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2442,7 +2442,7 @@ variants:
   - name: STM32L462VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2470,7 +2470,7 @@ variants:
   - name: STM32L471JEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2498,7 +2498,7 @@ variants:
   - name: STM32L471JGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2526,7 +2526,7 @@ variants:
   - name: STM32L471QEIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2554,7 +2554,7 @@ variants:
   - name: STM32L471QGIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2582,7 +2582,7 @@ variants:
   - name: STM32L471RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2610,7 +2610,7 @@ variants:
   - name: STM32L471RCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2638,7 +2638,7 @@ variants:
   - name: STM32L471RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2666,7 +2666,7 @@ variants:
   - name: STM32L471RGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2694,7 +2694,7 @@ variants:
   - name: STM32L471RGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2722,7 +2722,7 @@ variants:
   - name: STM32L471VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2750,7 +2750,7 @@ variants:
   - name: STM32L471VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2778,7 +2778,7 @@ variants:
   - name: STM32L471VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2806,7 +2806,7 @@ variants:
   - name: STM32L471ZETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2834,7 +2834,7 @@ variants:
   - name: STM32L471ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2862,7 +2862,7 @@ variants:
   - name: STM32L475JEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2890,7 +2890,7 @@ variants:
   - name: STM32L475JGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2918,7 +2918,7 @@ variants:
   - name: STM32L475QEIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2946,7 +2946,7 @@ variants:
   - name: STM32L475QGIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -2974,7 +2974,7 @@ variants:
   - name: STM32L475RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3002,7 +3002,7 @@ variants:
   - name: STM32L475RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3030,7 +3030,7 @@ variants:
   - name: STM32L475RGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3058,7 +3058,7 @@ variants:
   - name: STM32L475VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3086,7 +3086,7 @@ variants:
   - name: STM32L475VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3114,7 +3114,7 @@ variants:
   - name: STM32L475VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3142,7 +3142,7 @@ variants:
   - name: STM32L475ZETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3170,7 +3170,7 @@ variants:
   - name: STM32L475ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3198,7 +3198,7 @@ variants:
   - name: STM32L476JEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3226,7 +3226,7 @@ variants:
   - name: STM32L476JGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3254,7 +3254,7 @@ variants:
   - name: STM32L476MEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3282,7 +3282,7 @@ variants:
   - name: STM32L476MGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3310,7 +3310,7 @@ variants:
   - name: STM32L476QEIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3338,7 +3338,7 @@ variants:
   - name: STM32L476QGIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3366,7 +3366,7 @@ variants:
   - name: STM32L476RCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3394,7 +3394,7 @@ variants:
   - name: STM32L476RETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3422,7 +3422,7 @@ variants:
   - name: STM32L476RGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3450,7 +3450,7 @@ variants:
   - name: STM32L476VCTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3478,7 +3478,7 @@ variants:
   - name: STM32L476VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3506,7 +3506,7 @@ variants:
   - name: STM32L476VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3534,7 +3534,7 @@ variants:
   - name: STM32L476ZETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3562,7 +3562,7 @@ variants:
   - name: STM32L476ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3590,7 +3590,7 @@ variants:
   - name: STM32L485JCYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3618,7 +3618,7 @@ variants:
   - name: STM32L486JGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3646,7 +3646,7 @@ variants:
   - name: STM32L486QGIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3674,7 +3674,7 @@ variants:
   - name: STM32L486RGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3702,7 +3702,7 @@ variants:
   - name: STM32L486VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3730,7 +3730,7 @@ variants:
   - name: STM32L486ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3758,7 +3758,7 @@ variants:
   - name: STM32L496AGIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3786,7 +3786,7 @@ variants:
   - name: STM32L496QGIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3814,7 +3814,7 @@ variants:
   - name: STM32L496RGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3842,7 +3842,7 @@ variants:
   - name: STM32L496VETx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3870,7 +3870,7 @@ variants:
   - name: STM32L496VEYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3898,7 +3898,7 @@ variants:
   - name: STM32L496VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3926,7 +3926,7 @@ variants:
   - name: STM32L496VGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3954,7 +3954,7 @@ variants:
   - name: STM32L496ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -3982,7 +3982,7 @@ variants:
   - name: STM32L496ZGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4010,7 +4010,7 @@ variants:
   - name: STM32L4A6AGIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4038,7 +4038,7 @@ variants:
   - name: STM32L4A6QGIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4066,7 +4066,7 @@ variants:
   - name: STM32L4A6RGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4094,7 +4094,7 @@ variants:
   - name: STM32L4A6VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4122,7 +4122,7 @@ variants:
   - name: STM32L4A6VGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4150,7 +4150,7 @@ variants:
   - name: STM32L4A6ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4178,7 +4178,7 @@ variants:
   - name: STM32L4A6ZGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4206,7 +4206,7 @@ variants:
   - name: STM32L4P5AGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4233,7 +4233,7 @@ variants:
   - name: STM32L4P5CGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4260,7 +4260,7 @@ variants:
   - name: STM32L4P5QGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4287,7 +4287,7 @@ variants:
   - name: STM32L4P5RGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4314,7 +4314,7 @@ variants:
   - name: STM32L4P5VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4341,7 +4341,7 @@ variants:
   - name: STM32L4P5ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4368,7 +4368,7 @@ variants:
   - name: STM32L4Q5AGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4395,7 +4395,7 @@ variants:
   - name: STM32L4Q5CGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4422,7 +4422,7 @@ variants:
   - name: STM32L4Q5QGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4449,7 +4449,7 @@ variants:
   - name: STM32L4Q5RGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4476,7 +4476,7 @@ variants:
   - name: STM32L4Q5VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4503,7 +4503,7 @@ variants:
   - name: STM32L4Q5ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4530,7 +4530,7 @@ variants:
   - name: STM32L4R5AGIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4559,7 +4559,7 @@ variants:
   - name: STM32L4R5AIIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4588,7 +4588,7 @@ variants:
   - name: STM32L4R5QGIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4617,7 +4617,7 @@ variants:
   - name: STM32L4R5QIIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4646,7 +4646,7 @@ variants:
   - name: STM32L4R5VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4675,7 +4675,7 @@ variants:
   - name: STM32L4R5VITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4704,7 +4704,7 @@ variants:
   - name: STM32L4R5ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4733,7 +4733,7 @@ variants:
   - name: STM32L4R5ZGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4762,7 +4762,7 @@ variants:
   - name: STM32L4R5ZITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4791,7 +4791,7 @@ variants:
   - name: STM32L4R5ZIYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4820,7 +4820,7 @@ variants:
   - name: STM32L4R7AIIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4849,7 +4849,7 @@ variants:
   - name: STM32L4R7VITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4878,7 +4878,7 @@ variants:
   - name: STM32L4R7ZITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4907,7 +4907,7 @@ variants:
   - name: STM32L4R9AGIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4936,7 +4936,7 @@ variants:
   - name: STM32L4R9AIIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4965,7 +4965,7 @@ variants:
   - name: STM32L4R9VGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -4994,7 +4994,7 @@ variants:
   - name: STM32L4R9VITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5023,7 +5023,7 @@ variants:
   - name: STM32L4R9ZGJx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5052,7 +5052,7 @@ variants:
   - name: STM32L4R9ZGTx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5081,7 +5081,7 @@ variants:
   - name: STM32L4R9ZGYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5110,7 +5110,7 @@ variants:
   - name: STM32L4R9ZIJx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5139,7 +5139,7 @@ variants:
   - name: STM32L4R9ZITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5168,7 +5168,7 @@ variants:
   - name: STM32L4R9ZIYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5197,7 +5197,7 @@ variants:
   - name: STM32L4S5AIIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5226,7 +5226,7 @@ variants:
   - name: STM32L4S5QIIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5255,7 +5255,7 @@ variants:
   - name: STM32L4S5VITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5284,7 +5284,7 @@ variants:
   - name: STM32L4S5ZITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5313,7 +5313,7 @@ variants:
   - name: STM32L4S5ZIYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5342,7 +5342,7 @@ variants:
   - name: STM32L4S7AIIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5372,7 +5372,7 @@ variants:
   - name: STM32L4S7VITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5402,7 +5402,7 @@ variants:
   - name: STM32L4S7ZITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5432,7 +5432,7 @@ variants:
   - name: STM32L4S9AIIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5462,7 +5462,7 @@ variants:
   - name: STM32L4S9ZITx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5492,7 +5492,7 @@ variants:
   - name: STM32L4S9ZIYx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -5522,7 +5522,7 @@ variants:
   - name: STM32L4S9ZJIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32L5_Series.yaml
+++ b/probe-rs/targets/STM32L5_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: STM32L552CCTx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -30,7 +30,7 @@ variants:
   - name: STM32L552CCUx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -56,7 +56,7 @@ variants:
   - name: STM32L552CETx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -82,7 +82,7 @@ variants:
   - name: STM32L552CETxP
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -108,7 +108,7 @@ variants:
   - name: STM32L552CEUx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -134,7 +134,7 @@ variants:
   - name: STM32L552CEUxP
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -160,7 +160,7 @@ variants:
   - name: STM32L552MEYxP
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -186,7 +186,7 @@ variants:
   - name: STM32L552MEYxQ
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -212,7 +212,7 @@ variants:
   - name: STM32L552QCIxQ
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -238,7 +238,7 @@ variants:
   - name: STM32L552QEIx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -264,7 +264,7 @@ variants:
   - name: STM32L552QEIxP
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -290,7 +290,7 @@ variants:
   - name: STM32L552QEIxQ
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -316,7 +316,7 @@ variants:
   - name: STM32L552RCTx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -342,7 +342,7 @@ variants:
   - name: STM32L552RETx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -368,7 +368,7 @@ variants:
   - name: STM32L552RETxP
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -394,7 +394,7 @@ variants:
   - name: STM32L552RETxQ
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -420,7 +420,7 @@ variants:
   - name: STM32L552VCTxQ
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -446,7 +446,7 @@ variants:
   - name: STM32L552VETx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -472,7 +472,7 @@ variants:
   - name: STM32L552VETxQ
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -498,7 +498,7 @@ variants:
   - name: STM32L552ZCTxQ
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -524,7 +524,7 @@ variants:
   - name: STM32L552ZETx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -550,7 +550,7 @@ variants:
   - name: STM32L552ZETxQ
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -576,7 +576,7 @@ variants:
   - name: STM32L562CETx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -602,7 +602,7 @@ variants:
   - name: STM32L562CETxP
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -628,7 +628,7 @@ variants:
   - name: STM32L562CEUx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -654,7 +654,7 @@ variants:
   - name: STM32L562CEUxP
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -680,7 +680,7 @@ variants:
   - name: STM32L562MEYxP
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -706,7 +706,7 @@ variants:
   - name: STM32L562MEYxQ
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -732,7 +732,7 @@ variants:
   - name: STM32L562QEIxP
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -758,7 +758,7 @@ variants:
   - name: STM32L562QEIxQ
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -784,7 +784,7 @@ variants:
   - name: STM32L562RETx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -810,7 +810,7 @@ variants:
   - name: STM32L562RETxP
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -836,7 +836,7 @@ variants:
   - name: STM32L562VETx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -862,7 +862,7 @@ variants:
   - name: STM32L562VETxQ
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -888,7 +888,7 @@ variants:
   - name: STM32L562ZETx
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
@@ -914,7 +914,7 @@ variants:
   - name: STM32L562ZETxQ
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32WB_Series.yaml
+++ b/probe-rs/targets/STM32WB_Series.yaml
@@ -7,7 +7,7 @@ variants:
   - name: STM32WB30CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -30,7 +30,7 @@ variants:
   - name: STM32WB35CCUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -53,7 +53,7 @@ variants:
   - name: STM32WB35CEUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -76,7 +76,7 @@ variants:
   - name: STM32WB50CGUx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -100,7 +100,7 @@ variants:
     part: 0x495
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -124,7 +124,7 @@ variants:
     part: 0x495
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -148,7 +148,7 @@ variants:
     part: 0x495
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -172,7 +172,7 @@ variants:
     part: 0x495
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -196,7 +196,7 @@ variants:
     part: 0x495
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -220,7 +220,7 @@ variants:
     part: 0x495
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -243,7 +243,7 @@ variants:
   - name: STM32WB55VCQx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -267,7 +267,7 @@ variants:
     part: 0x495
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -290,7 +290,7 @@ variants:
   - name: STM32WB55VEQx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -314,7 +314,7 @@ variants:
     part: 0x495
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -337,7 +337,7 @@ variants:
   - name: STM32WB55VGQx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -361,7 +361,7 @@ variants:
     part: 0x495
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/STM32WL_Series.yaml
+++ b/probe-rs/targets/STM32WL_Series.yaml
@@ -5,7 +5,7 @@ variants:
   - name: STM32WLE5J8Ix
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -28,7 +28,7 @@ variants:
   - name: STM32WLE5JBIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -51,7 +51,7 @@ variants:
   - name: STM32WLE5JCIx
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/fe310.yaml
+++ b/probe-rs/targets/fe310.yaml
@@ -5,7 +5,7 @@ variants:
   - name: "fe310-g002"
     cores:
       - name: main
-        type: Riscv
+        type: riscv
         core_access_options:
           Riscv: {}
     memory_map:

--- a/probe-rs/targets/nRF51_Series.yaml
+++ b/probe-rs/targets/nRF51_Series.yaml
@@ -7,7 +7,7 @@ variants:
   - name: nRF51422_xxAA
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -32,7 +32,7 @@ variants:
   - name: nRF51422_xxAB
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -57,7 +57,7 @@ variants:
   - name: nRF51422_xxAC
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -82,7 +82,7 @@ variants:
   - name: nRF51801_xxAB
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -107,7 +107,7 @@ variants:
   - name: nRF51802_xxAA
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -132,7 +132,7 @@ variants:
   - name: nRF51822_xxAA
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -157,7 +157,7 @@ variants:
   - name: nRF51822_xxAB
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -182,7 +182,7 @@ variants:
   - name: nRF51822_xxAC
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0
@@ -207,7 +207,7 @@ variants:
   - name: nRF51824_xxAA
     cores:
       - name: main
-        type: M0
+        type: armv6m
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/nRF52_Series.yaml
+++ b/probe-rs/targets/nRF52_Series.yaml
@@ -7,7 +7,7 @@ variants:
   - name: nRF52805_xxAA
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -36,7 +36,7 @@ variants:
   - name: nRF52810_xxAA
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -65,7 +65,7 @@ variants:
   - name: nRF52811_xxAA
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -94,7 +94,7 @@ variants:
   - name: nRF52820_xxAA
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -123,7 +123,7 @@ variants:
   - name: nRF52832_xxAA
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -152,7 +152,7 @@ variants:
   - name: nRF52832_xxAB
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -181,7 +181,7 @@ variants:
   - name: nRF52833_xxAA
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0
@@ -210,7 +210,7 @@ variants:
   - name: nRF52840_xxAA
     cores:
       - name: main
-        type: M4
+        type: armv7em
         core_access_options:
           Arm:
             ap: 0

--- a/probe-rs/targets/nRF53_Series.yaml
+++ b/probe-rs/targets/nRF53_Series.yaml
@@ -4,13 +4,13 @@ variants:
   - name: nRF5340_xxAA
     cores:
       - name: application
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0
             psel: 0
       - name: network
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 1

--- a/probe-rs/targets/nRF91_Series.yaml
+++ b/probe-rs/targets/nRF91_Series.yaml
@@ -4,7 +4,7 @@ variants:
   - name: nRF9160_xxAA
     cores:
       - name: main
-        type: M33
+        type: armv8m
         core_access_options:
           Arm:
             ap: 0


### PR DESCRIPTION
The "core type" is really the architecture, which is ARMv6, ARMv7 or ARMv8.

This is almost exclusively a dumb rename. The only possibly dangerous thing is that GDB did distinguish between `armv7-m` and `armv7e-m`, which it no longer does now. I'm not sure if that's important in practice. 