### PR TITLE
Use vendored libftdi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,26 +29,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2.3.4
 
-      - name: Install libusb, libudev and libftdi (linux)
+      - name: Install libusb, libudev (linux)
         run: |
           sudo apt update
-          sudo apt install -y libusb-1.0-0-dev libftdi1-dev libudev-dev
+          sudo apt install -y libusb-1.0-0-dev libudev-dev
         # Only install on Ubuntu
         if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'ubuntu-20.04')
-
-      - name: Install libftdi (windows)
-        uses: lukka/run-vcpkg@v7
-        with:
-          vcpkgArguments: "libftdi1:x64-windows"
-          vcpkgGitCommitId: "7dbc05515b44bf54d2a42b4da9d1e1f910868b86"
-          vcpkgTriplet: x64-windows
-
-        if: matrix.os == 'windows-latest'
-
-      - name: Install libftdi (macos)
-        run: brew install libftdi
-        # Only install on macos
-        if: matrix.os == 'macos-latest'
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1.0.7
@@ -91,21 +77,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2.3.4
 
-      - name: Install libusb and libftdi (linux)
+      - name: Install libusb (linux)
         run: |
           sudo apt update
-          sudo apt install -y libusb-1.0-0-dev libftdi1-dev libudev-dev
+          sudo apt install -y libusb-1.0-0-dev libudev-dev
         # Only install on Ubuntu
         if: matrix.os == 'ubuntu-latest'
-
-      - name: Install libftdi (windows)
-        uses: lukka/run-vcpkg@v7
-        with:
-          vcpkgArguments: "libftdi1:x64-windows"
-          vcpkgGitCommitId: "7dbc05515b44bf54d2a42b4da9d1e1f910868b86"
-          vcpkgTriplet: x64-windows
-
-        if: matrix.os == 'windows-latest'
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1.0.7
@@ -160,7 +137,7 @@ jobs:
       - name: Install libusb
         run: |
           sudo apt update
-          sudo apt install -y libusb-1.0-0-dev libftdi1-dev libudev-dev
+          sudo apt install -y libusb-1.0-0-dev libudev-dev
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1.0.7

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -47,7 +47,7 @@ thousands = "0.2.0"
 
 # optional
 hexdump = { version = "0.1.0", optional = true }
-libftdi1-sys = { version = "1.0.0-alpha3", optional = true }
+libftdi1-sys = { version = "1.1.1", optional = true, features = ["vendored", "libusb1-sys"] }
 
 # path
 probe-rs-target = { path = "../probe-rs-target", version = "0.11.0", features = ["bincode"] }

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -36,7 +36,7 @@ once_cell = "1.7.2"
 log = "0.4.8"
 num-traits = "0.2.11"
 object = { version = "0.26.0", default-features = false, features = ["elf", "read_core", "std"] }
-rusb = "0.8.0"
+rusb = { version = "0.8.0", features = ["vendored"] }
 scroll = "0.10.1"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_yaml = "0.8.11"


### PR DESCRIPTION
- Use vendored libftdi
- Remove libftdi from CI

This should help with the build issues on Windows. libftdi is LGPL, so this should be considered. From what I understand, this does not require probe-rs to be LGPL, but users of probe-rs based programs need to be able to rebuild it with a different version of libftdi.