### PR TITLE
riscv debug sequences

### DIFF
--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod assembly;
 mod dtm;
 
 pub mod communication_interface;
+pub mod sequences;
 
 pub struct Riscv32<'probe> {
     interface: &'probe mut RiscvCommunicationInterface,

--- a/probe-rs/src/architecture/riscv/sequences/esp32c3.rs
+++ b/probe-rs/src/architecture/riscv/sequences/esp32c3.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use super::RiscvDebugSequence;
+use crate::MemoryInterface;
+
+pub struct ESP32C3(());
+
+impl ESP32C3 {
+    pub fn new() -> Arc<dyn RiscvDebugSequence> {
+        Arc::new(Self(()))
+    }
+}
+
+impl RiscvDebugSequence for ESP32C3 {
+    fn on_connect(
+        &self,
+        interface: &mut crate::architecture::riscv::communication_interface::RiscvCommunicationInterface,
+    ) -> Result<(), crate::Error> {
+        log::info!("Disabling esp32c3 watchdogs...");
+        // disable super wdt
+        interface.write_word_32(0x600080B0, 0x8F1D312Au32)?; // write protection off
+        let current = interface.read_word_32(0x600080AC)?;
+        interface.write_word_32(0x600080AC, current | 1 << 31)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
+        interface.write_word_32(0x600080B0, 0x0)?; // write protection on
+
+        // tg0 wdg
+        interface.write_word_32(0x6001f064, 0x50D83AA1u32)?; // write protection off
+        interface.write_word_32(0x6001F048, 0x0)?;
+        interface.write_word_32(0x6001f064, 0x0)?; // write protection on
+
+        // tg1 wdg
+        interface.write_word_32(0x60020064, 0x50D83AA1u32)?; // write protection off
+        interface.write_word_32(0x60020048, 0x0)?;
+        interface.write_word_32(0x60020064, 0x0)?; // write protection on
+
+        // rtc wdg
+        interface.write_word_32(0x600080a8, 0x50D83AA1u32)?; // write protection off
+        interface.write_word_32(0x60008090, 0x0)?;
+        interface.write_word_32(0x600080a8, 0x0)?; // write protection on
+
+        Ok(())
+    }
+}

--- a/probe-rs/src/architecture/riscv/sequences/mod.rs
+++ b/probe-rs/src/architecture/riscv/sequences/mod.rs
@@ -1,0 +1,20 @@
+use super::communication_interface::RiscvCommunicationInterface;
+use std::sync::Arc;
+
+pub mod esp32c3;
+
+pub trait RiscvDebugSequence: Send + Sync {
+    fn on_connect(&self, _interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+        Ok(())
+    }
+}
+
+pub struct DefaultRiscvSequence(pub(crate) ());
+
+impl DefaultRiscvSequence {
+    pub fn new() -> Arc<dyn RiscvDebugSequence> {
+        Arc::new(Self(()))
+    }
+}
+
+impl RiscvDebugSequence for DefaultRiscvSequence {}

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -2,6 +2,8 @@ use super::{Chip, Core, CoreType, MemoryRegion, RawFlashAlgorithm, TargetDescrip
 
 use crate::architecture::arm::sequences::nxp::LPC55S69;
 use crate::architecture::arm::sequences::ArmDebugSequence;
+use crate::architecture::riscv::sequences::esp32c3::ESP32C3;
+use crate::architecture::riscv::sequences::{DefaultRiscvSequence, RiscvDebugSequence};
 use crate::{core::Architecture, flashing::FlashLoader};
 use std::sync::Arc;
 
@@ -67,12 +69,15 @@ impl Target {
         // TODO: Figure out how to handle this if cores can have different architectures.
         let mut debug_sequence = match cores[0].core_type.architecture() {
             Architecture::Arm => DebugSequence::Arm(DefaultArmSequence::new()),
-            Architecture::Riscv => DebugSequence::Riscv,
+            Architecture::Riscv => DebugSequence::Riscv(DefaultRiscvSequence::new()),
         };
 
         if chip.name.starts_with("LPC55S69") {
             log::warn!("Using custom sequence for LPC55S69");
             debug_sequence = DebugSequence::Arm(LPC55S69::new());
+        } else if chip.name.starts_with("esp32c3") {
+            log::warn!("Using custom sequence for ESP32c3");
+            debug_sequence = DebugSequence::Riscv(ESP32C3::new());
         }
 
         Target {
@@ -186,5 +191,5 @@ pub enum DebugSequence {
     /// An ARM debug sequence.
     Arm(Arc<dyn ArmDebugSequence>),
     /// A RISC-V debug sequence.
-    Riscv,
+    Riscv(Arc<dyn RiscvDebugSequence>),
 }

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -273,7 +273,7 @@ impl SpecificCoreState {
     ) -> Result<Core<'probe>, Error> {
         let debug_sequence = match &target.debug_sequence {
             crate::config::DebugSequence::Arm(sequence) => sequence.clone(),
-            crate::config::DebugSequence::Riscv => {
+            crate::config::DebugSequence::Riscv(_) => {
                 return Err(Error::UnableToOpenProbe(
                     "Core architecture and Probe mismatch.",
                 ))


### PR DESCRIPTION
- Open up debug sequences to riscv targets.
- On stage method, for after connecting and halting the target
(`on_connect`).
- Implementation for the esp32c3 to disable watchdogs.

I couldn't find any discussion about adding custom reset sequences for riscv, so I implemented a simple mechanism that suits my need.

Edit: would the long term goal to push custom sequences to the target yaml files by the way?