### PR TITLE
Call inner_attach for RISCV

### DIFF
--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -230,6 +230,8 @@ impl Session {
             Architecture::Riscv => {
                 // TODO: Handle attach under reset
 
+                probe.inner_attach()?;
+
                 let interface = probe
                     .try_into_riscv_interface()
                     .map_err(|(_probe, err)| err)?;


### PR DESCRIPTION
Due to the introduction of sequences, the `inner_attach` method was not called anymore when RISCV chips were used.

This led to issues with FTDI, because the detection of JTAG taps was now missing, and no connection as possible.