### PR TITLE
Emit fresh as well as path when running rustc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped dependencies `bitvec 0.19.4`to `bitvec 0.22`, `nom 6.0.0` to `nom 7.0.0-alpha1`. (#756)
 - `DebugProbeError::CommandNotSupportedByProbe` now holds a name string of the unsupported command.
 - Target YAMLs: Renamed `core.type` values from `M0, M4, etc` to `armv6m`, `armv7m`, `armv8m`.
+- An opaque object is returned to represent a compiled artifact. This allows extra information to be provided
+  in future without a breaking change (#795).
+- Information on whether a rebuild was necessary is included in the artefact (nothing changed if
+ `fresh == true`) (#795).
+- `Debug` was reimplemented on `Session` (#795).
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).
@@ -122,7 +127,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `probe_rs::flashing::DownloadOptions` is now marked `non_exhaustive`, to make it easier to add additional flags in the future.
 - Replace `lazy_static` with `once_cell::sync::Lazy` (#685).
 - Use new `SendError` instead of `anyhow::Error` in `cmsisdap` module (#687).
-  
+
 ### Fixed
 
 - Fixed `M33` breakpoints (#543).

--- a/probe-rs-cli-util/src/lib.rs
+++ b/probe-rs-cli-util/src/lib.rs
@@ -68,22 +68,25 @@ pub fn read_metadata(work_dir: &Path) -> Result<Metadata, ArtifactError> {
     })
 }
 
+/// Represents compiled code that the compiler emitted during compilation.
 pub struct Artifact {
     path: PathBuf,
     fresh: bool,
 }
 
 impl Artifact {
+    /// Get the path of this output from the compiler.
     pub fn path(&self) -> &Path {
         &self.path
     }
 
+    /// If `true`, then the artifact was unchanged during compilation.
     pub fn fresh(&self) -> bool {
         self.fresh
     }
 }
 
-/// Run `cargo build` and return the path to the generated binary artifact.
+/// Run `cargo build` and return the generated binary artifact.
 ///
 /// `args` will be passed to cargo build, and `--message-format json` will be
 /// added to the list of arguments.

--- a/probe-rs-cli-util/tests/cargo_integration.rs
+++ b/probe-rs-cli-util/tests/cargo_integration.rs
@@ -21,10 +21,10 @@ fn get_binary_artifact() {
 
     let args = [];
 
-    let binary_path =
+    let binary_artifact =
         probe_rs_cli_util::build_artifact(&work_dir, &args).expect("Failed to read artifact path.");
 
-    assert_eq!(binary_path, expected_path);
+    assert_eq!(binary_artifact.path(), expected_path);
 }
 
 #[test]
@@ -38,11 +38,11 @@ fn get_binary_artifact_with_cargo_config() {
 
     let args = [];
 
-    let binary_path =
+    let binary_artifact =
         probe_rs_cli_util::build_artifact(&work_dir, &args).expect("Failed to read artifact path.");
 
     assert_eq!(
-        binary_path,
+        binary_artifact.path(),
         dunce::canonicalize(expected_path).expect("Failed to canonicalize path")
     );
 }
@@ -57,11 +57,11 @@ fn get_binary_artifact_with_cargo_config_toml() {
 
     let args = [];
 
-    let binary_path =
+    let binary_artifact =
         probe_rs_cli_util::build_artifact(&work_dir, &args).expect("Failed to read artifact path.");
 
     assert_eq!(
-        binary_path,
+        binary_artifact.path(),
         dunce::canonicalize(expected_path).expect("Failed to canonicalize path")
     );
 }
@@ -72,12 +72,12 @@ fn get_library_artifact_fails() {
 
     let args = ["--release".to_owned()];
 
-    let binary_path = probe_rs_cli_util::build_artifact(&work_dir, &args);
+    let binary_artifact = probe_rs_cli_util::build_artifact(&work_dir, &args);
 
     assert!(
-        binary_path.is_err(),
+        binary_artifact.is_err(),
         "Library project should not return a path to a binary, but got {}",
-        binary_path.unwrap().display()
+        binary_artifact.unwrap().path().display()
     );
 }
 
@@ -94,10 +94,10 @@ fn workspace_root() {
 
     let args = owned_args(&["--release"]);
 
-    let binary_path =
+    let binary_artifact =
         probe_rs_cli_util::build_artifact(&work_dir, &args).expect("Failed to read artifact path.");
 
-    assert_eq!(binary_path, expected_path);
+    assert_eq!(binary_artifact.path(), expected_path);
 }
 
 #[test]
@@ -114,10 +114,10 @@ fn workspace_binary_package() {
 
     let args = ["--release".to_owned()];
 
-    let binary_path =
+    let binary_artifact =
         probe_rs_cli_util::build_artifact(&work_dir, &args).expect("Failed to read artifact path.");
 
-    assert_eq!(binary_path, expected_path);
+    assert_eq!(binary_artifact.path(), expected_path);
 }
 
 #[test]
@@ -129,12 +129,12 @@ fn workspace_library_package() {
 
     let args = ["--release".to_owned()];
 
-    let binary_path = probe_rs_cli_util::build_artifact(&work_dir, &args);
+    let binary_artifact = probe_rs_cli_util::build_artifact(&work_dir, &args);
 
     assert!(
-        binary_path.is_err(),
+        binary_artifact.is_err(),
         "Library project should not return a path to a binary, but got {}",
-        binary_path.unwrap().display()
+        binary_artifact.unwrap().path().display()
     );
 }
 
@@ -146,12 +146,12 @@ fn multiple_binaries_in_crate() {
 
     let args = [];
 
-    let binary_path = probe_rs_cli_util::build_artifact(&work_dir, &args);
+    let binary_artifact = probe_rs_cli_util::build_artifact(&work_dir, &args);
 
     assert!(
-        binary_path.is_err(),
+        binary_artifact.is_err(),
         "With multiple binaries, an error message should be shown. Got path '{}' instead.",
-        binary_path.unwrap().display()
+        binary_artifact.unwrap().path().display()
     );
 }
 
@@ -166,10 +166,10 @@ fn multiple_binaries_in_crate_select_binary() {
 
     let args = ["--bin".to_owned(), "bin_a".to_owned()];
 
-    let binary_path =
+    let binary_artifact =
         probe_rs_cli_util::build_artifact(&work_dir, &args).expect("Failed to get artifact path.");
 
-    assert_eq!(binary_path, expected_path);
+    assert_eq!(binary_artifact.path(), expected_path);
 }
 
 #[test]
@@ -180,9 +180,9 @@ fn library_with_example() {
 
     let args = [];
 
-    let binary_path = probe_rs_cli_util::build_artifact(&work_dir, &args);
+    let binary_artifact = probe_rs_cli_util::build_artifact(&work_dir, &args);
 
-    assert!(binary_path.is_err())
+    assert!(binary_artifact.is_err())
 }
 
 #[test]
@@ -196,10 +196,10 @@ fn library_with_example_specified() {
 
     let args = owned_args(&["--example", "example"]);
 
-    let binary_path =
+    let binary_artifact =
         probe_rs_cli_util::build_artifact(&work_dir, &args).expect("Failed to get artifact path.");
 
-    assert_eq!(binary_path, expected_path);
+    assert_eq!(binary_artifact.path(), expected_path);
 }
 
 /// Return the path to a test project, located in

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -18,27 +18,27 @@ use crate::{
 };
 use crate::{AttachMethod, Core, CoreType, Error, Probe};
 use anyhow::anyhow;
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 /// The `Session` struct represents an active debug session.
 ///
-/// ## Creating a session  
+/// ## Creating a session
 /// The session can be created by calling the [Session::auto_attach()] function,
-/// which tries to automatically select a probe, and then connect to the target.  
+/// which tries to automatically select a probe, and then connect to the target.
 ///
 /// For more control, the [Probe::attach()] and [Probe::attach_under_reset()]
-/// methods can be used to open a `Session` from a specific [Probe].  
+/// methods can be used to open a `Session` from a specific [Probe].
 ///
-/// # Usage  
-/// The Session is the common handle that gives a user exclusive access to an active probe.  
-/// You can create and share a session between threads to enable multiple stakeholders (e.g. GDB and RTT) to access the target taking turns, by using  `Arc<Mutex<Session>>.`  
+/// # Usage
+/// The Session is the common handle that gives a user exclusive access to an active probe.
+/// You can create and share a session between threads to enable multiple stakeholders (e.g. GDB and RTT) to access the target taking turns, by using  `Arc<Mutex<Session>>.`
 ///
-/// If you do so, make sure that both threads sleep in between tasks such that other stakeholders may take their turn.  
+/// If you do so, make sure that both threads sleep in between tasks such that other stakeholders may take their turn.
 ///
 /// To get access to a single [Core] from the `Session`, the [Session::core()] method can be used.
 /// Please see the [Session::core()] method for more usage guidelines.
 ///
-
+#[derive(Debug)]
 pub struct Session {
     target: Target,
     interface: ArchitectureInterface,
@@ -48,6 +48,15 @@ pub struct Session {
 enum ArchitectureInterface {
     Arm(Box<dyn ArmProbeInterface + 'static>),
     Riscv(Box<RiscvCommunicationInterface>),
+}
+
+impl fmt::Debug for ArchitectureInterface {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ArchitectureInterface::Arm(..) => f.write_str("ArchitectureInterface::Arm(..)"),
+            ArchitectureInterface::Riscv(iface) => write!(f, "ArchitectureInterface({:?})", iface),
+        }
+    }
 }
 
 impl From<ArchitectureInterface> for Architecture {

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -54,7 +54,10 @@ impl fmt::Debug for ArchitectureInterface {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ArchitectureInterface::Arm(..) => f.write_str("ArchitectureInterface::Arm(..)"),
-            ArchitectureInterface::Riscv(iface) => write!(f, "ArchitectureInterface({:?})", iface),
+            ArchitectureInterface::Riscv(iface) => f
+                .debug_tuple("ArchitectureInterface::Riscv")
+                .field(iface)
+                .finish(),
         }
     }
 }


### PR DESCRIPTION
This patch includes information on whether a code rebuild occurred, in addition to the path of the output artefact. This information if e.g. you want to avoid flashing your device unnecessarily.

It's a breaking change, but allows extra information to be included with the artefact in future without a breaking change.

Let me know if this is something you'd like included or not.