### PR TITLE
Fix badge for crates.io in rtt readme

### DIFF
--- a/rtt/README.md
+++ b/rtt/README.md
@@ -1,6 +1,6 @@
 # probe-rs-rtt
 
-[![crates.io](https://meritbadge.herokuapp.com/probe-rs-rtt)](https://crates.io/crates/probe-rs-rtt) [![documentation](https://docs.rs/probe-rs-rtt/badge.svg)](https://docs.rs/probe-rs-rtt)
+[![crates.io](https://img.shields.io/crates/v/probe-rs-rtt)](https://crates.io/crates/probe-rs-rtt) [![documentation](https://docs.rs/probe-rs-rtt/badge.svg)](https://docs.rs/probe-rs-rtt)
 
 Host side implementation of the RTT (Real-Time Transfer) I/O protocol over probe-rs.
 


### PR DESCRIPTION
This was fixed for the main README in 0d4ea32191b4d94e47ad3d30d160cf39a6040531, this is the same fix for the `probe-rs-rtt` README.