### PR TITLE
targets: change flash_algorithms from map to array.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Information on whether a rebuild was necessary is included in the artefact (nothing changed if
  `fresh == true`) (#795).
 - `Debug` was reimplemented on `Session` (#795).
+- Target YAMLs: Changed `flash_algorithms` from a map to an array. (#813)
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).

--- a/probe-rs-target/src/chip_family.rs
+++ b/probe-rs-target/src/chip_family.rs
@@ -56,8 +56,6 @@ pub struct ChipFamily {
     /// This vector holds all the variants of the family.
     pub variants: Vec<Chip>,
     /// This vector holds all available algorithms.
-    #[serde(deserialize_with = "deserialize")]
-    #[serde(serialize_with = "serialize")]
     pub flash_algorithms: Vec<RawFlashAlgorithm>,
 
     #[serde(skip, default = "default_source")]
@@ -68,48 +66,6 @@ pub struct ChipFamily {
 /// When deserialization is used, this means that the target is read from an external source.
 fn default_source() -> TargetDescriptionSource {
     TargetDescriptionSource::External
-}
-
-pub fn serialize<S>(raw_algorithms: &[RawFlashAlgorithm], serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    use serde::ser::SerializeMap;
-    let mut map = serializer.serialize_map(Some(raw_algorithms.len()))?;
-    for entry in raw_algorithms {
-        map.serialize_entry(&entry.name, entry)?;
-    }
-    map.end()
-}
-
-pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<RawFlashAlgorithm>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    struct MapVisitor;
-
-    use serde::de::MapAccess;
-    impl<'de> serde::de::Visitor<'de> for MapVisitor {
-        type Value = Vec<RawFlashAlgorithm>;
-
-        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-            write!(formatter, "a map")
-        }
-
-        fn visit_map<A>(self, mut v: A) -> Result<Self::Value, A::Error>
-        where
-            A: MapAccess<'de>,
-        {
-            let mut result = vec![];
-            while let Some((_key, value)) = v.next_entry::<String, RawFlashAlgorithm>()? {
-                result.push(value);
-            }
-
-            Ok(result)
-        }
-    }
-
-    deserializer.deserialize_map(MapVisitor)
 }
 
 impl ChipFamily {

--- a/probe-rs/targets/EFM32PG12B_Series.yaml
+++ b/probe-rs/targets/EFM32PG12B_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFM32PG12B Series
 variants:
   - name: EFM32PG12B500F1024
@@ -7,44 +6,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 1048576
+            start: 0x0
+            end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
 flash_algorithms:
-  geckos1:
-    name: geckos1
+  - name: geckos1
     description: EFM32/EFR32 Gecko S1
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
-    pc_init: 81
-    pc_uninit: 105
-    pc_program_page: 229
-    pc_erase_sector: 163
-    pc_erase_all: 119
-    data_section_offset: 400
+    pc_init: 0x51
+    pc_uninit: 0x69
+    pc_program_page: 0xe5
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x77
+    data_section_offset: 0x190
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+        start: 0x0
+        end: 0x100000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32BG12P_Series.yaml
+++ b/probe-rs/targets/EFR32BG12P_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32BG12P Series
 variants:
   - name: EFR32BG12P132F1024
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32BG12P232F1024
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32BG12P232F512
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32BG12P332F1024
@@ -76,21 +81,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32BG12P432F1024
@@ -99,21 +106,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32BG12P433F1024
@@ -122,44 +131,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
 flash_algorithms:
-  geckos1:
-    name: geckos1
+  - name: geckos1
     description: EFM32/EFR32 Gecko S1
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
-    pc_init: 81
-    pc_uninit: 105
-    pc_program_page: 229
-    pc_erase_sector: 163
-    pc_erase_all: 119
-    data_section_offset: 400
+    pc_init: 0x51
+    pc_uninit: 0x69
+    pc_program_page: 0xe5
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x77
+    data_section_offset: 0x190
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32BG13P_Series.yaml
+++ b/probe-rs/targets/EFR32BG13P_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32BG13P Series
 variants:
   - name: EFR32BG13P532F512
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32BG13P632F512
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32BG13P732F512
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32BG13P733F512
@@ -76,44 +81,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
 flash_algorithms:
-  geckos1:
-    name: geckos1
+  - name: geckos1
     description: EFM32/EFR32 Gecko S1
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
-    pc_init: 81
-    pc_uninit: 105
-    pc_program_page: 229
-    pc_erase_sector: 163
-    pc_erase_all: 119
-    data_section_offset: 400
+    pc_init: 0x51
+    pc_uninit: 0x69
+    pc_program_page: 0xe5
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x77
+    data_section_offset: 0x190
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32BG14P_Series.yaml
+++ b/probe-rs/targets/EFR32BG14P_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32BG14P Series
 variants:
   - name: EFR32BG14P532F256
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32BG14P632F256
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32BG14P732F256
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32BG14P733F256
@@ -76,44 +81,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
 flash_algorithms:
-  geckos1:
-    name: geckos1
+  - name: geckos1
     description: EFM32/EFR32 Gecko S1
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
-    pc_init: 81
-    pc_uninit: 105
-    pc_program_page: 229
-    pc_erase_sector: 163
-    pc_erase_all: 119
-    data_section_offset: 400
+    pc_init: 0x51
+    pc_uninit: 0x69
+    pc_program_page: 0xe5
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x77
+    data_section_offset: 0x190
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32BG1P_Series.yaml
+++ b/probe-rs/targets/EFR32BG1P_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32BG1P Series
 variants:
   - name: EFR32BG1P232F256
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32BG1P233F256
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32BG1P332F256
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32BG1P333F256
@@ -76,45 +81,47 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
 flash_algorithms:
-  geckop2:
-    name: geckop2
+  - name: geckop2
     description: EFM32/EFR32 Gecko P2
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1WUtZTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1KSUH2cTAIZAAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3cf9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/92P/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgTOcAAICWmAAAAA5AAAAAAA==
-    pc_init: 81
-    pc_uninit: 93
-    pc_program_page: 217
-    pc_erase_sector: 151
-    pc_erase_all: 107
-    data_section_offset: 384
+    pc_init: 0x51
+    pc_uninit: 0x5d
+    pc_program_page: 0xd9
+    pc_erase_sector: 0x97
+    pc_erase_all: 0x6b
+    data_section_offset: 0x180
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x40000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0
 core: M4

--- a/probe-rs/targets/EFR32BG21_Series.yaml
+++ b/probe-rs/targets/EFR32BG21_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32BG21 Series
 variants:
   - name: EFR32BG21A010F1024
@@ -7,21 +6,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG21A010F512
@@ -30,21 +31,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG21A010F768
@@ -53,21 +56,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0xc0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG21A020F1024
@@ -76,21 +81,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG21A020F512
@@ -99,21 +106,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG21A020F768
@@ -122,21 +131,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0xc0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG21B010F1024
@@ -145,21 +156,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG21B010F512
@@ -168,21 +181,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG21B010F768
@@ -191,21 +206,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0xc0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG21B020F1024
@@ -214,21 +231,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG21B020F512
@@ -237,21 +256,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG21B020F768
@@ -260,44 +281,46 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0xc0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
 flash_algorithms:
-  geckos2:
-    name: geckos2
+  - name: geckos2
     description: EFM32/EFR32 Gecko S2
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: DUgBaAH0fBGx9bAfBNELSQpoQvQAMgpgCUlB9nEyCmAAIkpggGgHSQHqgCEGSgAgSfgCEHBHAL8EgOAPaIAAQDwAA0AA/P8DBAAAAAVJQfZxMAhgBEgBIgJgACIAIApgcEcAvzwAA0AMIANAsLUJTQAkWfgFAIRCJL8AILC9IEYA8Ar4ACgE9QBUHL8BILC97+cAvwQAAAAPSQJGCMoBMwPRACkB8QQB+NGTsbC1C0wBJQtJJWBIYAIgCGABIAAhAPBe+E/0gFEAKGVQGL8BILC9ACBwRwC/BOD//wwQA0AQAANALenwTQVGyBySRiJKIk8g8AMEASAQYC7gBfUAUIhDoOsFC2keXEWh6wAAb+oEATi/o0bQRohCfWCIvwFGTh3Y+AAAAC64YArQCCAIIQjxBAgA8CT4ACgG8QQG8NAW4AQgOGABIAAhASYA8Bj4eLnaRF1EpOsLBEH2/3EALMzRT/SAUAEhA0oAJhFQAOABJjBGvejwjQwQA0AQAANAcLUQTg1KDkwzHQngBUCNQgS/ACBwvQE0BL9v8AIAcL0VaR1C8tAQaDVCIPABAW/wAQAIv0/w/zARYHC9DAADQIBpZ/8CAAEAAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 77
-    pc_program_page: 229
-    pc_erase_sector: 153
-    pc_erase_all: 109
-    data_section_offset: 456
+    pc_init: 0x1
+    pc_uninit: 0x4d
+    pc_program_page: 0xe5
+    pc_erase_sector: 0x99
+    pc_erase_all: 0x6d
+    data_section_offset: 0x1c8
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 12288
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/EFR32BG22_Series.yaml
+++ b/probe-rs/targets/EFR32BG22_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32BG22 Series
 variants:
   - name: EFR32BG22C112F352
@@ -7,21 +6,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x58000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG22C222F352
@@ -30,21 +31,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x58000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32BG22C224F512
@@ -53,44 +56,46 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
 flash_algorithms:
-  geckos2:
-    name: geckos2
+  - name: geckos2
     description: EFM32/EFR32 Gecko S2
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: DUgBaAH0fBGx9bAfBNELSQpoQvQAMgpgCUlB9nEyCmAAIkpggGgHSQHqgCEGSgAgSfgCEHBHAL8EgOAPaIAAQDwAA0AA/P8DBAAAAAVJQfZxMAhgBEgBIgJgACIAIApgcEcAvzwAA0AMIANAsLUJTQAkWfgFAIRCJL8AILC9IEYA8Ar4ACgE9QBUHL8BILC97+cAvwQAAAAPSQJGCMoBMwPRACkB8QQB+NGTsbC1C0wBJQtJJWBIYAIgCGABIAAhAPBe+E/0gFEAKGVQGL8BILC9ACBwRwC/BOD//wwQA0AQAANALenwTQVGyBySRiJKIk8g8AMEASAQYC7gBfUAUIhDoOsFC2keXEWh6wAAb+oEATi/o0bQRohCfWCIvwFGTh3Y+AAAAC64YArQCCAIIQjxBAgA8CT4ACgG8QQG8NAW4AQgOGABIAAhASYA8Bj4eLnaRF1EpOsLBEH2/3EALMzRT/SAUAEhA0oAJhFQAOABJjBGvejwjQwQA0AQAANAcLUQTg1KDkwzHQngBUCNQgS/ACBwvQE0BL9v8AIAcL0VaR1C8tAQaDVCIPABAW/wAQAIv0/w/zARYHC9DAADQIBpZ/8CAAEAAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 77
-    pc_program_page: 229
-    pc_erase_sector: 153
-    pc_erase_all: 109
-    data_section_offset: 456
+    pc_init: 0x1
+    pc_uninit: 0x4d
+    pc_program_page: 0xe5
+    pc_erase_sector: 0x99
+    pc_erase_all: 0x6d
+    data_section_offset: 0x1c8
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 12288
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/EFR32FG12P_Series.yaml
+++ b/probe-rs/targets/EFR32FG12P_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32FG12P Series
 variants:
   - name: EFR32FG12P231F512
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG12P231F1024
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG12P232F1024
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG12P431F512
@@ -76,21 +81,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG12P431F1024
@@ -99,21 +106,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG12P432F1024
@@ -122,21 +131,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG12P433F1024
@@ -145,44 +156,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
 flash_algorithms:
-  geckos1:
-    name: geckos1
+  - name: geckos1
     description: EFM32/EFR32 Gecko S1
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
-    pc_init: 81
-    pc_uninit: 105
-    pc_program_page: 229
-    pc_erase_sector: 163
-    pc_erase_all: 119
-    data_section_offset: 400
+    pc_init: 0x51
+    pc_uninit: 0x69
+    pc_program_page: 0xe5
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x77
+    data_section_offset: 0x190
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32FG13P_Series.yaml
+++ b/probe-rs/targets/EFR32FG13P_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32FG13P Series
 variants:
   - name: EFR32FG13P231F512
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG13P232F512
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG13P233F512
@@ -53,44 +56,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
 flash_algorithms:
-  geckos1:
-    name: geckos1
+  - name: geckos1
     description: EFM32/EFR32 Gecko S1
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
-    pc_init: 81
-    pc_uninit: 105
-    pc_program_page: 229
-    pc_erase_sector: 163
-    pc_erase_all: 119
-    data_section_offset: 400
+    pc_init: 0x51
+    pc_uninit: 0x69
+    pc_program_page: 0xe5
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x77
+    data_section_offset: 0x190
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32FG14P_Series.yaml
+++ b/probe-rs/targets/EFR32FG14P_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32FG14P Series
 variants:
   - name: EFR32FG14P231F128
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG14P231F256
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG14P232F128
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG14P232F256
@@ -76,21 +81,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG14P233F128
@@ -99,21 +106,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32FG14P233F256
@@ -122,44 +131,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
 flash_algorithms:
-  geckos1:
-    name: geckos1
+  - name: geckos1
     description: EFM32/EFR32 Gecko S1
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
-    pc_init: 81
-    pc_uninit: 105
-    pc_program_page: 229
-    pc_erase_sector: 163
-    pc_erase_all: 119
-    data_section_offset: 400
+    pc_init: 0x51
+    pc_uninit: 0x69
+    pc_program_page: 0xe5
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x77
+    data_section_offset: 0x190
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32FG14V_Series.yaml
+++ b/probe-rs/targets/EFR32FG14V_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32FG14V Series
 variants:
   - name: EFR32FG14V132F256
@@ -7,44 +6,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
 flash_algorithms:
-  geckos1:
-    name: geckos1
+  - name: geckos1
     description: EFM32/EFR32 Gecko S1
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
-    pc_init: 81
-    pc_uninit: 105
-    pc_program_page: 229
-    pc_erase_sector: 163
-    pc_erase_all: 119
-    data_section_offset: 400
+    pc_init: 0x51
+    pc_uninit: 0x69
+    pc_program_page: 0xe5
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x77
+    data_section_offset: 0x190
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32FG1P_Series.yaml
+++ b/probe-rs/targets/EFR32FG1P_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32FG1P Series
 variants:
   - name: EFR32FG1P131F64
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32FG1P131F128
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32FG1P131F256
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32FG1P132F64
@@ -76,21 +81,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32FG1P132F128
@@ -99,21 +106,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32FG1P132F256
@@ -122,21 +131,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32FG1P133F64
@@ -145,21 +156,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32FG1P133F128
@@ -168,21 +181,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32FG1P133F256
@@ -191,44 +206,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
 flash_algorithms:
-  geckop2:
-    name: geckop2
+  - name: geckop2
     description: EFM32/EFR32 Gecko P2
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1WUtZTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1KSUH2cTAIZAAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3cf9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/92P/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgTOcAAICWmAAAAA5AAAAAAA==
-    pc_init: 81
-    pc_uninit: 93
-    pc_program_page: 217
-    pc_erase_sector: 151
-    pc_erase_all: 107
-    data_section_offset: 384
+    pc_init: 0x51
+    pc_uninit: 0x5d
+    pc_program_page: 0xd9
+    pc_erase_sector: 0x97
+    pc_erase_all: 0x6b
+    data_section_offset: 0x180
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x40000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32FG22_Series.yaml
+++ b/probe-rs/targets/EFR32FG22_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32FG22 Series
 variants:
   - name: EFR32FG22C121F256
@@ -7,21 +6,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32FG22C121F512
@@ -30,44 +31,46 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
 flash_algorithms:
-  geckos2:
-    name: geckos2
+  - name: geckos2
     description: EFM32/EFR32 Gecko S2
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: DUgBaAH0fBGx9bAfBNELSQpoQvQAMgpgCUlB9nEyCmAAIkpggGgHSQHqgCEGSgAgSfgCEHBHAL8EgOAPaIAAQDwAA0AA/P8DBAAAAAVJQfZxMAhgBEgBIgJgACIAIApgcEcAvzwAA0AMIANAsLUJTQAkWfgFAIRCJL8AILC9IEYA8Ar4ACgE9QBUHL8BILC97+cAvwQAAAAPSQJGCMoBMwPRACkB8QQB+NGTsbC1C0wBJQtJJWBIYAIgCGABIAAhAPBe+E/0gFEAKGVQGL8BILC9ACBwRwC/BOD//wwQA0AQAANALenwTQVGyBySRiJKIk8g8AMEASAQYC7gBfUAUIhDoOsFC2keXEWh6wAAb+oEATi/o0bQRohCfWCIvwFGTh3Y+AAAAC64YArQCCAIIQjxBAgA8CT4ACgG8QQG8NAW4AQgOGABIAAhASYA8Bj4eLnaRF1EpOsLBEH2/3EALMzRT/SAUAEhA0oAJhFQAOABJjBGvejwjQwQA0AQAANAcLUQTg1KDkwzHQngBUCNQgS/ACBwvQE0BL9v8AIAcL0VaR1C8tAQaDVCIPABAW/wAQAIv0/w/zARYHC9DAADQIBpZ/8CAAEAAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 77
-    pc_program_page: 229
-    pc_erase_sector: 153
-    pc_erase_all: 109
-    data_section_offset: 456
+    pc_init: 0x1
+    pc_uninit: 0x4d
+    pc_program_page: 0xe5
+    pc_erase_sector: 0x99
+    pc_erase_all: 0x6d
+    data_section_offset: 0x1c8
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 12288
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/EFR32FG23_Series.yaml
+++ b/probe-rs/targets/EFR32FG23_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32FG23 Series
 variants:
   - name: EFR32FG23A010F256
@@ -7,21 +6,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x8000000
             end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2c3
   - name: EFR32FG23A010F512
@@ -30,21 +31,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x8000000
             end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2c3
   - name: EFR32FG23A011F512
@@ -53,21 +56,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x8000000
             end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2c3
   - name: EFR32FG23A020F256
@@ -76,21 +81,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x8000000
             end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2c3
   - name: EFR32FG23A020F512
@@ -99,21 +106,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x8000000
             end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2c3
   - name: EFR32FG23A021F512
@@ -122,21 +131,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x8000000
             end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2c3
   - name: EFR32FG23B010F256
@@ -145,21 +156,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x8000000
             end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2c3
   - name: EFR32FG23B010F512
@@ -168,21 +181,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x8000000
             end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2c3
   - name: EFR32FG23B020F256
@@ -191,21 +206,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x8000000
             end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2c3
   - name: EFR32FG23B020F512
@@ -214,44 +231,46 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x8000000
             end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2c3
 flash_algorithms:
-  geckos2c3:
-    name: geckos2c3
+  - name: geckos2c3
     description: EFM32/EFR32 Gecko S2C3
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: DUgBaAH0fBGx9bAfBNkLSQpoQvSAMgpgCUlB9nEyCmAAIkpggGgHSQHqgCEGSgAgSfgCEHBHAL8EgOAPaIAAQDwAA0AA/P8DBAAAAAVJQfZxMAhgBEgBIgJgACIAIApgcEcAvzwAA0AMIANAsLUJTQAkWfgFAIRCJL8AILC9IEYA8Ar4ACgE9QBUHL8BILC97+cAvwQAAAAPSQJGCMoBMwPRACkB8QQB+NGTsbC1C0wBJQtJJWBIYAIgCGABIAAhAPBe+E/0gFEAKGVQGL8BILC9ACBwRwC/BOD//wwQA0AQAANALenwTQVGyBySRiJKIk8g8AMEASAQYC7gBfUAUIhDoOsFC2keXEWh6wAAb+oEATi/o0bQRohCfWCIvwFGTh3Y+AAAAC64YArQCCAIIQjxBAgA8CT4ACgG8QQG8NAW4AQgOGABIAAhASYA8Bj4eLnaRF1EpOsLBEH2/3EALMzRT/SAUAEhA0oAJhFQAOABJjBGvejwjQwQA0AQAANAcLUQTg1KDkwzHQngBUCNQgS/ACBwvQE0BL9v8AIAcL0VaR1C8tAQaDVCIPABAW/wAQAIv0/w/zARYHC9DAADQIBpZ/8CAAEAAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 77
-    pc_program_page: 229
-    pc_erase_sector: 153
-    pc_erase_all: 109
-    data_section_offset: 456
+    pc_init: 0x1
+    pc_uninit: 0x4d
+    pc_program_page: 0xe5
+    pc_erase_sector: 0x99
+    pc_erase_all: 0x6d
+    data_section_offset: 0x1c8
     flash_properties:
       address_range:
         start: 0x8000000
         end: 0x81e0000
-      page_size: 12288
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/EFR32MG12P_Series.yaml
+++ b/probe-rs/targets/EFR32MG12P_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32MG12P Series
 variants:
   - name: EFR32MG12P132F512
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG12P132F1024
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG12P231F1024
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG12P232F512
@@ -76,21 +81,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG12P232F1024
@@ -99,21 +106,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG12P332F1024
@@ -122,21 +131,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG12P431F1024
@@ -145,21 +156,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG12P432F1024
@@ -168,21 +181,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG12P433F1024
@@ -191,44 +206,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
 flash_algorithms:
-  geckos1:
-    name: geckos1
+  - name: geckos1
     description: EFM32/EFR32 Gecko S1
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
-    pc_init: 81
-    pc_uninit: 105
-    pc_program_page: 229
-    pc_erase_sector: 163
-    pc_erase_all: 119
-    data_section_offset: 400
+    pc_init: 0x51
+    pc_uninit: 0x69
+    pc_program_page: 0xe5
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x77
+    data_section_offset: 0x190
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32MG13P_Series.yaml
+++ b/probe-rs/targets/EFR32MG13P_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32MG13P Series
 variants:
   - name: EFR32MG13P632F512
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG13P731F512
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG13P732F512
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG13P733F512
@@ -76,21 +81,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG13P832F512
@@ -99,44 +106,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
 flash_algorithms:
-  geckos1:
-    name: geckos1
+  - name: geckos1
     description: EFM32/EFR32 Gecko S1
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
-    pc_init: 81
-    pc_uninit: 105
-    pc_program_page: 229
-    pc_erase_sector: 163
-    pc_erase_all: 119
-    data_section_offset: 400
+    pc_init: 0x51
+    pc_uninit: 0x69
+    pc_program_page: 0xe5
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x77
+    data_section_offset: 0x190
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32MG14P_Series.yaml
+++ b/probe-rs/targets/EFR32MG14P_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32MG14P Series
 variants:
   - name: EFR32MG14P632F256
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG14P632F256
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG14P731F256
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG14P732F256
@@ -76,21 +81,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG14P732F256
@@ -99,21 +106,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG14P732F256
@@ -122,21 +131,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG14P732F256
@@ -145,21 +156,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG14P733F256
@@ -168,21 +181,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
   - name: EFR32MG14P733F256
@@ -191,44 +206,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos1
 flash_algorithms:
-  geckos1:
-    name: geckos1
+  - name: geckos1
     description: EFM32/EFR32 Gecko S1
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1XEtcTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1NSUH2cTAIZExIQCEBYUFoSQP81AAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3a/9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/913/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgRucAAICWmAAAAA5AADAOQAAAAAA=
-    pc_init: 81
-    pc_uninit: 105
-    pc_program_page: 229
-    pc_erase_sector: 163
-    pc_erase_all: 119
-    data_section_offset: 400
+    pc_init: 0x51
+    pc_uninit: 0x69
+    pc_program_page: 0xe5
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x77
+    data_section_offset: 0x190
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32MG1P_Series.yaml
+++ b/probe-rs/targets/EFR32MG1P_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32MG1P Series
 variants:
   - name: EFR32MG1P131F256
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32MG1P132F256
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32MG1P133F256
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32MG1P231F256
@@ -76,21 +81,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32MG1P232F256
@@ -99,21 +106,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32MG1P233F256
@@ -122,21 +131,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32MG1P632F256
@@ -145,21 +156,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
   - name: EFR32MG1P732F256
@@ -168,44 +181,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20007c00
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckop2
 flash_algorithms:
-  geckop2:
-    name: geckop2
+  - name: geckop2
     description: EFM32/EFR32 Gecko P2
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR8C6cEdP6jAAcEcAAHC1WUtZTG/wAgXiaRLwFg8N0KBoIPABAKBgkAcC1W/wAQBwvVAHCdVP8P8wcL0CQIpCAdEAIHC9Wx7m0ShGcL1KSUH2cTAIZAAgcEdHSIFoIfABAYFgACBwRxC1Q0ygaEDwAQCgYEbyGjBgZaAVAPB1+AAhYWWhaCHwAQGhYAAoANABIBC9cLUERgAjT/QAYQTICR8C8QECAtAAKvjQAOBqsTJNqGhA8AEAqGAsYQMgAPBU+ANGqGgg8AEAqGALsQEgcL0AIHC9LenwTYBGJ0jJHCHwAwaBaJJGQfABAYFgg0Yx4Aj1AGDBCskCoesIB0BGt0IA2TdGAUZYRsv4EBDa+AAQy/gYEBEhCvEEBcv4DBA8HwngCCEIRv/3cf9guQLNWEbL+BgQJB8ALPPRBCHBYAAhASD/92P/ELEBIL3o8I26RLhE9hsALsvR2/gIECHwAQHL+AgQACDw5wNJyGAAIQEgTOcAAICWmAAAAA5AAAAAAA==
-    pc_init: 81
-    pc_uninit: 93
-    pc_program_page: 217
-    pc_erase_sector: 151
-    pc_erase_all: 107
-    data_section_offset: 384
+    pc_init: 0x51
+    pc_uninit: 0x5d
+    pc_program_page: 0xd9
+    pc_erase_sector: 0x97
+    pc_erase_all: 0x6b
+    data_section_offset: 0x180
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x40000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/EFR32MG21_Series.yaml
+++ b/probe-rs/targets/EFR32MG21_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32MG21 Series
 variants:
   - name: EFR32MG21A010F1024
@@ -7,21 +6,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32MG21A010F512
@@ -30,21 +31,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32MG21A010F768
@@ -53,21 +56,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0xc0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32MG21A020F1024
@@ -76,21 +81,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32MG21A020F512
@@ -99,21 +106,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32MG21A020F768
@@ -122,21 +131,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0xc0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32MG21B010F1024
@@ -145,21 +156,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32MG21B010F512
@@ -168,21 +181,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32MG21B010F768
@@ -191,21 +206,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0xc0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32MG21B020F1024
@@ -214,21 +231,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32MG21B020F512
@@ -237,21 +256,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32MG21B020F768
@@ -260,21 +281,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0xc0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: RM21Z000F1024
@@ -283,44 +306,46 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
 flash_algorithms:
-  geckos2:
-    name: geckos2
+  - name: geckos2
     description: EFM32/EFR32 Gecko S2
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: DUgBaAH0fBGx9bAfBNELSQpoQvQAMgpgCUlB9nEyCmAAIkpggGgHSQHqgCEGSgAgSfgCEHBHAL8EgOAPaIAAQDwAA0AA/P8DBAAAAAVJQfZxMAhgBEgBIgJgACIAIApgcEcAvzwAA0AMIANAsLUJTQAkWfgFAIRCJL8AILC9IEYA8Ar4ACgE9QBUHL8BILC97+cAvwQAAAAPSQJGCMoBMwPRACkB8QQB+NGTsbC1C0wBJQtJJWBIYAIgCGABIAAhAPBe+E/0gFEAKGVQGL8BILC9ACBwRwC/BOD//wwQA0AQAANALenwTQVGyBySRiJKIk8g8AMEASAQYC7gBfUAUIhDoOsFC2keXEWh6wAAb+oEATi/o0bQRohCfWCIvwFGTh3Y+AAAAC64YArQCCAIIQjxBAgA8CT4ACgG8QQG8NAW4AQgOGABIAAhASYA8Bj4eLnaRF1EpOsLBEH2/3EALMzRT/SAUAEhA0oAJhFQAOABJjBGvejwjQwQA0AQAANAcLUQTg1KDkwzHQngBUCNQgS/ACBwvQE0BL9v8AIAcL0VaR1C8tAQaDVCIPABAW/wAQAIv0/w/zARYHC9DAADQIBpZ/8CAAEAAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 77
-    pc_program_page: 229
-    pc_erase_sector: 153
-    pc_erase_all: 109
-    data_section_offset: 456
+    pc_init: 0x1
+    pc_uninit: 0x4d
+    pc_program_page: 0xe5
+    pc_erase_sector: 0x99
+    pc_erase_all: 0x6d
+    data_section_offset: 0x1c8
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 12288
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/EFR32MG22_Series.yaml
+++ b/probe-rs/targets/EFR32MG22_Series.yaml
@@ -1,4 +1,3 @@
----
 name: EFR32MG22 Series
 variants:
   - name: EFR32MG22A224F512
@@ -7,21 +6,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
   - name: EFR32MG22C224F512
@@ -30,44 +31,46 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - geckos2
 flash_algorithms:
-  geckos2:
-    name: geckos2
+  - name: geckos2
     description: EFM32/EFR32 Gecko S2
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: DUgBaAH0fBGx9bAfBNELSQpoQvQAMgpgCUlB9nEyCmAAIkpggGgHSQHqgCEGSgAgSfgCEHBHAL8EgOAPaIAAQDwAA0AA/P8DBAAAAAVJQfZxMAhgBEgBIgJgACIAIApgcEcAvzwAA0AMIANAsLUJTQAkWfgFAIRCJL8AILC9IEYA8Ar4ACgE9QBUHL8BILC97+cAvwQAAAAPSQJGCMoBMwPRACkB8QQB+NGTsbC1C0wBJQtJJWBIYAIgCGABIAAhAPBe+E/0gFEAKGVQGL8BILC9ACBwRwC/BOD//wwQA0AQAANALenwTQVGyBySRiJKIk8g8AMEASAQYC7gBfUAUIhDoOsFC2keXEWh6wAAb+oEATi/o0bQRohCfWCIvwFGTh3Y+AAAAC64YArQCCAIIQjxBAgA8CT4ACgG8QQG8NAW4AQgOGABIAAhASYA8Bj4eLnaRF1EpOsLBEH2/3EALMzRT/SAUAEhA0oAJhFQAOABJjBGvejwjQwQA0AQAANAcLUQTg1KDkwzHQngBUCNQgS/ACBwvQE0BL9v8AIAcL0VaR1C8tAQaDVCIPABAW/wAQAIv0/w/zARYHC9DAADQIBpZ/8CAAEAAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 77
-    pc_program_page: 229
-    pc_erase_sector: 153
-    pc_erase_all: 109
-    data_section_offset: 456
+    pc_init: 0x1
+    pc_uninit: 0x4d
+    pc_program_page: 0xe5
+    pc_erase_sector: 0x99
+    pc_erase_all: 0x6d
+    data_section_offset: 0x1c8
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x100000
-      page_size: 12288
-      erased_byte_value: 255
-      program_page_timeout: 260
-      erase_sector_timeout: 200
+      page_size: 0x3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x104
+      erase_sector_timeout: 0xc8
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/GD32VF1_Series.yaml
+++ b/probe-rs/targets/GD32VF1_Series.yaml
@@ -1,4 +1,3 @@
----
 name: GD32VF1 Series
 variants:
   - name: GD32VF103CBT6
@@ -10,15 +9,17 @@ variants:
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms: []
-flash_algorithms: {}
+flash_algorithms: []

--- a/probe-rs/targets/HF5032x_Series.yaml
+++ b/probe-rs/targets/HF5032x_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HF5032x Series
 variants:
   - name: HF5032
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,68 +84,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f_opt:
-    name: ht32f_opt
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f:
-    name: ht32f
+        - size: 0x200
+          address: 0x0
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F0006_Series.yaml
+++ b/probe-rs/targets/HT32F0006_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F0006 Series
 variants:
   - name: HT32F0006
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,68 +58,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f_opt:
-    name: ht32f_opt
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f:
-    name: ht32f
+        - size: 0x200
+          address: 0x0
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F0008_Series.yaml
+++ b/probe-rs/targets/HT32F0008_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F0008 Series
 variants:
   - name: HT32F0008
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,21 +84,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -103,68 +110,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f:
-    name: ht32f
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f_opt:
-    name: ht32f_opt
+        - size: 0x200
+          address: 0x0
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F123xx_Series.yaml
+++ b/probe-rs/targets/HT32F123xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F123xx Series
 variants:
   - name: HT32F12345
@@ -7,21 +6,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,21 +84,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -103,21 +110,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -127,21 +136,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -151,21 +162,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -175,21 +188,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -199,21 +214,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -223,21 +240,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -247,21 +266,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -271,21 +292,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -295,21 +318,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -319,21 +344,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -343,21 +370,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -367,21 +396,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -391,21 +422,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -415,21 +448,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -439,21 +474,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -463,21 +500,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -487,21 +526,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -511,21 +552,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -535,68 +578,70 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f:
-    name: ht32f
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f_opt:
-    name: ht32f_opt
+        - size: 0x200
+          address: 0x0
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F12xx_Series.yaml
+++ b/probe-rs/targets/HT32F12xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F12xx Series
 variants:
   - name: HT32F1251
@@ -7,21 +6,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 8192
+            start: 0x0
+            end: 0x2000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 8192
+            start: 0x0
+            end: 0x2000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,68 +84,70 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 31744
+            start: 0x0
+            end: 0x7c00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f_opt:
-    name: ht32f_opt
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f:
-    name: ht32f
+        - size: 0x200
+          address: 0x0
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F16xx_Series.yaml
+++ b/probe-rs/targets/HT32F16xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F16xx Series
 variants:
   - name: HT32F1653
@@ -7,21 +6,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,21 +84,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -103,21 +110,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -127,21 +136,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -151,21 +162,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -175,21 +188,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -199,21 +214,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -223,21 +240,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -247,21 +266,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -271,21 +292,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -295,21 +318,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -319,68 +344,70 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f:
-    name: ht32f
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f_opt:
-    name: ht32f_opt
+        - size: 0x200
+          address: 0x0
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F17xx_Series.yaml
+++ b/probe-rs/targets/HT32F17xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F17xx Series
 variants:
   - name: HT32F1755
@@ -7,21 +6,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,21 +84,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -103,21 +110,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -127,21 +136,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -151,21 +162,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -175,21 +188,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -199,21 +214,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -223,21 +240,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -247,21 +266,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -271,21 +292,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -295,21 +318,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -319,21 +344,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -343,68 +370,70 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f_opt:
-    name: ht32f_opt
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f:
-    name: ht32f
+        - size: 0x200
+          address: 0x0
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F502xx_Series.yaml
+++ b/probe-rs/targets/HT32F502xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F502xx Series
 variants:
   - name: HT32F50220
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,21 +84,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -103,21 +110,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -127,21 +136,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -151,21 +162,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -175,21 +188,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -199,21 +214,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -223,21 +240,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -247,21 +266,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -271,21 +292,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -295,21 +318,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -319,21 +344,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -343,21 +370,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -367,21 +396,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -391,21 +422,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -415,21 +448,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -439,21 +474,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -463,21 +500,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -487,21 +526,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -511,21 +552,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -535,21 +578,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -559,21 +604,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -583,21 +630,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -607,21 +656,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -631,21 +682,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -655,21 +708,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -679,21 +734,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -703,21 +760,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -727,21 +786,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -751,21 +812,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -775,21 +838,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -799,21 +864,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -823,21 +890,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -847,68 +916,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f_opt:
-    name: ht32f_opt
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f:
-    name: ht32f
+        - size: 0x200
+          address: 0x0
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F503xx_Series.yaml
+++ b/probe-rs/targets/HT32F503xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F503xx Series
 variants:
   - name: HT32F50343
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,21 +84,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -103,68 +110,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f_opt:
-    name: ht32f_opt
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f:
-    name: ht32f
+        - size: 0x200
+          address: 0x0
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F521xx_Series.yaml
+++ b/probe-rs/targets/HT32F521xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F521xx Series
 variants:
   - name: HT32F52142
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,21 +84,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -103,68 +110,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f:
-    name: ht32f
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f_opt:
-    name: ht32f_opt
+        - size: 0x200
+          address: 0x0
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F522xx_Series.yaml
+++ b/probe-rs/targets/HT32F522xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F522xx Series
 variants:
   - name: HT32F52220
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,21 +84,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -103,21 +110,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 31744
+            start: 0x0
+            end: 0x7c00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -127,21 +136,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 31744
+            start: 0x0
+            end: 0x7c00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -151,21 +162,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 31744
+            start: 0x0
+            end: 0x7c00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -175,21 +188,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 31744
+            start: 0x0
+            end: 0x7c00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -199,21 +214,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -223,21 +240,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -247,21 +266,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -271,21 +292,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -295,21 +318,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -319,21 +344,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -343,21 +370,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -367,21 +396,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -391,21 +422,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -415,21 +448,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -439,21 +474,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -463,21 +500,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -487,21 +526,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -511,21 +552,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -535,21 +578,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -559,21 +604,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -583,21 +630,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -607,21 +656,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -631,21 +682,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -655,68 +708,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130048
+            start: 0x0
+            end: 0x1fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f_opt:
-    name: ht32f_opt
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f:
-    name: ht32f
+        - size: 0x200
+          address: 0x0
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F523xx_Series.yaml
+++ b/probe-rs/targets/HT32F523xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F523xx Series
 variants:
   - name: HT32F52331
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,21 +84,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65024
+            start: 0x0
+            end: 0xfe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -103,21 +110,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65024
+            start: 0x0
+            end: 0xfe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -127,21 +136,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65024
+            start: 0x0
+            end: 0xfe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -151,21 +162,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -175,21 +188,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -199,21 +214,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -223,21 +240,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -247,21 +266,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -271,21 +292,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -295,21 +318,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -319,21 +344,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -343,21 +370,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -367,21 +396,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -391,21 +422,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -415,21 +448,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -439,21 +474,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -463,21 +500,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -487,21 +526,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -511,21 +552,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -535,21 +578,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -559,21 +604,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -583,21 +630,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -607,21 +656,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -631,21 +682,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -655,21 +708,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -679,21 +734,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -703,21 +760,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -727,21 +786,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -751,21 +812,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -775,21 +838,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -799,68 +864,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 261120
+            start: 0x0
+            end: 0x3fc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f_opt:
-    name: ht32f_opt
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f:
-    name: ht32f
+        - size: 0x200
+          address: 0x0
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F573xx_Series.yaml
+++ b/probe-rs/targets/HT32F573xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F573xx Series
 variants:
   - name: HT32F57331
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,21 +84,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65024
+            start: 0x0
+            end: 0xfe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -103,21 +110,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65024
+            start: 0x0
+            end: 0xfe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -127,21 +136,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65024
+            start: 0x0
+            end: 0xfe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -151,21 +162,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -175,21 +188,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -199,21 +214,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -223,21 +240,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -247,21 +266,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -271,21 +292,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -295,21 +318,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -319,68 +344,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f_opt:
-    name: ht32f_opt
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f:
-    name: ht32f
+        - size: 0x200
+          address: 0x0
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F5826_Series.yaml
+++ b/probe-rs/targets/HT32F5826_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F5826 Series
 variants:
   - name: HT32F5826
@@ -7,68 +6,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f:
-    name: ht32f
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f_opt:
-    name: ht32f_opt
+        - size: 0x200
+          address: 0x0
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F590xx_Series.yaml
+++ b/probe-rs/targets/HT32F590xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F590xx Series
 variants:
   - name: HT32F59041
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,68 +32,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f:
-    name: ht32f
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f_opt:
-    name: ht32f_opt
+        - size: 0x200
+          address: 0x0
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F597xx_Series.yaml
+++ b/probe-rs/targets/HT32F597xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F597xx Series
 variants:
   - name: HT32F59741
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65024
+            start: 0x0
+            end: 0xfe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,68 +32,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65024
+            start: 0x0
+            end: 0xfe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f_opt:
-    name: ht32f_opt
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f:
-    name: ht32f
+        - size: 0x200
+          address: 0x0
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F61352_Series.yaml
+++ b/probe-rs/targets/HT32F61352_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F61352 Series
 variants:
   - name: HT32F61352
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,68 +58,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f_opt:
-    name: ht32f_opt
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f:
-    name: ht32f
+        - size: 0x200
+          address: 0x0
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT32F652xx_Series.yaml
+++ b/probe-rs/targets/HT32F652xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT32F652xx Series
 variants:
   - name: HT32F65230
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,68 +84,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 64512
+            start: 0x0
+            end: 0xfc00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f:
-    name: ht32f
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f_opt:
-    name: ht32f_opt
+        - size: 0x200
+          address: 0x0
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT50F32002_Series.yaml
+++ b/probe-rs/targets/HT50F32002_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT50F32002 Series
 variants:
   - name: HT50F32002
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,21 +84,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -103,21 +110,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -127,21 +136,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -151,21 +162,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -175,21 +188,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -199,68 +214,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f_opt:
-    name: ht32f_opt
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f:
-    name: ht32f
+        - size: 0x200
+          address: 0x0
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/HT50F32003_Series.yaml
+++ b/probe-rs/targets/HT50F32003_Series.yaml
@@ -1,4 +1,3 @@
----
 name: HT50F32003 Series
 variants:
   - name: HT50F32003
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -55,21 +58,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
@@ -79,68 +84,70 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 130560
+            start: 0x0
+            end: 0x1fe00
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - ht32f
       - ht32f_opt
 flash_algorithms:
-  ht32f:
-    name: ht32f
+  - name: ht32f
     description: HT32 Series Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: SUkBIAhgSUkDIAhgHiDJAkhhiGFFSYAxCGhFSoMYRUoAIEpE0GCIaAArUGBJaADRSR5BQwAgEWBwRz9IDCEBYQAhwWAIRnBHOkhIRMFoOkgBYAohwWAUIQFhAOAAvwFpyQYJDw4p+dGBaTRKEUID0B4hgWEBIHBHACBwRy1KSkRRaEkeiEORaIhCAdEAIHBHE2jRaMkYgUIB2AEgcEcmSQhgCCPLYBQjC2GQYADgAL8IacAGAA8OKPnRiGkfShBA7NAeIIhh6OdwtRpLyRxLRIkIgAjdaIkAgAAbaEQY6xgkH5xCAdMBIHC9E0sEJNxgFCUSThPgGGAUaFxgHWEA4AC/HGnkBiQPDiz50ZxpNEIC0B4gmGHm5wAdCR8SHQAp6dEAIHC9AAAAgwhAAAEIQK7qifwIAAAAAAAIQB4AAgAAAAAAAAAAAAAAAAAAAAAA/////wAAAAA=
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 201
-    pc_erase_sector: 125
-    pc_erase_all: 73
-    data_section_offset: 320
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x49
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  ht32f_opt:
-    name: ht32f_opt
+        - size: 0x200
+          address: 0x0
+  - name: ht32f_opt
     description: HT32 Series Flash Options
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RUkBIAhgRUkDIAhgREgeIUFhgWFESUNISUTIYD9IgDCAaEhgCGAAIHBHPUgMIQFhACHBYAhGcEc7SEhEwWg4SAFgCiHBYBQhAWEA4AC/AWnJBgkPDin50YFpNEoRQgPQHiGBYQEgcEcAIHBHLkpKRFFoSR6IQ5FoiEIB0QAgcEcTaNFoyRiBQgHYASBwRyRJCGAII8tgFCMLYZBgAOAAvwhpwAYADw4o+dGIaR9KEEDs0B4giGHo53C1G0vJHEtEiQiACN1oiQCAABtoRBjrGCQfnEIB0wEgcL0RSwQk3GAUJRJOE+AYYBRoXGAdYQDgAL8caeQGJA8OLPnRnGk0QgLQHiCYYebnAB0JHxIdACnp0QAgcL0AAACDCEAAAQhAAAAIQAAA8B8IAAAAHgACAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAA==
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 109
-    pc_erase_all: 57
-    data_section_offset: 304
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x39
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535826432
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x1ff00000
+        end: 0x1ff01000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
+        - size: 0x200
+          address: 0x0

--- a/probe-rs/targets/LPC546xx_Series.yaml
+++ b/probe-rs/targets/LPC546xx_Series.yaml
@@ -1,4 +1,3 @@
----
 name: LPC546xx Series
 variants:
   - name: LPC54605J256BD100
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_256
       - lpc5460x_mt25ql128
@@ -31,21 +32,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_256
       - lpc5460x_mt25ql128
@@ -55,21 +58,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_256
       - lpc5460x_mt25ql128
@@ -79,21 +84,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5460x_mt25ql128
@@ -103,21 +110,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5460x_mt25ql128
@@ -127,21 +136,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5460x_mt25ql128
@@ -151,21 +162,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_256
       - lpc5460x_mt25ql128
@@ -175,21 +188,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_256
       - lpc5460x_mt25ql128
@@ -199,21 +214,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_256
       - lpc5460x_mt25ql128
@@ -223,21 +240,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5460x_mt25ql128
@@ -247,21 +266,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5460x_mt25ql128
@@ -271,21 +292,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5460x_mt25ql128
@@ -295,21 +318,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_256
       - lpc5460x_mt25ql128
@@ -319,21 +344,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_256
       - lpc5460x_mt25ql128
@@ -343,21 +370,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5460x_mt25ql128
@@ -367,21 +396,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5460x_mt25ql128
@@ -391,21 +422,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5460x_mt25ql128
@@ -415,21 +448,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_256
       - lpc5461x_mt25ql128
@@ -439,21 +474,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5461x_mt25ql128
@@ -463,21 +500,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5461x_mt25ql128
@@ -487,21 +526,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5461x_mt25ql128
@@ -511,21 +552,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5461x_mt25ql128
@@ -535,21 +578,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5461x_mt25ql128
@@ -559,137 +604,139 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc5460x_512
       - lpc5462x_w25q128jvfm
 flash_algorithms:
-  lpc5460x_256:
-    name: lpc5460x_256
+  - name: lpc5460x_256
     description: LPC5460x IAP 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: wAtwR0dJRkhJRAhgRkkAIAhgSGBFSQhgAiBBBwhwACBwRwAgcEf4tUFMMiBMRCFGACUHJmHEFDE9SD5PSEQMPACRuEdgaQAoDdE0IGHENUhIRABoIGA2SAw8SEQAmbhHYGkAKADQASD4vfi1ME3ECzIgTUQRxSlGDDEtSC1OLGAPRkhECD2wR2hpACgO0TQgEcUkSCxgSEQAaGhgJEg5RkhECD2wR2hpACgA0AEg+L34tRRGBgAO0QPMYmhAGCFoiRhAGKFoQBjhaEAYIWlAGEBCYGEIPBZN8AtNRDIhaGApYKhgKUYUMRJPKEYAkbhHaGkAKBHRMyCsYEHFASCAAmhgCEhIRABoqGAJSAg9SEQAmbhHaGkAKADQASD4vQAA4C4AAAQAAACAAgBAgAMAQAgAAAAFAgADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 5
-    pc_uninit: 35
-    pc_program_page: 177
-    pc_erase_sector: 107
-    pc_erase_all: 39
-    data_section_offset: 312
+    pc_init: 0x5
+    pc_uninit: 0x23
+    pc_program_page: 0xb1
+    pc_erase_sector: 0x6b
+    pc_erase_all: 0x27
+    data_section_offset: 0x138
     flash_properties:
       address_range:
-        start: 0
-        end: 262144
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x40000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 32768
-          address: 0
-  lpc5460x_512:
-    name: lpc5460x_512
+        - size: 0x8000
+          address: 0x0
+  - name: lpc5460x_512
     description: LPC5460x IAP 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: wAtwR0dJRkhJRAhgRkkAIAhgSGBFSQhgAiBBBwhwACBwRwAgcEf4tUFMMiBMRCFGACUPJmHEFDE9SD5PSEQMPACRuEdgaQAoDdE0IGHENUhIRABoIGA2SAw8SEQAmbhHYGkAKADQASD4vfi1ME3ECzIgTUQRxSlGDDEtSC1OLGAPRkhECD2wR2hpACgO0TQgEcUkSCxgSEQAaGhgJEg5RkhECD2wR2hpACgA0AEg+L34tRRGBgAO0QPMYmhAGCFoiRhAGKFoQBjhaEAYIWlAGEBCYGEIPBZN8AtNRDIhaGApYKhgKUYUMRJPKEYAkbhHaGkAKBHRMyCsYEHFASCAAmhgCEhIRABoqGAJSAg9SEQAmbhHaGkAKADQASD4vQAA4C4AAAQAAACAAgBAgAMAQAgAAAAFAgADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 5
-    pc_uninit: 35
-    pc_program_page: 177
-    pc_erase_sector: 107
-    pc_erase_all: 39
-    data_section_offset: 312
+    pc_init: 0x5
+    pc_uninit: 0x23
+    pc_program_page: 0xb1
+    pc_erase_sector: 0x6b
+    pc_erase_all: 0x27
+    data_section_offset: 0x138
     flash_properties:
       address_range:
-        start: 0
-        end: 524288
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x80000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 32768
-          address: 0
-  lpc5460x_mt25ql128:
-    name: lpc5460x_mt25ql128
+        - size: 0x8000
+          address: 0x0
+  - name: lpc5460x_mt25ql128
     description: LPC5460x MT25QL128 SPIFI
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR0C6cEdAunBHwLpwR8C6cEfAunBHcLWlTaVMTUQpRiBGAPDO+eJpkgb81WBpwAf10XC9ELWdSZ5MSUQQOSBGAPC/+ZpJIEZJRAg5APC5+UAhYWH/99//EL1wtQ0gAPAQ+f8klE0nNCNGFyIAIShGAPAY+SNGGCIAIShGAPAS+SNGGSIAIShGAPAM+SNGGiIAIShGAPAG+SNGGyIAIShGAPAA+SNGHCIAIShGAPD6+HC9MLV+Sf8gSUQBMBg5CIAAIopwynABIwtxS3EEJIxxayXNcQqBinLLcgpzSnOLcwYlzXMMgop0y3QKdUp1i3XLdQyDinbKdgp3SneLdwUlzXcIhAhGIDCCcMNwAnECJUVxhHE4JcVxCoWCcsNyAnNCc4RzICTEcwqGgnTDdAJ1QnWDdWAhwXUwvV9JELVJRAhgAyAA8J34BCAA8Jr4BSAA8Jf4WkgA8HL5WUkDIAhgACIKYlhJCGH/93f///eh/09ISEQgMADwvfhMSU1MSUQgMSBGAPDE+ElJIEZJRBg5APA5+QAgEL0AIHBHELVETBAg4GHhackG/NRASSBGSUQQOQDwBvk9SSBGSUQYMQDwAPn/9yj/OUkgRklEGDkA8Br5ACAQvXC1BUY1TBAg4GHgacAG/NQxSSBGSUQQOQDw6PilYC5JIEZJRBAxAPDh+P/3Cf8qSSBGSUQYOQDw+/gAIHC9ASBwR/e1BkYAJSRPgrAQIBRG+GH4acAG/NQfSEhEGDgBRggxIDABkQCQA5iFQhXSOEYBmQDwu/i+YDhGAJkA8Lb4ACACzHlhQBxAKPrb//fY/v81ATX/NgE25ucPSThGSUQYOQDwxfgAIAWw8L0BIwIKGUaBQAMqBdKQAAxKgDqAGAFicEcLSMNgC0hBYXBHyQEIGJEAQ1BwRyAAAAAAAAhAABAAQAQAAAAA2LgFgAIAQIADAEBAAABAAAAEQFZKELUBRgAgekSDANNYi0IC0EAc+dAB4AAoAdAA8OL4EL0AIclDAYAPIYFwACHBcAFxASJCcYFxwXEBcnBHcLUMAAVGEND/99v/RElAAHlESjkIWgEiAQoDKQfSgkCIAD9JQBgCYgbgAPC8+D1JymCCQD1IQmEQIOhh6GnABvzUoXggiAkHCQsIQ+F4onnJB9IHiQoSChFDCEMheckHCQkIQyF6yQfJCAhD4XnJB4kICENheckHSQgIQyhgcL0Qtf/3nv8lSUAAeUTEOQhaASIBCgMpBdKCQIgAIUlAGAJkEL2CQCBIgmEeSQAgyGAQvcJpkgf80QqIi3iSBNsHkgxbDBpDy3jbBxsMGkMLeVsHWwsaQ0t5mwfbChpDi3nJeVsHGwoaQwkGCkNCYMFpiQf81XBHwmmSB/zRCnlLeVIHmwdSC9sKGkOLecl5WwcbChpDCQYKQ4JhcEcAAIgCAAAAAgBAQAAAQAAABEBwtRdL3QCYQgbQmQCIQgPQqEIB0AEgcL0SSRAiCmMSShFolAXJAckPmEIV2Q9LEE6oQgbR2GgJBjBACEMNSQhDB+CYaAkGMEAIQwEhyQdAGCBDEGAAIHC9EGigQ/nnAAAAG7cAAAYAQAAFAEBABAAB/z//AABAAMAQtQAgAPAM+MBGwEYBIADwAfgQvQFJGCCrvv7nJgACABC1APAL+ADwAvgQvXBHELUAKAHQ//fu/xC9AAAQtQAhAqAA8BP4ASAQvQAAU0lHQUJSVDogQWJub3JtYWwgdGVybWluYXRpb24AAABwtQVGDEYKIADgbRwA8BL4AC0G0Ch4ACj30QLgZBwA8An4ACwC0CB4ACj30QogAPAB+HC9CLVpRghwAyCrvgi9CgAAAAAACEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 317
-    pc_uninit: 411
-    pc_program_page: 539
-    pc_erase_sector: 473
-    pc_erase_all: 415
-    data_section_offset: 1388
+    pc_init: 0x13d
+    pc_uninit: 0x19b
+    pc_program_page: 0x21b
+    pc_erase_sector: 0x1d9
+    pc_erase_all: 0x19f
+    data_section_offset: 0x56c
     flash_properties:
       address_range:
-        start: 268435456
-        end: 285212672
-      page_size: 4096
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x10000000
+        end: 0x11000000
+      page_size: 0x1000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 4096
-          address: 0
-  lpc5461x_mt25ql128:
-    name: lpc5461x_mt25ql128
+        - size: 0x1000
+          address: 0x0
+  - name: lpc5461x_mt25ql128
     description: LPC5461x MT25QL128 SPIFI
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR0C6cEdAunBHwLpwR8C6cEfAunBHcLWlTaVMTUQpRiBGAPDO+eJpkgb81WBpwAf10XC9ELWdSZ5MSUQQOSBGAPC/+ZpJIEZJRAg5APC5+UAhYWH/99//EL1wtQ0gAPAQ+f8klE0nNCNGFyIAIShGAPAY+SNGGCIAIShGAPAS+SNGGSIAIShGAPAM+SNGGiIAIShGAPAG+SNGGyIAIShGAPAA+SNGHCIAIShGAPD6+HC9MLV+Sf8gSUQBMBg5CIAAIopwynABIwtxS3EEJIxxayXNcQqBinLLcgpzSnOLcwYlzXMMgop0y3QKdUp1i3XLdQyDinbKdgp3SneLdwUlzXcIhAhGIDCCcMNwAnECJUVxhHE4JcVxCoWCcsNyAnNCc4RzICTEcwqGgnTDdAJ1QnWDdWAhwXUwvV9JELVJRAhgAyAA8J34BCAA8Jr4BSAA8Jf4WkgA8HL5WUkDIAhgACIKYlhJCGH/93f///eh/09ISEQgMADwvfhMSU1MSUQgMSBGAPDE+ElJIEZJRBg5APA5+QAgEL0AIHBHELVETBAg4GHhackG/NRASSBGSUQQOQDwBvk9SSBGSUQYMQDwAPn/9yj/OUkgRklEGDkA8Br5ACAQvXC1BUY1TBAg4GHgacAG/NQxSSBGSUQQOQDw6PilYC5JIEZJRBAxAPDh+P/3Cf8qSSBGSUQYOQDw+/gAIHC9ASBwR/e1BkYAJSRPgrAQIBRG+GH4acAG/NQfSEhEGDgBRggxIDABkQCQA5iFQhXSOEYBmQDwu/i+YDhGAJkA8Lb4ACACzHlhQBxAKPrb//fY/v81ATX/NgE25ucPSThGSUQYOQDwxfgAIAWw8L0BIwIKGUaBQAMqBdKQAAxKgDqAGAFicEcLSMNgC0hBYXBHyQEIGJEAQ1BwRyAAAAAAAAhAABAAQAQAAAAA2LgFgAIAQIADAEBAAABAAAAEQFZKELUBRgAgekSDANNYi0IC0EAc+dAB4AAoAdAA8OL4EL0AIclDAYAPIYFwACHBcAFxASJCcYFxwXEBcnBHcLUMAAVGEND/99v/RElAAHlESjkIWgEiAQoDKQfSgkCIAD9JQBgCYgbgAPC8+D1JymCCQD1IQmEQIOhh6GnABvzUoXggiAkHCQsIQ+F4onnJB9IHiQoSChFDCEMheckHCQkIQyF6yQfJCAhD4XnJB4kICENheckHSQgIQyhgcL0Qtf/3nv8lSUAAeUTEOQhaASIBCgMpBdKCQIgAIUlAGAJkEL2CQCBIgmEeSQAgyGAQvcJpkgf80QqIi3iSBNsHkgxbDBpDy3jbBxsMGkMLeVsHWwsaQ0t5mwfbChpDi3nJeVsHGwoaQwkGCkNCYMFpiQf81XBHwmmSB/zRCnlLeVIHmwdSC9sKGkOLecl5WwcbChpDCQYKQ4JhcEcAAIgCAAAAAgBAQAAAQAAABEBwtRdL3QCYQgbQmQCIQgPQqEIB0AEgcL0SSRAiCmMSShFolAXJAckPmEIV2Q9LEE6oQgbR2GgJBjBACEMNSQhDB+CYaAkGMEAIQwEhyQdAGCBDEGAAIHC9EGigQ/nnAAAAG7cAAAYAQAAFAEBABAAB/z//AABAAMAQtQAgAPAM+MBGwEYBIADwAfgQvQFJGCCrvv7nJgACABC1APAL+ADwAvgQvXBHELUAKAHQ//fu/xC9AAAQtQAhAqAA8BP4ASAQvQAAU0lHQUJSVDogQWJub3JtYWwgdGVybWluYXRpb24AAABwtQVGDEYKIADgbRwA8BL4AC0G0Ch4ACj30QLgZBwA8An4ACwC0CB4ACj30QogAPAB+HC9CLVpRghwAyCrvgi9CgAAAAAACEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 317
-    pc_uninit: 411
-    pc_program_page: 539
-    pc_erase_sector: 473
-    pc_erase_all: 415
-    data_section_offset: 1388
+    pc_init: 0x13d
+    pc_uninit: 0x19b
+    pc_program_page: 0x21b
+    pc_erase_sector: 0x1d9
+    pc_erase_all: 0x19f
+    data_section_offset: 0x56c
     flash_properties:
       address_range:
-        start: 268435456
-        end: 285212672
-      page_size: 4096
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x10000000
+        end: 0x11000000
+      page_size: 0x1000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 4096
-          address: 0
-  lpc5462x_w25q128jvfm:
-    name: lpc5462x_w25q128jvfm
+        - size: 0x1000
+          address: 0x0
+  - name: lpc5462x_w25q128jvfm
     description: LPC5462x W25Q128JVFM SPIFI
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR0C6cEfAunBHwLpwR0/qMABwRwAAT+owAHBHAABwtYZNhkxNRClGIEYA8JL54mmSBvzVYGnAB/XRcL0QtX5Jf0xJRBA5IEYA8IP5e0kgRklECDkA8H35QCFhYb3oEEDd50/0AFBBBMH4IAJ1SE/0k3HBZQFmQWaBZsFmAWdwRzC1bUhP9IB0SEQYOAAhBICBcMFwASICcUFxBCODcQslxXEBgYFywnIBc0FzgnMGJcVzA4KBdMJ0AXVBdYJ1wnUDg4F2wXYBd0F3gncFJcV3BISA+CIQgPgjIID4JBCA+CUQgPgmMAIkgPgnQAGFgPgqEID4KyCA+CwQgPgtEID4LjAgI4D4LzABhoD4MhCA+DMggPg0EID4NRCA+DYgYCGA+DcQML1HSRC1SUQIYE/wgEAAIcD4oBLA+JAT//eR///3nv89SEhEIDAA8I/4Okk7TElEIDEgRgDwlvg3SSBGSUQYOQDwIvkAIBC9ACBwRxC1MkwQIOBh4WnJBvzULkkgRklEEDkA8OT4K0kgRklEGDEA8N74//dC/ydJIEZJRBg5APAD+QAgEL1wtSRMBUYQIOBh4GnABvzUH0kgRklEEDkA8Mb4pWAcSSBGSUQQMQDwv/j/9yP/GEkgRklEGDkA8OT4ACBwvQEgcEdwtRNNBkYQIBRG6GHoacAG/NQOSShGSUQQOQDwpPiuYAtJKEZJRAgxAPCd+AAhBMxqYUkcQCn62//3+/4ESShGSUQYOQDwvPgAIHC9AAAgAAAAAAAIQAAQAEAEAAAAZUoQtQFGACB6RFL4IDCLQgLQQBz50AHgACgB0ADwwPgQvU/2/3EBgA8hgXAAIcFwAXEBIkJxgXHBcQFycEdwtQwABUYS0P/32/9TSXlESDkBIjH4EACTBwEKAykI0oJAiAAA8YBAwPggIgXgAPCY+NpkgkBJSEJhECDoYehpwAb81KF4IIhP9HAiAuoBQQhD4XhP9AASAupBUaJ5T/QABgbqwlIRQwhDIXkyAQLqwWEIQyF6UgAC6gFxCEPheVIAAupBcQhDYXkD6oFxCEMoYHC9ELX/95T/L0l5RNY5ASIx+BAAAQoDKQL6APIF0ogAAPGAQMD4QCIQvShIgmFP8IBBACDIZBC9ELXCaZIH/NEKiIt4T/SARMLzDQIE6oMzGkPLeE/2/3QE6sMzGkMLeU/04CQE6gNDGkNLeU/0wBQE6sNDGkOLeU/0YAQE6kNTyXkaQ0LqAWFBYMFpiQf81RC9ELXCaZIH/NEKeU/04CMD6gJCS3lP9MAUBOrDQxpDi3lP9GAEBOpDU8l5GkNC6gFhgWEQvQAASAIAAAAABEAQtQAgAPAO+K/zAIC96BBAASAA8AG4AAABSRggq77+5yYAAgAQtQDwC/i96BBAAPABuHBHACgB0P/37r9wRwAAELUAIQKgAPAT+AEgEL0AAFNJR0FCUlQ6IEFibm9ybWFsIHRlcm1pbmF0aW9uAAAAcLUFRgxGCiAA4G0cAPAR+DWxKHgAKPjRAuBkHADwCfgUsSB4ACj40b3ocEAKIK/zAIAItWlGjfgAAAMgq74IvQoAAAAAAAhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 297
-    pc_uninit: 367
-    pc_program_page: 495
-    pc_erase_sector: 429
-    pc_erase_all: 371
-    data_section_offset: 1188
+    pc_init: 0x129
+    pc_uninit: 0x16f
+    pc_program_page: 0x1ef
+    pc_erase_sector: 0x1ad
+    pc_erase_all: 0x173
+    data_section_offset: 0x4a4
     flash_properties:
       address_range:
-        start: 268435456
-        end: 285212672
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x10000000
+        end: 0x11000000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 4096
-          address: 0
+        - size: 0x1000
+          address: 0x0

--- a/probe-rs/targets/LPC5526.yaml
+++ b/probe-rs/targets/LPC5526.yaml
@@ -1,6 +1,5 @@
----
 name: LPC5526
-manufacturer: ~
+manufacturer: null
 variants:
   - name: LPC5526JBD100
     cores:
@@ -8,21 +7,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_256
   - name: LPC5526JBD64
@@ -31,21 +32,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_256
   - name: LPC5526JEV98
@@ -54,44 +57,46 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_256
 flash_algorithms:
-  lpc55xx_256:
-    name: lpc55xx_256
+  - name: lpc55xx_256
     description: LPC55xx IAP 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gLVA8gQAwPIAAEL24GFJ+AAQQPIAIMXyAAAAIcD4gBDA+IQQwPiAEUf2+3EBYED2BGD/IcXyAADM8t4BAWBP8KBAAiEBcEDyEADA8gAASEQA8HT4ACgYvwEggL0AIHBHgLVA8hAAwPIAAEbybGNIRAAhxvZlM0/0gCIA8H/4ACgYvwEggL0Av4C1IPBwQUDyEADA8gAARvJsY0hExvZlM0/0AEIA8Gr4ACgYvwEggL1wtRRGDUZBBCDwcEYN0UDyEADA8gAARvJsY0hEMUbG9mUzT/QAQgDwUfhA8hAAwPIAALX1AH+Yv0/0AHVIRDFGIkYrRgDwavgAKBi/ASBwvbC1DEYFRiDwcEARRiJGAPAB+gAoCL8lRChGsL2AtQpGIPBwQUDyEADA8gAASEQA8HX4ACgYvwEggL0AAEHy9ALB8gAy0WgAKQrQYCODYpJ4SWhA8gwDwPIAA0n4AyAIR0DyukDA8gAAQPLHQcDyAAF4RHlEhCIA8I35AL9A8gwMwPIADFn4DMC88QIPBNFE8jscwfIAPGBHQfIAHMHyADzc+ADAvPEADwLQ3PgIwGBHQPJqQMDyAABA8ndBwPIAAXhEeUSVIgDwZfkAv0DyDAzA8gAMWfgMwLzxAg8E0UTynRzB8gA8YEdB8gAcwfIAPNz4AMC88QAPAtDc+AzAYEdA8hpAwPIAAEDyJ0HA8gABeER5RKUiAPA9+QC/QfIAE8HyADMbaAArAdAbaRhHQPLsMMDyAABA8vkxwPIAAXhEeUStIgDwJvlA8gwMwPIADFn4DMC88QIPBNFE8n0swfIAPGBHQfIAHMHyADzc+ADAvPEADwLQ3PgUwGBHQPKeMMDyAABA8qsxwPIAAXhEeUTCIgDw//gAv0HyABPB8gAzG2gAKwHQm2kYR0DycDDA8gAAQPJ9McDyAAF4RHlEyyIA8Oj4QfIAEcHyADEJaAApAdCJaghHQPJEMMDyAABA8lExwPIAAXhEeUTVIgDw0vhB8gARwfIAMQloACkB0MlqCEdA8hgwwPIAAEDyJTHA8gABeER5RNwiAPC8+EHyABPB8gAzG2gAKwHQG2sYR0Dy7CDA8gAAQPL5IcDyAAF4RHlE4yIA8Kb4QfIAEsHyADISaAAqAdBSaxBHQPLAIMDyAABA8s0hwPIAAXhEeUTqIgDwkPhB8gAcwfIAPNz4AMC88QAPAtDc+DjAYEdA8o4gwPIAAEDymyHA8gABeER5RPEiAPB3+AC/QfIAEsHyADISaAAqAdDSaxBHQPJgIMDyAABA8m0hwPIAAXhEeUT4IgDwYPhB8gASwfIAMhJoACoB0BJsEEdA8jQgwPIAAEDyQSHA8gABeER5RP8iAPBK+EHyABPB8gAzG2gAKwHQW2wYR0DyCCDA8gAAQPIVIcDyAAF4RHlET/SDcgDwM/gAv0HyABPB8gAzG2gAKwHQm2wYR0Dy2BDA8gAAQPLlEcDyAAF4RHlEQPINEgDwG/gAv0HyABzB8gA83PgAwLzxAA8C0Nz4TMBgR0DyohDA8gAAQPKvEcDyAAF4RHlET/SKcgDwAPgOtQVGFEYORhOgAPBw+ChGAPBt+BagAPBq+DBGAPBn+BWgAPBk+AAhjfgLEAohDfEKAI34ChAI4JT78fIB+xJClPvx9DAyAPgBLQAs9NwA8E74APBB+AAAKioqIGFzc2VydGlvbiBmYWlsZWQ6IAAALCBmaWxlIAAsIGxpbmUgAEDqAQMQtZsHD9EEKg3TEMgIyRIfnEL40CC6GbqIQgHZASAQvU/w/zAQvRqx0wcD0FIcB+AAIBC9EPgBOxH4AUsbGwfREPgBOxH4AUsbGwHRkh7x0RhGEL0QtQAgAPAe+K/zAIC96BBAASAA8BG4ELUERgLgZBwA8AT4IHgAKPnREL0ItWlGjfgAAAMgq74IvQFJGCCrvv7nJgACABC1APAL+L3oEEAA8AG4cEcAKAHQ//fuv3BHAAAQtQAhAqAA8BP4ASAQvQAAU0lHQUJSVDogQWJub3JtYWwgdGVybWluYXRpb24AAABwtQVGDEYKIADgbRz/98X/NbEoeAAo+NEC4GQc//e9/xSxIHgAKPjRvehwQAog//e0v0ZMQVNIX0FQSV9UUkVFAGlhcDEvZnNsX2lhcDEuYwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 93
-    pc_program_page: 177
-    pc_erase_sector: 137
-    pc_erase_all: 97
-    data_section_offset: 1616
+    pc_init: 0x1
+    pc_uninit: 0x5d
+    pc_program_page: 0xb1
+    pc_erase_sector: 0x89
+    pc_erase_all: 0x61
+    data_section_offset: 0x650
     flash_properties:
       address_range:
-        start: 0
-        end: 262144
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x40000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 32768
-          address: 0
+        - size: 0x8000
+          address: 0x0

--- a/probe-rs/targets/LPC5528.yaml
+++ b/probe-rs/targets/LPC5528.yaml
@@ -1,6 +1,5 @@
----
 name: LPC5528
-manufacturer: ~
+manufacturer: null
 variants:
   - name: LPC5528JBD100
     cores:
@@ -8,21 +7,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_512
   - name: LPC5528JBD64
@@ -31,21 +32,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_512
   - name: LPC5528JEV98
@@ -54,44 +57,46 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_512
 flash_algorithms:
-  lpc55xx_512:
-    name: lpc55xx_512
+  - name: lpc55xx_512
     description: LPC55xx IAP 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gLVA8gQAwPIAAEL24GFJ+AAQQPIAIMXyAAAAIcD4gBDA+IQQwPiAEUf2+3EBYED2BGD/IcXyAADM8t4BAWBP8KBAAiEBcEDyEADA8gAASEQA8HT4ACgYvwEggL0AIHBHgLVA8hAAwPIAAEbybGNIRAAhxvZlM0/0ACIA8H/4ACgYvwEggL0Av4C1IPBwQUDyEADA8gAARvJsY0hExvZlM0/0AEIA8Gr4ACgYvwEggL1wtRRGDUZBBCDwcEYN0UDyEADA8gAARvJsY0hEMUbG9mUzT/QAQgDwUfhA8hAAwPIAALX1AH+Yv0/0AHVIRDFGIkYrRgDwavgAKBi/ASBwvbC1DEYFRiDwcEARRiJGAPAB+gAoCL8lRChGsL2AtQpGIPBwQUDyEADA8gAASEQA8HX4ACgYvwEggL0AAEHy9ALB8gAy0WgAKQrQYCODYpJ4SWhA8gwDwPIAA0n4AyAIR0DyukDA8gAAQPLHQcDyAAF4RHlEhCIA8I35AL9A8gwMwPIADFn4DMC88QIPBNFE8jscwfIAPGBHQfIAHMHyADzc+ADAvPEADwLQ3PgIwGBHQPJqQMDyAABA8ndBwPIAAXhEeUSVIgDwZfkAv0DyDAzA8gAMWfgMwLzxAg8E0UTynRzB8gA8YEdB8gAcwfIAPNz4AMC88QAPAtDc+AzAYEdA8hpAwPIAAEDyJ0HA8gABeER5RKUiAPA9+QC/QfIAE8HyADMbaAArAdAbaRhHQPLsMMDyAABA8vkxwPIAAXhEeUStIgDwJvlA8gwMwPIADFn4DMC88QIPBNFE8n0swfIAPGBHQfIAHMHyADzc+ADAvPEADwLQ3PgUwGBHQPKeMMDyAABA8qsxwPIAAXhEeUTCIgDw//gAv0HyABPB8gAzG2gAKwHQm2kYR0DycDDA8gAAQPJ9McDyAAF4RHlEyyIA8Oj4QfIAEcHyADEJaAApAdCJaghHQPJEMMDyAABA8lExwPIAAXhEeUTVIgDw0vhB8gARwfIAMQloACkB0MlqCEdA8hgwwPIAAEDyJTHA8gABeER5RNwiAPC8+EHyABPB8gAzG2gAKwHQG2sYR0Dy7CDA8gAAQPL5IcDyAAF4RHlE4yIA8Kb4QfIAEsHyADISaAAqAdBSaxBHQPLAIMDyAABA8s0hwPIAAXhEeUTqIgDwkPhB8gAcwfIAPNz4AMC88QAPAtDc+DjAYEdA8o4gwPIAAEDymyHA8gABeER5RPEiAPB3+AC/QfIAEsHyADISaAAqAdDSaxBHQPJgIMDyAABA8m0hwPIAAXhEeUT4IgDwYPhB8gASwfIAMhJoACoB0BJsEEdA8jQgwPIAAEDyQSHA8gABeER5RP8iAPBK+EHyABPB8gAzG2gAKwHQW2wYR0DyCCDA8gAAQPIVIcDyAAF4RHlET/SDcgDwM/gAv0HyABPB8gAzG2gAKwHQm2wYR0Dy2BDA8gAAQPLlEcDyAAF4RHlEQPINEgDwG/gAv0HyABzB8gA83PgAwLzxAA8C0Nz4TMBgR0DyohDA8gAAQPKvEcDyAAF4RHlET/SKcgDwAPgOtQVGFEYORhOgAPBw+ChGAPBt+BagAPBq+DBGAPBn+BWgAPBk+AAhjfgLEAohDfEKAI34ChAI4JT78fIB+xJClPvx9DAyAPgBLQAs9NwA8E74APBB+AAAKioqIGFzc2VydGlvbiBmYWlsZWQ6IAAALCBmaWxlIAAsIGxpbmUgAEDqAQMQtZsHD9EEKg3TEMgIyRIfnEL40CC6GbqIQgHZASAQvU/w/zAQvRqx0wcD0FIcB+AAIBC9EPgBOxH4AUsbGwfREPgBOxH4AUsbGwHRkh7x0RhGEL0QtQAgAPAe+K/zAIC96BBAASAA8BG4ELUERgLgZBwA8AT4IHgAKPnREL0ItWlGjfgAAAMgq74IvQFJGCCrvv7nJgACABC1APAL+L3oEEAA8AG4cEcAKAHQ//fuv3BHAAAQtQAhAqAA8BP4ASAQvQAAU0lHQUJSVDogQWJub3JtYWwgdGVybWluYXRpb24AAABwtQVGDEYKIADgbRz/98X/NbEoeAAo+NEC4GQc//e9/xSxIHgAKPjRvehwQAog//e0v0ZMQVNIX0FQSV9UUkVFAGlhcDEvZnNsX2lhcDEuYwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 93
-    pc_program_page: 177
-    pc_erase_sector: 137
-    pc_erase_all: 97
-    data_section_offset: 1616
+    pc_init: 0x1
+    pc_uninit: 0x5d
+    pc_program_page: 0xb1
+    pc_erase_sector: 0x89
+    pc_erase_all: 0x61
+    data_section_offset: 0x650
     flash_properties:
       address_range:
-        start: 0
-        end: 524288
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x80000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 32768
-          address: 0
+        - size: 0x8000
+          address: 0x0

--- a/probe-rs/targets/LPC55S26.yaml
+++ b/probe-rs/targets/LPC55S26.yaml
@@ -1,6 +1,5 @@
----
 name: LPC55S26
-manufacturer: ~
+manufacturer: null
 variants:
   - name: LPC55S26JBD100
     cores:
@@ -8,21 +7,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_256
   - name: LPC55S26JBD64
@@ -31,21 +32,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_256
   - name: LPC55S26JEV98
@@ -54,44 +57,46 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_256
 flash_algorithms:
-  lpc55xx_256:
-    name: lpc55xx_256
+  - name: lpc55xx_256
     description: LPC55xx IAP 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gLVA8gQAwPIAAEL24GFJ+AAQQPIAIMXyAAAAIcD4gBDA+IQQwPiAEUf2+3EBYED2BGD/IcXyAADM8t4BAWBP8KBAAiEBcEDyEADA8gAASEQA8HT4ACgYvwEggL0AIHBHgLVA8hAAwPIAAEbybGNIRAAhxvZlM0/0gCIA8H/4ACgYvwEggL0Av4C1IPBwQUDyEADA8gAARvJsY0hExvZlM0/0AEIA8Gr4ACgYvwEggL1wtRRGDUZBBCDwcEYN0UDyEADA8gAARvJsY0hEMUbG9mUzT/QAQgDwUfhA8hAAwPIAALX1AH+Yv0/0AHVIRDFGIkYrRgDwavgAKBi/ASBwvbC1DEYFRiDwcEARRiJGAPAB+gAoCL8lRChGsL2AtQpGIPBwQUDyEADA8gAASEQA8HX4ACgYvwEggL0AAEHy9ALB8gAy0WgAKQrQYCODYpJ4SWhA8gwDwPIAA0n4AyAIR0DyukDA8gAAQPLHQcDyAAF4RHlEhCIA8I35AL9A8gwMwPIADFn4DMC88QIPBNFE8jscwfIAPGBHQfIAHMHyADzc+ADAvPEADwLQ3PgIwGBHQPJqQMDyAABA8ndBwPIAAXhEeUSVIgDwZfkAv0DyDAzA8gAMWfgMwLzxAg8E0UTynRzB8gA8YEdB8gAcwfIAPNz4AMC88QAPAtDc+AzAYEdA8hpAwPIAAEDyJ0HA8gABeER5RKUiAPA9+QC/QfIAE8HyADMbaAArAdAbaRhHQPLsMMDyAABA8vkxwPIAAXhEeUStIgDwJvlA8gwMwPIADFn4DMC88QIPBNFE8n0swfIAPGBHQfIAHMHyADzc+ADAvPEADwLQ3PgUwGBHQPKeMMDyAABA8qsxwPIAAXhEeUTCIgDw//gAv0HyABPB8gAzG2gAKwHQm2kYR0DycDDA8gAAQPJ9McDyAAF4RHlEyyIA8Oj4QfIAEcHyADEJaAApAdCJaghHQPJEMMDyAABA8lExwPIAAXhEeUTVIgDw0vhB8gARwfIAMQloACkB0MlqCEdA8hgwwPIAAEDyJTHA8gABeER5RNwiAPC8+EHyABPB8gAzG2gAKwHQG2sYR0Dy7CDA8gAAQPL5IcDyAAF4RHlE4yIA8Kb4QfIAEsHyADISaAAqAdBSaxBHQPLAIMDyAABA8s0hwPIAAXhEeUTqIgDwkPhB8gAcwfIAPNz4AMC88QAPAtDc+DjAYEdA8o4gwPIAAEDymyHA8gABeER5RPEiAPB3+AC/QfIAEsHyADISaAAqAdDSaxBHQPJgIMDyAABA8m0hwPIAAXhEeUT4IgDwYPhB8gASwfIAMhJoACoB0BJsEEdA8jQgwPIAAEDyQSHA8gABeER5RP8iAPBK+EHyABPB8gAzG2gAKwHQW2wYR0DyCCDA8gAAQPIVIcDyAAF4RHlET/SDcgDwM/gAv0HyABPB8gAzG2gAKwHQm2wYR0Dy2BDA8gAAQPLlEcDyAAF4RHlEQPINEgDwG/gAv0HyABzB8gA83PgAwLzxAA8C0Nz4TMBgR0DyohDA8gAAQPKvEcDyAAF4RHlET/SKcgDwAPgOtQVGFEYORhOgAPBw+ChGAPBt+BagAPBq+DBGAPBn+BWgAPBk+AAhjfgLEAohDfEKAI34ChAI4JT78fIB+xJClPvx9DAyAPgBLQAs9NwA8E74APBB+AAAKioqIGFzc2VydGlvbiBmYWlsZWQ6IAAALCBmaWxlIAAsIGxpbmUgAEDqAQMQtZsHD9EEKg3TEMgIyRIfnEL40CC6GbqIQgHZASAQvU/w/zAQvRqx0wcD0FIcB+AAIBC9EPgBOxH4AUsbGwfREPgBOxH4AUsbGwHRkh7x0RhGEL0QtQAgAPAe+K/zAIC96BBAASAA8BG4ELUERgLgZBwA8AT4IHgAKPnREL0ItWlGjfgAAAMgq74IvQFJGCCrvv7nJgACABC1APAL+L3oEEAA8AG4cEcAKAHQ//fuv3BHAAAQtQAhAqAA8BP4ASAQvQAAU0lHQUJSVDogQWJub3JtYWwgdGVybWluYXRpb24AAABwtQVGDEYKIADgbRz/98X/NbEoeAAo+NEC4GQc//e9/xSxIHgAKPjRvehwQAog//e0v0ZMQVNIX0FQSV9UUkVFAGlhcDEvZnNsX2lhcDEuYwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 93
-    pc_program_page: 177
-    pc_erase_sector: 137
-    pc_erase_all: 97
-    data_section_offset: 1616
+    pc_init: 0x1
+    pc_uninit: 0x5d
+    pc_program_page: 0xb1
+    pc_erase_sector: 0x89
+    pc_erase_all: 0x61
+    data_section_offset: 0x650
     flash_properties:
       address_range:
-        start: 0
-        end: 262144
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x40000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 32768
-          address: 0
+        - size: 0x8000
+          address: 0x0

--- a/probe-rs/targets/LPC55S28.yaml
+++ b/probe-rs/targets/LPC55S28.yaml
@@ -1,6 +1,5 @@
----
 name: LPC55S28
-manufacturer: ~
+manufacturer: null
 variants:
   - name: LPC55S28JBD100
     cores:
@@ -8,21 +7,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_512
   - name: LPC55S28JBD64
@@ -31,21 +32,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_512
   - name: LPC55S28JEV98
@@ -54,44 +57,46 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_512
 flash_algorithms:
-  lpc55xx_512:
-    name: lpc55xx_512
+  - name: lpc55xx_512
     description: LPC55xx IAP 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gLVA8gQAwPIAAEL24GFJ+AAQQPIAIMXyAAAAIcD4gBDA+IQQwPiAEUf2+3EBYED2BGD/IcXyAADM8t4BAWBP8KBAAiEBcEDyEADA8gAASEQA8HT4ACgYvwEggL0AIHBHgLVA8hAAwPIAAEbybGNIRAAhxvZlM0/0ACIA8H/4ACgYvwEggL0Av4C1IPBwQUDyEADA8gAARvJsY0hExvZlM0/0AEIA8Gr4ACgYvwEggL1wtRRGDUZBBCDwcEYN0UDyEADA8gAARvJsY0hEMUbG9mUzT/QAQgDwUfhA8hAAwPIAALX1AH+Yv0/0AHVIRDFGIkYrRgDwavgAKBi/ASBwvbC1DEYFRiDwcEARRiJGAPAB+gAoCL8lRChGsL2AtQpGIPBwQUDyEADA8gAASEQA8HX4ACgYvwEggL0AAEHy9ALB8gAy0WgAKQrQYCODYpJ4SWhA8gwDwPIAA0n4AyAIR0DyukDA8gAAQPLHQcDyAAF4RHlEhCIA8I35AL9A8gwMwPIADFn4DMC88QIPBNFE8jscwfIAPGBHQfIAHMHyADzc+ADAvPEADwLQ3PgIwGBHQPJqQMDyAABA8ndBwPIAAXhEeUSVIgDwZfkAv0DyDAzA8gAMWfgMwLzxAg8E0UTynRzB8gA8YEdB8gAcwfIAPNz4AMC88QAPAtDc+AzAYEdA8hpAwPIAAEDyJ0HA8gABeER5RKUiAPA9+QC/QfIAE8HyADMbaAArAdAbaRhHQPLsMMDyAABA8vkxwPIAAXhEeUStIgDwJvlA8gwMwPIADFn4DMC88QIPBNFE8n0swfIAPGBHQfIAHMHyADzc+ADAvPEADwLQ3PgUwGBHQPKeMMDyAABA8qsxwPIAAXhEeUTCIgDw//gAv0HyABPB8gAzG2gAKwHQm2kYR0DycDDA8gAAQPJ9McDyAAF4RHlEyyIA8Oj4QfIAEcHyADEJaAApAdCJaghHQPJEMMDyAABA8lExwPIAAXhEeUTVIgDw0vhB8gARwfIAMQloACkB0MlqCEdA8hgwwPIAAEDyJTHA8gABeER5RNwiAPC8+EHyABPB8gAzG2gAKwHQG2sYR0Dy7CDA8gAAQPL5IcDyAAF4RHlE4yIA8Kb4QfIAEsHyADISaAAqAdBSaxBHQPLAIMDyAABA8s0hwPIAAXhEeUTqIgDwkPhB8gAcwfIAPNz4AMC88QAPAtDc+DjAYEdA8o4gwPIAAEDymyHA8gABeER5RPEiAPB3+AC/QfIAEsHyADISaAAqAdDSaxBHQPJgIMDyAABA8m0hwPIAAXhEeUT4IgDwYPhB8gASwfIAMhJoACoB0BJsEEdA8jQgwPIAAEDyQSHA8gABeER5RP8iAPBK+EHyABPB8gAzG2gAKwHQW2wYR0DyCCDA8gAAQPIVIcDyAAF4RHlET/SDcgDwM/gAv0HyABPB8gAzG2gAKwHQm2wYR0Dy2BDA8gAAQPLlEcDyAAF4RHlEQPINEgDwG/gAv0HyABzB8gA83PgAwLzxAA8C0Nz4TMBgR0DyohDA8gAAQPKvEcDyAAF4RHlET/SKcgDwAPgOtQVGFEYORhOgAPBw+ChGAPBt+BagAPBq+DBGAPBn+BWgAPBk+AAhjfgLEAohDfEKAI34ChAI4JT78fIB+xJClPvx9DAyAPgBLQAs9NwA8E74APBB+AAAKioqIGFzc2VydGlvbiBmYWlsZWQ6IAAALCBmaWxlIAAsIGxpbmUgAEDqAQMQtZsHD9EEKg3TEMgIyRIfnEL40CC6GbqIQgHZASAQvU/w/zAQvRqx0wcD0FIcB+AAIBC9EPgBOxH4AUsbGwfREPgBOxH4AUsbGwHRkh7x0RhGEL0QtQAgAPAe+K/zAIC96BBAASAA8BG4ELUERgLgZBwA8AT4IHgAKPnREL0ItWlGjfgAAAMgq74IvQFJGCCrvv7nJgACABC1APAL+L3oEEAA8AG4cEcAKAHQ//fuv3BHAAAQtQAhAqAA8BP4ASAQvQAAU0lHQUJSVDogQWJub3JtYWwgdGVybWluYXRpb24AAABwtQVGDEYKIADgbRz/98X/NbEoeAAo+NEC4GQc//e9/xSxIHgAKPjRvehwQAog//e0v0ZMQVNIX0FQSV9UUkVFAGlhcDEvZnNsX2lhcDEuYwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 93
-    pc_program_page: 177
-    pc_erase_sector: 137
-    pc_erase_all: 97
-    data_section_offset: 1616
+    pc_init: 0x1
+    pc_uninit: 0x5d
+    pc_program_page: 0xb1
+    pc_erase_sector: 0x89
+    pc_erase_all: 0x61
+    data_section_offset: 0x650
     flash_properties:
       address_range:
-        start: 0
-        end: 524288
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x80000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 32768
-          address: 0
+        - size: 0x8000
+          address: 0x0

--- a/probe-rs/targets/LPC55S66.yaml
+++ b/probe-rs/targets/LPC55S66.yaml
@@ -1,4 +1,3 @@
----
 name: LPC55S66
 variants:
   - name: LPC55S66JBD100
@@ -7,21 +6,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_256
       - lpc55xx_s_256
@@ -31,21 +32,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_256
       - lpc55xx_s_256
@@ -55,68 +58,70 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_256
       - lpc55xx_s_256
 flash_algorithms:
-  lpc55xx_256:
-    name: lpc55xx_256
+  - name: lpc55xx_256
     description: LPC55xx IAP 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: Z0xWQThnUUF3UElBQUVMMjRHRkorQUFRUVBJQUlNWHlBQUFBSWNENGdCREErSVFRd1BpQUVVZjIrM0VCWUVEMkJHRC9JY1h5QUFETTh0NEJBV0JQOEtCQUFpRUJjRUR5RUFEQThnQUFTRVFBOEhUNEFDZ1l2d0VnZ0wwQUlIQkhnTFZBOGhBQXdQSUFBRWJ5YkdOSVJBQWh4dlpsTTAvMGdDSUE4SC80QUNnWXZ3RWdnTDBBdjRDMUlQQndRVUR5RUFEQThnQUFSdkpzWTBoRXh2WmxNMC8wQUVJQThHcjRBQ2dZdndFZ2dMMXd0UlJHRFVaQkJDRHdjRVlOMFVEeUVBREE4Z0FBUnZKc1kwaEVNVWJHOW1VelQvUUFRZ0R3VWZoQThoQUF3UElBQUxYMUFIK1l2MC8wQUhWSVJERkdJa1lyUmdEd2F2Z0FLQmkvQVNCd3ZiQzFERVlGUmlEd2NFQVJSaUpHQVBBQitnQW9DTDhsUkNoR3NMMkF0UXBHSVBCd1FVRHlFQURBOGdBQVNFUUE4SFg0QUNnWXZ3RWdnTDBBQUVIeTlBTEI4Z0F5MFdnQUtRclFZQ09EWXBKNFNXaEE4Z3dEd1BJQUEwbjRBeUFJUjBEeXVrREE4Z0FBUVBMSFFjRHlBQUY0UkhsRWhDSUE4STM1QUw5QThnd013UElBREZuNERNQzg4UUlQQk5GRThqc2N3ZklBUEdCSFFmSUFITUh5QUR6YytBREF2UEVBRHdMUTNQZ0l3R0JIUVBKcVFNRHlBQUJBOG5kQndQSUFBWGhFZVVTVklnRHdaZmtBdjBEeURBekE4Z0FNV2ZnTXdMenhBZzhFMFVUeW5SekI4Z0E4WUVkQjhnQWN3ZklBUE56NEFNQzg4UUFQQXREYytBekFZRWRBOGhwQXdQSUFBRUR5SjBIQThnQUJlRVI1UktVaUFQQTkrUUMvUWZJQUU4SHlBRE1iYUFBckFkQWJhUmhIUVBMc01NRHlBQUJBOHZreHdQSUFBWGhFZVVTdElnRHdKdmxBOGd3TXdQSUFERm40RE1DODhRSVBCTkZFOG4wc3dmSUFQR0JIUWZJQUhNSHlBRHpjK0FEQXZQRUFEd0xRM1BnVXdHQkhRUEtlTU1EeUFBQkE4cXN4d1BJQUFYaEVlVVRDSWdEdy8vZ0F2MEh5QUJQQjhnQXpHMmdBS3dIUW0ya1lSMER5Y0REQThnQUFRUEo5TWNEeUFBRjRSSGxFeXlJQThPajRRZklBRWNIeUFERUphQUFwQWRDSmFnaEhRUEpFTU1EeUFBQkE4bEV4d1BJQUFYaEVlVVRWSWdEdzB2aEI4Z0FSd2ZJQU1RbG9BQ2tCME1scUNFZEE4aGd3d1BJQUFFRHlKVEhBOGdBQmVFUjVSTndpQVBDOCtFSHlBQlBCOGdBekcyZ0FLd0hRRzJzWVIwRHk3Q0RBOGdBQVFQTDVJY0R5QUFGNFJIbEU0eUlBOEtiNFFmSUFFc0h5QURJU2FBQXFBZEJTYXhCSFFQTEFJTUR5QUFCQThzMGh3UElBQVhoRWVVVHFJZ0R3a1BoQjhnQWN3ZklBUE56NEFNQzg4UUFQQXREYytEakFZRWRBOG80Z3dQSUFBRUR5bXlIQThnQUJlRVI1UlBFaUFQQjMrQUMvUWZJQUVzSHlBRElTYUFBcUFkRFNheEJIUVBKZ0lNRHlBQUJBOG0waHdQSUFBWGhFZVVUNElnRHdZUGhCOGdBU3dmSUFNaEpvQUNvQjBCSnNFRWRBOGpRZ3dQSUFBRUR5UVNIQThnQUJlRVI1UlA4aUFQQksrRUh5QUJQQjhnQXpHMmdBS3dIUVcyd1lSMER5Q0NEQThnQUFRUElWSWNEeUFBRjRSSGxFVC9TRGNnRHdNL2dBdjBIeUFCUEI4Z0F6RzJnQUt3SFFtMndZUjBEeTJCREE4Z0FBUVBMbEVjRHlBQUY0UkhsRVFQSU5FZ0R3Ry9nQXYwSHlBQnpCOGdBODNQZ0F3THp4QUE4QzBOejRUTUJnUjBEeW9oREE4Z0FBUVBLdkVjRHlBQUY0UkhsRVQvU0tjZ0R3QVBnT3RRVkdGRVlPUmhPZ0FQQncrQ2hHQVBCdCtCYWdBUEJxK0RCR0FQQm4rQldnQVBCaytBQWhqZmdMRUFvaERmRUtBSTM0Q2hBSTRKVDc4ZklCK3hKQ2xQdng5REF5QVBnQkxRQXM5TndBOEU3NEFQQkIrQUFBS2lvcUlHRnpjMlZ5ZEdsdmJpQm1ZV2xzWldRNklBQUFMQ0JtYVd4bElBQXNJR3hwYm1VZ0FFRHFBUU1RdFpzSEQ5RUVLZzNURU1nSXlSSWZuRUw0MENDNkdicUlRZ0haQVNBUXZVL3cvekFRdlJxeDB3Y0QwRkljQitBQUlCQzlFUGdCT3hINEFVc2JHd2ZSRVBnQk94SDRBVXNiR3dIUmtoN3gwUmhHRUwwUXRRQWdBUEFlK0svekFJQzk2QkJBQVNBQThCRzRFTFVFUmdMZ1pCd0E4QVQ0SUhnQUtQblJFTDBJdFdsR2pmZ0FBQU1ncTc0SXZRRkpHQ0NydnY3bkpnQUNBQkMxQVBBTCtMM29FRUFBOEFHNGNFY0FLQUhRLy9mdXYzQkhBQUFRdFFBaEFxQUE4QlA0QVNBUXZRQUFVMGxIUVVKU1ZEb2dRV0p1YjNKdFlXd2dkR1Z5YldsdVlYUnBiMjRBQUFCd3RRVkdERVlLSUFEZ2JSei85OFgvTmJFb2VBQW8rTkVDNEdRYy8vZTkveFN4SUhnQUtQalJ2ZWh3UUFvZy8vZTB2MFpNUVZOSVgwRlFTVjlVVWtWRkFHbGhjREV2Wm5Oc1gybGhjREV1WXdBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB
-    pc_init: 1
-    pc_uninit: 93
-    pc_program_page: 177
-    pc_erase_sector: 137
-    pc_erase_all: 97
-    data_section_offset: 1616
+    pc_init: 0x1
+    pc_uninit: 0x5d
+    pc_program_page: 0xb1
+    pc_erase_sector: 0x89
+    pc_erase_all: 0x61
+    data_section_offset: 0x650
     flash_properties:
       address_range:
-        start: 0
-        end: 262144
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x40000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 32768
-          address: 0
-  lpc55xx_s_256:
-    name: lpc55xx_s_256
+        - size: 0x8000
+          address: 0x0
+  - name: lpc55xx_s_256
     description: LPC55xx S IAP 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: Z0xWQThnUUF3UElBQUVMMjRHRkorQUFRUVBJQUlNWHlBQUFBSWNENGdCREErSVFRd1BpQUVVZjIrM0VCWUVEMkJHRC9JY1h5QUFETTh0NEJBV0JQOEtCQUFpRUJjRUR5RUFEQThnQUFTRVFBOEhUNEFDZ1l2d0VnZ0wwQUlIQkhnTFZBOGhBQXdQSUFBRWJ5YkdOSVJBQWh4dlpsTTAvMGdDSUE4SC80QUNnWXZ3RWdnTDBBdjRDMUlQQndRVUR5RUFEQThnQUFSdkpzWTBoRXh2WmxNMC8wQUVJQThHcjRBQ2dZdndFZ2dMMXd0UlJHRFVaQkJDRHdjRVlOMFVEeUVBREE4Z0FBUnZKc1kwaEVNVWJHOW1VelQvUUFRZ0R3VWZoQThoQUF3UElBQUxYMUFIK1l2MC8wQUhWSVJERkdJa1lyUmdEd2F2Z0FLQmkvQVNCd3ZiQzFERVlGUmlEd2NFQVJSaUpHQVBBQitnQW9DTDhsUkNoR3NMMkF0UXBHSVBCd1FVRHlFQURBOGdBQVNFUUE4SFg0QUNnWXZ3RWdnTDBBQUVIeTlBTEI4Z0F5MFdnQUtRclFZQ09EWXBKNFNXaEE4Z3dEd1BJQUEwbjRBeUFJUjBEeXVrREE4Z0FBUVBMSFFjRHlBQUY0UkhsRWhDSUE4STM1QUw5QThnd013UElBREZuNERNQzg4UUlQQk5GRThqc2N3ZklBUEdCSFFmSUFITUh5QUR6YytBREF2UEVBRHdMUTNQZ0l3R0JIUVBKcVFNRHlBQUJBOG5kQndQSUFBWGhFZVVTVklnRHdaZmtBdjBEeURBekE4Z0FNV2ZnTXdMenhBZzhFMFVUeW5SekI4Z0E4WUVkQjhnQWN3ZklBUE56NEFNQzg4UUFQQXREYytBekFZRWRBOGhwQXdQSUFBRUR5SjBIQThnQUJlRVI1UktVaUFQQTkrUUMvUWZJQUU4SHlBRE1iYUFBckFkQWJhUmhIUVBMc01NRHlBQUJBOHZreHdQSUFBWGhFZVVTdElnRHdKdmxBOGd3TXdQSUFERm40RE1DODhRSVBCTkZFOG4wc3dmSUFQR0JIUWZJQUhNSHlBRHpjK0FEQXZQRUFEd0xRM1BnVXdHQkhRUEtlTU1EeUFBQkE4cXN4d1BJQUFYaEVlVVRDSWdEdy8vZ0F2MEh5QUJQQjhnQXpHMmdBS3dIUW0ya1lSMER5Y0REQThnQUFRUEo5TWNEeUFBRjRSSGxFeXlJQThPajRRZklBRWNIeUFERUphQUFwQWRDSmFnaEhRUEpFTU1EeUFBQkE4bEV4d1BJQUFYaEVlVVRWSWdEdzB2aEI4Z0FSd2ZJQU1RbG9BQ2tCME1scUNFZEE4aGd3d1BJQUFFRHlKVEhBOGdBQmVFUjVSTndpQVBDOCtFSHlBQlBCOGdBekcyZ0FLd0hRRzJzWVIwRHk3Q0RBOGdBQVFQTDVJY0R5QUFGNFJIbEU0eUlBOEtiNFFmSUFFc0h5QURJU2FBQXFBZEJTYXhCSFFQTEFJTUR5QUFCQThzMGh3UElBQVhoRWVVVHFJZ0R3a1BoQjhnQWN3ZklBUE56NEFNQzg4UUFQQXREYytEakFZRWRBOG80Z3dQSUFBRUR5bXlIQThnQUJlRVI1UlBFaUFQQjMrQUMvUWZJQUVzSHlBRElTYUFBcUFkRFNheEJIUVBKZ0lNRHlBQUJBOG0waHdQSUFBWGhFZVVUNElnRHdZUGhCOGdBU3dmSUFNaEpvQUNvQjBCSnNFRWRBOGpRZ3dQSUFBRUR5UVNIQThnQUJlRVI1UlA4aUFQQksrRUh5QUJQQjhnQXpHMmdBS3dIUVcyd1lSMER5Q0NEQThnQUFRUElWSWNEeUFBRjRSSGxFVC9TRGNnRHdNL2dBdjBIeUFCUEI4Z0F6RzJnQUt3SFFtMndZUjBEeTJCREE4Z0FBUVBMbEVjRHlBQUY0UkhsRVFQSU5FZ0R3Ry9nQXYwSHlBQnpCOGdBODNQZ0F3THp4QUE4QzBOejRUTUJnUjBEeW9oREE4Z0FBUVBLdkVjRHlBQUY0UkhsRVQvU0tjZ0R3QVBnT3RRVkdGRVlPUmhPZ0FQQncrQ2hHQVBCdCtCYWdBUEJxK0RCR0FQQm4rQldnQVBCaytBQWhqZmdMRUFvaERmRUtBSTM0Q2hBSTRKVDc4ZklCK3hKQ2xQdng5REF5QVBnQkxRQXM5TndBOEU3NEFQQkIrQUFBS2lvcUlHRnpjMlZ5ZEdsdmJpQm1ZV2xzWldRNklBQUFMQ0JtYVd4bElBQXNJR3hwYm1VZ0FFRHFBUU1RdFpzSEQ5RUVLZzNURU1nSXlSSWZuRUw0MENDNkdicUlRZ0haQVNBUXZVL3cvekFRdlJxeDB3Y0QwRkljQitBQUlCQzlFUGdCT3hINEFVc2JHd2ZSRVBnQk94SDRBVXNiR3dIUmtoN3gwUmhHRUwwUXRRQWdBUEFlK0svekFJQzk2QkJBQVNBQThCRzRFTFVFUmdMZ1pCd0E4QVQ0SUhnQUtQblJFTDBJdFdsR2pmZ0FBQU1ncTc0SXZRRkpHQ0NydnY3bkpnQUNBQkMxQVBBTCtMM29FRUFBOEFHNGNFY0FLQUhRLy9mdXYzQkhBQUFRdFFBaEFxQUE4QlA0QVNBUXZRQUFVMGxIUVVKU1ZEb2dRV0p1YjNKdFlXd2dkR1Z5YldsdVlYUnBiMjRBQUFCd3RRVkdERVlLSUFEZ2JSei85OFgvTmJFb2VBQW8rTkVDNEdRYy8vZTkveFN4SUhnQUtQalJ2ZWh3UUFvZy8vZTB2MFpNUVZOSVgwRlFTVjlVVWtWRkFHbGhjREV2Wm5Oc1gybGhjREV1WXdBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB
-    pc_init: 1
-    pc_uninit: 93
-    pc_program_page: 177
-    pc_erase_sector: 137
-    pc_erase_all: 97
-    data_section_offset: 1616
+    pc_init: 0x1
+    pc_uninit: 0x5d
+    pc_program_page: 0xb1
+    pc_erase_sector: 0x89
+    pc_erase_all: 0x61
+    data_section_offset: 0x650
     flash_properties:
       address_range:
-        start: 268435456
-        end: 268697600
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x10000000
+        end: 0x10040000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 32768
-          address: 0
+        - size: 0x8000
+          address: 0x0

--- a/probe-rs/targets/LPC55S69.yaml
+++ b/probe-rs/targets/LPC55S69.yaml
@@ -1,6 +1,5 @@
----
 name: LPC55S69
-manufacturer: ~
+manufacturer: null
 variants:
   - name: LPC55S69JBD100
     cores:
@@ -8,21 +7,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537149440
+            start: 0x20000000
+            end: 0x20044000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 622592
+            start: 0x0
+            end: 0x98000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_640
       - lpc55xx_s_640
@@ -32,21 +33,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537149440
+            start: 0x20000000
+            end: 0x20044000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 622592
+            start: 0x0
+            end: 0x98000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_640
       - lpc55xx_s_640
@@ -56,68 +59,70 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537149440
+            start: 0x20000000
+            end: 0x20044000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 622592
+            start: 0x0
+            end: 0x98000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc55xx_640
       - lpc55xx_s_640
 flash_algorithms:
-  lpc55xx_640:
-    name: lpc55xx_640
+  - name: lpc55xx_640
     description: LPC55xx IAP 608kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gLVA8gQAwPIAAEL24GFJ+AAQQPIAIMXyAAAAIcD4gBDA+IQQwPiAEUf2+3EBYED2BGD/IcXyAADM8t4BAWBP8KBAAiEBcEDyEADA8gAASEQA8HT4ACgYvwEggL0AIHBHgLVA8hAAwPIAAEbybGNIRAAhxvZlM0/0GCIA8H/4ACgYvwEggL0Av4C1IPBwQUDyEADA8gAARvJsY0hExvZlM0/0AEIA8Gr4ACgYvwEggL1wtRRGDUZBBCDwcEYN0UDyEADA8gAARvJsY0hEMUbG9mUzT/QAQgDwUfhA8hAAwPIAALX1AH+Yv0/0AHVIRDFGIkYrRgDwavgAKBi/ASBwvbC1DEYFRiDwcEARRiJGAPAB+gAoCL8lRChGsL2AtQpGIPBwQUDyEADA8gAASEQA8HX4ACgYvwEggL0AAEHy9ALB8gAy0WgAKQrQYCODYpJ4SWhA8gwDwPIAA0n4AyAIR0DyukDA8gAAQPLHQcDyAAF4RHlEhCIA8I35AL9A8gwMwPIADFn4DMC88QIPBNFE8jscwfIAPGBHQfIAHMHyADzc+ADAvPEADwLQ3PgIwGBHQPJqQMDyAABA8ndBwPIAAXhEeUSVIgDwZfkAv0DyDAzA8gAMWfgMwLzxAg8E0UTynRzB8gA8YEdB8gAcwfIAPNz4AMC88QAPAtDc+AzAYEdA8hpAwPIAAEDyJ0HA8gABeER5RKUiAPA9+QC/QfIAE8HyADMbaAArAdAbaRhHQPLsMMDyAABA8vkxwPIAAXhEeUStIgDwJvlA8gwMwPIADFn4DMC88QIPBNFE8n0swfIAPGBHQfIAHMHyADzc+ADAvPEADwLQ3PgUwGBHQPKeMMDyAABA8qsxwPIAAXhEeUTCIgDw//gAv0HyABPB8gAzG2gAKwHQm2kYR0DycDDA8gAAQPJ9McDyAAF4RHlEyyIA8Oj4QfIAEcHyADEJaAApAdCJaghHQPJEMMDyAABA8lExwPIAAXhEeUTVIgDw0vhB8gARwfIAMQloACkB0MlqCEdA8hgwwPIAAEDyJTHA8gABeER5RNwiAPC8+EHyABPB8gAzG2gAKwHQG2sYR0Dy7CDA8gAAQPL5IcDyAAF4RHlE4yIA8Kb4QfIAEsHyADISaAAqAdBSaxBHQPLAIMDyAABA8s0hwPIAAXhEeUTqIgDwkPhB8gAcwfIAPNz4AMC88QAPAtDc+DjAYEdA8o4gwPIAAEDymyHA8gABeER5RPEiAPB3+AC/QfIAEsHyADISaAAqAdDSaxBHQPJgIMDyAABA8m0hwPIAAXhEeUT4IgDwYPhB8gASwfIAMhJoACoB0BJsEEdA8jQgwPIAAEDyQSHA8gABeER5RP8iAPBK+EHyABPB8gAzG2gAKwHQW2wYR0DyCCDA8gAAQPIVIcDyAAF4RHlET/SDcgDwM/gAv0HyABPB8gAzG2gAKwHQm2wYR0Dy2BDA8gAAQPLlEcDyAAF4RHlEQPINEgDwG/gAv0HyABzB8gA83PgAwLzxAA8C0Nz4TMBgR0DyohDA8gAAQPKvEcDyAAF4RHlET/SKcgDwAPgOtQVGFEYORhOgAPBw+ChGAPBt+BagAPBq+DBGAPBn+BWgAPBk+AAhjfgLEAohDfEKAI34ChAI4JT78fIB+xJClPvx9DAyAPgBLQAs9NwA8E74APBB+AAAKioqIGFzc2VydGlvbiBmYWlsZWQ6IAAALCBmaWxlIAAsIGxpbmUgAEDqAQMQtZsHD9EEKg3TEMgIyRIfnEL40CC6GbqIQgHZASAQvU/w/zAQvRqx0wcD0FIcB+AAIBC9EPgBOxH4AUsbGwfREPgBOxH4AUsbGwHRkh7x0RhGEL0QtQAgAPAe+K/zAIC96BBAASAA8BG4ELUERgLgZBwA8AT4IHgAKPnREL0ItWlGjfgAAAMgq74IvQFJGCCrvv7nJgACABC1APAL+L3oEEAA8AG4cEcAKAHQ//fuv3BHAAAQtQAhAqAA8BP4ASAQvQAAU0lHQUJSVDogQWJub3JtYWwgdGVybWluYXRpb24AAABwtQVGDEYKIADgbRz/98X/NbEoeAAo+NEC4GQc//e9/xSxIHgAKPjRvehwQAog//e0v0ZMQVNIX0FQSV9UUkVFAGlhcDEvZnNsX2lhcDEuYwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 93
-    pc_program_page: 177
-    pc_erase_sector: 137
-    pc_erase_all: 97
-    data_section_offset: 1616
+    pc_init: 0x1
+    pc_uninit: 0x5d
+    pc_program_page: 0xb1
+    pc_erase_sector: 0x89
+    pc_erase_all: 0x61
+    data_section_offset: 0x650
     flash_properties:
       address_range:
-        start: 0
-        end: 622592
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x98000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 32768
-          address: 0
-  lpc55xx_s_640:
-    name: lpc55xx_s_640
+        - size: 0x8000
+          address: 0x0
+  - name: lpc55xx_s_640
     description: LPC55xx S IAP 608kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gLVA8gQAwPIAAEL24GFJ+AAQQPIAIMXyAAAAIcD4gBDA+IQQwPiAEUf2+3EBYED2BGD/IcXyAADM8t4BAWBP8KBAAiEBcEDyEADA8gAASEQA8HT4ACgYvwEggL0AIHBHgLVA8hAAwPIAAEbybGNIRAAhxvZlM0/0GCIA8H/4ACgYvwEggL0Av4C1IPBwQUDyEADA8gAARvJsY0hExvZlM0/0AEIA8Gr4ACgYvwEggL1wtRRGDUZBBCDwcEYN0UDyEADA8gAARvJsY0hEMUbG9mUzT/QAQgDwUfhA8hAAwPIAALX1AH+Yv0/0AHVIRDFGIkYrRgDwavgAKBi/ASBwvbC1DEYFRiDwcEARRiJGAPAB+gAoCL8lRChGsL2AtQpGIPBwQUDyEADA8gAASEQA8HX4ACgYvwEggL0AAEHy9ALB8gAy0WgAKQrQYCODYpJ4SWhA8gwDwPIAA0n4AyAIR0DyukDA8gAAQPLHQcDyAAF4RHlEhCIA8I35AL9A8gwMwPIADFn4DMC88QIPBNFE8jscwfIAPGBHQfIAHMHyADzc+ADAvPEADwLQ3PgIwGBHQPJqQMDyAABA8ndBwPIAAXhEeUSVIgDwZfkAv0DyDAzA8gAMWfgMwLzxAg8E0UTynRzB8gA8YEdB8gAcwfIAPNz4AMC88QAPAtDc+AzAYEdA8hpAwPIAAEDyJ0HA8gABeER5RKUiAPA9+QC/QfIAE8HyADMbaAArAdAbaRhHQPLsMMDyAABA8vkxwPIAAXhEeUStIgDwJvlA8gwMwPIADFn4DMC88QIPBNFE8n0swfIAPGBHQfIAHMHyADzc+ADAvPEADwLQ3PgUwGBHQPKeMMDyAABA8qsxwPIAAXhEeUTCIgDw//gAv0HyABPB8gAzG2gAKwHQm2kYR0DycDDA8gAAQPJ9McDyAAF4RHlEyyIA8Oj4QfIAEcHyADEJaAApAdCJaghHQPJEMMDyAABA8lExwPIAAXhEeUTVIgDw0vhB8gARwfIAMQloACkB0MlqCEdA8hgwwPIAAEDyJTHA8gABeER5RNwiAPC8+EHyABPB8gAzG2gAKwHQG2sYR0Dy7CDA8gAAQPL5IcDyAAF4RHlE4yIA8Kb4QfIAEsHyADISaAAqAdBSaxBHQPLAIMDyAABA8s0hwPIAAXhEeUTqIgDwkPhB8gAcwfIAPNz4AMC88QAPAtDc+DjAYEdA8o4gwPIAAEDymyHA8gABeER5RPEiAPB3+AC/QfIAEsHyADISaAAqAdDSaxBHQPJgIMDyAABA8m0hwPIAAXhEeUT4IgDwYPhB8gASwfIAMhJoACoB0BJsEEdA8jQgwPIAAEDyQSHA8gABeER5RP8iAPBK+EHyABPB8gAzG2gAKwHQW2wYR0DyCCDA8gAAQPIVIcDyAAF4RHlET/SDcgDwM/gAv0HyABPB8gAzG2gAKwHQm2wYR0Dy2BDA8gAAQPLlEcDyAAF4RHlEQPINEgDwG/gAv0HyABzB8gA83PgAwLzxAA8C0Nz4TMBgR0DyohDA8gAAQPKvEcDyAAF4RHlET/SKcgDwAPgOtQVGFEYORhOgAPBw+ChGAPBt+BagAPBq+DBGAPBn+BWgAPBk+AAhjfgLEAohDfEKAI34ChAI4JT78fIB+xJClPvx9DAyAPgBLQAs9NwA8E74APBB+AAAKioqIGFzc2VydGlvbiBmYWlsZWQ6IAAALCBmaWxlIAAsIGxpbmUgAEDqAQMQtZsHD9EEKg3TEMgIyRIfnEL40CC6GbqIQgHZASAQvU/w/zAQvRqx0wcD0FIcB+AAIBC9EPgBOxH4AUsbGwfREPgBOxH4AUsbGwHRkh7x0RhGEL0QtQAgAPAe+K/zAIC96BBAASAA8BG4ELUERgLgZBwA8AT4IHgAKPnREL0ItWlGjfgAAAMgq74IvQFJGCCrvv7nJgACABC1APAL+L3oEEAA8AG4cEcAKAHQ//fuv3BHAAAQtQAhAqAA8BP4ASAQvQAAU0lHQUJSVDogQWJub3JtYWwgdGVybWluYXRpb24AAABwtQVGDEYKIADgbRz/98X/NbEoeAAo+NEC4GQc//e9/xSxIHgAKPjRvehwQAog//e0v0ZMQVNIX0FQSV9UUkVFAGlhcDEvZnNsX2lhcDEuYwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 93
-    pc_program_page: 177
-    pc_erase_sector: 137
-    pc_erase_all: 97
-    data_section_offset: 1616
+    pc_init: 0x1
+    pc_uninit: 0x5d
+    pc_program_page: 0xb1
+    pc_erase_sector: 0x89
+    pc_erase_all: 0x61
+    data_section_offset: 0x650
     flash_properties:
       address_range:
-        start: 268435456
-        end: 269058048
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x10000000
+        end: 0x10098000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 32768
-          address: 0
+        - size: 0x8000
+          address: 0x0

--- a/probe-rs/targets/LPC800_Series.yaml
+++ b/probe-rs/targets/LPC800_Series.yaml
@@ -1,4 +1,3 @@
----
 name: LPC800 Series
 variants:
   - name: LPC802M001JDH16
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268437504
+            start: 0x10000000
+            end: 0x10000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc80x_16
   - name: LPC802M001JDH20
@@ -30,21 +31,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268437504
+            start: 0x10000000
+            end: 0x10000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc80x_16
   - name: LPC802M001JHI33
@@ -53,21 +56,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268437504
+            start: 0x10000000
+            end: 0x10000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc80x_16
   - name: LPC802M011JDH20
@@ -76,21 +81,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268437504
+            start: 0x10000000
+            end: 0x10000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc80x_16
   - name: LPC804M101JDH20
@@ -99,21 +106,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268439552
+            start: 0x10000000
+            end: 0x10001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc80x_32
   - name: LPC804M101JDH24
@@ -122,21 +131,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268439552
+            start: 0x10000000
+            end: 0x10001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc80x_32
   - name: LPC804M101JHI33
@@ -145,21 +156,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268439552
+            start: 0x10000000
+            end: 0x10001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc80x_32
   - name: LPC804M111JDH24
@@ -168,21 +181,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268439552
+            start: 0x10000000
+            end: 0x10001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc80x_32
   - name: LPC810M021FN8
@@ -191,21 +206,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268436480
+            start: 0x10000000
+            end: 0x10000400
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 4096
+            start: 0x0
+            end: 0x1000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8xx_4
   - name: LPC811M001JDH16
@@ -214,21 +231,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268437504
+            start: 0x10000000
+            end: 0x10000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 8192
+            start: 0x0
+            end: 0x2000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8xx_8
   - name: LPC812M101JD20
@@ -237,21 +256,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268439552
+            start: 0x10000000
+            end: 0x10001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8xx_16
   - name: LPC812M101JDH16
@@ -260,21 +281,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268439552
+            start: 0x10000000
+            end: 0x10001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8xx_16
   - name: LPC812M101JDH20
@@ -283,21 +306,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268439552
+            start: 0x10000000
+            end: 0x10001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8xx_16
   - name: LPC812M101JTB16
@@ -306,21 +331,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268439552
+            start: 0x10000000
+            end: 0x10001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8xx_16
   - name: LPC822M101JDH20
@@ -329,21 +356,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268439552
+            start: 0x10000000
+            end: 0x10001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8xx_16
   - name: LPC822M101JHI33
@@ -352,21 +381,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268439552
+            start: 0x10000000
+            end: 0x10001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8xx_16
   - name: LPC824M201JDH20
@@ -375,21 +406,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268443648
+            start: 0x10000000
+            end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8xx_32
   - name: LPC824M201JHI33
@@ -398,21 +431,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268443648
+            start: 0x10000000
+            end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8xx_32
   - name: LPC832M101FDH20
@@ -421,21 +456,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268439552
+            start: 0x10000000
+            end: 0x10001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8xx_16
   - name: LPC834M101FHI33
@@ -444,21 +481,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268439552
+            start: 0x10000000
+            end: 0x10001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8xx_32
   - name: LPC844M201JBD48
@@ -467,21 +506,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268443648
+            start: 0x10000000
+            end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc84x_64
   - name: LPC844M201JBD64
@@ -490,21 +531,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268443648
+            start: 0x10000000
+            end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc84x_64
   - name: LPC844M201JHI33
@@ -513,21 +556,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268443648
+            start: 0x10000000
+            end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc84x_64
   - name: LPC844M201JHI48
@@ -536,21 +581,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268443648
+            start: 0x10000000
+            end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc84x_64
   - name: LPC845M301JBD48
@@ -559,21 +606,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268451840
+            start: 0x10000000
+            end: 0x10004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc84x_64
   - name: LPC845M301JBD64
@@ -582,21 +631,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268451840
+            start: 0x10000000
+            end: 0x10004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc84x_64
   - name: LPC845M301JHI33
@@ -605,21 +656,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268451840
+            start: 0x10000000
+            end: 0x10004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc84x_64
   - name: LPC845M301JHI48
@@ -628,21 +681,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268451840
+            start: 0x10000000
+            end: 0x10004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc84x_64
   - name: LPC8N04FHI24
@@ -651,205 +706,207 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268443648
+            start: 0x10000000
+            end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 30720
+            start: 0x0
+            end: 0x7800
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - lpc8n04_30
 flash_algorithms:
-  lpc80x_16:
-    name: lpc80x_16
+  - name: lpc80x_16
     description: LPC80x IAP 16kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gApwR0hJR0hJRAhgR0gAIgJhASFBYUJhQWGBYUNJAiBAOQhwEEZwRwAgcEf4tUBMMiBMRCFGACUPJmHEFDE8SDxPSEQMPACRuEdgaQAoDdE0IGHENEhIRABoIGA0SAw8SEQAmbhHYGkAKADQASD4vfi1L02ECjIgTUQRxSlGDDErSCxOLGAPRkhECD2wR2hpACgO0TQgEcUjSCxgSEQAaGhgI0g5RkhECD2wR2hpACgA0AEg+L34tRRGBgAO0QPMYmhAGCFoiRhAGKFoQBjhaEAYIWlAGEBCYGEIPBRNsApNRDIhaGApYKhgKUYUMRFPKEYAkbhHaGkAKBHRMyCsYEHF/yABMGhgB0hIRABoqGAHSAg9SEQAmbhHaGkAKADQASD4veAuAAAEAAAAQIAEQAgAAADxHwAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 5
-    pc_uninit: 41
-    pc_program_page: 183
-    pc_erase_sector: 113
-    pc_erase_all: 45
-    data_section_offset: 312
+    pc_init: 0x5
+    pc_uninit: 0x29
+    pc_program_page: 0xb7
+    pc_erase_sector: 0x71
+    pc_erase_all: 0x2d
+    data_section_offset: 0x138
     flash_properties:
       address_range:
-        start: 0
-        end: 16384
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x4000
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1024
-          address: 0
-  lpc80x_32:
-    name: lpc80x_32
+        - size: 0x400
+          address: 0x0
+  - name: lpc80x_32
     description: LPC80x IAP 32kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gApwR0hJR0hJRAhgR0gAIgJhASFBYUJhQWGBYUNJAiBAOQhwEEZwRwAgcEf4tUBMMiBMRCFGACUfJmHEFDE8SDxPSEQMPACRuEdgaQAoDdE0IGHENEhIRABoIGA0SAw8SEQAmbhHYGkAKADQASD4vfi1L02ECjIgTUQRxSlGDDErSCxOLGAPRkhECD2wR2hpACgO0TQgEcUjSCxgSEQAaGhgI0g5RkhECD2wR2hpACgA0AEg+L34tRRGBgAO0QPMYmhAGCFoiRhAGKFoQBjhaEAYIWlAGEBCYGEIPBRNsApNRDIhaGApYKhgKUYUMRFPKEYAkbhHaGkAKBHRMyCsYEHF/yABMGhgB0hIRABoqGAHSAg9SEQAmbhHaGkAKADQASD4veAuAAAEAAAAQIAEQAgAAADxHwAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 5
-    pc_uninit: 41
-    pc_program_page: 183
-    pc_erase_sector: 113
-    pc_erase_all: 45
-    data_section_offset: 312
+    pc_init: 0x5
+    pc_uninit: 0x29
+    pc_program_page: 0xb7
+    pc_erase_sector: 0x71
+    pc_erase_all: 0x2d
+    data_section_offset: 0x138
     flash_properties:
       address_range:
-        start: 0
-        end: 32768
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x8000
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1024
-          address: 0
-  lpc8xx_4:
-    name: lpc8xx_4
+        - size: 0x400
+          address: 0x0
+  - name: lpc8xx_4
     description: LPC8xx IAP 4kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gApwR0ZJRUhJRAhgRUgAIgJjASFBY0JjQWOBY0FJAiBAOQhwEEZwRwAgcEf4tT5MMiBMRAAlAyYiRmHCIUYUMTpPIEYAkbhHYGkAKAzRNCAhRmHBMkhIRABo4GAgRgCZuEdgaQAoANABIPi9+LUuTYQKTUQyIGxgKUasYBQxKGAqTg9GKEawR2hpACgN0WxgNCCsYChgIkg5RkhEAGjoYChGsEdoaQAoANABIPi9+LUURgYADtFhaCBo4mhAGKFoiRhAGCFpQBhhaUAYoWlAGEBC4GEUTbAKTUQyIWhgKWCoYClGFDERTyhGAJG4R2hpACgQ0W5gMyCsYChg/yABMOhgB0hIRABoKGEoRgCZuEdoaQAoANABIPi9AADgLgAABAAAAECABEAIAAAA8R//HwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-    pc_init: 5
-    pc_uninit: 41
-    pc_program_page: 175
-    pc_erase_sector: 109
-    pc_erase_all: 45
-    data_section_offset: 304
+    pc_init: 0x5
+    pc_uninit: 0x29
+    pc_program_page: 0xaf
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x2d
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 0
-        end: 4096
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x1000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1024
-          address: 0
-  lpc8xx_16:
-    name: lpc8xx_16
+        - size: 0x400
+          address: 0x0
+  - name: lpc8xx_16
     description: LPC8xx IAP 16kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gApwR0ZJRUhJRAhgRUgAIgJjASFBY0JjQWOBY0FJAiBAOQhwEEZwRwAgcEf4tT5MMiBMRAAlDyYiRmHCIUYUMTpPIEYAkbhHYGkAKAzRNCAhRmHBMkhIRABo4GAgRgCZuEdgaQAoANABIPi9+LUuTYQKTUQyIGxgKUasYBQxKGAqTg9GKEawR2hpACgN0WxgNCCsYChgIkg5RkhEAGjoYChGsEdoaQAoANABIPi9+LUURgYADtFhaCBo4mhAGKFoiRhAGCFpQBhhaUAYoWlAGEBC4GEUTbAKTUQyIWhgKWCoYClGFDERTyhGAJG4R2hpACgQ0W5gMyCsYChg/yABMOhgB0hIRABoKGEoRgCZuEdoaQAoANABIPi9AADgLgAABAAAAECABEAIAAAA8R//HwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-    pc_init: 5
-    pc_uninit: 41
-    pc_program_page: 175
-    pc_erase_sector: 109
-    pc_erase_all: 45
-    data_section_offset: 304
+    pc_init: 0x5
+    pc_uninit: 0x29
+    pc_program_page: 0xaf
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x2d
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 0
-        end: 16384
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x4000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1024
-          address: 0
-  lpc8xx_32:
-    name: lpc8xx_32
+        - size: 0x400
+          address: 0x0
+  - name: lpc8xx_32
     description: LPC8xx IAP 32kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gApwR0hJR0hJRAhgR0gAIgJjASFBY0JjQWOBY0NJAiBAOQhwEEZwRwAgcEf4tUBMMiBMRCFGACUfJmHEFDE8SDxPSEQMPACRuEdgaQAoDdE0IGHENEhIRABoIGA0SAw8SEQAmbhHYGkAKADQASD4vfi1L02ECjIgTUQRxSlGDDErSCxOLGAPRkhECD2wR2hpACgO0TQgEcUjSCxgSEQAaGhgI0g5RkhECD2wR2hpACgA0AEg+L34tRRGBgAO0QPMYmhAGCFoiRhAGKFoQBjhaEAYIWlAGEBCYGEIPBRNsApNRDIhaGApYKhgKUYUMRFPKEYAkbhHaGkAKBHRMyCsYEHF/yABMGhgB0hIRABoqGAHSAg9SEQAmbhHaGkAKADQASD4veAuAAAEAAAAQIAEQAgAAADxH/8fAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 5
-    pc_uninit: 41
-    pc_program_page: 183
-    pc_erase_sector: 113
-    pc_erase_all: 45
-    data_section_offset: 312
+    pc_init: 0x5
+    pc_uninit: 0x29
+    pc_program_page: 0xb7
+    pc_erase_sector: 0x71
+    pc_erase_all: 0x2d
+    data_section_offset: 0x138
     flash_properties:
       address_range:
-        start: 0
-        end: 32768
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x8000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1024
-          address: 0
-  lpc84x_64:
-    name: lpc84x_64
+        - size: 0x400
+          address: 0x0
+  - name: lpc84x_64
     description: LPC84x IAP 64kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gApwR0hJR0hJRAhgR0gAIgJhASFBYUJhQWGBYUNJAiBAOQhwEEZwRwAgcEf4tUBMMiBMRCFGACU/JmHEFDE8SDxPSEQMPACRuEdgaQAoDdE0IGHENEhIRABoIGA0SAw8SEQAmbhHYGkAKADQASD4vfi1L02ECjIgTUQRxSlGDDErSCxOLGAPRkhECD2wR2hpACgO0TQgEcUjSCxgSEQAaGhgI0g5RkhECD2wR2hpACgA0AEg+L34tRRGBgAO0QPMYmhAGCFoiRhAGKFoQBjhaEAYIWlAGEBCYGEIPBRNsApNRDIhaGApYKhgKUYUMRFPKEYAkbhHaGkAKBHRMyCsYEHF/yABMGhgB0hIRABoqGAHSAg9SEQAmbhHaGkAKADQASD4veAuAAAEAAAAQIAEQAgAAADxHwAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 5
-    pc_uninit: 41
-    pc_program_page: 183
-    pc_erase_sector: 113
-    pc_erase_all: 45
-    data_section_offset: 312
+    pc_init: 0x5
+    pc_uninit: 0x29
+    pc_program_page: 0xb7
+    pc_erase_sector: 0x71
+    pc_erase_all: 0x2d
+    data_section_offset: 0x138
     flash_properties:
       address_range:
-        start: 0
-        end: 65536
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x10000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1024
-          address: 0
-  lpc8n04_30:
-    name: lpc8n04_30
+        - size: 0x400
+          address: 0x0
+  - name: lpc8n04_30
     description: LPC8N04 IAP 30kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gApwR0FJfSCAAUlECGBASAFoASKSBJFDAWA+SAFqCQwJBAFiACFBYgEhQWIAIHBHACBwR/i1OEwyIExEIUYAJR0mYcQUMTRINE9IRAw8AJG4R2BpACgN0TQgYcQrSEhEAGggYCxIDDxIRACZuEdgaQAoANABIPi9+LUnTYQKMiBNRBHFKUYMMSNIJE4sYA9GSEQIPbBHaGkAKA7RNCARxRpILGBIRABoaGAbSDlGSEQIPbBHaGkAKADQASD4vfi1FUwFRoAKTEQyIWBgIWCgYCFGFDERThdGIEYAkbBHYGkAKBDRMyChxP8gATAgYAdISEQAaGBgCEgMPEhEAJmwR2BpACgA0AEg+L0AAAQAAAAAwANAAIAEQAgAAADxH/8fAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 5
-    pc_uninit: 49
-    pc_program_page: 191
-    pc_erase_sector: 121
-    pc_erase_all: 53
-    data_section_offset: 288
+    pc_init: 0x5
+    pc_uninit: 0x31
+    pc_program_page: 0xbf
+    pc_erase_sector: 0x79
+    pc_erase_all: 0x35
+    data_section_offset: 0x120
     flash_properties:
       address_range:
-        start: 0
-        end: 30720
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x7800
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1024
-          address: 0
-  lpc8xx_8:
-    name: lpc8xx_8
+        - size: 0x400
+          address: 0x0
+  - name: lpc8xx_8
     description: LPC8xx IAP 8kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: gApwR0ZJRUhJRAhgRUgAIgJjASFBY0JjQWOBY0FJAiBAOQhwEEZwRwAgcEf4tT5MMiBMRAAlByYiRmHCIUYUMTpPIEYAkbhHYGkAKAzRNCAhRmHBMkhIRABo4GAgRgCZuEdgaQAoANABIPi9+LUuTYQKTUQyIGxgKUasYBQxKGAqTg9GKEawR2hpACgN0WxgNCCsYChgIkg5RkhEAGjoYChGsEdoaQAoANABIPi9+LUURgYADtFhaCBo4mhAGKFoiRhAGCFpQBhhaUAYoWlAGEBC4GEUTbAKTUQyIWhgKWCoYClGFDERTyhGAJG4R2hpACgQ0W5gMyCsYChg/yABMOhgB0hIRABoKGEoRgCZuEdoaQAoANABIPi9AADgLgAABAAAAECABEAIAAAA8R//HwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-    pc_init: 5
-    pc_uninit: 41
-    pc_program_page: 175
-    pc_erase_sector: 109
-    pc_erase_all: 45
-    data_section_offset: 304
+    pc_init: 0x5
+    pc_uninit: 0x29
+    pc_program_page: 0xaf
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x2d
+    data_section_offset: 0x130
     flash_properties:
       address_range:
-        start: 0
-        end: 8192
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x2000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1024
-          address: 0
+        - size: 0x400
+          address: 0x0

--- a/probe-rs/targets/MAX32665-66.yaml
+++ b/probe-rs/targets/MAX32665-66.yaml
@@ -1,6 +1,5 @@
----
 name: MAX32665-66
-manufacturer: ~
+manufacturer: null
 variants:
   - name: MAX32665
     cores:
@@ -8,21 +7,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
-            end: 0x2008C000
+            end: 0x2008c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x10000000
             end: 0x10100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - max32665
   - name: MAX32666
@@ -31,44 +32,46 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
-            end: 0x2008C000
+            end: 0x2008c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x10000000
             end: 0x10100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - max32665
 flash_algorithms:
-  max32665:
-    name: max32665
+  - name: max32665
     description: MAX32665 1MB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QLpwR0C6cEdAunBHwLpwR8C6cEfAunBHT+owAHBHAABP6jAAcEcAAE/qMABwRwAAOLVP8IBBACSIaCD04HCIYIhoQPQAIIhgimgS8ABv+9CIaCD0YGBA9ABgiGCKaBL0AF/70IhoIPSAIIhgD0jQ+AARIfABAcD4ABFoRgDwQPgAKAy/IEYBIDi9ACBwRxC1APBN+AAgEL0QtQDwxPgAIBC9ELUA8Ar6ACAQvQCgAkBP8IBCkGgA9GBh+kix9QBvCL/5SBfQC9ypsbH1gG8Iv/ZIENCx9cBvCL9P9PpQCuCx9SBvCL9P9OEABNCx9UBvCL9P9ABAkWjB84IRyEBwRwDwI7wAIepL6koO4GmxASkMvxBGACCAaBDwBwAYv3BHSRwCKai/cEfw5xhG8+ct6fBN3k8AJNtNT/CASN/4dLPZTk/qZxoM4FyxASwMv1hGACCBaBHwBw8F0G/wBQC96PCN00j159j4CBAB9GBhsfUAbwi/MUYa0AzcubGx9YBvCL85RhPQsfXAbwi/T/T6UQ3QC+Cx9SBvCL9P9OEBBtCx9UBvCL9P9ABBANApRtj4CCDC84IS0UCx+/rxQWBBahHwAg8D0EFqIfACAUFigWgh8HBBQfAAUYFggWgh9H9BQfQqQYFggWhB8AIBgWCBaBHwBw/70YFoIfBwQYFgQWoR8AIPB9BBaiHwAgFBYm/wBgC96PCNAPCC+2QcAiyT2wAgvejwjRC1BEaCsAAgAJAhRmhGAPCL+wAoHL8CsBC9AakgRgDwo/sAKLy/ArAQvQCYAPDV+gAoHL8CsBC93fgAwNz4CAAg9H9AQPSqQMz4CAABmMz4AADc+AgAQPAEAMz4CACKSgAgiksg4PixASgMvxlGACGJaBHwBw/z0UAcAijz29z4CAAg8HBAzPgIANz4JAAQ8AIPC9Dc+CQAIPACAMz4JAACsG/wBgAQvRFG4ecA8CT7ArAAIBC9cLXA8wwChBrB8wwADRqsQgnYIEb/95n/ACgYv3C9BPUAVKxC9dkAIHC9MLUERoOwACANRhTwDw8AkB6/b/ACAAOwML0hRmhGAPAT+wAoHL8DsDC9AakgRgDwK/sAKLy/A7AwvQCYAPBd+gAoHL8DsDC9AJqQaCDwEACQYAGYEGAoaBBjaGhQY6hokGPoaNBjkGhA8AEAkGCQaBDwBw/70ZBoIPBwQJBgUGoQ8AIPB9BQaiDwAgBQYgOwb/CGADC9APC/+gQgBPEQAaFCiL8E64AAA9lU+AQboEL72AOwACAwvS3p8EGGsAAlD0Y7SQCVApUDlQSVBZUKaBL0AG8HvwloEfSAX2/wRgAGsBi/vejwgRDwAw8ev2/wAgAGsL3o8IEBIgFGAx2LQoi/AOuCAgTZAL9R+AQ7ikL72CDwDwYA8A8IMUZoRgDwk/oAKBy/BrC96PCBAakwRgDwqvoAKLy/BrC96PCBAJgA8Nv5ACgcvwawvejwgTRGBvEQAIZCOL8CqQfSAL9U+AQrQfglIG0chEL4093pAAEBYLjxBA84vwKXCdO48QgPOL8DlwTTuPEMDzS/BJcFlwKpMEb/9zT/BrC96PCBAIeTAwDYuAUASOgBAJACQACUAkAAbABALenwQYSwFkYPRgVGEPADDynQJfADAAXwAwjI8QQEAGgAkMTxBABpRghEIkYxRgDwhfql6wgAAJn/92P/ACgcvwSwvejwgSVEPxsmRAvgKEYxaP/3Vv8AKBy/BLC96PCBLR02HT8fBC8C0xXwDw/u0RAvKL9P8AAIYdMsRhXwDw/N+ASABNAEsG/wAgC96PCBKUYBqADw/fkAKBy/BLC96PCBAqkgRgDwFPoAKLy/BLC96PCBAZgA8EX5ACgcvwSwvejwgQGZiGgg8BAAiGACmAhgMGgIY3BoSGOwaIhj8GjIY4hoQPABAIhgiGgQ8AcP+9GIaCDwcECIYEhqEPACDwnQAZhAaiDwAgBIYgSwb/CGAL3o8IEA8KT5BCAE8RABoUKIvwTrgAAE2QC/VPgEG6BC+9gQNRA2ED8QL53SBC8N0yhGMWj/99z+ACgcvwSwvejwgS0dNh0/HwQv8dJ/sShoAJA6RjFGaEYA8Cz6KEYAmf/3xv4AKBy/BLC96PCBACAEsL3o8IEt6fBHiEbA8wwBRxrA8wwEyPMMAJJGqOsABcD1AFajQii/s0IE069CKNGgGZhCA9lv8AIAvejwhyJGOUZQRgDwufkK64QABUYyRkFGAPCy+ThG//fG/QAoGL+96PCHUkYhRjhG//cI/wAoGL+96PCHKkYxRkBGvejwR/3mIkY5RlBGAPCX+ThG//er/QAoGL+96PCHUkYhRjhG//ft/gAoGL+96PCHMkZBRlBGAPCC+ShG//eW/QAoGL+96PCHUkYxRkBG//fY/gAoGL+96PCHB/UAUcHzDAKl9QBQjBrA8wwBRRqsQgrYIEb/93r9ACgYv73o8IcE9QBUrEL02QAgvejwhxD0QHAEv2/wAgBwR0tJSmoQQ0hiACBwRxD0QHAEv2/wAgBwR0VJSmoi6gAASGIAIHBHQkhAagDwAwBwRxDwAwAEv2/wAgBwRzxJSmpQQEhiACBwRwi1ACEAkaDxhFGx9QBPJL9v8AIACL0BRmhGAPDK+AAoGL8IvTFJAJgBZDFJAWQxSQFkACAIvQi1ACEAkaDxhFGx9QBPJL9v8AIACL0BRmhGAPCv+AAoGL8IvSdIAJkIZAAgCL2BaBHwBw8cv2/wBQBwR0/wgEOZaAH0YGIfSbL1AG8Ivx5JF9AL3KqxsvWAbwi/HEkQ0LL1wG8Iv0/0+lEK4LL1IG8Iv0/04QEE0LL1QG8Iv0/0AEGaaMLzghLRQBFKsfvy8UFgQWoR8AIPA9BBaiHwAgFBYoFoIfBwQUHwAFGBYAAgcEcAkAJAo1x/OiBP46HBsgiW776t3gCHkwMA2LgFAEjoAUBCDwABIU/wgEIfKAbZkmwgOAH6APACQgXQBuBSagH6APACQgHRASBwRwAgcEcBIk/wgEEfKAbZi2wgOAL6APAYQ4hkcEdLagL6APAYQ0hicEcBIk/wgEEfKAfZi2wgOAL6APAj6gAAiGRwR0tqAvoA8CPqAABIYnBHMkiBsND4ABGB8AEBwPgAEdD4ABGB8AEBwPgAEU/wgFAAaCpIAGgAkAGwcEcAIHBHofGAUydKs/UALwrTo/UALCVLvPUALxDTofGEXLz1gE8B0gJgCuCh8YRRofWAQbH1gE8kv2/wAgBwRwNgACBwR6DxgFKy9QAvPL/A8xIACGAf06DxgFKi9QAisvUALzy/oPUAIMDzEgAS06DxhFKy9YBPCdOi9YBCsvWATzK/oPWAQG/wAgBwR8DzDQAA9QAgCGAAIHBHACBwRwCgAkAAIAAQAJACQACUAkADKkDyMIAQ8AMMAPAVgBH4ATu88QIPYkSYvxH4AcsA+AE7OL8R+AE7ovEEApi/APgByzi/APgBOxHwAwMA8CWACDrA8AiAUfgEOwg6UfgEy6DoCBD15xIdXL9R+AQ7QPgEO6/zAIDSByS/EfgBOxH4ActIvxH4ASskvwD4ATsA+AHLSL8A+AErcEcQtSA6wPALgLHoGFAgOqDoGFCx6BhQoOgYUL/09a9f6gJ8JL+x6BhQoOgYUES/GMkYwL3oEEBf6oJ8JL9R+AQ7QPgEOwi/cEfSByi/MfgCO0i/EfgBKyi/IPgCO0i/APgBK3BHAAAAAAAA
-    pc_init: 49
-    pc_uninit: 139
-    pc_program_page: 163
-    pc_erase_sector: 153
-    pc_erase_all: 143
-    data_section_offset: 2792
+    pc_init: 0x31
+    pc_uninit: 0x8b
+    pc_program_page: 0xa3
+    pc_erase_sector: 0x99
+    pc_erase_all: 0x8f
+    data_section_offset: 0xae8
     flash_properties:
       address_range:
         start: 0x10000000
         end: 0x10100000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 5000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1388
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/RP2040.yaml
+++ b/probe-rs/targets/RP2040.yaml
@@ -1,6 +1,3 @@
-# TODO: Flash XIP has noalloc/nocache aliases, add them?
-# TODO: ROM at 0x00000000 - 0x00004000? probe-rs doesn't seem to have support for ROM regions
-
 name: RP2040
 variants:
   - name: RP2040
@@ -9,63 +6,79 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0x01002927
+            ap: 0x0
+            psel: 0x1002927
       - name: core1
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
+            ap: 0x0
             psel: 0x11002927
     memory_map:
-      - Ram: # Banks 0-3 striped
+      - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [core0, core1]
-      - Ram: # Bank 4
+          cores:
+            - core0
+            - core1
+      - Ram:
           range:
             start: 0x20040000
             end: 0x20041000
           is_boot_memory: false
-          cores: [core0, core1]
-      - Ram: # Bank 5
+          cores:
+            - core0
+            - core1
+      - Ram:
           range:
             start: 0x20041000
             end: 0x20042000
           is_boot_memory: false
-          cores: [core0, core1]
-      - Ram: # Bank 0 non-striped alias
+          cores:
+            - core0
+            - core1
+      - Ram:
           range:
             start: 0x21000000
             end: 0x21010000
           is_boot_memory: false
-          cores: [core0, core1]
-      - Ram: # Bank 1 non-striped alias
+          cores:
+            - core0
+            - core1
+      - Ram:
           range:
             start: 0x21010000
             end: 0x21020000
           is_boot_memory: false
-          cores: [core0, core1]
-      - Ram: # Bank 2 non-striped alias
+          cores:
+            - core0
+            - core1
+      - Ram:
           range:
             start: 0x21020000
             end: 0x21030000
           is_boot_memory: false
-          cores: [core0, core1]
-      - Ram: # Bank 3 non-striped alias
+          cores:
+            - core0
+            - core1
+      - Ram:
           range:
             start: 0x21030000
             end: 0x21040000
           is_boot_memory: false
-          cores: [core0, core1]
-      - Nvm: # Flash XIP
+          cores:
+            - core0
+            - core1
+      - Nvm:
           range:
             start: 0x10000000
             end: 0x11000000
           is_boot_memory: true
-          cores: [core0, core1]
+          cores:
+            - core0
+            - core1
     flash_algorithms:
       - algo
   - name: RP2040_SELFDEBUG
@@ -74,80 +87,88 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
-      - Ram: # Banks 0-3 striped
+      - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [core0]
-      - Ram: # Bank 4
+          cores:
+            - core0
+      - Ram:
           range:
             start: 0x20040000
             end: 0x20041000
           is_boot_memory: false
-          cores: [core0]
-      - Ram: # Bank 5
+          cores:
+            - core0
+      - Ram:
           range:
             start: 0x20041000
             end: 0x20042000
           is_boot_memory: false
-          cores: [core0]
-      - Ram: # Bank 0 non-striped alias
+          cores:
+            - core0
+      - Ram:
           range:
             start: 0x21000000
             end: 0x21010000
           is_boot_memory: false
-          cores: [core0]
-      - Ram: # Bank 1 non-striped alias
+          cores:
+            - core0
+      - Ram:
           range:
             start: 0x21010000
             end: 0x21020000
           is_boot_memory: false
-          cores: [core0]
-      - Ram: # Bank 2 non-striped alias
+          cores:
+            - core0
+      - Ram:
           range:
             start: 0x21020000
             end: 0x21030000
           is_boot_memory: false
-          cores: [core0]
-      - Ram: # Bank 3 non-striped alias
+          cores:
+            - core0
+      - Ram:
           range:
             start: 0x21030000
             end: 0x21040000
           is_boot_memory: false
-          cores: [core0]
-      - Nvm: # Flash XIP
+          cores:
+            - core0
+      - Nvm:
           range:
             start: 0x10000000
             end: 0x11000000
           is_boot_memory: true
-          cores: [core0]
+          cores:
+            - core0
     flash_algorithms:
       - algo
 flash_algorithms:
-  algo:
-    name: algo
+  - name: algo
     description: algo
-    cores: [core0]
+    cores:
+      - core0
     default: true
     instructions: 8LWFsB5MfEQgeAEoAdEA8Dv4ASAEkCBwFU4wRvcwAPCJ+AOUBEYTT7gcAPCD+AVGMEYA8H/4ApAPSADwe/gBkA5IAPB3+AZGOEYA8HP4B0agR6hHC0h4RDDAApkBYAGZBDDCwASYA5kIcAAgBbDwvVJFAABDWAAAUlAAAEZDAABeAQAA9gAAALC1CEx8RCB4ASgI0QZNfUQoaYBHaGmARwAgIHCwvQEgsL3ARtgAAAC2AAAABUh4RAB4ACgB0QEgcEcBSHBHwEbQcAAArgAAABC1Ckl5RAl4ASkM0Q8hCQdAGAdJeUSMaAEiEQMSBNgjoEcAIBC9ASAQvcBGkAAAAGgAAAAQtQtGCEl5RAl4ASkK0Q8hCQdAGAVJeUTMaBFGGkagRwAgEL0BIBC9WgAAADIAAACAshQhCYiJHkqIACoE0AkdgkL50QiIcEf+3tTUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANTU1A==
-    pc_init: 1
-    pc_uninit: 137
-    pc_program_page: 261
-    pc_erase_sector: 209
-    pc_erase_all: 181
-    data_section_offset: 0
+    pc_init: 0x1
+    pc_uninit: 0x89
+    pc_program_page: 0x105
+    pc_erase_sector: 0xd1
+    pc_erase_all: 0xb5
+    data_section_offset: 0x0
     flash_properties:
       address_range:
         start: 0x10000000
         end: 0x11000000
       page_size: 0x1000
-      erased_byte_value: 0xFF
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0xbb8
       sectors:
         - size: 0x1000
-          address: 0
+          address: 0x0

--- a/probe-rs/targets/SAM4_Dualcore_Series.yaml
+++ b/probe-rs/targets/SAM4_Dualcore_Series.yaml
@@ -1,4 +1,3 @@
----
 name: SAM4 Dualcore Series
 variants:
   - name: ATSAM4C16C
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537927680
+            start: 0x20100000
+            end: 0x20102000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c_1024
       - atsam4c_gpnvm
@@ -31,21 +32,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537935872
+            start: 0x20100000
+            end: 0x20104000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c32_2048
   - name: ATSAM4C32E
@@ -54,21 +57,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537935872
+            start: 0x20100000
+            end: 0x20104000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c32_2048
   - name: ATSAM4C4C
@@ -77,21 +82,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537927680
+            start: 0x20100000
+            end: 0x20102000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c_256
       - atsam4c_gpnvm
@@ -101,21 +108,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537927680
+            start: 0x20100000
+            end: 0x20102000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c_512
       - atsam4c_gpnvm
@@ -125,21 +134,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537927680
+            start: 0x20100000
+            end: 0x20102000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c_1024
   - name: ATSAM4CMP32C
@@ -148,21 +159,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537935872
+            start: 0x20100000
+            end: 0x20104000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c32_2048
   - name: ATSAM4CMP8C
@@ -171,21 +184,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537927680
+            start: 0x20100000
+            end: 0x20102000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c_512
   - name: ATSAM4CMS16C
@@ -194,21 +209,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537927680
+            start: 0x20100000
+            end: 0x20102000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c_1024
   - name: ATSAM4CMS32C
@@ -217,21 +234,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537935872
+            start: 0x20100000
+            end: 0x20104000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c32_2048
   - name: ATSAM4CMS4C
@@ -240,21 +259,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537927680
+            start: 0x20100000
+            end: 0x20102000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c_256
   - name: ATSAM4CMS8C
@@ -263,21 +284,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537927680
+            start: 0x20100000
+            end: 0x20102000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c_512
   - name: ATSAM4CP16B
@@ -286,21 +309,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537927680
+            start: 0x20100000
+            end: 0x20102000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c_1024
   - name: ATSAM4CP16C
@@ -309,136 +334,138 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 537919488
-            end: 537927680
+            start: 0x20100000
+            end: 0x20102000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4c_1024
 flash_algorithms:
-  atsam4c_gpnvm:
-    name: atsam4c_gpnvm
+  - name: atsam4c_gpnvm
     description: ATSAM4C GPNVM bits
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: MLViSUlECGAPIGFJAAIIYAEgYEnAA0hhYEtfSFhiX0rAOhBrgAiAAEAcEGNbSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURalZNKUMRYoFqiQP81RFqoUNSTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NVCSEAcWGIAIDC9ACBwRwAgcEcAIHBHOko6SUpEEmiAGkAKgAiAAIAcAAQCCjpIEENIYIhowAf80DdIgB4CQ0pgiGjAB/zQiGgAB0APANABIHBHELUTeNgHAtAvTKQcAeAtTOQcJ0geIURggmjSB/zQgmgSBwHVSR720pkHAdUnTAHgJkxkHB4hRGCCaNIH/NCCaBIHAdVJHvbSWQcB1SBLAeAfS1scHiFDYIJo0gf80IJoEgcB1Uke9tIAIBC9MLUVTBBLEngkHVxgnGjkB/zQ22jUB90H5A/tD6xCBtECJBVGJUAcQKVCAdBAHDC9BCQiQCNAmkIB0IAcML1AGDC9BAAAAAAKDkBAFA5AAENNUMAEDkAIADcACQAAWgsBAFoLAgBaAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 223
-    pc_erase_sector: 163
-    pc_erase_all: 159
-    data_section_offset: 432
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0xdf
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x9f
+    data_section_offset: 0x1b0
     flash_properties:
       address_range:
-        start: 536870896
-        end: 536870912
-      page_size: 16
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x1ffffff0
+        end: 0x20000000
+      page_size: 0x10
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 16
-          address: 0
-  atsam4c32_2048:
-    name: atsam4c32_2048
+        - size: 0x10
+          address: 0x0
+  - name: atsam4c32_2048
     description: ATSAM4C32 2048kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVoSUlECGAPIGdJAAIIYGZJCGABIGZJwANIYWZLZUhYYmVKwDoQa4AIgABAHBBjYUiAOIFqCQf81RFrcCShQxFjgWoJB/zVEWpcTSlDEWKBaokD/NURaqFDWEwYNCFDEWIRauQEoUM3JCQEIUMRYoFqyQP81RFriQiJAEkcEWOBagkH/NUBIRFjgWoJB/zVSEhAHFhiACAwvQIoI9FCSEdJQWCBaMkH/NDCaJEHDNRDS/4zQ2CBaMkH/NCBaAkHA9VDYIFoyQf80FEHC9U9SkJggWjJB/zQgWgJBwPVQmCBaMkH/NAAIHBHNUouSAg6QmCBaMkH/NAsSEJggWjJB/zQACBwRydJASJJRAloEgWLGEEamEIB0iNIAeAjSIkaSQqJCIkAiRwJBAoKJEkJHxFDQWCBaMkH/NAhSYkfCkNCYIFoyQf80IBoAAdADwDQASBwR3C1E0sBJUtEG2gtBV4ZxBqwQgHSD0sB4A9LZBvJHGQKiQiJAALgIMoJHyDAACn60SAEDkkACgw5CENYYJhowAf80JhoAAdADwDQASBwvQAABAAAAAAKDkAADA5AQBQOQABDTVDABA5ACAA3AA0AAFoMAgBaAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 155
-    pc_program_page: 341
-    pc_erase_sector: 263
-    pc_erase_all: 235
-    data_section_offset: 456
+    pc_init: 0x1
+    pc_uninit: 0x9b
+    pc_program_page: 0x155
+    pc_erase_sector: 0x107
+    pc_erase_all: 0xeb
+    data_section_offset: 0x1c8
     flash_properties:
       address_range:
-        start: 4194304
-        end: 6291456
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x600000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4c_256:
-    name: atsam4c_256
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4c_256
     description: ATSAM4C 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVVSUlECGAPIFRJAAIIYAEgU0nAA0hhU0tSSFhiUkrAOhBrgAiAAEAcEGNOSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURaklNKUMRYoFqiQP81RFqoUNFTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NU1SEAcWGIAIDC9AigW0TVLL0geIUNggmjSB/zQgmgSBwHVSR720jBLHiFDYIJo0gf80IJoEgcB1Uke9tIAIHBHI0gqSUFggWjJB/zQACBwRx5KH0lKRBJogBpACoAIgACAHAAEAgohSAAdEENIYIhowAf80B1IgBwCQ0pgiGjAB/zQiGgAB0APANABIHBHMLUOTA9LTEQkaAQbyRxkCokIiQAC4CDKCR8gwAAp+tEgBA5JAAoJHwhDWGCYaMAH/NCYaAAHQA8A0AEgML0EAAAAAAoOQEAUDkAAQ01QwAQOQAgANwALAQBaDAIAWgUAAFoAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 283
-    pc_erase_sector: 221
-    pc_erase_all: 205
-    data_section_offset: 380
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0x11b
+    pc_erase_sector: 0xdd
+    pc_erase_all: 0xcd
+    data_section_offset: 0x17c
     flash_properties:
       address_range:
-        start: 16777216
-        end: 17039360
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x1000000
+        end: 0x1040000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4c_512:
-    name: atsam4c_512
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4c_512
     description: ATSAM4C 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVVSUlECGAPIFRJAAIIYAEgU0nAA0hhU0tSSFhiUkrAOhBrgAiAAEAcEGNOSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURaklNKUMRYoFqiQP81RFqoUNFTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NU1SEAcWGIAIDC9AigW0TVLL0geIUNggmjSB/zQgmgSBwHVSR720jBLHiFDYIJo0gf80IJoEgcB1Uke9tIAIHBHI0gqSUFggWjJB/zQACBwRx5KH0lKRBJogBpACoAIgACAHAAEAgohSAAdEENIYIhowAf80B1IgBwCQ0pgiGjAB/zQiGgAB0APANABIHBHMLUOTA9LTEQkaAQbyRxkCokIiQAC4CDKCR8gwAAp+tEgBA5JAAoJHwhDWGCYaMAH/NCYaAAHQA8A0AEgML0EAAAAAAoOQEAUDkAAQ01QwAQOQAgANwALAQBaDAIAWgUAAFoAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 283
-    pc_erase_sector: 221
-    pc_erase_all: 205
-    data_section_offset: 380
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0x11b
+    pc_erase_sector: 0xdd
+    pc_erase_all: 0xcd
+    data_section_offset: 0x17c
     flash_properties:
       address_range:
-        start: 16777216
-        end: 17301504
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x1000000
+        end: 0x1080000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4c_1024:
-    name: atsam4c_1024
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4c_1024
     description: ATSAM4C 1024kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVVSUlECGAPIFRJAAIIYAEgU0nAA0hhU0tSSFhiUkrAOhBrgAiAAEAcEGNOSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURaklNKUMRYoFqiQP81RFqoUNFTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NU1SEAcWGIAIDC9AigW0TVLL0geIUNggmjSB/zQgmgSBwHVSR720jBLHiFDYIJo0gf80IJoEgcB1Uke9tIAIHBHI0gqSUFggWjJB/zQACBwRx5KH0lKRBJogBpACoAIgACAHAAEAgohSAAdEENIYIhowAf80B1IgBwCQ0pgiGjAB/zQiGgAB0APANABIHBHMLUOTA9LTEQkaAQbyRxkCokIiQAC4CDKCR8gwAAp+tEgBA5JAAoJHwhDWGCYaMAH/NCYaAAHQA8A0AEgML0EAAAAAAoOQEAUDkAAQ01QwAQOQAgANwALAQBaDAIAWgUAAFoAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 283
-    pc_erase_sector: 221
-    pc_erase_all: 205
-    data_section_offset: 380
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0x11b
+    pc_erase_sector: 0xdd
+    pc_erase_all: 0xcd
+    data_section_offset: 0x17c
     flash_properties:
       address_range:
-        start: 16777216
-        end: 17825792
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x1000000
+        end: 0x1100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/SAM4_Series.yaml
+++ b/probe-rs/targets/SAM4_Series.yaml
@@ -1,4 +1,3 @@
----
 name: SAM4 Series
 variants:
   - name: ATSAM4E16C
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4e_1024
   - name: ATSAM4E16E
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4e_1024
   - name: ATSAM4E8C
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4e_512
   - name: ATSAM4E8E
@@ -76,21 +81,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4e_512
   - name: ATSAM4LC2A
@@ -99,21 +106,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_128
   - name: ATSAM4LC2B
@@ -122,21 +131,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_128
   - name: ATSAM4LC2C
@@ -145,21 +156,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_128
   - name: ATSAM4LC4A
@@ -168,21 +181,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_256
   - name: ATSAM4LC4B
@@ -191,21 +206,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_256
   - name: ATSAM4LC4C
@@ -214,21 +231,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_256
   - name: ATSAM4LC8A
@@ -237,21 +256,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_512
   - name: ATSAM4LC8B
@@ -260,21 +281,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_512
   - name: ATSAM4LC8C
@@ -283,21 +306,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_512
   - name: ATSAM4LS2A
@@ -306,21 +331,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_128
   - name: ATSAM4LS2B
@@ -329,21 +356,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_128
   - name: ATSAM4LS2C
@@ -352,21 +381,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_128
   - name: ATSAM4LS4A
@@ -375,21 +406,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_256
   - name: ATSAM4LS4B
@@ -398,21 +431,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_256
   - name: ATSAM4LS4C
@@ -421,21 +456,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_256
   - name: ATSAM4LS8A
@@ -444,21 +481,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_512
   - name: ATSAM4LS8B
@@ -467,21 +506,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_512
   - name: ATSAM4LS8C
@@ -490,21 +531,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4l_512
   - name: ATSAM4N16B
@@ -513,21 +556,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4n_1024
   - name: ATSAM4N16C
@@ -536,21 +581,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4n_1024
   - name: ATSAM4N8A
@@ -559,21 +606,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4n_512
   - name: ATSAM4N8B
@@ -582,21 +631,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4n_512
   - name: ATSAM4N8C
@@ -605,21 +656,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4n_512
   - name: ATSAM4S16B
@@ -628,21 +681,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4s_1024
       - atsam4s_gpnvm
@@ -652,21 +707,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4s_1024
       - atsam4s_gpnvm
@@ -676,21 +733,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4325376
+            start: 0x400000
+            end: 0x420000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4s_128
       - atsam4s_gpnvm
@@ -700,21 +759,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4325376
+            start: 0x400000
+            end: 0x420000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4s_128
       - atsam4s_gpnvm
@@ -724,21 +785,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4325376
+            start: 0x400000
+            end: 0x420000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4s_128
       - atsam4s_gpnvm
@@ -748,21 +811,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4456448
+            start: 0x400000
+            end: 0x440000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4s_256
       - atsam4s_gpnvm
@@ -772,21 +837,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4456448
+            start: 0x400000
+            end: 0x440000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4s_256
       - atsam4s_gpnvm
@@ -796,21 +863,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4456448
+            start: 0x400000
+            end: 0x440000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4s_256
       - atsam4s_gpnvm
@@ -820,21 +889,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4s_512
       - atsam4s_gpnvm
@@ -844,21 +915,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4s_512
       - atsam4s_gpnvm
@@ -868,21 +941,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4s_1024
       - atsam4s_gpnvm
@@ -892,21 +967,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4s_1024
       - atsam4s_gpnvm
@@ -916,21 +993,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4sd_1024
       - atsam4s_gpnvm
@@ -940,21 +1019,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4sd_1024
       - atsam4s_gpnvm
@@ -964,21 +1045,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 6291456
+            start: 0x400000
+            end: 0x600000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4sd_2048
       - atsam4s_gpnvm
@@ -988,21 +1071,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 6291456
+            start: 0x400000
+            end: 0x600000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4sd_2048
       - atsam4s_gpnvm
@@ -1012,366 +1097,368 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537034752
+            start: 0x20000000
+            end: 0x20028000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 6291456
+            start: 0x400000
+            end: 0x600000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsam4sp_2048
 flash_algorithms:
-  atsam4e_1024:
-    name: atsam4e_1024
+  - name: atsam4e_1024
     description: ATSAM4E 1024kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVVSUlECGAPIFRJAAIIYAEgU0nAA0hhU0tSSFhiUkrAOhBrgAiAAEAcEGNOSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURaklNKUMRYoFqiQP81RFqoUNFTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NU1SEAcWGIAIDC9AigV0TBINElBYIFoyQf80MJokQcF1DBJ/jFBYIFoyQf80FEHBNUtSUFggWjJB/zQACBwRylJI0gIOUFggWjJB/zQACBwRx5KH0lKRBJogBpACoAIgACAHAAEAgofSAAfEENIYIhowAf80BtIgB8CQ0pgiGjAB/zQiGgAB0APANABIHBHMLUOTA9LTEQkaAQbyRxkCokIiQAC4CDKCR8gwAAp+tEgBAxJAAoMOQhDWGCYaMAH/NCYaAAHQA8A0AEgML0EAAAAAAoOQEAYDkAAQ01QwAQOQAgANwANAABaDAIAWgAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 283
-    pc_erase_sector: 221
-    pc_erase_all: 203
-    data_section_offset: 376
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0x11b
+    pc_erase_sector: 0xdd
+    pc_erase_all: 0xcb
+    data_section_offset: 0x178
     flash_properties:
       address_range:
-        start: 4194304
-        end: 5242880
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x500000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4e_512:
-    name: atsam4e_512
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4e_512
     description: ATSAM4E 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVVSUlECGAPIFRJAAIIYAEgU0nAA0hhU0tSSFhiUkrAOhBrgAiAAEAcEGNOSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURaklNKUMRYoFqiQP81RFqoUNFTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NU1SEAcWGIAIDC9AigV0TBINElBYIFoyQf80MJokQcF1DBJ/jFBYIFoyQf80FEHBNUtSUFggWjJB/zQACBwRylJI0gIOUFggWjJB/zQACBwRx5KH0lKRBJogBpACoAIgACAHAAEAgofSAAfEENIYIhowAf80BtIgB8CQ0pgiGjAB/zQiGgAB0APANABIHBHMLUOTA9LTEQkaAQbyRxkCokIiQAC4CDKCR8gwAAp+tEgBAxJAAoMOQhDWGCYaMAH/NCYaAAHQA8A0AEgML0EAAAAAAoOQEAYDkAAQ01QwAQOQAgANwANAABaDAIAWgAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 283
-    pc_erase_sector: 221
-    pc_erase_all: 203
-    data_section_offset: 376
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0x11b
+    pc_erase_sector: 0xdd
+    pc_erase_all: 0xcb
+    data_section_offset: 0x178
     flash_properties:
       address_range:
-        start: 4194304
-        end: 4718592
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x480000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4l_128:
-    name: atsam4l_128
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4l_128
     description: ATSAM4L 128kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLU+SQpoVSMbBhpDUghSAApgCmhbABpDUghSAApgOUo3SZFhN0kBIkAxCmEKadIH/NAzSTRMTDmhYTNNgiFAPWlgMUmAMUppkgb81aNhBCIqYEppkgb81SxJSUQIYAAgML0AIHBHKUkQtUlECWhAGkAKAQQKCiZJCkMmSUpgimjSB/zQIksERtseIDQN4AIEEgoaQ0pgimjSB/zQimgSB5IPAdABIBC9QBygQu/TACAQvTC1FUsWTUtEG2jDGlwKFEutHl1gnWjtB/zQyR3JCMkAAuAgygkfIMAAKfrRIAQLSQAKCR8IQ1hgmGjAB/zQmGgAB4APANABIDC9AAwPQFAAAKoACA5AQAAOQAQAAAAFAAClAAAKQAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 99
-    pc_program_page: 179
-    pc_erase_sector: 103
-    pc_erase_all: ~
-    data_section_offset: 280
+    pc_init: 0x1
+    pc_uninit: 0x63
+    pc_program_page: 0xb3
+    pc_erase_sector: 0x67
+    pc_erase_all: null
+    data_section_offset: 0x118
     flash_properties:
       address_range:
-        start: 0
-        end: 131072
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x20000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 16384
-          address: 0
-  atsam4l_256:
-    name: atsam4l_256
+        - size: 0x4000
+          address: 0x0
+  - name: atsam4l_256
     description: ATSAM4L 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLU+SQpoVSMbBhpDUghSAApgCmhbABpDUghSAApgOUo3SZFhN0kBIkAxCmEKadIH/NAzSTRMTDmhYTNNgiFAPWlgMUmAMUppkgb81aNhBCIqYEppkgb81SxJSUQIYAAgML0AIHBHKUkQtUlECWhAGkAKAQQKCiZJCkMmSUpgimjSB/zQIksERtseIDQN4AIEEgoaQ0pgimjSB/zQimgSB5IPAdABIBC9QBygQu/TACAQvTC1FUsWTUtEG2jDGlwKFEutHl1gnWjtB/zQyR3JCMkAAuAgygkfIMAAKfrRIAQLSQAKCR8IQ1hgmGjAB/zQmGgAB4APANABIDC9AAwPQFAAAKoACA5AQAAOQAQAAAAFAAClAAAKQAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 99
-    pc_program_page: 179
-    pc_erase_sector: 103
-    pc_erase_all: ~
-    data_section_offset: 280
+    pc_init: 0x1
+    pc_uninit: 0x63
+    pc_program_page: 0xb3
+    pc_erase_sector: 0x67
+    pc_erase_all: null
+    data_section_offset: 0x118
     flash_properties:
       address_range:
-        start: 0
-        end: 262144
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x40000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 16384
-          address: 0
-  atsam4l_512:
-    name: atsam4l_512
+        - size: 0x4000
+          address: 0x0
+  - name: atsam4l_512
     description: ATSAM4L 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLU+SQpoVSMbBhpDUghSAApgCmhbABpDUghSAApgOUo3SZFhN0kBIkAxCmEKadIH/NAzSTRMTDmhYTNNgiFAPWlgMUmAMUppkgb81aNhBCIqYEppkgb81SxJSUQIYAAgML0AIHBHKUkQtUlECWhAGkAKAQQKCiZJCkMmSUpgimjSB/zQIksERtseIDQN4AIEEgoaQ0pgimjSB/zQimgSB5IPAdABIBC9QBygQu/TACAQvTC1FUsWTUtEG2jDGlwKFEutHl1gnWjtB/zQyR3JCMkAAuAgygkfIMAAKfrRIAQLSQAKCR8IQ1hgmGjAB/zQmGgAB4APANABIDC9AAwPQFAAAKoACA5AQAAOQAQAAAAFAAClAAAKQAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 99
-    pc_program_page: 179
-    pc_erase_sector: 103
-    pc_erase_all: ~
-    data_section_offset: 280
+    pc_init: 0x1
+    pc_uninit: 0x63
+    pc_program_page: 0xb3
+    pc_erase_sector: 0x67
+    pc_erase_all: null
+    data_section_offset: 0x118
     flash_properties:
       address_range:
-        start: 0
-        end: 524288
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 300
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x80000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x12c
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 16384
-          address: 0
-  atsam4n_1024:
-    name: atsam4n_1024
+        - size: 0x4000
+          address: 0x0
+  - name: atsam4n_1024
     description: ATSAM4N 1024kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVVSUlECGAPIFRJAAIIYAEgU0nAA0hhU0tSSFhiUkrAOhBrgAiAAEAcEGNOSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURaklNKUMRYoFqiQP81RFqoUNFTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NU1SEAcWGIAIDC9AigV0TBINElBYIFoyQf80MJokQcF1DBJ/jFBYIFoyQf80FEHBNUtSUFggWjJB/zQACBwRylJI0gIOUFggWjJB/zQACBwRx5KH0lKRBJogBpACoAIgACAHAAEAgofSAAfEENIYIhowAf80BtIgB8CQ0pgiGjAB/zQiGgAB0APANABIHBHMLUOTA9LTEQkaAQbyRxkCokIiQAC4CDKCR8gwAAp+tEgBAxJAAoMOQhDWGCYaMAH/NCYaAAHQA8A0AEgML0EAAAAAAoOQEAUDkAAQ01QwAQOQAgANwANAABaDAIAWgAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 283
-    pc_erase_sector: 221
-    pc_erase_all: 203
-    data_section_offset: 376
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0x11b
+    pc_erase_sector: 0xdd
+    pc_erase_all: 0xcb
+    data_section_offset: 0x178
     flash_properties:
       address_range:
-        start: 4194304
-        end: 5242880
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x500000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4n_512:
-    name: atsam4n_512
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4n_512
     description: ATSAM4N 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVVSUlECGAPIFRJAAIIYAEgU0nAA0hhU0tSSFhiUkrAOhBrgAiAAEAcEGNOSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURaklNKUMRYoFqiQP81RFqoUNFTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NU1SEAcWGIAIDC9AigV0TBINElBYIFoyQf80MJokQcF1DBJ/jFBYIFoyQf80FEHBNUtSUFggWjJB/zQACBwRylJI0gIOUFggWjJB/zQACBwRx5KH0lKRBJogBpACoAIgACAHAAEAgofSAAfEENIYIhowAf80BtIgB8CQ0pgiGjAB/zQiGgAB0APANABIHBHMLUOTA9LTEQkaAQbyRxkCokIiQAC4CDKCR8gwAAp+tEgBAxJAAoMOQhDWGCYaMAH/NCYaAAHQA8A0AEgML0EAAAAAAoOQEAUDkAAQ01QwAQOQAgANwANAABaDAIAWgAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 283
-    pc_erase_sector: 221
-    pc_erase_all: 203
-    data_section_offset: 376
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0x11b
+    pc_erase_sector: 0xdd
+    pc_erase_all: 0xcb
+    data_section_offset: 0x178
     flash_properties:
       address_range:
-        start: 4194304
-        end: 4718592
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x480000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4s_128:
-    name: atsam4s_128
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4s_128
     description: ATSAM4S 128kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVVSUlECGAPIFRJAAIIYAEgU0nAA0hhU0tSSFhiUkrAOhBrgAiAAEAcEGNOSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURaklNKUMRYoFqiQP81RFqoUNFTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NU1SEAcWGIAIDC9AigV0TBINElBYIFoyQf80MJokQcF1DBJ/jFBYIFoyQf80FEHBNUtSUFggWjJB/zQACBwRylJI0gIOUFggWjJB/zQACBwRx5KH0lKRBJogBpACoAIgACAHAAEAgofSAAfEENIYIhowAf80BtIgB8CQ0pgiGjAB/zQiGgAB0APANABIHBHMLUOTA9LTEQkaAQbyRxkCokIiQAC4CDKCR8gwAAp+tEgBAxJAAoMOQhDWGCYaMAH/NCYaAAHQA8A0AEgML0EAAAAAAoOQEAUDkAAQ01QwAQOQAgANwANAABaDAIAWgAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 283
-    pc_erase_sector: 221
-    pc_erase_all: 203
-    data_section_offset: 376
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0x11b
+    pc_erase_sector: 0xdd
+    pc_erase_all: 0xcb
+    data_section_offset: 0x178
     flash_properties:
       address_range:
-        start: 4194304
-        end: 4325376
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x420000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4s_256:
-    name: atsam4s_256
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4s_256
     description: ATSAM4S 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVVSUlECGAPIFRJAAIIYAEgU0nAA0hhU0tSSFhiUkrAOhBrgAiAAEAcEGNOSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURaklNKUMRYoFqiQP81RFqoUNFTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NU1SEAcWGIAIDC9AigV0TBINElBYIFoyQf80MJokQcF1DBJ/jFBYIFoyQf80FEHBNUtSUFggWjJB/zQACBwRylJI0gIOUFggWjJB/zQACBwRx5KH0lKRBJogBpACoAIgACAHAAEAgofSAAfEENIYIhowAf80BtIgB8CQ0pgiGjAB/zQiGgAB0APANABIHBHMLUOTA9LTEQkaAQbyRxkCokIiQAC4CDKCR8gwAAp+tEgBAxJAAoMOQhDWGCYaMAH/NCYaAAHQA8A0AEgML0EAAAAAAoOQEAUDkAAQ01QwAQOQAgANwANAABaDAIAWgAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 283
-    pc_erase_sector: 221
-    pc_erase_all: 203
-    data_section_offset: 376
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0x11b
+    pc_erase_sector: 0xdd
+    pc_erase_all: 0xcb
+    data_section_offset: 0x178
     flash_properties:
       address_range:
-        start: 4194304
-        end: 4456448
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x440000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4s_512:
-    name: atsam4s_512
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4s_512
     description: ATSAM4S 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVVSUlECGAPIFRJAAIIYAEgU0nAA0hhU0tSSFhiUkrAOhBrgAiAAEAcEGNOSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURaklNKUMRYoFqiQP81RFqoUNFTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NU1SEAcWGIAIDC9AigV0TBINElBYIFoyQf80MJokQcF1DBJ/jFBYIFoyQf80FEHBNUtSUFggWjJB/zQACBwRylJI0gIOUFggWjJB/zQACBwRx5KH0lKRBJogBpACoAIgACAHAAEAgofSAAfEENIYIhowAf80BtIgB8CQ0pgiGjAB/zQiGgAB0APANABIHBHMLUOTA9LTEQkaAQbyRxkCokIiQAC4CDKCR8gwAAp+tEgBAxJAAoMOQhDWGCYaMAH/NCYaAAHQA8A0AEgML0EAAAAAAoOQEAUDkAAQ01QwAQOQAgANwANAABaDAIAWgAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 283
-    pc_erase_sector: 221
-    pc_erase_all: 203
-    data_section_offset: 376
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0x11b
+    pc_erase_sector: 0xdd
+    pc_erase_all: 0xcb
+    data_section_offset: 0x178
     flash_properties:
       address_range:
-        start: 4194304
-        end: 4718592
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x480000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4s_1024:
-    name: atsam4s_1024
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4s_1024
     description: ATSAM4S 1024kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVVSUlECGAPIFRJAAIIYAEgU0nAA0hhU0tSSFhiUkrAOhBrgAiAAEAcEGNOSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURaklNKUMRYoFqiQP81RFqoUNFTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NU1SEAcWGIAIDC9AigV0TBINElBYIFoyQf80MJokQcF1DBJ/jFBYIFoyQf80FEHBNUtSUFggWjJB/zQACBwRylJI0gIOUFggWjJB/zQACBwRx5KH0lKRBJogBpACoAIgACAHAAEAgofSAAfEENIYIhowAf80BtIgB8CQ0pgiGjAB/zQiGgAB0APANABIHBHMLUOTA9LTEQkaAQbyRxkCokIiQAC4CDKCR8gwAAp+tEgBAxJAAoMOQhDWGCYaMAH/NCYaAAHQA8A0AEgML0EAAAAAAoOQEAUDkAAQ01QwAQOQAgANwANAABaDAIAWgAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 283
-    pc_erase_sector: 221
-    pc_erase_all: 203
-    data_section_offset: 376
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0x11b
+    pc_erase_sector: 0xdd
+    pc_erase_all: 0xcb
+    data_section_offset: 0x178
     flash_properties:
       address_range:
-        start: 4194304
-        end: 5242880
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x500000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4sd_1024:
-    name: atsam4sd_1024
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4sd_1024
     description: ATSAM4SD 1024kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVhSUlECGAPIGBJAAIIYF9JCGABIF9JwANIYV9LXkhYYl5KwDoQa4AIgABAHBBjWkiAOIFqCQf81RFrcCShQxFjgWoJB/zVEWpVTSlDEWKBaokD/NURaqFDUUwYNCFDEWIRauQEoUM3JCQEIUMRYoFqyQP81RFriQiJAEkcEWOBagkH/NUBIRFjgWoJB/zVQUhAHFhiACAwvQIoFdE7SEBJQWCBaMkH/NDCaJEHBdQ8Sf4xQWCBaMkH/NBRBwTVOUlBYIFoyQf80AAgcEc1Si5ICDpCYIFoyQf80CxIQmCBaMkH/NAAIHBHJ0kBIklECWjSBIsYQRqYQgHSI0gB4CNIiRpJCokIiQCJHAkECgokSQkfEUNBYIFoyQf80CFJiR8KQ0JggWjJB/zQgGgAB0APANABIHBHcLUTSwElS0QbaO0EXhnEGrBCAdIPSwHgD0tkG8kcZAqJCIkAAuAgygkfIMAAKfrRIAQOSQAKDDkIQ1hgmGjAB/zQmGgAB0APANABIHC9AAAEAAAAAAoOQAAMDkBAFA5AAENNUMAEDkAIADcADQAAWgwCAFoAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 155
-    pc_program_page: 313
-    pc_erase_sector: 235
-    pc_erase_all: 207
-    data_section_offset: 428
+    pc_init: 0x1
+    pc_uninit: 0x9b
+    pc_program_page: 0x139
+    pc_erase_sector: 0xeb
+    pc_erase_all: 0xcf
+    data_section_offset: 0x1ac
     flash_properties:
       address_range:
-        start: 4194304
-        end: 5242880
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x500000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4sd_2048:
-    name: atsam4sd_2048
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4sd_2048
     description: ATSAM4SD 2048kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVhSUlECGAPIGBJAAIIYF9JCGABIF9JwANIYV9LXkhYYl5KwDoQa4AIgABAHBBjWkiAOIFqCQf81RFrcCShQxFjgWoJB/zVEWpVTSlDEWKBaokD/NURaqFDUUwYNCFDEWIRauQEoUM3JCQEIUMRYoFqyQP81RFriQiJAEkcEWOBagkH/NUBIRFjgWoJB/zVQUhAHFhiACAwvQIoFdE7SEBJQWCBaMkH/NDCaJEHBdQ8Sf4xQWCBaMkH/NBRBwTVOUlBYIFoyQf80AAgcEc1Si5ICDpCYIFoyQf80CxIQmCBaMkH/NAAIHBHJ0kBIklECWgSBYsYQRqYQgHSI0gB4CNIiRpJCokIiQCJHAkECgokSQkfEUNBYIFoyQf80CFJiR8KQ0JggWjJB/zQgGgAB0APANABIHBHcLUTSwElS0QbaC0FXhnEGrBCAdIPSwHgD0tkG8kcZAqJCIkAAuAgygkfIMAAKfrRIAQOSQAKDDkIQ1hgmGjAB/zQmGgAB0APANABIHC9AAAEAAAAAAoOQAAMDkBAFA5AAENNUMAEDkAIADcADQAAWgwCAFoAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 155
-    pc_program_page: 313
-    pc_erase_sector: 235
-    pc_erase_all: 207
-    data_section_offset: 428
+    pc_init: 0x1
+    pc_uninit: 0x9b
+    pc_program_page: 0x139
+    pc_erase_sector: 0xeb
+    pc_erase_all: 0xcf
+    data_section_offset: 0x1ac
     flash_properties:
       address_range:
-        start: 4194304
-        end: 6291456
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x600000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsam4s_gpnvm:
-    name: atsam4s_gpnvm
+        - size: 0x2000
+          address: 0x0
+  - name: atsam4s_gpnvm
     description: ATSAM4S GPNVM bits
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: MLVwSUlECGAPIG9JAAIIYAEgbknAA0hhbkttSFhibUrAOhBrgAiAAEAcEGNpSIA4gWoJB/zVEWtwJKFDEWOBagkH/NURamRNKUMRYoFqiQP81RFqoUNgTBg0IUMRYhFq5AShQzckJAQhQxFigWrJA/zVEWuJCIkASRwRY4FqCQf81QEhEWOBagkH/NVQSEAcWGIAIDC9ACBwRwAgcEcAIHBHSEpISUpEEmiAGkAKgAiAAIAcAAQCCkhIEENIYIhowAf80EVIgB4CQ0pgiGjAB/zQiGgAB0APANABIHBHELU+STlLEHgJHVlgmWjJB/zQ2WjCB8wH0g/kD6JCEdDCBwLQNkqSHAHgNErSHFpgnGjkB/zQnGgkBwPVWmCaaNIH/NACIgRGFEAKQJRCENCCBwHVK0oB4CpKUhxaYJxo5Af80JxoJAcD1VpgmmjSB/zQBCIERhRAEUCMQhDQQAcB1SBIAeAfSEAcWGCZaMkH/NCZaAkHA9VYYJhowAf80AAgEL0wtRVMEEsSeCQdXGCcaOQH/NDbaNQH3QfkD+0PrEIG0QIkFUYlQBxApUIB0EAcML0EJCJAI0CaQgHQgBwwvUAYML0EAAAAAAoOQEAUDkAAQ01QwAQOQAgANwAJAABaCwEAWgsCAFoAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 151
-    pc_program_page: 223
-    pc_erase_sector: 163
-    pc_erase_all: 159
-    data_section_offset: 488
+    pc_init: 0x1
+    pc_uninit: 0x97
+    pc_program_page: 0xdf
+    pc_erase_sector: 0xa3
+    pc_erase_all: 0x9f
+    data_section_offset: 0x1e8
     flash_properties:
       address_range:
-        start: 536870896
-        end: 536870912
-      page_size: 16
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x1ffffff0
+        end: 0x20000000
+      page_size: 0x10
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 16
-          address: 0
-  atsam4sp_2048:
-    name: atsam4sp_2048
+        - size: 0x10
+          address: 0x0
+  - name: atsam4sp_2048
     description: ATSAM4SP 2048kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVhSUlECGAPIGBJAAIIYF9JCGABIF9JwANIYV9LXkhYYl5KwDoQa4AIgABAHBBjWkiAOIFqCQf81RFrcCShQxFjgWoJB/zVEWpVTSlDEWKBaokD/NURaqFDUUwYNCFDEWIRauQEoUM3JCQEIUMRYoFqyQP81RFriQiJAEkcEWOBagkH/NUBIRFjgWoJB/zVQUhAHFhiACAwvQIoFdE7SEBJQWCBaMkH/NDCaJEHBdQ8Sf4xQWCBaMkH/NBRBwTVOUlBYIFoyQf80AAgcEc1Si5ICDpCYIFoyQf80CxIQmCBaMkH/NAAIHBHJ0kBIklECWgSBYsYQRqYQgHSI0gB4CNIiRpJCokIiQCJHAkECgokSQkfEUNBYIFoyQf80CFJiR8KQ0JggWjJB/zQgGgAB0APANABIHBHcLUTSwElS0QbaC0FXhnEGrBCAdIPSwHgD0tkG8kcZAqJCIkAAuAgygkfIMAAKfrRIAQOSQAKDDkIQ1hgmGjAB/zQmGgAB0APANABIHC9AAAEAAAAAAoOQAAMDkBAFA5AAENNUMAEDkAIADcADQAAWgwCAFoAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 155
-    pc_program_page: 313
-    pc_erase_sector: 235
-    pc_erase_all: 207
-    data_section_offset: 428
+    pc_init: 0x1
+    pc_uninit: 0x9b
+    pc_program_page: 0x139
+    pc_erase_sector: 0xeb
+    pc_erase_all: 0xcf
+    data_section_offset: 0x1ac
     flash_properties:
       address_range:
-        start: 4194304
-        end: 6291456
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x600000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/SAMD10.yaml
+++ b/probe-rs/targets/SAMD10.yaml
@@ -1,4 +1,3 @@
----
 name: SAMD10
 variants:
   - name: ATSAMD10C13A
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Flash:
           range:
-            start: 0
-            end: 8192
+            start: 0x0
+            end: 0x2000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd10_8
   - name: ATSAMD10C14A
@@ -30,21 +31,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Flash:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd10_16
   - name: ATSAMD10D13AM
@@ -53,21 +56,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Flash:
           range:
-            start: 0
-            end: 8192
+            start: 0x0
+            end: 0x2000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd10_8
   - name: ATSAMD10D13AS
@@ -76,21 +81,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Flash:
           range:
-            start: 0
-            end: 8192
+            start: 0x0
+            end: 0x2000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd10_8
   - name: ATSAMD10D14AM
@@ -99,21 +106,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Flash:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd10_16
   - name: ATSAMD10D14AS
@@ -122,21 +131,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Flash:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd10_16
   - name: ATSAMD10D14AU
@@ -145,67 +156,69 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Flash:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd10_16
 flash_algorithms:
-  atsamd10_8:
-    name: atsamd10_8
+  - name: atsamd10_8
     description: ATSAMD10 8kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QSEJBgpoUgcB1QQiCmAoSiZJUWAnSUlECGAAIHBHACBwRw8hSQIBQEIIDyAAAgJAELUfSMJhIEoCgAJ90gf80B1Myx0/PP8z+jMM4EoIwmEEgAJ90gf80AJ9kgcB1QEgEL3/MQExmULw0wAgEL0QtRFMD0vkHByAHH3kB/zQyRyJCIkAAuAQygkfEMAAKfrRCUg9OBiAGH3AB/zQGH2ABwHVASAQvQAgEL0AAJ4ABAAAQABBBAAAAEGlAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 111
-    pc_erase_sector: 35
-    pc_erase_all: ~
-    data_section_offset: 188
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x6f
+    pc_erase_sector: 0x23
+    pc_erase_all: null
+    data_section_offset: 0xbc
     flash_properties:
       address_range:
-        start: 0
-        end: 8192
-      page_size: 64
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x2000
+      page_size: 0x40
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 512
-          address: 0
-  atsamd10_16:
-    name: atsamd10_16
+        - size: 0x200
+          address: 0x0
+  - name: atsamd10_16
     description: ATSAMD10 16kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QSEJBgpoUgcB1QQiCmAoSiZJUWAnSUlECGAAIHBHACBwRw8hiQIBQEIIDyBAAgJAELUfSMJhIEoCgAJ90gf80B1MASI/PJICixgM4EoIwmEEgAJ90gf80AJ9kgcB1QEgEL3/MQExmULw0wAgEL0QtRFMD0vkHByAHH3kB/zQyRyJCIkAAuAQygkfEMAAKfrRCUg9OBiAGH3AB/zQGH2ABwHVASAQvQAgEL0AAJ4ABAAAQABBBAAAAEGlAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 111
-    pc_erase_sector: 35
-    pc_erase_all: ~
-    data_section_offset: 188
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x6f
+    pc_erase_sector: 0x23
+    pc_erase_all: null
+    data_section_offset: 0xbc
     flash_properties:
       address_range:
-        start: 0
-        end: 16384
-      page_size: 64
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x4000
+      page_size: 0x40
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 1024
-          address: 0
+        - size: 0x400
+          address: 0x0

--- a/probe-rs/targets/SAMD11.yaml
+++ b/probe-rs/targets/SAMD11.yaml
@@ -1,4 +1,3 @@
----
 name: SAMD11
 variants:
   - name: ATSAMD11C14A
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd11_16
   - name: ATSAMD11D14AM
@@ -30,21 +31,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd11_16
   - name: ATSAMD11D14AS
@@ -53,21 +56,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd11_16
   - name: ATSAMD11D14AU
@@ -76,44 +81,46 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 16384
+            start: 0x0
+            end: 0x4000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd11_16
 flash_algorithms:
-  atsamd11_16:
-    name: atsamd11_16
+  - name: atsamd11_16
     description: ATSAMD11 16kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QSEJBgpoUgcB1QQiCmAoSiZJUWAnSUlECGAAIHBHACBwRw8hiQIBQEIIDyBAAgJAELUfSMJhIEoCgAJ90gf80B1MASI/PJICixgM4EoIwmEEgAJ90gf80AJ9kgcB1QEgEL3/MQExmULw0wAgEL0QtRFMD0vkHByAHH3kB/zQyRyJCIkAAuAQygkfEMAAKfrRCUg9OBiAGH3AB/zQGH2ABwHVASAQvQAgEL0AAJ4ABAAAQABBBAAAAEGlAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 111
-    pc_erase_sector: 35
-    pc_erase_all: ~
-    data_section_offset: 188
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x6f
+    pc_erase_sector: 0x23
+    pc_erase_all: null
+    data_section_offset: 0xbc
     flash_properties:
       address_range:
-        start: 0
-        end: 16384
-      page_size: 64
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x4000
+      page_size: 0x40
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 1024
-          address: 0
+        - size: 0x400
+          address: 0x0

--- a/probe-rs/targets/SAMD21.yaml
+++ b/probe-rs/targets/SAMD21.yaml
@@ -1,4 +1,3 @@
----
 name: SAMD21
 variants:
   - name: ATSAMD21E15A
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_32
   - name: ATSAMD21E15B
@@ -30,21 +31,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_32
   - name: ATSAMD21E15BU
@@ -53,21 +56,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_32
       - atsamd21_32_eeprom
@@ -77,21 +82,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_32
       - atsamd21_32_eeprom
@@ -101,21 +108,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_32
       - atsamd21_32_eeprom
@@ -125,21 +134,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_64
       - atsamd21_64_eeprom
@@ -149,21 +160,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_64
       - atsamd21_64_eeprom
@@ -173,21 +186,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_64
       - atsamd21_64_eeprom
@@ -197,21 +212,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_64
       - atsamd21_64_eeprom
@@ -221,21 +238,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_64
       - atsamd21_64_eeprom
@@ -245,21 +264,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_128
   - name: ATSAMD21E17D
@@ -268,21 +289,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_128
       - atsamd21_128_eeprom
@@ -292,21 +315,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_128
       - atsamd21_128_eeprom
@@ -316,21 +341,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_128
       - atsamd21_128_eeprom
@@ -340,21 +367,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_256
   - name: ATSAMD21G15A
@@ -363,21 +392,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_32
   - name: ATSAMD21G15B
@@ -386,21 +417,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_32
       - atsamd21_32_eeprom
@@ -410,21 +443,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_32
       - atsamd21_32_eeprom
@@ -434,21 +469,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_64
   - name: ATSAMD21G16B
@@ -457,21 +494,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_64
       - atsamd21_64_eeprom
@@ -481,21 +520,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_64
       - atsamd21_64_eeprom
@@ -505,21 +546,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_128
   - name: ATSAMD21G17AU
@@ -528,21 +571,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_128
   - name: ATSAMD21G17D
@@ -551,21 +596,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_128
       - atsamd21_128_eeprom
@@ -575,21 +622,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_128
       - atsamd21_128_eeprom
@@ -599,21 +648,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_256
   - name: ATSAMD21G18AU
@@ -622,21 +673,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_256
   - name: ATSAMD21J15A
@@ -645,21 +698,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_32
   - name: ATSAMD21J15B
@@ -668,21 +723,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 32768
+            start: 0x0
+            end: 0x8000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_32
       - atsamd21_32_eeprom
@@ -692,21 +749,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_64
   - name: ATSAMD21J16B
@@ -715,21 +774,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 65536
+            start: 0x0
+            end: 0x10000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_64
       - atsamd21_64_eeprom
@@ -739,21 +800,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_128
   - name: ATSAMD21J17D
@@ -762,21 +825,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_128
       - atsamd21_128_eeprom
@@ -786,182 +851,184 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd21_256
 flash_algorithms:
-  atsamd21_32:
-    name: atsamd21_32
+  - name: atsamd21_32
     description: ATSAMD21 32kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QSEJBgpoUgcB1QQiCmAoSiZJUWAnSUlECGAAIHBHACBwRw8hyQIBQEIIDyCAAgJAELUfSMJhIEoCgAJ90gf80B1MASI/PNICixgM4EoIwmEEgAJ90gf80AJ9kgcB1QEgEL3/MQExmULw0wAgEL0QtRFMD0vkHByAHH3kB/zQyRyJCIkAAuAQygkfEMAAKfrRCUg9OBiAGH3AB/zQGH2ABwHVASAQvQAgEL0AAJ4ABAAAQABBBAAAAEGlAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 111
-    pc_erase_sector: 35
-    pc_erase_all: ~
-    data_section_offset: 188
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x6f
+    pc_erase_sector: 0x23
+    pc_erase_all: null
+    data_section_offset: 0xbc
     flash_properties:
       address_range:
-        start: 0
-        end: 32768
-      page_size: 64
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x8000
+      page_size: 0x40
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 2048
-          address: 0
-  atsamd21_32_eeprom:
-    name: atsamd21_32_eeprom
+        - size: 0x800
+          address: 0x0
+  - name: atsamd21_32_eeprom
     description: ATSAMD21 1kB Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QSEJBgpoUgcB1QQiCmAcShpJUWAbSUlECGAAIHBHACBwR0EIFkjBYRdJAYABfckH/NAAfYAHAdUBIHBHACBwRxC1EUwOSyo0HIAcfeQH/NDJHIkIiQAC4BDKCR8QwAAp+tEJSIAcGIAYfcAH/NAYfYAHAdUBIBC9ACAQvZ4ABAAAQABBBAAAABqlAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 65
-    pc_erase_sector: 35
-    pc_erase_all: ~
-    data_section_offset: 140
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x41
+    pc_erase_sector: 0x23
+    pc_erase_all: null
+    data_section_offset: 0x8c
     flash_properties:
       address_range:
-        start: 4194304
-        end: 4195328
-      page_size: 64
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x400400
+      page_size: 0x40
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 256
-          address: 0
-  atsamd21_64:
-    name: atsamd21_64
+        - size: 0x100
+          address: 0x0
+  - name: atsamd21_64
     description: ATSAMD21 64kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QSEJBgpoUgcB1QQiCmAoSiZJUWAnSUlECGAAIHBHACBwRw8hCQMBQEIIDyDAAgJAELUfSMJhIEoCgAJ90gf80B1MASI/PBIDixgM4EoIwmEEgAJ90gf80AJ9kgcB1QEgEL3/MQExmULw0wAgEL0QtRFMD0vkHByAHH3kB/zQyRyJCIkAAuAQygkfEMAAKfrRCUg9OBiAGH3AB/zQGH2ABwHVASAQvQAgEL0AAJ4ABAAAQABBBAAAAEGlAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 111
-    pc_erase_sector: 35
-    pc_erase_all: ~
-    data_section_offset: 188
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x6f
+    pc_erase_sector: 0x23
+    pc_erase_all: null
+    data_section_offset: 0xbc
     flash_properties:
       address_range:
-        start: 0
-        end: 65536
-      page_size: 64
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x10000
+      page_size: 0x40
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 4096
-          address: 0
-  atsamd21_64_eeprom:
-    name: atsamd21_64_eeprom
+        - size: 0x1000
+          address: 0x0
+  - name: atsamd21_64_eeprom
     description: ATSAMD21 2kB Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QSEJBgpoUgcB1QQiCmAcShpJUWAbSUlECGAAIHBHACBwR0EIFkjBYRdJAYABfckH/NAAfYAHAdUBIHBHACBwRxC1EUwOSyo0HIAcfeQH/NDJHIkIiQAC4BDKCR8QwAAp+tEJSIAcGIAYfcAH/NAYfYAHAdUBIBC9ACAQvZ4ABAAAQABBBAAAABqlAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 65
-    pc_erase_sector: 35
-    pc_erase_all: ~
-    data_section_offset: 140
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x41
+    pc_erase_sector: 0x23
+    pc_erase_all: null
+    data_section_offset: 0x8c
     flash_properties:
       address_range:
-        start: 4194304
-        end: 4196352
-      page_size: 64
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x400800
+      page_size: 0x40
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 256
-          address: 0
-  atsamd21_128:
-    name: atsamd21_128
+        - size: 0x100
+          address: 0x0
+  - name: atsamd21_128
     description: ATSAMD21 128kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QSEJBgpoUgcB1QQiCmAtSitJUWAsSUlECGAAIHBHACBwRw8hSQMBQEIIDyAAAwJAELUkSMJhJUoCgAJ90gf80CJMASI/PFIDixgM4EoIwmEEgAJ90gf80AJ9kgcB1QEgEL3/MQExmULw0wAgEL3wtckciQgVS4kAEk3bHCuAK33bB/zQEU49PgApFtADRkApAdlAJAXgDEYD4IDKCR+AwyQfACz50S6AQDArfdsH/NArfZsH6NUBIPC9ACDwvQAAngAEAABAAEEEAAAAQaUAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 111
-    pc_erase_sector: 35
-    pc_erase_all: ~
-    data_section_offset: 208
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x6f
+    pc_erase_sector: 0x23
+    pc_erase_all: null
+    data_section_offset: 0xd0
     flash_properties:
       address_range:
-        start: 0
-        end: 131072
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x20000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsamd21_128_eeprom:
-    name: atsamd21_128_eeprom
+        - size: 0x2000
+          address: 0x0
+  - name: atsamd21_128_eeprom
     description: ATSAMD21 4kB Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QSEJBgpoUgcB1QQiCmAcShpJUWAbSUlECGAAIHBHACBwR0EIFkjBYRdJAYABfckH/NAAfYAHAdUBIHBHACBwRxC1EUwOSyo0HIAcfeQH/NDJHIkIiQAC4BDKCR8QwAAp+tEJSIAcGIAYfcAH/NAYfYAHAdUBIBC9ACAQvZ4ABAAAQABBBAAAABqlAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 65
-    pc_erase_sector: 35
-    pc_erase_all: ~
-    data_section_offset: 140
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x41
+    pc_erase_sector: 0x23
+    pc_erase_all: null
+    data_section_offset: 0x8c
     flash_properties:
       address_range:
-        start: 4194304
-        end: 4198400
-      page_size: 64
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x401000
+      page_size: 0x40
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 256
-          address: 0
-  atsamd21_256:
-    name: atsamd21_256
+        - size: 0x100
+          address: 0x0
+  - name: atsamd21_256
     description: ATSAMD21 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: QSEJBgpoUgcB1QQiCmAoSiZJUWAnSUlECGAAIHBHACBwRw8hiQMBQEIIDyBAAwJAELUfSMJhIEoCgAJ90gf80B1MASI/PJIDixgM4EoIwmEEgAJ90gf80AJ9kgcB1QEgEL3/MQExmULw0wAgEL0QtRFMD0vkHByAHH3kB/zQyRyJCIkAAuAQygkfEMAAKfrRCUg9OBiAGH3AB/zQGH2ABwHVASAQvQAgEL0AAJ4ABAAAQABBBAAAAEGlAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 111
-    pc_erase_sector: 35
-    pc_erase_all: ~
-    data_section_offset: 188
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x6f
+    pc_erase_sector: 0x23
+    pc_erase_all: null
+    data_section_offset: 0xbc
     flash_properties:
       address_range:
-        start: 0
-        end: 262144
-      page_size: 64
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x40000
+      page_size: 0x40
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 16384
-          address: 0
+        - size: 0x4000
+          address: 0x0

--- a/probe-rs/targets/SAMD51.yaml
+++ b/probe-rs/targets/SAMD51.yaml
@@ -1,6 +1,5 @@
----
 name: SAMD51
-manufacturer: ~
+manufacturer: null
 variants:
   - name: ATSAMD51G18A
     cores:
@@ -8,21 +7,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd51_256
   - name: ATSAMD51G19A
@@ -31,21 +32,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd51_512
   - name: ATSAMD51J18A
@@ -54,21 +57,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd51_256
   - name: ATSAMD51J19A
@@ -77,21 +82,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd51_512
   - name: ATSAMD51J20A
@@ -100,21 +107,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 1048576
+            start: 0x0
+            end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd51_1024
   - name: ATSAMD51N19A
@@ -123,21 +132,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd51_512
   - name: ATSAMD51N20A
@@ -146,21 +157,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 1048576
+            start: 0x0
+            end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd51_1024
   - name: ATSAMD51P19A
@@ -169,21 +182,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd51_512
   - name: ATSAMD51P20A
@@ -192,90 +207,92 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 1048576
+            start: 0x0
+            end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsamd51_1024
 flash_algorithms:
-  atsamd51_256:
-    name: atsamd51_256
+  - name: atsamd51_256
     description: ATSAMD51 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 37
-    pc_program_page: 81
-    pc_erase_sector: 41
-    pc_erase_all: ~
-    data_section_offset: 160
+    pc_init: 0x1
+    pc_uninit: 0x25
+    pc_program_page: 0x51
+    pc_erase_sector: 0x29
+    pc_erase_all: null
+    data_section_offset: 0xa0
     flash_properties:
       address_range:
-        start: 0
-        end: 262144
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x40000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsamd51_512:
-    name: atsamd51_512
+        - size: 0x2000
+          address: 0x0
+  - name: atsamd51_512
     description: ATSAMD51 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 37
-    pc_program_page: 81
-    pc_erase_sector: 41
-    pc_erase_all: ~
-    data_section_offset: 160
+    pc_init: 0x1
+    pc_uninit: 0x25
+    pc_program_page: 0x51
+    pc_erase_sector: 0x29
+    pc_erase_all: null
+    data_section_offset: 0xa0
     flash_properties:
       address_range:
-        start: 0
-        end: 524288
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x80000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsamd51_1024:
-    name: atsamd51_1024
+        - size: 0x2000
+          address: 0x0
+  - name: atsamd51_1024
     description: ATSAMD51 1024kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 37
-    pc_program_page: 81
-    pc_erase_sector: 41
-    pc_erase_all: ~
-    data_section_offset: 160
+    pc_init: 0x1
+    pc_uninit: 0x25
+    pc_program_page: 0x51
+    pc_erase_sector: 0x29
+    pc_erase_all: null
+    data_section_offset: 0xa0
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/SAME51.yaml
+++ b/probe-rs/targets/SAME51.yaml
@@ -1,4 +1,3 @@
----
 name: SAME51
 variants:
   - name: ATSAME51G18A
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms: []
   - name: ATSAME51G19A
     cores:
@@ -29,21 +30,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms: []
   - name: ATSAME51J18A
     cores:
@@ -51,21 +54,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame51_256
   - name: ATSAME51J19A
@@ -74,21 +79,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame51_512
   - name: ATSAME51J20A
@@ -97,21 +104,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 1048576
+            start: 0x0
+            end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame51_1024
   - name: ATSAME51N19A
@@ -120,21 +129,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame51_512
   - name: ATSAME51N20A
@@ -143,90 +154,92 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 1048576
+            start: 0x0
+            end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame51_1024
 flash_algorithms:
-  atsame51_256:
-    name: atsame51_256
+  - name: atsame51_256
     description: ATSAME51 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 37
-    pc_program_page: 81
-    pc_erase_sector: 41
-    pc_erase_all: ~
-    data_section_offset: 160
+    pc_init: 0x1
+    pc_uninit: 0x25
+    pc_program_page: 0x51
+    pc_erase_sector: 0x29
+    pc_erase_all: null
+    data_section_offset: 0xa0
     flash_properties:
       address_range:
-        start: 0
-        end: 262144
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x40000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsame51_512:
-    name: atsame51_512
+        - size: 0x2000
+          address: 0x0
+  - name: atsame51_512
     description: ATSAME51 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 37
-    pc_program_page: 81
-    pc_erase_sector: 41
-    pc_erase_all: ~
-    data_section_offset: 160
+    pc_init: 0x1
+    pc_uninit: 0x25
+    pc_program_page: 0x51
+    pc_erase_sector: 0x29
+    pc_erase_all: null
+    data_section_offset: 0xa0
     flash_properties:
       address_range:
-        start: 0
-        end: 524288
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x80000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsame51_1024:
-    name: atsame51_1024
+        - size: 0x2000
+          address: 0x0
+  - name: atsame51_1024
     description: ATSAME51 1024kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 37
-    pc_program_page: 81
-    pc_erase_sector: 41
-    pc_erase_all: ~
-    data_section_offset: 160
+    pc_init: 0x1
+    pc_uninit: 0x25
+    pc_program_page: 0x51
+    pc_erase_sector: 0x29
+    pc_erase_all: null
+    data_section_offset: 0xa0
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/SAME53.yaml
+++ b/probe-rs/targets/SAME53.yaml
@@ -1,4 +1,3 @@
----
 name: SAME53
 variants:
   - name: ATSAME53J18A
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame53_256
   - name: ATSAME53J19A
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame53_512
   - name: ATSAME53J20A
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 1048576
+            start: 0x0
+            end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame53_1024
   - name: ATSAME53N19A
@@ -76,21 +81,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame53_512
   - name: ATSAME53N20A
@@ -99,90 +106,92 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 1048576
+            start: 0x0
+            end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame53_1024
 flash_algorithms:
-  atsame53_256:
-    name: atsame53_256
+  - name: atsame53_256
     description: ATSAME53 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 37
-    pc_program_page: 81
-    pc_erase_sector: 41
-    pc_erase_all: ~
-    data_section_offset: 160
+    pc_init: 0x1
+    pc_uninit: 0x25
+    pc_program_page: 0x51
+    pc_erase_sector: 0x29
+    pc_erase_all: null
+    data_section_offset: 0xa0
     flash_properties:
       address_range:
-        start: 0
-        end: 262144
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x40000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsame53_512:
-    name: atsame53_512
+        - size: 0x2000
+          address: 0x0
+  - name: atsame53_512
     description: ATSAME53 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 37
-    pc_program_page: 81
-    pc_erase_sector: 41
-    pc_erase_all: ~
-    data_section_offset: 160
+    pc_init: 0x1
+    pc_uninit: 0x25
+    pc_program_page: 0x51
+    pc_erase_sector: 0x29
+    pc_erase_all: null
+    data_section_offset: 0xa0
     flash_properties:
       address_range:
-        start: 0
-        end: 524288
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x80000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsame53_1024:
-    name: atsame53_1024
+        - size: 0x2000
+          address: 0x0
+  - name: atsame53_1024
     description: ATSAME53 1024kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 37
-    pc_program_page: 81
-    pc_erase_sector: 41
-    pc_erase_all: ~
-    data_section_offset: 160
+    pc_init: 0x1
+    pc_uninit: 0x25
+    pc_program_page: 0x51
+    pc_erase_sector: 0x29
+    pc_erase_all: null
+    data_section_offset: 0xa0
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/SAME54.yaml
+++ b/probe-rs/targets/SAME54.yaml
@@ -1,4 +1,3 @@
----
 name: SAME54
 variants:
   - name: ATSAME54N19A
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame54_512
   - name: ATSAME54N20A
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 1048576
+            start: 0x0
+            end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame54_1024
   - name: ATSAME54P19A
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 524288
+            start: 0x0
+            end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame54_512
   - name: ATSAME54P20A
@@ -76,67 +81,69 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 1048576
+            start: 0x0
+            end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame54_1024
 flash_algorithms:
-  atsame54_512:
-    name: atsame54_512
+  - name: atsame54_512
     description: ATSAME54 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 37
-    pc_program_page: 81
-    pc_erase_sector: 41
-    pc_erase_all: ~
-    data_section_offset: 160
+    pc_init: 0x1
+    pc_uninit: 0x25
+    pc_program_page: 0x51
+    pc_erase_sector: 0x29
+    pc_erase_all: null
+    data_section_offset: 0xa0
     flash_properties:
       address_range:
-        start: 0
-        end: 524288
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x80000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsame54_1024:
-    name: atsame54_1024
+        - size: 0x2000
+          address: 0x0
+  - name: atsame54_1024
     description: ATSAME54 1024kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 37
-    pc_program_page: 81
-    pc_erase_sector: 41
-    pc_erase_all: ~
-    data_section_offset: 160
+    pc_init: 0x1
+    pc_uninit: 0x25
+    pc_program_page: 0x51
+    pc_erase_sector: 0x29
+    pc_erase_all: null
+    data_section_offset: 0xa0
     flash_properties:
       address_range:
-        start: 0
-        end: 1048576
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x0
+        end: 0x100000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/SAME70.yaml
+++ b/probe-rs/targets/SAME70.yaml
@@ -1,4 +1,3 @@
----
 name: SAME70
 variants:
   - name: ATSAME70J19
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541327360
+            start: 0x20400000
+            end: 0x20440000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_512
       - atsame7x_gpnvm
@@ -31,21 +32,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541327360
+            start: 0x20400000
+            end: 0x20440000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_512
       - atsame7x_gpnvm
@@ -55,21 +58,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541458432
+            start: 0x20400000
+            end: 0x20460000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_1024
       - atsame7x_gpnvm
@@ -79,21 +84,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541458432
+            start: 0x20400000
+            end: 0x20460000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_1024
       - atsame7x_gpnvm
@@ -103,21 +110,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541458432
+            start: 0x20400000
+            end: 0x20460000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 6291456
+            start: 0x400000
+            end: 0x600000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_2048
       - atsame7x_gpnvm
@@ -127,21 +136,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541458432
+            start: 0x20400000
+            end: 0x20460000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 6291456
+            start: 0x400000
+            end: 0x600000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_2048
       - atsame7x_gpnvm
@@ -151,21 +162,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541327360
+            start: 0x20400000
+            end: 0x20440000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_512
       - atsame7x_gpnvm
@@ -175,21 +188,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541327360
+            start: 0x20400000
+            end: 0x20440000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_512
       - atsame7x_gpnvm
@@ -199,21 +214,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541458432
+            start: 0x20400000
+            end: 0x20460000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_1024
       - atsame7x_gpnvm
@@ -223,21 +240,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541458432
+            start: 0x20400000
+            end: 0x20460000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_1024
       - atsame7x_gpnvm
@@ -247,21 +266,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541458432
+            start: 0x20400000
+            end: 0x20460000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 6291456
+            start: 0x400000
+            end: 0x600000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_2048
       - atsame7x_gpnvm
@@ -271,21 +292,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541458432
+            start: 0x20400000
+            end: 0x20460000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 6291456
+            start: 0x400000
+            end: 0x600000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_2048
       - atsame7x_gpnvm
@@ -295,21 +318,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541327360
+            start: 0x20400000
+            end: 0x20440000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_512
       - atsame7x_gpnvm
@@ -319,21 +344,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541327360
+            start: 0x20400000
+            end: 0x20440000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 4718592
+            start: 0x400000
+            end: 0x480000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_512
       - atsame7x_gpnvm
@@ -343,21 +370,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541458432
+            start: 0x20400000
+            end: 0x20460000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_1024
       - atsame7x_gpnvm
@@ -367,21 +396,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541458432
+            start: 0x20400000
+            end: 0x20460000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 5242880
+            start: 0x400000
+            end: 0x500000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_1024
       - atsame7x_gpnvm
@@ -391,21 +422,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541458432
+            start: 0x20400000
+            end: 0x20460000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 6291456
+            start: 0x400000
+            end: 0x600000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_2048
       - atsame7x_gpnvm
@@ -415,114 +448,116 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 541065216
-            end: 541458432
+            start: 0x20400000
+            end: 0x20460000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 4194304
-            end: 6291456
+            start: 0x400000
+            end: 0x600000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - atsame7x_2048
       - atsame7x_gpnvm
 flash_algorithms:
-  atsame7x_512:
-    name: atsame7x_512
+  - name: atsame7x_512
     description: ATSAME7x 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVdSUlECGBdSVxISGIPIFtJAALAOQhgASBaScADSGFYScAxSGBZS1dIWGJXSsA6EGuACIAAQBwQY1RIgDiBagkH/NURa3AkoUMRY4FqCQf81RFqTk0pQxFigWqJA/zVEWqhQ0pMGDQhQxFiEWrkBKFDNyQkBCFDEWKBaskD/NURa4kIiQBJHBFjgWoJB/zVASERY4FqCQf81TtIQBxYYgAgML0CKBHRNUg6ScA4QWCBaMkH/NDBaIkHB9Q1Sf4xQWAA4AC/gWjJB/vQK0gsSUAcSGIAIHBHLkkpSAg5wDhBYADgAL+BaMkH+9AAIHBHIUojSUpEEmjAOYAaQAqACIAAgBwABAIKIkgAHxBDSGAA4AC/iGjAB/vQHkiAHwJDSmAA4AC/iGjAB/vQiGgAB0APANABIHBHMLUPSRBLSUQJaMA7QRpMClkVIMoJHyDAACn60SAED0kACgw5CENYYADgAL+YaMAH+9CYaAAHQA8A0AEgML0AAAQAAAAAQ0ZFwAwOQEAYDkAAQ01QwAYOQAgANwANAABaAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 165
-    pc_program_page: 313
-    pc_erase_sector: 241
-    pc_erase_all: 217
-    data_section_offset: 408
+    pc_init: 0x1
+    pc_uninit: 0xa5
+    pc_program_page: 0x139
+    pc_erase_sector: 0xf1
+    pc_erase_all: 0xd9
+    data_section_offset: 0x198
     flash_properties:
       address_range:
-        start: 4194304
-        end: 4718592
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x480000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsame7x_1024:
-    name: atsame7x_1024
+        - size: 0x2000
+          address: 0x0
+  - name: atsame7x_1024
     description: ATSAME7x 1024kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVdSUlECGBdSVxISGIPIFtJAALAOQhgASBaScADSGFYScAxSGBZS1dIWGJXSsA6EGuACIAAQBwQY1RIgDiBagkH/NURa3AkoUMRY4FqCQf81RFqTk0pQxFigWqJA/zVEWqhQ0pMGDQhQxFiEWrkBKFDNyQkBCFDEWKBaskD/NURa4kIiQBJHBFjgWoJB/zVASERY4FqCQf81TtIQBxYYgAgML0CKBHRNUg6ScA4QWCBaMkH/NDBaIkHB9Q1Sf4xQWAA4AC/gWjJB/vQK0gsSUAcSGIAIHBHLkkpSAg5wDhBYADgAL+BaMkH+9AAIHBHIUojSUpEEmjAOYAaQAqACIAAgBwABAIKIkgAHxBDSGAA4AC/iGjAB/vQHkiAHwJDSmAA4AC/iGjAB/vQiGgAB0APANABIHBHMLUPSRBLSUQJaMA7QRpMClkVIMoJHyDAACn60SAED0kACgw5CENYYADgAL+YaMAH+9CYaAAHQA8A0AEgML0AAAQAAAAAQ0ZFwAwOQEAYDkAAQ01QwAYOQAgANwANAABaAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 165
-    pc_program_page: 313
-    pc_erase_sector: 241
-    pc_erase_all: 217
-    data_section_offset: 408
+    pc_init: 0x1
+    pc_uninit: 0xa5
+    pc_program_page: 0x139
+    pc_erase_sector: 0xf1
+    pc_erase_all: 0xd9
+    data_section_offset: 0x198
     flash_properties:
       address_range:
-        start: 4194304
-        end: 5242880
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x500000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsame7x_2048:
-    name: atsame7x_2048
+        - size: 0x2000
+          address: 0x0
+  - name: atsame7x_2048
     description: ATSAME7x 2048kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: MLVdSUlECGBdSVxISGIPIFtJAALAOQhgASBaScADSGFYScAxSGBZS1dIWGJXSsA6EGuACIAAQBwQY1RIgDiBagkH/NURa3AkoUMRY4FqCQf81RFqTk0pQxFigWqJA/zVEWqhQ0pMGDQhQxFiEWrkBKFDNyQkBCFDEWKBaskD/NURa4kIiQBJHBFjgWoJB/zVASERY4FqCQf81TtIQBxYYgAgML0CKBHRNUg6ScA4QWCBaMkH/NDBaIkHB9Q1Sf4xQWAA4AC/gWjJB/vQK0gsSUAcSGIAIHBHLkkpSAg5wDhBYADgAL+BaMkH+9AAIHBHIUojSUpEEmjAOYAaQAqACIAAgBwABAIKIkgAHxBDSGAA4AC/iGjAB/vQHkiAHwJDSmAA4AC/iGjAB/vQiGgAB0APANABIHBHMLUPSRBLSUQJaMA7QRpMClkVIMoJHyDAACn60SAED0kACgw5CENYYADgAL+YaMAH+9CYaAAHQA8A0AEgML0AAAQAAAAAQ0ZFwAwOQEAYDkAAQ01QwAYOQAgANwANAABaAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 165
-    pc_program_page: 313
-    pc_erase_sector: 241
-    pc_erase_all: 217
-    data_section_offset: 408
+    pc_init: 0x1
+    pc_uninit: 0xa5
+    pc_program_page: 0x139
+    pc_erase_sector: 0xf1
+    pc_erase_all: 0xd9
+    data_section_offset: 0x198
     flash_properties:
       address_range:
-        start: 4194304
-        end: 6291456
-      page_size: 512
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x400000
+        end: 0x600000
+      page_size: 0x200
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 8192
-          address: 0
-  atsame7x_gpnvm:
-    name: atsame7x_gpnvm
+        - size: 0x2000
+          address: 0x0
+  - name: atsame7x_gpnvm
     description: ATSAME7x GPNVM bits
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: MLWASUlECGCASX9ISGIPIH5JAALAOQhgASB9ScADSGF7ScAxSGB8S3pIWGJ6SsA6EGuACIAAQBwQY3dIgDiBagkH/NURa3AkoUMRY4FqCQf81RFqcU0pQxFigWqJA/zVEWqhQ21MGDQhQxFiEWrkBKFDNyQkBCFDEWKBaskD/NURa4kIiQBJHBFjgWoJB/zVASERY4FqCQf81V5IQBxYYgAgML1YSFlJQBxIYgAgcEcAIHBHACBwR1JKVElKRBJowDmAGkAKgAiAAIAcAAQCClNIEENIYADgAL+IaMAH+9BPSIAeAkNKYADgAL+IaMAH+9CIaAAHQA8A0AEgcEcQtRBoR0pBSRIdwDlKYIpo0gf80MpowwfUB9sP5A+jQgzQwwcC0D5LmxwB4D1L2xxLYADgAL+LaNsH+9ACIwRGHEATQJxCC9CDBwHVNksB4DVLWxxLYADgAL+LaNsH+9CAIwRGHEATQJxCC9ADBgHVLksB4C1LWxxLYADgAL+LaNsH+9D/IwEzBEYcQBpAlEIL0MAFAdUlSAHgJEhAHEhgAOAAv4howAf70AAgEL0wtRxMFkskHRJowDtcYJxo5Af80Nto1AfdB+QP7Q+sQgbRAiQVRiVAHEClQgHQQBwwvYAkFUYlQBxApUIB0MAdML3/JAE0IkAjQJpCAdAIMDC9QBgwvQAABAAAAABDRkXADA5AQBgOQABDTVDABg5ACAA3AAkAAFoLAQBaCwcAWgsIAFoAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 165
-    pc_program_page: 255
-    pc_erase_sector: 185
-    pc_erase_all: 181
-    data_section_offset: 560
+    pc_init: 0x1
+    pc_uninit: 0xa5
+    pc_program_page: 0xff
+    pc_erase_sector: 0xb9
+    pc_erase_all: 0xb5
+    data_section_offset: 0x230
     flash_properties:
       address_range:
-        start: 536870896
-        end: 536870912
-      page_size: 16
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 1000
+        start: 0x1ffffff0
+        end: 0x20000000
+      page_size: 0x10
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x3e8
       sectors:
-        - size: 16
-          address: 0
+        - size: 0x10
+          address: 0x0

--- a/probe-rs/targets/STM32F0_Series.yaml
+++ b/probe-rs/targets/STM32F0_Series.yaml
@@ -1,4 +1,3 @@
----
 name: STM32F0 Series
 variants:
   - name: STM32F030C6Tx
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -31,21 +32,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -55,21 +58,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -79,21 +84,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -103,21 +110,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -127,21 +136,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -151,21 +162,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -175,21 +188,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -199,21 +214,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -223,21 +240,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -247,21 +266,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -271,21 +292,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -295,21 +318,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -319,21 +344,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -343,21 +370,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -367,21 +396,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -391,21 +422,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -415,21 +448,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -439,21 +474,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -463,21 +500,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -487,21 +526,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -511,21 +552,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -535,21 +578,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -559,21 +604,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -583,21 +630,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -607,21 +656,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -631,21 +682,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -655,21 +708,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -679,21 +734,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -703,21 +760,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -727,21 +786,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -751,21 +812,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -775,21 +838,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -799,21 +864,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -823,21 +890,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -847,21 +916,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -871,21 +942,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -895,21 +968,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -919,21 +994,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -943,21 +1020,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -967,21 +1046,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -991,21 +1072,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -1015,21 +1098,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1039,21 +1124,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1063,21 +1150,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -1087,21 +1176,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -1111,21 +1202,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -1135,21 +1228,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -1159,21 +1254,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1183,21 +1280,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1207,21 +1306,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_16
       - stm32f0xx_opt
@@ -1231,21 +1332,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -1255,21 +1358,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1279,21 +1384,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1303,21 +1410,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1327,21 +1436,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1351,21 +1462,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1375,21 +1488,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1399,21 +1514,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1423,21 +1540,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -1447,21 +1566,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1471,21 +1592,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_32
       - stm32f0xx_opt
@@ -1495,21 +1618,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1519,21 +1644,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1543,21 +1670,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1567,21 +1696,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1591,21 +1722,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1615,21 +1748,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1639,21 +1774,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1663,21 +1800,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1687,21 +1826,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1711,21 +1852,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1735,21 +1878,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1759,21 +1904,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1783,21 +1930,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1807,21 +1956,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1831,21 +1982,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1855,21 +2008,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1879,21 +2034,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1903,21 +2060,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1927,21 +2086,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1951,21 +2112,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -1975,21 +2138,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -1999,21 +2164,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_64
       - stm32f0xx_opt
@@ -2023,21 +2190,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2047,21 +2216,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2071,21 +2242,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2095,21 +2268,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2119,21 +2294,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2143,21 +2320,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2167,21 +2346,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2191,21 +2372,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2215,21 +2398,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2239,21 +2424,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2263,21 +2450,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2287,21 +2476,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2311,21 +2502,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2335,21 +2528,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2359,21 +2554,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2383,21 +2580,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2407,21 +2606,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2431,21 +2632,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_128
       - stm32f0xx_opt
@@ -2455,21 +2658,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2479,21 +2684,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2503,21 +2710,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2527,21 +2736,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2551,21 +2762,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2575,21 +2788,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2599,21 +2814,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2623,21 +2840,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
@@ -2647,160 +2866,162 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f0xx_256
       - stm32f0xx_opt
 flash_algorithms:
-  stm32f0xx_256:
-    name: stm32f0xx_256
+  - name: stm32f0xx_256
     description: STM32F0xx 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RkhFSUFgRklBYAAhAWDBaBQiEUPBYMBpQAcG1EJIQUkBYAYhQWBBSYFgACBwRztIAWmAIhFDAWEAIHBHMLU3SMFoFCQhQ8FgAWkEJSlDAWEBaUAiEUMBYTVJM0oA4BFgw2jbB/vRAWmpQwFhwWghQgTQwWghQ8FgASAwvQAgML0wtSZJymgUIxpDymAKaQIkIkMKYUhhCGlAIhBDCGEkSCFKAOAQYM1o7Qf70QhpoEMIYchoGEAD0MhoGEPIYAEgML3wtRVNSRxJCOtoSQAEJCND62AUJxZMGuAraQEmM0MrYROIA4AQSwDgHGDuaPYH+9EraVsIWwArYetoO0IE0OhoOEPoYAEg8L2AHIkekhwAKeLRACDwvSMBZ0UAIAJAq4nvzVVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 47
-    pc_program_page: 195
-    pc_erase_sector: 129
-    pc_erase_all: 61
-    data_section_offset: 308
+    pc_init: 0x1
+    pc_uninit: 0x2f
+    pc_program_page: 0xc3
+    pc_erase_sector: 0x81
+    pc_erase_all: 0x3d
+    data_section_offset: 0x134
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134479872
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8040000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 1024
-          address: 0
-  stm32f0xx_opt:
-    name: stm32f0xx_opt
+        - size: 0x400
+          address: 0x0
+  - name: stm32f0xx_opt
     description: STM32F0xx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: U0hSSkJgU0lBYIJggWAAIQFgwWgUIhFDwWDAaUAHBtROSE1JAWAGIUFgTUmBYAAgcEdHSAFpgCIRQwFhAWmCFZFDAWEAIHBHcLVBSMFoFCMZQ8FgAWkgJCFDAWEBaUAiEUMBYT9JPUoA4BFgxWjtB/vRBWmlQwVhBWkQJCVDBWE1TTlOVTU1gADgEWDFaO0H+9EBaaFDAWHBaBlCBNDBaBlDwWABIHC9ACBwvTC1KEjBaBQkIUPBYAFpICUpQwFhAWlAIhFDAWEmSSRKAOARYMNo2wf70QFpqUMBYcFoIUIE0MFoIUPBYAEgML0AIDC9ASBwR/C1Fk1JHEkI62hJAAQkI0PrYBAmFksa4CxpNEMsYRSIBIARTADgI2DvaP8H+9EsabRDLGHsaBQnPEIF0OhoFCEIQ+hgASDwvYAckhyJHgAp4tEAIPC9AAAjAWdFACACQKuJ781VVQAAADAAQP8PAACqqgAAAPj/HwAAAAA=
-    pc_init: 1
-    pc_uninit: 51
-    pc_program_page: 245
-    pc_erase_sector: 173
-    pc_erase_all: 73
-    data_section_offset: 364
+    pc_init: 0x1
+    pc_uninit: 0x33
+    pc_program_page: 0xf5
+    pc_erase_sector: 0xad
+    pc_erase_all: 0x49
+    data_section_offset: 0x16c
     flash_properties:
       address_range:
-        start: 536868864
-        end: 536868880
-      page_size: 16
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ffff800
+        end: 0x1ffff810
+      page_size: 0x10
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 16
-          address: 0
-  stm32f0xx_16:
-    name: stm32f0xx_16
+        - size: 0x10
+          address: 0x0
+  - name: stm32f0xx_16
     description: STM32F0xx 16kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RkhFSUFgRklBYAAhAWDBaBQiEUPBYMBpQAcG1EJIQUkBYAYhQWBBSYFgACBwRztIAWmAIhFDAWEAIHBHMLU3SMFoFCQhQ8FgAWkEJSlDAWEBaUAiEUMBYTVJM0oA4BFgw2jbB/vRAWmpQwFhwWghQgTQwWghQ8FgASAwvQAgML0wtSZJymgUIxpDymAKaQIkIkMKYUhhCGlAIhBDCGEkSCFKAOAQYM1o7Qf70QhpoEMIYchoGEAD0MhoGEPIYAEgML3wtRVNSRxJCOtoSQAEJCND62AUJxZMGuAraQEmM0MrYROIA4AQSwDgHGDuaPYH+9EraVsIWwArYetoO0IE0OhoOEPoYAEg8L2AHJIciR4AKeLRACDwvSMBZ0UAIAJAq4nvzVVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 47
-    pc_program_page: 195
-    pc_erase_sector: 129
-    pc_erase_all: 61
-    data_section_offset: 308
+    pc_init: 0x1
+    pc_uninit: 0x2f
+    pc_program_page: 0xc3
+    pc_erase_sector: 0x81
+    pc_erase_all: 0x3d
+    data_section_offset: 0x134
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134234112
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8004000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 1024
-          address: 0
-  stm32f0xx_128:
-    name: stm32f0xx_128
+        - size: 0x400
+          address: 0x0
+  - name: stm32f0xx_128
     description: STM32F0xx 128kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RkhFSUFgRklBYAAhAWDBaBQiEUPBYMBpQAcG1EJIQUkBYAYhQWBBSYFgACBwRztIAWmAIhFDAWEAIHBHMLU3SMFoFCQhQ8FgAWkEJSlDAWEBaUAiEUMBYTVJM0oA4BFgw2jbB/vRAWmpQwFhwWghQgTQwWghQ8FgASAwvQAgML0wtSZJymgUIxpDymAKaQIkIkMKYUhhCGlAIhBDCGEkSCFKAOAQYM1o7Qf70QhpoEMIYchoGEAD0MhoGEPIYAEgML3wtRVNSRxJCOtoSQAEJCND62AUJxZMGuAraQEmM0MrYROIA4AQSwDgHGDuaPYH+9EraVsIWwArYetoO0IE0OhoOEPoYAEg8L2AHJIciR4AKeLRACDwvSMBZ0UAIAJAq4nvzVVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 47
-    pc_program_page: 195
-    pc_erase_sector: 129
-    pc_erase_all: 61
-    data_section_offset: 308
+    pc_init: 0x1
+    pc_uninit: 0x2f
+    pc_program_page: 0xc3
+    pc_erase_sector: 0x81
+    pc_erase_all: 0x3d
+    data_section_offset: 0x134
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134348800
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8020000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 1024
-          address: 0
-  stm32f0xx_64:
-    name: stm32f0xx_64
+        - size: 0x400
+          address: 0x0
+  - name: stm32f0xx_64
     description: STM32F0xx 64kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RkhFSUFgRklBYAAhAWDBaBQiEUPBYMBpQAcG1EJIQUkBYAYhQWBBSYFgACBwRztIAWmAIhFDAWEAIHBHMLU3SMFoFCQhQ8FgAWkEJSlDAWEBaUAiEUMBYTVJM0oA4BFgw2jbB/vRAWmpQwFhwWghQgTQwWghQ8FgASAwvQAgML0wtSZJymgUIxpDymAKaQIkIkMKYUhhCGlAIhBDCGEkSCFKAOAQYM1o7Qf70QhpoEMIYchoGEAD0MhoGEPIYAEgML3wtRVNSRxJCOtoSQAEJCND62AUJxZMGuAraQEmM0MrYROIA4AQSwDgHGDuaPYH+9EraVsIWwArYetoO0IE0OhoOEPoYAEg8L2AHJIciR4AKeLRACDwvSMBZ0UAIAJAq4nvzVVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 47
-    pc_program_page: 195
-    pc_erase_sector: 129
-    pc_erase_all: 61
-    data_section_offset: 308
+    pc_init: 0x1
+    pc_uninit: 0x2f
+    pc_program_page: 0xc3
+    pc_erase_sector: 0x81
+    pc_erase_all: 0x3d
+    data_section_offset: 0x134
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134283264
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8010000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 1024
-          address: 0
-  stm32f0xx_32:
-    name: stm32f0xx_32
+        - size: 0x400
+          address: 0x0
+  - name: stm32f0xx_32
     description: STM32F0xx 32kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: RkhFSUFgRklBYAAhAWDBaBQiEUPBYMBpQAcG1EJIQUkBYAYhQWBBSYFgACBwRztIAWmAIhFDAWEAIHBHMLU3SMFoFCQhQ8FgAWkEJSlDAWEBaUAiEUMBYTVJM0oA4BFgw2jbB/vRAWmpQwFhwWghQgTQwWghQ8FgASAwvQAgML0wtSZJymgUIxpDymAKaQIkIkMKYUhhCGlAIhBDCGEkSCFKAOAQYM1o7Qf70QhpoEMIYchoGEAD0MhoGEPIYAEgML3wtRVNSRxJCOtoSQAEJCND62AUJxZMGuAraQEmM0MrYROIA4AQSwDgHGDuaPYH+9EraVsIWwArYetoO0IE0OhoOEPoYAEg8L2AHJIciR4AKeLRACDwvSMBZ0UAIAJAq4nvzVVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 47
-    pc_program_page: 195
-    pc_erase_sector: 129
-    pc_erase_all: 61
-    data_section_offset: 308
+    pc_init: 0x1
+    pc_uninit: 0x2f
+    pc_program_page: 0xc3
+    pc_erase_sector: 0x81
+    pc_erase_all: 0x3d
+    data_section_offset: 0x134
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134250496
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8008000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 1024
-          address: 0
+        - size: 0x400
+          address: 0x0

--- a/probe-rs/targets/STM32F1_Series.yaml
+++ b/probe-rs/targets/STM32F1_Series.yaml
@@ -1,4 +1,3 @@
----
 name: STM32F1 Series
 variants:
   - name: STM32F100C4
@@ -7,21 +6,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_16
       - stm32f10x_opt
@@ -31,21 +32,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -55,21 +58,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -79,21 +84,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -103,21 +110,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_16
       - stm32f10x_opt
@@ -127,21 +136,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -151,21 +162,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -175,21 +188,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -199,21 +214,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -223,21 +240,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -247,21 +266,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -271,21 +292,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -295,21 +318,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -319,21 +344,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -343,21 +370,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -367,21 +396,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -391,21 +422,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -415,21 +448,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -439,21 +474,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -463,21 +500,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_16
       - stm32f10x_opt
@@ -487,21 +526,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -511,21 +552,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -535,21 +578,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -559,21 +604,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_16
       - stm32f10x_opt
@@ -583,21 +630,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -607,21 +656,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -631,21 +682,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -655,21 +708,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -679,21 +734,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -703,21 +760,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -727,21 +786,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_1024
       - stm32f10x_opt
@@ -751,21 +812,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_1024
       - stm32f10x_opt
@@ -775,21 +838,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_16
       - stm32f10x_opt
@@ -799,21 +864,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -823,21 +890,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -847,21 +916,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -871,21 +942,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -895,21 +968,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -919,21 +994,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -943,21 +1020,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -967,21 +1046,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -991,21 +1072,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_1024
       - stm32f10x_opt
@@ -1015,21 +1098,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_1024
       - stm32f10x_opt
@@ -1039,21 +1124,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -1063,21 +1150,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -1087,21 +1176,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -1111,21 +1202,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_1024
       - stm32f10x_opt
@@ -1135,21 +1228,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_1024
       - stm32f10x_opt
@@ -1159,21 +1254,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_16
       - stm32f10x_opt
@@ -1183,21 +1280,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1207,21 +1306,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1231,21 +1332,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1255,21 +1358,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_16
       - stm32f10x_opt
@@ -1279,21 +1384,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1303,21 +1410,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1327,21 +1436,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1351,21 +1462,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_16
       - stm32f10x_opt
@@ -1375,21 +1488,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1399,21 +1514,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1423,21 +1540,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1447,21 +1566,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_16
       - stm32f10x_opt
@@ -1471,21 +1592,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1495,21 +1618,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1519,21 +1644,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1543,21 +1670,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -1567,21 +1696,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -1591,21 +1722,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -1615,21 +1748,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_1024
       - stm32f10x_opt
@@ -1639,21 +1774,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_1024
       - stm32f10x_opt
@@ -1663,21 +1800,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536877056
+            start: 0x20000000
+            end: 0x20001800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_16
       - stm32f10x_opt
@@ -1687,21 +1826,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1711,21 +1852,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1735,21 +1878,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1759,21 +1904,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1783,21 +1930,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_128
       - stm32f10x_opt
@@ -1807,21 +1956,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -1831,21 +1982,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -1855,21 +2008,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -1879,21 +2034,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_1024
       - stm32f10x_opt
@@ -1903,21 +2060,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_1024
       - stm32f10x_opt
@@ -1927,21 +2086,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -1951,21 +2112,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -1975,21 +2138,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_512
       - stm32f10x_opt
@@ -1999,21 +2164,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_1024
       - stm32f10x_opt
@@ -2023,21 +2190,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_1024
       - stm32f10x_opt
@@ -2047,21 +2216,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_cl
       - stm32f10x_opt
@@ -2071,21 +2242,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_cl
       - stm32f10x_opt
@@ -2095,21 +2268,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_cl
       - stm32f10x_opt
@@ -2119,21 +2294,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_cl
       - stm32f10x_opt
@@ -2143,21 +2320,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_cl
       - stm32f10x_opt
@@ -2167,21 +2346,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_cl
       - stm32f10x_opt
@@ -2191,21 +2372,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_cl
       - stm32f10x_opt
@@ -2215,21 +2398,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_cl
       - stm32f10x_opt
@@ -2239,21 +2424,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_cl
       - stm32f10x_opt
@@ -2263,160 +2450,162 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f10x_cl
       - stm32f10x_opt
 flash_algorithms:
-  stm32f10x_512:
-    name: stm32f10x_512
+  - name: stm32f10x_512
     description: STM32F10x High-density Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRgAgREwgYERIYGBESGBgIEbAaRDwBA8I0UXyVVBATCBgBiBgYED2/3CgYAAgEL0BRjhIAGlA8IAANkoQYQAgcEc0SABpQPAEADJJCGEIRgBpQPBAAAhhA+BK9qogMEkIYCxIwGgQ8AEP9tEqSABpIPAEAChJCGEAIHBHAUYlSABpQPACACNKEGEQRkFhAGlA8EAAEGED4Er2qiAhShBgHUjAaBDwAQ/20RpIAGkg8AIAGEoQYQAgcEcQtQNGSBwg8AEBIuATSABpQPABABFMIGEQiBiAAL8PSMBoEPABD/rRDEgAaSDwAQAKTCBhIEbAaBDwFA8G0CBGwGhA8BQA4GABIBC9mxySHIkeACna0QAg9+cAAAAgAkAjAWdFq4nvzQAwAEAAAAAA
-    pc_init: 1
-    pc_uninit: 51
-    pc_program_page: 189
-    pc_erase_sector: 127
-    pc_erase_all: 69
-    data_section_offset: 296
+    pc_init: 0x1
+    pc_uninit: 0x33
+    pc_program_page: 0xbd
+    pc_erase_sector: 0x7f
+    pc_erase_all: 0x45
+    data_section_offset: 0x128
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134742016
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8080000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 2048
-          address: 0
-  stm32f10x_128:
-    name: stm32f10x_128
+        - size: 0x800
+          address: 0x0
+  - name: stm32f10x_128
     description: STM32F10x Med-density Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRgAgREwgYERIYGBESGBgIEbAaRDwBA8I0UXyVVBATCBgBiBgYED2/3CgYAAgEL0BRjhIAGlA8IAANkoQYQAgcEc0SABpQPAEADJJCGEIRgBpQPBAAAhhA+BK9qogMEkIYCxIwGgQ8AEP9tEqSABpIPAEAChJCGEAIHBHAUYlSABpQPACACNKEGEQRkFhAGlA8EAAEGED4Er2qiAhShBgHUjAaBDwAQ/20RpIAGkg8AIAGEoQYQAgcEcQtQNGSBwg8AEBIuATSABpQPABABFMIGEQiBiAAL8PSMBoEPABD/rRDEgAaSDwAQAKTCBhIEbAaBDwFA8G0CBGwGhA8BQA4GABIBC9mxySHIkeACna0QAg9+cAAAAgAkAjAWdFq4nvzQAwAEAAAAAA
-    pc_init: 1
-    pc_uninit: 51
-    pc_program_page: 189
-    pc_erase_sector: 127
-    pc_erase_all: 69
-    data_section_offset: 296
+    pc_init: 0x1
+    pc_uninit: 0x33
+    pc_program_page: 0xbd
+    pc_erase_sector: 0x7f
+    pc_erase_all: 0x45
+    data_section_offset: 0x128
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134348800
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8020000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 1024
-          address: 0
-  stm32f10x_opt:
-    name: stm32f10x_opt
+        - size: 0x400
+          address: 0x0
+  - name: stm32f10x_opt
     description: STM32F10x Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ELUDRgAgXkwgYF5IYGBeSGBgXEigYFxIoGAgRsBpEPAEDwjRRfJVUFhMIGAGIGBgQPb/cKBgACAQvQFGUEgAaSD0gHBOShBhEEYAaUDwgAAQYQAgcEdKSABpQPAgAEhJCGEIRgBpQPBAAAhhA+BK9qogRkkIYEJIwGgQ8AEP9tE/SABpIPAgAD1JCGEIRgBpQPAQAAhhRfalID1JCIAD4Er2qiA5SQhgNUjAaBDwAQ/20TNIAGkg8BAAMUkIYQhGwGgQ8BQPBtAIRsBoQPAUAMhgASBwRwAg/OcBRihIAGlA8CAAJkoQYRBGAGlA8EAAEGED4Er2qiAkShBgIEjAaBDwAQ/20R5IAGkg8CAAHEoQYQAgcEcDRgEgcEcQtQNGSBwg8AEBJuAVSABpQPAQABNMIGEQiBiAA+BK9qogE0wgYA9IwGgQ8AEP9tEMSABpIPAQAApMIGEgRsBoEPAUDwbQIEbAaEDwFADgYAEgEL2bHJIciR4AKdbRACD35wAAACACQCMBZ0Wrie/NADAAQAD4/x8AAAAA
-    pc_init: 1
-    pc_uninit: 59
-    pc_program_page: 285
-    pc_erase_sector: 219
-    pc_erase_all: 87
-    data_section_offset: 404
+    pc_init: 0x1
+    pc_uninit: 0x3b
+    pc_program_page: 0x11d
+    pc_erase_sector: 0xdb
+    pc_erase_all: 0x57
+    data_section_offset: 0x194
     flash_properties:
       address_range:
-        start: 536868864
-        end: 536868880
-      page_size: 16
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ffff800
+        end: 0x1ffff810
+      page_size: 0x10
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 16
-          address: 0
-  stm32f10x_cl:
-    name: stm32f10x_cl
+        - size: 0x10
+          address: 0x0
+  - name: stm32f10x_cl
     description: STM32F10x Connectivity Line Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRgAgREwgYERIYGBESGBgIEbAaRDwBA8I0UXyVVBATCBgBiBgYED2/3CgYAAgEL0BRjhIAGlA8IAANkoQYQAgcEc0SABpQPAEADJJCGEIRgBpQPBAAAhhA+BK9qogMEkIYCxIwGgQ8AEP9tEqSABpIPAEAChJCGEAIHBHAUYlSABpQPACACNKEGEQRkFhAGlA8EAAEGED4Er2qiAhShBgHUjAaBDwAQ/20RpIAGkg8AIAGEoQYQAgcEcQtQNGSBwg8AEBIuATSABpQPABABFMIGEQiBiAAL8PSMBoEPABD/rRDEgAaSDwAQAKTCBhIEbAaBDwFA8G0CBGwGhA8BQA4GABIBC9mxySHIkeACna0QAg9+cAAAAgAkAjAWdFq4nvzQAwAEAAAAAA
-    pc_init: 1
-    pc_uninit: 51
-    pc_program_page: 189
-    pc_erase_sector: 127
-    pc_erase_all: 69
-    data_section_offset: 296
+    pc_init: 0x1
+    pc_uninit: 0x33
+    pc_program_page: 0xbd
+    pc_erase_sector: 0x7f
+    pc_erase_all: 0x45
+    data_section_offset: 0x128
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134479872
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8040000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 2048
-          address: 0
-  stm32f10x_1024:
-    name: stm32f10x_1024
+        - size: 0x800
+          address: 0x0
+  - name: stm32f10x_1024
     description: STM32F10x XL-density Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRtgMwASATExEIGAAIH9MIGB/SGBgf0hgYH1IYGR9SGBkIEbAaRDwBA8I0UXyVVB6TCBgBiBgYED2/3CgYAAgEL0BRnJIAGlA8IAAcEoQYRBGAG1A8IAAEGUAIHBHa0gAaUDwBABpSQhhCEYAaUDwQAAIYQPgSvaqIGdJCGBjSMBoEPABD/bRYUgAaSDwBABfSQhhCEYAbUDwBAAIZQhGAG1A8EAACGUD4Er2qiBaSQhgVkjAbBDwAQ/20VRIAG0g8AQAUkkIZQAgcEcBRk5ISEQAaAD1ACCBQhzSTEgAaUDwAgBKShBhEEZBYQBpQPBAABBhA+BK9qogR0oQYENIwGgQ8AEP9tFBSABpIPACAD9KEGEb4D1IAG1A8AIAO0oQZRBGQWUAbUDwQAAQZQPgSvaqIDlKEGA1SMBsEPABD/bRMkgAbSDwAgAwShBlACBwRxC1A0ZIHCDwAQErSEhEAGgA9QAgg0Im0iLgKEgAaUDwAQAmTCBhEIgYgAC/I0jAaBDwAQ/60SFIAGkg8AEAH0wgYSBGwGgQ8BQPBtAgRsBoQPAUAOBgASAQvZsckhyJHgAp2tEl4CLgFEgAbUDwAQASTCBlEIgYgAC/EEjAbBDwAQ/60Q1IAG0g8AEAC0wgZSBGwGwQ8BQPBtAgRsBsQPAUAOBkASDX55sckhyJHgAp2tEAINDnAAAEAAAAACACQCMBZ0Wrie/NADAAQAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 69
-    pc_program_page: 341
-    pc_erase_sector: 207
-    pc_erase_all: 97
-    data_section_offset: 544
+    pc_init: 0x1
+    pc_uninit: 0x45
+    pc_program_page: 0x155
+    pc_erase_sector: 0xcf
+    pc_erase_all: 0x61
+    data_section_offset: 0x220
     flash_properties:
       address_range:
-        start: 134217728
-        end: 135266304
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8100000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 2048
-          address: 0
-  stm32f10x_16:
-    name: stm32f10x_16
+        - size: 0x800
+          address: 0x0
+  - name: stm32f10x_16
     description: STM32F10x Low-density Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRgAgREwgYERIYGBESGBgIEbAaRDwBA8I0UXyVVBATCBgBiBgYED2/3CgYAAgEL0BRjhIAGlA8IAANkoQYQAgcEc0SABpQPAEADJJCGEIRgBpQPBAAAhhA+BK9qogMEkIYCxIwGgQ8AEP9tEqSABpIPAEAChJCGEAIHBHAUYlSABpQPACACNKEGEQRkFhAGlA8EAAEGED4Er2qiAhShBgHUjAaBDwAQ/20RpIAGkg8AIAGEoQYQAgcEcQtQNGSBwg8AEBIuATSABpQPABABFMIGEQiBiAAL8PSMBoEPABD/rRDEgAaSDwAQAKTCBhIEbAaBDwFA8G0CBGwGhA8BQA4GABIBC9mxySHIkeACna0QAg9+cAAAAgAkAjAWdFq4nvzQAwAEAAAAAA
-    pc_init: 1
-    pc_uninit: 51
-    pc_program_page: 189
-    pc_erase_sector: 127
-    pc_erase_all: 69
-    data_section_offset: 296
+    pc_init: 0x1
+    pc_uninit: 0x33
+    pc_program_page: 0xbd
+    pc_erase_sector: 0x7f
+    pc_erase_all: 0x45
+    data_section_offset: 0x128
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134234112
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8004000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 1024
-          address: 0
+        - size: 0x400
+          address: 0x0

--- a/probe-rs/targets/STM32F2_Series.yaml
+++ b/probe-rs/targets/STM32F2_Series.yaml
@@ -1,4 +1,3 @@
----
 name: STM32F2 Series
 variants:
   - name: STM32F205RBTx
@@ -7,21 +6,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -32,21 +33,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -57,21 +60,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -82,21 +87,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -107,21 +114,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -132,21 +141,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -157,21 +168,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -182,21 +195,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -207,21 +222,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -232,21 +249,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -257,21 +276,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -282,21 +303,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -307,21 +330,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -332,21 +357,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -357,21 +384,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -382,21 +411,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -407,21 +438,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -432,21 +465,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -457,21 +492,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -482,21 +519,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -507,21 +546,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -532,21 +573,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -557,21 +600,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -582,21 +627,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -607,21 +654,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -632,21 +681,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -657,21 +708,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -682,21 +735,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -707,21 +762,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -732,21 +789,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -757,21 +816,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135004160
+            start: 0x8000000
+            end: 0x80c0000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -782,21 +843,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -807,21 +870,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -832,21 +897,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -857,21 +924,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -882,21 +951,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -907,21 +978,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -932,21 +1005,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -957,21 +1032,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -982,21 +1059,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -1007,21 +1086,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -1032,21 +1113,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -1057,21 +1140,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -1082,21 +1167,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -1107,21 +1194,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
@@ -1132,96 +1221,98 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f2xx_1024
       - stm32f2xx_opt
       - stm32f2xx_otp
 flash_algorithms:
-  stm32f2xx_1024:
-    name: stm32f2xx_1024
+  - name: stm32f2xx_1024
     description: STM32F2xx Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: AAMADiAoAtNACQAdcEcQKALTAAnAHHBHgAhwR0JIQUlBYEJJQWAAIQFgwWjwIhFDwWBAaYAGBtQ+SD1JAWAGIUFgPUmBYAAgcEc3SAFpQgURQwFhACBwRxC1M0gBaQQkIUMBYQFpogMRQwFhM0kxSgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97v/J0nKaPAjGkPKYAIkDGEKaQAHQA4CQwphCGniAxBDCGEkSCFKAOAQYM1o7QP71AhpoEMIYchoAAYADwPQyGgYQ8hgASAwvXC1FU3JHIkI62iJAPAmM0PrYAAjK2EWSxfgLGkcQyxhFGgEYOxo5AP81CxpZAhkACxh7GgkBiQPBNDoaDBD6GABIHC9AB0SHQkfACnl0QAgcL0AACMBZ0UAPAJAq4nvzVVVAAAAMABA/w8AAKqqAAABAgAAAAAAAA==
-    pc_init: 29
-    pc_uninit: 75
-    pc_program_page: 209
-    pc_erase_sector: 133
-    pc_erase_all: 89
-    data_section_offset: 324
+    pc_init: 0x1d
+    pc_uninit: 0x4b
+    pc_program_page: 0xd1
+    pc_erase_sector: 0x85
+    pc_erase_all: 0x59
+    data_section_offset: 0x144
     flash_properties:
       address_range:
-        start: 134217728
-        end: 135266304
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8100000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-  stm32f2xx_opt:
-    name: stm32f2xx_opt
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+  - name: stm32f2xx_opt
     description: STM32F2xx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: AAMADiAoAtNACQAdcEcQKALTAAnAHHBHgAhwRylIKEmBYClJgWDBaPAiEUPBYEBpgAYG1CZIJUkBYAYhQWAlSYFgACBwRx9IQWkBIhFDQWEAIHBHG0jCaPAhCkPCYB5KQmFCaQIjGkNCYcJoEgYSDwTQwmgKQ8JgASBwRwAgcEcAIHBHEYkQiAkFCQmACIAAAUMMSMNo8CITQ8NgAiMZQ0FhwWjJA/zUwWgJBgkPBNDBaBFDwWABIHBHACBwRwAAOyoZCAA8AkB/bl1MVVUAAAAwAED/DwAA7Kr/DwAAAAA=
-    pc_init: 29
-    pc_uninit: 71
-    pc_program_page: 133
-    pc_erase_sector: 129
-    pc_erase_all: 85
-    data_section_offset: 220
+    pc_init: 0x1d
+    pc_uninit: 0x47
+    pc_program_page: 0x85
+    pc_erase_sector: 0x81
+    pc_erase_all: 0x55
+    data_section_offset: 0xdc
     flash_properties:
       address_range:
-        start: 536854528
-        end: 536854544
-      page_size: 16
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fffc000
+        end: 0x1fffc010
+      page_size: 0x10
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 16
-          address: 0
-  stm32f2xx_otp:
-    name: stm32f2xx_otp
+        - size: 0x10
+          address: 0x0
+  - name: stm32f2xx_otp
     description: STM32F2xx Flash OTP
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: AAMADiAoAtNACQAdcEcQKALTAAnAHHBHgAhwRyVIJElBYCVJQWAAIQFgwWjwIhFDwWBAaYAGBtQhSCBJAWAGIUFgIEmBYAAgcEcaSAFpQgURQwFhACBwRwAgcEdwtRVNyRyJCOtoiQDwJjND62AAIythFUsX4CxpHEMsYRRoBGDsaOQD/NQsaWQIZAAsYexoJAYkDwTQ6GgwQ+hgASBwvQAdEh0JHwAp5dEAIHC9AAAjAWdFADwCQKuJ781VVQAAADAAQP8PAAABAgAAAAAAAA==
-    pc_init: 29
-    pc_uninit: 75
-    pc_program_page: 93
-    pc_erase_sector: 89
-    pc_erase_all: ~
-    data_section_offset: 204
+    pc_init: 0x1d
+    pc_uninit: 0x4b
+    pc_program_page: 0x5d
+    pc_erase_sector: 0x59
+    pc_erase_all: null
+    data_section_offset: 0xcc
     flash_properties:
       address_range:
-        start: 536836096
-        end: 536836624
-      page_size: 528
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fff7800
+        end: 0x1fff7a10
+      page_size: 0x210
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 528
-          address: 0
+        - size: 0x210
+          address: 0x0

--- a/probe-rs/targets/STM32F3_Series.yaml
+++ b/probe-rs/targets/STM32F3_Series.yaml
@@ -1,4 +1,3 @@
----
 name: STM32F3 Series
 variants:
   - name: STM32F301C6Tx
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -31,21 +32,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -55,21 +58,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -79,21 +84,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -103,21 +110,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -127,21 +136,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -151,21 +162,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -175,21 +188,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -199,21 +214,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -223,21 +240,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -247,21 +266,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -271,21 +292,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -295,21 +318,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -319,21 +344,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -343,21 +370,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -367,21 +396,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -391,21 +422,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -415,21 +448,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -439,21 +474,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -463,21 +500,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -487,21 +526,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -511,21 +552,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -535,21 +578,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -559,21 +604,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -583,21 +630,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -607,21 +656,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -631,21 +682,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -655,21 +708,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -679,21 +734,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -703,21 +760,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -727,21 +786,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -751,21 +812,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -775,21 +838,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268443648
+            start: 0x10000000
+            end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -799,21 +864,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -823,21 +890,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -847,21 +916,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -871,21 +942,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -895,21 +968,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -919,21 +994,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -943,21 +1020,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536883200
+            start: 0x20000000
+            end: 0x20003000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -967,21 +1046,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268443648
+            start: 0x10000000
+            end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -991,21 +1072,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268443648
+            start: 0x10000000
+            end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1015,21 +1098,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -1039,21 +1124,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -1063,21 +1150,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268443648
+            start: 0x10000000
+            end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1087,21 +1176,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 268435456
-            end: 268443648
+            start: 0x10000000
+            end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1111,21 +1202,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1135,21 +1228,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -1159,21 +1254,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -1183,21 +1280,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -1207,21 +1306,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -1231,21 +1332,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -1255,21 +1358,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -1279,21 +1384,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
@@ -1303,21 +1410,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1327,21 +1436,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1351,21 +1462,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1375,21 +1488,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1399,21 +1514,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1423,21 +1540,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1447,21 +1566,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1471,21 +1592,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1495,15 +1618,16 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1513,15 +1637,16 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1531,21 +1656,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1555,21 +1682,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1579,21 +1708,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1603,21 +1734,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1627,21 +1760,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1651,21 +1786,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1675,21 +1812,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536911872
+            start: 0x20000000
+            end: 0x2000a000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1699,21 +1838,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536911872
+            start: 0x20000000
+            end: 0x2000a000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1723,21 +1864,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536911872
+            start: 0x20000000
+            end: 0x2000a000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1747,21 +1890,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1771,21 +1916,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1795,21 +1942,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1819,21 +1968,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1843,21 +1994,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1867,21 +2020,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1891,21 +2046,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1915,21 +2072,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1939,21 +2098,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1963,21 +2124,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536895488
+            start: 0x20000000
+            end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -1987,21 +2150,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -2011,21 +2176,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -2035,21 +2202,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -2059,21 +2228,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -2083,21 +2254,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -2107,21 +2280,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_256
       - stm32f3xx_opt
@@ -2131,91 +2306,93 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f3xx_512
       - stm32f3xx_opt
 flash_algorithms:
-  stm32f3xx_256:
-    name: stm32f3xx_256
+  - name: stm32f3xx_256
     description: STM32F3xx Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: N0g2SUFgN0lBYAAhAWDBaBQiEUPBYMBpwAUG1DNIMkkBYAYhQWAySYFgACBwRyxIAWmAIhFDAWEAIHBHELUoSAFpBCQhQwFhAWlAIhFDAWEoSSZKAOARYMNo2wf70QFpoUMBYQAgEL0QtR1JCmkCJCJDCmFIYQhpQCIQQwhhHUgaSgDgEGDLaNsH+9EIaaBDCGEAIBC9cLVJHEkISQAUJg9NASMW4CxpHEMsYRSIBIDsaOQH/NEsaWQIZAAsYexoNEIE0OhoMEPoYAEgcL2AHJIciR4AKebRACBwvSMBZ0UAIAJAq4nvzVVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 47
-    pc_program_page: 151
-    pc_erase_sector: 105
-    pc_erase_all: 61
-    data_section_offset: 248
+    pc_init: 0x1
+    pc_uninit: 0x2f
+    pc_program_page: 0x97
+    pc_erase_sector: 0x69
+    pc_erase_all: 0x3d
+    data_section_offset: 0xf8
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134479872
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8040000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 2048
-          address: 0
-  stm32f3xx_512:
-    name: stm32f3xx_512
+        - size: 0x800
+          address: 0x0
+  - name: stm32f3xx_512
     description: STM32F3xx 512KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: N0g2SUFgN0lBYAAhAWDBaBQiEUPBYMBpwAUG1DNIMkkBYAYhQWAySYFgACBwRyxIAWmAIhFDAWEAIHBHELUoSAFpBCQhQwFhAWlAIhFDAWEoSSZKAOARYMNo2wf70QFpoUMBYQAgEL0QtR1JCmkCJCJDCmFIYQhpQCIQQwhhHUgaSgDgEGDLaNsH+9EIaaBDCGEAIBC9cLVJHEkISQAUJg9NASMW4CxpHEMsYRSIBIDsaOQH/NEsaWQIZAAsYexoNEIE0OhoMEPoYAEgcL2AHIkekhwAKebRACBwvSMBZ0UAIAJAq4nvzVVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 47
-    pc_program_page: 151
-    pc_erase_sector: 105
-    pc_erase_all: 61
-    data_section_offset: 248
+    pc_init: 0x1
+    pc_uninit: 0x2f
+    pc_program_page: 0x97
+    pc_erase_sector: 0x69
+    pc_erase_all: 0x3d
+    data_section_offset: 0xf8
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134742016
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8080000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 2048
-          address: 0
-  stm32f3xx_opt:
-    name: stm32f3xx_opt
+        - size: 0x800
+          address: 0x0
+  - name: stm32f3xx_opt
     description: STM32F3xx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: S0hKSkJgS0lBYIJggWAAIQFgwWgUIhFDwWDAacAFBtRGSEVJAWAGIUFgRUmBYAAgcEc/SAFpQhWRQwFhAWmAIhFDAWEAIHBHcLU5SMFoFCMZQ8FgAWkgJCFDAWEBaUAiEUMBYTdJNUoA4BFgxWjtB/vRBWmlQwVhBWkQJCVDBWEtTTFOVTU1gADgEWDFaO0H+9EBaaFDAWHBaBlCBNDBaBlDwWABIHC9ACBwvRC1IEgBaSAkIUMBYQFpQCIRQwFhIEkeSgDgEWDDaNsH+9EBaaFDAWEAIBC9ASBwR/C1SRxJCEkAEk0QJhZLGuAsaTRDLGEUiASAEUwA4CNg72j/B/vRLGm0Qyxh7GgUJzxCBdDpaBQgAUPpYAEg8L2AHJIciR4AKeLRACDwvQAAIwFnRQAgAkCrie/NVVUAAAAwAED/DwAAqqoAAAD4/x8AAAAA
-    pc_init: 1
-    pc_uninit: 51
-    pc_program_page: 221
-    pc_erase_sector: 173
-    pc_erase_all: 73
-    data_section_offset: 332
+    pc_init: 0x1
+    pc_uninit: 0x33
+    pc_program_page: 0xdd
+    pc_erase_sector: 0xad
+    pc_erase_all: 0x49
+    data_section_offset: 0x14c
     flash_properties:
       address_range:
-        start: 536868864
-        end: 536868880
-      page_size: 16
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ffff800
+        end: 0x1ffff810
+      page_size: 0x10
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 16
-          address: 0
+        - size: 0x10
+          address: 0x0

--- a/probe-rs/targets/STM32F4_Series.yaml
+++ b/probe-rs/targets/STM32F4_Series.yaml
@@ -1,4 +1,3 @@
----
 name: STM32F4 Series
 variants:
   - name: STM32F401CBUx
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f401xx_opt
@@ -32,21 +33,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f401xx_opt
@@ -57,21 +60,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f401xx_opt
@@ -82,21 +87,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f401xx_opt
@@ -107,21 +114,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_384
       - stm32f401xx_opt
@@ -132,21 +141,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_384
       - stm32f401xx_opt
@@ -157,21 +168,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f401xx_opt
@@ -182,21 +195,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f401xx_opt
@@ -207,21 +222,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f401xx_opt
@@ -232,21 +249,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f401xx_opt
@@ -257,21 +276,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_384
       - stm32f401xx_opt
@@ -282,21 +303,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f401xx_opt
@@ -307,21 +330,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f401xx_opt
@@ -332,21 +357,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f401xx_opt
@@ -357,21 +384,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f401xx_opt
@@ -382,21 +411,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f401xx_opt
@@ -407,21 +438,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_384
       - stm32f401xx_opt
@@ -432,21 +465,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_384
       - stm32f401xx_opt
@@ -457,21 +492,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f401xx_opt
@@ -482,21 +519,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f401xx_opt
@@ -507,21 +546,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f40xxx_41xxx_opt
@@ -532,21 +573,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -557,21 +600,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -582,21 +627,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -607,21 +654,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -632,21 +681,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f40xxx_41xxx_opt
@@ -657,21 +708,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f40xxx_41xxx_opt
@@ -682,21 +735,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -707,21 +762,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -732,21 +789,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f40xxx_41xxx_opt
@@ -757,21 +816,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -782,21 +843,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f40xxx_41xxx_opt
@@ -807,21 +870,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -832,21 +897,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f410xx_412xx_opt
@@ -856,21 +923,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f410xx_412xx_opt
@@ -880,21 +949,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f410xx_412xx_opt
@@ -904,21 +975,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f410xx_412xx_opt
@@ -928,21 +1001,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f410xx_412xx_opt
@@ -952,21 +1027,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f410xx_412xx_opt
@@ -976,21 +1053,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f410xx_412xx_opt
@@ -1000,21 +1079,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f410xx_412xx_opt
@@ -1024,21 +1105,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f410xx_412xx_opt
@@ -1048,21 +1131,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_128
       - stm32f410xx_412xx_opt
@@ -1072,21 +1157,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f411xx_opt
@@ -1097,21 +1184,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f411xx_opt
@@ -1122,21 +1211,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f411xx_opt
@@ -1147,21 +1238,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f411xx_opt
@@ -1172,21 +1265,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f411xx_opt
@@ -1197,21 +1292,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f411xx_opt
@@ -1222,21 +1319,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f411xx_opt
@@ -1247,21 +1346,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f411xx_opt
@@ -1272,21 +1373,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f411xx_opt
@@ -1297,21 +1400,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f411xx_opt
@@ -1322,21 +1427,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f410xx_412xx_opt
@@ -1347,21 +1454,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f410xx_412xx_opt
@@ -1372,21 +1481,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f410xx_412xx_opt
@@ -1397,21 +1508,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f410xx_412xx_opt
@@ -1422,21 +1535,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f410xx_412xx_opt
@@ -1447,21 +1562,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f410xx_412xx_opt
@@ -1472,21 +1589,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f410xx_412xx_opt
@@ -1497,21 +1616,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f410xx_412xx_opt
@@ -1522,21 +1643,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f410xx_412xx_opt
@@ -1547,21 +1670,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f410xx_412xx_opt
@@ -1572,21 +1697,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f410xx_412xx_opt
@@ -1597,21 +1724,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f410xx_412xx_opt
@@ -1622,21 +1751,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f410xx_412xx_opt
@@ -1647,21 +1778,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f410xx_412xx_opt
@@ -1672,21 +1805,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f413xx_423xx_opt
@@ -1696,21 +1831,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -1720,21 +1857,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f413xx_423xx_opt
@@ -1744,21 +1883,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -1768,21 +1909,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f413xx_423xx_opt
@@ -1792,21 +1935,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -1816,21 +1961,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f413xx_423xx_opt
@@ -1840,21 +1987,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f413xx_423xx_opt
@@ -1864,21 +2013,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -1888,21 +2039,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -1912,21 +2065,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f413xx_423xx_opt
@@ -1936,21 +2091,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f413xx_423xx_opt
@@ -1960,21 +2117,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -1984,21 +2143,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -2008,21 +2169,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -2033,21 +2196,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -2058,21 +2223,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -2083,21 +2250,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -2108,21 +2277,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f40xxx_41xxx_opt
@@ -2133,21 +2304,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f40xxx_41xxx_opt
@@ -2158,21 +2331,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -2183,21 +2358,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -2208,21 +2385,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f40xxx_41xxx_opt
@@ -2233,21 +2412,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -2258,21 +2439,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f40xxx_41xxx_opt
@@ -2283,21 +2466,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f40xxx_41xxx_opt
@@ -2308,21 +2493,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -2332,21 +2519,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -2356,21 +2545,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -2380,21 +2571,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -2404,21 +2597,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -2428,21 +2623,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -2452,21 +2649,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135790592
+            start: 0x8000000
+            end: 0x8180000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1536
       - stm32f413xx_423xx_opt
@@ -2476,21 +2675,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -2502,21 +2703,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -2527,21 +2730,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -2553,21 +2758,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -2579,21 +2786,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -2604,21 +2813,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -2629,21 +2840,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -2655,21 +2868,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -2680,21 +2895,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -2706,21 +2923,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -2731,21 +2950,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -2757,21 +2978,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -2782,21 +3005,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f42xxx_43xxx_opt
@@ -2807,21 +3032,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -2833,21 +3060,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -2858,21 +3087,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f42xxx_43xxx_opt
@@ -2883,21 +3114,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f42xxx_43xxx_opt
@@ -2908,21 +3141,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -2934,21 +3169,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -2960,21 +3197,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -2985,21 +3224,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3010,21 +3251,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f42xxx_43xxx_opt
@@ -3035,21 +3278,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3061,21 +3306,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3086,21 +3333,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f42xxx_43xxx_opt
@@ -3111,21 +3360,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3137,21 +3388,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3162,21 +3415,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f42xxx_43xxx_opt
@@ -3187,21 +3442,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3213,21 +3470,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3238,21 +3497,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3263,21 +3524,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3288,21 +3551,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3314,21 +3579,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3340,21 +3607,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3365,21 +3634,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3390,21 +3661,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3416,21 +3689,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3441,21 +3716,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3467,21 +3744,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3492,21 +3771,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3517,21 +3798,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3543,21 +3826,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3568,21 +3853,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3594,21 +3881,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3620,21 +3909,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3645,21 +3936,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3670,21 +3963,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3696,21 +3991,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3721,21 +4018,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3747,21 +4046,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3772,21 +4073,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -3798,21 +4101,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3823,21 +4128,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537067520
+            start: 0x20000000
+            end: 0x20030000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f42xxx_43xxx_opt
@@ -3848,21 +4155,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f446xx_opt
@@ -3873,21 +4182,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f446xx_opt
@@ -3898,21 +4209,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f446xx_opt
@@ -3923,21 +4236,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f446xx_opt
@@ -3948,21 +4263,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f446xx_opt
@@ -3973,21 +4290,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f446xx_opt
@@ -3998,21 +4317,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f446xx_opt
@@ -4023,21 +4344,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_256
       - stm32f446xx_opt
@@ -4048,21 +4371,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f446xx_opt
@@ -4073,21 +4398,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f446xx_opt
@@ -4098,21 +4425,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f446xx_opt
@@ -4123,21 +4452,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f469xx_479xx_opt
@@ -4148,21 +4479,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f469xx_479xx_opt
@@ -4173,21 +4506,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4199,21 +4534,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4225,21 +4562,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4250,21 +4589,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4275,21 +4616,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f469xx_479xx_opt
@@ -4300,21 +4643,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4326,21 +4671,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4351,21 +4698,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f469xx_479xx_opt
@@ -4376,21 +4725,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f469xx_479xx_opt
@@ -4401,21 +4752,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4427,21 +4780,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4453,21 +4808,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4478,21 +4835,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4503,21 +4862,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f469xx_479xx_opt
@@ -4528,21 +4889,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4554,21 +4917,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4579,21 +4944,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f469xx_479xx_opt
@@ -4604,21 +4971,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4630,21 +4999,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4655,21 +5026,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_512
       - stm32f469xx_479xx_opt
@@ -4680,21 +5053,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4706,21 +5081,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4731,21 +5108,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4757,21 +5136,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4783,21 +5164,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4808,21 +5191,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4833,21 +5218,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4859,21 +5246,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4884,21 +5273,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4910,21 +5301,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -4936,21 +5329,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4961,21 +5356,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -4986,21 +5383,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -5012,21 +5411,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -5037,21 +5438,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -5063,21 +5466,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
@@ -5088,21 +5493,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_1024
       - stm32f4xx_1024dual
@@ -5114,479 +5521,481 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f4xx_2048
       - stm32f469xx_479xx_opt
       - stm32f469_quad_spi
 flash_algorithms:
-  stm32f469xx_479xx_opt:
-    name: stm32f469xx_479xx_opt
+  - name: stm32f469xx_479xx_opt
     description: STM32F469xx/479xx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEc0SDJJgWAzSYFgwWjwIhFDwWBAaYAGBtQxSC9JAWAGIUFgL0mBYAAgcEcpSEFpASIRQ0FhACBwRyZIwmjwIQpDwmAoSoJhKEpCYUJpAiMaQ0JhwmgSBhIPBNDCaApDwmABIHBHACBwRwAgcEcQtRhIBsrEaPAjHEPEYBpMIkCCYRtKEUCJHEFhwWjJA/zUwWgJBgkPBNDBaBlDwWABIBC9ACAQvXC1Ck4TaBBMUmh1aSNAJUCrQgbRC0u0aRpAHECiQgHQQBxwvUAYcL0AADsqGQgAPAJAf25dTFVVAAAAMABA/w8AAAAA/w/sqv8P/P//DwAAAAA=
-    pc_init: 39
-    pc_uninit: 81
-    pc_program_page: 147
-    pc_erase_sector: 143
-    pc_erase_all: 95
-    data_section_offset: 280
+    pc_init: 0x27
+    pc_uninit: 0x51
+    pc_program_page: 0x93
+    pc_erase_sector: 0x8f
+    pc_erase_all: 0x5f
+    data_section_offset: 0x118
     flash_properties:
       address_range:
-        start: 536854528
-        end: 536854536
-      page_size: 8
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fffc000
+        end: 0x1fffc008
+      page_size: 0x8
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 8
-          address: 0
-  stm32f40xxx_41xxx_opt:
-    name: stm32f40xxx_41xxx_opt
+        - size: 0x8
+          address: 0x0
+  - name: stm32f40xxx_41xxx_opt
     description: STM32F40xxx/41xxx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEcsSCpJgWArSYFgwWjwIhFDwWBAaYAGBtQpSCdJAWAGIUFgJ0mBYAAgcEchSEFpASIRQ0FhACBwRx5IwmjwIQpDwmAgSkJhQmkCIxpDQmHCaBIGEg8E0MJoCkPCYAEgcEcAIHBHACBwRxJIEWjDaPAiE0PDYBVLGUCJHEFhwWjJA/zUwWgJBgkPBNDBaBFDwWABIHBHACBwRxC1BUwSaApLZGkaQBxAokIA0UAYEL07KhkIADwCQH9uXUxVVQAAADAAQP8PAADsqv8P/P//DwAAAAA=
-    pc_init: 39
-    pc_uninit: 81
-    pc_program_page: 143
-    pc_erase_sector: 139
-    pc_erase_all: 95
-    data_section_offset: 244
+    pc_init: 0x27
+    pc_uninit: 0x51
+    pc_program_page: 0x8f
+    pc_erase_sector: 0x8b
+    pc_erase_all: 0x5f
+    data_section_offset: 0xf4
     flash_properties:
       address_range:
-        start: 536854528
-        end: 536854532
-      page_size: 4
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fffc000
+        end: 0x1fffc004
+      page_size: 0x4
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 4
-          address: 0
-  stm32f4xx_1024dual:
-    name: stm32f4xx_1024dual
+        - size: 0x4
+          address: 0x0
+  - name: stm32f4xx_1024dual
     description: STM32F4xx 1MB dual bank Flash
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: AUZAA0AOICgC00AJAB0F4BAoAtMACcAcAOCACAkDAdUQIQhDcEdCSEBJQWBBSUFgACEBYMFo8CIRQ8FgQGmABgbUPkg8SQFgBiFBYDxJgWAAIHBHNkgBaUIFEUMBYQAgcEcQtTJIAWkEJCFDAWEBaaIDEUMBYTNJMEoA4BFgw2jbA/vUAWmhQwFhACAQvTC1//e2/yZJymjwIxpDymACJAxhCmnABgAOAkMKYQhp4gMQQwhhI0ghSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML1wtRRNyRyJCOtoiQDwJjND62AAIythFUsX4CxpHEMsYRRoBGDsaOQD/NQsaWQIZAAsYexoJAYkDwTQ6GgwQ+hgASBwvQAdCR8SHQAp5dEAIHC9IwFnRQA8AkCrie/NVVUAAAAwAED/DwAAqqoAAAECAAAAAAAA
-    pc_init: 39
-    pc_uninit: 85
-    pc_program_page: 219
-    pc_erase_sector: 143
-    pc_erase_all: 99
-    data_section_offset: 332
+    pc_init: 0x27
+    pc_uninit: 0x55
+    pc_program_page: 0xdb
+    pc_erase_sector: 0x8f
+    pc_erase_all: 0x63
+    data_section_offset: 0x14c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 135266304
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8100000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-        - size: 16384
-          address: 524288
-        - size: 65536
-          address: 589824
-        - size: 131072
-          address: 655360
-  stm32f469_quad_spi:
-    name: stm32f469_quad_spi
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+        - size: 0x4000
+          address: 0x80000
+        - size: 0x10000
+          address: 0x90000
+        - size: 0x20000
+          address: 0xa0000
+  - name: stm32f469_quad_spi
     description: STM32F469 QSPI Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUGIfdISEQAaADwa/xjIwIiBSHzSEhEAGgA8FD9EL0t6fBBBkYPRhRGIGgIub3o8IHtTf/35P8Av+pISEQAaIBoAPAgAAAo99EgaEAe5UlJRAloCGFF9KBlRfQAVQC/4EhIRABogGgA8CAAACj30dxISEQAaEVh2khIRABoh2EP4AC/10hIRABogGgA8AQABCj30Rb4AQvSSUlECWiB+CAAIWhIHiBgACnq0QAgIGAZIwEiBSHLSEhEAGgA8P/8yEhIRABoAGhA8AIAxUlJRAloCGAAv8NISEQAaIBoAPAgAAAo99EAv6HncLUERv/3h/8Av7tISEQAaIBoAPAgAAAo99G3SUlECWgIYbdNRfQAVQC/s0hIRABogGgA8CAAACj30a9ISEQAaEVhAL+tSEhEAGiAaADwIAAAKPfRqUhIRABohGH/91v/GSMBIgUhpEhIRABoAPCy/AC/oUhIRABogGgA8CAAACj30XC9fLUERg1GFkYA8On/ACCcSUlECHABIQIgAPCe/gEhiAUA8HD+CSIKIZdISEQAaADwt/oKIgYhlEhIRABoAPCw+goiCCGQSEhEAGgA8Kn6CiIJIYxISEQAaADwovoJIgchiUhIRABoAPCb+gkiBiGFSEhEAGgA8JT6APA1+wAgA0YCRgFGAJB7SEhEAGgA8F37ACMBIk/0+BF3SEhEAGgA8EX7dEhIRABoAGhA8AEAcUlJRAloCGAAv29ISEQAaIBoAPAgAAAo99FA8v8QaklJRAloCGFuSAGQAZhA9ABQAZAAv2RISEQAaIBoAPAgAAAo99FgSUlEAZgJaEhhACB8vQFGACBwRxC1BEYk8HBA//c1/wAgEL1wtU/wEERP8BJFBOAgRv/37/8E9YA0pUL40gAgcL0t6fxNB0YORhRGT/AACtBGw0YAJQAgAZAAkAbw/wvL9YB1IGhP6hAqlPgAgLvxAA8k0brxAA8H0SBoAJBqRjFGOEb/95z+ZeAL4E/0gHAAkGpGMUY4Rv/3kv4G9YB2B/WAd1/qCgCq8QEK7tHN+ACAakYxRjhG//eC/kvguvEADxzRqEUS2ajrBQABkACVakYxRjhG//dz/i5EL0QBmACQakYxRjhG//dq/jPgIGgAkGpGMUY4Rv/3Yv4r4CBoQBsgYCBoT+oQKpT4AIAAlWpGMUY4Rv/3U/4uRC9EC+BP9IBwAJBqRjFGOEb/90j+BvWAdgf1gHdf6goAqvEBCu7RuPEADwbQzfgAgGpGMUY4Rv/3Nf696PyNLen4QwRGDUYWRiTwfkewRgCVakY5RkBG//dm/wAgvej4gwNGASBwRwAASAAAAAIAAAHYBQAErAAAAIAAAABwAAAAOwUgDhC1BEbE8wkAACg+0aASoPWAEIA4Cig40t/oAPAFCg8UGR4jKC0yASEIRgDwIv0u4AEhAiAA8B39KeABIQQgAPAY/STgASEIIADwE/0f4AEhECAA8A79GuABISAgAPAJ/RXgASFAIADwBP0Q4AEhgCAA8P/8C+ABIQgCAPD6/AbgASFIAgDw9fwB4AC//ucAvxC9ELUERsTzCQAAKHTRoBKg9YAQgDgLKG7S3+gA8AYPGCEqMzxFTlhiAAEhCEYA8EH9ACEBIADwPf1e4AEhAiAA8Dj9ACECIADwNP1V4AEhBCAA8C/9ACEEIADwK/1M4AEhCCAA8Cb9ACEIIADwIv1D4AEhECAA8B39ACEQIADwGf064AEhICAA8BT9ACEgIADwEP0x4AEhQCAA8Av9ACFAIADwB/0o4AEhgCAA8AL9ACGAIADw/vwf4AEhCAIA8Pn8ACFP9IBwAPD0/BXgASFIAgDw7/wAIU/0AHAA8Or8C+ABIYgCAPDl/AAhT/SAYADw4PwB4P/nAL8AvxC9LenwTQxG3ekIZwAhACWMRgC/YuBP8AEICPoB9QTqBQysRVnR0PgAgE/qQQtP8AMKCvoL+ijqCgjA+ACA0PgAgE/qQQoC+gr6SOoKCMD4AIABKgHQAiop0dD4CIBP6kELT/ADCgr6C/oo6goIwPgIgND4CIBP6kEKA/oK+kjqCgjA+AiAsPgEgE/wAQoK+gH6KOoKCKD4BICw+ASABvoB+h/6ivpI6goIoPgEgND4DIBP6kELT/ADCgr6C/oo6goIwPgMgND4DIBP6kEKB/oK+kjqCgjA+AyASRwQKZrTvejwjQJGACATigtAC7EBIADgACBwRwFGCIpwRwJGACCTigtAC7EBIADgACBwRwFGiIpwRwGDcEdBg3BHCrEBgwDgQYNwR4GCcEdP9IAyCkPCYcFhwmHCacJpcEfwtQAjACRNB+0OAvoF884QAPEgBVX4JlBOB/cODya+QLVDzxAA8SAGRvgnUM4QAPEgBVX4JlBF6gMEzhAA8SAFRfgmQPC9Len8QQVGDEYWRgAnKEb/93D+ASCgQIeyACAAkAIjGkY5RgGQKEb/9yv/MkYhRihG//fD/73o/IEt6fxBBUYMRhZGACcoRv/3VP4BIKBAh7IAIAEhAiMaRs3pABA5RihG//cO/zJGIUYoRv/3pv+96PyBLen8QQZGDEYVRgAnMEb/9zf+ASCgQIeyACACIwEiOUbN6QBQMEb/9/L+vej8gS3p/EEGRgxGFUYAJzBG//cg/gEgoECHsgAgAiMCRjlGzekABTBG//fb/r3o/IFwtQRGDUYBJiBG//cL/uBoagADIZFAiEPgYOBoaQAG+gHxCEPgYHC9cLUERg1GAiYgRv/39/3gaGoAAyGRQIhD4GDgaGkABvoB8QhD4GBwvXC1BEYNRgAmIEb/9+P94GhqAAMhkUCIQ+Bg4GhpAAb6AfEIQ+BgcL0QtQEhAiAA8K37ACECIADwqfsQvRC1AL+EaATwIAQALPrRAiTEYgRoJPQABARgBGgcQwRggWJCYgC/hGgE8CAEACz60RC9MLUAv4VoBfAgBQAt+tFB6gIlReoDBEVoJUNFYDC9cLUEnQZoJvABBgZgAL+GaAbwIAYALvrRCQZB6gIGHkNG6gUEBmgmQwZgcL0Av4NoA/AgAwAr+tEDYUH0gHJCYQC/g2gD8CADACv60XBH8LUORt3pBUUAIVceB2FGYYNhCC0O0QC/AL+HaAfwBAcAL/rQNSeA+CBwh2gH8AIHAC/x0BYtGNEAvwC/h2gH8AQHAC/60NT4BMAM8QIHZ2C8+ABwB4RPHPmyBSkA0QC/h2gH8AIHAC/n0DItGNEAvwC/h2gH8AQHAC/60NT4CMAM8QQHp2Dc+ABwB2JPHPmyAykA0QC/h2gH8AIHAC/n0AInx2DwvfC13ekFRQJhRmkOQ0Zhg2EILRTRAL8I4JD4IHDU+ADADPEBBiZgjPgAcIZoBvAEBgAu8dCGaAbwAgYALuvRFi0T0QC/B+AHjNT4BMAM8QIGZmCs+ABwhmgG8AQGAC7y0IZoBvACBgAu7NEyLRPRAL8H4Adq1PgIwAzxBAamYMz4AHCGaAbwBAYALvLQhmgG8AIGAC7s0fC98LUMRk/2/3ZC6gIhAL+HaAfwIAcAL/rRfx4HYUT0gHdH8KBlAL+HaAfwIAcAL/rRRWEZKwnRBOCHaAfwBAcHsQaMBuoBBwAv9tFjKwrRACYE4IdoB/AEBwexBowG6gEHj0L20QdoR/ACBwdgAL+HaAfwIAcAL/rR8L1wtf8lAL+GaAbwIAYALvrRdh4GYUH0gHZG8KBkAL+GaAbwIAYALvrRRGEZKwrRBeCGaAbwBAYOsZD4IFAF6gIGAC710WMrC9EAJQXghmgG8AQGDrGQ+CBQBeoCBpZC9dEGaEbwAgYGYAC/hmgG8CAGAC760XC9Len4TQRGDUYWRh9G3ekKq934JIBgaQCQUUYgRv/3yP47RjJGKUYgRv/3hP6r8QEAIGEAv6BoAPAgAAAo+tFI8ABgQPABIGBhAL+gaADwCAAAKPrQIGhA8AIAIGAAv6BoAPACAAAo+tAAv6BoAPAgAAAo+tHgaEDwCADgYOBoQPACAOBgvej4jfZISEQAaABoQPABAPNJSUQJaAhgACDxSUlECWiIYO9ISEQAaABo7kkIQOxJSUQJaAhgACDpSUlECWhIYOdISEQAaABoIPSAIORJSUQJaAhgACDiSUlECWjIYHBH30lJRAloCWgh9IAx3EpKRBJoEWDaSUlECWgJaCH0gCHXSkpEEmgRYLD1gD8D0LD1gC8W0Qrg0klJRAloCWhB9IAxz0pKRBJoEWAL4MxJSUQJaAloQfSgIclKSkQSaBFgAOAAvwC/cEcBRgAgxEpKRBJoEGgg8PgAQOrBAMBKSkQSaBBgcEfwtd3pBUVB6oIWASfH61MHRuoHRgZDRuoEZkbqBXa2T09EP2h+YPC9AUYAILNKSkQSaJBoIPADAAhDr0pKRBJokGBwR61ISEQAaIBoAPAMAHBHAUYAIKhKSkQSaJBoIPDwAAhDpUpKRBJokGBwRwFGACChSkpEEmiQaCD04FAIQ55KSkQSaJBgcEcBRgAgmkpKRBJokGgg9GBAQOrBAJZKSkQSaJBgcEcAIZVKEXARcAEoAtAEKAjRA+ABIZFKEXAE4AUhj0oRcADgAL8Av3BHACEA9EBysvVAfwzRh0pKRBJokWgh9PgRh0oCQBFDgkpKRBJokWCASkpEEmgSbyL0QHJ9S0tEG2gaZ3tKSkQSaBJvwPMLAxpDeEtLRBtoGmdwR3C1ACEAIgAkAiNzTU1ELWitaAXwDAEhsQQpBdAIKRrRBeBxTQVgGeBwTQVgFuBqTU1ELWhtaMXziBRnTU1ELWhtaMXzAUVtHGsAtPvz9WhOdUMFYALgZE0FYAC/AL9eTU1ELWitaAXw8AEJCWFNfURqXAVo1UBFYFdNTUQtaK1oBfTgUYkKW019RBo9alxFaNVAhWBQTU1ELWitaAX0YEFJC1RNfUQ2PWpcRWjVQMVgcL1JsUhKSkQSaBJrAkNGS0tEG2gaYwjgQ0pKRBJoEmuCQ0FLS0QbaBpjcEdJsT5KSkQSaFJrAkM7S0tEG2haYwjgOUpKRBJoUmuCQzZLS0QbaFpjcEdJsTNKSkQSaJJrAkMxS0tEG2iaYwjgLkpKRBJokmuCQyxLS0QbaJpjcEdJsSlKSkQSaBJsAkMmS0tEG2gaZAjgJEpKRBJoEmyCQyFLS0QbaBpkcEdJsR5KSkQSaFJsAkMcS0tEG2haZAjgGUpKRBJoUmyCQxdLS0QbaFpkcEdJsRRKSkQSaBJpAkMRS0tEG2gaYQjgD0pKRBJoEmmCQwxLS0QbaBphcEdJsQlKSkQSaFJpAkMHS0tEG2haYQjgBEpKRBJoUmmCQwJLS0QbaFphcEeMAAAA///2/nA4AkD//P8PACT0AIDDyQFAQg8A3gQAAEmxY0pKRBJokmkCQ2BLS0QbaJphCOBeSkpEEmiSaYJDW0tLRBtommFwR0mxWEpKRBJoEmoCQ1ZLS0QbaBpiCOBTSkpEEmgSaoJDUUtLRBtoGmJwR0mxTkpKRBJoUmoCQ0tLS0QbaFpiCOBJSkpEEmhSaoJDRktLRBtoWmJwR0mxQ0pKRBJoEm0CQ0FLS0QbaBplCOA+SkpEEmgSbYJDPEtLRBtoGmVwR0mxOUpKRBJoUm0CQzZLS0QbaFplCOA0SkpEEmhSbYJDMUtLRBtoWmVwR0mxLkpKRBJokm0CQyxLS0QbaJplCOApSkpEEmiSbYJDJ0tLRBtommVwR0mxJEpKRBJoEm4CQyFLS0QbaBpmCOAfSkpEEmgSboJDHEtLRBtoGmZwR0mxGUpKRBJoUm4CQxdLS0QbaFpmCOAUSkpEEmhSboJDEktLRBtoWmZwRwJGACAOS0tEG2iYaCDw7GBC6gEDGEMKS0tEG2iYYHBHAkYAIAZLS0QbaJhoIPBiUELqAQMYQwJLS0QbaJhgcEeMAAAAT/CAQEFJSUQIYEFIQUlJRAhgQUhBSUlECGBBSEFJSUQIYEFIQUlJRAhgQUhBSUlECGBBSEFJSUQIYEFIQUlJRAhgQUhBSUlECGBBSEFJSUQIYEFIQUlJRAhgQUhBSUlECGBBSEFJSUQIYEFIQUlJRAhgQUhBSUlECGBBSEFJSUQIYEFIQUlJRAhgQUhBSUlECGBBSEFJSUQIYEFIQUlJRAhgP0i4MEBJSUQIYCJIP0lJRAhgPkg/SUlECGA+SD9JSUQIYDxIkDA9SUlECGBwRwG1AuAAmEAeAJAAmAAo+dEIvQFGICkC2gEgiEBwR0ApBdqh8SAAASIC+gDw9ueh8UAAASIC+gDw8OcAAFAAAAAAEACgSAAAAABMAEBUAAAAAHAAQFgAAAAAAAFAXAAAAAAQAUBgAAAAADgBQGQAAAAAPAFAaAAAAAAAAkBsAAAAAAQCQHAAAAAACAJAdAAAAAAMAkB4AAAAABACQHwAAAAAFAJAgAAAAAAYAkCEAAAAABwCQIgAAAAAOAJAjAAAAAA8AkCQAAAAAGACQJQAAAAAZAJAmAAAAJwAAABMAAAAAOEA4KAAAAAA7QDgpAAAAKgAAAAAAAAAAQIDBAECAwQGBwgJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAJAAAACgAAAACAgIBQYFC2s7De29AjIyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-    pc_init: 367
-    pc_uninit: 623
-    pc_program_page: 955
-    pc_erase_sector: 629
-    pc_erase_all: 645
-    data_section_offset: 4896
+    pc_init: 0x16f
+    pc_uninit: 0x26f
+    pc_program_page: 0x3bb
+    pc_erase_sector: 0x275
+    pc_erase_all: 0x285
+    data_section_offset: 0x1320
     flash_properties:
       address_range:
-        start: 2415919104
-        end: 2449473536
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
+        start: 0x90000000
+        end: 0x92000000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 65536
-          address: 0
-  stm32f413xx_423xx_opt:
-    name: stm32f413xx_423xx_opt
+        - size: 0x10000
+          address: 0x0
+  - name: stm32f413xx_423xx_opt
     description: STM32F413xx/423xx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEcsSCpJgWArSYFgwWjwIhFDwWBAaYAGBtQpSCdJAWAGIUFgJ0mBYAAgcEchSEFpASIRQ0FhACBwRx5IwmjwIQpDwmAgSkJhQmkCIxpDQmHCaBIGEg8E0MJoCkPCYAEgcEcAIHBHACBwRxJIEWjDaPAiE0PDYBVLGUCJHEFhwWjJA/zUwWgJBgkPBNDBaBFDwWABIHBHACBwRxC1BUwSaApLZGkaQBxAokIA0UAYEL07KhkIADwCQH9uXUxVVQAAADAAQP8PAADsqv8P/P//DwAAAAA=
-    pc_init: 39
-    pc_uninit: 81
-    pc_program_page: 143
-    pc_erase_sector: 139
-    pc_erase_all: 95
-    data_section_offset: 244
+    pc_init: 0x27
+    pc_uninit: 0x51
+    pc_program_page: 0x8f
+    pc_erase_sector: 0x8b
+    pc_erase_all: 0x5f
+    data_section_offset: 0xf4
     flash_properties:
       address_range:
-        start: 536854528
-        end: 536854532
-      page_size: 4
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fffc000
+        end: 0x1fffc004
+      page_size: 0x4
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 4
-          address: 0
-  stm32f446xx_opt:
-    name: stm32f446xx_opt
+        - size: 0x4
+          address: 0x0
+  - name: stm32f446xx_opt
     description: STM32F446xx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEcsSCpJgWArSYFgwWjwIhFDwWBAaYAGBtQpSCdJAWAGIUFgJ0mBYAAgcEchSEFpASIRQ0FhACBwRx5IwmjwIQpDwmAgSkJhQmkCIxpDQmHCaBIGEg8E0MJoCkPCYAEgcEcAIHBHACBwRxJIEWjDaPAiE0PDYBVLGUCJHEFhwWjJA/zUwWgJBgkPBNDBaBFDwWABIHBHACBwRxC1BUwSaApLZGkaQBxAokIA0UAYEL07KhkIADwCQH9uXUxVVQAAADAAQP8PAADsqv8P/P//DwAAAAA=
-    pc_init: 39
-    pc_uninit: 81
-    pc_program_page: 143
-    pc_erase_sector: 139
-    pc_erase_all: 95
-    data_section_offset: 244
+    pc_init: 0x27
+    pc_uninit: 0x51
+    pc_program_page: 0x8f
+    pc_erase_sector: 0x8b
+    pc_erase_all: 0x5f
+    data_section_offset: 0xf4
     flash_properties:
       address_range:
-        start: 536854528
-        end: 536854532
-      page_size: 4
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fffc000
+        end: 0x1fffc004
+      page_size: 0x4
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 4
-          address: 0
-  stm32f411xx_opt:
-    name: stm32f411xx_opt
+        - size: 0x4
+          address: 0x0
+  - name: stm32f411xx_opt
     description: STM32F411xx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEcsSCpJgWArSYFgwWjwIhFDwWBAaYAGBtQpSCdJAWAGIUFgJ0mBYAAgcEchSEFpASIRQ0FhACBwRx5IwmjwIQpDwmAgSkJhQmkCIxpDQmHCaBIGEg8E0MJoCkPCYAEgcEcAIHBHACBwRxJIEWjDaPAiE0PDYBVLGUCJHEFhwWjJA/zUwWgJBgkPBNDBaBFDwWABIHBHACBwRxC1BUwSaApLZGkaQBxAokIA0UAYEL07KhkIADwCQH9uXUxVVQAAADAAQP8PAADsqv8P/P//DwAAAAA=
-    pc_init: 39
-    pc_uninit: 81
-    pc_program_page: 143
-    pc_erase_sector: 139
-    pc_erase_all: 95
-    data_section_offset: 244
+    pc_init: 0x27
+    pc_uninit: 0x51
+    pc_program_page: 0x8f
+    pc_erase_sector: 0x8b
+    pc_erase_all: 0x5f
+    data_section_offset: 0xf4
     flash_properties:
       address_range:
-        start: 536854528
-        end: 536854532
-      page_size: 4
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fffc000
+        end: 0x1fffc004
+      page_size: 0x4
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 4
-          address: 0
-  stm32f4xx_1024:
-    name: stm32f4xx_1024
+        - size: 0x4
+          address: 0x0
+  - name: stm32f4xx_1024
     description: STM32F4xx Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: AAMADiAoAtNACQAdcEcQKALTAAnAHHBHgAhwR0JIQUlBYEJJQWAAIQFgwWjwIhFDwWBAaYAGBtQ+SD1JAWAGIUFgPUmBYAAgcEc3SAFpQgURQwFhACBwRxC1M0gBaQQkIUMBYQFpogMRQwFhM0kxSgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97v/J0nKaPAjGkPKYAIkDGEKaQAHQA4CQwphCGniAxBDCGEkSCFKAOAQYM1o7QP71AhpoEMIYchoAAYADwPQyGgYQ8hgASAwvXC1FU3JHIkI62iJAPAmM0PrYAAjK2EWSxfgLGkcQyxhFGgEYOxo5AP81CxpZAhkACxh7GgkBiQPBNDoaDBD6GABIHC9AB0SHQkfACnl0QAgcL0AACMBZ0UAPAJAq4nvzVVVAAAAMABA/w8AAKqqAAABAgAAAAAAAA==
-    pc_init: 29
-    pc_uninit: 75
-    pc_program_page: 209
-    pc_erase_sector: 133
-    pc_erase_all: 89
-    data_section_offset: 324
+    pc_init: 0x1d
+    pc_uninit: 0x4b
+    pc_program_page: 0xd1
+    pc_erase_sector: 0x85
+    pc_erase_all: 0x59
+    data_section_offset: 0x144
     flash_properties:
       address_range:
-        start: 134217728
-        end: 135266304
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8100000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-  stm32f42xxx_43xxx_opt:
-    name: stm32f42xxx_43xxx_opt
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+  - name: stm32f42xxx_43xxx_opt
     description: STM32F42xxx/43xxx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEc0SDJJgWAzSYFgwWjwIhFDwWBAaYAGBtQxSC9JAWAGIUFgL0mBYAAgcEcpSEFpASIRQ0FhACBwRyZIwmjwIQpDwmAoSoJhKEpCYUJpAiMaQ0JhwmgSBhIPBNDCaApDwmABIHBHACBwRwAgcEcQtRhIBsrEaPAjHEPEYBpMIkCCYRtKEUCJHEFhwWjJA/zUwWgJBgkPBNDBaBlDwWABIBC9ACAQvXC1Ck4TaBBMUmh1aSNAJUCrQgbRC0u0aRpAHECiQgHQQBxwvUAYcL0AADsqGQgAPAJAf25dTFVVAAAAMABA/w8AAAAA/w/sqv8P/P//DwAAAAA=
-    pc_init: 39
-    pc_uninit: 81
-    pc_program_page: 147
-    pc_erase_sector: 143
-    pc_erase_all: 95
-    data_section_offset: 280
+    pc_init: 0x27
+    pc_uninit: 0x51
+    pc_program_page: 0x93
+    pc_erase_sector: 0x8f
+    pc_erase_all: 0x5f
+    data_section_offset: 0x118
     flash_properties:
       address_range:
-        start: 536854528
-        end: 536854536
-      page_size: 8
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fffc000
+        end: 0x1fffc008
+      page_size: 0x8
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 8
-          address: 0
-  stm32f4xx_1536:
-    name: stm32f4xx_1536
+        - size: 0x8
+          address: 0x0
+  - name: stm32f4xx_1536
     description: STM32F4xx 1.5MB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: wALADSAoAtNACQAdcEcQKALTAAnAHHBHgAhwR0JIQUlBYEJJQWAAIQFgwWjwIhFDwWBAaYAGBtQ+SD1JAWAGIUFgPUmBYAAgcEc3SAFpQgURQwFhACBwRxC1M0gBaQQkIUMBYQFpogMRQwFhM0kxSgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97v/J0nKaPAjGkPKYAIkDGEKacAGAA4CQwphCGniAxBDCGEkSCFKAOAQYM1o7QP71AhpoEMIYchoAAYADwPQyGgYQ8hgASAwvXC1FU3JHIkI62iJAPAmM0PrYAAjK2EWSxfgLGkcQyxhFGgEYOxo5AP81CxpZAhkACxh7GgkBiQPBNDoaDBD6GABIHC9AB0JHxIdACnl0QAgcL0AACMBZ0UAPAJAq4nvzVVVAAAAMABA/w8AAKqqAAABAgAAAAAAAA==
-    pc_init: 29
-    pc_uninit: 75
-    pc_program_page: 209
-    pc_erase_sector: 133
-    pc_erase_all: 89
-    data_section_offset: 324
+    pc_init: 0x1d
+    pc_uninit: 0x4b
+    pc_program_page: 0xd1
+    pc_erase_sector: 0x85
+    pc_erase_all: 0x59
+    data_section_offset: 0x144
     flash_properties:
       address_range:
-        start: 134217728
-        end: 135790592
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8180000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-  stm32f401xx_opt:
-    name: stm32f401xx_opt
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+  - name: stm32f401xx_opt
     description: STM32F401xx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEcsSCpJgWArSYFgwWjwIhFDwWBAaYAGBtQpSCdJAWAGIUFgJ0mBYAAgcEchSEFpASIRQ0FhACBwRx5IwmjwIQpDwmAgSkJhQmkCIxpDQmHCaBIGEg8E0MJoCkPCYAEgcEcAIHBHACBwRxJIEWjDaPAiE0PDYBVLGUCJHEFhwWjJA/zUwWgJBgkPBNDBaBFDwWABIHBHACBwRxC1BUwSaApLZGkaQBxAokIA0UAYEL07KhkIADwCQH9uXUxVVQAAADAAQP8PAADsqv8P/P//DwAAAAA=
-    pc_init: 39
-    pc_uninit: 81
-    pc_program_page: 143
-    pc_erase_sector: 139
-    pc_erase_all: 95
-    data_section_offset: 244
+    pc_init: 0x27
+    pc_uninit: 0x51
+    pc_program_page: 0x8f
+    pc_erase_sector: 0x8b
+    pc_erase_all: 0x5f
+    data_section_offset: 0xf4
     flash_properties:
       address_range:
-        start: 536854528
-        end: 536854532
-      page_size: 4
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fffc000
+        end: 0x1fffc004
+      page_size: 0x4
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 4
-          address: 0
-  stm32f410xx_412xx_opt:
-    name: stm32f410xx_412xx_opt
+        - size: 0x4
+          address: 0x0
+  - name: stm32f410xx_412xx_opt
     description: STM32F410xx/412xx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEcsSCpJgWArSYFgwWjwIhFDwWBAaYAGBtQpSCdJAWAGIUFgJ0mBYAAgcEchSEFpASIRQ0FhACBwRx5IwmjwIQpDwmAgSkJhQmkCIxpDQmHCaBIGEg8E0MJoCkPCYAEgcEcAIHBHACBwRxJIEWjDaPAiE0PDYBVLGUCJHEFhwWjJA/zUwWgJBgkPBNDBaBFDwWABIHBHACBwRxC1BUwSaApLZGkaQBxAokIA0UAYEL07KhkIADwCQH9uXUxVVQAAADAAQP8PAADsqv8P/P//DwAAAAA=
-    pc_init: 39
-    pc_uninit: 81
-    pc_program_page: 143
-    pc_erase_sector: 139
-    pc_erase_all: 95
-    data_section_offset: 244
+    pc_init: 0x27
+    pc_uninit: 0x51
+    pc_program_page: 0x8f
+    pc_erase_sector: 0x8b
+    pc_erase_all: 0x5f
+    data_section_offset: 0xf4
     flash_properties:
       address_range:
-        start: 536854528
-        end: 536854532
-      page_size: 4
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fffc000
+        end: 0x1fffc004
+      page_size: 0x4
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 4
-          address: 0
-  stm32f4xx_otp:
-    name: stm32f4xx_otp
+        - size: 0x4
+          address: 0x0
+  - name: stm32f4xx_otp
     description: STM32F4xx Flash OTP
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: AAMADiAoAtNACQAdcEcQKALTAAnAHHBHgAhwRyVIJElBYCVJQWAAIQFgwWjwIhFDwWBAaYAGBtQhSCBJAWAGIUFgIEmBYAAgcEcaSAFpQgURQwFhACBwRwAgcEdwtRVNyRyJCOtoiQDwJjND62AAIythFUsX4CxpHEMsYRRoBGDsaOQD/NQsaWQIZAAsYexoJAYkDwTQ6GgwQ+hgASBwvQAdEh0JHwAp5dEAIHC9AAAjAWdFADwCQKuJ781VVQAAADAAQP8PAAABAgAAAAAAAA==
-    pc_init: 29
-    pc_uninit: 75
-    pc_program_page: 93
-    pc_erase_sector: 89
-    pc_erase_all: ~
-    data_section_offset: 204
+    pc_init: 0x1d
+    pc_uninit: 0x4b
+    pc_program_page: 0x5d
+    pc_erase_sector: 0x59
+    pc_erase_all: null
+    data_section_offset: 0xcc
     flash_properties:
       address_range:
-        start: 536836096
-        end: 536836624
-      page_size: 528
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fff7800
+        end: 0x1fff7a10
+      page_size: 0x210
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 528
-          address: 0
-  stm32f4xx_256:
-    name: stm32f4xx_256
+        - size: 0x210
+          address: 0x0
+  - name: stm32f4xx_256
     description: STM32F4xx 256kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEdCSEBJQWBBSUFgACEBYMFo8CIRQ8FgQGmABgbUPkg8SQFgBiFBYDxJgWAAIHBHNkgBaUIFEUMBYQAgcEcQtTJIAWkEJCFDAWEBaaIDEUMBYTNJMEoA4BFgw2jbA/vUAWmhQwFhACAQvTC1//e2/yZJymjwIxpDymACJAxhCmnABgAOAkMKYQhp4gMQQwhhI0ghSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML1wtRRNyRyJCOtoiQDwJjND62AAIythFUsX4CxpHEMsYRRoBGDsaOQD/NQsaWQIZAAsYexoJAYkDwTQ6GgwQ+hgASBwvQAdEh0JHwAp5dEAIHC9IwFnRQA8AkCrie/NVVUAAAAwAED/DwAAqqoAAAECAAAAAAAA
-    pc_init: 39
-    pc_uninit: 85
-    pc_program_page: 219
-    pc_erase_sector: 143
-    pc_erase_all: 99
-    data_section_offset: 332
+    pc_init: 0x27
+    pc_uninit: 0x55
+    pc_program_page: 0xdb
+    pc_erase_sector: 0x8f
+    pc_erase_all: 0x63
+    data_section_offset: 0x14c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134479872
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8040000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-  stm32f4xx_384:
-    name: stm32f4xx_384
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+  - name: stm32f4xx_384
     description: STM32F4xx 384kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEdCSEBJQWBBSUFgACEBYMFo8CIRQ8FgQGmABgbUPkg8SQFgBiFBYDxJgWAAIHBHNkgBaUIFEUMBYQAgcEcQtTJIAWkEJCFDAWEBaaIDEUMBYTNJMEoA4BFgw2jbA/vUAWmhQwFhACAQvTC1//e2/yZJymjwIxpDymACJAxhCmnABgAOAkMKYQhp4gMQQwhhI0ghSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML1wtRRNyRyJCOtoiQDwJjND62AAIythFUsX4CxpHEMsYRRoBGDsaOQD/NQsaWQIZAAsYexoJAYkDwTQ6GgwQ+hgASBwvQAdEh0JHwAp5dEAIHC9IwFnRQA8AkCrie/NVVUAAAAwAED/DwAAqqoAAAECAAAAAAAA
-    pc_init: 39
-    pc_uninit: 85
-    pc_program_page: 219
-    pc_erase_sector: 143
-    pc_erase_all: 99
-    data_section_offset: 332
+    pc_init: 0x27
+    pc_uninit: 0x55
+    pc_program_page: 0xdb
+    pc_erase_sector: 0x8f
+    pc_erase_all: 0x63
+    data_section_offset: 0x14c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134610944
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8060000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-  stm32f4xx_128:
-    name: stm32f4xx_128
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+  - name: stm32f4xx_128
     description: STM32F4xx 128kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEdCSEBJQWBBSUFgACEBYMFo8CIRQ8FgQGmABgbUPkg8SQFgBiFBYDxJgWAAIHBHNkgBaUIFEUMBYQAgcEcQtTJIAWkEJCFDAWEBaaIDEUMBYTNJMEoA4BFgw2jbA/vUAWmhQwFhACAQvTC1//e2/yZJymjwIxpDymACJAxhCmnABgAOAkMKYQhp4gMQQwhhI0ghSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML1wtRRNyRyJCOtoiQDwJjND62AAIythFUsX4CxpHEMsYRRoBGDsaOQD/NQsaWQIZAAsYexoJAYkDwTQ6GgwQ+hgASBwvQAdEh0JHwAp5dEAIHC9IwFnRQA8AkCrie/NVVUAAAAwAED/DwAAqqoAAAECAAAAAAAA
-    pc_init: 39
-    pc_uninit: 85
-    pc_program_page: 219
-    pc_erase_sector: 143
-    pc_erase_all: 99
-    data_section_offset: 332
+    pc_init: 0x27
+    pc_uninit: 0x55
+    pc_program_page: 0xdb
+    pc_erase_sector: 0x8f
+    pc_erase_all: 0x63
+    data_section_offset: 0x14c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134348800
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8020000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-  stm32f4xx_2048:
-    name: stm32f4xx_2048
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+  - name: stm32f4xx_2048
     description: STM32F4xx 2MB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEdGSERJQWBFSUFgACEBYMFo8CIRQ8FgQGmABgbUQkhASQFgBiFBYEBJgWAAIHBHOkgBaUIFEUMBYQAgcEcwtTZIAWkEJCFDAWEBaWUDKUMBYQFpogMRQwFhNUkySgDgEWDDaNsD+9QBaaFDAWEBaalDAWEAIDC9MLX/96//J0nKaPAjGkPKYAIkDGEKacAGAA4CQwphCGniAxBDCGEkSCFKAOAQYM1o7QP71AhpoEMIYchoAAYADwPQyGgYQ8hgASAwvXC1FU3JHIkI62iJAPAmM0PrYAAjK2EWSxfgLGkcQyxhFGgEYOxo5AP81CxpZAhkACxh7GgkBiQPBNDoaDBD6GABIHC9AB0SHQkfACnl0QAgcL0AACMBZ0UAPAJAq4nvzVVVAAAAMABA/w8AAKqqAAABAgAAAAAAAA==
-    pc_init: 39
-    pc_uninit: 85
-    pc_program_page: 233
-    pc_erase_sector: 157
-    pc_erase_all: 99
-    data_section_offset: 348
+    pc_init: 0x27
+    pc_uninit: 0x55
+    pc_program_page: 0xe9
+    pc_erase_sector: 0x9d
+    pc_erase_all: 0x63
+    data_section_offset: 0x15c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 136314880
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8200000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-        - size: 16384
-          address: 1048576
-        - size: 65536
-          address: 1114112
-        - size: 131072
-          address: 1179648
-  stm32f4xx_512:
-    name: stm32f4xx_512
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+        - size: 0x4000
+          address: 0x100000
+        - size: 0x10000
+          address: 0x110000
+        - size: 0x20000
+          address: 0x120000
+  - name: stm32f4xx_512
     description: STM32F4xx 512kB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: AUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEdCSEBJQWBBSUFgACEBYMFo8CIRQ8FgQGmABgbUPkg8SQFgBiFBYDxJgWAAIHBHNkgBaUIFEUMBYQAgcEcQtTJIAWkEJCFDAWEBaaIDEUMBYTNJMEoA4BFgw2jbA/vUAWmhQwFhACAQvTC1//e2/yZJymjwIxpDymACJAxhCmnABgAOAkMKYQhp4gMQQwhhI0ghSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML1wtRRNyRyJCOtoiQDwJjND62AAIythFUsX4CxpHEMsYRRoBGDsaOQD/NQsaWQIZAAsYexoJAYkDwTQ6GgwQ+hgASBwvQAdEh0JHwAp5dEAIHC9IwFnRQA8AkCrie/NVVUAAAAwAED/DwAAqqoAAAECAAAAAAAA
-    pc_init: 39
-    pc_uninit: 85
-    pc_program_page: 219
-    pc_erase_sector: 143
-    pc_erase_all: 99
-    data_section_offset: 332
+    pc_init: 0x27
+    pc_uninit: 0x55
+    pc_program_page: 0xdb
+    pc_erase_sector: 0x8f
+    pc_erase_all: 0x63
+    data_section_offset: 0x14c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134742016
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8080000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000

--- a/probe-rs/targets/STM32F7_Series.yaml
+++ b/probe-rs/targets/STM32F7_Series.yaml
@@ -1,4 +1,3 @@
----
 name: STM32F7 Series
 variants:
   - name: STM32F722ICKx
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -39,21 +40,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -71,21 +74,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -103,21 +108,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -135,21 +142,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -167,21 +176,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -199,21 +210,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -231,21 +244,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -263,21 +278,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -295,21 +312,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -327,21 +346,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -359,21 +380,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -391,21 +414,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -423,21 +448,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -455,21 +482,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -487,21 +516,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -519,21 +550,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -551,21 +584,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -583,21 +618,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -615,21 +652,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_64_axi
       - stm32f7x_64_tcm
@@ -647,21 +686,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_64_axi
       - stm32f7x_64_tcm
@@ -679,21 +720,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_64_axi
       - stm32f7x_64_tcm
@@ -711,21 +754,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_64_axi
       - stm32f7x_64_tcm
@@ -743,21 +788,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -775,21 +822,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -807,21 +856,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -839,21 +890,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -871,21 +924,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -903,21 +958,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -935,21 +992,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -967,21 +1026,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -999,21 +1060,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -1031,21 +1094,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -1063,21 +1128,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x2_512
       - stm32f7x2tcm_512
@@ -1095,21 +1162,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1127,21 +1196,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1159,21 +1230,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1191,21 +1264,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1223,21 +1298,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1255,21 +1332,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1287,21 +1366,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1319,21 +1400,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1351,21 +1434,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1383,21 +1468,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1415,21 +1502,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1447,21 +1536,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1479,21 +1570,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1511,21 +1604,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1543,21 +1638,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1575,21 +1672,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1607,21 +1706,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1639,21 +1740,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1671,21 +1774,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1703,21 +1808,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1735,21 +1842,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1767,21 +1876,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1799,21 +1910,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1831,21 +1944,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1863,21 +1978,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1895,21 +2012,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -1927,21 +2046,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f75x_64_axi
       - stm32f75x_64_tcm
@@ -1959,21 +2080,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f75x_64_axi
       - stm32f75x_64_tcm
@@ -1991,21 +2114,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f75x_64_axi
       - stm32f75x_64_tcm
@@ -2023,21 +2148,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2055,21 +2182,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2087,21 +2216,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2119,21 +2250,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2151,21 +2284,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2183,21 +2318,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2215,21 +2352,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2247,21 +2386,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2279,21 +2420,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2313,21 +2456,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -2347,21 +2492,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2381,21 +2528,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2415,21 +2564,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -2449,21 +2600,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -2483,21 +2636,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2517,21 +2672,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -2551,21 +2708,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2585,21 +2744,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -2619,21 +2780,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2653,21 +2816,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -2687,21 +2852,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2721,21 +2888,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -2755,21 +2924,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2789,21 +2960,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2823,21 +2996,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -2857,21 +3032,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -2891,21 +3068,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2925,21 +3104,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -2959,21 +3140,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -2993,21 +3176,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3027,21 +3212,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -3061,21 +3248,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3095,21 +3284,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3129,21 +3320,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7x_1024dual
@@ -3163,21 +3356,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3197,21 +3392,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -3231,21 +3428,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3265,21 +3464,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -3299,21 +3500,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3333,21 +3536,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_1024
       - stm32f7xtcm_1024
@@ -3367,21 +3572,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3401,21 +3608,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3435,21 +3644,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3469,21 +3680,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3503,21 +3716,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3537,21 +3752,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3571,21 +3788,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3605,21 +3824,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3639,21 +3860,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3673,21 +3896,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3707,21 +3932,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3741,21 +3968,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537395200
+            start: 0x20000000
+            end: 0x20080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32f7x_2048
       - stm32f7x_2048dual
@@ -3770,642 +3999,642 @@ variants:
       - stm32f769i_qspi_macronix
       - stm32f723e_qspi_macronix
 flash_algorithms:
-  stm32f7x_64_axi:
-    name: stm32f7x_64_axi
+  - name: stm32f7x_64_axi
     description: STM32F7xx 64k AXI Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHwPOEMAgoAtMEIQHr0ABwR1RIUkkBYFNJAWAAIQAfAWBQSAgwAWhB8PABAWBNSBAwAGiABgjUTEhF8lVRAWAGIUFgQPb/cYFgACBwR0VIDDABaEHwAEEBYAAgcEcQtUBMDDQgaEDwBAAgYCBoQPSAMCBgPUkiH0r2qiAA4AhgE2jbA/vUIGgg8AQAIGAAIBC9ELX/97X/MkkIMQpoQvDwAgpgAiIMHSJgImh4IwPqwAACQyJgIGhA9IAwIGArSkr2qiAA4BBgC2jbA/vUIGgg8AIAIGAIaBDw8AAE0AhoQPDwAAhgASAQvfC1HUzJHCHwAwEINCNoQ/DwAyNgACMlHStgQPIBLBhPSvaqJiLgK2hD6gwDK2DA8xMOE2hO8ABuzvgAML/zT48A4D5gI2jbA/vUK2gj8AEDK2AjaBPw8A8F0CBoQPDwACBgASDwvQAdCR8SHQAp2tEAIPC9AAAjAWdFBDwCQKuJ780AMABAAAAAAA==
-    pc_init: 23
-    pc_uninit: 83
-    pc_program_page: 239
-    pc_erase_sector: 151
-    pc_erase_all: 99
-    data_section_offset: 372
+    pc_init: 0x17
+    pc_uninit: 0x53
+    pc_program_page: 0xef
+    pc_erase_sector: 0x97
+    pc_erase_all: 0x63
+    data_section_offset: 0x174
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134283264
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8010000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-  stm32f7x_64_tcm:
-    name: stm32f7x_64_tcm
+        - size: 0x4000
+          address: 0x0
+  - name: stm32f7x_64_tcm
     description: STM32F7xx 64k TCM Flash
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHwPOEMAgoAtMEIQHr0ABwR1RIUkkBYFNJAWAAIQAfAWBQSAgwAWhB8PABAWBNSBAwAGiABgjUTEhF8lVRAWAGIUFgQPb/cYFgACBwR0VIDDABaEHwAEEBYAAgcEcQtUBMDDQgaEDwBAAgYCBoQPSAMCBgPUkiH0r2qiAA4AhgE2jbA/vUIGgg8AQAIGAAIBC9ELX/97X/MkkIMQpoQvDwAgpgAiIMHSJgImh4IwPqwAACQyJgIGhA9IAwIGArSkr2qiAA4BBgC2jbA/vUIGgg8AIAIGAIaBDw8AAE0AhoQPDwAAhgASAQvfC1HUzJHCHwAwEINCNoQ/DwAyNgACMlHStgQPIBLBhPSvaqJiLgK2hD6gwDK2DA8xMOE2hO8ABuzvgAML/zT48A4D5gI2jbA/vUK2gj8AEDK2AjaBPw8A8F0CBoQPDwACBgASDwvQAdCR8SHQAp2tEAIPC9AAAjAWdFBDwCQKuJ780AMABAAAAAAA==
-    pc_init: 23
-    pc_uninit: 83
-    pc_program_page: 239
-    pc_erase_sector: 151
-    pc_erase_all: 99
-    data_section_offset: 372
+    pc_init: 0x17
+    pc_uninit: 0x53
+    pc_program_page: 0xef
+    pc_erase_sector: 0x97
+    pc_erase_all: 0x63
+    data_section_offset: 0x174
     flash_properties:
       address_range:
-        start: 2097152
-        end: 2162688
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x200000
+        end: 0x210000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-  stm32f7x2_512:
-    name: stm32f7x2_512
+        - size: 0x4000
+          address: 0x0
+  - name: stm32f7x2_512
     description: STM32F72x/3x 512KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHAAMADiAoAtNACQAdcEcQKALTAAnAHHBHgAhwR0lIR0lBYEhJQWAAIQFgwWjwIhFDwWBAaYAGBtRFSENJAWAGIUFgQ0mBYAAgcEc9SAFpQgURQwFhACBwRxC1OUgBaQQkIUMBYQFpogMRQwFhOkk3SgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97v/LUnKaPAjGkPKYAIkDGEKacAGAA4CQwphCGniAxBDCGG/80+PKUgnSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML3wtRpMyRyJCOVoiQDwIx1D5WAAIyNhASf/BhlNIeAjaRlOM0MjYcYC9gr2GRNoM2C/80+PEU4A4DVg42jbA/vUI2lbCFsAI2HjaBsGGw8F0OBo8CEIQ+BgASDwvQAdCR8SHQAp29EAIPC9IwFnRQA8AkCrie/NVVUAAAAwAED/DwAAqqoAAAECAAAAAAAA
-    pc_init: 35
-    pc_uninit: 81
-    pc_program_page: 219
-    pc_erase_sector: 139
-    pc_erase_all: 95
-    data_section_offset: 356
+    pc_init: 0x23
+    pc_uninit: 0x51
+    pc_program_page: 0xdb
+    pc_erase_sector: 0x8b
+    pc_erase_all: 0x5f
+    data_section_offset: 0x164
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134742016
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8080000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-  stm32f7x2tcm_512:
-    name: stm32f7x2tcm_512
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+  - name: stm32f7x2tcm_512
     description: STM32F72x/3x TCM 512KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHAAMADiAoAtNACQAdcEcQKALTAAnAHHBHgAhwR0lIR0lBYEhJQWAAIQFgwWjwIhFDwWBAaYAGBtRFSENJAWAGIUFgQ0mBYAAgcEc9SAFpQgURQwFhACBwRxC1OUgBaQQkIUMBYQFpogMRQwFhOkk3SgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97v/LUnKaPAjGkPKYAIkDGEKacAGAA4CQwphCGniAxBDCGG/80+PKUgnSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML3wtRpMyRyJCOVoiQDwIx1D5WAAIyNhASf/BhlNIeAjaRlOM0MjYcYC9gr2GRNoM2C/80+PEU4A4DVg42jbA/vUI2lbCFsAI2HjaBsGGw8F0OBo8CEIQ+BgASDwvQAdCR8SHQAp29EAIPC9IwFnRQA8AkCrie/NVVUAAAAwAED/DwAAqqoAAAECAAAAAAAA
-    pc_init: 35
-    pc_uninit: 81
-    pc_program_page: 219
-    pc_erase_sector: 139
-    pc_erase_all: 95
-    data_section_offset: 356
+    pc_init: 0x23
+    pc_uninit: 0x51
+    pc_program_page: 0xdb
+    pc_erase_sector: 0x8b
+    pc_erase_all: 0x5f
+    data_section_offset: 0x164
     flash_properties:
       address_range:
-        start: 2097152
-        end: 2621440
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 6000
+        start: 0x200000
+        end: 0x280000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-  stm32f72x_73x_opt:
-    name: stm32f72x_73x_opt
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+  - name: stm32f72x_73x_opt
     description: STM32F72x/3x Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHQkhASYFgQUmBYMFo8CIRQ8FgQGmABgbUP0g9SQFgBiFBYD1JgWAAIHBHN0hBaQEiEUNBYQAgcEcQtTNIwWjwJCFDwWAAIcFhNUmBYTVJQWFBaQIiEUNBYb/zT48ySS1KAOARYMNo2wP71MFoCQYJDwTQwWghQ8FgASAQvQAgEL0AIHBHMLUKyiBIEmjFaPAkJUPFYCVNKkDCYYNhJEoRQEFhQWkCIhFDQWG/80+PHUkZSgDgEWDDaNsD+9TBaAkGCQ8E0MFoIUPBYAEgML0AIDC98LUNThRoU2gUTZJod2ksQC9AvEID0bRpnEIB0EAc8L0NS/RpGkAcQKJCAdCAHPC9QBjwvTsqGQgAPAJAf25dTFVVAAAAMABA/w8AAIAAQAD8qv//qqoAAP8AAID8///AAAAAAA==
-    pc_init: 7
-    pc_uninit: 49
-    pc_program_page: 139
-    pc_erase_sector: 135
-    pc_erase_all: 63
-    data_section_offset: 312
+    pc_init: 0x7
+    pc_uninit: 0x31
+    pc_program_page: 0x8b
+    pc_erase_sector: 0x87
+    pc_erase_all: 0x3f
+    data_section_offset: 0x138
     flash_properties:
       address_range:
-        start: 536805376
-        end: 536805388
-      page_size: 12
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fff0000
+        end: 0x1fff000c
+      page_size: 0xc
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 12
-          address: 0
-  stm32f7x2_otp:
-    name: stm32f7x2_otp
+        - size: 0xc
+          address: 0x0
+  - name: stm32f7x2_otp
     description: STM32F72x/3x Flash OTP
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHK0gpSUFgKklBYAAhAWDBaPAiEUPBYEBpgAYG1CdIJUkBYAYhQWAlSYFgACBwRx9IAWlCBRFDAWEAIHBHACBwR/C1GkzJHIkI5WiJAPAjHUPlYAAjI2EaTxtNIeAjaRpOM0MjYUYFdg32GRNoM2C/80+PEU4A4DVg42jbA/vUI2lbCFsAI2HjaBsGGw8F0OBo8CEIQ+BgASDwvQAdCR8SHQAp29EAIPC9AAAjAWdFADwCQKuJ781VVQAAADAAQP8PAAAAePAfqqoAAAECAAAAAAAA
-    pc_init: 7
-    pc_uninit: 53
-    pc_program_page: 71
-    pc_erase_sector: 67
-    pc_erase_all: ~
-    data_section_offset: 212
+    pc_init: 0x7
+    pc_uninit: 0x35
+    pc_program_page: 0x47
+    pc_erase_sector: 0x43
+    pc_erase_all: null
+    data_section_offset: 0xd4
     flash_properties:
       address_range:
-        start: 535853056
-        end: 535853584
-      page_size: 528
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ff07800
+        end: 0x1ff07a10
+      page_size: 0x210
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 528
-          address: 0
-  stm32f75x_64_axi:
-    name: stm32f75x_64_axi
+        - size: 0x210
+          address: 0x0
+  - name: stm32f75x_64_axi
     description: STM32F75x 64k TCM Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHwPOEMAgoAtMEIQHr0ABwR1RIUkkBYFNJAWAAIQAfAWBQSAgwAWhB8PABAWBNSBAwAGiABgjUTEhF8lVRAWAGIUFgQPb/cYFgACBwR0VIDDABaEHwAEEBYAAgcEcQtUBMDDQgaEDwBAAgYCBoQPSAMCBgPUkiH0r2qiAA4AhgE2jbA/vUIGgg8AQAIGAAIBC9ELX/97X/MkkIMQpoQvDwAgpgAiIMHSJgImh4IwPqwAACQyJgIGhA9IAwIGArSkr2qiAA4BBgC2jbA/vUIGgg8AIAIGAIaBDw8AAE0AhoQPDwAAhgASAQvfC1HUzJHCHwAwEINCNoQ/DwAyNgACMlHStgQPIBLBhPSvaqJiLgK2hD6gwDK2DA8xMOE2hO8ABuzvgAML/zT48A4D5gI2jbA/vUK2gj8AEDK2AjaBPw8A8F0CBoQPDwACBgASDwvQAdCR8SHQAp2tEAIPC9AAAjAWdFBDwCQKuJ780AMABAAAAAAA==
-    pc_init: 23
-    pc_uninit: 83
-    pc_program_page: 239
-    pc_erase_sector: 151
-    pc_erase_all: 99
-    data_section_offset: 372
+    pc_init: 0x17
+    pc_uninit: 0x53
+    pc_program_page: 0xef
+    pc_erase_sector: 0x97
+    pc_erase_all: 0x63
+    data_section_offset: 0x174
     flash_properties:
       address_range:
-        start: 2097152
-        end: 2162688
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x200000
+        end: 0x210000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 32768
-          address: 0
-  stm32f75x_64_tcm:
-    name: stm32f75x_64_tcm
+        - size: 0x8000
+          address: 0x0
+  - name: stm32f75x_64_tcm
     description: STM32F75x 64k TCM Flash
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHwPOEMAgoAtMEIQHr0ABwR1RIUkkBYFNJAWAAIQAfAWBQSAgwAWhB8PABAWBNSBAwAGiABgjUTEhF8lVRAWAGIUFgQPb/cYFgACBwR0VIDDABaEHwAEEBYAAgcEcQtUBMDDQgaEDwBAAgYCBoQPSAMCBgPUkiH0r2qiAA4AhgE2jbA/vUIGgg8AQAIGAAIBC9ELX/97X/MkkIMQpoQvDwAgpgAiIMHSJgImh4IwPqwAACQyJgIGhA9IAwIGArSkr2qiAA4BBgC2jbA/vUIGgg8AIAIGAIaBDw8AAE0AhoQPDwAAhgASAQvfC1HUzJHCHwAwEINCNoQ/DwAyNgACMlHStgQPIBLBhPSvaqJiLgK2hD6gwDK2DA8xMOE2hO8ABuzvgAML/zT48A4D5gI2jbA/vUK2gj8AEDK2AjaBPw8A8F0CBoQPDwACBgASDwvQAdCR8SHQAp2tEAIPC9AAAjAWdFBDwCQKuJ780AMABAAAAAAA==
-    pc_init: 23
-    pc_uninit: 83
-    pc_program_page: 239
-    pc_erase_sector: 151
-    pc_erase_all: 99
-    data_section_offset: 372
+    pc_init: 0x17
+    pc_uninit: 0x53
+    pc_program_page: 0xef
+    pc_erase_sector: 0x97
+    pc_erase_all: 0x63
+    data_section_offset: 0x174
     flash_properties:
       address_range:
-        start: 2097152
-        end: 2162688
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x200000
+        end: 0x210000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 32768
-          address: 0
-  stm32f74x_75x_opt:
-    name: stm32f74x_75x_opt
+        - size: 0x8000
+          address: 0x0
+  - name: stm32f74x_75x_opt
     description: STM32F74x/5x Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHO0g5SYFgOkmBYMFo8CIRQ8FgQGmABgbUOEg2SQFgBiFBYDZJgWAAIHBHMEhBaQEiEUNBYQAgcEcQtSxIwWjwJCFDwWAvSYFhL0lBYUFpAiIRQ0Fhv/NPjyxJJ0oA4BFgw2jbA/vUwWgJBgkPBNDBaCFDwWABIBC9ACAQvQAgcEcQtRpIBsrDaPAkI0PDYIJhH0oRQEFhQWkCIhFDQWG/80+PGUkVSgDgEWDDaNsD+9TBaAkGCQ8E0MFoIUPBYAEgEL0AIBC9cLUJTBNoEE5SaGVpM0A1QKtCA9GjaZNCAdBAHHC9QBhwvQAAOyoZCAA8AkB/bl1MVVUAAAAwAED/DwAAgABAAPyq//+qqgAA/P//wAAAAAA=
-    pc_init: 7
-    pc_uninit: 49
-    pc_program_page: 135
-    pc_erase_sector: 131
-    pc_erase_all: 63
-    data_section_offset: 280
+    pc_init: 0x7
+    pc_uninit: 0x31
+    pc_program_page: 0x87
+    pc_erase_sector: 0x83
+    pc_erase_all: 0x3f
+    data_section_offset: 0x118
     flash_properties:
       address_range:
-        start: 536805376
-        end: 536805384
-      page_size: 8
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fff0000
+        end: 0x1fff0008
+      page_size: 0x8
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 8
-          address: 0
-  stm32f7x_1024:
-    name: stm32f7x_1024
+        - size: 0x8
+          address: 0x0
+  - name: stm32f7x_1024
     description: STM32F7x 1MB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHwALADUAoAtOACQAdcEcgKALTQAnAHHBHwAhwR0lIR0lBYEhJQWAAIQFgwWjwIhFDwWBAaYAGBtRFSENJAWAGIUFgQ0mBYAAgcEc9SAFpQgURQwFhACBwRxC1OUgBaQQkIUMBYQFpogMRQwFhOkk3SgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97v/LUnKaPAjGkPKYAIkDGEKacAGAA4CQwphCGniAxBDCGG/80+PKUgnSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML3wtRpMyRyJCOVoiQDwIx1D5WAAIyNhASf/BhlNIeAjaRlOM0MjYcYC9gr2GRNoM2C/80+PEU4A4DVg42jbA/vUI2lbCFsAI2HjaBsGGw8F0OBo8CEIQ+BgASDwvQAdCR8SHQAp29EAIPC9IwFnRQA8AkCrie/NVVUAAAAwAED/DwAAqqoAAAECAAAAAAAA
-    pc_init: 35
-    pc_uninit: 81
-    pc_program_page: 219
-    pc_erase_sector: 139
-    pc_erase_all: 95
-    data_section_offset: 356
+    pc_init: 0x23
+    pc_uninit: 0x51
+    pc_program_page: 0xdb
+    pc_erase_sector: 0x8b
+    pc_erase_all: 0x5f
+    data_section_offset: 0x164
     flash_properties:
       address_range:
-        start: 134217728
-        end: 135266304
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8100000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 32768
-          address: 0
-        - size: 131072
-          address: 131072
-        - size: 262144
-          address: 262144
-  stm32f7xtcm_1024:
-    name: stm32f7xtcm_1024
+        - size: 0x8000
+          address: 0x0
+        - size: 0x20000
+          address: 0x20000
+        - size: 0x40000
+          address: 0x40000
+  - name: stm32f7xtcm_1024
     description: STM32F7x TCM 1MB Flash
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHwALADUAoAtOACQAdcEcgKALTQAnAHHBHwAhwR0lIR0lBYEhJQWAAIQFgwWjwIhFDwWBAaYAGBtRFSENJAWAGIUFgQ0mBYAAgcEc9SAFpQgURQwFhACBwRxC1OUgBaQQkIUMBYQFpogMRQwFhOkk3SgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97v/LUnKaPAjGkPKYAIkDGEKacAGAA4CQwphCGniAxBDCGG/80+PKUgnSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML3wtRpMyRyJCOVoiQDwIx1D5WAAIyNhASf/BhlNIeAjaRlOM0MjYcYC9gr2GRNoM2C/80+PEU4A4DVg42jbA/vUI2lbCFsAI2HjaBsGGw8F0OBo8CEIQ+BgASDwvQAdCR8SHQAp29EAIPC9IwFnRQA8AkCrie/NVVUAAAAwAED/DwAAqqoAAAECAAAAAAAA
-    pc_init: 35
-    pc_uninit: 81
-    pc_program_page: 219
-    pc_erase_sector: 139
-    pc_erase_all: 95
-    data_section_offset: 356
+    pc_init: 0x23
+    pc_uninit: 0x51
+    pc_program_page: 0xdb
+    pc_erase_sector: 0x8b
+    pc_erase_all: 0x5f
+    data_section_offset: 0x164
     flash_properties:
       address_range:
-        start: 2097152
-        end: 3145728
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 6000
+        start: 0x200000
+        end: 0x300000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 32768
-          address: 0
-        - size: 131072
-          address: 131072
-        - size: 262144
-          address: 262144
-  stm32f7x_1024dual:
-    name: stm32f7x_1024dual
+        - size: 0x8000
+          address: 0x0
+        - size: 0x20000
+          address: 0x20000
+        - size: 0x40000
+          address: 0x40000
+  - name: stm32f7x_1024dual
     description: STM32F7x dual bank 1MB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHAUZAA0AOICgC00AJAB0F4BAoAtMACcAcAOCACAkDAdUQIQhDcEdLSEpJQWBLSUFgACEBYMFo8CIRQ8FgQGmABgbUR0hGSQFgBiFBYEZJgWAAIHBHQEgBaUIFEUMBYQAgcEcQtTxIAWkEJCFDAWEBaWIDEUMBYQFpUgARQwFhOkk4SgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97L/LknKaPAjGkPKYAIkDGEKacAGAA4CQwphCGniAxBDCGG/80+PKkgnSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML3wtRtMyRyJCOVoiQDwIx1D5WAAIyNhASf/BhpNIeAjaRlOM0MjYcYC9gr2GRNoM2C/80+PEU4A4DVg42jbA/vUI2lbCFsAI2HjaBsGGw8F0OBo8CEIQ+BgASDwvQAdCR8SHQAp29EAIPC9AAAjAWdFADwCQKuJ781VVQAAADAAQP8PAACqqgAAAQIAAAAAAAA=
-    pc_init: 45
-    pc_uninit: 91
-    pc_program_page: 237
-    pc_erase_sector: 157
-    pc_erase_all: 105
-    data_section_offset: 376
+    pc_init: 0x2d
+    pc_uninit: 0x5b
+    pc_program_page: 0xed
+    pc_erase_sector: 0x9d
+    pc_erase_all: 0x69
+    data_section_offset: 0x178
     flash_properties:
       address_range:
-        start: 134217728
-        end: 135266304
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8100000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-        - size: 16384
-          address: 524288
-        - size: 65536
-          address: 589824
-        - size: 131072
-          address: 655360
-  stm32f7xtcm_1024dual:
-    name: stm32f7xtcm_1024dual
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+        - size: 0x4000
+          address: 0x80000
+        - size: 0x10000
+          address: 0x90000
+        - size: 0x20000
+          address: 0xa0000
+  - name: stm32f7xtcm_1024dual
     description: STM32F7x TCM dual bank 1MB Flash
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHAUZAA0AOICgC00AJAB0F4BAoAtMACcAcAOCACAkDAdUQIQhDcEdLSEpJQWBLSUFgACEBYMFo8CIRQ8FgQGmABgbUR0hGSQFgBiFBYEZJgWAAIHBHQEgBaUIFEUMBYQAgcEcQtTxIAWkEJCFDAWEBaWIDEUMBYQFpUgARQwFhOkk4SgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97L/LknKaPAjGkPKYAIkDGEKacAGAA4CQwphCGniAxBDCGG/80+PKkgnSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML3wtRtMyRyJCOVoiQDwIx1D5WAAIyNhASf/BhpNIeAjaRlOM0MjYcYC9gr2GRNoM2C/80+PEU4A4DVg42jbA/vUI2lbCFsAI2HjaBsGGw8F0OBo8CEIQ+BgASDwvQAdCR8SHQAp29EAIPC9AAAjAWdFADwCQKuJ781VVQAAADAAQP8PAACqqgAAAQIAAAAAAAA=
-    pc_init: 45
-    pc_uninit: 91
-    pc_program_page: 237
-    pc_erase_sector: 157
-    pc_erase_all: 105
-    data_section_offset: 376
+    pc_init: 0x2d
+    pc_uninit: 0x5b
+    pc_program_page: 0xed
+    pc_erase_sector: 0x9d
+    pc_erase_all: 0x69
+    data_section_offset: 0x178
     flash_properties:
       address_range:
-        start: 2097152
-        end: 3145728
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 6000
+        start: 0x200000
+        end: 0x300000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-        - size: 16384
-          address: 524288
-        - size: 65536
-          address: 589824
-        - size: 131072
-          address: 655360
-  stm32f7x_2048:
-    name: stm32f7x_2048
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+        - size: 0x4000
+          address: 0x80000
+        - size: 0x10000
+          address: 0x90000
+        - size: 0x20000
+          address: 0xa0000
+  - name: stm32f7x_2048
     description: STM32F7x 2MB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHwALADUAoAtOACQAdcEcgKALTQAnAHHBHwAhwR0lIR0lBYEhJQWAAIQFgwWjwIhFDwWBAaYAGBtRFSENJAWAGIUFgQ0mBYAAgcEc9SAFpQgURQwFhACBwRxC1OUgBaQQkIUMBYQFpogMRQwFhOkk3SgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97v/LUnKaPAjGkPKYAIkDGEKacAGAA4CQwphCGniAxBDCGG/80+PKUgnSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML3wtRpMyRyJCOVoiQDwIx1D5WAAIyNhASf/BhlNIeAjaRlOM0MjYcYC9gr2GRNoM2C/80+PEU4A4DVg42jbA/vUI2lbCFsAI2HjaBsGGw8F0OBo8CEIQ+BgASDwvQAdCR8SHQAp29EAIPC9IwFnRQA8AkCrie/NVVUAAAAwAED/DwAAqqoAAAECAAAAAAAA
-    pc_init: 35
-    pc_uninit: 81
-    pc_program_page: 219
-    pc_erase_sector: 139
-    pc_erase_all: 95
-    data_section_offset: 356
+    pc_init: 0x23
+    pc_uninit: 0x51
+    pc_program_page: 0xdb
+    pc_erase_sector: 0x8b
+    pc_erase_all: 0x5f
+    data_section_offset: 0x164
     flash_properties:
       address_range:
-        start: 134217728
-        end: 136314880
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8200000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 32768
-          address: 0
-        - size: 131072
-          address: 131072
-        - size: 262144
-          address: 262144
-  stm32f7x_2048dual:
-    name: stm32f7x_2048dual
+        - size: 0x8000
+          address: 0x0
+        - size: 0x20000
+          address: 0x20000
+        - size: 0x40000
+          address: 0x40000
+  - name: stm32f7x_2048dual
     description: STM32F7x dual bank 2MB Flash
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHAUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEdLSEpJQWBLSUFgACEBYMFo8CIRQ8FgQGmABgbUR0hGSQFgBiFBYEZJgWAAIHBHQEgBaUIFEUMBYQAgcEcQtTxIAWkEJCFDAWEBaWIDEUMBYQFpUgARQwFhOkk4SgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97L/LknKaPAjGkPKYAIkDGEKacAGAA4CQwphCGniAxBDCGG/80+PKkgnSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML3wtRtMyRyJCOVoiQDwIx1D5WAAIyNhASf/BhpNIeAjaRlOM0MjYcYC9gr2GRNoM2C/80+PEU4A4DVg42jbA/vUI2lbCFsAI2HjaBsGGw8F0OBo8CEIQ+BgASDwvQAdCR8SHQAp29EAIPC9AAAjAWdFADwCQKuJ781VVQAAADAAQP8PAACqqgAAAQIAAAAAAAA=
-    pc_init: 45
-    pc_uninit: 91
-    pc_program_page: 237
-    pc_erase_sector: 157
-    pc_erase_all: 105
-    data_section_offset: 376
+    pc_init: 0x2d
+    pc_uninit: 0x5b
+    pc_program_page: 0xed
+    pc_erase_sector: 0x9d
+    pc_erase_all: 0x69
+    data_section_offset: 0x178
     flash_properties:
       address_range:
-        start: 134217728
-        end: 136314880
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8200000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-        - size: 16384
-          address: 1048576
-        - size: 65536
-          address: 1114112
-        - size: 131072
-          address: 1179648
-  stm32f7xtcm_2048:
-    name: stm32f7xtcm_2048
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+        - size: 0x4000
+          address: 0x100000
+        - size: 0x10000
+          address: 0x110000
+        - size: 0x20000
+          address: 0x120000
+  - name: stm32f7xtcm_2048
     description: STM32F7x TCM 2MB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHwALADUAoAtOACQAdcEcgKALTQAnAHHBHwAhwR0lIR0lBYEhJQWAAIQFgwWjwIhFDwWBAaYAGBtRFSENJAWAGIUFgQ0mBYAAgcEc9SAFpQgURQwFhACBwRxC1OUgBaQQkIUMBYQFpogMRQwFhOkk3SgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97v/LUnKaPAjGkPKYAIkDGEKacAGAA4CQwphCGniAxBDCGG/80+PKUgnSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML3wtRpMyRyJCOVoiQDwIx1D5WAAIyNhASf/BhlNIeAjaRlOM0MjYcYC9gr2GRNoM2C/80+PEU4A4DVg42jbA/vUI2lbCFsAI2HjaBsGGw8F0OBo8CEIQ+BgASDwvQAdCR8SHQAp29EAIPC9IwFnRQA8AkCrie/NVVUAAAAwAED/DwAAqqoAAAECAAAAAAAA
-    pc_init: 35
-    pc_uninit: 81
-    pc_program_page: 219
-    pc_erase_sector: 139
-    pc_erase_all: 95
-    data_section_offset: 356
+    pc_init: 0x23
+    pc_uninit: 0x51
+    pc_program_page: 0xdb
+    pc_erase_sector: 0x8b
+    pc_erase_all: 0x5f
+    data_section_offset: 0x164
     flash_properties:
       address_range:
-        start: 2097152
-        end: 4194304
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 6000
+        start: 0x200000
+        end: 0x400000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 32768
-          address: 0
-        - size: 131072
-          address: 131072
-        - size: 262144
-          address: 262144
-  stm32f7xtcm_2048dual:
-    name: stm32f7xtcm_2048dual
+        - size: 0x8000
+          address: 0x0
+        - size: 0x20000
+          address: 0x20000
+        - size: 0x40000
+          address: 0x40000
+  - name: stm32f7xtcm_2048dual
     description: STM32F7x TCM dual bank 2MB Flash
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHAUYAAwAOICgC00AJAB0F4BAoAtMACcAcAOCACMkCAdUQIQhDcEdLSEpJQWBLSUFgACEBYMFo8CIRQ8FgQGmABgbUR0hGSQFgBiFBYEZJgWAAIHBHQEgBaUIFEUMBYQAgcEcQtTxIAWkEJCFDAWEBaWIDEUMBYQFpUgARQwFhOkk4SgDgEWDDaNsD+9QBaaFDAWEAIBC9MLX/97L/LknKaPAjGkPKYAIkDGEKacAGAA4CQwphCGniAxBDCGG/80+PKkgnSgDgEGDNaO0D+9QIaaBDCGHIaAAGAA8D0MhoGEPIYAEgML3wtRtMyRyJCOVoiQDwIx1D5WAAIyNhASf/BhpNIeAjaRlOM0MjYcYC9gr2GRNoM2C/80+PEU4A4DVg42jbA/vUI2lbCFsAI2HjaBsGGw8F0OBo8CEIQ+BgASDwvQAdCR8SHQAp29EAIPC9AAAjAWdFADwCQKuJ781VVQAAADAAQP8PAACqqgAAAQIAAAAAAAA=
-    pc_init: 45
-    pc_uninit: 91
-    pc_program_page: 237
-    pc_erase_sector: 157
-    pc_erase_all: 105
-    data_section_offset: 376
+    pc_init: 0x2d
+    pc_uninit: 0x5b
+    pc_program_page: 0xed
+    pc_erase_sector: 0x9d
+    pc_erase_all: 0x69
+    data_section_offset: 0x178
     flash_properties:
       address_range:
-        start: 2097152
-        end: 4194304
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 6000
+        start: 0x200000
+        end: 0x400000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 16384
-          address: 0
-        - size: 65536
-          address: 65536
-        - size: 131072
-          address: 131072
-        - size: 16384
-          address: 1048576
-        - size: 65536
-          address: 1114112
-        - size: 131072
-          address: 1179648
-  stm32f76x_77x_opt:
-    name: stm32f76x_77x_opt
+        - size: 0x4000
+          address: 0x0
+        - size: 0x10000
+          address: 0x10000
+        - size: 0x20000
+          address: 0x20000
+        - size: 0x4000
+          address: 0x100000
+        - size: 0x10000
+          address: 0x110000
+        - size: 0x20000
+          address: 0x120000
+  - name: stm32f76x_77x_opt
     description: STM32F76x/7x Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHO0g5SYFgOkmBYMFo8CIRQ8FgQGmABgbUOEg2SQFgBiFBYDZJgWAAIHBHMEhBaQEiEUNBYQAgcEcQtSxIwWjwJCFDwWAvSYFhL0lBYUFpAiIRQ0Fhv/NPjyxJJ0oA4BFgw2jbA/vUwWgJBgkPBNDBaCFDwWABIBC9ACAQvQAgcEcQtRpIBsrDaPAkI0PDYIJhiQiJAEFhQWkCIhFDQWG/80+PGUkVSgDgEWDDaNsD+9TBaAkGCQ8E0MFoIUPBYAEgEL0AIBC9MLUTaFJonAgHS6QAXWmtCK0ArEID0Ztpk0IB0EAcML1AGDC9OyoZCAA8AkB/bl1MVVUAAAAwAED/DwAAgABAAPyq//+qqgAAAAAAAA==
-    pc_init: 7
-    pc_uninit: 49
-    pc_program_page: 135
-    pc_erase_sector: 131
-    pc_erase_all: 63
-    data_section_offset: 276
+    pc_init: 0x7
+    pc_uninit: 0x31
+    pc_program_page: 0x87
+    pc_erase_sector: 0x83
+    pc_erase_all: 0x3f
+    data_section_offset: 0x114
     flash_properties:
       address_range:
-        start: 536805376
-        end: 536805384
-      page_size: 8
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fff0000
+        end: 0x1fff0008
+      page_size: 0x8
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 8
-          address: 0
-  stm32f7xx_otp:
-    name: stm32f7xx_otp
+        - size: 0x8
+          address: 0x0
+  - name: stm32f7xx_otp
     description: STM32F7xx Flash OTP
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHK0gpSUFgKklBYAAhAWDBaPAiEUPBYEBpgAYG1CdIJUkBYAYhQWAlSYFgACBwRx9IAWlCBRFDAWEAIHBHACBwR/C1GkzJHIkI5WiJAPAjHUPlYAAjI2EaTxtNIeAjaRpOM0MjYQYFNg32GRNoM2C/80+PEU4A4DVg42jbA/vUI2lbCFsAI2HjaBsGGw8F0OBo8CEIQ+BgASDwvQAdCR8SHQAp29EAIPC9AAAjAWdFADwCQKuJ781VVQAAADAAQP8PAAAA8PAfqqoAAAECAAAAAAAA
-    pc_init: 7
-    pc_uninit: 53
-    pc_program_page: 71
-    pc_erase_sector: 67
-    pc_erase_all: ~
-    data_section_offset: 212
+    pc_init: 0x7
+    pc_uninit: 0x35
+    pc_program_page: 0x47
+    pc_erase_sector: 0x43
+    pc_erase_all: null
+    data_section_offset: 0xd4
     flash_properties:
       address_range:
-        start: 535883776
-        end: 535884816
-      page_size: 1040
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ff0f000
+        end: 0x1ff0f410
+      page_size: 0x410
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1040
-          address: 0
-  stm32f7xx_qspi_disco:
-    name: stm32f7xx_qspi_disco
+        - size: 0x410
+          address: 0x0
+  - name: stm32f7xx_qspi_disco
     description: STM32F746G-DISCO_N25Q128A
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: QLpwR0C6cEdAunBHQLpwR0C6cEfAunBHwLpwR8C6cEfAunBHwLpwR0/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAAD3SQAiCnAIcHBHAkYAIFEJASkM0AIpDdDxSXIxCWgC8B8CASOTQAtCANABIHBH7EmJHvPn6kluMfDnGLUAIE/0oGQAkDEg//fg/wCZSRwAkaFCAdAAKPXQMSD/99b/ACgA0AEgGL3eSYkeCmgi8PgCQurAAAhgcEfZSYkeACgIaALQQPABAAHgIPABAAhgcEfTSQAibjEKcApwASgC0AQoAdEFIAhwcEfNSm4yEWgh8BgBAUMRYHBHyUlyMQAoCGgC0EDwAQAB4CDwAQAIYHBHQeqCEVoIELXCSwKcA+sCQhFDAUNB6gRgvUmJHAhgEL27SYkeACgIaALQQPCAcAHgIPCAcAhgcEcQtbZMSQgE6wFBQeqAELJJQOoCYIIxQOoDcAhgEL2uSYkeACgIaALQQPCAYAHgIPCAYAhgcEcQtahMSQgE6wFBQeqAEKRJQOoCYIYxQOoDcAhgEL2gSYkeACgIaALQQPCAUAHgIPCAUAhgcEeaSYkeACgIaALQQPQAIAHgIPQAIAhgcEeUSpIdE2gIQyPw7GMYQxBgcEeQSpIdE2gIQyPweEMYQxBgcEeLSpIdEWgh8AMBAUMRYHBHh0iAHQBoAPAMAHBHhEqSHRFoIfDwAQFDEWBwR4BKkh0RaCH04FEBQxFgcEd8SYkdCmgi9GBCQurAAAhgcEfA8wEhAykI0XZKkh0RaCH0+BN1SQFAGUMRYHFJbjEKaMDzCwACQwpgcEdtSW4xACgIaALQQPQAQAHgIPQAQAhgcEdnSW4xACgIaALQQPSAMAHgIPSAMAhgcEdhSYkdACgIaALQQPQAAAHgIPQAAAhgcEdbSooyEWhAHiHwHwEBQxFgcEdXSYoxCmhv8P8DIvT4UgPrACAQQwhgcEdRSooyEWgh9EARAUMRYHBHTUqKMhFoIfRAAQFDEWBwR0lKijIRaCH0QDEBQxFgcEdFSYoxACgIaALQQPCAcAHgIPCAcAhgcEc/Si4yACkRaAHQAUMA4IFDEWBwRzpKMjIAKRFoAdABQwDggUMRYHBHNUo2MgApEWgB0AFDAOCBQxFgcEcwSj4yACkRaAHQAUMA4IFDEWBwRytKQjIAKRFoAdABQwDggUMRYHBHJkoOMgApEWgB0AFDAOCBQxFgcEchShIyACkRaAHQAUMA4IFDEWBwRxxKFjIAKRFoAdABQwDggUMRYHBHF0oeMgApEWgB0AFDAOCBQxFgcEcSSiIyACkRaAHQAUMA4IFDEWBwRw1KTjIAKRFoAdABQwDggUMRYHBHCEpSMgApEWgB0AFDAOCBQxFgcEcDSlYyACkRaAfQAUMG4AI4AkAAAP////z/D4FDEWBwR0tKACkRaAHQAUMA4IFDEWBwR0ZKEh0AKRFoAdABQwDggUMRYHBHQUpTOgApEXgB0AFDAOCBQxFwcEc8SBQwAWhB8IBxAWBwRwFGOEoAIFQ6EmgKQgDQASBwRzRJUjkIcHBHMkowMhFoAw8BKwbQAisH0AMrCNAEKwvRCOAh9EAxB+Ah9EAhBOAh9EARAeAh9EABAPR/AAhDEGBwRyRLELUwMxloAg8JKh3S3+gC8BwFCAsOERQXGgAh8AMBE+Ah8AwBEOAh8DABDeAh8MABCuAh9EBxB+Ah9EBhBOAh9EBRAeAh9EBBgLIIQxhgEL0PSjAyEWgh8EBxAUMRYHBHC0owMhFoIfCAYQFDEWBwRwdKMDIRaCHwAGEBQxFgcEcDSjAyEWgh8IBRAUMRYHBHYDgCQBC1ASECIP/3IP8AIb3oEEACIP/3Gr8AIQFgQWCBYMFgAWFBYYFhcEcAIUFggWDBYAFgAWFBYYFhwWEBYkFigWLBYnBHMLV/Sxlof0pEaRFAAmgFeSJDhGlE6gVkIkMKQxpgWWh5ShFA0OkCQgCKIkNB6gBAAkNaYDC9MLVxSlFpc0sZQNDpADQjQ9DpAkUsQyNDBGkjQ4RpI0PEaSNDBGojQ0RqI0OEaiNDxGqAiiNDQ+qAQAhDUGEwvWJJACgIaALQQPABAAHgIPABAAhgcEdcSxC1nGikBgnUmGJZYhhoErFA9AAAAeAg9AAAGGAQvVRJimiSBgTUympv8w8CAkPKYnBHT0mKaJIGBNQKa2/zDwICQwpjcEdKSYpokgYA1IhhcEdHSYpokgYA1MhhcEdESQpoIvRwYkLqACAIYHBHQEmKaJIGANQIYXBHPUmKaJIGCNQAKAhoAtBA8AgAAeAg8AgACGBwRzZJimiSBgjUACgIaALQQPSAAAHgIPSAAAhgcEcvSAFoQfACAQFgcEcsSSAxCHBwRypJIDEIgHBHKEkIYnBHJ0ggMAB4cEclSCAwAIhwRyNIAGpwRyFJACgIaALQQPAEAAHgIPAEAAhgcEccSxpoCbECQwDggkMaYHBHGEiAaMDzBCBwRxVIQGkA8EBgcEcTSgFGACCSaApCANABIHBHD0nIYHBHDUoAIBFoHyOSaAPqEUEC8B8CEUIA0AEgcEcHSQAMyGBwRwVJACgIaALQQPBAAAHgIPBAAAhgcEcAEACgz///AP734P8AAICQLen8QQAg//cl/Y9IHCFIRADwCv2MSDAhSEQcMADwBP2KSAFoQfACAQFgASE/IP/3nP0BIYgD//fA/QIgjfgEAAAkjfgGQI34B0ADIN/4AIKN+AUACSICIUBGAPDq+QQlaUZARgCVAPBb+XpOCSILITBGAPDe+WgCAJBpRjBGAPBP+QkiDCEwRgDw0/moAgCQaUYwRgDwRPlvTwkiAiE4RgDwx/lpRjhGAJUA8Dn5CSINITBGAPC9+e0CaUYwRgCVAPAu+QoiBiFARgDwsvlAIACQASCN+AcAaUZARgDwIPkAIP/3t/z/92H+V0gGIUhEwOkAQRghhGDA6QNBRGGEYf/3dv5QSGkRSEQcMARgxGBEYYRhBGHA6QhUxGGBYgEg//eh/gAg//fZ/gAg//fe/kpIgWiJBvzUQvJmEUFhhGHEYQRhv/NPj4FoiQb81ELymRFBYYRhxGEEYb/zT4+BaIkG/NRC8mYhQWGEYcRhBGG/80+PgWiJBvzUQvKZIUFhhGHEYQRhv/NPj4FoiQb81ELyZjFBYYRhxGEEYb/zT4+BaIkG/NRC8pkxQWGEYcRhBGG/80+PACC96PyBELUg8HBAAPDF+QAgEL0Qtf/37v0AIBC9ELUA8Af6ACAQvQi1E0YAkSDwcEFqRhhGAPDU+gAgCL1wtRRLBkZLRBwzCCBYYU/wQGAYYE/0gGBYYsAAGGJP8EBwGGFP9IBwmGJrINhiFUYMRhhG//f9/QbgAL8W+AELFfgBG4hCAdFkHvfSMEZwvQEgcEcIAAAAODgCQAAEAkAADAJAABACQAAQAKB8SRC1iEIG0QEhCEb/96/8ACEBIE/geEmIQgbRASECIP/3pfwAIQIgReB0SYhCBtEBIQQg//eb/AAhBCA74HBJiEIG0QEhCCD/95H8ACEIIDHgbEmIQgbRASEQIP/3h/wAIRAgJ+BoSYhCBtEBISAg//d9/AAhICAd4GRJiEIG0QEhQCD/93P8ACFAIBPgYEmIQgbRASGAIP/3afwAIYAgCeBcSYhCCtGEFQEhIEb/9178ACEgRr3oEED/91i8EL3wtQAjASQDJw1oBPoD8hVAlUJC0dD4AMBeAAf6BvUs6gUMwPgAwJH4BMDQ+ADgDPoG/EzqDgzA+ADAkfgEwLzxAQ8C0LzxAg8f0dD4CMAs6gUMwPgIwJH4BcDQ+AjgDPoG/EzqDgzA+AjA0PgEwCzqAgzA+ATAQmiR+AbADPoD/B/6jPxC6gwCQmDCaKpDwmDKecVoskAqQ8JgWxwQK7PT8L1P9v9xAWAAIQFxQXGBccFxcEcItUH0gDIAksJhwWEAmcFhwWnAaQCQCL0CRgAgEmkKQgDQASBwRwBpgLJwRwJGACBSaQpCANABIHBHQGmAsnBHAYNwR0GDcEcKsQGDcEdBg3BHQWFwR0JpSkBCYXBHSwfbDppAyQgQtQDrgQABag8knEChQwFiAWoRQwFiEL0AAAAAAkAABAJAAAgCQAAMAkAAEAJAABQCQAAYAkAAHAJAACACQHC1/0wAJUxET/QAUCVg5WBlYaVhJWHE6QgFQBHlYaBiKEb/9x/9ACD/9yT9BiDgYiBG//e8/CAg//d3/QEo+tACIQAiCEb/9938ASD/9yb9ACD/9w/9T/AAYGViIGDAECBhBSDgYuZISET/96D8CCD/91v9ACj60Agg//de/QIg//db/SAg//dQ/QEo+tBwvRC1jLAERv/3s/8AIQGRBZEDkQCRT/QAUAaRzekHEEARBJHN6QkQCEb/99T8ACD/99n8aEYLlP/3cvwgIP/3Lf0BKPrQDLAQvXC1Bkb/95D/ACD/98f8xkhIRP/3N/zETE/0gHBMRAAloGKAAGBiwAAgYkADJWEgYNgg4GIgRv/3TvwwRv/3mvz/93L/ACD/96n8ACIBIRBG//ds/AEg//e1/AAg//ee/Agg//f+/E/wAGBlYiBgwBAgYQUg4GIgRv/3LfwIIP/36PwAKPrQCCD/9+v8ICD/9+D8ASj60HC9cLX/90X/ACD/93z8oEhIRP/37PueTE/0gHBMRAAlxOkJUEABIGJAAyVhIGDHIOBiIEb/9wT8//cr/wAg//di/AAiASEQRv/3JfwBIP/3bvwAIP/3V/wIIP/3t/xP8ABgZWIgYMAQIGEFIOBiIEb/9+b7CCD/96H8ACj60Agg//ek/CAg//eZ/AEo+tBwvXC1BUb/9/3+fkwAIUxET/QAUCFgoWEhYcTpCAEIRv/3IvwAIP/3J/wNsbcgAODpIOBic0hIRP/3u/sgIP/3dvwBKPrQcL0t6fBBBkYQaBVGDEYAKGPQ//fU/ihoQB7/9wr8IEb/9/P7ZkhIRP/3d/tkTAAnTERP9IBwJ2CgYoAAYGLAACBiT/BAcCBhMiDgYiBG//eN+wjgBCD/90f8ACj60Bb4AQv/9w78KGhAHihgQBzx0S9gICD/9zj8ASj60AIg//cz/AAo+tACIP/3NvwAIP/30PsAIgEhEEb/95P7ASD/99z7ACD/98X7T/AAYGdiIGDAECBhBSDgYkFISET/91b7CCD/9xH8ACj60Agg//cU/CAg//cJ/AEo+tC96PCBLen4T4BGACAAkBBoAfD/CwUKAPD/ChZGD0bL9YB0ASD/913/u/EADxbQ+LLA9YBwB+sACzWzMGhqRgAbMGAGCgDw/wo5RkBGAJT/92v/XUZERE/0gHcy4CWzT/SAdG0eCtNqRjlGQEYAlP/3W/8I9YB4B/WAd/LnzfgAoGpGOUZARibgokUN2arrBAVqRjlGQEYAlP/3Rv9ZRgjrBABqRgCVFuAwaACQ6OdqRilGIEYAl//3N/8E9YB0BfWAdXYe89K68QAPBtBqRilGIEbN+ACg//cn/wAg//cB/73o+I8kAAAAcLUFRhRGDkYBIP/39v5lSEhE//eh+mNICiFIREFhT/SAcYFiiQQBYE/0QGFBYokAAWIJAwFh6yHBYv/3tvogaEAe//cV+zBG//f++grgBCD/92n7GLH/9z77BfgBCyBoQB4gYCAg//de+wAo79EgIP/3WfsBKPrQAiD/91T7ACj60AIg//dX+73ocEAAILTmELVETAAgTERP9ABRIGDgYGBhoGEgYcTpCBDgYUgRoGIAIP/31foAIP/32voGIOBiIEb/93L6ICD/9y37ASj60E/w/zD/98z6T/CAYCBggBAgYQUg4GIvSEhE//de+i5MTEQF4AQg//cW+//37PogcCB4gAf21f/31fogIP/3C/sBKPrQEL1wtf/3cP0hTAAlTERP9ABQJWDGAiZhpWEgYihG//eV+gAg//ea+oEg4GIgRv/3MvrzIP/3uvogIP/36voBKPrQACD/94r6ACIIIRBG//dN+gEg//eW+gAg//d/+iZhT/AAYGViIGCFIOBiCEhIRP/3EfoIIP/3zPoAKPrQCCD/98/6ICD/98T6ASj60HC9JAAAAAQAAABP8AACALUTRpRGlkYgOSK/oOgMUKDoDFCx8SABv/T3rwkHKL+g6AxQSL8MwF34BOuJACi/QPgEKwi/cEdIvyD4AisR8IBPGL8A+AErcEcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 1993
-    pc_uninit: 2451
-    pc_program_page: 2471
-    pc_erase_sector: 2437
-    pc_erase_all: 2461
-    data_section_offset: 4672
+    pc_init: 0x7c9
+    pc_uninit: 0x993
+    pc_program_page: 0x9a7
+    pc_erase_sector: 0x985
+    pc_erase_all: 0x99d
+    data_section_offset: 0x1240
     flash_properties:
       address_range:
-        start: 2415919104
-        end: 2432696320
-      page_size: 8192
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x90000000
+        end: 0x91000000
+      page_size: 0x2000
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 65536
-          address: 0
-  stm32f7xx_qspi_micron:
-    name: stm32f7xx_qspi_micron
+        - size: 0x10000
+          address: 0x0
+  - name: stm32f7xx_qspi_micron
     description: MT25QL512A_STM32756G-EVAL
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: QLpwR0C6cEdAunBHQLpwR0C6cEfAunBHwLpwR8C6cEfAunBHwLpwR/dJACIKcAhwcEcCRgAgUQkBKQzQAikN0PFJcjEJaALwHwIBI5NAC0IA0AEgcEfsSYke8+fqSW4x8OcYtQAgT/SgZACQMSD/9+D/AJlJHACRoUIB0AAo9dAxIP/31v8AKADQASAYvd5JiR4KaCLw+AJC6sAACGBwR9lJiR4AKAhoAtBA8AEAAeAg8AEACGBwR9NJACJuMQpwCnABKALQBCgB0QUgCHBwR81KbjIRaCHwGAEBQxFgcEfJSXIxACgIaALQQPABAAHgIPABAAhgcEdB6oIRWggQtcJLApwD6wJCEUMBQ0HqBGC9SYkcCGAQvbtJiR4AKAhoAtBA8IBwAeAg8IBwCGBwRxC1tkxJCATrAUFB6oAQsklA6gJggjFA6gNwCGAQva5JiR4AKAhoAtBA8IBgAeAg8IBgCGBwRxC1qExJCATrAUFB6oAQpElA6gJghjFA6gNwCGAQvaBJiR4AKAhoAtBA8IBQAeAg8IBQCGBwR5pJiR4AKAhoAtBA9AAgAeAg9AAgCGBwR5RKkh0TaAhDI/DsYxhDEGBwR5BKkh0TaAhDI/B4QxhDEGBwR4tKkh0RaCHwAwEBQxFgcEeHSIAdAGgA8AwAcEeESpIdEWgh8PABAUMRYHBHgEqSHRFoIfTgUQFDEWBwR3xJiR0KaCL0YEJC6sAACGBwR8DzASEDKQjRdkqSHRFoIfT4E3VJAUAZQxFgcUluMQpowPMLAAJDCmBwR21JbjEAKAhoAtBA9ABAAeAg9ABACGBwR2dJbjEAKAhoAtBA9IAwAeAg9IAwCGBwR2FJiR0AKAhoAtBA9AAAAeAg9AAACGBwR1tKijIRaEAeIfAfAQFDEWBwR1dJijEKaG/w/wMi9PhSA+sAIBBDCGBwR1FKijIRaCH0QBEBQxFgcEdNSooyEWgh9EABAUMRYHBHSUqKMhFoIfRAMQFDEWBwR0VJijEAKAhoAtBA8IBwAeAg8IBwCGBwRz9KLjIAKRFoAdABQwDggUMRYHBHOkoyMgApEWgB0AFDAOCBQxFgcEc1SjYyACkRaAHQAUMA4IFDEWBwRzBKPjIAKRFoAdABQwDggUMRYHBHK0pCMgApEWgB0AFDAOCBQxFgcEcmSg4yACkRaAHQAUMA4IFDEWBwRyFKEjIAKRFoAdABQwDggUMRYHBHHEoWMgApEWgB0AFDAOCBQxFgcEcXSh4yACkRaAHQAUMA4IFDEWBwRxJKIjIAKRFoAdABQwDggUMRYHBHDUpOMgApEWgB0AFDAOCBQxFgcEcISlIyACkRaAHQAUMA4IFDEWBwRwNKVjIAKRFoB9ABQwbgAjgCQAAA/////P8PgUMRYHBHS0oAKRFoAdABQwDggUMRYHBHRkoSHQApEWgB0AFDAOCBQxFgcEdBSlM6ACkReAHQAUMA4IFDEXBwRzxIFDABaEHwgHEBYHBHAUY4SgAgVDoSaApCANABIHBHNElSOQhwcEcySjAyEWgDDwErBtACKwfQAysI0AQrC9EI4CH0QDEH4CH0QCEE4CH0QBEB4CH0QAEA9H8ACEMQYHBHJEsQtTAzGWgCDwkqHdLf6ALwHAUICw4RFBcaACHwAwET4CHwDAEQ4CHwMAEN4CHwwAEK4CH0QHEH4CH0QGEE4CH0QFEB4CH0QEGAsghDGGAQvQ9KMDIRaCHwQHEBQxFgcEcLSjAyEWgh8IBhAUMRYHBHB0owMhFoIfAAYQFDEWBwRwNKMDIRaCHwgFEBQxFgcEdgOAJAELUBIQIg//cg/wAhvegQQAIg//cavwAhAWBBYIFgwWABYUFhgWFwRwAhQWCBYMFgAWABYUFhgWHBYQFiQWKBYsFicEcwtX9LGWh/SkRpEUACaAV5IkOEaUTqBWQiQwpDGmBZaHlKEUDQ6QJCAIoiQ0HqAEACQ1pgML0wtXFKUWlzSxlA0OkANCND0OkCRSxDI0MEaSNDhGkjQ8RpI0MEaiNDRGojQ4RqI0PEaoCKI0ND6oBACENQYTC9YkkAKAhoAtBA8AEAAeAg8AEACGBwR1xLELWcaKQGCdSYYlliGGgSsUD0AAAB4CD0AAAYYBC9VEmKaJIGBNTKam/zDwICQ8picEdPSYpokgYE1Aprb/MPAgJDCmNwR0pJimiSBgDUiGFwR0dJimiSBgDUyGFwR0RJCmgi9HBiQuoAIAhgcEdASYpokgYA1AhhcEc9SYpokgYI1AAoCGgC0EDwCAAB4CDwCAAIYHBHNkmKaJIGCNQAKAhoAtBA9IAAAeAg9IAACGBwRy9IAWhB8AIBAWBwRyxJIDEIcHBHKkkgMQiAcEcoSQhicEcnSCAwAHhwRyVIIDAAiHBHI0gAanBHIUkAKAhoAtBA8AQAAeAg8AQACGBwRxxLGmgJsQJDAOCCQxpgcEcYSIBowPMEIHBHFUhAaQDwQGBwRxNKAUYAIJJoCkIA0AEgcEcPSchgcEcNSgAgEWgfI5JoA+oRQQLwHwIRQgDQASBwRwdJAAzIYHBHBUkAKAhoAtBA8EAAAeAg8EAACGBwRwAQAKDP//8A/vfg/wAAgJAt6fxBACD/9yX9kEgcIUhEAPDs/I1IMCFIRBwwAPDm/ItIAWhB8AIBAWABIT8g//ec/QEhiAP/98D9AiCN+AQAACSN+AZAjfgHQAMg3/gEgo34BQAJIgIhQEYA8Or5BCAAkGlGQEYA8Fv5e08KIgghOEYA8N75vRVpRjhGAJUA8E/5CiIJIThGAPDT+WgAAJBpRjhGAPBE+QkiByE4RgDwyPmAIACQaUY4RgDwOfkJIgYhOEYA8L35QCZpRjhGAJYA8C75CiIGIUBGAPCy+QEgjfgHAACWaUZARgDwIfkAIP/3uPz/92L+WEgGIUhEwOkAQRghhGDA6QNBRGGEYf/3d/5SSE/0QFFIRBwwBGDEYERhhGEEYcDpCBSFYsRhASD/96H+ACD/99n+ACD/997+SkiBaIkG/NRC8mYRQWGEYcRhBGG/80+PgWiJBvzUQvKZEUFhhGHEYQRhv/NPj4FoiQb81ELyZiFBYYRhxGEEYb/zT4+BaIkG/NRC8pkhQWGEYcRhBGG/80+PgWiJBvzUQvJmMUFhhGHEYQRhv/NPj4FoiQb81ELymTFBYYRhxGEEYb/zT48BIADwPvoAIL3o/IEQtSDwcEAA8J/5ACAQvRC1//fr/QAgEL0QtQDw4/kAIBC9CLUTRgCRIPBwQWpGGEYA8LD6ACAIvXC1E0sGRktEHDMIIFhhT/BAYBhgT/SAYFhiT/RAUBhiAAMYYU/0gHCYYmsg2GIVRgxGGEb/9/r9BeAW+AELFfgBG4hCAdFkHvfSMEZwvQEgcEcIAAAAODgCQAAEAkAAFAJAABAAoHxJELWIQgbRASEIRv/3r/wAIQEgT+B4SYhCBtEBIQIg//el/AAhAiBF4HRJiEIG0QEhBCD/95v8ACEEIDvgcEmIQgbRASEIIP/3kfwAIQggMeBsSYhCBtEBIRAg//eH/AAhECAn4GhJiEIG0QEhICD/9338ACEgIB3gZEmIQgbRASFAIP/3c/wAIUAgE+BgSYhCBtEBIYAg//dp/AAhgCAJ4FxJiEIK0YQVASEgRv/3XvwAISBGvegQQP/3WLwQvfC1ACMBJAMnDWgE+gPyFUCVQkLR0PgAwF4AB/oG9SzqBQzA+ADAkfgEwND4AOAM+gb8TOoODMD4AMCR+ATAvPEBDwLQvPECDx/R0PgIwCzqBQzA+AjAkfgFwND4COAM+gb8TOoODMD4CMDQ+ATALOoCDMD4BMBCaJH4BsAM+gP8H/qM/ELqDAJCYMJoqkPCYMp5xWiyQCpDwmBbHBArs9PwvU/2/3EBYAAhAXFBcYFxwXFwRwi1QfSAMgCSwmHBYQCZwWHBacBpAJAIvQJGACASaQpCANABIHBHAGmAsnBHAkYAIFJpCkIA0AEgcEdAaYCycEcBg3BHQYNwRwqxAYNwR0GDcEdBYXBHQmlKQEJhcEdLB9sOmkDJCBC1AOuBAAFqDyScQKFDAWIBahFDAWIQvQAAAAACQAAEAkAACAJAAAwCQAAQAkAAFAJAABgCQAAcAkAAIAJAcLX/TAAlTERP9EBQJWDlYGVhpWElYcTpCAVP9IBw5WGgYihG//ce/QAg//cj/QYg4GIgRv/3u/wgIP/3dv0BKPrQAiEAIghG//fc/AEg//cl/QAg//cO/U/wAGBlYiBgwBAgYQUg4GLlSEhE//ef/Agg//da/QAo+tAIIP/3Xf0CIP/3Wv0gIP/3T/0BKPrQcL1wtQZG//ez/wAg//fq/NdISET/91r81UxP9IBwTEQAJaBigABgYk/0QFAgYk/wgGAlYSBg2CDgYiBG//dv/DBG//e7/P/3k/8AIP/3yvwAIgEhEEb/9438ASD/99b8ACD/97/8CCD/9x/9T/AAYGViIGDAECBhBSDgYiBG//dO/Agg//cJ/QAo+tAIIP/3DP0gIP/3Af0BKPrQcL1wtf/3Zv8AIP/3nfyxSEhE//cN/K9MT/SAcExEACXE6QlQT/RAUCBiT/CAYCVhIGDHIOBiIEb/9yP8//dK/wAg//eB/AAiASEQRv/3RPwBIP/3jfwAIP/3dvwIIP/31vxP8ABgZWIgYMAQIGEFIOBiIEb/9wX8CCD/98D8ACj60Agg//fD/CAg//e4/AEo+tBwvXC1BUb/9xz/jUwAIUxET/RAUCFgoWEhYcTpCAEIRv/3QfwAIP/3RvwNsbcgAODpIOBig0hIRP/32vsgIP/3lfwBKPrQcL0t6fBBBkYQaBVGDEYAKGHQ//fz/ihoQB7/9yn8IEb/9xL8dUhIRP/3lvtzTAAnTERP9IBwJ2CgYoAAYGJP9EBQIGIAAyBhMiDgYiBG//es+wbgBCD/92b8FvgBC//3L/woaEAeKGBAHPPRL2AgIP/3WfwBKPrQAiD/91T8ACj60AIg//dX/AAg//fx+wAiASEQRv/3tPsBIP/3/fsAIP/35vtP8ABgZ2IgYMAQIGEFIOBiUUhIRP/3d/sIIP/3MvwAKPrQCCD/9zX8ICD/9yr8ASj60L3o8IEt6fhPgEYAIACQEGgB8P8LBQoA8P8KFkYPRsv1gHQBIP/3X/+78QAPFtD4ssD1gHAH6wALNbMwaGpGABswYAYKAPD/CjlGQEYAlP/3bf9dRkRET/SAdzLgJbNP9IB0bR4K02pGOUZARgCU//dd/wj1gHgH9YB38ufN+ACgakY5RkBGJuCiRQ3ZqusEBWpGOUZARgCU//dI/1lGCOsEAGpGAJUW4DBoAJDo52pGKUYgRgCX//c5/wT1gHQF9YB1dh7z0rrxAA8G0GpGKUYgRs34AKD/9yn/ACD/9wP/vej4j3C1BUYURg5GASD/9/r+DEhIRP/3xPoKSAohSERBYU/0gHGBYokEAWBP9EBhQWKJAAFiCQMBYeshwWL/99n6IGgB4CQAAABAHv/3NfswRv/3HvsK4AQg//eJ+xix//de+wX4AQsgaEAeIGAgIP/3fvsAKO/RICD/93n7ASj60AIg//d0+wAo+tACIP/3d/u96HBAACC15hC1RUwAIExET/RAUSBg4GBgYaBhIGHE6QgQ4GFP9IBwoGIAIP/39PoAIP/3+foGIOBiIEb/95H6ICD/90z7ASj60E/w/zD/9+v6T/CAYCBggBAgYQUg4GIvSEhE//d9+i5MTEQF4AQg//c1+//3C/sgcCB4gAf21f/39PogIP/3KvsBKPrQEL1wtf/3j/0iTAAlTERP8IB2JWAmYU/0QFClYSBiKEb/97P6ACD/97j6gSDgYiBG//dQ+vMg//fY+iAg//cI+wEo+tAAIP/3qPoAIgghEEb/92v6ASD/97T6ACD/9536JmFP8ABgZWIgYIUg4GIISEhE//cv+ggg//fq+gAo+tAIIP/37fogIP/34voBKPrQcL0kAAAABAAAAE/wAAIAtRNGlEaWRiA5Ir+g6AxQoOgMULHxIAG/9PevCQcov6DoDFBIvwzAXfgE64kAKL9A+AQrCL9wR0i/IPgCKxHwgE8YvwD4AStwRwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 1953
-    pc_uninit: 2417
-    pc_program_page: 2437
-    pc_erase_sector: 2403
-    pc_erase_all: 2427
-    data_section_offset: 4572
+    pc_init: 0x7a1
+    pc_uninit: 0x971
+    pc_program_page: 0x985
+    pc_erase_sector: 0x963
+    pc_erase_all: 0x97b
+    data_section_offset: 0x11dc
     flash_properties:
       address_range:
-        start: 2415919104
-        end: 2483027968
-      page_size: 12288
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x90000000
+        end: 0x94000000
+      page_size: 0x3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 65536
-          address: 0
-  stm32f77x_qspi_micron:
-    name: stm32f77x_qspi_micron
+        - size: 0x10000
+          address: 0x0
+  - name: stm32f77x_qspi_micron
     description: MT25QL512A_STM32769IG-EVAL
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: QLpwR0C6cEdAunBHQLpwR0C6cEfAunBHwLpwR8C6cEfAunBHwLpwR/dJACIKcAhwcEcCRgAgUQkBKQzQAikN0PFJcjEJaALwHwIBI5NAC0IA0AEgcEfsSYke8+fqSW4x8OcYtQAgT/SgZACQMSD/9+D/AJlJHACRoUIB0AAo9dAxIP/31v8AKADQASAYvd5JiR4KaCLw+AJC6sAACGBwR9lJiR4AKAhoAtBA8AEAAeAg8AEACGBwR9NJACJuMQpwCnABKALQBCgB0QUgCHBwR81KbjIRaCHwGAEBQxFgcEfJSXIxACgIaALQQPABAAHgIPABAAhgcEdB6oIRWggQtcJLApwD6wJCEUMBQ0HqBGC9SYkcCGAQvbtJiR4AKAhoAtBA8IBwAeAg8IBwCGBwRxC1tkxJCATrAUFB6oAQsklA6gJggjFA6gNwCGAQva5JiR4AKAhoAtBA8IBgAeAg8IBgCGBwRxC1qExJCATrAUFB6oAQpElA6gJghjFA6gNwCGAQvaBJiR4AKAhoAtBA8IBQAeAg8IBQCGBwR5pJiR4AKAhoAtBA9AAgAeAg9AAgCGBwR5RKkh0TaAhDI/DsYxhDEGBwR5BKkh0TaAhDI/B4QxhDEGBwR4tKkh0RaCHwAwEBQxFgcEeHSIAdAGgA8AwAcEeESpIdEWgh8PABAUMRYHBHgEqSHRFoIfTgUQFDEWBwR3xJiR0KaCL0YEJC6sAACGBwR8DzASEDKQjRdkqSHRFoIfT4E3VJAUAZQxFgcUluMQpowPMLAAJDCmBwR21JbjEAKAhoAtBA9ABAAeAg9ABACGBwR2dJbjEAKAhoAtBA9IAwAeAg9IAwCGBwR2FJiR0AKAhoAtBA9AAAAeAg9AAACGBwR1tKijIRaEAeIfAfAQFDEWBwR1dJijEKaG/w/wMi9PhSA+sAIBBDCGBwR1FKijIRaCH0QBEBQxFgcEdNSooyEWgh9EABAUMRYHBHSUqKMhFoIfRAMQFDEWBwR0VJijEAKAhoAtBA8IBwAeAg8IBwCGBwRz9KLjIAKRFoAdABQwDggUMRYHBHOkoyMgApEWgB0AFDAOCBQxFgcEc1SjYyACkRaAHQAUMA4IFDEWBwRzBKPjIAKRFoAdABQwDggUMRYHBHK0pCMgApEWgB0AFDAOCBQxFgcEcmSg4yACkRaAHQAUMA4IFDEWBwRyFKEjIAKRFoAdABQwDggUMRYHBHHEoWMgApEWgB0AFDAOCBQxFgcEcXSh4yACkRaAHQAUMA4IFDEWBwRxJKIjIAKRFoAdABQwDggUMRYHBHDUpOMgApEWgB0AFDAOCBQxFgcEcISlIyACkRaAHQAUMA4IFDEWBwRwNKVjIAKRFoB9ABQwbgAjgCQAAA/////P8PgUMRYHBHS0oAKRFoAdABQwDggUMRYHBHRkoSHQApEWgB0AFDAOCBQxFgcEdBSlM6ACkReAHQAUMA4IFDEXBwRzxIFDABaEHwgHEBYHBHAUY4SgAgVDoSaApCANABIHBHNElSOQhwcEcySjAyEWgDDwErBtACKwfQAysI0AQrC9EI4CH0QDEH4CH0QCEE4CH0QBEB4CH0QAEA9H8ACEMQYHBHJEsQtTAzGWgCDwkqHdLf6ALwHAUICw4RFBcaACHwAwET4CHwDAEQ4CHwMAEN4CHwwAEK4CH0QHEH4CH0QGEE4CH0QFEB4CH0QEGAsghDGGAQvQ9KMDIRaCHwQHEBQxFgcEcLSjAyEWgh8IBhAUMRYHBHB0owMhFoIfAAYQFDEWBwRwNKMDIRaCHwgFEBQxFgcEdgOAJAELUBIQIg//cg/wAhvegQQAIg//cavwAhAWBBYIFgwWABYUFhgWFwRwAhQWCBYMFgAWABYUFhgWHBYQFiQWKBYsFicEcwtX9LGWh/SkRpEUACaAV5IkOEaUTqBWQiQwpDGmBZaHlKEUDQ6QJCAIoiQ0HqAEACQ1pgML0wtXFKUWlzSxlA0OkANCND0OkCRSxDI0MEaSNDhGkjQ8RpI0MEaiNDRGojQ4RqI0PEaoCKI0ND6oBACENQYTC9YkkAKAhoAtBA8AEAAeAg8AEACGBwR1xLELWcaKQGCdSYYlliGGgSsUD0AAAB4CD0AAAYYBC9VEmKaJIGBNTKam/zDwICQ8picEdPSYpokgYE1Aprb/MPAgJDCmNwR0pJimiSBgDUiGFwR0dJimiSBgDUyGFwR0RJCmgi9HBiQuoAIAhgcEdASYpokgYA1AhhcEc9SYpokgYI1AAoCGgC0EDwCAAB4CDwCAAIYHBHNkmKaJIGCNQAKAhoAtBA9IAAAeAg9IAACGBwRy9IAWhB8AIBAWBwRyxJIDEIcHBHKkkgMQiAcEcoSQhicEcnSCAwAHhwRyVIIDAAiHBHI0gAanBHIUkAKAhoAtBA8AQAAeAg8AQACGBwRxxLGmgJsQJDAOCCQxpgcEcYSIBowPMEIHBHFUhAaQDwQGBwRxNKAUYAIJJoCkIA0AEgcEcPSchgcEcNSgAgEWgfI5JoA+oRQQLwHwIRQgDQASBwRwdJAAzIYHBHBUkAKAhoAtBA8EAAAeAg8EAACGBwRwAQAKDP//8A/vfg/wAAgJAt6fxBACD/9yX9mkgcIUhEAPAA/ZdIMCFIRBwwAPD6/JVIAWhB8AIBAWABIT8g//ec/QEhiAP/98D9AiCN+AQAACSN+AZAjfgHQAMg3/gsgo34BQAJIgIhQEYA8P75BCAAkGlGQEYA8G/5hU8KIgghOEYA8PL5vhVpRjhGAJYA8GP5CiIJIThGAPDn+XAAAJBpRjhGAPBY+QkiByE4RgDw3PmAIACQaUY4RgDwTfkJIgYhOEYA8NH5QCVpRjhGAJUA8EL5CiIGIUBGAPDG+QEgjfgHAACVaUZARgDwNfkAIP/3uPz/92L+YkgGIUhEwOkAQRohhGDA6QNBRGGEYf/3d/5cTU/0QFdNRBw1ASAsYOxgbGGsYSxhxekIdK5i7GH/96H+ACD/99n+ACD/997+VEiBaIkG/NRC8mYRQWGEYcRhBGG/80+PgWiJBvzUQvKZEUFhhGHEYQRhv/NPj4FoiQb81ELyZiFBYYRhxGEEYb/zT4+BaIkG/NRC8pkhQWGEYcRhBGG/80+PgWiJBvzUQvJmMUFhhGHEYQRhv/NPj4FoiQb81ELymTFBYYRhxGEEYb/zT48BIADwUvoIIGhhT/BAYChgT/SAYMXpCHBP8EBwKGFrIMXpCmAmSEhEHDD/9yH+ACC96PyBELUg8HBAAPCf+QAgEL0Qtf/31/0AIBC9ELUA8OP5ACAQvQi1E0YAkSDwcEFqRhhGAPCw+gAgCL1wtRNLBkZLRBwzCCBYYU/wQGAYYE/0gGBYYk/0QFAYYgADGGFP9IBwmGJrINhiFUYMRhhG//fm/QXgFvgBCxX4ARuIQgHRZB730jBGcL0BIHBHCAAAADg4AkAABAJAABQCQAAQAKB8SRC1iEIG0QEhCEb/95v8ACEBIE/geEmIQgbRASECIP/3kfwAIQIgReB0SYhCBtEBIQQg//eH/AAhBCA74HBJiEIG0QEhCCD/9338ACEIIDHgbEmIQgbRASEQIP/3c/wAIRAgJ+BoSYhCBtEBISAg//dp/AAhICAd4GRJiEIG0QEhQCD/91/8ACFAIBPgYEmIQgbRASGAIP/3VfwAIYAgCeBcSYhCCtGEFQEhIEb/90r8ACEgRr3oEED/90S8EL3wtQAjASQDJw1oBPoD8hVAlUJC0dD4AMBeAAf6BvUs6gUMwPgAwJH4BMDQ+ADgDPoG/EzqDgzA+ADAkfgEwLzxAQ8C0LzxAg8f0dD4CMAs6gUMwPgIwJH4BcDQ+AjgDPoG/EzqDgzA+AjA0PgEwCzqAgzA+ATAQmiR+AbADPoD/B/6jPxC6gwCQmDCaKpDwmDKecVoskAqQ8JgWxwQK7PT8L1P9v9xAWAAIQFxQXGBccFxcEcItUH0gDIAksJhwWEAmcFhwWnAaQCQCL0CRgAgEmkKQgDQASBwRwBpgLJwRwJGACBSaQpCANABIHBHQGmAsnBHAYNwR0GDcEcKsQGDcEdBg3BHQWFwR0JpSkBCYXBHSwfbDppAyQgQtQDrgQABag8knEChQwFiAWoRQwFiEL0AAAAAAkAABAJAAAgCQAAMAkAAEAJAABQCQAAYAkAAHAJAACACQHC1/0wAJUxET/RAUCVg5WBlYaVhJWHE6QgFT/SAcOVhoGIoRv/3Cv0AIP/3D/0GIOBiIEb/96f8ICD/92L9ASj60AIhACIIRv/3yPwBIP/3Ef0AIP/3+vxP8ABgZWIgYMAQIGEFIOBi5UhIRP/3i/wIIP/3Rv0AKPrQCCD/90n9AiD/90b9ICD/9zv9ASj60HC9cLUGRv/3s/8AIP/31vzXSEhE//dG/NVMT/SAcExEACWgYoAAYGJP9EBQIGJP8IBgJWEgYNgg4GIgRv/3W/wwRv/3p/z/95P/ACD/97b8ACIBIRBG//d5/AEg//fC/AAg//er/Agg//cL/U/wAGBlYiBgwBAgYQUg4GIgRv/3OvwIIP/39fwAKPrQCCD/9/j8ICD/9+38ASj60HC9cLX/92b/ACD/94n8sUhIRP/3+fuvTE/0gHBMRAAlxOkJUE/0QFAgYk/wgGAlYSBgxyDgYiBG//cP/P/3Sv8AIP/3bfwAIgEhEEb/9zD8ASD/93n8ACD/92L8CCD/98L8T/AAYGViIGDAECBhBSDgYiBG//fx+wgg//es/AAo+tAIIP/3r/wgIP/3pPwBKPrQcL1wtQVG//cc/41MACFMRE/0QFAhYKFhIWHE6QgBCEb/9y38ACD/9zL8DbG3IADg6SDgYoNISET/98b7ICD/94H8ASj60HC9LenwQQZGEGgVRgxGAChh0P/38/4oaEAe//cV/CBG//f++3VISET/94L7c0wAJ0xET/SAcCdgoGKAAGBiT/RAUCBiAAMgYTIg4GIgRv/3mPsG4AQg//dS/Bb4AQv/9xv8KGhAHihgQBzz0S9gICD/90X8ASj60AIg//dA/AAo+tACIP/3Q/wAIP/33fsAIgEhEEb/96D7ASD/9+n7ACD/99L7T/AAYGdiIGDAECBhBSDgYlFISET/92P7CCD/9x78ACj60Agg//ch/CAg//cW/AEo+tC96PCBLen4T4BGACAAkBBoAfD/CwUKAPD/ChZGD0bL9YB0ASD/91//u/EADxbQ+LLA9YBwB+sACzWzMGhqRgAbMGAGCgDw/wo5RkBGAJT/923/XUZERE/0gHcy4CWzT/SAdG0eCtNqRjlGQEYAlP/3Xf8I9YB4B/WAd/LnzfgAoGpGOUZARibgokUN2arrBAVqRjlGQEYAlP/3SP9ZRgjrBABqRgCVFuAwaACQ6OdqRilGIEYAl//3Of8E9YB0BfWAdXYe89K68QAPBtBqRilGIEbN+ACg//cp/wAg//cD/73o+I9wtQVGFEYORgEg//f6/gxISET/97D6CkgKIUhEQWFP9IBxgWKJBAFgT/RAYUFiiQABYgkDAWHrIcFi//fF+iBoAeAkAAAAQB7/9yH7MEb/9wr7CuAEIP/3dfsYsf/3SvsF+AELIGhAHiBgICD/92r7ACjv0SAg//dl+wEo+tACIP/3YPsAKPrQAiD/92P7vehwQAAgteYQtUVMACBMRE/0QFEgYOBgYGGgYSBhxOkIEOBhT/SAcKBiACD/9+D6ACD/9+X6BiDgYiBG//d9+iAg//c4+wEo+tBP8P8w//fX+k/wgGAgYIAQIGEFIOBiL0hIRP/3afouTExEBeAEIP/3Ifv/9/f6IHAgeIAH9tX/9+D6ICD/9xb7ASj60BC9cLX/94/9IkwAJUxET/CAdiVgJmFP9EBQpWEgYihG//ef+gAg//ek+oEg4GIgRv/3PPrzIP/3xPogIP/39PoBKPrQACD/95T6ACIIIRBG//dX+gEg//eg+gAg//eJ+iZhT/AAYGViIGCFIOBiCEhIRP/3G/oIIP/31voAKPrQCCD/99n6ICD/9876ASj60HC9JAAAAAQAAABP8AACALUTRpRGlkYgOSK/oOgMUKDoDFCx8SABv/T3rwkHKL+g6AxQSL8MwF34BOuJACi/QPgEKwi/cEdIvyD4AisR8IBPGL8A+AErcEcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 1953
-    pc_uninit: 2457
-    pc_program_page: 2477
-    pc_erase_sector: 2443
-    pc_erase_all: 2467
-    data_section_offset: 4612
+    pc_init: 0x7a1
+    pc_uninit: 0x999
+    pc_program_page: 0x9ad
+    pc_erase_sector: 0x98b
+    pc_erase_all: 0x9a3
+    data_section_offset: 0x1204
     flash_properties:
       address_range:
-        start: 2415919104
-        end: 2483027968
-      page_size: 12288
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x90000000
+        end: 0x94000000
+      page_size: 0x3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 65536
-          address: 0
-  stm32f7xx_nor_micron:
-    name: stm32f7xx_nor_micron
+        - size: 0x10000
+          address: 0x0
+  - name: stm32f7xx_nor_micron
     description: PC28F128M29EWxx_STM32756G-EVAL
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ELUBiIZMwfOAE0xEIWABiCFgwfOAEppCDNATRokG9tUBiCFgwfOAEgGIIWDB84ARkUIB0QAgEL3wIQGAASAQvXdJCLVJREhgdkgBaEHweAEBYABodUl0SAhgCB1P8MwyAmBySXJIIDkIYHBJb/DwABg5CGBtSAAhHDgBYGtLbUgUOxhgbEgTAgNiQmJoSpYyAmBv8A8CgmBBYGZKSzLCYGZKGAoQYGVLAgQbHRpgY0tjSiA7GmBhS2JKGDsaYBofEWAbHWBKGmBgShBgX0pA9qogIDoQYF1KQPb/cBg6EGAQHwFgER1A8lVQCGBNSAgwAWhB8AEBAWAAaE/wIEBUSQFgVElBYG/wcEHA+AQRAWhB8AEBAWAAaACQACAIvQAgcEc/SBC0SESqIkFoofiqKr/zT49DaFUho/hUFb/zT49EaIAjpPiqOr/zT49DaKP4qiq/80+PQmii+FQVv/NPj0JoECGi+Koav/NPj0BoELxG5ytJMLRJRKojSmii+Ko6v/NPj0xoVSKk+FQlv/NPj01ogCSl+KpKv/NPj0xopPiqOr/zT49JaKH4VCW/80+PMCEBgL/zT48wvCHnLenwTRdPFUYGRgAkT/CqCE9ET/BVCk/woAsB8QEMHOB5aKH4qoq/80+PeWih+FSlv/NPj3loofiqur/zT48oiDCAv/NPjzBG//f8/hCxASC96PCNZBytHLYctOtcD9/TACD15wQAAAAwOAJAzADMzCAMAkAKqqqqBVVVVQAQAkAgFAJAqgoAqv8PAP9VBQBVIBgCQNiwEAA0CBEAAAAAAAAAAAAAAAAA
-    pc_init: 65
-    pc_uninit: 287
-    pc_program_page: 445
-    pc_erase_sector: 371
-    pc_erase_all: 291
-    data_section_offset: 600
+    pc_init: 0x41
+    pc_uninit: 0x11f
+    pc_program_page: 0x1bd
+    pc_erase_sector: 0x173
+    pc_erase_all: 0x123
+    data_section_offset: 0x258
     flash_properties:
       address_range:
-        start: 1610612736
-        end: 1627389952
-      page_size: 4096
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 3000
+        start: 0x60000000
+        end: 0x61000000
+      page_size: 0x1000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 131072
-          address: 0
-  stm32f769i_qspi_macronix:
-    name: stm32f769i_qspi_macronix
+        - size: 0x20000
+          address: 0x0
+  - name: stm32f769i_qspi_macronix
     description: MX25L51245G_STM32F769I-DISCO
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: QLpwR0C6cEdAunBHQLpwR0C6cEfAunBHwLpwR8C6cEfAunBHwLpwR/dJACIKcAhwcEcCRgAgUQkBKQzQAikN0PFJcjEJaALwHwIBI5NAC0IA0AEgcEfsSYke8+fqSW4x8OcYtQAgT/SgZACQMSD/9+D/AJlJHACRoUIB0AAo9dAxIP/31v8AKADQASAYvd5JiR4KaCLw+AJC6sAACGBwR9lJiR4AKAhoAtBA8AEAAeAg8AEACGBwR9NJACJuMQpwCnABKALQBCgB0QUgCHBwR81KbjIRaCHwGAEBQxFgcEfJSXIxACgIaALQQPABAAHgIPABAAhgcEdB6oIRWggQtcJLApwD6wJCEUMBQ0HqBGC9SYkcCGAQvbtJiR4AKAhoAtBA8IBwAeAg8IBwCGBwRxC1tkxJCATrAUFB6oAQsklA6gJggjFA6gNwCGAQva5JiR4AKAhoAtBA8IBgAeAg8IBgCGBwRxC1qExJCATrAUFB6oAQpElA6gJghjFA6gNwCGAQvaBJiR4AKAhoAtBA8IBQAeAg8IBQCGBwR5pJiR4AKAhoAtBA9AAgAeAg9AAgCGBwR5RKkh0TaAhDI/DsYxhDEGBwR5BKkh0TaAhDI/B4QxhDEGBwR4tKkh0RaCHwAwEBQxFgcEeHSIAdAGgA8AwAcEeESpIdEWgh8PABAUMRYHBHgEqSHRFoIfTgUQFDEWBwR3xJiR0KaCL0YEJC6sAACGBwR8DzASEDKQjRdkqSHRFoIfT4E3VJAUAZQxFgcUluMQpowPMLAAJDCmBwR21JbjEAKAhoAtBA9ABAAeAg9ABACGBwR2dJbjEAKAhoAtBA9IAwAeAg9IAwCGBwR2FJiR0AKAhoAtBA9AAAAeAg9AAACGBwR1tKijIRaEAeIfAfAQFDEWBwR1dJijEKaG/w/wMi9PhSA+sAIBBDCGBwR1FKijIRaCH0QBEBQxFgcEdNSooyEWgh9EABAUMRYHBHSUqKMhFoIfRAMQFDEWBwR0VJijEAKAhoAtBA8IBwAeAg8IBwCGBwRz9KLjIAKRFoAdABQwDggUMRYHBHOkoyMgApEWgB0AFDAOCBQxFgcEc1SjYyACkRaAHQAUMA4IFDEWBwRzBKPjIAKRFoAdABQwDggUMRYHBHK0pCMgApEWgB0AFDAOCBQxFgcEcmSg4yACkRaAHQAUMA4IFDEWBwRyFKEjIAKRFoAdABQwDggUMRYHBHHEoWMgApEWgB0AFDAOCBQxFgcEcXSh4yACkRaAHQAUMA4IFDEWBwRxJKIjIAKRFoAdABQwDggUMRYHBHDUpOMgApEWgB0AFDAOCBQxFgcEcISlIyACkRaAHQAUMA4IFDEWBwRwNKVjIAKRFoB9ABQwbgAjgCQAAA/////P8PgUMRYHBHS0oAKRFoAdABQwDggUMRYHBHRkoSHQApEWgB0AFDAOCBQxFgcEdBSlM6ACkReAHQAUMA4IFDEXBwRzxIFDABaEHwgHEBYHBHAUY4SgAgVDoSaApCANABIHBHNElSOQhwcEcySjAyEWgDDwErBtACKwfQAysI0AQrC9EI4CH0QDEH4CH0QCEE4CH0QBEB4CH0QAEA9H8ACEMQYHBHJEsQtTAzGWgCDwkqHdLf6ALwHAUICw4RFBcaACHwAwET4CHwDAEQ4CHwMAEN4CHwwAEK4CH0QHEH4CH0QGEE4CH0QFEB4CH0QEGAsghDGGAQvQ9KMDIRaCHwQHEBQxFgcEcLSjAyEWgh8IBhAUMRYHBHB0owMhFoIfAAYQFDEWBwRwNKMDIRaCHwgFEBQxFgcEdgOAJAELUBIQIg//cg/wAhvegQQAIg//cavwAhAWBBYIFgwWABYUFhgWFwRwAhQWCBYMFgAWABYUFhgWHBYQFiQWKBYsFicEcwtX9LGWh/SkRpEUACaAV5IkOEaUTqBWQiQwpDGmBZaHlKEUDQ6QJCAIoiQ0HqAEACQ1pgML0wtXFKUWlzSxlA0OkANCND0OkCRSxDI0MEaSNDhGkjQ8RpI0MEaiNDRGojQ4RqI0PEaoCKI0ND6oBACENQYTC9YkkAKAhoAtBA8AEAAeAg8AEACGBwR1xLELWcaKQGCdSYYlliGGgSsUD0AAAB4CD0AAAYYBC9VEmKaJIGBNTKam/zDwICQ8picEdPSYpokgYE1Aprb/MPAgJDCmNwR0pJimiSBgDUiGFwR0dJimiSBgDUyGFwR0RJCmgi9HBiQuoAIAhgcEdASYpokgYA1AhhcEc9SYpokgYI1AAoCGgC0EDwCAAB4CDwCAAIYHBHNkmKaJIGCNQAKAhoAtBA9IAAAeAg9IAACGBwRy9IAWhB8AIBAWBwRyxJIDEIcHBHKkkgMQiAcEcoSQhicEcnSCAwAHhwRyVIIDAAiHBHI0gAanBHIUkAKAhoAtBA8AQAAeAg8AQACGBwRxxLGmgJsQJDAOCCQxpgcEcYSIBowPMEIHBHFUhAaQDwQGBwRxNKAUYAIJJoCkIA0AEgcEcPSchgcEcNSgAgEWgfI5JoA+oRQQLwHwIRQgDQASBwRwdJAAzIYHBHBUkAKAhoAtBA8EAAAeAg8EAACGBwRwAQAKDP//8A/vfg/wAAgJAt6fxHACD/9yX9m0gcIUhEAPBA/ZhIMCFIRBwwAPA6/ZZIAWhB8AIBAWABIT8g//ec/QEhiAP/98D9AiWN+ARQACSN+AZAjfgHQAMg3/gwoo34BQAJIilGUEYA8AT6BCZpRlBGAJYA8HX5hk8JIhFGOEYA8Pj5KAIAkGlGOEYA8Gn5CSIKIThGAPDt+U/0gGhpRjhGzfgAgADwXPl6TwkiAiE4RgDw3/lpRjhGAJYA8FH5dk4JIg0hMEYA8NT5KAMAkGlGMEYA8EX5CiIGIVBGAPDJ+UAgAJABII34BwBpRlBGAPA3+QAg//e0/P/3Xv5hSBohSETA6QBFhGDA6QNBRGGEYf/3dP5bTU/0QFZNRBw1vxUsYOxgbGGsYSxhxekIZK9iASDsYf/3nf4AIP/31f4AIP/32v5VSIFoiQb81ELyZhFBYYRhxGEEYb/zT4+BaIkG/NRC8pkRQWGEYcRhBGG/80+PgWiJBvzUQvJmIUFhhGHEYQRhv/NPj4FoiQb81ELymSFBYYRhxGEEYb/zT4+BaIkG/NRC8mYxQWGEYcRhBGG/80+PgWiJBvzUQvKZMUFhhGHEYQRhv/NPjwEgAPBs+wggaGFP8EBgKGCAEChhayDF6QpwJ0jF6QhoSEQcMP/3IP4AIL3o/IcQtSDwcEAA8Mn5ACAQvRC1//fW/QAgEL0QtQDwDfoAIBC9CLUTRgCRIPBwQWpGGEYA8Nf6ACAIvXC1FEsGRktEHDMIIFhhT/BAYBhgT/SAYFhiT/RAUBhiAAMYYU/0gHCYYmsg2GIVRgxGGEb/9+X9BuAAvxb4AQsV+AEbiEIB0WQe99IwRnC9ASBwRwgAAAA4OAJAAAQCQAAIAkAAEAJAAAwCQAAQAKB8SRC1iEIG0QEhCEb/95X8ACEBIE/geEmIQgbRASECIP/3i/wAIQIgReB0SYhCBtEBIQQg//eB/AAhBCA74HBJiEIG0QEhCCD/93f8ACEIIDHgbEmIQgbRASEQIP/3bfwAIRAgJ+BoSYhCBtEBISAg//dj/AAhICAd4GRJiEIG0QEhQCD/91n8ACFAIBPgYEmIQgbRASGAIP/3T/wAIYAgCeBcSYhCCtGEFQEhIEb/90T8ACEgRr3oEED/9z68EL3wtQAjASQDJw1oBPoD8hVAlUJC0dD4AMBeAAf6BvUs6gUMwPgAwJH4BMDQ+ADgDPoG/EzqDgzA+ADAkfgEwLzxAQ8C0LzxAg8f0dD4CMAs6gUMwPgIwJH4BcDQ+AjgDPoG/EzqDgzA+AjA0PgEwCzqAgzA+ATAQmiR+AbADPoD/B/6jPxC6gwCQmDCaKpDwmDKecVoskAqQ8JgWxwQK7PT8L1P9v9xAWAAIQFxQXGBccFxcEcItUH0gDIAksJhwWEAmcFhwWnAaQCQCL0CRgAgEmkKQgDQASBwRwBpgLJwRwJGACBSaQpCANABIHBHQGmAsnBHAYNwR0GDcEcKsQGDcEdBg3BHQWFwR0JpSkBCYXBHSwfbDppAyQgQtQDrgQABag8knEChQwFiAWoRQwFiEL0AAAAAAkAABAJAAAgCQAAMAkAAEAJAABQCQAAYAkAAHAJAACACQHC1+kwAJUxET/RAUCVg5WBlYaVhJWHE6QgFT/SAcOVhoGIoRv/3BP0AIP/3Cf0GIOBiIEb/96H8ICD/91z9ASj60AIhACIIRv/3wvwBIP/3C/0AIP/39PxP8ABgZWIgYMAQIGEFIOBi4EhIRP/3hfwIIP/3QP0AKPrQCCD/90P9AiD/90D9ICD/9zX9ASj60HC9ELWMsARG//ey/wAhAZEFkQORAJFP9EBQBpHN6QcQT/SAcASRzekJEAhG//e4/AAg//e9/GhGC5T/91b8ICD/9xH9ASj60AywEL1wtQZG//eO/wAg//er/MBISET/9xv8vkxP9IBwTEQAJaBigABgYk/0QFAgYk/wgGAlYSBg2CDgYiBG//cw/DBG//d8/P/3bv8AIP/3i/wAIgEhEEb/9078ASD/95f8ACD/94D8CCD/9+D8T/AAYGViIGDAECBhBSDgYiBG//cP/Agg//fK/AAo+tAIIP/3zfwgIP/3wvwBKPrQcL1wtf/3Qf8AIP/3XvyZSEhE//fO+5dMT/SAcExEACXE6QlQT/RAUCBiT/CAYCVhIGDHIOBiIEb/9+T7//cl/wAg//dC/AAiASEQRv/3BfwBIP/3TvwAIP/3N/wIIP/3l/xP8ABgZWIgYMAQIGEFIOBiIEb/98b7CCD/94H8ACj60Agg//eE/CAg//d5/AEo+tBwvRC1//f4/gAg//cV/HVISET/94X7c0hP9IBxSERP9EBSgWIAIcDpCCFP8IBiAmABYZghwWK96BBA//eauy3p8EEGRhBoFUYMRgAoY9D/99P+KGhAHv/37/sgRv/32PtgSEhE//dc+15MACdMRE/0gHAnYKBigABgYk/0QFAgYgADIGEyIOBiIEb/93L7COAEIP/3LPwAKPrQFvgBC//38/soaEAeKGBAHPHRL2AgIP/3HfwBKPrQAiD/9xj8ACj60AIg//cb/AAg//e1+wAiASEQRv/3ePsBIP/3wfsAIP/3qvtP8ABgZ2IgYMAQIGEFIOBiO0hIRP/3O/sIIP/39vsAKPrQCCD/9/n7ICD/9+77ASj60L3o8IEt6fhPB0YAIACQEGgORhHw/wHDssH1gHRP6hAlmEZP9IB7FNDxssH1gHEG6wEKNbMAGxBgBQoA8P8IakYxRjhGAJT/92//PERWRl9GMeAls1xGbR4K02pGMUY4RgCU//dh/wb1gHYH9YB38ufN+ACAakYxRjhG//dV/73o+I+gRQvZHRtqRjFGOEYAlP/3Sv9RRjgZakYAle3nAJDo52pGMUYgRgCX//c9/wT1gHQG9YB2bR7z0rjxAA/e0GpGMUYgRs34AIDW5wAAJAAAAHC1BUb/9wT+eUwAIUxET/RAUCFgoWEhYcTpCAEIRv/3D/sAIP/3FPsNsbcgAODpIOBib0hIRP/3qPogIP/3Y/sBKPrQcL1wtQVGFEYORgEg//fW/2ZISET/9276ZEgKIUhEQWFP9IBxgWKJBAFgT/RAYUFiiQABYgkDAWHrIcFi//eD+iBoQB7/9+L6MEb/98v6CuAEIP/3NvsYsf/3C/sF+AELIGhAHiBgICD/9yv7ACjv0SAg//cm+wEo+tACIP/3IfsAKPrQAiD/9yT7vehwQAAglOcQtUVMACBMRE/0QFEgYOBgYGGgYSBhxOkIEOBhT/SAcKBiACD/96H6ACD/96b6BiDgYiBG//c++iAg//f5+gEo+tBP8P8w//eY+k/wgGAgYIAQIGEFIOBiMEhIRP/3KvovTExEBuAEIP/34voQsf/3t/ogcCB4gAf11f/3oPogIP/31voBKPrQEL1wtf/3Vf0iTAAlTERP8IB2JWAmYU/0QFClYSBiKEb/91/6ACD/92T6gSDgYiBG//f8+fMg//eE+iAg//e0+gEo+tAAIP/3VPoAIgghEEb/9xf6ASD/92D6ACD/90n6JmFP8ABgZWIgYIUg4GIISEhE//fb+Qgg//eW+gAo+tAIIP/3mfogIP/3jvoBKPrQcL0kAAAABAAAAE/wAAIAtRNGlEaWRiA5Ir+g6AxQoOgMULHxIAG/9PevCQcov6DoDFBIvwzAXfgE64kAKL9A+AQrCL9wR0i/IPgCKxHwgE8YvwD4AStwRwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 1953
-    pc_uninit: 2459
-    pc_program_page: 2479
-    pc_erase_sector: 2445
-    pc_erase_all: 2469
-    data_section_offset: 4740
+    pc_init: 0x7a1
+    pc_uninit: 0x99b
+    pc_program_page: 0x9af
+    pc_erase_sector: 0x98d
+    pc_erase_all: 0x9a5
+    data_section_offset: 0x1284
     flash_properties:
       address_range:
-        start: 2415919104
-        end: 2483027968
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x90000000
+        end: 0x94000000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 65536
-          address: 0
-  stm32f723e_qspi_macronix:
-    name: stm32f723e_qspi_macronix
+        - size: 0x10000
+          address: 0x0
+  - name: stm32f723e_qspi_macronix
     description: MX25L51245G_STM32F723E-DISCO
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: QLpwR0C6cEdAunBHQLpwR0C6cEfAunBHwLpwR8C6cEfAunBHwLpwR/dJACIKcAhwcEcCRgAgUQkBKQzQAikN0PFJcjEJaALwHwIBI5NAC0IA0AEgcEfsSYke8+fqSW4x8OcYtQAgT/SgZACQMSD/9+D/AJlJHACRoUIB0AAo9dAxIP/31v8AKADQASAYvd5JiR4KaCLw+AJC6sAACGBwR9lJiR4AKAhoAtBA8AEAAeAg8AEACGBwR9NJACJuMQpwCnABKALQBCgB0QUgCHBwR81KbjIRaCHwGAEBQxFgcEfJSXIxACgIaALQQPABAAHgIPABAAhgcEdB6oIRWggQtcJLApwD6wJCEUMBQ0HqBGC9SYkcCGAQvbtJiR4AKAhoAtBA8IBwAeAg8IBwCGBwRxC1tkxJCATrAUFB6oAQsklA6gJggjFA6gNwCGAQva5JiR4AKAhoAtBA8IBgAeAg8IBgCGBwRxC1qExJCATrAUFB6oAQpElA6gJghjFA6gNwCGAQvaBJiR4AKAhoAtBA8IBQAeAg8IBQCGBwR5pJiR4AKAhoAtBA9AAgAeAg9AAgCGBwR5RKkh0TaAhDI/DsYxhDEGBwR5BKkh0TaAhDI/B4QxhDEGBwR4tKkh0RaCHwAwEBQxFgcEeHSIAdAGgA8AwAcEeESpIdEWgh8PABAUMRYHBHgEqSHRFoIfTgUQFDEWBwR3xJiR0KaCL0YEJC6sAACGBwR8DzASEDKQjRdkqSHRFoIfT4E3VJAUAZQxFgcUluMQpowPMLAAJDCmBwR21JbjEAKAhoAtBA9ABAAeAg9ABACGBwR2dJbjEAKAhoAtBA9IAwAeAg9IAwCGBwR2FJiR0AKAhoAtBA9AAAAeAg9AAACGBwR1tKijIRaEAeIfAfAQFDEWBwR1dJijEKaG/w/wMi9PhSA+sAIBBDCGBwR1FKijIRaCH0QBEBQxFgcEdNSooyEWgh9EABAUMRYHBHSUqKMhFoIfRAMQFDEWBwR0VJijEAKAhoAtBA8IBwAeAg8IBwCGBwRz9KLjIAKRFoAdABQwDggUMRYHBHOkoyMgApEWgB0AFDAOCBQxFgcEc1SjYyACkRaAHQAUMA4IFDEWBwRzBKPjIAKRFoAdABQwDggUMRYHBHK0pCMgApEWgB0AFDAOCBQxFgcEcmSg4yACkRaAHQAUMA4IFDEWBwRyFKEjIAKRFoAdABQwDggUMRYHBHHEoWMgApEWgB0AFDAOCBQxFgcEcXSh4yACkRaAHQAUMA4IFDEWBwRxJKIjIAKRFoAdABQwDggUMRYHBHDUpOMgApEWgB0AFDAOCBQxFgcEcISlIyACkRaAHQAUMA4IFDEWBwRwNKVjIAKRFoB9ABQwbgAjgCQAAA/////P8PgUMRYHBHS0oAKRFoAdABQwDggUMRYHBHRkoSHQApEWgB0AFDAOCBQxFgcEdBSlM6ACkReAHQAUMA4IFDEXBwRzxIFDABaEHwgHEBYHBHAUY4SgAgVDoSaApCANABIHBHNElSOQhwcEcySjAyEWgDDwErBtACKwfQAysI0AQrC9EI4CH0QDEH4CH0QCEE4CH0QBEB4CH0QAEA9H8ACEMQYHBHJEsQtTAzGWgCDwkqHdLf6ALwHAUICw4RFBcaACHwAwET4CHwDAEQ4CHwMAEN4CHwwAEK4CH0QHEH4CH0QGEE4CH0QFEB4CH0QEGAsghDGGAQvQ9KMDIRaCHwQHEBQxFgcEcLSjAyEWgh8IBhAUMRYHBHB0owMhFoIfAAYQFDEWBwRwNKMDIRaCHwgFEBQxFgcEdgOAJAELUBIQIg//cg/wAhvegQQAIg//cavwAhAWBBYIFgwWABYUFhgWFwRwAhQWCBYMFgAWABYUFhgWHBYQFiQWKBYsFicEcwtX9LGWh/SkRpEUACaAV5IkOEaUTqBWQiQwpDGmBZaHlKEUDQ6QJCAIoiQ0HqAEACQ1pgML0wtXFKUWlzSxlA0OkANCND0OkCRSxDI0MEaSNDhGkjQ8RpI0MEaiNDRGojQ4RqI0PEaoCKI0ND6oBACENQYTC9YkkAKAhoAtBA8AEAAeAg8AEACGBwR1xLELWcaKQGCdSYYlliGGgSsUD0AAAB4CD0AAAYYBC9VEmKaJIGBNTKam/zDwICQ8picEdPSYpokgYE1Aprb/MPAgJDCmNwR0pJimiSBgDUiGFwR0dJimiSBgDUyGFwR0RJCmgi9HBiQuoAIAhgcEdASYpokgYA1AhhcEc9SYpokgYI1AAoCGgC0EDwCAAB4CDwCAAIYHBHNkmKaJIGCNQAKAhoAtBA9IAAAeAg9IAACGBwRy9IAWhB8AIBAWBwRyxJIDEIcHBHKkkgMQiAcEcoSQhicEcnSCAwAHhwRyVIIDAAiHBHI0gAanBHIUkAKAhoAtBA8AQAAeAg8AQACGBwRxxLGmgJsQJDAOCCQxpgcEcYSIBowPMEIHBHFUhAaQDwQGBwRxNKAUYAIJJoCkIA0AEgcEcPSchgcEcNSgAgEWgfI5JoA+oRQQLwHwIRQgDQASBwRwdJAAzIYHBHBUkAKAhoAtBA8EAAAeAg8EAACGBwRwAQAKDP//8A/vfg/wAAgJAt6fxHACD/9yX9m0gcIUhEAPBA/ZhIMCFIRBwwAPA6/ZZIAWhB8AIBAWABIT8g//ec/QEhiAP/98D9AiWN+ARQACSN+AZAjfgHQAMg3/gwoo34BQAJIilGUEYA8AT6BCZpRlBGAJYA8HX5hk8JIhFGOEYA8Pj5KAIAkGlGOEYA8Gn5CSIKIThGAPDt+U/0gGhpRjhGzfgAgADwXPl6TwkiAiE4RgDw3/lpRjhGAJYA8FH5dk4JIg0hMEYA8NT5KAMAkGlGMEYA8EX5CiIGIVBGAPDJ+UAgAJABII34BwBpRlBGAPA3+QAg//e0/P/3Xv5hSBohSETA6QBFhGDA6QNBRGGEYf/3dP5bTU/0QFZNRBw1vxUsYOxgbGGsYSxhxekIZK9iASDsYf/3nf4AIP/31f4AIP/32v5VSIFoiQb81ELyZhFBYYRhxGEEYb/zT4+BaIkG/NRC8pkRQWGEYcRhBGG/80+PgWiJBvzUQvJmIUFhhGHEYQRhv/NPj4FoiQb81ELymSFBYYRhxGEEYb/zT4+BaIkG/NRC8mYxQWGEYcRhBGG/80+PgWiJBvzUQvKZMUFhhGHEYQRhv/NPjwEgAPBs+wggaGFP8EBgKGCAEChhayDF6QpwJ0jF6QhoSEQcMP/3IP4AIL3o/IcQtSDwcEAA8Mn5ACAQvRC1//fW/QAgEL0QtQDwDfoAIBC9CLUTRgCRIPBwQWpGGEYA8Nf6ACAIvXC1FEsGRktEHDMIIFhhT/BAYBhgT/SAYFhiT/RAUBhiAAMYYU/0gHCYYmsg2GIVRgxGGEb/9+X9BuAAvxb4AQsV+AEbiEIB0WQe99IwRnC9ASBwRwgAAAA4OAJAAAQCQAAIAkAAEAJAAAwCQAAQAKB8SRC1iEIG0QEhCEb/95X8ACEBIE/geEmIQgbRASECIP/3i/wAIQIgReB0SYhCBtEBIQQg//eB/AAhBCA74HBJiEIG0QEhCCD/93f8ACEIIDHgbEmIQgbRASEQIP/3bfwAIRAgJ+BoSYhCBtEBISAg//dj/AAhICAd4GRJiEIG0QEhQCD/91n8ACFAIBPgYEmIQgbRASGAIP/3T/wAIYAgCeBcSYhCCtGEFQEhIEb/90T8ACEgRr3oEED/9z68EL3wtQAjASQDJw1oBPoD8hVAlUJC0dD4AMBeAAf6BvUs6gUMwPgAwJH4BMDQ+ADgDPoG/EzqDgzA+ADAkfgEwLzxAQ8C0LzxAg8f0dD4CMAs6gUMwPgIwJH4BcDQ+AjgDPoG/EzqDgzA+AjA0PgEwCzqAgzA+ATAQmiR+AbADPoD/B/6jPxC6gwCQmDCaKpDwmDKecVoskAqQ8JgWxwQK7PT8L1P9v9xAWAAIQFxQXGBccFxcEcItUH0gDIAksJhwWEAmcFhwWnAaQCQCL0CRgAgEmkKQgDQASBwRwBpgLJwRwJGACBSaQpCANABIHBHQGmAsnBHAYNwR0GDcEcKsQGDcEdBg3BHQWFwR0JpSkBCYXBHSwfbDppAyQgQtQDrgQABag8knEChQwFiAWoRQwFiEL0AAAAAAkAABAJAAAgCQAAMAkAAEAJAABQCQAAYAkAAHAJAACACQHC1+kwAJUxET/RAUCVg5WBlYaVhJWHE6QgFT/SAcOVhoGIoRv/3BP0AIP/3Cf0GIOBiIEb/96H8ICD/91z9ASj60AIhACIIRv/3wvwBIP/3C/0AIP/39PxP8ABgZWIgYMAQIGEFIOBi4EhIRP/3hfwIIP/3QP0AKPrQCCD/90P9AiD/90D9ICD/9zX9ASj60HC9ELWMsARG//ey/wAhAZEFkQORAJFP9EBQBpHN6QcQT/SAcASRzekJEAhG//e4/AAg//e9/GhGC5T/91b8ICD/9xH9ASj60AywEL1wtQZG//eO/wAg//er/MBISET/9xv8vkxP9IBwTEQAJaBigABgYk/0QFAgYk/wgGAlYSBg2CDgYiBG//cw/DBG//d8/P/3bv8AIP/3i/wAIgEhEEb/9078ASD/95f8ACD/94D8CCD/9+D8T/AAYGViIGDAECBhBSDgYiBG//cP/Agg//fK/AAo+tAIIP/3zfwgIP/3wvwBKPrQcL1wtf/3Qf8AIP/3XvyZSEhE//fO+5dMT/SAcExEACXE6QlQT/RAUCBiT/CAYCVhIGDHIOBiIEb/9+T7//cl/wAg//dC/AAiASEQRv/3BfwBIP/3TvwAIP/3N/wIIP/3l/xP8ABgZWIgYMAQIGEFIOBiIEb/98b7CCD/94H8ACj60Agg//eE/CAg//d5/AEo+tBwvRC1//f4/gAg//cV/HVISET/94X7c0hP9IBxSERP9EBSgWIAIcDpCCFP8IBiAmABYZghwWK96BBA//eauy3p8EEGRhBoFUYMRgAoY9D/99P+KGhAHv/37/sgRv/32PtgSEhE//dc+15MACdMRE/0gHAnYKBigABgYk/0QFAgYgADIGEyIOBiIEb/93L7COAEIP/3LPwAKPrQFvgBC//38/soaEAeKGBAHPHRL2AgIP/3HfwBKPrQAiD/9xj8ACj60AIg//cb/AAg//e1+wAiASEQRv/3ePsBIP/3wfsAIP/3qvtP8ABgZ2IgYMAQIGEFIOBiO0hIRP/3O/sIIP/39vsAKPrQCCD/9/n7ICD/9+77ASj60L3o8IEt6fhPB0YAIACQEGgORhHw/wHDssH1gHRP6hAlmEZP9IB7FNDxssH1gHEG6wEKNbMAGxBgBQoA8P8IakYxRjhGAJT/92//PERWRl9GMeAls1xGbR4K02pGMUY4RgCU//dh/wb1gHYH9YB38ufN+ACAakYxRjhG//dV/73o+I+gRQvZHRtqRjFGOEYAlP/3Sv9RRjgZakYAle3nAJDo52pGMUYgRgCX//c9/wT1gHQG9YB2bR7z0rjxAA/e0GpGMUYgRs34AIDW5wAAJAAAAHC1BUb/9wT+eUwAIUxET/RAUCFgoWEhYcTpCAEIRv/3D/sAIP/3FPsNsbcgAODpIOBib0hIRP/3qPogIP/3Y/sBKPrQcL1wtQVGFEYORgEg//fW/2ZISET/9276ZEgKIUhEQWFP9IBxgWKJBAFgT/RAYUFiiQABYgkDAWHrIcFi//eD+iBoQB7/9+L6MEb/98v6CuAEIP/3NvsYsf/3C/sF+AELIGhAHiBgICD/9yv7ACjv0SAg//cm+wEo+tACIP/3IfsAKPrQAiD/9yT7vehwQAAglOcQtUVMACBMRE/0QFEgYOBgYGGgYSBhxOkIEOBhT/SAcKBiACD/96H6ACD/96b6BiDgYiBG//c++iAg//f5+gEo+tBP8P8w//eY+k/wgGAgYIAQIGEFIOBiMEhIRP/3KvovTExEBuAEIP/34voQsf/3t/ogcCB4gAf11f/3oPogIP/31voBKPrQEL1wtf/3Vf0iTAAlTERP8IB2JWAmYU/0QFClYSBiKEb/91/6ACD/92T6gSDgYiBG//f8+fMg//eE+iAg//e0+gEo+tAAIP/3VPoAIgghEEb/9xf6ASD/92D6ACD/90n6JmFP8ABgZWIgYIUg4GIISEhE//fb+Qgg//eW+gAo+tAIIP/3mfogIP/3jvoBKPrQcL0kAAAABAAAAE/wAAIAtRNGlEaWRiA5Ir+g6AxQoOgMULHxIAG/9PevCQcov6DoDFBIvwzAXfgE64kAKL9A+AQrCL9wR0i/IPgCKxHwgE8YvwD4AStwRwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 1953
-    pc_uninit: 2459
-    pc_program_page: 2479
-    pc_erase_sector: 2445
-    pc_erase_all: 2469
-    data_section_offset: 4740
+    pc_init: 0x7a1
+    pc_uninit: 0x99b
+    pc_program_page: 0x9af
+    pc_erase_sector: 0x98d
+    pc_erase_all: 0x9a5
+    data_section_offset: 0x1284
     flash_properties:
       address_range:
-        start: 2415919104
-        end: 2483027968
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x90000000
+        end: 0x94000000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 65536
-          address: 0
+        - size: 0x10000
+          address: 0x0

--- a/probe-rs/targets/STM32G0_Series.yaml
+++ b/probe-rs/targets/STM32G0_Series.yaml
@@ -1,4 +1,3 @@
----
 name: STM32G0 Series
 variants:
   - name: STM32G030C6Tx
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -32,21 +33,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -57,21 +60,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -82,21 +87,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -107,21 +114,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -132,21 +141,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -157,21 +168,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_16
       - stm32g0xx_otp
@@ -182,21 +195,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_16
       - stm32g0xx_otp
@@ -207,21 +222,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -232,21 +249,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -257,21 +276,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -282,21 +303,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -307,21 +330,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_16
       - stm32g0xx_otp
@@ -332,21 +357,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -357,21 +384,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -382,21 +411,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_16
       - stm32g0xx_otp
@@ -407,21 +438,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -432,21 +465,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -457,21 +492,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_16
       - stm32g0xx_otp
@@ -482,21 +519,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -507,21 +546,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_16
       - stm32g0xx_otp
@@ -532,21 +573,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_16
       - stm32g0xx_otp
@@ -557,21 +600,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -582,21 +627,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -607,21 +654,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -632,21 +681,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -657,21 +708,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -682,21 +735,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -707,21 +762,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -732,21 +789,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -757,21 +816,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -782,21 +843,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -807,21 +870,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -832,21 +897,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -857,21 +924,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -882,21 +951,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -907,21 +978,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -932,21 +1005,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -957,21 +1032,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -982,21 +1059,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -1007,21 +1086,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -1032,21 +1113,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1057,21 +1140,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1082,21 +1167,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1107,21 +1194,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -1132,21 +1221,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -1157,21 +1248,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -1182,21 +1275,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -1207,21 +1302,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1232,21 +1329,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1257,21 +1356,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1282,21 +1383,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -1307,21 +1410,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -1332,21 +1437,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -1357,21 +1464,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1382,21 +1491,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1407,21 +1518,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -1432,21 +1545,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -1457,21 +1572,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -1482,21 +1599,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -1507,21 +1626,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -1532,21 +1653,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -1557,21 +1680,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1582,21 +1707,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1607,21 +1734,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1632,21 +1761,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1657,21 +1788,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_32
       - stm32g0xx_otp
@@ -1682,21 +1815,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_64
       - stm32g0xx_otp
@@ -1707,21 +1842,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1732,21 +1869,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1757,21 +1896,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1782,21 +1923,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1807,21 +1950,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1832,21 +1977,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1857,21 +2004,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1882,21 +2031,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1907,21 +2058,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1932,21 +2085,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1957,21 +2112,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -1982,21 +2139,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
@@ -2007,184 +2166,186 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536907776
+            start: 0x20000000
+            end: 0x20009000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g0xx_128
       - stm32g0xx_otp
       - stm32g0x1_opt
 flash_algorithms:
-  stm32g0xx_otp:
-    name: stm32g0xx_otp
+  - name: stm32g0xx_otp
     description: STM32G0xx Flash OTP
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHG0gZSYFgGkmBYBpJAWEAIHBHASAWScAHSGEAIHBHASBwRwAgcEfwtckdEEzJCBFNyQAlYQEmACcT4GZhE2gDYFNoQ2C/80+PI2nbA/zUZ2EjaStCAtAlYQEg8L0IMAg5CDIAKenRACDwvSMBZ0UAIAJAq4nvzfrDAAAAAAAA
-    pc_init: 7
-    pc_uninit: 25
-    pc_program_page: 45
-    pc_erase_sector: 41
-    pc_erase_all: ~
-    data_section_offset: 128
+    pc_init: 0x7
+    pc_uninit: 0x19
+    pc_program_page: 0x2d
+    pc_erase_sector: 0x29
+    pc_erase_all: null
+    data_section_offset: 0x80
     flash_properties:
       address_range:
-        start: 536834048
-        end: 536835072
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fff7000
+        end: 0x1fff7400
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1024
-          address: 0
-  stm32g0xx_16:
-    name: stm32g0xx_16
+        - size: 0x400
+          address: 0x0
+  - name: stm32g0xx_16
     description: STM32G0xx 16 KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
-    pc_init: 13
-    pc_uninit: 31
-    pc_program_page: 157
-    pc_erase_sector: 101
-    pc_erase_all: 47
-    data_section_offset: 240
+    pc_init: 0xd
+    pc_uninit: 0x1f
+    pc_program_page: 0x9d
+    pc_erase_sector: 0x65
+    pc_erase_all: 0x2f
+    data_section_offset: 0xf0
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134234112
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8004000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32g0x1_opt:
-    name: stm32g0x1_opt
+        - size: 0x800
+          address: 0x0
+  - name: stm32g0x1_opt
     description: STM32G0x1 Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHPEg6SYFgO0mBYDtJwWA7ScFgO0kBYQAgcEcBITVIyQdBYUEEQWEAIHBHASBwRzBINEsDYTRJAWI/IcFiAWP/IUFiACKCYkFjgmMpSYAxCmABIUkEQWG/80+PAWnJA/zUQmEBaRlCBNABaRlDAWEBIHBHACBwRwAgcEfwtRd7Fn28Rhd+FWi+RlRok2gRaRhI0mkbTwdhHE89QAViHE0sQMRiK0ADY2dG+7JDYhlLGUCBYvGyQWN3RvmygWMWSQpADEmAMQpgmQtBYb/zT48BackD/NQCaQpJCkIE0AJpCkMCYQEg8L0AIPC9QBhwRyMBZ0UAIAJAq4nvzTsqGQh/bl1M+sMAAKr+Tzj//08/PwA/AP8AAID/AAEAAAAAAA==
-    pc_init: 7
-    pc_uninit: 33
-    pc_program_page: 129
-    pc_erase_sector: 125
-    pc_erase_all: 53
-    data_section_offset: 288
+    pc_init: 0x7
+    pc_uninit: 0x21
+    pc_program_page: 0x81
+    pc_erase_sector: 0x7d
+    pc_erase_all: 0x35
+    data_section_offset: 0x120
     flash_properties:
       address_range:
-        start: 536836096
-        end: 536836128
-      page_size: 32
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fff7800
+        end: 0x1fff7820
+      page_size: 0x20
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 32
-          address: 0
-  stm32g0xx_64:
-    name: stm32g0xx_64
+        - size: 0x20
+          address: 0x0
+  - name: stm32g0xx_64
     description: STM32G0xx 64 KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
-    pc_init: 13
-    pc_uninit: 31
-    pc_program_page: 157
-    pc_erase_sector: 101
-    pc_erase_all: 47
-    data_section_offset: 240
+    pc_init: 0xd
+    pc_uninit: 0x1f
+    pc_program_page: 0x9d
+    pc_erase_sector: 0x65
+    pc_erase_all: 0x2f
+    data_section_offset: 0xf0
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134283264
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8010000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32g0xx_128:
-    name: stm32g0xx_128
+        - size: 0x800
+          address: 0x0
+  - name: stm32g0xx_128
     description: STM32G0xx 128 KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
-    pc_init: 13
-    pc_uninit: 31
-    pc_program_page: 157
-    pc_erase_sector: 101
-    pc_erase_all: 47
-    data_section_offset: 240
+    pc_init: 0xd
+    pc_uninit: 0x1f
+    pc_program_page: 0x9d
+    pc_erase_sector: 0x65
+    pc_erase_all: 0x2f
+    data_section_offset: 0xf0
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134348800
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8020000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32g0x0_opt:
-    name: stm32g0x0_opt
+        - size: 0x800
+          address: 0x0
+  - name: stm32g0x0_opt
     description: STM32G0x0 Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHLUgrSYFgLEmBYCxJwWAsScFgLEkBYQAgcEcBISZIyQdBYUEEQWEAIHBHASBwRyFIJUoCYSVJAWI/IcFiAWMBIUkEQWG/80+PAWnJA/zUACFBYQFpEUIE0AFpEUMBYQEgcEcAIHBHACBwRzC1lGgTaFFoEEgUSgJhFU0rQANiFEsZQMFiHEAEYwEhSQRBYb/zT48BackD/NQBaRFCBNABaRFDAWEBIDC9ACAwvUAYcEcAACMBZ0UAIAJAq4nvzTsqGQh/bl1M+sMAAKr+Tzj//08/PwA/AAAAAAA=
-    pc_init: 7
-    pc_uninit: 33
-    pc_program_page: 113
-    pc_erase_sector: 109
-    pc_erase_all: 53
-    data_section_offset: 220
+    pc_init: 0x7
+    pc_uninit: 0x21
+    pc_program_page: 0x71
+    pc_erase_sector: 0x6d
+    pc_erase_all: 0x35
+    data_section_offset: 0xdc
     flash_properties:
       address_range:
-        start: 536836096
-        end: 536836108
-      page_size: 12
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fff7800
+        end: 0x1fff780c
+      page_size: 0xc
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 12
-          address: 0
-  stm32g0xx_32:
-    name: stm32g0xx_32
+        - size: 0xc
+          address: 0x0
+  - name: stm32g0xx_32
     description: STM32G0xx 32 KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
-    pc_init: 13
-    pc_uninit: 31
-    pc_program_page: 157
-    pc_erase_sector: 101
-    pc_erase_all: 47
-    data_section_offset: 240
+    pc_init: 0xd
+    pc_uninit: 0x1f
+    pc_program_page: 0x9d
+    pc_erase_sector: 0x65
+    pc_erase_all: 0x2f
+    data_section_offset: 0xf0
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134250496
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8008000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/STM32G4_Series.yaml
+++ b/probe-rs/targets/STM32G4_Series.yaml
@@ -1,4 +1,3 @@
----
 name: STM32G4 Series
 variants:
   - name: STM32G431C6Tx
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_32
   - name: STM32G431C6Ux
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_32
   - name: STM32G431C8Tx
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_64
   - name: STM32G431C8Ux
@@ -76,21 +81,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_64
   - name: STM32G431CBTx
@@ -99,21 +106,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G431CBUx
@@ -122,21 +131,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G431CBYx
@@ -145,21 +156,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G431K6Tx
@@ -168,21 +181,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_32
   - name: STM32G431K6Ux
@@ -191,21 +206,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_32
   - name: STM32G431K8Tx
@@ -214,21 +231,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_64
   - name: STM32G431K8Ux
@@ -237,21 +256,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_64
   - name: STM32G431KBTx
@@ -260,21 +281,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G431KBUx
@@ -283,21 +306,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G431M6Tx
@@ -306,21 +331,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_32
   - name: STM32G431M8Tx
@@ -329,21 +356,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_64
   - name: STM32G431R6Ix
@@ -352,21 +381,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_32
   - name: STM32G431R6Tx
@@ -375,21 +406,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_32
   - name: STM32G431R8Ix
@@ -398,21 +431,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_64
   - name: STM32G431R8Tx
@@ -421,21 +456,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_64
   - name: STM32G431RBIx
@@ -444,21 +481,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G431RBTx
@@ -467,21 +506,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G431V6Tx
@@ -490,21 +531,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_32
   - name: STM32G431V8Tx
@@ -513,21 +556,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_64
   - name: STM32G431VBTx
@@ -536,21 +581,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G441CBTx
@@ -559,21 +606,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G441CBUx
@@ -582,21 +631,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G441CBYx
@@ -605,21 +656,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G441KBTx
@@ -628,21 +681,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G441KBUx
@@ -651,21 +706,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G441RBIx
@@ -674,21 +731,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G441RBTx
@@ -697,21 +756,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G441VBTx
@@ -720,21 +781,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G471CCTx
@@ -743,21 +806,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G471CCUx
@@ -766,21 +831,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G471CETx
@@ -789,21 +856,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -813,21 +882,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -837,21 +908,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G471METx
@@ -860,21 +933,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -884,21 +959,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -908,21 +985,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G471QETx
@@ -931,21 +1010,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -955,21 +1036,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G471RE
@@ -978,21 +1061,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1002,21 +1087,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G471VCIx
@@ -1025,21 +1112,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G471VCTx
@@ -1048,21 +1137,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G471VEHx
@@ -1071,21 +1162,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1095,21 +1188,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1119,21 +1214,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1143,21 +1240,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G473CBUx
@@ -1166,21 +1265,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G473CCTx
@@ -1189,21 +1290,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G473CCUx
@@ -1212,21 +1315,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G473CETx
@@ -1235,21 +1340,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1259,21 +1366,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1283,21 +1392,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G473MCTx
@@ -1306,21 +1417,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G473METx
@@ -1329,21 +1442,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1353,21 +1468,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1377,21 +1494,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G473QCTx
@@ -1400,21 +1519,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G473QETx
@@ -1423,21 +1544,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1447,21 +1570,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G473RCTx
@@ -1470,21 +1595,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G473RETx
@@ -1493,21 +1620,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1517,21 +1646,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G473VBIx
@@ -1540,21 +1671,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G473VBTx
@@ -1563,21 +1696,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G473VCHx
@@ -1586,21 +1721,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G473VCIx
@@ -1609,21 +1746,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G473VCTx
@@ -1632,21 +1771,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G473VEHx
@@ -1655,21 +1796,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1679,21 +1822,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1703,21 +1848,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1727,21 +1874,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G474CBUx
@@ -1750,21 +1899,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G474CCTx
@@ -1773,21 +1924,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G474CCUx
@@ -1796,21 +1949,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G474CETx
@@ -1819,21 +1974,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1843,21 +2000,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1867,21 +2026,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G474MCTx
@@ -1890,21 +2051,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G474METx
@@ -1913,21 +2076,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1937,21 +2102,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -1961,21 +2128,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G474QCTx
@@ -1984,21 +2153,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G474QETx
@@ -2007,21 +2178,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2031,21 +2204,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G474RCTx
@@ -2054,21 +2229,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G474RETx
@@ -2077,21 +2254,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2101,21 +2280,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G474VBIx
@@ -2124,21 +2305,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G474VBTx
@@ -2147,21 +2330,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
   - name: STM32G474VCHx
@@ -2170,21 +2355,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G474VCIx
@@ -2193,21 +2380,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G474VCTx
@@ -2216,21 +2405,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_256
   - name: STM32G474VEHx
@@ -2239,21 +2430,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2263,21 +2456,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2287,21 +2482,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2311,21 +2508,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2335,21 +2534,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2359,21 +2560,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2383,21 +2586,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2407,21 +2612,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2431,21 +2638,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2455,21 +2664,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2479,21 +2690,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2503,21 +2716,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2527,21 +2742,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2551,21 +2768,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2575,21 +2794,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2599,21 +2820,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2623,21 +2846,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2647,21 +2872,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2671,21 +2898,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2695,21 +2924,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2719,21 +2950,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_512_dual
       - stm32g4xx_512
@@ -2743,159 +2976,161 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32g4xx_128
 flash_algorithms:
-  stm32g4xx_32:
-    name: stm32g4xx_32
+  - name: stm32g4xx_32
     description: STM32G4xx 32 Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRnZId0ygYHdIoGAgRgBqwLKqKBfQdEjgYHRI4GAgRgBqIPD/ACBiIEYAakDwqgAgYiBGQGlA9AAwYGEgRkBpQPAAYGBhAL9mSABpAPSAMAAo+dEQvQFGYkhAaUDwAEBgSlBhACBwRwNGASBwRwPgTPL7MFtJCGFaSABpAPSAMAAo9dEEIFZJSGEIRkBpQPSAMEhhAL9SSABpAPSAMAAo+dFPSABpRPL6MQhAILEIRkxJCGEBIHBHSkhAaSDwBABISUhhACD25wFGTPL7MERLGGEYRkBpQPACAFhhRUhIRABogUIJ08oKgDoC8H8CGEZAaUD0AGBYYQfgwfPGIjhIQGkg9ABgNktYYTVIQGkg9H5wM0tYYRhGQGlA6sIAWGEYRkBpQPSAMFhhAL8tSABpAPSAMAAo+dEAvylIAGkA9IAwACj50SZIAGlE8vozGEAgsRhGI0sYYQEgcEchSEBpIPACAB9LWGEAIPbnELUDRsgdIPAHAQC/GkgAaQD0gDAAKPnRTPL7MBZMIGEgRkBpQPABAGBhGOAQaBhgUGhYYAC/D0gAaQD0gDAAKPnRCDMIMgg5C0gAaQDwAQAosUTy+jAHTCBhASAQvQAp5NEESEBpIPABAAJMYGEAIPTnIwFnRQAgAkCrie/NOyoZCH9uXUwEAAAAAAAAAAAABAg=
-    pc_init: 1
-    pc_uninit: 89
-    pc_program_page: 367
-    pc_erase_sector: 203
-    pc_erase_all: 113
-    data_section_offset: 504
+    pc_init: 0x1
+    pc_uninit: 0x59
+    pc_program_page: 0x16f
+    pc_erase_sector: 0xcb
+    pc_erase_all: 0x71
+    data_section_offset: 0x1f8
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134250496
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8008000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32g4xx_64:
-    name: stm32g4xx_64
+        - size: 0x800
+          address: 0x0
+  - name: stm32g4xx_64
     description: STM32G4xx 64 Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRnZId0ygYHdIoGAgRgBqwLKqKBfQdEjgYHRI4GAgRgBqIPD/ACBiIEYAakDwqgAgYiBGQGlA9AAwYGEgRkBpQPAAYGBhAL9mSABpAPSAMAAo+dEQvQFGYkhAaUDwAEBgSlBhACBwRwNGASBwRwPgTPL7MFtJCGFaSABpAPSAMAAo9dEEIFZJSGEIRkBpQPSAMEhhAL9SSABpAPSAMAAo+dFPSABpRPL6MQhAILEIRkxJCGEBIHBHSkhAaSDwBABISUhhACD25wFGTPL7MERLGGEYRkBpQPACAFhhRUhIRABogUIJ08oKgDoC8H8CGEZAaUD0AGBYYQfgwfPGIjhIQGkg9ABgNktYYTVIQGkg9H5wM0tYYRhGQGlA6sIAWGEYRkBpQPSAMFhhAL8tSABpAPSAMAAo+dEAvylIAGkA9IAwACj50SZIAGlE8vozGEAgsRhGI0sYYQEgcEchSEBpIPACAB9LWGEAIPbnELUDRsgdIPAHAQC/GkgAaQD0gDAAKPnRTPL7MBZMIGEgRkBpQPABAGBhGOAQaBhgUGhYYAC/D0gAaQD0gDAAKPnRCDMIMgg5C0gAaQDwAQAosUTy+jAHTCBhASAQvQAp5NEESEBpIPABAAJMYGEAIPTnIwFnRQAgAkCrie/NOyoZCH9uXUwEAAAAAAAAAAAABAg=
-    pc_init: 1
-    pc_uninit: 89
-    pc_program_page: 367
-    pc_erase_sector: 203
-    pc_erase_all: 113
-    data_section_offset: 504
+    pc_init: 0x1
+    pc_uninit: 0x59
+    pc_program_page: 0x16f
+    pc_erase_sector: 0xcb
+    pc_erase_all: 0x71
+    data_section_offset: 0x1f8
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134283264
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8010000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32g4xx_256:
-    name: stm32g4xx_256
-    description: "STM32G4xx 256 "
-    cores: [main]
+        - size: 0x800
+          address: 0x0
+  - name: stm32g4xx_256
+    description: 'STM32G4xx 256 '
+    cores:
+      - main
     default: true
     instructions: ELUDRmlIakygYGpIoGAAv2dIAGkA9IAwACj50RC9AUZjSEBpQPAAQGFKUGEAIHBHA0YBIHBHA+BM8vswXEkIYVtIAGkA9IAwACj10UjyBABXSUhhCEZAaUD0gDBIYQC/U0gAaQD0gDAAKPnRUEgAaUTy+jEIQCCxCEZNSQhhASBwR0tIQGkg8AQASUlIYQhGQGkg9ABASGEAIPHnAUZESEBpQPACAEJLWGFDSEhEAGiBQgnTygqAOgLwfwIYRkBpQPQAYFhhB+DB88YiOEhAaSD0AGA2S1hhNUhAaSD0fnAzS1hhGEZAaUDqwgBYYRhGQGlA9IAwWGEAvy1IAGkA9IAwACj50QC/KUgAaQD0gDAAKPnRJkgAaUTy+jMYQCCxGEYjSxhhASBwRyFIQGkg8AIAH0tYYQAg9ucQtQNGyB0g8AcBAL8aSABpAPSAMAAo+dFM8vswFkwgYSBGQGlA8AEAYGEY4BBoGGBQaFhgAL8PSABpAPSAMAAo+dEIMwgyCDkLSABpAPABACixRPL6MAdMIGEBIBC9ACnk0QRIQGkg8AEAAkxgYQAg9OcjAWdFACACQKuJ780EAAAAAAAAAAAABAg=
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 315
-    pc_erase_sector: 157
-    pc_erase_all: 55
-    data_section_offset: 444
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x13b
+    pc_erase_sector: 0x9d
+    pc_erase_all: 0x37
+    data_section_offset: 0x1bc
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134479872
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8040000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 4096
-          address: 0
-  stm32g4xx_512_dual:
-    name: stm32g4xx_512_dual
+        - size: 0x1000
+          address: 0x0
+  - name: stm32g4xx_512_dual
     description: STM32G4xx 512 Dual Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRmlIakygYGpIoGAAv2dIAGkA9IAwACj50RC9AUZjSEBpQPAAQGFKUGEAIHBHA0YBIHBHA+BM8vswXEkIYVtIAGkA9IAwACj10UjyBABXSUhhCEZAaUD0gDBIYQC/U0gAaQD0gDAAKPnRUEgAaUTy+jEIQCCxCEZNSQhhASBwR0tIQGkg8AQASUlIYQhGQGkg9ABASGEAIPHnAUZESEBpQPACAEJLWGFDSEhEAGiBQgnTygqAOgLwfwIYRkBpQPQAYFhhB+DB88YiOEhAaSD0AGA2S1hhNUhAaSD0fnAzS1hhGEZAaUDqwgBYYRhGQGlA9IAwWGEAvy1IAGkA9IAwACj50QC/KUgAaQD0gDAAKPnRJkgAaUTy+jMYQCCxGEYjSxhhASBwRyFIQGkg8AIAH0tYYQAg9ucQtQNGyB0g8AcBAL8aSABpAPSAMAAo+dFM8vswFkwgYSBGQGlA8AEAYGEY4BBoGGBQaFhgAL8PSABpAPSAMAAo+dEIMwgyCDkLSABpAPABACixRPL6MAdMIGEBIBC9ACnk0QRIQGkg8AEAAkxgYQAg9OcjAWdFACACQKuJ780EAAAAAAAAAAAABAgAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 315
-    pc_erase_sector: 157
-    pc_erase_all: 55
-    data_section_offset: 444
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x13b
+    pc_erase_sector: 0x9d
+    pc_erase_all: 0x37
+    data_section_offset: 0x1bc
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134742016
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8080000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32g4xx_512:
-    name: stm32g4xx_512
+        - size: 0x800
+          address: 0x0
+  - name: stm32g4xx_512
     description: STM32G4xx 512 Single Flash
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ELUDRmFIYkygYGJIoGAAv19IAGkA9IAwACj50RC9AUZbSEBpQPAAQFlKUGEAIHBHA0YBIHBHA+BM8vswVEkIYVNIAGkA9IAwACj10UjyBABPSUhhCEZAaUD0gDBIYQC/S0gAaQD0gDAAKPnRSEgAaUTy+jEIQCCxCEZFSQhhASBwR0NIQGkg8AQAQUlIYQhGQGkg9ABASGEAIPHnAUY8SEBpQPACADpLWGHB8wYyGEZAaSD0AGBYYRhGQGkg9H5wWGEYRkBpQOrCAFhhGEZAaUD0gDBYYQC/LUgAaQD0gDAAKPnRAL8qSABpAPSAMAAo+dEnSABpRPL6MxhAILEYRiNLGGEBIHBHIUhAaSDwAgAfS1hhACD25xC1A0bIHSDwBwEAvxpIAGkA9IAwACj50Uzy+zAWTCBhIEZAaUDwAQBgYRjgEGgYYFBoWGAAvxBIAGkA9IAwACj50QgzCDIIOQtIAGkA8AEAKLFE8vowCEwgYQEgEL0AKeTRBUhAaSDwAQADTGBhACD05wAAIwFnRQAgAkCrie/NAAAAAA==
-    pc_init: 1
-    pc_uninit: 31
-    pc_program_page: 281
-    pc_erase_sector: 157
-    pc_erase_all: 55
-    data_section_offset: 408
+    pc_init: 0x1
+    pc_uninit: 0x1f
+    pc_program_page: 0x119
+    pc_erase_sector: 0x9d
+    pc_erase_all: 0x37
+    data_section_offset: 0x198
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134742016
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8080000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 4096
-          address: 0
-  stm32g4xx_128:
-    name: stm32g4xx_128
+        - size: 0x1000
+          address: 0x0
+  - name: stm32g4xx_128
     description: STM32G4xx 128 Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRnZId0ygYHdIoGAgRgBqwLKqKBfQdEjgYHRI4GAgRgBqIPD/ACBiIEYAakDwqgAgYiBGQGlA9AAwYGEgRkBpQPAAYGBhAL9mSABpAPSAMAAo+dEQvQFGYkhAaUDwAEBgSlBhACBwRwNGASBwRwPgTPL7MFtJCGFaSABpAPSAMAAo9dEEIFZJSGEIRkBpQPSAMEhhAL9SSABpAPSAMAAo+dFPSABpRPL6MQhAILEIRkxJCGEBIHBHSkhAaSDwBABISUhhACD25wFGTPL7MERLGGEYRkBpQPACAFhhRUhIRABogUIJ08oKgDoC8H8CGEZAaUD0AGBYYQfgwfPGIjhIQGkg9ABgNktYYTVIQGkg9H5wM0tYYRhGQGlA6sIAWGEYRkBpQPSAMFhhAL8tSABpAPSAMAAo+dEAvylIAGkA9IAwACj50SZIAGlE8vozGEAgsRhGI0sYYQEgcEchSEBpIPACAB9LWGEAIPbnELUDRsgdIPAHAQC/GkgAaQD0gDAAKPnRTPL7MBZMIGEgRkBpQPABAGBhGOAQaBhgUGhYYAC/D0gAaQD0gDAAKPnRCDMIMgg5C0gAaQDwAQAosUTy+jAHTCBhASAQvQAp5NEESEBpIPABAAJMYGEAIPTnIwFnRQAgAkCrie/NOyoZCH9uXUwEAAAAAAAAAAAABAgAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 89
-    pc_program_page: 367
-    pc_erase_sector: 203
-    pc_erase_all: 113
-    data_section_offset: 504
+    pc_init: 0x1
+    pc_uninit: 0x59
+    pc_program_page: 0x16f
+    pc_erase_sector: 0xcb
+    pc_erase_all: 0x71
+    data_section_offset: 0x1f8
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134348800
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8020000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/STM32H7_Series.yaml
+++ b/probe-rs/targets/STM32H7_Series.yaml
@@ -1,4 +1,3 @@
----
 name: STM32H7 Series
 variants:
   - name: STM32H742AGIx
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742AIIx
@@ -30,21 +31,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742BGTx
@@ -53,21 +56,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742BITx
@@ -76,21 +81,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742IGKx
@@ -99,21 +106,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742IGTx
@@ -122,21 +131,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742IIKx
@@ -145,21 +156,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742IITx
@@ -168,21 +181,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742VGHx
@@ -191,21 +206,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742VGTx
@@ -214,21 +231,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742VIHx
@@ -237,21 +256,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742VITx
@@ -260,21 +281,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742XGHx
@@ -283,21 +306,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742XIHx
@@ -306,21 +331,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742ZGTx
@@ -329,21 +356,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H742ZITx
@@ -352,21 +381,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24060000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743AGIx
@@ -375,21 +406,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743AIIx
@@ -398,21 +431,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743BGTx
@@ -421,21 +456,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743BITx
@@ -444,21 +481,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743IGKx
@@ -467,21 +506,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743IGTx
@@ -490,21 +531,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743IIKx
@@ -513,21 +556,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743IITx
@@ -536,21 +581,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743VGHx
@@ -559,21 +606,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743VGTx
@@ -582,21 +631,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743VIHx
@@ -605,21 +656,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743VITx
@@ -628,21 +681,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743XGHx
@@ -651,21 +706,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743XIHx
@@ -674,21 +731,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743ZGTx
@@ -697,21 +756,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H743ZITx
@@ -720,21 +781,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H745BGTx
@@ -743,21 +806,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H745BITx
@@ -766,21 +831,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H745IGKx
@@ -789,21 +856,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H745IGTx
@@ -812,21 +881,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H745IIKx
@@ -835,21 +906,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H745IITx
@@ -858,21 +931,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H745XGHx
@@ -881,21 +956,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H745XIHx
@@ -904,21 +981,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H745ZGTx
@@ -927,21 +1006,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H745ZITx
@@ -950,21 +1031,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H747AGIx
@@ -973,21 +1056,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H747AIIx
@@ -996,21 +1081,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H747BGTx
@@ -1019,21 +1106,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H747BITx
@@ -1042,21 +1131,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H747IGTx
@@ -1065,21 +1156,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H747IITx
@@ -1088,21 +1181,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H747XGHx
@@ -1111,21 +1206,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H747XIHx
@@ -1134,21 +1231,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H747ZIYx
@@ -1157,21 +1256,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H750IBKx
@@ -1180,21 +1281,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08020000
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_128k
   - name: STM32H750IBTx
@@ -1203,21 +1306,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08020000
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_128k
   - name: STM32H750VBTx
@@ -1226,21 +1331,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08020000
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_128k
   - name: STM32H750XBHx
@@ -1249,21 +1356,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08020000
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_128k
   - name: STM32H750ZBTx
@@ -1272,21 +1381,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08020000
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_128k
   - name: STM32H753AIIx
@@ -1295,21 +1406,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H753BITx
@@ -1318,21 +1431,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H753IIKx
@@ -1341,21 +1456,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H753IITx
@@ -1364,21 +1481,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H753VIHx
@@ -1387,21 +1506,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H753VITx
@@ -1410,21 +1531,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H753XIHx
@@ -1433,21 +1556,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H753ZITx
@@ -1456,21 +1581,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H755BITx
@@ -1479,21 +1606,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H755IIKx
@@ -1502,21 +1631,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H755IITx
@@ -1525,21 +1656,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H755XIHx
@@ -1548,21 +1681,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H755ZITx
@@ -1571,21 +1706,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H757AIIx
@@ -1594,21 +1731,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H757BITx
@@ -1617,21 +1756,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H757IITx
@@ -1640,21 +1781,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H757XIHx
@@ -1663,21 +1806,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H757ZIYx
@@ -1686,21 +1831,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24080000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7x_2048
   - name: STM32H7A3AGIxQ
@@ -1709,21 +1856,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3AIIxQ
@@ -1732,21 +1881,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3IGKx
@@ -1755,21 +1906,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3IGKxQ
@@ -1778,21 +1931,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3IGTx
@@ -1801,21 +1956,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3IGTxQ
@@ -1824,21 +1981,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3IIKx
@@ -1847,21 +2006,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3IIKxQ
@@ -1870,21 +2031,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3IITx
@@ -1893,21 +2056,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3IITxQ
@@ -1916,21 +2081,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3LGHxQ
@@ -1939,21 +2106,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3LIHxQ
@@ -1962,21 +2131,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3NGHx
@@ -1985,21 +2156,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3NIHx
@@ -2008,21 +2181,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3QIYxQ
@@ -2031,21 +2206,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3RGTx
@@ -2054,21 +2231,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3RITx
@@ -2077,21 +2256,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3VGHx
@@ -2100,21 +2281,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3VGHxQ
@@ -2123,21 +2306,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3VGTx
@@ -2146,21 +2331,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3VGTxQ
@@ -2169,21 +2356,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3VIHx
@@ -2192,21 +2381,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3VIHxQ
@@ -2215,21 +2406,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3VITx
@@ -2238,21 +2431,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3VITxQ
@@ -2261,21 +2456,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3ZGTx
@@ -2284,21 +2481,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3ZGTxQ
@@ -2307,21 +2506,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08100000
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3ZITx
@@ -2330,21 +2531,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7A3ZITxQ
@@ -2353,21 +2556,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B0ABIxQ
@@ -2376,21 +2581,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08020000
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7b0_flash
   - name: STM32H7B0IBKxQ
@@ -2399,21 +2606,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08020000
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7b0_flash
   - name: STM32H7B0IBTx
@@ -2422,21 +2631,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08020000
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7b0_flash
   - name: STM32H7B0RBTx
@@ -2445,21 +2656,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08020000
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7b0_flash
   - name: STM32H7B0VBTx
@@ -2468,21 +2681,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08020000
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7b0_flash
   - name: STM32H7B0ZBTx
@@ -2491,21 +2706,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08020000
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7b0_flash
   - name: STM32H7B3AIIxQ
@@ -2514,21 +2731,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3IIKx
@@ -2537,21 +2756,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3IIKxQ
@@ -2560,21 +2781,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3IITx
@@ -2583,21 +2806,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3IITxQ
@@ -2606,21 +2831,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3LIHxQ
@@ -2629,21 +2856,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3NIHx
@@ -2652,21 +2881,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3QIYxQ
@@ -2675,21 +2906,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3RITx
@@ -2698,21 +2931,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3VIHx
@@ -2721,21 +2956,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3VIHxQ
@@ -2744,21 +2981,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3VITx
@@ -2767,21 +3006,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3VITxQ
@@ -2790,21 +3031,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3ZITx
@@ -2813,21 +3056,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
   - name: STM32H7B3ZITxQ
@@ -2836,113 +3081,115 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x24000000
             end: 0x24100000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0x08000000
-            end: 0x08200000
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32h7a-b3_flash_2m
 flash_algorithms:
-  stm32h7x_128k:
-    name: stm32h7x_128k
+  - name: stm32h7x_128k
     description: STM32H750xx
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHELUDRk/0gHDtTCBg7UgAaEDwBwDrTCBg60hgYQC/6EgAaQDwBAAAKPnR50jlTGBg50hgYORI5kwgYAC/5UgAHwBoAPAEAAAo+NHfSOFMEDwgYN5I20zE+AQBACAQvQFG2EjAaEDwAQDWStBg2UgIOABoQPABAML4DAEAIHBH0UjQSUhhAL/OSABpAPAEAAAo+dHMSM9JCGAAv81IAB8AaADwBAAAKPjRAL/FSABpAPAEAAAo+dHCSMBoIPAwAMBJyGAIRsBoQPAIAMhgCEbAaEDwgADIYAC/ukgAaQDwBAAAKPnRt0jAaCDwCAC1SchgAL+3SAAfAGgA8AQAACj40bRICDgAaCDwMACtScH4DAEIRtD4DAFA8AgAwfgMAQhG0PgMAUDwgADB+AwBAL+oSAAfAGgA8AQAACj40aVICDgAaCDwCACeScH4DAEAIHBHELUBRsHzQ0Kx8QBvN9Ox8QFvNNKXSEBpl0sYQ5VLWGEAv5NIAGkA8AQAACj50ZBIwGhH9jBzmEOOS9hgGEbAaAQjQ+oCIxhDikvYYBhGwGhA8IAA2GAAv4ZIAGkA8AQAACj50YNIwGgg8AQAgUvYYBhGAGkA8AEA6LMBIBC9gEgAaHxLGEN6S8P4FAEAv3xIAB8AaADwBAAAKPjReUgIOABoR/Ywc5hDckvD+AwBdEgIOABoovEIAwQkROoDIxhDbEvD+AwBGEbQ+AwBQPCAAMP4DAEAv2pIAB8AaADwBAAAKPjRZ0gIOABoIPAEAGBLw/gMAQDgB+BiSAAfAGgA8AEACLEBILnnACC35/C1A0YMRhZGGUY1RgAis/EAbw3Ts/EBbwrSAL9SSABpAPAEAAAo+dFQSE5PeGEK4AC/UEgAHwBoAPAEAAAo+NFKSExPOGCH4LPxAG8M07PxAW8J0kRIwGhH9jB3uENBT/hgAiD4YAzgQ0gIOABoR/Ywd7hDPE/H+AwBAiA+Twg/OGAgLAzTACIG4C9oaGgPYEhgCDUIMVIcBCr22yA8E+AAIgTgFfgBCwH4AQtSHKJC+NMAIgPg/yAB+AELUhzE8SAAkEL32AAk//dp/rPxAG8K07PxAW8H0gC/IkgAaQDwBAAAKPnRB+AAvyJIAB8AaADwBAAAKPjRG0gAaQAgsLGz8QBvCdOz8QFvBtIWSMBoIPACABRP+GAH4BZICDgAaCDwAgAQT8f4DAEBIPC9s/EAbwnTs/EBbwbSCkjAaCDwAgAIT/hgB+ALSAg4AGgg8AIABE/H+AwBACx/9HWvACDk55RFAlgAIABSAADvDyMBZ0Wrie/NFCEAUgAAAAA=
-    pc_init: 7
-    pc_uninit: 101
-    pc_program_page: 611
-    pc_erase_sector: 343
-    pc_erase_all: 133
-    data_section_offset: 988
+    pc_init: 0x7
+    pc_uninit: 0x65
+    pc_program_page: 0x263
+    pc_erase_sector: 0x157
+    pc_erase_all: 0x85
+    data_section_offset: 0x3dc
     flash_properties:
       address_range:
-        start: 0x08000000
-        end: 0x08020000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8020000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 131072
-          address: 0
-  stm32h7x_2048:
-    name: stm32h7x_2048
+        - size: 0x20000
+          address: 0x0
+  - name: stm32h7x_2048
     description: STM32H7x_2048
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHELUDRk/0gHDtTCBg7UgAaEDwBwDrTCBg60hgYQC/6EgAaQDwBAAAKPnR50jlTGBg50hgYORI5kwgYAC/5UgAHwBoAPAEAAAo+NHfSOFMEDwgYN5I20zE+AQBACAQvQFG2EjAaEDwAQDWStBg2UgIOABoQPABAML4DAEAIHBH0UjQSUhhAL/OSABpAPAEAAAo+dHMSM9JCGAAv81IAB8AaADwBAAAKPjRAL/FSABpAPAEAAAo+dHCSMBoIPAwAMBJyGAIRsBoQPAIAMhgCEbAaEDwgADIYAC/ukgAaQDwBAAAKPnRt0jAaCDwCAC1SchgAL+3SAAfAGgA8AQAACj40bRICDgAaCDwMACtScH4DAEIRtD4DAFA8AgAwfgMAQhG0PgMAUDwgADB+AwBAL+oSAAfAGgA8AQAACj40aVICDgAaCDwCACeScH4DAEAIHBHELUBRsHzQ0Kx8QBvN9Ox8QFvNNKXSEBpl0sYQ5VLWGEAv5NIAGkA8AQAACj50ZBIwGhH9jBzmEOOS9hgGEbAaAQjQ+oCIxhDikvYYBhGwGhA8IAA2GAAv4ZIAGkA8AQAACj50YNIwGgg8AQAgUvYYBhGAGkA8AEA6LMBIBC9gEgAaHxLGEN6S8P4FAEAv3xIAB8AaADwBAAAKPjReUgIOABoR/Ywc5hDckvD+AwBdEgIOABoovEIAwQkROoDIxhDbEvD+AwBGEbQ+AwBQPCAAMP4DAEAv2pIAB8AaADwBAAAKPjRZ0gIOABoIPAEAGBLw/gMAQDgB+BiSAAfAGgA8AEACLEBILnnACC35/C1A0YMRhZGGUY1RgAis/EAbw3Ts/EBbwrSAL9SSABpAPAEAAAo+dFQSE5PeGEK4AC/UEgAHwBoAPAEAAAo+NFKSExPOGCH4LPxAG8M07PxAW8J0kRIwGhH9jB3uENBT/hgAiD4YAzgQ0gIOABoR/Ywd7hDPE/H+AwBAiA+Twg/OGAgLAzTACIG4C9oaGgPYEhgCDUIMVIcBCr22yA8E+AAIgTgFfgBCwH4AQtSHKJC+NMAIgPg/yAB+AELUhzE8SAAkEL32AAk//dp/rPxAG8K07PxAW8H0gC/IkgAaQDwBAAAKPnRB+AAvyJIAB8AaADwBAAAKPjRG0gAaQAgsLGz8QBvCdOz8QFvBtIWSMBoIPACABRP+GAH4BZICDgAaCDwAgAQT8f4DAEBIPC9s/EAbwnTs/EBbwbSCkjAaCDwAgAIT/hgB+ALSAg4AGgg8AIABE/H+AwBACx/9HWvACDk55RFAlgAIABSAADvDyMBZ0Wrie/NFCEAUgAAAAA=
-    pc_init: 7
-    pc_uninit: 101
-    pc_program_page: 611
-    pc_erase_sector: 343
-    pc_erase_all: 133
-    data_section_offset: 988
+    pc_init: 0x7
+    pc_uninit: 0x65
+    pc_program_page: 0x263
+    pc_erase_sector: 0x157
+    pc_erase_all: 0x85
+    data_section_offset: 0x3dc
     flash_properties:
       address_range:
-        start: 0x08000000
-        end: 0x08200000
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8200000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 131072
-          address: 0
-  stm32h7b0_flash:
-    name: stm32h7b0_flash
+        - size: 0x20000
+          address: 0x0
+  - name: stm32h7b0_flash
     description: STM32H7B0_Flash_128k
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHELUDRupI6kxgYQC/6UgAaQDwAQAAKPnR50jlTGBg5khgYOJI5kwgYAC/5EgAHwBoAPABAAAo+NHfSOBMEDwgYN5I20zE+AQBIEbAaQAgEL0BRtdIwGhA8AEA1UrQYNdICDgAaEDwAQDC+AwBACBwRwC/z0gAaQDwAQAAKPnRy0jMSUhhCEbAaCDwAQDIYAhGwGhA8AgAyGAIRsBoQPAgAMhgAL/DSABpAPABAAAo+dHASMBoIPAIAL5JyGAAv79IAB8AaADwAQAAKPjRuEi7SQhgt0jQ+AwBIPABALVJwfgMAQhG0PgMAUDwCADB+AwBCEbQ+AwBQPAgALBJCDkIYAC/rkgAHwBoAPABAAAo+NGrSAg4AGgg8AgApUnB+AwBACBwRxC1AUbB80cysfEAbzbTsfEBbzPSnkhAaaFLGEOcS1hhAL+aSABpAPAEAAAo+dGXSMBoIPT+UJVL2GAYRsBoBCND6oITGEORS9hgGEbAaEDwIADYYAC/jUgAaQDwBAAAKPnRikjAaCDwBACIS9hgGEYAaQDwAQDwswEgEL2HSABoh0sYQ4JLw/gUAQC/g0gAHwBoAPAEAAAo+NF/SAg4AGgg9P5QekvD+AwBe0gIOABoovGAAwQkROqDExhDdEvD+AwBGEbQ+AwBQPAgAMP4DAEAv3FIAB8AaADwBAAAKPjRbkgIOABoIPAEAGhLw/gMAWpIAB8A4AXgAGgA8AEACLEBILrn//fn/gAgtufwtQNGFkYaRjVGACQAv1xIAGkA8AEAACj50VhIWU94YQC/WkgAHwBoAPABAAAo+NFTSFZPOGCc4FJIwGgg8AEAUE/4YDhGwGhA8AIA+GBPSAg4AGgg8AEAx/gMAThG0PgMAUDwAgDH+AwBECkM0wAkBuAvaGhoF2BQYAg1CDJkHAIs9tsQOSjgACQE4BX4AQsC+AELZByMQvjTACQD4P8gAvgBC2QcwfEQAKBC99iz8QBvCdOz8QFvBtIxSMBoQPBAAC9P+GAH4DFICDgAaEDwQAArT8f4DAEAIf/3dv6z8QBvCtOz8QFvB9IAvyVIAGkA8AEAACj50QfgAL8kSAAfAGgA8AEAACj40R1IAGkAIB9PPx8/aABDsLGz8QBvCdOz8QFvBtIWSMBoIPACABRP+GAH4BZICDgAaCDwAgAQT8f4DAEBIPC9s/EAbwnTs/EBbwbSC0jAaCDwAgAJT/hgB+AKSAg4AGgg8AIABU/H+AwBACl/9GCvACDk5wAAAACvDwAgAFIjAWdFq4nvzRQhAFIAAO8PAAAAAA==
-    pc_init: 7
-    pc_uninit: 87
-    pc_program_page: 567
-    pc_erase_sector: 299
-    pc_erase_all: 119
-    data_section_offset: 972
+    pc_init: 0x7
+    pc_uninit: 0x57
+    pc_program_page: 0x237
+    pc_erase_sector: 0x12b
+    pc_erase_all: 0x77
+    data_section_offset: 0x3cc
     flash_properties:
       address_range:
-        start: 0x08000000
-        end: 0x08020000
-      page_size: 32768
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8020000
+      page_size: 0x8000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 8192
-          address: 0
-  stm32h7a-b3_flash_2m:
-    name: stm32h7a-b3_flash_2m
+        - size: 0x2000
+          address: 0x0
+  - name: stm32h7a-b3_flash_2m
     description: STM32H7A-B3_Flash_2M
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHELUDRupI6kxgYQC/6UgAaQDwAQAAKPnR50jlTGBg5khgYOJI5kwgYAC/5EgAHwBoAPABAAAo+NHfSOBMEDwgYN5I20zE+AQBIEbAaQAgEL0BRtdIwGhA8AEA1UrQYNdICDgAaEDwAQDC+AwBACBwRwC/z0gAaQDwAQAAKPnRy0jMSUhhCEbAaCDwAQDIYAhGwGhA8AgAyGAIRsBoQPAgAMhgAL/DSABpAPABAAAo+dHASMBoIPAIAL5JyGAAv79IAB8AaADwAQAAKPjRuEi7SQhgt0jQ+AwBIPABALVJwfgMAQhG0PgMAUDwCADB+AwBCEbQ+AwBQPAgALBJCDkIYAC/rkgAHwBoAPABAAAo+NGrSAg4AGgg8AgApUnB+AwBACBwRxC1AUbB80cysfEAbzbTsfEBbzPSnkhAaaFLGEOcS1hhAL+aSABpAPAEAAAo+dGXSMBoIPT+UJVL2GAYRsBoBCND6oITGEORS9hgGEbAaEDwIADYYAC/jUgAaQDwBAAAKPnRikjAaCDwBACIS9hgGEYAaQDwAQDwswEgEL2HSABoh0sYQ4JLw/gUAQC/g0gAHwBoAPAEAAAo+NF/SAg4AGgg9P5QekvD+AwBe0gIOABoovGAAwQkROqDExhDdEvD+AwBGEbQ+AwBQPAgAMP4DAEAv3FIAB8AaADwBAAAKPjRbkgIOABoIPAEAGhLw/gMAWpIAB8A4AXgAGgA8AEACLEBILrn//fn/gAgtufwtQNGFkYaRjVGACQAv1xIAGkA8AEAACj50VhIWU94YQC/WkgAHwBoAPABAAAo+NFTSFZPOGCc4FJIwGgg8AEAUE/4YDhGwGhA8AIA+GBPSAg4AGgg8AEAx/gMAThG0PgMAUDwAgDH+AwBECkM0wAkBuAvaGhoF2BQYAg1CDJkHAIs9tsQOSjgACQE4BX4AQsC+AELZByMQvjTACQD4P8gAvgBC2QcwfEQAKBC99iz8QBvCdOz8QFvBtIxSMBoQPBAAC9P+GAH4DFICDgAaEDwQAArT8f4DAEAIf/3dv6z8QBvCtOz8QFvB9IAvyVIAGkA8AEAACj50QfgAL8kSAAfAGgA8AEAACj40R1IAGkAIB9PPx8/aABDsLGz8QBvCdOz8QFvBtIWSMBoIPACABRP+GAH4BZICDgAaCDwAgAQT8f4DAEBIPC9s/EAbwnTs/EBbwbSC0jAaCDwAgAJT/hgB+AKSAg4AGgg8AIABU/H+AwBACl/9GCvACDk5wAAAACvDwAgAFIjAWdFq4nvzRQhAFIAAO8PAAAAAA==
-    pc_init: 7
-    pc_uninit: 87
-    pc_program_page: 567
-    pc_erase_sector: 299
-    pc_erase_all: 119
-    data_section_offset: 972
+    pc_init: 0x7
+    pc_uninit: 0x57
+    pc_program_page: 0x237
+    pc_erase_sector: 0x12b
+    pc_erase_all: 0x77
+    data_section_offset: 0x3cc
     flash_properties:
       address_range:
-        start: 0x08000000
-        end: 0x08200000
-      page_size: 32768
-      erased_byte_value: 255
-      program_page_timeout: 100
-      erase_sector_timeout: 6000
+        start: 0x8000000
+        end: 0x8200000
+      page_size: 0x8000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x64
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 8192
-          address: 0
+        - size: 0x2000
+          address: 0x0

--- a/probe-rs/targets/STM32L0_Series.yaml
+++ b/probe-rs/targets/STM32L0_Series.yaml
@@ -1,4 +1,3 @@
----
 name: STM32L0 Series
 variants:
   - name: STM32L010C6Tx
@@ -7,21 +6,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l010x6_8_eeprom
@@ -32,21 +33,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l010x4_eeprom
@@ -57,21 +60,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l010x4_eeprom
@@ -82,21 +87,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l010x6_8_eeprom
@@ -107,21 +114,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l010x6_8_eeprom
@@ -132,21 +141,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l010xb_eeprom
@@ -157,21 +168,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134225920
+            start: 0x8000000
+            end: 0x8002000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_8
       - stm32l01_2x_eeprom
@@ -182,21 +195,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -207,21 +222,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -232,21 +249,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134225920
+            start: 0x8000000
+            end: 0x8002000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_8
       - stm32l01_2x_eeprom
@@ -257,21 +276,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134225920
+            start: 0x8000000
+            end: 0x8002000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_8
       - stm32l01_2x_eeprom
@@ -282,21 +303,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -307,21 +330,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -332,21 +357,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134225920
+            start: 0x8000000
+            end: 0x8002000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_8
       - stm32l01_2x_eeprom
@@ -357,21 +384,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -382,21 +411,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134225920
+            start: 0x8000000
+            end: 0x8002000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_8
       - stm32l01_2x_eeprom
@@ -407,21 +438,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134225920
+            start: 0x8000000
+            end: 0x8002000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_8
       - stm32l01_2x_eeprom
@@ -432,21 +465,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -457,21 +492,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -482,21 +519,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -507,21 +546,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -532,21 +573,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -557,21 +600,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -582,21 +627,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -607,21 +654,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536872960
+            start: 0x20000000
+            end: 0x20000800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l01_2x_eeprom
@@ -632,21 +681,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l03_4x_eeprom
@@ -657,21 +708,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -682,21 +735,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l03_4x_eeprom
@@ -707,21 +762,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -732,21 +789,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l03_4x_eeprom
@@ -757,21 +816,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -782,21 +843,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l03_4x_eeprom
@@ -807,21 +870,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -832,21 +897,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -857,21 +924,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l03_4x_eeprom
@@ -882,21 +951,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l03_4x_eeprom
@@ -907,21 +978,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -932,21 +1005,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -957,21 +1032,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134234112
+            start: 0x8000000
+            end: 0x8004000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_16
       - stm32l03_4x_eeprom
@@ -982,21 +1059,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -1007,21 +1086,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -1032,21 +1113,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -1057,21 +1140,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -1082,21 +1167,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -1107,21 +1194,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l03_4x_eeprom
@@ -1132,21 +1221,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1157,21 +1248,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1182,21 +1275,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1207,21 +1302,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1232,21 +1329,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1257,21 +1356,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1282,21 +1383,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1307,21 +1410,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1332,21 +1437,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1357,21 +1464,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1382,21 +1491,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1407,21 +1518,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1432,21 +1545,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1457,21 +1572,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1482,21 +1599,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1507,21 +1626,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1532,21 +1653,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1557,21 +1680,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1582,21 +1707,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1607,21 +1734,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1632,21 +1761,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1657,21 +1788,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1682,21 +1815,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1707,21 +1842,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1732,21 +1869,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1757,21 +1896,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1782,21 +1923,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1807,21 +1950,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_32
       - stm32l05_6x_eeprom
@@ -1832,21 +1977,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1857,21 +2004,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1882,21 +2031,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1907,21 +2058,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1932,21 +2085,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1957,21 +2112,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l05_6x_eeprom
@@ -1982,21 +2139,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l07x_64_eeprom
@@ -2007,21 +2166,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2032,21 +2193,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2057,21 +2220,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2082,21 +2247,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2107,21 +2274,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l07x_64_eeprom
@@ -2132,27 +2301,30 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
-      - Nvm: # Flash program memory
+          cores:
+            - main
+      - Nvm:
           range:
-            start: 134217728 # 0x0800_0000
-            end: 134348800 # 0x0800_3FFF + 1
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
-      - Nvm: # Data EEPROM
+          cores:
+            - main
+      - Nvm:
           range:
-            start: 134742016 # 0x0808_0000
-            end: 134742528 # 0x0808_01FF + 1
+            start: 0x8080000
+            end: 0x8080200
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2163,21 +2335,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2188,21 +2362,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2213,21 +2389,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2238,21 +2416,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2263,21 +2443,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2288,21 +2470,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2313,21 +2497,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2338,21 +2524,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l07x_64_eeprom
@@ -2363,21 +2551,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l07x_64_eeprom
@@ -2388,21 +2578,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2413,21 +2605,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2438,21 +2632,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2463,21 +2659,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2488,21 +2686,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2513,21 +2713,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2538,21 +2740,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2563,21 +2767,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2588,21 +2794,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2613,21 +2821,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2638,21 +2848,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2663,21 +2875,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2688,21 +2902,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2713,21 +2929,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2738,21 +2956,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2763,21 +2983,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2788,21 +3010,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2813,21 +3037,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2838,21 +3064,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2863,21 +3091,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l07x_64_eeprom
@@ -2888,21 +3118,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l07x_64_eeprom
@@ -2913,21 +3145,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2938,21 +3172,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -2963,21 +3199,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -2988,21 +3226,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3013,21 +3253,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -3038,21 +3280,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3063,21 +3307,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -3088,21 +3334,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -3113,21 +3361,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3138,21 +3388,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3163,21 +3415,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l07x_64_eeprom
@@ -3188,21 +3442,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l07x_64_eeprom
@@ -3213,21 +3469,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -3238,21 +3496,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -3263,21 +3523,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3288,21 +3550,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3313,21 +3577,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3338,21 +3604,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3363,21 +3631,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3388,21 +3658,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l0xx_opt
@@ -3413,21 +3685,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l0xx_opt
@@ -3438,21 +3712,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l0xx_opt
@@ -3463,21 +3739,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l0xx_opt
@@ -3488,21 +3766,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l0xx_opt
@@ -3513,21 +3793,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -3538,21 +3820,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3563,21 +3847,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -3588,21 +3874,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -3613,21 +3901,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3638,21 +3928,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3663,21 +3955,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l07x_64_eeprom
@@ -3688,21 +3982,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537198592
+            start: 0x20000000
+            end: 0x20050000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_64
       - stm32l07x_64_eeprom
@@ -3713,21 +4009,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -3738,21 +4036,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_128
       - stm32l07_8x_eeprom
@@ -3763,21 +4063,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
@@ -3788,370 +4090,372 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134414336
+            start: 0x8000000
+            end: 0x8030000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l0xx_192
       - stm32l07_8x_eeprom
       - stm32l0xx_opt
 flash_algorithms:
-  stm32l0xx_16:
-    name: stm32l0xx_16
+  - name: stm32l0xx_16
     description: STM32L0 16KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASoB0AIqF9E7SIFpDyISAhFDgWE5ScFgOUnBYDlJAWE5SQFhwGnAAgbUOUg3SQFgBiFBYDdJgWAAIHBHASgB0AIoCNEsSEFoAiIRQ0FgQWgBIhFDQWAAIHBHMLUmSUpoTBUiQ0pgSmgIJSpDSmAAIgJgKUgmSgDgEGCLadsH+9FIaKBDSGBIaKhDSGAAIDC9ASBwR/C1GEwAIyUVCCY/MYkJjEYk4GFoKUNhYGFoMUNhYEAhgMqAwAkfACn60RZJp2n/BwLQEk85YPnnoWkJBQkPBtCgaQ8hCQIIQ6BhASDwvWFoqUNhYGFosUNhYFscnEXY2AAg8L0AIAJA782riQUEAwK/rp2MFhUUE1VVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 61
-    pc_program_page: 149
-    pc_erase_sector: 91
-    pc_erase_all: ~
-    data_section_offset: 284
+    pc_init: 0x1
+    pc_uninit: 0x3d
+    pc_program_page: 0x95
+    pc_erase_sector: 0x5b
+    pc_erase_all: null
+    data_section_offset: 0x11c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134234112
-      page_size: 1024
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8004000
+      page_size: 0x400
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 128
-          address: 0
-  stm32l01_2x_eeprom:
-    name: stm32l01_2x_eeprom
+        - size: 0x80
+          address: 0x0
+  - name: stm32l01_2x_eeprom
     description: STM32L0 512 Byte Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ASoB0AIqE9E3SIFpDyISAhFDgWE1ScFgNUnBYMBpwAIG1DVIM0kBYAYhQWAzSYFgACBwRwEoAdACKATRKkhBaAEiEUNBYAAgcEfwtf8hATElTP8wAApiaAACTQAqQ2JgYmgQJzpDYmAlSiNLACYGYADgGmCmafYH+9GmaTYFNg8G0KBpDyEJAghDoGEBIPC9AB0JH+rRYGioQ2BgYGi4Q2BgACDwvQEgcEfwtf8jATMNTv8xCQp0aAkCnEN0YBBMDU0K4BdoB2AA4Cxgt2n/B/vRAB0JHxIdGx8AKQHQACvw0QAg8L0AAAAgAkDvzauJBQQDAlVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 53
-    pc_program_page: 171
-    pc_erase_sector: 75
-    pc_erase_all: ~
-    data_section_offset: 260
+    pc_init: 0x1
+    pc_uninit: 0x35
+    pc_program_page: 0xab
+    pc_erase_sector: 0x4b
+    pc_erase_all: null
+    data_section_offset: 0x104
     flash_properties:
       address_range:
-        start: 134742016
-        end: 134742528
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8080000
+        end: 0x8080200
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  stm32l0xx_192:
-    name: stm32l0xx_192
-    description: "STM32L0 192KB Flash "
-    cores: [main]
+        - size: 0x200
+          address: 0x0
+  - name: stm32l0xx_192
+    description: 'STM32L0 192KB Flash '
+    cores:
+      - main
     default: true
     instructions: ASoB0AIqF9E7SIFpDyISAhFDgWE5ScFgOUnBYDlJAWE5SQFhwGnAAgbUOUg3SQFgBiFBYDdJgWAAIHBHASgB0AIoCNEsSEFoAiIRQ0FgQWgBIhFDQWAAIHBHMLUmSUpoTBUiQ0pgSmgIJSpDSmAAIgJgKUgmSgDgEGCLadsH+9FIaKBDSGBIaKhDSGAAIDC9ASBwR/C1GEwAIyUVCCY/MYkJjEYk4GFoKUNhYGFoMUNhYEAhgMqAwAkfACn60RZJp2n/BwLQEk85YPnnoWkJBQkPBtCgaQ8hCQIIQ6BhASDwvWFoqUNhYGFosUNhYFscnEXY2AAg8L0AIAJA782riQUEAwK/rp2MFhUUE1VVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 61
-    pc_program_page: 149
-    pc_erase_sector: 91
-    pc_erase_all: ~
-    data_section_offset: 284
+    pc_init: 0x1
+    pc_uninit: 0x3d
+    pc_program_page: 0x95
+    pc_erase_sector: 0x5b
+    pc_erase_all: null
+    data_section_offset: 0x11c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134414336
-      page_size: 1024
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8030000
+      page_size: 0x400
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 128
-          address: 0
-  stm32l010xb_eeprom:
-    name: stm32l010xb_eeprom
+        - size: 0x80
+          address: 0x0
+  - name: stm32l010xb_eeprom
     description: STM32L010 512 Byte Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ASoB0AIqE9E3SIFpDyISAhFDgWE1ScFgNUnBYMBpwAIG1DVIM0kBYAYhQWAzSYFgACBwRwEoAdACKATRKkhBaAEiEUNBYAAgcEfwtf8hATElTP8wAApiaAACTQAqQ2JgYmgQJzpDYmAlSiNLACYGYADgGmCmafYH+9GmaTYFNg8G0KBpDyEJAghDoGEBIPC9AB0JH+rRYGioQ2BgYGi4Q2BgACDwvQEgcEfwtf8jATMNTv8xCQp0aAkCnEN0YBBMDU0K4BdoB2AA4Cxgt2n/B/vRAB0JHxIdGx8AKQHQACvw0QAg8L0AAAAgAkDvzauJBQQDAlVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 53
-    pc_program_page: 171
-    pc_erase_sector: 75
-    pc_erase_all: ~
-    data_section_offset: 260
+    pc_init: 0x1
+    pc_uninit: 0x35
+    pc_program_page: 0xab
+    pc_erase_sector: 0x4b
+    pc_erase_all: null
+    data_section_offset: 0x104
     flash_properties:
       address_range:
-        start: 134742016
-        end: 134742528
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8080000
+        end: 0x8080200
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 512
-          address: 0
-  stm32l05_6x_eeprom:
-    name: stm32l05_6x_eeprom
+        - size: 0x200
+          address: 0x0
+  - name: stm32l05_6x_eeprom
     description: STM32L0 2 KByte Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ASoB0AIqE9E3SIFpDyISAhFDgWE1ScFgNUnBYMBpwAIG1DVIM0kBYAYhQWAzSYFgACBwRwEoAdACKATRKkhBaAEiEUNBYAAgcEfwtf8hATElTP8wAApiaAACTQAqQ2JgYmgQJzpDYmAlSiNLACYGYADgGmCmafYH+9GmaTYFNg8G0KBpDyEJAghDoGEBIPC9AB0JH+rRYGioQ2BgYGi4Q2BgACDwvQEgcEfwtf8jATMNTv8xCQp0aAkCnEN0YBBMDU0K4BdoB2AA4Cxgt2n/B/vRAB0JHxIdGx8AKQHQACvw0QAg8L0AAAAgAkDvzauJBQQDAlVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 53
-    pc_program_page: 171
-    pc_erase_sector: 75
-    pc_erase_all: ~
-    data_section_offset: 260
+    pc_init: 0x1
+    pc_uninit: 0x35
+    pc_program_page: 0xab
+    pc_erase_sector: 0x4b
+    pc_erase_all: null
+    data_section_offset: 0x104
     flash_properties:
       address_range:
-        start: 134742016
-        end: 134744064
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8080000
+        end: 0x8080800
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 2048
-          address: 0
-  stm32l03_4x_eeprom:
-    name: stm32l03_4x_eeprom
+        - size: 0x800
+          address: 0x0
+  - name: stm32l03_4x_eeprom
     description: STM32L0 1KB Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ASoB0AIqE9E3SIFpDyISAhFDgWE1ScFgNUnBYMBpwAIG1DVIM0kBYAYhQWAzSYFgACBwRwEoAdACKATRKkhBaAEiEUNBYAAgcEfwtf8hATElTP8wAApiaAACTQAqQ2JgYmgQJzpDYmAlSiNLACYGYADgGmCmafYH+9GmaTYFNg8G0KBpDyEJAghDoGEBIPC9AB0JH+rRYGioQ2BgYGi4Q2BgACDwvQEgcEfwtf8jATMNTv8xCQp0aAkCnEN0YBBMDU0K4BdoB2AA4Cxgt2n/B/vRAB0JHxIdGx8AKQHQACvw0QAg8L0AAAAgAkDvzauJBQQDAlVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 53
-    pc_program_page: 171
-    pc_erase_sector: 75
-    pc_erase_all: ~
-    data_section_offset: 260
+    pc_init: 0x1
+    pc_uninit: 0x35
+    pc_program_page: 0xab
+    pc_erase_sector: 0x4b
+    pc_erase_all: null
+    data_section_offset: 0x104
     flash_properties:
       address_range:
-        start: 134742016
-        end: 134743040
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8080000
+        end: 0x8080400
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 1024
-          address: 0
-  stm32l07_8x_eeprom:
-    name: stm32l07_8x_eeprom
+        - size: 0x400
+          address: 0x0
+  - name: stm32l07_8x_eeprom
     description: STM32L0 2 KByte Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ASoB0AIqE9E3SIFpDyISAhFDgWE1ScFgNUnBYMBpwAIG1DVIM0kBYAYhQWAzSYFgACBwRwEoAdACKATRKkhBaAEiEUNBYAAgcEfwtf8hATElTP8wAApiaAACTQAqQ2JgYmgQJzpDYmAlSiNLACYGYADgGmCmafYH+9GmaTYFNg8G0KBpDyEJAghDoGEBIPC9AB0JH+rRYGioQ2BgYGi4Q2BgACDwvQEgcEfwtf8jATMNTv8xCQp0aAkCnEN0YBBMDU0K4BdoB2AA4Cxgt2n/B/vRAB0JHxIdGx8AKQHQACvw0QAg8L0AAAAgAkDvzauJBQQDAlVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 53
-    pc_program_page: 171
-    pc_erase_sector: 75
-    pc_erase_all: ~
-    data_section_offset: 260
+    pc_init: 0x1
+    pc_uninit: 0x35
+    pc_program_page: 0xab
+    pc_erase_sector: 0x4b
+    pc_erase_all: null
+    data_section_offset: 0x104
     flash_properties:
       address_range:
-        start: 134742016
-        end: 134748160
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8080000
+        end: 0x8081800
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 3072
-          address: 0
-        - size: 3072
-          address: 3072
-  stm32l0xx_32:
-    name: stm32l0xx_32
+        - size: 0xc00
+          address: 0x0
+        - size: 0xc00
+          address: 0xc00
+  - name: stm32l0xx_32
     description: STM32L0 32KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASoB0AIqF9E7SIFpDyISAhFDgWE5ScFgOUnBYDlJAWE5SQFhwGnAAgbUOUg3SQFgBiFBYDdJgWAAIHBHASgB0AIoCNEsSEFoAiIRQ0FgQWgBIhFDQWAAIHBHMLUmSUpoTBUiQ0pgSmgIJSpDSmAAIgJgKUgmSgDgEGCLadsH+9FIaKBDSGBIaKhDSGAAIDC9ASBwR/C1GEwAIyUVCCY/MYkJjEYk4GFoKUNhYGFoMUNhYEAhgMqAwAkfACn60RZJp2n/BwLQEk85YPnnoWkJBQkPBtCgaQ8hCQIIQ6BhASDwvWFoqUNhYGFosUNhYFscnEXY2AAg8L0AIAJA782riQUEAwK/rp2MFhUUE1VVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 61
-    pc_program_page: 149
-    pc_erase_sector: 91
-    pc_erase_all: ~
-    data_section_offset: 284
+    pc_init: 0x1
+    pc_uninit: 0x3d
+    pc_program_page: 0x95
+    pc_erase_sector: 0x5b
+    pc_erase_all: null
+    data_section_offset: 0x11c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134250496
-      page_size: 1024
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8008000
+      page_size: 0x400
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 128
-          address: 0
-  stm32l0xx_128:
-    name: stm32l0xx_128
+        - size: 0x80
+          address: 0x0
+  - name: stm32l0xx_128
     description: STM32L0 128KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASoB0AIqF9E7SIFpDyISAhFDgWE5ScFgOUnBYDlJAWE5SQFhwGnAAgbUOUg3SQFgBiFBYDdJgWAAIHBHASgB0AIoCNEsSEFoAiIRQ0FgQWgBIhFDQWAAIHBHMLUmSUpoTBUiQ0pgSmgIJSpDSmAAIgJgKUgmSgDgEGCLadsH+9FIaKBDSGBIaKhDSGAAIDC9ASBwR/C1GEwAIyUVCCY/MYkJjEYk4GFoKUNhYGFoMUNhYEAhgMqAwAkfACn60RZJp2n/BwLQEk85YPnnoWkJBQkPBtCgaQ8hCQIIQ6BhASDwvWFoqUNhYGFosUNhYFscnEXY2AAg8L0AIAJA782riQUEAwK/rp2MFhUUE1VVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 61
-    pc_program_page: 149
-    pc_erase_sector: 91
-    pc_erase_all: ~
-    data_section_offset: 284
+    pc_init: 0x1
+    pc_uninit: 0x3d
+    pc_program_page: 0x95
+    pc_erase_sector: 0x5b
+    pc_erase_all: null
+    data_section_offset: 0x11c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134348800
-      page_size: 1024
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8020000
+      page_size: 0x400
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 128
-          address: 0
-  stm32l0xx_8:
-    name: stm32l0xx_8
+        - size: 0x80
+          address: 0x0
+  - name: stm32l0xx_8
     description: STM32L0 8KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ASoB0AIqF9E7SIFpDyISAhFDgWE5ScFgOUnBYDlJAWE5SQFhwGnAAgbUOUg3SQFgBiFBYDdJgWAAIHBHASgB0AIoCNEsSEFoAiIRQ0FgQWgBIhFDQWAAIHBHMLUmSUpoTBUiQ0pgSmgIJSpDSmAAIgJgKUgmSgDgEGCLadsH+9FIaKBDSGBIaKhDSGAAIDC9ASBwR/C1GEwAIyUVCCY/MYkJjEYk4GFoKUNhYGFoMUNhYEAhgMqAwAkfACn60RZJp2n/BwLQEk85YPnnoWkJBQkPBtCgaQ8hCQIIQ6BhASDwvWFoqUNhYGFosUNhYFscnEXY2AAg8L0AIAJA782riQUEAwK/rp2MFhUUE1VVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 61
-    pc_program_page: 149
-    pc_erase_sector: 91
-    pc_erase_all: ~
-    data_section_offset: 284
+    pc_init: 0x1
+    pc_uninit: 0x3d
+    pc_program_page: 0x95
+    pc_erase_sector: 0x5b
+    pc_erase_all: null
+    data_section_offset: 0x11c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134225920
-      page_size: 1024
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8002000
+      page_size: 0x400
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 128
-          address: 0
-  stm32l010x6_8_eeprom:
-    name: stm32l010x6_8_eeprom
+        - size: 0x80
+          address: 0x0
+  - name: stm32l010x6_8_eeprom
     description: STM32L010 256 Byte Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ASoB0AIqE9E3SIFpDyISAhFDgWE1ScFgNUnBYMBpwAIG1DVIM0kBYAYhQWAzSYFgACBwRwEoAdACKATRKkhBaAEiEUNBYAAgcEfwtf8hATElTP8wAApiaAACTQAqQ2JgYmgQJzpDYmAlSiNLACYGYADgGmCmafYH+9GmaTYFNg8G0KBpDyEJAghDoGEBIPC9AB0JH+rRYGioQ2BgYGi4Q2BgACDwvQEgcEfwtf8jATMNTv8xCQp0aAkCnEN0YBBMDU0K4BdoB2AA4Cxgt2n/B/vRAB0JHxIdGx8AKQHQACvw0QAg8L0AAAAgAkDvzauJBQQDAlVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 53
-    pc_program_page: 171
-    pc_erase_sector: 75
-    pc_erase_all: ~
-    data_section_offset: 260
+    pc_init: 0x1
+    pc_uninit: 0x35
+    pc_program_page: 0xab
+    pc_erase_sector: 0x4b
+    pc_erase_all: null
+    data_section_offset: 0x104
     flash_properties:
       address_range:
-        start: 134742016
-        end: 134742272
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8080000
+        end: 0x8080100
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 256
-          address: 0
-  stm32l07x_64_eeprom:
-    name: stm32l07x_64_eeprom
+        - size: 0x100
+          address: 0x0
+  - name: stm32l07x_64_eeprom
     description: STM32L0 2 KByte Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ASoB0AIqE9E3SIFpDyISAhFDgWE1ScFgNUnBYMBpwAIG1DVIM0kBYAYhQWAzSYFgACBwRwEoAdACKATRKkhBaAEiEUNBYAAgcEfwtf8hATElTP8wAApiaAACTQAqQ2JgYmgQJzpDYmAlSiNLACYGYADgGmCmafYH+9GmaTYFNg8G0KBpDyEJAghDoGEBIPC9AB0JH+rRYGioQ2BgYGi4Q2BgACDwvQEgcEfwtf8jATMNTv8xCQp0aAkCnEN0YBBMDU0K4BdoB2AA4Cxgt2n/B/vRAB0JHxIdGx8AKQHQACvw0QAg8L0AAAAgAkDvzauJBQQDAlVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 53
-    pc_program_page: 171
-    pc_erase_sector: 75
-    pc_erase_all: ~
-    data_section_offset: 260
+    pc_init: 0x1
+    pc_uninit: 0x35
+    pc_program_page: 0xab
+    pc_erase_sector: 0x4b
+    pc_erase_all: null
+    data_section_offset: 0x104
     flash_properties:
       address_range:
-        start: 134745088
-        end: 134748160
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8080c00
+        end: 0x8081800
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 3072
-          address: 0
-  stm32l0xx_opt:
-    name: stm32l0xx_opt
+        - size: 0xc00
+          address: 0x0
+  - name: stm32l0xx_opt
     description: STM32L0xx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ASoB0AIqF9E/SIFpDyISAhFDgWE9ScFgPUnBYD1JQWE9SUFhwGnAAgbUPUg7SQFgBiFBYDtJgWAAIHBHASgB0AIoCNEwSEFoBCIRQ0FgQWgBIhFDQWAAIHBHNEgySQFgM0lBYDNJgWCBYCdIMkksSgDgEWCDadsH+9GBaQkFCQ8G0IFpDyISAhFDgWEBIHBHACBwRwAgcEcBIHBH8LUmTR9OGUwUIQdoE2ifQgLQA2AA4DVgo2nbB/vRo2kbBRsPBtCgaQ8hCQIIQ6BhASDwvQAdCR8SHQAp5dEAIPC98LUVTA9NCE4UIQNoF2i7QgnRAOAsYLNp2wf70QAdCR8SHQAp8dHwvQAAACACQO/Nq4kFBAMCyNnq+ycmJSRVVQAAADAAQP8PAACqAFX/AAD4H3CAj38AAP//qqoAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 61
-    pc_program_page: 157
-    pc_erase_sector: 149
-    pc_erase_all: 91
-    data_section_offset: 316
+    pc_init: 0x1
+    pc_uninit: 0x3d
+    pc_program_page: 0x9d
+    pc_erase_sector: 0x95
+    pc_erase_all: 0x5b
+    data_section_offset: 0x13c
     flash_properties:
       address_range:
-        start: 536346624
-        end: 536346644
-      page_size: 12
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ff80000
+        end: 0x1ff80014
+      page_size: 0xc
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 20
-          address: 0
-  stm32l010x4_eeprom:
-    name: stm32l010x4_eeprom
+        - size: 0x14
+          address: 0x0
+  - name: stm32l010x4_eeprom
     description: STM32L010 128 Byte Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ASoB0AIqE9E3SIFpDyISAhFDgWE1ScFgNUnBYMBpwAIG1DVIM0kBYAYhQWAzSYFgACBwRwEoAdACKATRKkhBaAEiEUNBYAAgcEfwtf8hATElTP8wAApiaAACTQAqQ2JgYmgQJzpDYmAlSiNLACYGYADgGmCmafYH+9GmaTYFNg8G0KBpDyEJAghDoGEBIPC9AB0JH+rRYGioQ2BgYGi4Q2BgACDwvQEgcEfwtf8jATMNTv8xCQp0aAkCnEN0YBBMDU0K4BdoB2AA4Cxgt2n/B/vRAB0JHxIdGx8AKQHQACvw0QAg8L0AAAAgAkDvzauJBQQDAlVVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 53
-    pc_program_page: 171
-    pc_erase_sector: 75
-    pc_erase_all: ~
-    data_section_offset: 260
+    pc_init: 0x1
+    pc_uninit: 0x35
+    pc_program_page: 0xab
+    pc_erase_sector: 0x4b
+    pc_erase_all: null
+    data_section_offset: 0x104
     flash_properties:
       address_range:
-        start: 134742016
-        end: 134742144
-      page_size: 128
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8080000
+        end: 0x8080080
+      page_size: 0x80
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 128
-          address: 0
-  stm32l0xx_64:
-    name: stm32l0xx_64
-    description: "STM32L0 64KB Flash "
-    cores: [main]
+        - size: 0x80
+          address: 0x0
+  - name: stm32l0xx_64
+    description: 'STM32L0 64KB Flash '
+    cores:
+      - main
     default: true
     instructions: ASoB0AIqF9E7SIFpDyISAhFDgWE5ScFgOUnBYDlJAWE5SQFhwGnAAgbUOUg3SQFgBiFBYDdJgWAAIHBHASgB0AIoCNEsSEFoAiIRQ0FgQWgBIhFDQWAAIHBHMLUmSUpoTBUiQ0pgSmgIJSpDSmAAIgJgKUgmSgDgEGCLadsH+9FIaKBDSGBIaKhDSGAAIDC9ASBwR/C1GEwAIyUVCCY/MYkJjEYk4GFoKUNhYGFoMUNhYEAhgMqAwAkfACn60RZJp2n/BwLQEk85YPnnoWkJBQkPBtCgaQ8hCQIIQ6BhASDwvWFoqUNhYGFosUNhYFscnEXY2AAg8L0AIAJA782riQUEAwK/rp2MFhUUE1VVAAAAMABA/w8AAKqqAAAAAAAA
-    pc_init: 1
-    pc_uninit: 61
-    pc_program_page: 149
-    pc_erase_sector: 91
-    pc_erase_all: ~
-    data_section_offset: 284
+    pc_init: 0x1
+    pc_uninit: 0x3d
+    pc_program_page: 0x95
+    pc_erase_sector: 0x5b
+    pc_erase_all: null
+    data_section_offset: 0x11c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134283264
-      page_size: 1024
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8010000
+      page_size: 0x400
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 128
-          address: 0
+        - size: 0x80
+          address: 0x0

--- a/probe-rs/targets/STM32L1_Series.yaml
+++ b/probe-rs/targets/STM32L1_Series.yaml
@@ -1,6 +1,5 @@
----
 name: STM32L1 Series
-manufacturer: ~
+manufacturer: null
 variants:
   - name: STM32L100C6
     cores:
@@ -8,21 +7,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -33,21 +34,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536875008
+            start: 0x20000000
+            end: 0x20001000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -58,21 +61,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -83,21 +88,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536879104
+            start: 0x20000000
+            end: 0x20002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -108,21 +115,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -133,21 +142,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -158,21 +169,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -183,21 +196,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -208,21 +223,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -233,21 +250,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -258,21 +277,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -283,21 +304,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -308,21 +331,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -333,21 +358,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -358,21 +385,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -383,21 +412,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_384
       - stm32l1xx_384_eeprom
@@ -408,21 +439,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_512
       - stm32l1xx_512_eeprom
@@ -433,21 +466,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -458,21 +493,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -483,21 +520,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -508,21 +547,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -533,21 +574,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -558,21 +601,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -583,21 +628,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -608,21 +655,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -633,21 +682,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_384
       - stm32l1xx_384_eeprom
@@ -658,21 +709,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_512
       - stm32l1xx_512_eeprom
@@ -683,21 +736,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -708,21 +763,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -733,21 +790,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -758,21 +817,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -783,21 +844,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -808,21 +871,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -833,21 +898,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -858,21 +925,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_384
       - stm32l1xx_384_eeprom
@@ -883,21 +952,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_512
       - stm32l1xx_512_eeprom
@@ -908,21 +979,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -933,21 +1006,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_384
       - stm32l1xx_384_eeprom
@@ -958,21 +1033,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_512
       - stm32l1xx_512_eeprom
@@ -983,21 +1060,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1008,21 +1087,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1033,21 +1114,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1058,21 +1141,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1083,21 +1168,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1108,21 +1195,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1133,21 +1222,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -1158,21 +1249,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -1183,21 +1276,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_384
       - stm32l1xx_384_eeprom
@@ -1208,21 +1303,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_512
       - stm32l1xx_512_eeprom
@@ -1233,21 +1330,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1258,21 +1357,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134250496
+            start: 0x8000000
+            end: 0x8008000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1283,21 +1384,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1308,21 +1411,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1333,21 +1438,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1358,21 +1465,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1383,21 +1492,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -1408,21 +1519,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -1433,21 +1546,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_384
       - stm32l1xx_384_eeprom
@@ -1458,21 +1573,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_512
       - stm32l1xx_512_eeprom
@@ -1483,21 +1600,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536881152
+            start: 0x20000000
+            end: 0x20002800
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1508,21 +1627,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1533,21 +1654,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1558,21 +1681,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_128
       - stm32l1xx_128_eeprom
@@ -1583,21 +1708,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -1608,21 +1735,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -1633,21 +1762,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_384
       - stm32l1xx_384_eeprom
@@ -1658,21 +1789,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_512
       - stm32l1xx_512_eeprom
@@ -1683,21 +1816,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -1708,21 +1843,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_384
       - stm32l1xx_384_eeprom
@@ -1733,21 +1870,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_512
       - stm32l1xx_512_eeprom
@@ -1758,21 +1897,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_384
       - stm32l1xx_384_eeprom
@@ -1783,21 +1924,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -1808,21 +1951,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -1833,21 +1978,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_384
       - stm32l1xx_384_eeprom
@@ -1858,21 +2005,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_512
       - stm32l1xx_512_eeprom
@@ -1883,21 +2032,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -1908,21 +2059,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_256
       - stm32l1xx_256_eeprom
@@ -1933,21 +2086,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_384
       - stm32l1xx_384_eeprom
@@ -1958,21 +2113,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_512
       - stm32l1xx_512_eeprom
@@ -1983,21 +2140,23 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134610944
+            start: 0x8000000
+            end: 0x8060000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_384
       - stm32l1xx_384_eeprom
@@ -2008,299 +2167,301 @@ variants:
         type: armv7m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536952832
+            start: 0x20000000
+            end: 0x20014000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l1xx_512
       - stm32l1xx_512_eeprom
       - stm32l1xx_512_opt
 flash_algorithms:
-  stm32l1xx_128:
-    name: stm32l1xx_128
+  - name: stm32l1xx_128
     description: STM32L1xx Med-density Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRgEqAtACKiLRAOAAv3JIAGhA9HBgcEwgYHBIb0wMPCBgb0ggYG9IJB0gYG9IIGBqSAAdAGgQ9IAfCNFF8lVQa0wgYAYgYGBA9v9woGAAvwC/ACAQvQFGASkC0AIpD9EA4AC/XUgUOABoQPACAFpKFDoQYBBGAGhA8AEAEGAAvwC/ACBwRwFGVEgUOABoQPQAcFFKFDoQYBBGAGhA8AgAEGAAIAhgA+BK9qogUEoQYEpIAGgQ8AEP9tFHSBQ4AGgg9ABwRUoUOhBgEEYAaCDwCAAQYAAgcEcDRgEgcEcwtQNGgCQB8f8AIPD/ATtIFDgAaED0gGA4TRQ9KGAoRgBoQPAIAChgAL8F4BBoGGAbHRIdCR8kHwmxACz20QPgSvaqIDJNKGAsSABoEPABD/bRKkgAaBD0cG8H0CdIAGhA9HBgJU0oYAEgML0jSBQ4AGgg9IBgIU0UPShgKEYAaCDwCAAoYChGAGhA9IBgKGAoRgBoQPAIAChggCQF4BBoGGAbHRIdCR8kHwmxACz20QPgSvaqIBZNKGAQSABoEPABD/bRDUgAaBD0cG8H0AtIAGhA9HBgCU0oYAEgxecHSBQ4AGgg9IBgBE0UPShgKEYAaCDwCAAoYAAgtucYPAJA782riQUEAwK/rp2MFhUUEwAwAEAAAAAA
-    pc_init: 1
-    pc_uninit: 89
-    pc_program_page: 225
-    pc_erase_sector: 137
-    pc_erase_all: ~
-    data_section_offset: 500
+    pc_init: 0x1
+    pc_uninit: 0x59
+    pc_program_page: 0xe1
+    pc_erase_sector: 0x89
+    pc_erase_all: null
+    data_section_offset: 0x1f4
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134348800
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8020000
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 256
-          address: 0
-  stm32l1xx_128_eeprom:
-    name: stm32l1xx_128_eeprom
+        - size: 0x100
+          address: 0x0
+  - name: stm32l1xx_128_eeprom
     description: STM32L1xx Mid-density Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ELUDRgEqAtACKh3RAOAAv0RIAGhA9HBgQkwgYEJIQUwMPCBgQUggYD5IAB0AaBD0gB8I0UXyVVA9TCBgBiBgYED2/3CgYAC/AL8AIBC9AUYBKQLQAikK0QDgAL8xSBQ4AGhA8AEAL0oUOhBgAL8AvwAgcEcBRk/0gHIB8f8AIPD/AQPgSvaqIClLGGAlSABoEPABD/bRDeAAIAhgA+BK9qogI0sYYB9IAGgQ8AEP9tEJHRIfACrv0QAgcEcDRgEgcEcwtQNGT/SAdAHx/wAg8P8BA+BK9qogFU0oYBFIAGgQ8AEP9tEX4A5IFDgAaCD0gHAMTRQ9KGAQaBhgA+BK9qogC00oYAdIAGgQ8AEP9tEbHRIdCR8kHwmxACzk0QAgML0AABg8AkDvzauJBQQDAgAwAEAAAAAA
-    pc_init: 1
-    pc_uninit: 79
-    pc_program_page: 195
-    pc_erase_sector: 117
-    pc_erase_all: ~
-    data_section_offset: 308
+    pc_init: 0x1
+    pc_uninit: 0x4f
+    pc_program_page: 0xc3
+    pc_erase_sector: 0x75
+    pc_erase_all: null
+    data_section_offset: 0x134
     flash_properties:
       address_range:
-        start: 134742016
-        end: 134746112
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8080000
+        end: 0x8081000
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 256
-          address: 0
-  stm32l1xx_128_opt:
-    name: stm32l1xx_128_opt
+        - size: 0x100
+          address: 0x0
+  - name: stm32l1xx_128_opt
     description: STM32L1xx Mid-density Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ELUDRgEqAtACKiPRAOAAv0dIAGhA9HBgRUwgYEVIREwMPCBgREggYERIQUwkHyBgQ0ggYD5IAB0AaBD0gB8I0UXyVVA/TCBgBiBgYED2/3CgYAC/AL8AIBC9AUYBKQLQAikP0QDgAL8xSBQ4AGhA8AQAL0oUOhBgEEYAaEDwAQAQYAC/AL8AIHBHL0gvSQhgL0hIYC9IiGDIYAPgSvaqIChJCGAiSABoEPABD/bRIEgAaBD0cG8H0B1IAGhA9HBgG0kIYAEgcEcAIPznAUYAIHBHA0YBIHBHELUDRgHxDwAg8A8BH+AYaBRooEIB0BBoGGAD4Er2qiASTCBgDEgAaBDwAQ/20QpIAGgQ9HBvB9AHSABoQPRwYAVMIGABIBC9Gx0SHQkfACnd0QAg9+cAABg8AkDvzauJBQQDAsjZ6vsnJiUkADAAQKoAVf8AAPgfeACH/wAA//8AAAAA
-    pc_init: 1
-    pc_uninit: 91
-    pc_program_page: 217
-    pc_erase_sector: 205
-    pc_erase_all: 139
-    data_section_offset: 344
+    pc_init: 0x1
+    pc_uninit: 0x5b
+    pc_program_page: 0xd9
+    pc_erase_sector: 0xcd
+    pc_erase_all: 0x8b
+    data_section_offset: 0x158
     flash_properties:
       address_range:
-        start: 536346624
-        end: 536346640
-      page_size: 16
-      erased_byte_value: 0
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ff80000
+        end: 0x1ff80010
+      page_size: 0x10
+      erased_byte_value: 0x0
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 16
-          address: 0
-  stm32l1xx_256:
-    name: stm32l1xx_256
+        - size: 0x10
+          address: 0x0
+  - name: stm32l1xx_256
     description: STM32L1xx Med+-density Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRgEqAtACKiLRAOAAv3JIAGhA9HBgcEwgYHBIb0wMPCBgb0ggYG9IJB0gYG9IIGBqSAAdAGgQ9IAfCNFF8lVQa0wgYAYgYGBA9v9woGAAvwC/ACAQvQFGASkC0AIpD9EA4AC/XUgUOABoQPACAFpKFDoQYBBGAGhA8AEAEGAAvwC/ACBwRwFGVEgUOABoQPQAcFFKFDoQYBBGAGhA8AgAEGAAIAhgA+BK9qogUEoQYEpIAGgQ8AEP9tFHSBQ4AGgg9ABwRUoUOhBgEEYAaCDwCAAQYAAgcEcDRgEgcEcwtQNGgCQB8f8AIPD/ATtIFDgAaED0gGA4TRQ9KGAoRgBoQPAIAChgAL8F4BBoGGAbHRIdCR8kHwmxACz20QPgSvaqIDJNKGAsSABoEPABD/bRKkgAaBD0cG8H0CdIAGhA9HBgJU0oYAEgML0jSBQ4AGgg9IBgIU0UPShgKEYAaCDwCAAoYChGAGhA9IBgKGAoRgBoQPAIAChggCQF4BBoGGAbHRIdCR8kHwmxACz20QPgSvaqIBZNKGAQSABoEPABD/bRDUgAaBD0cG8H0AtIAGhA9HBgCU0oYAEgxecHSBQ4AGgg9IBgBE0UPShgKEYAaCDwCAAoYAAgtucYPAJA782riQUEAwK/rp2MFhUUEwAwAEAAAAAA
-    pc_init: 1
-    pc_uninit: 89
-    pc_program_page: 225
-    pc_erase_sector: 137
-    pc_erase_all: ~
-    data_section_offset: 500
+    pc_init: 0x1
+    pc_uninit: 0x59
+    pc_program_page: 0xe1
+    pc_erase_sector: 0x89
+    pc_erase_all: null
+    data_section_offset: 0x1f4
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134479872
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8040000
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 256
-          address: 0
-  stm32l1xx_256_eeprom:
-    name: stm32l1xx_256_eeprom
+        - size: 0x100
+          address: 0x0
+  - name: stm32l1xx_256_eeprom
     description: STM32L1xx Mid+-density Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ELUDRgEqAtACKh3RAOAAv0RIAGhA9HBgQkwgYEJIQUwMPCBgQUggYD5IAB0AaBD0gB8I0UXyVVA9TCBgBiBgYED2/3CgYAC/AL8AIBC9AUYBKQLQAikK0QDgAL8xSBQ4AGhA8AEAL0oUOhBgAL8AvwAgcEcBRk/0gHIB8f8AIPD/AQPgSvaqIClLGGAlSABoEPABD/bRDeAAIAhgA+BK9qogI0sYYB9IAGgQ8AEP9tEJHRIfACrv0QAgcEcDRgEgcEcwtQNGT/SAdAHx/wAg8P8BA+BK9qogFU0oYBFIAGgQ8AEP9tEX4A5IFDgAaCD0gHAMTRQ9KGAQaBhgA+BK9qogC00oYAdIAGgQ8AEP9tEbHRIdCR8kHwmxACzk0QAgML0AABg8AkDvzauJBQQDAgAwAEAAAAAA
-    pc_init: 1
-    pc_uninit: 79
-    pc_program_page: 195
-    pc_erase_sector: 117
-    pc_erase_all: ~
-    data_section_offset: 308
+    pc_init: 0x1
+    pc_uninit: 0x4f
+    pc_program_page: 0xc3
+    pc_erase_sector: 0x75
+    pc_erase_all: null
+    data_section_offset: 0x134
     flash_properties:
       address_range:
-        start: 134742016
-        end: 134750208
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8080000
+        end: 0x8082000
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 256
-          address: 0
-  stm32l1xx_256_opt:
-    name: stm32l1xx_256_opt
+        - size: 0x100
+          address: 0x0
+  - name: stm32l1xx_256_opt
     description: STM32L1xx Mid+-density Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ELUDRgEqAtACKiPRAOAAv0hIAGhA9HBgRkwgYEZIRUwMPCBgRUggYEVIQkwkHyBgREggYD9IAB0AaBD0gB8I0UXyVVBATCBgBiBgYED2/3CgYAC/AL8AIBC9AUYBKQLQAikP0QDgAL8ySBQ4AGhA8AQAMEoUOhBgEEYAaEDwAQAQYAC/AL8AIHBHMEgwSQhgMEhIYDBIiGDIYAhhSGED4Er2qiAoSQhgIkgAaBDwAQ/20SBIAGgQ9HBvB9AdSABoQPRwYBtJCGABIHBHACD85wFGACBwRwNGASBwRxC1A0YB8RcAIPAXAR/gGGgUaKBCAdAQaBhgA+BK9qogEkwgYAxIAGgQ8AEP9tEKSABoEPRwbwfQB0gAaED0cGAFTCBgASAQvRsdEh0JHwAp3dEAIPfnAAAYPAJA782riQUEAwLI2er7JyYlJAAwAECqAFX/AAD4H3gAh/8AAP//AAAAAA==
-    pc_init: 1
-    pc_uninit: 91
-    pc_program_page: 221
-    pc_erase_sector: 209
-    pc_erase_all: 139
-    data_section_offset: 348
+    pc_init: 0x1
+    pc_uninit: 0x5b
+    pc_program_page: 0xdd
+    pc_erase_sector: 0xd1
+    pc_erase_all: 0x8b
+    data_section_offset: 0x15c
     flash_properties:
       address_range:
-        start: 536346624
-        end: 536346640
-      page_size: 24
-      erased_byte_value: 0
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ff80000
+        end: 0x1ff80010
+      page_size: 0x18
+      erased_byte_value: 0x0
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 24
-          address: 0
-  stm32l1xx_384:
-    name: stm32l1xx_384
+        - size: 0x18
+          address: 0x0
+  - name: stm32l1xx_384
     description: STM32L1xx High-density Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRgEqAtACKiLRAOAAv3JIAGhA9HBgcEwgYHBIb0wMPCBgb0ggYG9IJB0gYG9IIGBqSAAdAGgQ9IAfCNFF8lVQa0wgYAYgYGBA9v9woGAAvwC/ACAQvQFGASkC0AIpD9EA4AC/XUgUOABoQPACAFpKFDoQYBBGAGhA8AEAEGAAvwC/ACBwRwFGVEgUOABoQPQAcFFKFDoQYBBGAGhA8AgAEGAAIAhgA+BK9qogUEoQYEpIAGgQ8AEP9tFHSBQ4AGgg9ABwRUoUOhBgEEYAaCDwCAAQYAAgcEcDRgEgcEcwtQNGgCQB8f8AIPD/ATtIFDgAaED0gGA4TRQ9KGAoRgBoQPAIAChgAL8F4BBoGGAbHRIdCR8kHwmxACz20QPgSvaqIDJNKGAsSABoEPABD/bRKkgAaBD0cG8H0CdIAGhA9HBgJU0oYAEgML0jSBQ4AGgg9IBgIU0UPShgKEYAaCDwCAAoYChGAGhA9IBgKGAoRgBoQPAIAChggCQF4BBoGGAbHRIdCR8kHwmxACz20QPgSvaqIBZNKGAQSABoEPABD/bRDUgAaBD0cG8H0AtIAGhA9HBgCU0oYAEgxecHSBQ4AGgg9IBgBE0UPShgKEYAaCDwCAAoYAAgtucYPAJA782riQUEAwK/rp2MFhUUEwAwAEAAAAAA
-    pc_init: 1
-    pc_uninit: 89
-    pc_program_page: 225
-    pc_erase_sector: 137
-    pc_erase_all: ~
-    data_section_offset: 500
+    pc_init: 0x1
+    pc_uninit: 0x59
+    pc_program_page: 0xe1
+    pc_erase_sector: 0x89
+    pc_erase_all: null
+    data_section_offset: 0x1f4
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134610944
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8060000
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 256
-          address: 0
-  stm32l1xx_384_eeprom:
-    name: stm32l1xx_384_eeprom
+        - size: 0x100
+          address: 0x0
+  - name: stm32l1xx_384_eeprom
     description: STM32L1xx High-density Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ELUDRgEqAtACKh3RAOAAv0RIAGhA9HBgQkwgYEJIQUwMPCBgQUggYD5IAB0AaBD0gB8I0UXyVVA9TCBgBiBgYED2/3CgYAC/AL8AIBC9AUYBKQLQAikK0QDgAL8xSBQ4AGhA8AEAL0oUOhBgAL8AvwAgcEcBRk/0gHIB8f8AIPD/AQPgSvaqIClLGGAlSABoEPABD/bRDeAAIAhgA+BK9qogI0sYYB9IAGgQ8AEP9tEJHRIfACrv0QAgcEcDRgEgcEcwtQNGT/SAdAHx/wAg8P8BA+BK9qogFU0oYBFIAGgQ8AEP9tEX4A5IFDgAaCD0gHAMTRQ9KGAQaBhgA+BK9qogC00oYAdIAGgQ8AEP9tEbHRIdCR8kHwmxACzk0QAgML0AABg8AkDvzauJBQQDAgAwAEAAAAAA
-    pc_init: 1
-    pc_uninit: 79
-    pc_program_page: 195
-    pc_erase_sector: 117
-    pc_erase_all: ~
-    data_section_offset: 308
+    pc_init: 0x1
+    pc_uninit: 0x4f
+    pc_program_page: 0xc3
+    pc_erase_sector: 0x75
+    pc_erase_all: null
+    data_section_offset: 0x134
     flash_properties:
       address_range:
-        start: 134742016
-        end: 134754304
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8080000
+        end: 0x8083000
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 256
-          address: 0
-  stm32l1xx_384_opt:
-    name: stm32l1xx_384_opt
+        - size: 0x100
+          address: 0x0
+  - name: stm32l1xx_384_opt
     description: STM32L1xx High-density Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ELUDRgEqAtACKiPRAOAAv0lIAGhA9HBgR0wgYEdIRkwMPCBgRkggYEZIQ0wkHyBgRUggYEBIAB0AaBD0gB8I0UXyVVBBTCBgBiBgYED2/3CgYAC/AL8AIBC9AUYBKQLQAikP0QDgAL8zSBQ4AGhA8AQAMUoUOhBgEEYAaEDwAQAQYAC/AL8AIHBHMUgxSQhgMUhIYDFIiGDIYAhhSGGIYchhA+BK9qogKEkIYCJIAGgQ8AEP9tEgSABoEPRwbwfQHUgAaED0cGAbSQhgASBwRwAg/OcBRgAgcEcDRgEgcEcQtQNGAfEfACDwHwEf4BhoFGigQgHQEGgYYAPgSvaqIBJMIGAMSABoEPABD/bRCkgAaBD0cG8H0AdIAGhA9HBgBUwgYAEgEL0bHRIdCR8AKd3RACD35wAAGDwCQO/Nq4kFBAMCyNnq+ycmJSQAMABAqgBV/wAA+B94AIf/AAD//wAAAAA=
-    pc_init: 1
-    pc_uninit: 91
-    pc_program_page: 225
-    pc_erase_sector: 213
-    pc_erase_all: 139
-    data_section_offset: 352
+    pc_init: 0x1
+    pc_uninit: 0x5b
+    pc_program_page: 0xe1
+    pc_erase_sector: 0xd5
+    pc_erase_all: 0x8b
+    data_section_offset: 0x160
     flash_properties:
       address_range:
-        start: 536346624
-        end: 536346656
-      page_size: 32
-      erased_byte_value: 0
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ff80000
+        end: 0x1ff80020
+      page_size: 0x20
+      erased_byte_value: 0x0
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 32
-          address: 0
-  stm32l1xx_512:
-    name: stm32l1xx_512
+        - size: 0x20
+          address: 0x0
+  - name: stm32l1xx_512
     description: STM32L1xx XL-density Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: ELUDRgEqAtACKiLRAOAAv3RIAGhA9HBgckwgYHJIcUwMPCBgcUggYHFIJB0gYHFIIGBsSAAdAGgA9IAQQLlF8lVQbUwgYAYgYGBA9v9woGAAvwC/ACAQvQFGASkC0AIpD9EA4AC/X0gUOABoQPACAFxKFDoQYBBGAGhA8AEAEGAAvwC/ACBwRwFGVkgUOABoQPQAcFNKFDoQYBBGAGhA8AgAEGAAIAhgA+BK9qogUkoQYExIAGgA8AEAACj10UlIFDgAaCD0AHBGShQ6EGAQRgBoIPAIABBgACBwRwNGASBwRzC1A0aAJAHx/wAg8P8BPEgUOABoQPSAYDpNFD0oYChGAGhA8AgAKGAAvwXgEGgYYBsdEh0JHyQfCbEALPbRA+BK9qogNE0oYC5IAGgA8AEAACj10StIAGgA9HBgOLEoSABoQPRwYCZNKGABIDC9JEgUOABoIPSAYCJNFD0oYChGAGgg8AgAKGAoRgBoQPSAYChgKEYAaEDwCAAoYIAkBeAQaBhgGx0SHQkfJB8JsQAs9tED4Er2qiAXTShgEUgAaADwAQAAKPXRDkgAaAD0cGA4sQtIAGhA9HBgCU0oYAEgxOcHSBQ4AGgg9IBgBU0UPShgKEYAaCDwCAAoYAAgtecAABg8AkDvzauJBQQDAr+unYwWFRQTADAAQAAAAAA=
-    pc_init: 1
-    pc_uninit: 89
-    pc_program_page: 227
-    pc_erase_sector: 137
-    pc_erase_all: ~
-    data_section_offset: 508
+    pc_init: 0x1
+    pc_uninit: 0x59
+    pc_program_page: 0xe3
+    pc_erase_sector: 0x89
+    pc_erase_all: null
+    data_section_offset: 0x1fc
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134742016
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8000000
+        end: 0x8080000
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 256
-          address: 0
-  stm32l1xx_512_eeprom:
-    name: stm32l1xx_512_eeprom
+        - size: 0x100
+          address: 0x0
+  - name: stm32l1xx_512_eeprom
     description: STM32L1xx XL-density Data EEPROM
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ELUDRgEqAtACKh3RAOAAv0ZIAGhA9HBgREwgYERIQ0wMPCBgQ0ggYEBIAB0AaAD0gBBAuUXyVVA/TCBgBiBgYED2/3CgYAC/AL8AIBC9AUYBKQLQAikK0QDgAL8zSBQ4AGhA8AEAMUoUOhBgAL8AvwAgcEcBRk/0gHIB8f8AIPD/AQPgSvaqICtLGGAnSABoAPABAAAo9dEO4AAgCGAD4Er2qiAkSxhgIEgAaADwAQAAKPXRCR0SHwAq7tEAIHBHA0YBIHBHMLUDRk/0gHQB8f8AIPD/AQPgSvaqIBZNKGASSABoAPABAAAo9dEY4A9IFDgAaCD0gHAMTRQ9KGAQaBhgA+BK9qogC00oYAdIAGgA8AEAACj10RsdEh0JHyQfCbEALOPRACAwvQAAGDwCQO/Nq4kFBAMCADAAQAAAAAA=
-    pc_init: 1
-    pc_uninit: 79
-    pc_program_page: 199
-    pc_erase_sector: 117
-    pc_erase_all: ~
-    data_section_offset: 316
+    pc_init: 0x1
+    pc_uninit: 0x4f
+    pc_program_page: 0xc7
+    pc_erase_sector: 0x75
+    pc_erase_all: null
+    data_section_offset: 0x13c
     flash_properties:
       address_range:
-        start: 134742016
-        end: 134758400
-      page_size: 256
-      erased_byte_value: 0
-      program_page_timeout: 500
-      erase_sector_timeout: 500
+        start: 0x8080000
+        end: 0x8084000
+      page_size: 0x100
+      erased_byte_value: 0x0
+      program_page_timeout: 0x1f4
+      erase_sector_timeout: 0x1f4
       sectors:
-        - size: 256
-          address: 0
-  stm32l1xx_512_opt:
-    name: stm32l1xx_512_opt
+        - size: 0x100
+          address: 0x0
+  - name: stm32l1xx_512_opt
     description: STM32L1xx XL-density Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ELUDRgEqAtACKiPRAOAAv19IAGhA9HBgXUwgYF1IXEwMPCBgXEggYFxIWUwkHyBgW0ggYFZIAB0AaAD0gBBAuUXyVVBXTCBgBiBgYED2/3CgYAC/AL8AIBC9AUYBKQLQAikP0QDgAL9JSBQ4AGhA8AQAR0oUOhBgEEYAaEDwAQAQYAC/AL8AIHBHR0hHSQhgR0hIYEdIiGDIYAhhSGGIYchhQkmAMQhgQEnB+IQAA+BK9qogO0kIYDVIAGgA8AEAACj10TJIAGgA9HBgOLEwSABoQPRwYC5JCGABIHBHACD85wFGACBwRwNGASBwRzC1A0YAJCghJeAYWRVoqEIB0BBoGFED4Er2qiAmTShgIEgAaADwAQAAKPXRHUgAaAD0cGA4sRpIAGhA9HBgGE0oYAEgML0bHRIdCR8cSCAwg0IA0WAkACnX0QAg8ucwtQNGACQoIRjgGFkVaKhCAdAYRjC9A+BK9qogDk0oYAhIAGgA8AEAACj10RsdEh0JHwtIIDCDQgDRYCQAKeTRWBjn5xg8AkDvzauJBQQDAsjZ6vsnJiUkADAAQKoAVf8AAPgfeACH/wAA//8AAAAA
-    pc_init: 1
-    pc_uninit: 91
-    pc_program_page: 239
-    pc_erase_sector: 227
-    pc_erase_all: 139
-    data_section_offset: 440
+    pc_init: 0x1
+    pc_uninit: 0x5b
+    pc_program_page: 0xef
+    pc_erase_sector: 0xe3
+    pc_erase_all: 0x8b
+    data_section_offset: 0x1b8
     flash_properties:
       address_range:
-        start: 536346624
-        end: 536346664
-      page_size: 40
-      erased_byte_value: 0
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ff80000
+        end: 0x1ff80028
+      page_size: 0x28
+      erased_byte_value: 0x0
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 40
-          address: 0
+        - size: 0x28
+          address: 0x0

--- a/probe-rs/targets/STM32L4_Series.yaml
+++ b/probe-rs/targets/STM32L4_Series.yaml
@@ -1,4 +1,3 @@
----
 name: STM32L4 Series
 variants:
   - name: Flash
@@ -7,21 +6,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048
       - stm32l4rx_2048_dual
@@ -37,21 +38,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_64
       - stm32l4xx_sb_opt
@@ -65,21 +68,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_64
       - stm32l4xx_sb_opt
@@ -93,21 +98,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -121,21 +128,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -149,21 +158,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_64
       - stm32l4xx_sb_opt
@@ -177,21 +188,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_64
       - stm32l4xx_sb_opt
@@ -205,21 +218,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_64
       - stm32l4xx_sb_opt
@@ -233,21 +248,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -261,21 +278,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -289,21 +308,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -317,21 +338,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_64
       - stm32l4xx_sb_opt
@@ -345,21 +368,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -373,21 +398,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -401,21 +428,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -429,21 +458,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -457,21 +488,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -485,21 +518,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -513,21 +548,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -541,21 +578,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -569,21 +608,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -597,21 +638,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -625,21 +668,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -653,21 +698,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -681,21 +728,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -709,21 +758,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -737,21 +788,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -765,21 +818,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -793,21 +848,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -821,21 +878,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -849,21 +908,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -877,21 +938,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -905,21 +968,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -933,21 +998,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -961,21 +1028,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -989,21 +1058,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -1017,21 +1088,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1045,21 +1118,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -1073,21 +1148,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -1101,21 +1178,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -1129,21 +1208,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1157,21 +1238,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1185,21 +1268,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1213,21 +1298,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -1241,21 +1328,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -1269,21 +1358,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_128
       - stm32l4xx_sb_opt
@@ -1297,21 +1388,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1325,21 +1418,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1353,21 +1448,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1381,21 +1478,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1409,21 +1508,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1437,21 +1538,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1465,21 +1568,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1493,21 +1598,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1521,21 +1628,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1549,21 +1658,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1577,21 +1688,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1605,21 +1718,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1633,21 +1748,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1661,21 +1778,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -1689,21 +1808,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1717,21 +1838,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1745,21 +1868,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1773,21 +1898,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -1801,21 +1928,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -1829,21 +1958,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -1857,21 +1988,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1885,21 +2018,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1913,21 +2048,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -1941,21 +2078,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -1969,21 +2108,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -1997,21 +2138,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -2025,21 +2168,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -2053,21 +2198,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -2081,21 +2228,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -2109,21 +2258,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -2137,21 +2288,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -2165,21 +2318,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -2193,21 +2348,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -2221,21 +2378,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_sb_opt
@@ -2249,21 +2408,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -2277,21 +2438,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -2305,21 +2468,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -2333,21 +2498,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -2361,21 +2528,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -2389,21 +2558,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -2417,21 +2588,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -2445,21 +2618,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_sb_opt
@@ -2473,21 +2648,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -2501,21 +2678,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -2529,21 +2708,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -2557,21 +2738,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -2585,21 +2768,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_db_opt
@@ -2613,21 +2798,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_db_opt
@@ -2641,21 +2828,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -2669,21 +2858,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -2697,21 +2888,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -2725,21 +2918,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_db_opt
@@ -2753,21 +2948,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -2781,21 +2978,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -2809,21 +3008,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -2837,21 +3038,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -2865,21 +3068,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -2893,21 +3098,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -2921,21 +3128,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -2949,21 +3158,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -2977,21 +3188,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_db_opt
@@ -3005,21 +3218,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -3033,21 +3248,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3061,21 +3278,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_db_opt
@@ -3089,21 +3308,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -3117,21 +3338,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3145,21 +3368,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -3173,21 +3398,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3201,21 +3428,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -3229,21 +3458,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3257,21 +3488,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -3285,21 +3518,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3313,21 +3548,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -3341,21 +3578,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3369,21 +3608,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_db_opt
@@ -3397,21 +3638,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -3425,21 +3668,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3453,21 +3698,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_256
       - stm32l4xx_db_opt
@@ -3481,21 +3728,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -3509,21 +3758,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3537,21 +3788,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -3565,21 +3818,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3593,21 +3848,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3621,21 +3878,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3649,21 +3908,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3677,21 +3938,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3705,21 +3968,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3733,21 +3998,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536969216
+            start: 0x20000000
+            end: 0x20018000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3761,21 +4028,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3789,21 +4058,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3817,21 +4088,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3845,21 +4118,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -3873,21 +4148,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_512
       - stm32l4xx_db_opt
@@ -3901,21 +4178,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3929,21 +4208,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3957,21 +4238,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -3985,21 +4268,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -4013,21 +4298,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -4041,21 +4328,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -4069,21 +4358,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -4097,21 +4388,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -4125,21 +4418,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -4153,21 +4448,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -4181,21 +4478,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4xx_1024
       - stm32l4xx_db_opt
@@ -4209,21 +4508,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4p5xx_1m
       - stm32l4r9i_eval
@@ -4236,21 +4537,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4p5xx_1m
       - stm32l4r9i_eval
@@ -4263,21 +4566,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4p5xx_1m
       - stm32l4r9i_eval
@@ -4290,21 +4595,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4p5xx_1m
       - stm32l4r9i_eval
@@ -4317,21 +4624,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4p5xx_1m
       - stm32l4r9i_eval
@@ -4344,21 +4653,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4p5xx_1m
       - stm32l4r9i_eval
@@ -4371,21 +4682,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4p5xx_1m
       - stm32l4r9i_eval
@@ -4398,21 +4711,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4p5xx_1m
       - stm32l4r9i_eval
@@ -4425,21 +4740,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4p5xx_1m
       - stm32l4r9i_eval
@@ -4452,21 +4769,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4p5xx_1m
       - stm32l4r9i_eval
@@ -4479,21 +4798,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4p5xx_1m
       - stm32l4r9i_eval
@@ -4506,21 +4827,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4p5xx_1m
       - stm32l4r9i_eval
@@ -4533,21 +4856,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4562,21 +4887,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4591,21 +4918,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4620,21 +4949,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4649,21 +4980,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4678,21 +5011,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4707,21 +5042,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4736,21 +5073,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4765,21 +5104,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4794,21 +5135,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4823,21 +5166,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4852,21 +5197,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4881,21 +5228,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4910,21 +5259,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4939,21 +5290,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4968,21 +5321,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -4997,21 +5352,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -5026,21 +5383,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -5055,21 +5414,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -5084,21 +5445,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -5113,21 +5476,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -5142,21 +5507,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -5171,21 +5538,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -5200,21 +5569,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -5229,21 +5600,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -5258,21 +5631,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -5287,21 +5662,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -5316,21 +5693,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048_dual
       - stm32l4rx_sb_opt
@@ -5345,21 +5724,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048
       - stm32l4rx_2048_dual
@@ -5375,21 +5756,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048
       - stm32l4rx_2048_dual
@@ -5405,21 +5788,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048
       - stm32l4rx_2048_dual
@@ -5435,21 +5820,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048
       - stm32l4rx_2048_dual
@@ -5465,21 +5852,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048
       - stm32l4rx_2048_dual
@@ -5495,21 +5884,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048
       - stm32l4rx_2048_dual
@@ -5525,21 +5916,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537526272
+            start: 0x20000000
+            end: 0x200a0000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 136314880
+            start: 0x8000000
+            end: 0x8200000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l4rx_2048
       - stm32l4rx_2048_dual
@@ -5550,371 +5943,371 @@ variants:
       - stm32l4r9i_disco_ospi2
       - mx25lm51245g_stm32l4p5-disco
 flash_algorithms:
-  stm32l4r9i_eval:
-    name: stm32l4r9i_eval
+  - name: stm32l4r9i_eval
     description: MX25LM51245G_STM32L4R9I_EVAL
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEdP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEdP8AACALUTRpRGlkYgOSK/oOgMUKDoDFCx8SABv/T3rwkHKL+g6AxQSL8MwF34BOuJACi/QPgEKwi/cEdIvyD4AisR8IBPGL8A+AErcEcQtQdIB0lJRAhgCEYC8ET/CLEBIBC9BfCd/AAg+ucAAAAQAKAwAAAAALWXsCZISEQF8Dr/ELEBIBewAL0BIAOQACAEkE72E0AFkAQgBpAQIAeQACAIkE/0gGAKkE/0QFALkAAgDJAOkE/wgGARkAAgE5AIIBSQACAVkBaQQh4DqRFISEQC8E7+CLEBINTnAiADkEHy7SAFkAAgFJBCHgOpCUhIRALwPv4IsQEgxOcAIAGQAakESEhEA/AO+QixASC65wAguOcAADAAAAAAtZewJkhIRAXw6P4QsQEgF7AAvQIgA5AAIASQTvYTQAWQBCAGkBAgB5AAIAiQT/SAYAqQT/RAUAuQACAMkA6QT/CAYBGQACATkAggFJAAIBWQFpBCHgOpEUhIRALw/P0IsQEg1OcCIAOQQfLtIAWQACAUkEIeA6kJSEhEAvDs/QixASDE5wAgAZABqQRISEQD8Lz4CLEBILrnACC45wAAMAAAAAC1lbAAIAGQApBL9kYQA5AEIASQECAFkAAgBpAIkAyQD5ASkBOQFJBCHgGpBEhIRALwwP0QsQEgFbAAvQAg++cwAAAAELWUsARGACAAkAGQTfYjQAKQBCADkBAgBJAAIAWQBpRP9IBgB5BP9EBQCJAAIAmQC5AOkBGQEpATkApISEQF8Fn+T/D/MmlGBkhIRALwkP1P8P8xA0hIRAXwWvsAIBSwEL0AADAAAAAAtZWwACABkAKQRvKfAAOQBCAEkBAgBZAAIAaQCJAMkA+QEpATkBSQCUhIRAXwLv5P8P8yAakGSEhEAvBl/W/wDwEDSEhEBfAv+wAgFbAAvTAAAAAQtZSwBEa09YBPAtMBIBSwEL0AIACQAZBC8t4QApAEIAOQECAEkAAgBZAgAwaQT/SAYAeQT/RAUAiQACAJkAuQDpARkBKQE5AJSEhEBfD0/QixASDb50/w/zJpRgRISEQC8Cj9CLEBINHnACDP5wAAMAAAAAFGT/CAYAhggBJIYIARiGCAEMhggAIIYQAgcEcAtZWwACABkAKQQvbUMAOQBCAEkBAgBZAAIAaQB5BP9IBgCJBP9EBQCZAAIAqQDJBP8IBgD5ABIBCQACARkAYgEpAAIBOQFJBCHgGpH0hIRALw6PwQsQEgFbAAvU/w/zJpRhpISEQC8PP/CLEBIPPnnfgAAADwYAAIsQEg7Oed+AAAAPAMAAixCCDl50Dy+lADkE/w/zIBqQxISEQC8ML8CLEBINjnT/D/MmlGB0hIRALwzv8IsQEgzued+AAAAPABAAixAiDH5wAgxecwAAAAELUgSCBJSUQIYAhGAvBc/QixASAQvQXwB/sEIBpJSURIYAAhGEhIRIFgwWBP8IBgkPqg8LD6gPBAHhNJSUQIYQIhEUhIREFhACGBYcFhAWIEIUFiACGBYsFiAWMC8Lb+CLEBINbnCEhIRAXw+/wBIQVISEQF8J77CLEBIMrnACDI5wAAABAAoDAAAAAAtZWwACABkAKQ/yADkAQgBJAQIAWQACAGkAiQDJAPkBKQE5AUkEIeAakFSEhEAvBL/BCxASAVsAC9ACD75wAAMAAAAHC1lLAERg1GFkYAIACQAZBO9hNAApAEIAOQECAEkAAgBZAGlU/0gGAHkE/0QFAIkAAgCZALkE/wgGAOkA+WACAQkAggEZAAIBKQE5ABIQtISERBYooeaUYC8BT8ELEBIBSwcL1P8P8yIUYESEhEAvAf/wixASDz5wAg8ecwAAAAALWVsP/37P4IKCPRACABkAKQQ/LPAAOQBCAEkBAgBZAAIAaQCJAMkA+QEpATkBSQQh4BqQhISEQC8OT7ELEBIBWwAL3/98z+AigB0QAg9+cBIPXnACDz5zAAAAAAtZWw//e+/gIoI9EAIAGQApBL8k8AA5AEIASQECAFkAAgBpAIkAyQD5ASkBOQFJBCHgGpCEhIRALwtvsQsQEgFbAAvf/3nv4IKAHRACD35wEg9ecAIPPnMAAAAC3p8EWVsIJGDUaQRuiywPWAdkZFANlGRixGBesIBwAgAZACkEHy7SADkAQgBJAQIAWQACAGkE/0gGAIkE/0QFAJkAAgCpAMkE/wgGAPkAAgEZASkBOQFJAEIR1ISERBYgC/B5QQlhpISEQF8DH8GLEBIBWwvejwhU/w/zIBqRRISEQC8GP7CLEBIPLnT/D/MlFGD0hIRALw8/8IsQEg6OdP8P8xCkhIRAXwIPkIsQEg3+c0RLJEBPWAcLhCAdk4GwHgT/SAcAZGvELK0wAg0OcwAAAAA0YBIHBHAL/+5wAAAUYMSwhomEID0wtLCGiYQgHZACBwRwhLeDsIaJhCAdIGSgHgBUocMkhsgAgC64AA8OcAAAgAAkCABAJAAAgCQPC1BEYLRgTwAwXesgTwAwAkGgPwAwAIuQAgA+AD8AMAwPEEAANEACdV4CFo/bEBLQTQAi0N0AMtGNES4MHzByACRMHzB0ACRALrEWJoHsWyDODB8wdAAkQC6xFiqB7FsgTgAusRYugexbIAvzHgmBsA8AMAGLPYGwQoINiYGwEoBNACKA3QAygY0RLgyLICRMHzByACRMHzB0ACRHAexrIM4MiyAkTB8wcgAkSwHsayBODIsgJE8B7GsgC/CeDIsgJEwfMHIAJEwfMHQAJEAusRYiQdPx2fQqfTEEbwvTC1kPhEUAEkrEAFbGxgBGhjYIRoECwE0QRoomAEaOFgA+AEaKFgBGjiYDC9cEdwtU/wEEUAJAC/B+Al8HBA//fO/AXrBEVkHGQctPWAb/TbACBwvRC1BEYk8HBA//e//AixASAQvQAg/OceSEhEAH8BKATQHEhIRAB/AygR0QC/GkgAaED0AGAYSQhgCEYAaCD0AGAIYAC/CEYAaED0AHAIYBBISEQAfwIoBNAOSEhEAH8DKBHRAL8MSABoQPSAUApJCGAIRgBoIPSAUAhgAL8IRgBoQPSAYAhgACACSUlECHdwRwAAEAAAAAAgAkASSQlqAfSAAZGxAPABASmxDklJaUHwBAEMSlFhAPACAWmxCklJaUH0AEEISlFhBuAGSUlpSPIEAhFDBEpRYQNJSWlB9IAxAUpRYXBHACACQPC1A0YAIEdONmgG9IB2lrlP8ABkRE42iE/2/3e+QgHRphED4EBONog2BbYKT/AAZwfrZgUR4DxONohP9v93vkIC0U/0ABYD4DdONog2BbYKT/AAZwfrZgQ9RjRONmoG9IAGfrseeAbwAwYBLhLRL052asbzEABP8ABmBusAFg5gKk62asbzEABP8ABmBusAFhZgP+AeeAbwAwYCLjrRI052bMbzEABP8ABmBusAFg5gHk62bMbzEABP8ABmBusAFhZgJ+D/5x54BvADBgEuDtEWTnZqxvMQAATrwAYOYBNOtmrG8xAABOvABhZgEuAeeAbwAwYCLg3RDE52bMbzEAAF68AGDmAJTrZsxvMQAAXrwAYWYAVPHmi/agfwAEc+Qx5g8L0AAAFA4HX/HwAgAkAHSABqwLKqKAbQBUgAasCyzCgB0LsgcEcBSABqwLL65wAgAkACSQhqIPD/AHBHAAAAIAJASLkXS9tq27ILYBVL22rD8wdDE2Ai4AEoCdERSxtr27ILYA9LG2vD8wdDE2AW4AIoCdELS9ts27ILYAlL22zD8wdDE2AK4AQoCNEFSxtt27ILYANLG23D8wdDE2BwRwAAACACQC3p8E0FRg5GF0ZP8AALACRM8lAwAPDu+oNGu/EAD3jRVUgAaAD0gHCYuU/wAGhTSACIT/b/cYhCAtFP9AAQA+BOSACIAAWACk/wAGEB62AKEeBKSACIT/b/cYhCAtFP9AAQA+BFSACIAAWACk/wAGEB62AIikZCSABqAPSAAHi7BfADAAEoE9Gm8QBgBAk8SEBqb/MQACBDOUlIYqfxAGAECQhGgGpv8xAAIEOIYkjgBfADAAIoRNGm8QBgBAkwSEBsb/MQACBDLUlIZKfxAGAECQhGgGxv8xAAIEOIZDDg/+cF8AMAASgU0abrCADECCNIQGpv8xAAIEMhSUhip+sIAMQICEaAam/zEAAgQ4hiF+At4AXwAwACKBLRpusKAMQIF0hAbG/zEAAgQxRJSGSn6woAxAgIRoBsb/MQACBDiGQPSIFqKEZh8x4ADEmIYghGQGlA9AAwSGFM8lAwAPBJ+oNGBkhAaSD0ADAESUhhWEa96PCNAAAAAAFA4HX/HwAgAkBwtQRGACVM8lAwAPAx+gVGtbkMSABqIPD/ACBDCUkIYghGQGlA9AAwSGFM8lAwAPAf+gVGA0hAaSD0ADABSUhhKEZwvQAgAkAt6fBBBEYNRgAmACewRkzyUDAA8An6gEa48QAPftEE8AEAILEF9OBgBkNH9OBnBPACACCxBfSAUAZDR/SAVwTwBAAgsQX0AFAGQ0f0AFcE9IBQILEF9IBABkNH9IBHBPAIACCxBfSAMAZDR/SANwTwEAAgsQX0ADAGQ0f0ADcE8CAAILEF9IAgBkNH9IAnBPBAACCxBfQAIAZDR/QAJwTwgAAgsQX0gBAGQ0f0gBcE9IBwILEF9AAQBkNH9AAXBPQAcCCxBfQAAAZDR/QABwT0gGAgsQXwgHAGQ0fwgHcE9ABgILEF8ABwBkNH8AB3BPQAUCCxBfCAYAZDR/CAZwT0gEAgsQXwAGAGQ0fwAGcNSABquEMwQwtJCGIA4A/gCEZAaUD0ADBIYUzyUDAA8Hz5gEYESEBpIPQAMAJJSGFARr3o8IEAIAJALenwQQRGDUYWRgAnTPJQMADwZvkHRu+7TLkhSMBqAPD/IEXqBkEIQx1JyGIi4AEsCdEbSABrAPD/IEXqBkEIQxdJCGMW4AIsCdEVSMBsAPD/IEXqBkEIQxFJyGQK4AQsCNEPSABtAPD/IEXqBkEIQwtJCGUKSEBpQPQAMAhJSGFM8lAwAPAs+QdGBUhAaSD0ADAA4AHgAklIYThGvejwgQAgAkAaShJqAvSAAjK5GEpSaSL0AGIWS1phD+AB8AECMrETSlJpIvQAYhFLWmEF4A9KUmlC9ABiDUtaYQxKUmki9P9iT/T/Y5P6o/Oz+oPzAPoD8xpDBktaYRpGUmlC8AICWmEaRlJpQvSAMlphcEcAIAJAELUESUlpQfABAQJMYWECYENgEL0AIAJAcLWAJAJGC0YHTW1pRfSAJQVOdWFytgC/IMsgwmUe7bIsHvnRYrZwvQAgAkBfSABpAPACAAIoB9FdSEhEQGhA8AEAW0lJREhgWEgAaQDwCAAIKAfRVkhIREBoQPACAFRJSURIYFFIAGkA8BAAECgH0U9ISERAaEDwBABNSUlESGBKSABpAPAgACAoB9FISEhEQGhA8AgARklJREhgQ0gAaQDwQABAKAfRQUhIREBoQPAQAD9JSURIYDxIAGkA8IAAgCgH0TpISERAaEDwIAA4SUlESGA1SABpAPSAcLD1gH8H0TNISERAaEDwQAAwSUlESGAuSABpAPQAcLD1AH8H0StISERAaEDwgAApSUlESGAmSABpAPSAQLD1gE8H0SRISERAaED0gHAhSUlESGAfSABpAPQAQLD1AE8H0RxISERAaED0AHAaSUlESGAXSIBpAPAAQLDxAE8H0RVISERAaED0gGASSUlESGAQSABpAPQAMLD1AD8N0Q1ISERAaED0AGALSUlESGAAv0/0ADAHSQhhAL8AvwVIgGlA8ABAA0mIYUzy+jAIYQC/cEcAIAJAEAAAAHC1BEYB8B75BRkH4GAcKLEB8Bj5qEIB0wMgcL0ySABpAPSAMLD1gD/w0C9IAGkA8AIAAihH0CxIAGkA8AgACChB0ClIAGkA8BAAECg70CZIAGkA8CAAICg10CNIAGkA8EAAQCgv0CBIAGkA8IAAgCgp0B1IAGkA9IBwsPWAfyLQGUgAaQD0AHCw9QB/G9AWSABpAPSAQLD1gE8U0BJIAGkA9ABAsPUATw3QD0iAaQDwAECw8QBPBtALSABpAPQAMLD1AD8D0f/31/4BIKXnBkgAaQDwAQAgsQC/ASACSQhhAL8AIJnnAAAAIAJAA0hAaCDwAQABSUhgcEcAAAAgBOADSEBoIPAEAAFJSGBwRwAAACAE4ANIQGgg8AIAAUlIYHBHAAAAIATgA0hAaEDwAQABSUhgcEcAAAAgBOADSEBoQPAEAAFJSGBwRwAAACAE4ANIQGhA8AIAAUlIYHBHAAAAIATgAUYAIApoEmgi8A4CC2gaYApoEmgi8AECC2gaYJH4RDABIppAC2xaYAEigfgmIAC/ACKB+CQgAL9wR3C1BEYAJZT4JgACKAPQBCDgYwElHuAgaABoIPAOACFoCGAgaABoIPABACFoCGCU+EQQASCIQCFsSGABIIT4JgAAvwAghPgkAAC/oGsQsSBGoWuIRyhGcL0AADC1BEYMuQEgML0gaABoIPABACFoCGAaSSBoiEIL0hlJIGhAGhQhsPvx8IAAYGQVSAg4IGQK4BJJIGhAGhQhsPvx8IAAYGQOSAg4IGQAICFoCGCU+EQQASCIQCFsSGAgRv/3xvkFRg2xACAoYAAg4GOE+CYAAL+E+CQAAL8Av8PnCAQCQAgAAkABRshrcEcBRpH4JgBwR3C1BEYgbAVoIGgGaJT4RBAEIIhAKEDQsQbwBAC4sSBoAGgA8CAAKLkgaABoIPAEACFoCGCU+EQQBCCIQCFsSGAgawAoTtAgRiFriEdK4JT4RBACIIhAKEAIswbwAgDwsSBoAGgA8CAAQLkgaABoIPAKACFoCGABIIT4JgCU+EQQAiCIQCFsSGAAvwAghPgkAAC/4GowsyBG4WqIRyLglPhEEAggiEAoQOCxBvAIAMixIGgAaCDwDgAhaAhglPhEEAEgiEAhbEhgASDgY4T4JgAAvwAghPgkAAC/YGsQsSBGYWuIR3C9cLUERgAlACYMuQEgcL2gaLD1gE8A0AC/JkkgaIhCC9IlSSBoQBoUIbD78fCAAGBkIUgIOCBkCuAeSSBoQBoUIbD78fCAAGBkGkgIOCBkIEb/9xD5BkYOuQEg1+emZGBoMGACIIT4JgAgaAVoR/bwcIVD1OkCAQhDIWkIQ2FpCEOhaQhD4WkIQyFqCEMFQyBoBWAAIOBiIGNgY6Bj4GOE+CUAASCE+CYAACCE+CQAAL+s5wAACAQCQAgAAkAt6fBBBEYORhVGT/AACJT4JgACKAnQBCDgYwC/ACCE+CQAAL8BIL3o8IEgaABoAPAgACCxT/SAcOBjASDz5y65lPhEEAIgAPoB9wTglPhEEAQgAPoB9wDw3f6ARi3gIGwAaJT4RCAIIZFACECAsZT4RBABIIhAIWxIYAEg4GOE+CYAAL8AIIT4JAAAvwEgyudoHJCxLbEA8L3+oOsIAKhCC9kgIOBjASCE+CYAAL8AIIT4JAAAvwEgtecgbABoOEAAKMzQTrmU+EQQAiCIQCFsSGABIIT4JgAF4JT4RBAEIIhAIWxIYAC/ACCE+CQAAL8Av5jnELUDRgAkAL+T+CQAASgB0QIgEL0BIIP4JAAAv5P4JgABKBLRMbEBKQbQAikG0AMpCNEF4NpiB+AaYwXgWmMD4JpjAeABJAC/AOABJAC/ACCD+CQAAL8gRtvnLenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JgABKBfRAiCE+CYAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//eb+CBoAGhA8AEAIWgIYAbgAL8AIIT4JAAAv0/wAghARtTnLenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JgABKCzRAiCE+CYAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//di+CBrMLEgaABoQPAOACFoCGAL4CBoAGgg8AQAIWgIYCBoAGhA8AoAIWgIYCBoAGhA8AEAIWgIYAbgAL8AIIT4JAAAv0/wAghARr/nAkYAIwC/kvgkAAEoAdECIHBHASCC+CQAAL+S+CYAASgb0QUpFtLf6AHwAwYJDA8AACDQYhDgACAQYw3gACBQYwrgACCQYwfgACDQYhBjUGOQYwHgASMAvwDgASMAvwAggvgkAAC/GEbS5wAAELVP8P8wDEmIYwAgiGNAHghkACAIZEAeiGIAIIhiQB7IYgAgyGJAHghjACAIYwDw+f0AIBC9AAAAEAJAcLUERgAlAPCD/QVGAL8A8H/9QBugQvrTcL0AAC3p8EEERg5GAScAJQC/Q0hIRAB4ASgC0QIgvejwgQEgPklJRAhwAL9M8lAw//dA/AdGAC9p0TlJSURIYDhIAGgA9ABwyLE2SABoIPQAcDRJCGAIRgBoAPSAYEixCEYAaCD0gGAIYAMgLElJRAh3GOABICpJSUQIdxPgKUgAaAD0gGBQsSZIAGgg9IBgJEkIYAIgIklJRAh3A+AAIB9JSUQIdyBoASgP0WBo/vf7/0zyUDD/9/37B0YZSEBpSPIEAYhDF0lIYR7gT/D/MDBgpWgT4ChGYWj/9836TPJQMP/35/sHRg5IQGlA8vpxiEMMSUhhD7E1YAXgbRzU6QIBCESoQubYAL/+94v/AL8AIANJSUQIcAC/OEZ/5wAAEAAAAAAgAkBwtQRGACUAvzFISEQAeAEoAdECIHC9ASAtSUlECHAAvwAgSGArSABoAPQAcMixKUgAaCD0AHAnSQhgCEYAaAD0gGBIsQhGAGgg9IBgCGADIB9JSUQIdxjgASAdSUlECHcT4BxIAGgA9IBgULEZSABoIPSAYBdJCGACIBVJSUQIdwPgACASSUlECHcAvxFIQGlA8EBwD0lIYQC/DUlJRGBoCGEgaAEoBdECIAhyYGj+92f/C+ABIAZJSUQIcuBoiGGgaEhh1OkBEP/3QvooRqHnEAAAAAAgAkAQtQRGBiAgYGBoQLFgaAEoBdBgaAIoAtBgaAQoCdEgaEDwAQAgYATxDAIRH2Bo//cV+P73+f8gYf/3CPigYeBpASgC0OBpAigJ0SBoQPAIACBgBPEkAhEfCB/+903/EL1wtQRGASUAvx5ISEQAeAEoAdECIHC9ASAaSUlECHAAvwAgSGAgeADwAQAgsSAdB8j/96D5BUYgeADwAgAYsSBp//fQ+AVGIHgA8AQAILHU6QUB//fr+AVGIHgA8AgASLHU6QgBiEIF0NTpCBLgaf739/8FRgC/ACACSUlECHAAvyhGx+cQAAAAcEcAAAFISERAaHBHEAAAABC1fkhAaW/zCgB8SUhhCEZAaSD0AEBIYXlISEQAegQoBNEIRkBpIPSAIEhhc0gAaQDwAgACKEfQcEgAaQDwCAAIKEHQbUgAaQDwEAAQKDvQakgAaQDwIAAgKDXQZ0gAaQDwQABAKC/QZEgAaQDwgACAKCnQYUgAaQD0gHCw9YB/ItBeSABpAPQAcLD1AH8b0FpIAGkA9IBAsPWATxTQV0gAaQD0AECw9QBPDdBTSIBpAPAAQLDxAE8G0FBIAGkA9AAwsPUAPyzR//e0+f73Lv5LSEhEAHoBKAXRSUlJREhpAPDI+BngRkhIRAB6AigF0UNJSUQIaQDwvfgO4EBISEQAegMoBNA+SEhEAHoEKATRO0lJRMhoAPCt+AAgOElJRAhyNkgAaQDwAQAAKFPQAL8BIDJJCGEAvzFISEQAegEoKdEvSEhEgGlAHi1JSUSIYQhGgGmAsUhp//dK/yhISERAaUAcJklJREhhCEZEaQFpIEb/9wX5LuBP8P8wIElJREhhACAIcv730f0dSUlESGn/9y7/H+D+98n9GUhIRAB6AigF0RZJSUQIaf/3If8O4BNISEQAegMoBNARSEhEAHoEKATRDklJRMho//cR/wAgC0lJRAhyCkhIRAB6aLkAvwZIQGkg8EBwBElIYQC/AL8AIANJSUQIcAC/EL0AIAJAEAAAAANIQGlA8ABAAUlIYQAgcEcAIAJAELUFSEBpQPAAYANJSGFM8lAw//fH+RC9ACACQANIQGlA8IBAAUlIYQAgcEcAIAJAB0hAaQDwgEAosQZIBEnIYAVIyGAB4AEgcEcAIPznAAAAIAJAOyoZCH9uXUxwRwAALenwRwRGD0YVRh5GT/ABCE/wAAoAvy1ISEQAeAEoAtECIL3o8IcBIChJSUQIcAC/TPJQMP/3hvmARrjxAA880QAgIklJREhgIUgAaAD0gGBQsR9IAGgg9IBgHUkIYAIgGklJRAh3A+AAIBhJSUQIdzy5KkYzRjhG//d++E/wAQoL4AEsAdACLAfRKUY4Rv/3f/gCLAHRT/SAKkzyUDD/91H5gEa68QAPBdAJSEBpIOoKAAdJSGH+9/38AL8AIANJSUQIcAC/QEar5wAAEAAAAAAgAkAt6fBBBEYPRhVGHkZP8AAIAL8lSEhEAHgBKALRAiC96PCBASAgSUlECHAAvwAgSGAeSABoAPSAYFCxHEgAaCD0gGAaSQhgAiAXSUlECHcD4AAgFUlJRAh3AiwE0QQgEklJRAhyA+ADIA9JSUQIcg5ISETHYAC/DUhAaUDwQHALSUhhAL8suSpGM0Y4Rv/3CvgH4AEsAdACLAPRKUY4Rv/3DfhARrvnAAAQAAAAACACQAdIQGkA8ABAKLEGSARJiGAFSIhgAeABIHBHACD85wAAACACQCMBZ0Wrie/N8LULRgAhACIAJIbgASWNQAXqAwIAKn/QBWhPAAMmvkA1QwVgzggA8SAFVfgmUE4H9w4PJr5AtUPPCADxIAZG+CdQhWhPAAMmvkC1Q4VgRWgBJo5AtUNFYMVoTwADJr5AtUPFYDBNjghV+CZAjQcuDw8ltUAsQLDxkE8B0QAlI+AqTahCAdEBJR7gKU2oQgHRAiUZ4CdNqEIB0QMlFOAmTahCAdEEJQ/gJE2oQgHRBSUK4CNNqEIB0QYlBeAhTahCAdEHJQDgCCWOBzYPtUClQiLRjQcuDw8lBfoG9BJNjghV+CZgpkOPCEX4J2AWTS1olUMVTjVgNR0taJVDNh01YDUdLWiVQzYdNWA1HS1olUM2HQDgAOA1YEkcI/oB9QAtf/R0r/C9AAAIAAFAAAQASAAIAEgADABIABAASAAUAEgAGABIABwASAAEAUBwRwAAELUERgRIAGggQCCxAkgEYCBG//fz/xC9FAQBQHi1AkYAIwAkACDa4AEmnkANaAXqBgQALHLQTWgCLQLQTWgSLRPR3ggC8SAFVfgmAF0H7g4PJbVAqENeB/YODWm1QChD3ggC8SAFRfgmABBoXgADJbVAqEMNeQXwAwVeALVAKEMQYE1oAS0I0E1oAi0F0E1oES0C0E1oEi0T0ZBoXgADJbVAqENeAM1otUAoQ5BgUGgBJZ1AqEMNecXzABWdQChDUGDQaF4AAyW1QKhDXgCNaLVAKEPQYE1oBfCAVbXxgF980QC/QU0tbkXwAQU/TjVmNUYtbgXwAQUAlQC/AL9P6rY1nghV+CYAnQcuDw8ltUCoQ7LxkE8C0QAlJOBe4DRNqkIB0QElHuAyTapCAdECJRngMU2qQgHRAyUU4C9NqkIB0QQlD+AuTapCAdEFJQrgLE2qQgHRBiUF4CtNqkIB0QclAOAIJZ4HNg+1QChDJ02eCEX4JgAmTShooENNaAX0gDW19YA/ANEgQyFNKGAtHShooENNaAX0ADW19QA/ANEgQxtNLR0oYC0dKGigQ01oBfSAFbX1gB8A0SBDFE0INShgLR0oaKBDTWgF9AAVtfUAHwDRIEMOTQw1KGBbHA1o3UAALX/0IK94vQAAABACQAAEAEgACABIAAwASAAQAEgAFABIABgASAAcAEgIAAFAAAQBQAi1AkZP9IAwAJAAmAhDAJAAmNBh0WEAmNBh0GkAkNBpAPSAMAixACAIvQEg/OcCRhNpC0ALsQEgAOAAIHBHQmlKQEJhcEcKsYFhAOCBYnBHAkgAaMDzCwBwRwAAACAE4ABIcEcCAAgBAUgAaAAMcEcAIATgBEhIRAFoCEZKHAJLS0QaYHBHAAAIAAAAA0hIRABoQBwBSUlECGBwRwgAAAAQtQVIAGhA9IBwA0kIYADwTvgAIBC9AAAAIAJAcLUERghISEQAaE/0enGw+/H1KEYD8DH4ACIhRlAeAPDn+AAgcL0AAAQAAAABRgAgcEcAAEF4FUoRYAF4+bESHUFoEWABewkHwnpB6gJhgnpB6sJBQntB6oJBgntB6kJBwntB6gJBQnpB6gIhAnpB6kIBAngRQwVKCDIRYAXgACECShIdEWASHRFgcEeY7QDgcEdwRwC/APAfAgEhkUADSkMJQvgjEAC/cEcAAIDiAOAAvwDwHwIBIZFAA0pDCUL4IxAAv3BHAACA4QDgAL8A8B8CASGRQEIJkgAC8eAiwvgAEQC/cEcAABC1AUYIRgdKQwlS+CMgAPAfBAEjo0AaQAqxASIA4AAiEEYQvQDjAOAQtQFGCEYHSkMJUvgjIADwHwQBI6NAGkAKsQEiAOAAIhBGEL0A4gDgLenwRQRGIEYAKAjaH08A8A8MrPEEDBf4DHA/CQLgHE8/XD8JPUYORgbwBwDA8QcIuPEEDwLZT/AECAHgwPEHCMRGAPEECLjxBw8C0k/wAAgB4KDxAwhHRiX6B/hP8AEKCvoM+qrxAQoI6goIwvgAgE/wAQgI+gf4qPEBCAjqBQjD+ACAAL+96PCFAAAY7QDgAOQA4BC1AvC3/xC9AL8A8B8CASGRQANKQwlC+CMQAL9wRwAAAOIA4C3p8E2ARg1GFkYAJwLwoP8HRjlGKkYzRgHwBwDA8QcLu/EEDwLZT/AECwHgwPEHC9pGAPEEC7vxBw8C0k/wAAsB4KDxAwvcRk/wAQsL+gr7q/EBCwvqAgsL+gz7T/ABDg76DP6u8QEODuoDDkvqDgQhRkBGAvB0/73o8I0AvwDwBwIGSxloT/b/AxlABEsLQ0PqAiEBSxlgAL9wRwztAOAAAPoFAL8AvwC/AL8Av7/zT48AvwC/AL8JSABoAPTgYAhJCEMAHQZJCGAAvwC/AL+/80+PAL8AvwC/AL8Av/3nDO0A4AAA+gUt6fBNjLCCRgxGT/AAC//3Z/4LkAAnuEYAJQAm/kna+AAAiEIC0QC/ASYB4AElACYAJxDgB+uHAgGrA+uCAXoc0LIC8C3/ILFP8AELCCDK+EgAeBzHsgIv7Nu78QAPfdHtSABoAPABADix60gAaCDwAQDpSQhgSPABCOhIAGgA8AEAOLHlSABoIPABAONJCGBI8AIIBeuFAAGpUfggAAAobdDfSAXrhQEBqlL4IRBJHlD4IQAg8AEC2UgF64UBAatT+CEQSR5A+CEgBeuFAQGqAuuBAUloSR5Q+CEAIPAQAs9IBeuFAQPrgQFJaEkeQPghIAXrhQEBqgLrgQGJaEkeUPghACD0gHLFSAXrhQED64EBiWhJHkD4ISAF64UBAaoC64EBCXsB8A8BSR5Q+CEAIPSAMrpIBeuFAQPrgQEJewHwDwFJHkD4ISAF64UBAaoC64EBCXwB8A8BAOB24UkeUPghACDwgHKtSAXrhQED64EBCXwB8A8BSR5A+CEgBuuGAQGqUvghECBoiEIf0AbrhgEC64EBYGhJaIhCF9AG64YBAuuBAaBoiWiIQg/QBuuGAQLrgQHgaMloiEIH0AbrhgEC64EBIGkJaYhCa9GUSAbrhgEBqlL4IRBJHlD4IQAg8AECjkgG64YBAatT+CEQSR5A+CEgBuuGAQGqAuuBAUloSR5Q+CEAIPAQAoRIBuuGAQPrgQFJaEkeQPghIAbrhgEBqgLrgQGJaEkeUPghACD0gHJ6SAbrhgED64EBiWhJHkD4ISAG64YBAaoC64EBCXsB8A8BSR5Q+CEAIPSAMm9IBuuGAQPrgQEJewHwDwFJHkD4ISAG64YBAaoC64EBCXwB8A8BSR5Q+CEAIPCAcmNIBuuGAQPrgQEJfAHwDwFJHkD4ISBeSCFoSR5Q+CEAIPADAAIhkfqh8bH6gfEF+gHxQfABAQhDVUkiaFIeQfgiAAhGYWhJHlD4IQAg8DAAICGR+qHxsfqB8QX6AfFB8BABCENKSWJoUh5B+CIACEahaEkeUPghACD0QHFP9ABwkPqg8LD6gPAF+gDwQPSAcAFDP0iiaFIeQPgiEOBoAPSAMNixOkghewHwDwFJHlD4IQAg9OAgT/SAIZH6ofGx+oHxBfoB8UH0gDEIQzBJInsC8A8CUh5B+CIAGuAsSCF7AfAPAUkeUPghACDw4GFP8IBgkPqg8LD6gPAF+gDwQPCAcAFDIkgiewLwDwJSHkD4IhAgaQD0gDDYsR1IIXwB8A8BSR5Q+CEAIPTgIE/0gCGR+qHxsfqB8QX6AfFB9EAxCEMTSSJ8AvAPAlIeQfgiACLgD0ghfAHwDwFJHlD4IQAg8OBgT/CAYZH6ofGx+oHxBfoB8UHwQHEIQwVJInwC8A8CUh4G4AAAABAAoAAUAKAEHAZQQfgiAAjwAQAosQlIAGhA8AEAB0kIYAjwAgAosQVIAGhA8AEAA0kIYFhGDLC96PCNABAAoAAUAKD4tQRGACX/9z38Bka0+EQAAPAIACC5tPhEAADwBACQsyBoAGgA8AQAYLEgaABoIPAEACFoCGAgbP73tPsFRg2xBCCgZCBoAGhA8AIAIWgIYOBsM0YBIgIhAJAgRgPwMvoFRqW5AiAhaEhi4GwzRgAiICEAkCBGA/Al+gVGPbkCIKT4RAAD4P/nASUQIKBkKEb4vXBHcLUERgAltPhEAADwCAAgubT4RAAA8AQAYLMgaABoIPT4ECFoCGBP9IBwpPhEACBoAGgA8AQAaLEgaABoIPAEACFoCGAOSHhEIWyIYyBs/vd8+xLgAiAhaEhiIGgAaED0ADAhaAhgIGgAaEDwAgAhaAhgAuABJRAgoGQoRnC9AACfLAAALen4TwRGDUYWRgAn//eu+4JGIGjQ+EiAIGjQ+BCxtPhEAAQoStHoaLD1gA9G0VNGACIgISBGAJYD8Lj5B0YALz/RKGghaMH4iABoaCFowfiAAChpIWjB+JAA1ekCAQhDQPAAUCFoCWgh8ENRCEMhaAhg4Giw8YBvA9EgaMD4SIAM4CBo0PgAAQD04GAYsSBowPhIgALgIGjA+BCxU0YBIgghIEYAlgPwgfkHRk+5CCAhaEhiAiCk+EQAAuABJxAgoGQ4Rr3o+I8t6fhFBEYNRgAm//dL+4BGIGiHbCBo0PgQobT4RAAEKEHR4GxDRgAiICEAkCBGA/BZ+QZGTrsoaCFowfiIAGhoIWjB+IAAKGkhaMH4kADV6QIBCENA8ABQIWgJaCHwQ1EIQyFoCGAJICFoSGJIIKT4RAAgaABoQPQQICFoCGDgaLDxgG8C0SBoh2QP4CBo0PgAAQD04GAQsSBoh2QG4CBowPgQoQLgASYQIKBkMEa96PiFcEct6fhDBEYNRhZGACf/9/D6gEagaAC5AL/oaACxAL/oaQCxAL/oagCxAL+oawCxAL+0+EQAAigD0eBosPGAbw3RtPhEABQoAtEoaAIoBtC0+EQAJChC0ShoASg/0UNGACIgISBGAJYD8OP4B0YvuwAgoGQpRiBGAvAN/AdG77moa1i5Q0YBIgIhIEYAlgPw0PgHRgIgIWhIYiPgKGgYuQQgpPhEAB3gKGgBKAvRtPhEACQoA9EEIKT4RAAS4BQgpPhEAA7gtPhEABQoA9EEIKT4RAAG4CQgpPhEAALgAScQIKBkOEa96PiD+LUERg1GACb/9376B0agaAC5AL/oaACxAL/oaQCxAL/oagCxAL+oawCxAL+0+EQAAigm0ShoILuoaxC74Giw8YBvHtDgbDtGACIgIQCQIEYD8Hr4Bka+uQAgoGQDICFoSGIpRiBGAvCh+wZGZrkIIKT4RAAgaABoQPRAMCFoCGAC4AEmECCgZDBG+L1wtQRGACUMuQElC+AgaABoIPABACFoCGAgRgDwS/oAIKT4RAAoRnC9cEdwRwFGiGxwRwFGCGgAaAD0+FBP9PhSkvqi8rL6gvLQQEAccEcBRrH4RABwRy3p+EMERg1GFkYAJ//3C/qARrT4RAABKCTRQ0YAIiAhIEYAlgPwH/gHRve5T/R/AZH6ofGx+oHxKGiIQE/0f0KS+qLysvqC8mlokUAIQ6loCEPpaAhDIWjB+AACAiCk+EQAAuABJxAgoGQ4Rr3o+IMt6fhDBEYNRhZGACf/99P5gEa0+EQAAigv0eBosPGAbyvRQ0YAIiAhIEYAlgLw4/8HRg+7IGgAaCDwQFAhaAhgIGiAaCDwgHApaAhDIWiIYChpQPBAYKloCENA9EBgIWjB+AAB6GhAHiFoCGRoaCFoiGQEIKT4RAAC4AEnECCgZDhGvej4gy3p8EEERiBoAPFQCCBoBWogaAdotPhEYAXwBAAoswf0gCAQsxguCdFha0gcYGMIeIj4AADga0Ae4GMK4CguCNGY+AAQYmtQHGBjEXDga0Ae4GPgayi5IGgAaCD0gCAhaAhgIEb/9zv/ouAF8AIAAChM0Af0ADAAKEjQKC4h0QX0fFBYseBrSLGY+AAQYmtQHGBjEXDga0Ae4GOJ4OBrACji0QIgIWhIYiBoAGgg9OAgIWgIYAIgpPhEACBGAPC0+nbgAiAhaEhiIGgAaCD04CAhaAhgAiCk+EQAGC4D0SBGAPDQ+2TgCC4D0SBG//cn/l7gtvWAf1vRoGwYuSBG//ce/VXgIEb/9+n+UeAF8AgAuLEH9AAgoLEIICFoSGIgaABoAPSAAECxIGgAaCD0ECAhaAhgAiCk+EQAIEYA8Jj6NuAF8AEAOLMH9IAwILMBICFoSGIgaABoIPT4ECFoCGACIKBkIGgAaADwBABosSBoAGgg8AQAIWgIYA5IeEQhbIhjIGz+94H4EuACIKT4RAAgRv/3o/4L4AXwEABAsQf0gBAosRAgIWhIYiBGAPBh+r3o8IGpJgAA+LUERgAl//e3+AZGDLkBJY/gACCgZLT4RABAuSBGAPDI+E/w/zEgRgDwQvoFRgAtf9HU6QMQQB5P9PgSkvqi8rL6gvKQQAhDYWlJHk/04GKS+qLysvqC8pFACEOhaQhD4WkIQyFoiWgzShFACEMhaIhgIGjAaCD04CAhaghDIWjIYE/0+BGR+qHxsfqB8SBriEAhaAhhIGgAaCD0+FFgaEAeT/T4UpL6ovKy+oLykEABQyBoAWDgbDNGACIgIQCQIEYC8Hn+BUZ9uyBowGgg8P8BYGpAHv8ikvqi8rL6gvKQQAFDIGjBYCBoAGgg8EAAoWgIQyFoCGDU6QoBCEMhaNH4CBEh8KBBCEMhaMH4CAEgaABoQPABACFoCGDgaLDxgG8D0QEgpPhEAALgAiCk+EQAKEb4vQAA/Pjg+Pi1BEYNRgAm//cY+AdGtPhEAAQoJ9HgbDtGACIgIQCQIEYC8Cv+BkYGu4ggpPhEAChoCCgM0WhoIWjB+DABECAhaEhiIGgAaED0gBAhaAhgIGgAaAZJCEApaEHwQFEIQyFoCGAC4AEmECCgZDBG+L33///PcEdwRy3p/E0ERg5GF0YAJf732v8BkCBoAPFQCiBo0PhIgCBo0PgQsR65ASUIIKBkUuC0+EQABChL0SBoAGxAHOBj4GugY2ZjIGgAaCDwQFBA8IBQIWgIYOBosPGAbwPRIGjA+EiADOAgaND4AAEA9OBgGLEgaMD4SIAC4CBowPgQsQC/AJcBIgYhIEYBmwLwu/0FRgWxC+Ca+AAQYmtQHGBjEXDga0Ae4GPgawAo6dEAv425AJcBIgIhIEYBmwLwo/0FRkW5AiAhaEhipPhEAALgASUQIKBkKEa96PyNAAAt6fNHBEYAJiBoAGxFHCBo0PhIgCBo0PgQoQGYGLkBJgggoGSO4LT4RAAEKHLRIGxAaQi55WMk4CBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggoGQBJhTgaAjgYxHgIGxAabD1AH8M0QXwAwAYuSB5APADABixCCCgZAEmAeCoCOBjAC5e0eBroGMBmGBjIGgAaCDwQFBA8IBQIWgIYAMgIWhIYiggpPhEAChIeEQhbMhiJ0h4RCFsCGMmSHhEIWxIYwAgIWyIYwAhIGyBYCBsAGgAaCDwEAAhbIloCEMhbAloCGABr6NrOmjU+ADADPFQASBs/vfO+CBoAGhA9IAwIWgIYOBosPGAbwTRIGjA+EiADeAT4CBo0PgAAQD04GAYsSBowPhIgALgIGjA+BChIGgAaEDwBAAhaAhgAuABJhAgoGQwRr3o/IcAAHMjAAC7IwAAkSMAAHC1AkYAIBVoq2wVaNX4EEEZuQEgCCWVZDXgsvhEUAQtLtEVaC1sbRzVY9VrlWNRYxVoLWgl8EBVRfCAVRZoNWADJRZodWIoJaL4RFAVaC1oRfTgJRZoNWDVaLXxgG8C0RVoq2QP4BVo1fgAUQX04GUVsRVoq2QG4BVoxfgQQQLgASAQJZVkcL1wR3BHMLUCRgAgsvhEMAPwCAOLuVFgE2gbaCP0+FRTaFseT/T4VZX6pfW1+oX1q0AcQxNoHGAC4AEgECOTZDC9AkbRZAAgcEdwR3BHLen4RQRGDkYXRgAl/vdW/oBGIGgA8VAKHrkBJQggoGQ74LT4RAAEKDTRIGgAbEAc4GPga6BjZmMgaABoIPBAUCFoCGAAv0NGASIEISBGAJcC8FT8BUYFsQvgYWtIHGBjCHiK+AAA4GtAHuBj4GsAKOnRAL+NuUNGASICISBGAJcC8Dz8BUZFuQIgIWhIYqT4RAAC4AElECCgZChGvej4hS3p80EERgAmIGgAbEUcAZgYuQEmCCCgZHfgtPhEAAQocNEgbEBpCLnlYyTgIGxAabD1gH8N0QXwAQAYuSB5APABABixCCCgZAEmFOBoCOBjEeAgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIIKBkASYB4KgI4GMALkfR4GugYwGYYGMgaABoIPBAUCFoCGADICFoSGIYIKT4RAAdSHhEIWzIYhxIeEQhbAhjG0h4RCFsSGMAICFsiGMQISBsgWAgbABoAGgg8BAAIWyJaAhDIWwJaAhgAa+ja9T4AMAM8VACOWggbP33cP8gaABoQPSAMCFoCGAgaABoQPAEACFoCGAD4P/nASYQIKBkMEa96PyBtyAAAP8gAADVIAAAELUCRgAgGbkBIAgjk2Qg4LL4RDAEKxnRE2gbbFsc02PTa5NjUWMTaBtoI/BAUxRoI2ADIxRoY2IYI6L4RDATaBtoQ/TgIxRoI2AC4AEgECOTZBC9cEdwRwFGCGgQKAbQIChS0EAofNCAKHvR7OCgSABoIPAIAJ5KEGAQHwBoIPAIABIfEGCaSAgwAGgg8AgAl0oIMhBgEB8AaCDwCAASHxBgSGgA9IAwsPWAPwfRkEgAHwBoQPAIAI1KEh8QYEhoAPQAMLD1AD8F0YlIAGhA8AgAh0oQYAh5APABADixhEgAHQBoQPAIAIFKEh0QYAh5APACAAIoB9F9SAgwAGhA8AgAe0oIMhBg7uB5SABoIPAQAHdKEGAQHwBoIPAQABIfEGBzSAgwAGgg8BAAcEoIMhBgEB8AaCDwEAASHxBgSGgA9IAwsPWAPwfRaUgAHwBoQPAQAGZKEh8QYEhoAPQAMAHgI+C+4LD1AD8F0WBIAGhA8BAAXkoQYAh5APABADixW0gAHQBoQPAQAFlKEh0QYAh5APACAAIoB9FVSAgwAGhA8BAAUkoIMhBgneBQSABoIPAgAE5KEGAQHwBoIPAgABIfEGBKSAgwAGgg8CAASEoIMhBgEB8AaCDwIAASHxBgSGgA9IAwsPWAPwfRQEgAHwBoQPAgAD5KEh8QYEhoAPQAMLD1AD8F0TlIAGhA8CAAN0oQYAh5APABADixNEgAHQBoQPAgADJKEh0QYAh5APACAAIoB9EuSAgwAGhA8CAAK0oIMhBgT+ApSABoIPBAACdKEGAQHwBoIPBAABIfEGAjSAgwAGgg8EAAIUoIMhBgEB8AaCDwQAASHxBgSGgA9IAwsPWAPwfRGUgAHwBoQPBAABdKEh8QYEhoAPQAMLD1AD8F0RJIAGhA8EAAEEoQYAh5APABADixDUgAHQBoQPBAAAtKEh0QYAh5APACAAIoB9EHSAgwAGhA8EAABEoIMhBgAeABIHBHAL8AIPvnAAAkBAFAAkYAIbL1AH8q0R5IAGgA9MBgsPUAfzLQGkgAaCD0wGBA9ABwF0sYYBdISEQAaBdLsPvz8DIjAPsD8QDgSR4xsRBIQGkA9IBgsPWAb/bQDUhAaQD0gGCw9YBvENEDIHBHCEgAaAD0wGCw9YBvB9AFSABoIPTAYED0gGACSxhgACDt5wAAAHAAQAQAAABAQg8AA0jAaCD0gHABSchgcEcAAABwAEACRgkqQ9Lf6ALwBQ0VGyEnLTM6ACBIQGoh9CBDmEMeS1hiNuAcSMBqIfAQA5hDGkvYYi7gGEhAa4hDF0tYYyjgFUjAa4hDFEvYYyLgEkhAbIhDEUtYZBzgD0jAbIhDDkvYZBbgDEhAbYhDC0tYZRDgCUjAbYuymEMHS9hlCeAGSEBuwfMLA5hDA0tYZgHgASBwRwC/ACD75wBwAEACRgkqQdLf6ALwBQ0TGR8lKzE4AB9IAGoh9IBDmEMdSxhiNOAbSIBqiEMaS5hiLuAYSABriEMXSxhjKOAVSIBriEMUS5hjIuASSABsiEMRSxhkHOAPSIBsiEMOS5hkFuAMSABtiEMLSxhlEOAJSIBti7KYQwdLmGUJ4AZIAG7B8wsDmEMDSxhmAeABIHBHAL8AIPvnAHAAQANIgGgg9ABAAUmIYHBHAAAAcABAAL8SSABoIPSAQBBKEGAQSEhEAGgPSrD78vAyIgD7AvEA4EkeMbEJSEBpAPQAcLD1AH/20AVIQGkA9ABwsPUAfwHRAyBwRwAg/OcAAABwAEAEAAAAQEIPAANIQGgg8BAAAUlIYHBHAAAAcABAA0hAaCDwIAABSUhgcEcAAABwAEADSEBoIPBAAAFJSGBwRwAAAHAAQANIQGgg8IAAAUlIYHBHAAAAcABAA0iAaCD0gGABSYhgcEcAAABwAEADSIBoIPSAcAFJiGBwRwAAAHAAQANIQGgg9ABwAUlIYHBHAAAAcABAA0hAaCD0gGABSUhgcEcAAABwAEAGScloIfQAcQFDBErRYBFGyWhB9IBx0WBwRwAAAHAAQAJGCSpw0t/oAvAFFCAqND5IUl8AN0hAaiH0IEMYQzVLWGIYRgBqIfSAQ5hDMUsYYlzgMEjAaiHwEAMYQy1L2GIYRoBqiEOYYlDgKkhAawhDKEtYYxhGAGuIQxhjRuAlSMBrCEMjS9hjGEaAa4hDmGM84CBIQGwIQx5LWGQYRgBsiEMYZDLgG0jAbAhDGUvYZBhGgGyIQ5hkKOAWSEBtCEMUS1hlGEYAbYhDGGUe4BFIwG2LshhDD0vYZRhGgG2LsphDDEuYZRHgCkhAbsHzCwMYQwhLWGYYRgBuwfMLA5hDBEsYZgLg/+cBIHBHAL8AIPvnAAAAcABAAkYJKnHS3+gC8AUUISs1P0lTYAA3SABqIfSAQxhDNUsYYhhGQGoh9CBDmEMxS1hiXeAwSIBqCEMuS5hiGEbAaiHwEAOYQytL2GJQ4ClIAGsIQyhLGGMYRkBriENYY0bgJEiAawhDI0uYYxhGwGuIQ9hjPOAfSABsCEMeSxhkGEZAbIhDWGQy4BpIgGwIQxlLmGQYRsBsiEPYZCjgFUgAbQhDFEsYZRhGQG2IQ1hlHuAQSIBti7IYQw5LmGUYRsBti7KYQwtL2GUR4ApIAG7B8wsDGEMHSxhmGEZAbsHzCwOYQwRLWGYC4P/nASBwRwC/ACD75wBwAEADSIBoQPQAQAFJiGBwRwAAAHAAQANIAGhA9IBAAUkIYHBHAAAAcABAA0hAaEDwEAABSUhgcEcAAABwAEADSEBoQPAgAAFJSGBwRwAAAHAAQANIQGhA8EAAAUlIYHBHAAAAcABAA0hAaEDwgAABSUhgcEcAAABwAEADSIBoQPSAYAFJiGBwRwAAAHAAQANIgGhA9IBwAUmIYHBHAAAAcABAA0hAaED0AHABSUhgcEcAAABwAEADSEBoQPSAYAFJSGBwRwAAAHAAQAhIAGgg8AcAAB0GSQhgBkgAaEDwBAAESQhgAL8AvzC/cEcAAABwAEAQ7QDgDEkJaCHwBwEKShFgCkkJaEHwBAEIShFgASgB0TC/AuBAvyC/IL8ESQloIfAEAQJKEWBwRwBwAEAQ7QDgDUkJaCHwBwFJHAtKEWALSQloQfAEAQlKEWABKAHRML8C4EC/IL8gvwRJCWgh8AQBAkoRYHBHAAAAcABAEO0A4A1JCWgh8AcBiRwLShFgC0kJaEHwBAEJShFgASgB0TC/AuBAvyC/IL8ESQloIfAEAQJKEWBwRwAAAHAAQBDtAOACSABoAPTAYHBHAAAAcABAELUeSABoAPSAMCixAPBg+U/0gDAZSQhgGEggMABoAPAIACixAPAs+AggFEkgMQhgEkggMABoAPAQACixAPAh+BAgDkkgMQhgDEggMABoAPAgACixAPAW+CAgCEkgMQhgBkggMABoAPBAACixAPAL+EAgAkkgMQhgEL0AABQEAUBwR3BHcEdwRwFGK0hAaCDwDgAKaBBDKEpQYChIAGgg9IAwJkoQYBAfAGgg9IAwEh8QYCJICDAAaCD0gDAfSggyEGAQHwBoIPSAMBIfEGBIaAD0gDCw9YA/B9EYSAAfAGhA9IAwFUoSHxBgSGgA9AAwsPUAPwXREUgAaED0gDAPShBgCHkA8AEAOLEMSAAdAGhA9IAwCUoSHRBgCHkA8AIAAigH0QVICDAAaED0gDADSggyEGAAIHBHAHAAQAQEAUAFSIBrQPCAUANJiGMIRoBrIPCAUIhjcEcAEAJAA0gAaCD0gHABSQhgcEcAAABwAEADSEBoIPABAAFJSGBwRwAAAHAAQANIAGgg8BAAAUkIYHBHAAAQ7QDgA0gAaCDwAgABSQhgcEcAABDtAOADSYloAPAfApFDAUqRYHBHAHAAQANIAGhA9IBwAUkIYHBHAAAAcABAA0hAaEDwAQABSUhgcEcAAABwAEADSABoQPAQAAFJCGBwRwAAEO0A4ANIAGhA8AIAAUkIYHBHAAAQ7QDgCEnJaADwHwKRQ0HqUBEFStFgEUaJaADwHwIRQwFKkWBwRwAAAHAAQHC1BUYMRk25D0hAaQD0AHCw9QB/CdH/93P8BuAKSEBpwPNAIAi5//f5/QhIAGgg8AQABkkIYAEsAdEwvwLgQL8gvyC/cL0AAABwAEAQ7QDgCEgAaCDwBwDAHAZJCGAGSABoQPAEAARJCGAAvwC/ML9wRwAAAHAAQBDtAOBwtQVGDEa19YBPA9EgRv/3Vf4C4CBG//cz/nC9cEdwRy3p8EEERg1GACYAJ7BGkEgAaADwDwCoQg/SjUgAaCDwDwAoQ4pJCGAIRgBoAPAPAKhCAtABIL3o8IEgeADwAQAAKG7QYGgDKCPRgkgAaADwAHAIuQEg7ucB8Hj9B0Z+SIdCBtkgeADwAgACKAHRoGggsXhIgGgA8PAAoLt1SIBoIPDwAEDwgABySYhgT/CACCngYGgCKAbRbkgAaAD0ADCIuQEgx+dgaDC5akgAaADwAgBAuQEgvudmSABoAPSAYAi5ASC35wDwRfoHRmJIh0IJ2WBIgGgg8PAAQPCAAF1JiGBP8IAIW0iAaCDwAwBhaAhDWEmIYP33xf4GRmBoAygQ0Qjg/fe+/oAbQfKIMYhCAdkDII/nT0iAaADwDAAMKPDRNuBgaAIoENEI4P33qv6AG0HyiDGIQgHZAyB750VIgGgA8AwACCjw0SLgYGiAuQjg/feX/oAbQfKIMYhCAdkDIGjnO0iAaADwDAAAKPDRD+AI4P33hv6AG0HyiDGIQgHZAyBX5zNIgGgA8AwABCjw0SB4APACAAIoCNEtSIBoIPDwAKFoCEMqSYhgCOC48YAPBdEnSIBoIPDwACVJiGAjSABoAPAPAKhCDtkgSABoIPAPAChDHkkIYAhGAGgA8A8AqEIB0AEgJecgeADwBAAEKAfRF0iAaCD04GDhaAhDFEmIYCB4APAIAAgoCNERSIBoIPRgUCFpQOrBAA1JiGAA8Jj5C0mJaAHw8AHwIpL6ovKy+oLy0UAISnpEUVzIQAdJSUQIYA8g/fdW/gAg8uYAIAJAABACQAC0xAR6HQAABAAAAB9IAGhA8AEAHUkIYADgAL8bSABoAPACAAAo+NAYSABoIPDwAEDwYAAVSQhgACCIYAhGAGgTSQhAEUkIYAAgyGAIRsBoQPSAUMhgACAIYQhGAGlA9IBQCGEAIEhhCEZAaUD0gFBIYQhGAGgg9IAgCGAAIIhhBEgFSUlECGBwRwAAABACQP/0/uoACT0ABAAAAANIAGhA9AAgAUkIYHBHAAAAEAJADyICYA1KkmgC8AMCQmALSpJoAvDwAoJgCEqSaAL04GLCYAZKkmgC9GBS0ggCYQRKEmgC8A8CCmBwRwAAABACQAAgAkABSEhEAGhwRwQAAAA/IQFgZEkJaAH0gCGx9YAvA9FP9KAhQWAM4F9JCWgB9IAxsfWAPwPRT/SAMUFgAeAAIUFgWEkJaAHwAQERsQEhgWEB4AAhgWFTSQloAfR/QU/0f0KS+qLysvqC8tFAwWFNSQloAfDwAQFiS0kJaAH0gHGx9YB/A9FP9IBxwWAB4AAhwWBESUloAfD+QU/w/kKS+qLysvqC8tFAAWE+SZAxCWgB8AQBBCkC0QUhgWAK4DlJkDEJaAHwAQERsQEhgWAB4AAhgWA0SZQxCWgB8AEBEbEBIUFhAeAAIUFhLkmYMQloAfABARGxASFBYgHgACFBYilJCWgB8IBxsfGAfwLRAiGBYgHgASGBYiNJyWgB8AMCwmIgScloAfDwAfAikvqi8rL6gvLRQEkcAWMaScloAfT+QU/0/kKS+qLysvqC8tFAQWMUScloAfTAAU/0wAKS+qLysvqC8tFASRxKAMJjDUnJaAHwwGFP8MBikvqi8rL6gvLRQEkcSgACZAZJyWgB8HhBT/B4QpL6ovKy+oLy0UCBY3BHAAAAEAJAALX/9yn/CEmJaAH04GFP9OBikvqi8rL6gvLRQANKekRRXMhAAL0AAAAQAkCaGgAAALX/9xH/CEmJaAH0YFFP9GBSkvqi8rL6gvLRQANKekRRXMhAAL0AAAAQAkBqGgAA8LUAIQAjACQCJQIiACBWTrZoBvAMBl6xU062aAbwDAYMLi7RUE72aAbwAwYBLijRTU42aAbwCAZuuUtOlDY2aAb0cGZP9HBnl/qn97f6h/cm+gfxCuBETjZoBvDwBvAnl/qn97f6h/cm+gfxP05+RFb4IRA8TrZoBvAMBoa5CEYO4DlOtmgG8AwGBC4B0ThIBuA1TrZoBvAMBgguANE1SDFOtmgG8AwGDC5b0S5O9mgG8AMELE72aAbw8AbwJ5f6p/e3+of3/kByHAEsKdACLALQAywk0RHgJU62+/L2Ik//aAf0/kdP9P5MnPqs/Lz6jPwn+gz3BvsH8yPgHU62+/L2GU//aAf0/kdP9P5MnPqs/Lz6jPwn+gz3BvsH8xHgAL+x+/L2EE//aAf0/kdP9P5MnPqs/Lz6jPwn+gz3BvsH8wC/AL8ITvZoBvDAZk/wwGeX+qf3t/qH9/5Adhx1ALP79fDwvQAAABACQAIaAAAAJPQAABJ6AHC1hrAGRg1GFEYAvxJIwGxA8AEAEEnIZAhGwGwA8AEAAJAAvwC/iBUBkAIgApAEkAAgA5AFkAGpT/CQQP33hvoFSIBoIPD+QEXqBAEIQwJJiGAGsHC9AAAAEAJAELUHSMBpAPSAcLD1gH8F0f/3YfxP9IBwAUkIYhC9AAAAEAJA+LUERgAlIHgA8BAAECh20f5IgGgA8AwAAChy0ftIAGgA8AIAGLGgaQi5ASD4vfdIIWoAaADwCAAgsfRIAGgA8PAABeDxSJQwAGgA9HBgAAmBQh/ZIGoB8Gf6CLEBIOXnAL/qSABoQPAIAOhJCGAIRgBoIPDwACFqCEPkSQhgAL8IRkBoIPR/QOFpQOoBIN9JSGAe4AC/3UgAaEDwCADbSQhgCEYAaCDw8AAhaghD10kIYAC/CEZAaCD0f0DhaUDqASDSSUhgIGoB8C76CLEBIKzn//eZ/s1JiWgB8PAB8CKS+qLysvqC8tFAyUp6RFFcyEDISUlECGAPIP33V/tL4P/noGmAs8FIAGhA8AEAv0kIYP33EfsFRgbg/fcN+0AbAigB2QMggee4SABoAPACAAAo8tAAv7VIAGhA8AgAs0kIYAhGAGgg8PAAIWoIQ69JCGAAvwhGQGgg9H9A4WlA6gEgqklIYBfg/+eoSABoIPABAKZJCGD999/6BUYG4P332/pAGwIoAdkDIE/nn0gAaADwAgAAKPLRIHgA8AEAAChs0JpIgGgA8AwACCgL0JdIgGgA8AwADCgO0ZRIwGgA8AMAAygI0ZFIAGgA9AAwiLNgaHi7ASAp5wC/YGiw9YA/BtGKSABoQPSAMIhJCGAa4GBosPWgLwvRhEgAaED0gCCCSQhgCEYAaED0gDAIYArgfkgAaCD0gDB8SQhgCEYAaCD0gCAIYAC/YGigsf33hPoFRgngIuD993/6QBtB8ogxiEIB2QMg8eZwSABoAPQAMAAo8NAS4P33b/oFRgjg/fdr+kAbQfKIMYhCAdkDIN3mZkgAaAD0ADAAKPDRIHgA8AIAAihq0WFIgGgA8AwABCgL0F5IgGgA8AwADCge0VtIwGgA8AMAAigY0VhIAGgA9IBgGLHgaAi5ASC35lNIQGgg8P5AT/D+QpL6ovKy+oLyIWmRQAhDTUlIYD/g4Ggws0pIAGhA9IBwSEkIYP33JPoFRgbg/fcg+kAbAigB2QMglOZCSABoAPSAYAAo8tA/SEBoIPD+QE/w/kKS+qLysvqC8iFpkUAIQzhJSGAW4DdIAGgg9IBwNUkIYP33/fkFRgbg/ff5+UAbAigB2QMgbeYuSABoAPSAYAAo8tEgeADwCAAIKDbRYGnQsShIlDAAaEDwAQAlScH4lAD99935BUYG4P332flAGwIoAdkDIE3mHkiUMABoAPACAAAo8dAZ4BpIlDAAaCDwAQAYScH4lAD998L5BUYG4P33vvlAGwIoAdkDIDLmEUiUMABoAPACAAAo8dEgeADwBAAEKG/RACYKSIBtAPCAUHC5AL8HSIBtQPCAUAVJiGUIRoBtAPCAUACQAL8AvwEmA0gH4AAQAkB8FwAABAAAAABwAEAAaAD0gHCwuahIAGhA9IBwpkkIYP33gvkFRgbg/fd++UAbAigB2QMg8uWgSABoAPSAcAAo8tAAv6BoASgI0ZxIAGhA8AEAmkmQOcH4kAAh4KBoBSgP0ZZIAGhA8AQAlEmQOcH4kAAIRtD4kABA8AEAwfiQAA7gjkgAaCDwAQCMSZA5wfiQAAhG0PiQACDwBADB+JAAAL+gaKCx/fc/+QVGCeAt4P33OvlAG0HyiDGIQgHZAyCs5X5IAGgA8AIAACjw0BLg/fcq+QVGCOD99yb5QBtB8ogxiEIB2QMgmOV0SABoAPACAAAo8NEBLgfRcEiQOIBtIPCAUG1JkDmIZQC/IHgA8CAAICg40WBq2LFoSAgwAGhA8AEAZUmQOcH4mAD99/z4BUYG4P33+PhAGwIoAdkDIGzlXkgIMABoAPACAAAo8dAa4FpICDAAaCDwAQBXSZA5wfiYAP334PgFRgbg/ffc+EAbAigB2QMgUOVQSAgwAGgA8AIAACjx0aBq6LNLSJA4gGgA8AwADCh50KBqAihT0UZIkDgAaCDwgHBESZA5CGD997r4BUYG4P33tvhAGwIoAdkDICrlPUiQOABoAPAAcAAo8dEga0AeAQFga0HqACDhaghDoY8BIsLrUQFA6kFRQCAAXcLrUABB6kBhOCAAXUHqwGAtSQDgU+CQOchgCEYAaEDwgHAIYAhGwGhA8IBwyGD994H4BUYG4P33ffhAGwIoAdkDIPHkIEiQOABoAPAAcAAo8dA04BxIkDgAaCDwgHAaSZA5CGAIRgBoAPAAYEi5CEYAaADwAFAguQhGwGgg8AMAyGARSJA4wGgQSQhADkmQOchg/fdP+AVGB+AO4P33SvhAGwIoAdkDIL7kB0iQOABoAPAAcAAo8dEB4AEgtOQAILLkAAAAcABAkBACQP//7v5P8OAgAGlA8AIAT/DgIQhhcEcAAANIQGgg9IBwAUlIYHBHAAAAAAFAACABSQhicEcAACBCA0gAayDwAQABSQhjcEcAAAAAAUADSEBoQPSAcAFJSGBwRwAAAAABQAEgAUkIYnBHAAAgQhC1ACQMSABrQPABAApJCGP89/T/BEYG4Pz38P8AGwooAdkDIBC9BEgAawDwCAAAKPLQACD25wAAAAABQMogBElIYlMgSGIBIAJJCGBwRwAAAAABQAADIEIDSQlrIfACAQFDAUoRY3BHAAABQANJSWsh8D8BAUMBSlFjcEcAAAFAA0kJayHwBAEBQwFKEWNwRwAAAUAEKAjRT/DgIQlpQfAEAU/w4CIRYQfgT/DgIQlpIfAEAU/w4CIRYXBHcEdwtQRGJUZoHrDxgH8B0wEgD+BoHk/w4CFIYQ8hT/D/MADwWfgAIE/w4CGIYQcgCGEAIHC9ELX/9+L/EL1P8OAgAGkg8AIAT/DgIQhhcEcAv/7ncLUERg1GFkZQIQhISET697z9UCEGSEhE+ve3/fz3fP8A8MH++vfA/wAgcL3QAAAAMAAAABC1BEZQIQpISET696T9UCEISEhE+vef/fz3ZP8A8Kn++veo/wy5+vfR/QEgEL0AAIAAAAAwAAAAAL/+53BHAAACSABowPMCIHBHAAAM7QDgELUAKAfaCgcUDgVKAPAPAxsf1FQD4AoHEw4CShNUEL0Y7QDgAOQA4PC1BEYAIAAiACUAIxSxAiwA3Am5ASBg4AAmDmHOYI5gTmAOYAEsAdEAJQLgAiwA0SpNACNP4CpOVvgjIALwAQY+sQLwAgYF8AIHvkIB0V4cDmAC8BAGPrEC8CAGBfAgB75CAdFeHE5gAvSAdj6xAvQAdgX0AHe+QgHRXhyOYAL0gDaOsQL0gCYF9IAnvkIL0QL0ADYmuV4cRvSANs5gA+BeHEbwgHbOYALwgHaOsQLwgGYF8IBnvkIL0QLwAHYmuV4cRvSANg5hA+BeHEbwgHYOYV4c87ICK63b8L0iAgQEBBwGUC3p8EECRgAgF2g/aCfwQFfS+ADAzPgAcJdoX7kXaD9oJ/CAB9H4BMBH6gwH0vgAwMz4AHAPaAIvDNAXaAf1gHMXaAf1hHQXaAf1iHUXaAf1kHYL4BdoB/XAcxdoB/XEdBdoB/XIdRdoB/XQdtHpEnxH6gwHH2DPao+xj2o3YNH4NMDPakfqDAfR+DDAR+oMB9P4AMAs9HwcR+oMBx9gJ2gn8B8H0fhEwEfqDAcnYI9rP7EPaC+5z2t/HtL4AMDM+EBwz2gAL2/Qz2nns49rN7PR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMBH6gwH0fggwEfqDAfR+DjAR+oMB9H4QMBH6gwH0/gAwN/4PIEM6ggMR+oMBx9gH+DR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMBH6gwH0fggwADgEuBH6gwH0/gAwEP2P3gs6ggMR+oMBx9gj2gvYI9p0vgAwMz4SHBr4I9r37HR+BTAz2hH6gwH0fgQwEfqDAfR+DjAR+oMB9H4QMBH6gwH0/gAwN/4tIAM6ggMR+oMBx9gEOAS4NH4FMDPaEfqDAfR+BDAR+oMB9P4AMAs8D8MR+oMBx9gj2gvYDrgz2mns49r57HR+CTAz2lH6gwH0fggwEfqDAfR+DjAR+oMB9H4QMBH6gwH0/gAwN/4TIAI8T8IDOoIDEfqDAcfYA/g0fgkwM9pR+oMB9H4IMBH6gwH0/gAwCz0fFxH6gwHH2CPadL4AMDM+EhwA+D/5wEgCCeXZL3o8IEAAMDA//DA///wcLUFRqxqACDgY7T4RACw9YB/D9ECICFoSGIgaABoQPQAMCFoCGAgaABoQPACACFoCGAF4AIgpPhEACBG/fc6+3C9AUaIagAiwmMCaBJoIvAEAgNoGmAKaBJoIvABAgtoGmACaBJoQvQAMgNoGmBwR3C1BUasagAg4GMEIKBkIGgAaCDwBAAhaAhgIEb990T5cL1wtQVGrGrga0AI4GO0+EQAKCgD0SBG/fer/gLgIEb999X/cL0AADC1mbAFRgxGACAFkAaQQPL6UAeQBCAIkBAgCZAAIAqQC5BP9IBgDJBP9EBQDZAAIA6QEJBP8IBgE5ABIBSQACAVkAYgFpAAIBeQGJAAkAEgAZAAIAKQECAEkIAEA5BP8P8yBakJSEhE/ff6+RCxASAZsDC9IkZpRgRISET99zL5CLEBIPTnACDy5wAAMAAAAAC1hbDAIU/wkED89+36ByEfSPz36foYIR5I/Pfl+k/0AGEdSPz34PoEIRxI/Pfc+gAgAZAEIACQACACkAOQaUZP8JBA/PeG+wEgAZAAIAKQCCAAkGlGT/CQQPz3e/sAIgghT/CQQPz3lPwNSABrQPSAcAtJCGMIRgBrIPSAcAhjCEYAbSD0gHAIZQWwAL0AAAAEAEgACABIABgASAAcAEgAEAJAALWHsAC/W0jAbED0gBBZSchkCEbAbAD0gBABkAC/AL8AvwhGAG1A9IBwCGUIRgBtAPSAcAGQAL8AvwhGAGtA9IBwCGMIRgBrIPSAcAhjAL8IRoBtQPCAUIhlCEaAbQDwgFABkAC/AL9DSEBoQPQAcEFJSGAAvz9IwGxA8AEAPUnIZAhGwGwA8AEAAZAAvwC/AL8IRsBsQPACAMhkCEbAbADwAgABkAC/AL8AvwhGwGxA8AQAyGQIRsBsAPAEAAGQAL8AvwC/CEbAbEDwQADIZAhGwGwA8EAAAZAAvwC/AL8IRsBsQPCAAMhkCEbAbADwgAABkAC/AL8EIAKQAiADkAEgBJADIAWQCiAGkAKpT/CQQPz3zfoEIAKQAiAEkAKpFkj898X6yCACkAAgBJACqU/wkED897z6AyACkAKpD0j897b6GCACkAKpDUj897D6T/QAYAKQAyAGkAKpCUj896f6BCACkAKpB0j896H6B7AAvQAAABACQABwAEAABABIAAgASAAYAEgAHABIMLWbsAVGDEYAIAeQCJAMkE/0QFAPkAAgEJASkBeQGZAakASQECAGkIAEBZABLHPRBiAJkAEgCpAAIAuQDpAVkBiQQh4HqZhISET996n4ELEBIBuwML0CIAKQA5AFIAmQT/CAcBWQASAWkIIeB6mOSEhE/feV+AixASDq50/w/zICqYlISET8983/CLEBIODnciAJkE/0QHANkE/0gHAOkAYgAZDCHwepf0hIRP33ePgIsQEgzedP8P8yAal6SEhE/fcI/QixASDD5wYgCZAAIA6QFZBCHgepc0hIRP33YPgIsQEgtecFIAmQT/CAcBWQT/D/MgepbEhIRP33UfgIsQEgpudP8P8yAqlnSEhE/PeJ/xCxASCc503gciAJkAAgDZBP9IBwDpABIAGQgh4HqV1ISET99zT4CLEBIInnT/D/MgGpWEhIRP33xPwIsQEgf+dWSPv3lP1P8P8xUkhIRP/37v0IsQEgc+dH8o4QCZAEIAqQECALkIABDpAABBWQBiAYkMIfB6lHSEhE/fcI+AixASBd50/w/zIBqUJISET99xT7CLEBIFPnnfgEAAEod9ABIE3nPEhIRADws/gIsQEgRudH8o0gCZAEIAqQECALkAAgDZBP9IBgDpAABBWQASAWkAYgGJAAIAGQQh4HqS1ISET899T/CLEBICnnT/D/MgGpKEhIRP33ZPwIsQEgH+cmSPv3NP0FIAmQASAKkAAgC5AOkE/wgHAVkAEgFpAAIBiQApABIAOQgh4HqRpISET8963/CLEBIALnT/D/MgKpFUhIRPz35f4IsQEg+OZxIAmQACANkE/0gHAOkE/w/zIHqQxISET895L/CLEBIOfmT/D/MgGpB0hIRP33nvoQsQEg3eYE4J34BAAIsQEg1+YAINXmAAAwAAAAgFhPABC1lLAERgAgAJABkEbymWACkAQgA5AQIASQACAFkAeQC5AOkBGQEpATkEIeaUYQSEhE/Pdd/xCxASAUsBC9SfZmEAKQT/D/MmlGCUhIRPz3T/8IsQEg8OdP8P8xBEhIRP/3Fv0IsQEg5+cAIOXnAAAwAAAAELWasARGACAGkAeQQPL5YAiQBCAJkBAgCpAAIAuQDZARkBSQF5AYkBmQQh4GqR5ISET89yP/ELEBIBqwEL0CIAGQApAAIAOQECAFkIAEBJBA8vpQCJAAIAyQT/SAYA2QT/RAUA6QACAPkE/wgGAUkAEgFZAAIBaQBiAXkMIfBqkJSEhE/Pf6/gixASDV50/w/zIBqQRISET89zL+CLEBIMvnACDJ5wAAMAAAAC3p8EcERg5GF0aaRgid/PfX+YBGE+BoHIixLbH899D5oOsIAKhCCtlP9ABwpPhEAKBsQPABAKBkASC96PCHIGgAajBACLEBIADgACC4QuLRACDy53BHcLUERg1GFkYqRiFGMEb69w77CLEBIHC9ACD85wFGASBwRxC1AkhIRP33B/gQvYAAAADwtQAiACMAJAIlAiEAIEJO9mgG8AMGAS4h0T9ONmgG8AgGbrk8TpQ2NmgG9HBmT/RwZ5f6p/e3+of3JvoH8grgNU42aAbw8AbwJ5f6p/e3+of3JvoH8jFOfkRW+CIgLk72aAbwAwQsTvZoBvDwBvAnl/qn97f6h/f+QHEcASwp0AIsAtADLCTREeAlTrb78fYhT/9oB/T+R0/0/kyc+qz8vPqM/Cf6DPcG+wfzI+AdTrb78fYYT/9oB/T+R0/0/kyc+qz8vPqM/Cf6DPcG+wfzEeAAv7L78fYPT/9oB/T+R0/0/kyc+qz8vPqM/Cf6DPcG+wfzAL8AvwdO9mgG8MBmT/DAZ5f6p/e3+of3/kB2HHUAs/v18PC9ABACQCAEAAAAJPQAABJ6APi1BEYAJgAlIUiAbQDwgFAYsf73SfgGRhbgAL8cSIBtQPCAUBpJiGUIRoBtAPCAUACQAL8Av/73N/gGRhRIgG0g8IBQEkmIZbb1AH8H0YAsDNmgLAHZAiUI4AElBuCALAHTAiUC4HAsANEBJQlIAGgg8A8AKEMHSQhgCEYAaADwDwCoQgHQASD4vQAg/OcAAAAQAkAAIAJAcEdwtQRGDUagsiQaCeAk8HBGMEb69wD4CLEAIHC9BPWANKVC89IBIPjnELX897D4EL0AtZewFCESqPn37P5EIQGo+ffo/hAgAZABIAeQACAIkAIgC5ABIQyRYCAJkA2RPCEOkQIhEZEQkQchD5EBqP735vwPIBKQAyATkIAgFJAAIBWQFpADIRKo/vcz+QIgEpAAIBSQBSESqP73K/kXsAC9AADwtQAjACAAIgIkACUCITZONmgG8AgGLrkzTpQ2NmjG8wMgA+AwTjZoxvMDEC9OfkRW+CAALE62aAbwDAY2sQQuCNAILgvQDC450Q3gKE5ORDBgOOAnTiZPT0Q+YDPgJk4jT09EPmAu4B9O9mgG8AMFHU72aMbzAxZxHAItAtADLQjRA+AbTrb78fIG4BpOtvvx8gLgsPvx8gC/AL8STvZoxvMGJnJDEE72aMbzQWZ2HHQAsvv09g5PT0Q+YAPgDE5ORDBgAL8AvwdOtmjG8wMWCk9/RLtdBk5ORDZo3kAET09EPmDwvQAAABACQOYBAAAEAAAAACT0AAASegAyAQAAEEgAaED0cAAOSQhgDkgAaEDwAQAMSQhgACCIYAhGAGgKSQhACEkIYMgUyGAIRgBoIPSAIAhgACCIYcgDAUmAOQhgcEeI7QDgABACQP//9uoQtQRG+fc0/gAgEL0Av/7ncLUERg5GFUb59z7+B+AU+AEbFfgBK5FCAdAgRnC9MB6m8QEG89EgRvjnLenYTQZGi0YXRppGT/AACAAgAJC/APn3Iv7K8wNCuRoK8A8CkBkAmvr3gfkERg/gFvgBGxv4CACBQgfQACIG6wgAEBhE6wIBvejYjQjxAQhHRe3YIUYAIPbncLUERg1GFkYqRiFGMEb699H4CLEAIHC9ASD85wAAAAAAAAAAAAAAAAAAAAABAgMEBgcICaCGAQBADQMAgBoGAAA1DABAQg8AgIQeAAAJPQAAEnoAACT0AAA2bgEASOgBAGzcAk1YMjVMTTUxMjQ1R19TVE0zMkw0UjlJLUVWQUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAkAAAAAQAAAEA/wAAAAAEAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 21877
-    pc_uninit: 25821
-    pc_program_page: 24823
-    pc_erase_sector: 2423
-    pc_erase_all: 2385
-    data_section_offset: 26268
+    pc_init: 0x5575
+    pc_uninit: 0x64dd
+    pc_program_page: 0x60f7
+    pc_erase_sector: 0x977
+    pc_erase_all: 0x951
+    data_section_offset: 0x669c
     flash_properties:
       address_range:
-        start: 2415919104
-        end: 2483027968
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 10000
-      erase_sector_timeout: 10000
+        start: 0x90000000
+        end: 0x94000000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0x2710
+      erase_sector_timeout: 0x2710
       sectors:
-        - size: 65536
-          address: 0
-  stm32l4r9i_disco_ospi2:
-    name: stm32l4r9i_disco_ospi2
+        - size: 0x10000
+          address: 0x0
+  - name: stm32l4r9i_disco_ospi2
     description: MX25L51245G_STM32L4R9I_DISCO_OSPI2
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAARkgAaEDwAQBESQhgACCIYAhGAGhCSQhAQEkIYMgUyGAIRgBoIPSAIAhgACCIYcgDPEkIYHBH8LUAIwAgACICJAAlAiE1TjZoBvAIBi65M06UNjZoxvMDIAPgME42aMbzAxAxTn5EVvggACxOtmgG8AwGNrEELgjQCC4L0AwuOdEN4CpOTkQwYDjgKU4nT09EPmAz4CdOJU9PRD5gLuAfTvZoBvADBR1O9mjG8wMWcRwCLQLQAy0I0QPgHU62+/HyBuAcTrb78fIC4LD78fIAvwC/Ek72aMbzBiZyQw9O9mjG80Fmdhx0ALL79PYPT09EPmAD4A1OTkQwYAC/AL8HTrZoxvMDFgxPf0S7XQdOTkQ2aN5ABU9PRD5g8L0AEAJA///26gjtAOBwUwAABAAAAAAk9AAAEnoAtFIAAHtIgGtA8IBQeUmIYwhGgGsg8IBQiGNwR3ZIAGhA9IBwdEkIYHBHc0gAaCD0gHBxSQhgcEcBRm9IQGgg8A4ACmgQQ2xKUGBsSABoIPSAMGpKEGAQHwBoIPSAMBIfEGBmSAgwAGgg9IAwY0oIMhBgEB8AaCD0gDASHxBgSGgA9IAwsPWAPwfRXEgAHwBoQPSAMFlKEh8QYEhoAPQAMLD1AD8F0VVIAGhA9IAwU0oQYAh5APABADixUEgAHQBoQPSAME1KEh0QYAh5APACAAIoB9FJSAgwAGhA9IAwR0oIMhBgACBwR0NIQGhA8AEAQUlIYHBHQEhAaCDwAQA+SUhgcEc8ScloAPAfApFDQepQETlK0WARRoloAPAfAhFDNUqRYHBHNEmJaADwHwKRQzFKkWBwR3C1BUYMRk25LkhAaQD0AHCw9QB/CdED8BX5BuApSEBpwPNAIAi5A/AG+SdIAGgg8AQAJUkIYAEsAdEwvwLgQL8gvyC/cL1wtQVGDEa19YBPA9EgRgPwNfkC4CBGA/AX+XC9F0gAaCDwBwDAHBVJCGAWSABoQPAEABRJCGAAvwC/ML9wRxFIAGhA8AIAD0kIYHBHDUgAaCDwAgALSQhgcEcKSABoQPAQAAhJCGBwRwZIAGgg8BAABEkIYHBHcEcAEAJAAHAAQAQEAUAQ7QDgcEdwtQRGhUhIRABoT/R6cbD78fUoRgDwofkAIiFGUB4A8DL5ACBwvRC1fUgAaED0gHB7SQhgAyAA8BT5DyAE8PL///fd/wAgEL1wRxC1T/D/MHRJiGMAIIhjQB4IZAAgCGRAHohiACCIYkAeyGIAIMhiQB4IYwAgCGP/9+b/ACAQvWlISEQAaEAcZ0lJRAhgcEdlSEhEAWgIRkocYktLRBpgcEdwtQRG//fz/wZGJUZoHACxbRwAv//36/+AG6hC+tNwvU/w4CAAaSDwAgBP8OAhCGFwR0/w4CAAaUDwAgBP8OAhCGFwR1BIcEdQSABoAAxwR05IAGjA8wsAcEdNSABocEdLSAAdAGhwR0lICDAAaHBHRkhAaEDwAQBESUhgcEdDSEBoIPABAEFJSGBwRz9IQGhA8AIAPUlIYHBHPEhAaCDwAgA6SUhgcEc4SEBoQPAEADZJSGBwRzVIQGgg8AQAM0lIYHBHyiAzSUhiUyBIYgEgMUkIYHBHASAwSQhicEcAIC5JCGJwRytJCWsh8AQBAUMoShFjcEcnSQlrIfACAQFDJEoRY3BHI0lJayHwPwEBQyBKUWNwRxC1ACQeSABrQPABABxJCGP/92L/BEYG4P/3Xv8AGwooAdkDIBC9FUgAawDwCAAAKPLQACD25xFIAGsg8AEAD0kIY3BHDkhAaED0gHAMSUhgcEcKSEBoIPSAcAhJSGBwRwAABAAAAAAgAkAAEAJACAAAAAUACAEAIATgkHX/HwAAAUAAAyBCAAAgQhC1ACgH2goHFA65SgDwDwMbH9RUA+AKBxMOtkoTVBC9AL8A8AcCsksMOxloT/b/AxlAsUsLQ0PqAiGtSww7GWAAv3BHLenwTYBGDUYWRgAnAPBI+QdGOUYqRjNGAfAHAMDxBwu78QQPAtlP8AQLAeDA8QcL2kYA8QQLu/EHDwLST/AACwHgoPEDC9xGT/ABCwv6Cvur8QELC+oCCwv6DPtP8AEODvoM/q7xAQ4O6gMOS+oOBCFGQEb/96L/vejwjXBHAL8A8B8CASGRQItKQwlC+CMQAL9wRwC/AL8AvwC/AL+/80+PAL8AvwC/gEgMOABoAPTgYIBJCEMAHXxJDDkIYAC/AL8Av7/zT48AvwC/AL8AvwC//edwtQRGJUZoHrDxgH8B0wEgD+BoHk/w4CFIYQ8hT/D/MP/3Yv8AIE/w4CGIYQcgCGEAIHC9ELUA8Mn4EL0t6fBFBEYgRgAoCNpjTwDwDwys8QQMF/gMcD8JAuBgTz9cPwk9Rg5GBvAHAMDxBwi48QQPAtlP8AQIAeDA8QcIxEYA8QQIuPEHDwLST/AACAHgoPEDCEdGJfoH+E/wAQoK+gz6qvEBCgjqCgjC+ACAT/ABCAj6B/io8QEICOoFCMP4AIAAv73o8IUAvwDwHwIBIZFAREqAMkMJQvgjEAC/cEcQtQFGCEY/SoAyQwlS+CMgAPAfBAEjo0AaQAqxASIA4AAiEEYQvQC/APAfAgEhkUA2SkMJQvgjEAC/cEcQtQFGCEYxSoAyQwlS+CMgAPAfBAEjo0AaQAqxASIA4AAiEEYQvQQoCNFP8OAhCWlB8AQBT/DgIhFhB+BP8OAhCWkh8AQBT/DgIhFhcEdwRxC1//f8/xC9QXgYSoAyEWABePmxEh1BaBFgAXsJB8J6QeoCYYJ6QerCQUJ7QeqCQYJ7QepCQcJ7QeoCQUJ6QeoCIQJ6QepCAQJ4EUMISogyEWAF4AAhBUqEMhFgEh0RYHBHAkgMOABowPMCIHBHGO0A4ADkAOAAAPoFgOEA4IDiAOAt6fBHBEYORhdGmEYInf/3nP2CRhPgaByIsS2x//eV/aDrCACoQgrZT/QAcKT4RACgbEDwAQCgZAEgvejwhyBoAGowQAixASAA4AAguELi0QAg8ucCRtFkACBwR3BH+LUERgAl//dx/QZGDLkBJY/gACCgZLT4RABAuSBGBPD6+k/w/zEgRv/35f8FRgAtf9HU6QMQQB5P9PgSkvqi8rL6gvKQQAhDYWlJHk/04GKS+qLysvqC8pFACEOhaQhD4WkIQyFoiWj+ShFACEMhaIhgIGjAaCD04CAhaghDIWjIYE/0+BGR+qHxsfqB8SBriEAhaAhhIGgAaCD0+FFgaEAeT/T4UpL6ovKy+oLykEABQyBoAWDgbDNGACIgIQCQIEb/927/BUZ9uyBowGgg8P8BYGpAHv8ikvqi8rL6gvKQQAFDIGjBYCBoAGgg8EAAoWgIQyFoCGDU6QoBCEMhaNH4CBEh8KBBCEMhaMH4CAEgaABoQPABACFoCGDgaLDxgG8D0QEgpPhEAALgAiCk+EQAKEb4vXBHcLUERgAlDLkBJQvgIGgAaCDwAQAhaAhgIEYE8JD7ACCk+EQAKEZwvXBHcEdwtQVGrGoAIOBjtPhEALD1gH8P0QIgIWhIYiBoAGhA9AAwIWgIYCBoAGhA8AIAIWgIYAXgAiCk+EQAIEb/99//cL1wR3BHcEdwR3BHcEct6fBBBEYgaADxUAggaAVqIGgHaLT4RGAF8AQAKLMH9IAgELMYLgnRYWtIHGBjCHiI+AAA4GtAHuBjCuAoLgjRmPgAEGJrUBxgYxFw4GtAHuBj4GsouSBoAGgg9IAgIWgIYCBG//fL/6LgBfACAAAoTNAH9AAwAChI0CguIdEF9HxQWLHga0ixmPgAEGJrUBxgYxFw4GtAHuBjieDgawAo4tECICFoSGIgaABoIPTgICFoCGACIKT4RAAgRv/3nv924AIgIWhIYiBoAGgg9OAgIWgIYAIgpPhEABguA9EgRv/3i/9k4AguA9EgRv/3hP9e4Lb1gH9b0aBsGLkgRv/3ev9V4CBG//dT/1HgBfAIALixB/QAIKCxCCAhaEhiIGgAaAD0gABAsSBoAGgg9BAgIWgIYAIgpPhEACBG//da/zbgBfABADizB/SAMCCzASAhaEhiIGgAaCD0+BAhaAhgAiCgZCBoAGgA8AQAaLEgaABoIPAEACFoCGBOSHhEIWyIYyBsA/Cu/xLgAiCk+EQAIEb/9w3/C+AF8BAAQLEH9IAQKLEQICFoSGIgRv/3//696PCBLenwQQNGACAfaD9oJ/BAV9P4AMDM+ABwn2hfuR9oP2gn8IAH0fgEwEfqDAfT+ADAzPgAcA9oAi8M0B9oB/WAch9oB/WEdB9oB/WIdR9oB/WQdgvgH2gH9cByH2gH9cR0H2gH9ch1H2gH9dB20ekSfEfqDAcXYM9qj7GPajdg0fg0wM9qR+oMB9H4MMBH6gwH0vgAwCz0fBxH6gwHF2AnaCfwHwfR+ETAR+oMBydgj2s/sQ9oL7nPa38e0/gAwMz4QHDPaAAvfNDPae+zj2tfs9H4FMDPaEfqDAfR+BDAR+oMB9H4HMBH6gwH0fgkwEfqDAfR+CDAR+oMBwPg/Pjg+DP+///R+DjAR+oMB9H4QMBH6gwH0vgAwN/4YIoM6ggMR+oMBxdgKuDR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMAA4CHgR+oMB9H4IMBH6gwH0vgAwEP2P3gs6ggMR+oMBxdg32q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2CPadP4AMDM+Ehwd+CPa+ex0fgUwM9oR+oMB9H4EMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+MSJDOoIDADgIeBH6gwHF2Aa4NH4FMDPaEfqDAfR+BDAR+oMB9L4AMAs8D8MR+oMBxdg32q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2A64M9pp7OPa+ex0fgkwM9pR+oMB9H4IMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+ESJCPE/CAzqCAxH6gwHF2AP4NH4JMDPaUfqDAfR+CDAR+oMB9L4AMAs9HxcR+oMBxdgj2nT+ADAzPhIcAPg/+cBIAgnn2S96PCBLen4QwRGDUYWRgAn//d6+oBGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsYsShoALkAvwC/tPhEAAIoA9HgaLDxgG8N0bT4RAAUKALRKGgCKAbQtPhEACQoQtEoaAEoP9FDRgAiICEgRgCW//el/AdGL7sAIKBkKUYgRv/3f/4HRu+5qGtYuUNGASICISBGAJb/95L8B0YCICFoSGIj4ChoGLkEIKT4RAAd4ChoASgL0bT4RAAkKAPRBCCk+EQAEuAUIKT4RAAO4LT4RAAUKAPRBCCk+EQABuAkIKT4RAAC4AEnECCgZDhGvej4g/i1BEYNRgAm//cF+gdGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsAsQC/tPhEAAIoJtEoaCC7qGsQu+BosPGAbx7Q4Gw7RgAiICEAkCBG//c8/AZGvrkAIKBkAyAhaEhiKUYgRv/3E/4GRma5CCCk+EQAIGgAaED0QDAhaAhgAuABJhAgoGQwRvi9Len4QwRGDUYWRgAn//e9+YBGtPhEAAEoA9C0+EQAAigk0UNGACIgISBGAJb/9wj8B0b3uU/0fwGR+qHxsfqB8ShoiEBP9H9Ckvqi8rL6gvJpaJFACEOpaAhD6WgIQyFowfgAAgIgpPhEAALgAScQIKBkOEa96PiDLen4QwRGDUYWRgAn//eB+YBGtPhEAAIoOdHgaLDxgG810UNGACIgISBGAJb/98z7B0ZfuyBoAGgg8EBQIWgIYCBogGgg8IBwKWgIQyFoiGAoaUDwQGCpaAhDQPRAYCFowfgAAShpQPBAYKloCENA9EBgIWjB+IAB6GhAHiFoCGRoaCFoiGQEIKT4RAAC4AEnECCgZDhGvej4gy3p+EUERg5GF0YAJf/3NPmARiBoAPFQCh65ASUIIKBkO+C0+EQABCg00SBoAGxAHOBj4GugY2ZjIGgAaCDwQFAhaAhgAL9DRgEiBCEgRgCX//dt+wVGBbEL4GFrSBxgYwh4ivgAAOBrQB7gY+BrACjp0QC/jblDRgEiAiEgRgCX//dV+wVGRbkCICFoSGKk+EQAAuABJRAgoGQoRr3o+IUt6fxNBEYORhdGACX/9+T4AZAgaADxUAogaND4SIAgaND4ELEeuQElCCCgZFLgtPhEAAQoS9EgaABsQBzgY+BroGNmYyBoAGgg8EBQQPCAUCFoCGDgaLDxgG8D0SBowPhIgAzgIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4ELEAvwCXASIGISBGAZv/9wD7BUYFsQvgmvgAEGJrUBxgYxFw4GtAHuBj4GsAKOnRAL+NuQCXASICISBGAZv/9+j6BUZFuQIgIWhIYqT4RAAC4AElECCgZChGvej8jRC1AkYAIBm5ASAII5NkIOCy+EQwBCsZ0RNoG2xbHNNj02uTY1FjE2gbaCPwQFMUaCNgAyMUaGNiGCOi+EQwE2gbaEP04CMUaCNgAuABIBAjk2QQvXC1AkYAIBVoq2wVaNX4EEEZuQEgCCWVZDXgsvhEUAQtLtEVaC1sbRzVY9VrlWNRYxVoLWgl8EBVRfCAVRZoNWADJRZodWIoJaL4RFAVaC1oRfTgJRZoNWDVaLXxgG8C0RVoq2QP4BVo1fgAUQX04GUVsRVoq2QG4BVoxfgQQQLgASAQJZVkcL1wtQRGACW0+EQAAPAIACC5tPhEAADwBABgsyBoAGgg9PgQIWgIYE/0gHCk+EQAIGgAaADwBABosSBoAGgg8AQAIWgIYPZIeEQhbIhjIGwD8L37EuACICFoSGIgaABoQPQAMCFoCGAgaABoQPACACFoCGAC4AElECCgZChGcL1wtQVGrGoAIOBjBCCgZCBoAGgg8AQAIWgIYCBG//ex/3C9cEdwR3C1BUasauBrQAjgY7T4RAAoKAPRIEb/9/L/AuAgRv/37f9wvQFGiGoAIsJjAmgSaCLwBAIDaBpgCmgSaCLwAQILaBpgAmgSaEL0ADIDaBpgcEct6fNBBEYAJiBoAGxFHAGYGLkBJgggoGR34LT4RAAEKHDRIGxAaQi55WMk4CBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggoGQBJhTgaAjgYxHgIGxAabD1AH8M0QXwAwAYuSB5APADABixCCCgZAEmAeCoCOBjAC5H0eBroGMBmGBjIGgAaCDwQFAhaAhgAyAhaEhiGCCk+EQApEh4RCFsyGKjSHhEIWwIY6JIeEQhbEhjACAhbIhjECEgbIFgIGwAaABoIPAQACFsiWgIQyFsCWgIYAGvo2vU+ADADPFQAjloIGwD8GH6IGgAaED0gDAhaAhgIGgAaEDwBAAhaAhgA+D/5wEmECCgZDBGvej8gS3p80cERgAmIGgAbEUcIGjQ+EiAIGjQ+BChAZgYuQEmCCCgZI7gtPhEAAQoctEgbEBpCLnlYyTgIGxAabD1gH8N0QXwAQAYuSB5APABABixCCCgZAEmFOBoCOBjEeAgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIIKBkASYB4KgI4GMALl7R4GugYwGYYGMgaABoIPBAUEDwgFAhaAhgAyAhaEhiKCCk+EQAX0h4RCFsyGJeSHhEIWwIY11IeEQhbEhjACAhbIhjACEgbIFgIGwAaABoIPAQACFsiWgIQyFsCWgIYAGvo2s6aNT4AMAM8VABIGwD8NH5IGgAaED0gDAhaAhg4Giw8YBvBNEgaMD4SIAN4BPgIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4EKEgaABoQPAEACFoCGAC4AEmECCgZDBGvej8hy3p+E8ERg1GFkYAJ/73Yf6CRiBo0PhIgCBo0PgQsbT4RAAEKErR6Giw9YAPRtFTRgAiICEgRgCW//em+AdGAC8/0ShoIWjB+IgAaGghaMH4gAAoaSFowfiQANXpAgEIQ0DwAFAhaAloIfBDUQhDIWgIYOBosPGAbwPRIGjA+EiADOAgaND4AAEA9OBgGLEgaMD4SIAC4CBowPgQsVNGASIIISBGAJb/92/4B0ZPuQggIWhIYgIgpPhEAALgAScQIKBkOEa96PiPwMD/8MD///BR9v//M////wf////Z/v//E/7//+f9//+5/f//Len4RQRGDUYAJv737P2ARiBoh2wgaND4EKG0+EQABChB0eBsQ0YAIiAhAJAgRv/3NfgGRk67KGghaMH4iABoaCFowfiAAChpIWjB+JAA1ekCAQhDQPAAUCFoCWgh8ENRCEMhaAhgCSAhaEhiSCCk+EQAIGgAaED0ECAhaAhg4Giw8YBvAtEgaIdkD+AgaND4AAEA9OBgELEgaIdkBuAgaMD4EKEC4AEmECCgZDBGvej4hfi1BEYNRgAm/veU/QdGtPhEAAQoJ9HgbDtGACIgIQCQIEb+9+L/BkYGu4ggpPhEAChoCCgM0WhoIWjB+DABECAhaEhiIGgAaED0gBAhaAhgIGgAaP5JCEApaEHwQFEIQyFoCGAC4AEmECCgZDBG+L34tQRGACX+9139Bka0+EQAAPAIACC5tPhEAADwBACQsyBoAGgA8AQAYLEgaABoIPAEACFoCGAgbAPw5PgFRg2xBCCgZCBoAGhA8AIAIWgIYOBsM0YBIgIhAJAgRv73jf8FRqW5AiAhaEhi4GwzRgAiICEAkCBG/veA/wVGPbkCIKT4RAAD4P/nASUQIKBkKEb4vTC1AkYAILL4RDAD8AgDi7lRYBNoG2gj9PhUU2hbHk/0+FWV+qX1tfqF9atAHEMTaBxgAuABIBAjk2QwvQFGCGgAaAD0+FBP9PhSkvqi8rL6gvLQQEAccEcBRohscEcBRrH4RABwR/C1BEYAIAAiACUAIxSxAiwA3Am5ASBg4AAmDmHOYI5gTmAOYAEsAdEAJQLgAiwA0a5NACNP4K1OVvgjIALwAQY+sQLwAgYF8AIHvkIB0V4cDmAC8BAGPrEC8CAGBfAgB75CAdFeHE5gAvSAdj6xAvQAdgX0AHe+QgHRXhyOYAL0gDaOsQL0gCYF9IAnvkIL0QL0ADYmuV4cRvSANs5gA+BeHEbwgHbOYALwgHaOsQLwgGYF8IBnvkIL0QLwAHYmuV4cRvSANg5hA+BeHEbwgHYOYV4c87ICK63b8L0t6fBNjLCCRgxGT/AAC/73b/wLkAAnuEYAJQAmfkna+AAAiEIC0QC/ASYB4AElACYAJxDgB+uHAgGrA+uCAXoc0LL/92//ILFP8AELCCDK+EgAeBzHsgIv7Nu78QAPftFtSABoAPABADixakgAaCDwAQBoSQhgSPABCGdIAGgA8AEAOLFlSABoIPABAGNJCGBI8AIIBeuFAAGpUfggAAAobdBbSAXrhQEBqlL4IRBJHlD4IQAg8AECVkgF64UBAatT+CEQSR5A+CEgBeuFAQGqAuuBAUloSR5Q+CEAIPAQAkxIBeuFAQPrgQFJaEkeQPghIAXrhQEBqgLrgQGJaEkeUPghACD0gHJCSAXrhQED64EBiWhJHkD4ISAF64UBAaoC64EBCXsB8A8BSR5Q+CEAIPSAMjdIBeuFAQPrgQEJewHwDwFJHkD4ISAF64UBAaoC64EBCXwB8A8BSR4A4HjhUPghACDwgHIqSAXrhQED64EBCXwB8A8BSR5A+CEgBuuGAQGqUvghECBoiEIf0AbrhgEC64EBYGhJaIhCF9AG64YBAuuBAaBoiWiIQg/QBuuGAQLrgQHgaMloiEIH0AbrhgEC64EBIGkJaYhCdtEQSAbrhgEBqlL4IRBJHlD4IQAg8AECC0gG64YBAatT+CEQSR5A+CEgBuuGAQGqAuuBAUloSR5Q+CEACeD3///PIgIEBAQcBlAAEACgABQAoCDwEAKNSAbrhgED64EBSWhJHkD4ISAG64YBAaoC64EBiWhJHlD4IQAg9IByg0gG64YBA+uBAYloSR5A+CEgBuuGAQGqAuuBAQl7AfAPAUkeUPghACD0gDJ4SAbrhgED64EBCXsB8A8BSR5A+CEgBuuGAQGqAuuBAQl8AfAPAUkeUPghACDwgHJsSAbrhgED64EBCXwB8A8BSR5A+CEgZ0ghaEkeUPghACDwAwACIZH6ofGx+oHxBfoB8UHwAQEIQ15JImhSHkH4IgAIRmFoSR5Q+CEAIPAwACAhkfqh8bH6gfEF+gHxQfAQAQhDU0liaFIeQfgiAAhGoWhJHlD4IQAg9EBxT/QAcJD6oPCw+oDwBfoA8ED0gHABQ0hIomhSHkD4IhDgaAD0gDDYsUNIIXsB8A8BSR5Q+CEAIPTgIE/0gCGR+qHxsfqB8QX6AfFB9IAxCEM5SSJ7AvAPAlIeQfgiABrgNUghewHwDwFJHlD4IQAg8OBhT/CAYJD6oPCw+oDwBfoA8EDwgHABQytIInsC8A8CUh5A+CIQIGkA9IAw2LEmSCF8AfAPAUkeUPghACD04CBP9IAhkfqh8bH6gfEF+gHxQfRAMQhDHEkifALwDwJSHkH4IgAa4BhIIXwB8A8BSR5Q+CEAIPDgYE/wgGGR+qHxsfqB8QX6AfFB8EBxCEMOSSJ8AvAPAlIeQfgiAAjwAQAosQpIAGhA8AEACEkIYAjwAgAosQZIAGhA8AEABEkIYFhGDLC96PCNBBwGUAAQAKAAFACgELWasARGACAGkAeQQPL5YAiQBCAJkBAgCpAAIA2QEZAUkBeQGJAZkAggC5BP8P8yBqn+SEhE/vem/xCxASAasBC9AiABkAKQACADkBAgBZCABASQQPL6UAiQACAMkE/0gGANkE/0QFAOkE/wgGAUkAIgFZCAAg+QAAQWkIAAGJAEIBeQAL8BIP73CPpP8P8yBqnmSEhE/vd2/wixASDO50/w/zJpRuFISET/9wL5CLEBIMTnnfgAAAKZCEABmYhC4dEAILvnMLWbsARGDUYAIAeQCJBA8vpQCZAEIAqQECALkAAgDZBP9IBgDpBP9EBQD5AAIBKQT/CAYBWQAiAWkAYgGJAAIBqQCCAMkAACEJAABBeQgAAZkAAgApABIAOQACAEkBAgBpCABAWQAL8BIP73tPlP8P8yB6m8SEhE/vci/xCxASAbsDC9T/D/MgGptkhIRP/3rfgIsQEg8+ed+AQAA5kIQAKZiELg0QAg6ucwtZuwBUYMRgAgB5AIkAyQT/RAUA+QACAQkBKQF5AZkBqQBJAQIAaQgAQFkAEsddEGIAmQASAKkAAgC5AOkBWQGJBCHgepnUhIRP735P4QsQEgG7AwvQIgApADkAUgCZBP8IBwFZABIBaQgh4HqZNISET+99D+CLEBIOrnT/D/MgKpjkhIRP/33/oIsQEg4OdyIAmQT/RAcA2QT/SAcA6QByCN+AQAT/D/Mgepg0hIRP73sf4IsQEgy+dP8P8yAal+SEhE/vft/wixASDB5wYgCZAAIA6QFZBCHgepd0hIRP73mf4IsQEgs+cFIAmQT/CAcBWQT/D/MgepcEhIRP73iv4IsQEgpOdP8P8yAqlrSEhE//eZ+hCxASCa51zgciAJkAAgDZBP9IBwDpACII34BADCHgepYUhIRP73bP4IsQEghudP8P8yAalcSEhE/veo/wixASB85ygg/vfn+E/w/zFWSEhE//f2/gixASBw50fyjhAJkAQgCpAQIAuQgAEOkAAEFZAGIBiQAiAWkAAgjfgEAAggDJAAAhCQAAQXkIAAGZBP8P8yB6lESEhE/vcy/gixASBM50/w/zIBqT9ISET+977/CLEBIELnnfgEAAIoddABIDznOEhIRP/3WP4IsQEgNedH8o0gCZAEIAqQECALkAAgDZBP9IBgDpAABBWQAiAWkAAgGJCN+AQAjfgFAAggDJAAAhCQAAQXkE/w/zIHqSVISET+9/X9CLEBIA/nT/D/MgGpIEhIRP73Mf8IsQEgBecoIP73cPgFIAmQASAKkAAgC5AOkE/wgHAVkAEgFpAAIBiQDJAQkBeQApABIAOQgh4HqRBISET+98v9CLEBIOXmT/D/MgKpC0hIRP/32vkIsQEg2+ZxIAmQACANkE/0gHAOkE/w/zIHqQNISET+97D9ILEBIMrmEAAAAA7gT/D/MgGp/khIRP73Of8IsQEgvead+AQACLEBILjmACC25hC1mrAERgAgBpAHkGYgCJABIAmQACAKkAuQDZARkBSQF5AYkBmQQh4Gqe1ISET+94D9ELEBIBqwEL2ZIAiQT/D/Mgap5khIRP73c/0IsQEg8ecFIAiQT/CAcBSQASAVkAAgFpABkAEgApAAIAOQECAFkIAEBJBP8P8yBqnYSEhE/vdX/QixASDV50/w/zIBqdNISET/92b5CLEBIMvnACDJ5wC1h7AAv85IwGxA9IAQzEnIZAhGwGwA9IAQAZAAvwC/AL8IRgBtQPSAcAhlCEYAbQD0gHABkAC/AL8IRgBrQPSAcAhjCEYAayD0gHAIYwC/CEaAbUDwgFCIZQhGgG0A8IBQAZAAvwC/t0hAaED0AHC1SUhgAL+ySMBsQPBAALBJyGQIRsBsAPBAAAGQAL8AvwC/CEbAbEDwgADIZAhGwGwA8IAAAZAAvwC/AL8IRsBsQPSAcMhkCEbAbAD0gHABkAC/AL+IFAKQAiADkAEgBJADIAWQBSAGkAKpm0gB8J//T/QAQAKQAqmYSAHwmP9P9GRgApAAIASQAqmUSAHwj/9P9OBgApACqZJIAfCI/0/0wGACkAKpjEgB8IH/B7AAvQC1hbCMSIVJSUQIYAhG/vdX+hCxASAFsAC9//dh/wQgf0lJREhgACF9SEhEgWBP8IBgkPqg8LD6gPF4SEhEAWECIUFhACGBYcFhAWICIUFiACGBYk/wgHHBYAkBwWIAIQFj/veR+QixASDU5wIgAJABkHFIBJBxSAOQAiACkMIeaUZmSEhE//d9+gixASDC52NISET/99P+CLEEILvnASFfSEhE//dZ/QixASCz5wAgsecAtYWwT/QWQVtIAvAG+E/04GFbSALwAfhP9GRhV0gB8Pz/ACABkE/0gFAAkAAgApADkGlGUEgB8An/ASABkAAgApBP9ABAAJBpRktIAfD+/gAiT/QAQUhIAvB4+ERIAGtA9IBwQkkIYwhGAGsg9IBwCGMIRgBtIPSAcAhlBbAAvRC1Q0g5SUlECGAIRv/3r/kCKAbQNUhIRP/3MfkIsQEgEL0AITFISET/9/78CLEBIPbnLkhIRP73qvkIsQEg7+f/957/ACDr53C1lLAERg1GFkYAIACQAZAEIAOQECAEkAaVgAEHkE/0QFAIkAAgC5BP8IBgDpAPlgYgEZAAIBOQTvYRYAKQCCAFkAACCZAABBCQgAASkE/w/zJpRhNISET+9837ELEBIBSwcL1P8P8yIUYOSEhE/vdY/QixASDz5wAg8ect6fBFlbCCRg1GkEbossD1gHZGRQDZRkYsRgXrCAcAIAGQApAU4AAAEAAAAAAQAkAAcABAABgASAAgAEgAHABIABQAoAIAAAECAAEAABAAoEHy7SADkAQgBJAQIAWQgAEIkE/0QFAJkAAgDJBP8IBgD5AAIBKQFJAIIAaQAAIKkAAEEZCAABOQAL8HlBCW+UhIRP/3r/sYsQEgFbC96PCFT/D/MgGp80hIRP73ZvsIsQEg8udP8P8yUUbuSEhE/vei/AixASDo50/w/zHpSEhE//fz+wixASDf5zREskQE9YBwuEIB2TgbAeBP9IBwBka8QsrTACDQ5xC1lLAERgAgAJABkE32I0ACkAQgA5AQIASQBpSAAQeQT/RAUAiQACALkA6QEZASkBOQCCAFkAACCZDQSEhE//dd+xCxASAUsBC9T/D/MmlGykhIRP73FfsIsQEg8+dP9PphxkhIRP/3rPsIsQEg6ucAIOjnELWUsARGtPWATwLTASAUsBC9ACAAkAGQQvLeEAKQBCADkBAgBJAgAwaQT/SAYAeQT/RAUAiQACALkA6QEZASkBOQCCAFkAACCZCvSEhE//cb+wixASDa50/w/zJpRqpISET+99T6CLEBINDnACDO5wC1lbAAIAGQApBG8p8AA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkJtISET/9/P6ELEBIBWwAL1P8P8yAamVSEhE/ver+gixASDz55NJkUhIRP/3Q/sIsQEg6+cAIOnnALWVsAAgAZACkEL21DADkAQgBJAQIAWQACAHkE/0gGAIkE/0QFAJkAAgDJBP8IBgD5ACIBCQBiASkAAgFJAIIAaQAAIKkAAEEZCAABOQT/D/MgGpeEhIRP73cPoQsQEgFbAAvU/w/zJpRnJISET+9/v7CLEBIPPnnfgAAADwYAAIsQEg7Oed+AAAAPAMAAixCCDl50Dy+lADkE/w/zIBqWVISET+90r6CLEBINjnT/D/MmlGYEhIRP731vsIsQEgzued+AAAAPABAAixAiDH5wAgxecBRk/wgGAIYIASSGCAEYhggBDIYIACCGEAIHBHALWXsFBISET/9136ELEBIBewAL0BIAOQACAEkAQgBpAQIAeQgAEKkE/0QFALkAAgDpBP8IBgEZAGIBSQACAWkE72EWAFkAggCJAAAgyQAAQTkIAAFZBP8P8yA6k6SEhE/vf0+QixASDS5wIgA5BB8u0gBZAAIBSQQh4DqTJISET+9+T5CLEBIMLnACABkAGpLUhIRP73wv4IsQEguOcAILbnALWVsP/3M/8CKCXRACABkAKQS/JPAAOQBCAEkBAgBZAAIAiQDJAPkBKQE5AUkAggBpBP8P8yAakaSEhE/ve1+RCxASAVsAC9//cR/wgoAdEAIPfnASD15wAg8+cAtZWw//cF/wgoKdEAIAGQApBD8s8AA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkE/w/zIBqQNISET+94f5MLEBIBWwAL0QAAAA4JMEAP/33/4CKAHRACDz5wEg8ecAIO/nALWVsAAgAZACkEv2RhADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQT/D/MgGpFUhIRP73WfkQsQEgFbAAvQAg++cAtZWwACABkAKQ/yADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQT/D/MgGpBUhIRP73OPkQsQEgFbAAvQAg++cAABAAAAD7SABoAPTAYLD1gG8C0U/0gGBwR/ZIgDAAaAD0gHCw9YB/AtFP9ABw8+cAIPHnAkYAIYq77kgAaAD0wGCw9YBvK9HrSIAwAGgg9IBw6EvD+IAAGEYAaCD0wGBA9ABwGGDkSEhEAGjkS7D78/AyIwD7A/EA4EkeMbHdSEBpAPSAYLD1gG/20NpIQGkA9IBgsPWAb1HRAyBwRwjg1UiAMABoIPSAcNJLw/iAAEXgsvUAfzrRz0gAaAD0wGCw9YBvKtHLSIAwAGhA9IBwyUvD+IAAGEYAaCD0wGBA9ABwGGDFSEhEAGjES7D78/AyIwD7A/EA4EkeMbG+SEBpAPSAYLD1gG/20LpIQGkA9IBgsPWAbxLRAyC/57ZIgDAAaED0gHCzS8P4gAAH4LFIAGgg9MBgQPSAYK5LGGAAIKznrEnJaCH0AHEBQ6pK0WARRsloQfSAcdFgcEemSMBoIPSAcKRJyGBwR6JIQGhA9IBgoElIYHBHn0hAaCD0gGCdSUhgcEebSEBoQPQAcJlJSGBwR5hIQGgg9ABwlklIYHBHlEiAaED0AECSSYhgcEeRSIBoIPQAQI9JiGBwRwJGCSpx0t/oAvAFFCErNT9JU2AAiEgAaiH0gEMYQ4ZLGGIYRkBqIfQgQ5hDgktYYl3ggUiAaghDf0uYYhhGwGoh8BADmEN8S9hiUOB6SABrCEN5SxhjGEZAa4hDWGNG4HVIgGsIQ3RLmGMYRsBriEPYYzzgcEgAbAhDb0sYZBhGQGyIQ1hkMuBrSIBsCENqS5hkGEbAbIhD2GQo4GZIAG0IQ2VLGGUYRkBtiENYZR7gYUiAbYuyGENfS5hlGEbAbYuymENcS9hlEeBbSABuwfMLAxhDWEsYZhhGQG7B8wsDmENVS1hmAuD/5wEgcEcAvwAg++cCRgkqQdLf6ALwBQ0TGR8lKzE4AEtIAGoh9IBDmENJSxhiNOBHSIBqiENGS5hiLuBESABriENDSxhjKOBBSIBriENAS5hjIuA+SABsiEM9SxhkHOA7SIBsiEM6S5hkFuA4SABtiEM3SxhlEOA1SIBti7KYQzNLmGUJ4DJIAG7B8wsDmEMvSxhmAeABIHBHAL8AIPvnAkYJKnfS3+gC8AUUICo0PkhZZgAmSEBqIfQgQxhDJEtYYhhGAGoh9IBDmEMgSxhiY+AfSMBqIfAQAxhDHEvYYhhGgGqIQ5hiV+AZSEBrCEMXS1hjGEYAa4hDGGNN4BRIwGsIQxJL2GMYRoBriEOYY0PgD0hAbAhDDUtYZBhGAGyIQxhkOeAKSMBsCEMIS9hkGEaAbIhDmGQv4AVIQG0IQwNLWGUYRgBtiEMYZSXgAAAAcABABAAAAEBCDwD+SMBti7IYQ/xL2GUYRoBti7KYQ/lLmGUR4PhIQG7B8wsDGEP1S1hmGEYAbsHzCwOYQ/JLGGYC4P/nASBwRwC/ACD75wJGCSpD0t/oAvAFDRUbISctMzoA6EhAaiH0IEOYQ+ZLWGI24ORIwGoh8BADmEPiS9hiLuDgSEBriEPfS1hjKODdSMBriEPcS9hjIuDaSEBsiEPZS1hkHODXSMBsiEPWS9hkFuDUSEBtiEPTS1hlEODRSMBti7KYQ89L2GUJ4M5IQG7B8wsDmEPLS1hmAeABIHBHAL8AIPvnx0iAaED0gGDFSYhgcEfESIBoIPSAYMJJiGBwR8BIgGhA9IBwvkmIYHBHvUiAaCD0gHC7SYhgcEe5SABoQPAQALdJCGBwR7ZIAGgg8BAAtEkIYHBHskhAaEDwEACwSUhgcEevSEBoIPAQAK1JSGBwR6tIQGhA8CAAqUlIYHBHqEhAaCDwIACmSUhgcEekSEBoQPBAAKJJSGBwR6FIQGgg8EAAn0lIYHBHnUhAaEDwgACbSUhgcEeaSEBoIPCAAJhJSGBwRwFGCGgQKAbQIChS0EAofNCAKHvR7OCSSABoIPAIAJBKEGAQHwBoIPAIABIfEGCMSAgwAGgg8AgAiUoIMhBgEB8AaCDwCAASHxBgSGgA9IAwsPWAPwfRgkgAHwBoQPAIAH9KEh8QYEhoAPQAMLD1AD8F0XtIAGhA8AgAeUoQYAh5APABADixdkgAHQBoQPAIAHNKEh0QYAh5APACAAIoB9FvSAgwAGhA8AgAbUoIMhBg8eBrSABoIPAQAGlKEGAQHwBoIPAQABIfEGBlSAgwAGgg8BAAYkoIMhBgEB8AaCDwEAASHxBgSGgA9IAwsPWAPwfRW0gAHwBoQPAQAFhKEh8QYEhoAPQAMAHgI+DB4LD1AD8F0VJIAGhA8BAAUEoQYAh5APABADixTUgAHQBoQPAQAEtKEh0QYAh5APACAAIoB9FHSAgwAGhA8BAAREoIMhBgoOBCSABoIPAgAEBKEGAQHwBoIPAgABIfEGA8SAgwAGgg8CAAOkoIMhBgEB8AaCDwIAASHxBgSGgA9IAwsPWAPwfRMkgAHwBoQPAgADBKEh8QYEhoAPQAMLD1AD8F0StIAGhA8CAAKUoQYAh5APABADixJkgAHQBoQPAgACRKEh0QYAh5APACAAIoB9EgSAgwAGhA8CAAHUoIMhBgUuAbSABoIPBAABlKEGAQHwBoIPBAABIfEGAVSAgwAGgg8EAAE0oIMhBgEB8AaCDwQAASHxBgSGgA9IAwsPWAPwfRC0gAHwBoQPBAAAlKEh8QYEhoAPQAMLD1AD8F0QRIAGhA8EAAAkoQYAh5A+AAcABAJAQBQADwAQAosXRIAGhA8EAAckoQYAh5APACAAIoB9FuSAAdAGhA8EAAbEoSHRBgAeABIHBHAL8AIPvnaEgAaED0gEBmSQhgcEcAv2RIAGgg9IBAYkoQYGJISEQAaGJKsPvy8DIiAPsC8QDgSR4xsVtIQGkA9ABwsPUAf/bQWEhAaQD0AHCw9QB/AdEDIHBHACD851JJCWgh8AcBUEoRYFJJCWhB8AQBUEoRYAEoAdEwvwLgQL8gvyC/TEkJaCHwBAFKShFgcEdFSQloIfAHAUkcQ0oRYEVJCWhB8AQBQ0oRYAEoAdEwvwLgQL8gvyC/PkkJaCHwBAE8ShFgcEc4SQloIfAHAYkcNUoRYDdJCWhB8AQBNUoRYAEoAdEwvwLgQL8gvyC/MUkJaCHwBAEvShFgcEcqSABoIPAHAAAdKEkIYCpIAGhA8AQAKEkIYAC/AL8wv3BHcEdwR3BHcEcQtR5IFDgAaAD0gDAwsfz3qf5P9IAwGUkUOQhgGEgMMABoAPAIACix//fp/wggE0kMMQhgEkgMMABoAPAQACix//fc/xAgDUkMMQhgDEgMMABoAPAgACix//fP/yAgB0kMMQhgBkgMMABoAPBAACix//fC/0AgAUkMMQhgEL0oBAFAAHAAQAQAAABAQg8AEO0A4PpIAGhA8AEA+EkIYADgAL/2SABoAPACAAAo+NDzSABoIPDwAEDwYADwSQhgACCIYAhGAGjuSQhA7EkIYAAgyGAIRsBoQPSAUMhgACAIYQhGAGlA9IBQCGEAIEhhCEZAaUD0gFBIYQhGAGgg9IAgCGAAIIhh30jgSUlECGBwR/C1ACEAIwAkAiUCIgAg1062aAbwDAZesdVOtmgG8AwGDC4f0dJO9mgG8AMGAS4Z0c9ONmgG8AgGLrnMTpQ2NmjG8wMhA+DJTjZoxvMDEctOfkRW+CEQxU62aAbwDAaGuQhGDuDCTrZoBvAMBgQuAdHESAbgvk62aAbwDAYILgDRwUi6TrZoBvAMBgwuNtG3TvZoBvADBLVO9mjG8wMWchwBLBnQAiwC0AMsFNEJ4LROtvvy9q5P/2jH8wYnBvsH8xPgsE62+/L2qU//aMfzBicG+wfzCeAAv7H78vakT/9ox/MGJwb7B/MAvwC/oE72aMbzQWZ2HHUAs/v18PC9+LUERgAmACWZSIBtAPCAUBix//dB+gZGFuAAv5RIgG1A8IBQkkmIZQhGgG0A8IBQAJAAvwC///cv+gZGjEiAbSDwgFCKSYhltvUAfwfRgCwM2aAsAdkCJQjgASUG4IAsAdMCJQLgcCwA0QElh0gAaCDwDwAoQ4VJCGAIRgBoAPAPAKhCAdABIPi9ACD85/i1BEYAJSB4APAQABAocNF0SIBoAPAMAAAoa9FxSABoAPACABixoGkIuQEg+L1sSCFqAGgA8AgAILFpSABoAPDwAAXgZ0iUMABoAPRwYAAJgUIf2SBq//eM/wixASDl5wC/X0gAaEDwCABdSQhgCEYAaCDw8AAhaghDWUkIYAC/CEZAaCD0f0DhaUDqASBUSUhgHuAAv1JIAGhA8AgAUEkIYAhGAGgg8PAAIWoIQ0xJCGAAvwhGQGgg9H9A4WlA6gEgR0lIYCBq//dT/wixASCs5//3z/5CSYlowfMDEUhKekRRXMhAQUlJRAhgDyAB8Af9SuCgaYCzOkgAaEDwAQA4SQhg/Pcy/QVGBuD89y79QBsCKAHZAyCI5zFIAGgA8AIAACjy0AC/LkgAaEDwCAAsSQhgCEYAaCDw8AAhaghDKEkIYAC/CEZAaCD0f0DhaUDqASAjSUhgF+D/5yFIAGgg8AEAH0kIYPz3AP0FRgbg/Pf8/EAbAigB2QMgVucYSABoAPACAAAo8tEgeADwAQAAKH7QE0iAaADwDAAIKAvQEEiAaADwDAAMKA7RDUjAaADwAwADKAjRCkgAaAD0ADCIs2BoeLsBIDDnAL9gaLD1gD8Y0QNIAGhA9IAwAUkIYC3gABACQP/0/uoACT0ABAAAAK4cAAAAJPQAABJ6AAAgAkB6GgAAYGiw9aAvDNH9SABoQPSAIPtJCGAIRgBoQPSAMAhgC+A04PdIAGgg9IAw9UkIYAhGAGgg9IAgCGAAv2BomLH895L8BUYI4Pz3jvxAG0HyiDGIQgHZAyDm5ulIAGgA9AAwACjw0BLg/Pd+/AVGCOD893r8QBtB8ogxiEIB2QMg0ubfSABoAPQAMAAo8NEgeADwAgACKF7R2kiAaADwDAAEKAvQ10iAaADwDAAMKBjR1EjAaADwAwACKBLR0UgAaAD0gGAYseBoCLkBIKzmzEhAaCDw/kAhfEDqAWDJSUhgOeDgaACzxkgAaED0gHDESQhg/Pc5/AVGBuD89zX8QBsCKAHZAyCP5r5IAGgA9IBgACjy0LtIQGgg8P5AIXxA6gFgt0lIYBbgtkgAaCD0gHC0SQhg/PcY/AVGBuD89xT8QBsCKAHZAyBu5q1IAGgA9IBgACjy0SB4APAIAAgoNtFgadCxp0iUMABoQPABAKRJwfiUAPz3+PsFRgbg/Pf0+0AbAigB2QMgTuadSJQwAGgA8AIAACjx0BngmUiUMABoIPABAJdJwfiUAPz33fsFRgbg/PfZ+0AbAigB2QMgM+aQSJQwAGgA8AIAACjx0SB4APAEAAQob9EAJolIgG0A8IBQcLkAv4ZIgG1A8IBQhEmIZQhGgG0A8IBQAJAAvwC/ASaASABoAPSAcLC5fkgAaED0gHB8SQhg/Pem+wVGBuD896L7QBsCKAHZAyD85XVIAGgA9IBwACjy0AC/oGgBKAjRb0iQMABoQPABAG1JwfiQACHgoGgFKA/RaUiQMABoQPAEAGdJwfiQAAhG0PiQAEDwAQDB+JAADuBhSJAwAGgg8AEAX0nB+JAACEbQ+JAAIPAEAMH4kAAAv6BoqLH892P7BUYJ4Pz3X/tAG0HyiDGIQgLZAyC35STgUUiQMABoAPACAAAo7tAT4Pz3TfsFRgjg/PdJ+0AbQfKIMYhCAdkDIKHlR0iQMABoAPACAAAo79EBLgXRQkiAbSDwgFBASYhlAL8geADwIAAgKDbRYGrQsTtImDAAaEDwAQA5ScH4mAD89yH7BUYG4Pz3HftAGwIoAdkDIHflMkiYMABoAPACAAAo8dAZ4C5ImDAAaCDwAQArScH4mAD89wb7BUYG4Pz3AvtAGwIoAdkDIFzlJEiYMABoAPACAAAo8dGgavCzIEiAaADwDAAMKHXQoGoCKFPRG0gAaCDwgHAZSQhg/Pfj+gVGBuD899/6QBsCKAHZAyA55RNIAGgA8ABwACjy0SBrQB4BAWBrQeoAIOFqCEOhjwEiwutRAUDqQVFAIABdwutQAEHqQGE4IABdQerAYARJyGAIRgBoQPCAcAXgTOAAAAAQAkAAcABACGAIRsBoQPCAcMhg/Pen+gVGBuD896P6QBsCKAHZAyD95PdIAGgA8ABwACjy0C/g80gAaCDwgHDxSQhgCEYAaADwAGBIuQhGAGgA8ABQILkIRsBoIPADAMhg6UjAaOlJCEDnSchg/Pd6+gVGB+AN4Pz3dfpAGwIoAdkDIM/k4EgAaADwAHAAKPLRAeABIMbkACDE5PC1ACIAIwAkAiUCIQAg1072aAbwAwYBLhLR1E42aAbwCAYuudFOlDY2aMbzAyID4M5ONmjG8wMSzk5+RFb4IiDKTvZoBvADBMhO9mjG8wMWcRwBLBnQAiwC0AMsFNEJ4MVOtvvx9sFP/2jH8wYnBvsH8xPgwU62+/H2vE//aMfzBicG+wfzCeAAv7L78fa3T/9ox/MGJwb7B/MAvwC/s072aMbzQWZ2HHUAs/v18PC9LenwQQRGDUYAJgAnsEawSABoAPAPAKhCD9KtSABoIPAPAChDqkkIYAhGAGgA8A8AqEIC0AEgvejwgSB4APABAAAobtBgaAMoI9GcSABoAPAAcAi5ASDu5//3ev8HRp1Ih0IG2SB4APACAAIoAdGgaCCxkkiAaADw8ACgu49IgGgg8PAAQPCAAIxJiGBP8IAIKeBgaAIoBtGISABoAPQAMIi5ASDH52BoMLmESABoAPACAEC5ASC+54BIAGgA9IBgCLkBILfn//cs+wdGgUiHQgnZekiAaCDw8ABA8IAAd0mIYE/wgAh1SIBoIPADAGFoCENySYhg/PeQ+QZGYGgDKBDRCOD894n5gBtB8ogxiEIB2QMgj+dpSIBoAPAMAAwo8NE24GBoAigQ0Qjg/Pd1+YAbQfKIMYhCAdkDIHvnX0iAaADwDAAIKPDRIuBgaIC5COD892L5gBtB8ogxiEIB2QMgaOdVSIBoAPAMAAAo8NEP4Ajg/PdR+YAbQfKIMYhCAdkDIFfnTUiAaADwDAAEKPDRIHgA8AIAAigI0UdIgGgg8PAAoWgIQ0RJiGAI4LjxgA8F0UFIgGgg8PAAP0mIYENIAGgA8A8AqEIO2UBIAGgg8A8AKEM+SQhgCEYAaADwDwCoQgHQASAl5yB4APAEAAQoB9ExSIBoIPTgYOFoCEMuSYhgIHgA8AgACCgI0StIgGgg9GBQIWlA6sEAJ0mIYP/3f/olSYlowfMDESpKekRRXMhAKUlJRAhgDyAB8Lf4ACD45nC1hrAGRg1GFEYAvxpIwGxA8AEAGEnIZAhGwGwA8AEAAJAAvwC/iBUBkAIgApAEkAAgA5AFkAGpT/CQQADwEPkNSIBoIPD+QEXqBAEIQwpJiGAGsHC9EEhIRABocEcAtf/3+f8ESYlowfMCIQtKekRRXMhAAL0AAAAQAkD//+7+lhQAAAAk9AAAEnoAACACQAC0xATaEQAABAAAAGYRAAAAtf/32P9rSYlowfPCIWpKekRRXMhAAL0/IQFgZUkJaAH0gCGx9YAvA9FP9KAhQWAM4GBJCWgB9IAxsfWAPwPRT/SAMUFgAeAAIUFgWUkJaAHwAQERsQEhgWEB4AAhgWFUSUlowfMHIcFhUkkJaAHw8AEBYk9JCWgB9IBxsfWAfwPRT/SAccFgAeAAIcFgSUlJaMHzBmEBYUZJkDEJaAHwBAEEKQLRBSGBYArgQUmQMQloAfABARGxASGBYAHgACGBYDxJlDEJaAHwAQERsQEhQWEB4AAhQWE2SZgxCWgB8AEBEbEBIUFiAeAAIUFiMUkJaAHwgHGx8YB/AtECIYFiAeABIYFiK0nJaAHwAwLCYihJyWjB8wMRSRwBYyVJyWjB8wYiQmMjSclowfNBUUkcSgDCYx9JyWjB80FhSRxKAAJkHEnJaMoOgmNwRw8iAmAYSpJoAvADAkJgFkqSaALw8AKCYBNKkmgC9OBiwmARSpJoAvRgUtIIAmEQShJoAvAPAgpgcEcLSABoQPQAIAlJCGBwR3BHELUGSMBpAPSAcLD1gH8F0f/39f9P9IBwAUkIYhC9ABACQCQRAAAAIAJAeLUCRgAjACQAINrgASaeQA1oBeoGBAAsctBNaAItAtBNaBItE9HeCALxIAVV+CYAXQfuDg8ltUCoQ14H9g4NabVAKEPeCALxIAVF+CYAEGheAAMltUCoQw15BfADBV4AtUAoQxBgTWgBLQjQTWgCLQXQTWgRLQLQTWgSLRPRkGheAAMltUCoQ14AzWi1QChDkGBQaAElnUCoQw15xfMAFZ1AKENQYNBoXgADJbVAqENeAI1otUAoQ9BgTWgF8IBVtfGAX3zRAL+lTS1uRfABBaNONWY1Ri1uBfABBQCVAL8Av0/qtjWeCFX4JgCdBy4PDyW1QKhDsvGQTwLRACUk4F7gmE2qQgHRASUe4JZNqkIB0QIlGeCVTapCAdEDJRTgk02qQgHRBCUP4JJNqkIB0QUlCuCQTapCAdEGJQXgj02qQgHRByUA4Aglngc2D7VAKEOLTZ4IRfgmAIpNKGigQ01oBfSANbX1gD8A0SBDhU0oYC0dKGigQ01oBfQANbX1AD8A0SBDf00tHShgLR0oaKBDTWgF9IAVtfWAHwDRIEN4TQg1KGAtHShooENNaAX0ABW19QAfANEgQ3JNDDUoYFscDWjdQAAtf/Qgr3i98LULRgAhACIAJITgASWNQAXqAwIAKn3QBWhPAAMmvkA1QwVgzggA8SAFVfgmUE4H9w4PJr5AtUPPCADxIAZG+CdQhWhPAAMmvkC1Q4VgRWgBJo5AtUNFYMVoTwADJr5AtUPFYFNNjghV+CZAjQcuDw8ltUAsQLDxkE8B0QAlI+BFTahCAdEBJR7gQ02oQgHRAiUZ4EJNqEIB0QMlFOBATahCAdEEJQ/gP02oQgHRBSUK4D1NqEIB0QYlBeA8TahCAdEHJQDgCCWOBzYPtUClQiDRjQcuDw8lBfoG9DVNjghV+CZgpkOPCEX4J2AyTS1olUMwTjVgNR0taJVDNh01YDUdLWiVQzYdNWA1HS1olUM2HTVgSRwj+gH1AC1/9Hav8L0CRhNpC0ALsQEgAOAAIHBHCrGBYQDggWJwR0JpSkBCYXBHCLUCRk/0gDAAkACYCEMAkACY0GHRYQCY0GHQaQCQ0GkA9IAwCLEAIAi9ASD853BHELUERg9IFDAAaCBAKLEMSBQwBGAgRv/38v8QvQAAABACQAAEAEgACABIAAwASAAQAEgAFABIABgASAAcAEgIAAFAAAQBQAF5Sh7+SwPrggJCZfxKQDKCZUoeASOTQMNlcEcQtQAi+EwDaKNCAdL3SQHg9kkcMQN4CDsUJLP79PJDbJsIAeuDA4Nk7kuAO8NkASOTQANlEL1wtQRGACUMuQEgcL3pSSBoiEIL0ulJIGhAGhQhsPvx8IAAYGTlSAg4IGQK4OFJIGhAGhQhsPvx8IAAYGTdSAg4IGQCIIT4JQAgaAVoR/bwcIVD1OkCAQhDIWkIQ2FpCEOhaQhD4WkIQyFqCEMFQyBoBWAgRv/3qf+gaLD1gE8B0QAgYGAgeaFsCGDU6RMQSGBgaGCxYGgEKAnYIEb/94f/ACBhbQhg1OkWEEhgA+AAIGBloGXgZQAg4GIgY2BjoGPgYwEghPglAAAghPgkAAC/m+cQtQRGDLkBIBC9IGgAaCDwAQAhaAhgskkgaIhCC9KySSBoQBoUIbD78fCAAGBkrkgIOCBkCuCqSSBoQBoUIbD78fCAAGBkpkgIOCBkACAhaAhglPhEEAEgiEAhbEhgIEb/90r/ACChbAhg1OkTEEhgYG0osQAgYW0IYNTpFhBIYAAgYGWgZeBl4GOE+CUAAL+E+CQAAL8Av7bnMLXQ6RNUbGBEbRSx0OkWVGxgkPhEUAEkrEAFbGxgBGhjYIRoECwE0QRoomAEaOFgA+AEaKFgBGjiYDC9LenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKBfRAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//e5/yBoAGhA8AEAIWgIYAbgAL8AIIT4JAAAv0/wAghARtTnLenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKD/RAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//eA/yBrMLEgaABoQPAOACFoCGAL4CBoAGgg8AQAIWgIYCBoAGhA8AoAIWgIYKBsAGgA9IAwKLGgbABoQPSAcKFsCGBgbSixYG0AaED0gHBhbQhgIGgAaEDwAQAhaAhgBuAAvwAghPgkAAC/T/ACCEBGrOcBRgAiCbkBIHBHCGgAaCDwDgALaBhgiGwAaCD0gHCLbBhgCGgAaCDwAQALaBhgkfhEMAEgmEALbFhg0ekTMFhgSG1AsUhtAGgg9IBwS20YYNHpFjBYYAEggfglAAC/ACCB+CQAAL8QRs7ncLUERgAllPglAAIoA9AEIOBjASU84CBoAGgg8A4AIWgIYCBoAGgg8AEAIWgIYKBsAGgg9IBwoWwIYJT4RBABIIhAIWxIYNTpExBIYGBtQLFgbQBoIPSAcGFtCGDU6RYQSGABIAjgAAAACQJACAQCQAAIAkAIAAJAhPglAAC/ACCE+CQAAL+gaxCxIEaha4hHKEZwvS3p8EEERg5GFUZP8AAIlPglAAIoCdAEIOBjAL8AIIT4JAAAvwEgvejwgSBoAGgA8CAAILFP9IBw4GMBIPPnLrmU+EQQAiAA+gH3BOCU+EQQBCAA+gH3+/e0+4BGLeAgbABolPhEIAghkUAIQICxlPhEEAEgiEAhbEhgASDgY4T4JQAAvwAghPgkAAC/ASDK52gckLEtsfv3lPug6wgAqEIL2SAg4GMBIIT4JQAAvwAghPgkAAC/ASC15yBsAGg4QAAozNBgbYixoG0AaOFtCEBgsWBtAGhA9IBwYW0IYNTpFhBIYOBrQPSAYOBj4GwAaCFtCEAwsdTpExBIYOBrQPQAcOBjTrmU+EQQAiCIQCFsSGABIIT4JQAF4JT4RBAEIIhAIWxIYAC/ACCE+CQAAL8Av3jncLUERiBsBWggaAZolPhEEAQgiEAoQNCxBvAEALixIGgAaADwIAAouSBoAGgg8AQAIWgIYJT4RBAEIIhAIWxIYCBrAChO0CBGIWuIR0rglPhEEAIgiEAoQAizBvACAPCxIGgAaADwIABAuSBoAGgg8AoAIWgIYAEghPglAJT4RBACIIhAIWxIYAC/ACCE+CQAAL/gajCzIEbhaohHIuCU+EQQCCCIQChA4LEG8AgAyLEgaABoIPAOACFoCGCU+EQQASCIQCFsSGABIOBjhPglAAC/ACCE+CQAAL9gaxCxIEZha4hHcL0QtQNGACQAv5P4JAABKAHRAiAQvQEgg/gkAAC/k/glAAEoEtExsQEpBtACKQbQAykI0QXg2mIH4BpjBeBaYwPgmmMB4AEkAL8A4AEkAL8AIIP4JAAAvyBG2+cCRgAjAL+S+CQAASgB0QIgcEcBIIL4JAAAv5L4JQABKBvRBSkW0t/oAfADBgkMDwAAINBiEOAAIBBjDeAAIFBjCuAAIJBjB+AAINBiEGNQY5BjAeABIwC/AOABIwC/ACCC+CQAAL8YRtLnAUaR+CUAcEcBRshrcEcQtYywBEYAv75IAG1A9ABwvEkIZQhGAG0A9ABwAZAAvwC/AL8IRsBsQPSAEMhkCEbAbAD0gBABkAC/AL8IRgBrQPQAcAhjCEYAayD0AHAIYwC/CEaAbUDwgFCIZQhGgG0A8IBQAZAAvwC/p0hAaED0AHClSUhgAL+iSMBsQPBAAKBJyGQIRsBsAPBAAAGQAL8AvwC/CEbAbED0gHDIZAhGwGwA9IBwAZAAvwC/AL8IRsBsQPSAcMhkCEbAbAD0gHABkAC/AL8AvwhGwGxA9IBwyGQIRsBsAPSAcAGQAL8AvwC/CEbAbED0gHDIZAhGwGwA9IBwAZAAvwC/AL8IRsBsQPCAAMhkCEbAbADwgAABkAC/AL8AvwhGwGxA8IAAyGQIRsBsAPCAAAGQAL8AvwC/CEbAbEDwgADIZAhGwGwA8IAAAZAAvwC/AL8IRsBsQPBAAMhkCEbAbADwQAABkAC/AL8AvwhGwGxA8EAAyGQIRsBsAPBAAAGQAL8AvwC/CEbAbEDwQADIZAhGwGwA8EAAAZAAvwC/iBQHkAIgCJABIAmQAiAKkAUgC5AHqVdI//fX+UAgB5AAIAmQB6lUSP/3z/lP9ABgB5AHqVFI//fI+U/0gGAHkAepTUj/98H5T/QAcAeQB6lKSP/3uvlP9IBwB5AHqUdI//ez+U/0AHAHkAepREj/96z5T/SAYAeQB6lASP/3pflP9ABwB5AHqTtI//ee+U/0gGAHkAepN0j/95f5T/QAQAeQB6k0SP/3kPkCIAKQA5A0SAaQNEgFkAIgBJDCHgKpIEb898X8DLAQvRC1BEZMIPv3cPpP9IBRJ0j/9136QCEmSP/3WfpP9ABhI0j/91T6T/SAYSFI//dP+k/0AHEeSP/3SvpP9IBxHUj/90X6T/QAcRpI//dA+k/0gGEYSP/3O/pP9ABxE0j/9zb6T/SAYRFI//cx+k/0AEEOSP/3LPoLSABrQPQAcAlJCGMIRgBrIPQAcAhjCEYAbSD0AHAIZQhGwGwg9IAQyGQQvQAAABACQABwAEAAGABIACAASAAcAEgCAAABAgABAAC1l7AUIRKoAPCm+EQhAagA8KL4ECABkAEgB5AAIAiQAiALkAEhDJFgIAmQDZE3IQ6RAiERkRCRByEPkQGo/vcE+wixF7AAvQ8gEpADIBOQgCAUkAAgFZAWkAMhEqj+953+ALHu5wIgEpAAIBSQBSESqP73k/4AseTnAL/i53y1BEYNRhZGUCExSEhEAPBk+FAhMEhIRADwX/gAIACQAZD791T4//es/wIgKklJRAhgQfLtIIhgT/CAYIhjASDIYwhgTvYTQIhgCCBIZACQICABkP33NvkIsQEgfL0AIPzncLUERgAlJPBwRShG/feg+gAgcL0BRgAgcEcQtf33CvsAIBC9cLUERg1GFkYqRiFGMEb99xH6ACBwvXC1BEYORhVG/feg+wfgFPgBGxX4ASuRQgHQIEZwvTAepvEBBvPRIEb45wNGASBwRwFGACBwRxAAAABgAAAAT/AAAgC1E0aURpZGIDkiv6DoDFCg6AxQsfEgAb/0968JByi/oOgMUEi/DMBd+ATriQAov0D4BCsIv3BHSL8g+AIrEfCATxi/APgBK3BHAAAAAAAAAAAAAAECAwQGBwgJAAAAAAECAwSghgEAQA0DAIAaBgAANQwAQEIPAICEHgAACT0AABJ6AAAk9AAANm4BAEjoAQBs3AIAAAAAAAk9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 21335
-    pc_uninit: 21453
-    pc_program_page: 21469
-    pc_erase_sector: 21433
-    pc_erase_all: 21459
-    data_section_offset: 21704
+    pc_init: 0x5357
+    pc_uninit: 0x53cd
+    pc_program_page: 0x53dd
+    pc_erase_sector: 0x53b9
+    pc_erase_all: 0x53d3
+    data_section_offset: 0x54c8
     flash_properties:
       address_range:
-        start: 1879048192
-        end: 1946157056
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x70000000
+        end: 0x74000000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 65536
-          address: 0
-  stm32l4xx_256:
-    name: stm32l4xx_256
+        - size: 0x10000
+          address: 0x0
+  - name: stm32l4xx_256
     description: STM32L4xx 256 KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: T/T/YUD2+nMB6hAhQvIUAMTyAgACaJpDEUQCMQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvACAgJgOCDA8gEACEAYvwEgcEdC8hQAxPICAAFoQfAEAQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvAEAgJgOCDA8gEACEAYvwEgcEdC8ggAQPIjEcTyAgDE8mdRAWBI9qsRzPbvUQFgwGjAD3BH8LUDry3pAAtA8jgMQvIQAyHwBw7A8gEMxPICA77xAA8v0BZG8UZms6nxCAkG8QgINWh2aFxoRPABBFxgBWBGYBxo5ANBvxxoX+rENBxoX+rENALVHGjkA/LUHGgU6gwPadEcaAgwRkbkBx6/HGgk8AEEHGBcaLnxAA8k8AEEXGDR0RHwBwFl0ALrDgVqGBL4AR2VQmHw/wEj0BL4AW2VQkbqASQg0BL4AW2VQkbqBC4e0BL4AW2VQkbqDigc0BL4AW2VQkbqCCYa0BL4AR2VQkHqBiEX0BL4ASxC6gEhckYS4E/w/zIP4E/w/zIhRgvgT/D/MnFGB+BP8P8yQUYD4ApGMUYA4CJGXmhG8AEGXmABYEJgGGjAA0G/GGhf6sAwGGhf6sAwAtUYaMAD8tQYaBDqDA8D0AEgvegAC/C9GGjABx6/GGgg8AEAGGBYaCDwAQBYYAAgvegAC/C9QvIUAMTyAgABaEHwAEEBYAAgcEeAtW9G//cz/wAg//fV/v/3BP8AIAAhACL/9zr///fm//7n1NQEAAAA
-    pc_init: 183
-    pc_uninit: 565
-    pc_program_page: 217
-    pc_erase_sector: 1
-    pc_erase_all: 99
-    data_section_offset: 620
+    pc_init: 0xb7
+    pc_uninit: 0x235
+    pc_program_page: 0xd9
+    pc_erase_sector: 0x1
+    pc_erase_all: 0x63
+    data_section_offset: 0x26c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134479872
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8040000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32l4xx_512:
-    name: stm32l4xx_512
+        - size: 0x800
+          address: 0x0
+  - name: stm32l4xx_512
     description: STM32L4xx 512 KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: T/T/YUD2+nMB6hAhQvIUAMTyAgACaJpDEUQCMQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvACAgJgOCDA8gEACEAYvwEgcEdC8hQAxPICAAFoQfAEAQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvAEAgJgOCDA8gEACEAYvwEgcEdC8ggAQPIjEcTyAgDE8mdRAWBI9qsRzPbvUQFgwGjAD3BH8LUDry3pAAtA8jgMQvIQAyHwBw7A8gEMxPICA77xAA8v0BZG8UZms6nxCAkG8QgINWh2aFxoRPABBFxgBWBGYBxo5ANBvxxoX+rENBxoX+rENALVHGjkA/LUHGgU6gwPadEcaAgwRkbkBx6/HGgk8AEEHGBcaLnxAA8k8AEEXGDR0RHwBwFl0ALrDgVqGBL4AR2VQmHw/wEj0BL4AW2VQkbqASQg0BL4AW2VQkbqBC4e0BL4AW2VQkbqDigc0BL4AW2VQkbqCCYa0BL4AR2VQkHqBiEX0BL4ASxC6gEhckYS4E/w/zIP4E/w/zIhRgvgT/D/MnFGB+BP8P8yQUYD4ApGMUYA4CJGXmhG8AEGXmABYEJgGGjAA0G/GGhf6sAwGGhf6sAwAtUYaMAD8tQYaBDqDA8D0AEgvegAC/C9GGjABx6/GGgg8AEAGGBYaCDwAQBYYAAgvegAC/C9QvIUAMTyAgABaEHwAEEBYAAgcEeAtW9G//cz/wAg//fV/v/3BP8AIAAhACL/9zr///fm//7n1NQEAAAA
-    pc_init: 183
-    pc_uninit: 565
-    pc_program_page: 217
-    pc_erase_sector: 1
-    pc_erase_all: 99
-    data_section_offset: 620
+    pc_init: 0xb7
+    pc_uninit: 0x235
+    pc_program_page: 0xd9
+    pc_erase_sector: 0x1
+    pc_erase_all: 0x63
+    data_section_offset: 0x26c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134742016
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8080000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32l4xx_1024:
-    name: stm32l4xx_1024
+        - size: 0x800
+          address: 0x0
+  - name: stm32l4xx_1024
     description: STM32L4xx 1MB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: T/T/YUD2+nMB6hAhQvIUAMTyAgACaJpDEUQCMQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvACAgJgOCDA8gEACEAYvwEgcEdC8hQAxPICAAFoQfAEAQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvAEAgJgOCDA8gEACEAYvwEgcEdC8ggAQPIjEcTyAgDE8mdRAWBI9qsRzPbvUQFgwGjAD3BH8LUDry3pAAtA8jgMQvIQAyHwBw7A8gEMxPICA77xAA8v0BZG8UZms6nxCAkG8QgINWh2aFxoRPABBFxgBWBGYBxo5ANBvxxoX+rENBxoX+rENALVHGjkA/LUHGgU6gwPadEcaAgwRkbkBx6/HGgk8AEEHGBcaLnxAA8k8AEEXGDR0RHwBwFl0ALrDgVqGBL4AR2VQmHw/wEj0BL4AW2VQkbqASQg0BL4AW2VQkbqBC4e0BL4AW2VQkbqDigc0BL4AW2VQkbqCCYa0BL4AR2VQkHqBiEX0BL4ASxC6gEhckYS4E/w/zIP4E/w/zIhRgvgT/D/MnFGB+BP8P8yQUYD4ApGMUYA4CJGXmhG8AEGXmABYEJgGGjAA0G/GGhf6sAwGGhf6sAwAtUYaMAD8tQYaBDqDA8D0AEgvegAC/C9GGjABx6/GGgg8AEAGGBYaCDwAQBYYAAgvegAC/C9QvIUAMTyAgABaEHwAEEBYAAgcEeAtW9G//cz/wAg//fV/v/3BP8AIAAhACL/9zr///fm//7n1NQEAAAA
-    pc_init: 183
-    pc_uninit: 565
-    pc_program_page: 217
-    pc_erase_sector: 1
-    pc_erase_all: 99
-    data_section_offset: 620
+    pc_init: 0xb7
+    pc_uninit: 0x235
+    pc_program_page: 0xd9
+    pc_erase_sector: 0x1
+    pc_erase_all: 0x63
+    data_section_offset: 0x26c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 135266304
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8100000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32l4xx_128:
-    name: stm32l4xx_128
+        - size: 0x800
+          address: 0x0
+  - name: stm32l4xx_128
     description: STM32L4xx 128 KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: T/T/YUD2+nMB6hAhQvIUAMTyAgACaJpDEUQCMQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvACAgJgOCDA8gEACEAYvwEgcEdC8hQAxPICAAFoQfAEAQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvAEAgJgOCDA8gEACEAYvwEgcEdC8ggAQPIjEcTyAgDE8mdRAWBI9qsRzPbvUQFgwGjAD3BH8LUDry3pAAcB8AcIQPI4DELyEAOh6wgOwPIBDMTyAgO+8QgPL9MWRvJGZrOq8QgKBvEICTRodmhdaEXwAQVdYARgRmAcaOQDRL8caF/qxDQF1Rxo5AMC1Rxo5APy1BxoFOoMD2nRHGgIME5G5AcevxxoJPABBBxgXGi68QgPJPABBFxg0dK48QAPZdAC6w4GCkQS+AEdlkJh8P8BI9AS+AFdlkJF6gElINAS+AFNlkJE6gUoHtAS+AFNlkJE6gguHNAS+AFNlkJE6g4uGtAS+AEdlkJB6g4hF9AS+AEsQuoBIUJGEuBP8P8yD+BP8P8yKUYL4E/w/zJBRgfgT/D/MnFGA+AKRnFGAOAqRl5oRvABBl5gAWBCYBhowANEvxhoX+rAMAXVGGjAAwLVGGjAA/LUGGgQ6gwPA9ABIL3oAAfwvRhowAcevxhoIPABABhgWGgg8AEAWGAAIL3oAAfwvULyFADE8gIAAWhB8ABBAWAAIHBHgLVvRv/3Mf8AIP/30/7/9wL/ACAAIQAi//c4///35v/+59TUBAAAAA==
-    pc_init: 183
-    pc_uninit: 569
-    pc_program_page: 217
-    pc_erase_sector: 1
-    pc_erase_all: 99
-    data_section_offset: 624
+    pc_init: 0xb7
+    pc_uninit: 0x239
+    pc_program_page: 0xd9
+    pc_erase_sector: 0x1
+    pc_erase_all: 0x63
+    data_section_offset: 0x270
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134348800
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8020000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32l4r9i_disco_ospi1:
-    name: stm32l4r9i_disco_ospi1
+        - size: 0x800
+          address: 0x0
+  - name: stm32l4r9i_disco_ospi1
     description: MX25L51245G_STM32L4R9I_DISCO_OSPI1
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAARkgAaEDwAQBESQhgACCIYAhGAGhCSQhAQEkIYMgUyGAIRgBoIPSAIAhgACCIYcgDPEkIYHBH8LUAIwAgACICJAAlAiE1TjZoBvAIBi65M06UNjZoxvMDIAPgME42aMbzAxAxTn5EVvggACxOtmgG8AwGNrEELgjQCC4L0AwuOdEN4CpOTkQwYDjgKU4nT09EPmAz4CdOJU9PRD5gLuAfTvZoBvADBR1O9mjG8wMWcRwCLQLQAy0I0QPgHU62+/HyBuAcTrb78fIC4LD78fIAvwC/Ek72aMbzBiZyQw9O9mjG80Fmdhx0ALL79PYPT09EPmAD4A1OTkQwYAC/AL8HTrZoxvMDFgxPf0S7XQdOTkQ2aN5ABU9PRD5g8L0AEAJA///26gjtAOBsUwAABAAAAAAk9AAAEnoAsFIAAHtIgGtA8IBQeUmIYwhGgGsg8IBQiGNwR3ZIAGhA9IBwdEkIYHBHc0gAaCD0gHBxSQhgcEcBRm9IQGgg8A4ACmgQQ2xKUGBsSABoIPSAMGpKEGAQHwBoIPSAMBIfEGBmSAgwAGgg9IAwY0oIMhBgEB8AaCD0gDASHxBgSGgA9IAwsPWAPwfRXEgAHwBoQPSAMFlKEh8QYEhoAPQAMLD1AD8F0VVIAGhA9IAwU0oQYAh5APABADixUEgAHQBoQPSAME1KEh0QYAh5APACAAIoB9FJSAgwAGhA9IAwR0oIMhBgACBwR0NIQGhA8AEAQUlIYHBHQEhAaCDwAQA+SUhgcEc8ScloAPAfApFDQepQETlK0WARRoloAPAfAhFDNUqRYHBHNEmJaADwHwKRQzFKkWBwR3C1BUYMRk25LkhAaQD0AHCw9QB/CdED8BP5BuApSEBpwPNAIAi5A/AE+SdIAGgg8AQAJUkIYAEsAdEwvwLgQL8gvyC/cL1wtQVGDEa19YBPA9EgRgPwM/kC4CBGA/AV+XC9F0gAaCDwBwDAHBVJCGAWSABoQPAEABRJCGAAvwC/ML9wRxFIAGhA8AIAD0kIYHBHDUgAaCDwAgALSQhgcEcKSABoQPAQAAhJCGBwRwZIAGgg8BAABEkIYHBHcEcAEAJAAHAAQAQEAUAQ7QDgcEdwtQRGhUhIRABoT/R6cbD78fUoRgDwofkAIiFGUB4A8DL5ACBwvRC1fUgAaED0gHB7SQhgAyAA8BT5DyAE8PD///fd/wAgEL1wRxC1T/D/MHRJiGMAIIhjQB4IZAAgCGRAHohiACCIYkAeyGIAIMhiQB4IYwAgCGP/9+b/ACAQvWlISEQAaEAcZ0lJRAhgcEdlSEhEAWgIRkocYktLRBpgcEdwtQRG//fz/wZGJUZoHACxbRwAv//36/+AG6hC+tNwvU/w4CAAaSDwAgBP8OAhCGFwR0/w4CAAaUDwAgBP8OAhCGFwR1BIcEdQSABoAAxwR05IAGjA8wsAcEdNSABocEdLSAAdAGhwR0lICDAAaHBHRkhAaEDwAQBESUhgcEdDSEBoIPABAEFJSGBwRz9IQGhA8AIAPUlIYHBHPEhAaCDwAgA6SUhgcEc4SEBoQPAEADZJSGBwRzVIQGgg8AQAM0lIYHBHyiAzSUhiUyBIYgEgMUkIYHBHASAwSQhicEcAIC5JCGJwRytJCWsh8AQBAUMoShFjcEcnSQlrIfACAQFDJEoRY3BHI0lJayHwPwEBQyBKUWNwRxC1ACQeSABrQPABABxJCGP/92L/BEYG4P/3Xv8AGwooAdkDIBC9FUgAawDwCAAAKPLQACD25xFIAGsg8AEAD0kIY3BHDkhAaED0gHAMSUhgcEcKSEBoIPSAcAhJSGBwRwAABAAAAAAgAkAAEAJACAAAAAUACAEAIATgkHX/HwAAAUAAAyBCAAAgQhC1ACgH2goHFA65SgDwDwMbH9RUA+AKBxMOtkoTVBC9AL8A8AcCsksMOxloT/b/AxlAsUsLQ0PqAiGtSww7GWAAv3BHLenwTYBGDUYWRgAnAPBI+QdGOUYqRjNGAfAHAMDxBwu78QQPAtlP8AQLAeDA8QcL2kYA8QQLu/EHDwLST/AACwHgoPEDC9xGT/ABCwv6Cvur8QELC+oCCwv6DPtP8AEODvoM/q7xAQ4O6gMOS+oOBCFGQEb/96L/vejwjXBHAL8A8B8CASGRQItKQwlC+CMQAL9wRwC/AL8AvwC/AL+/80+PAL8AvwC/gEgMOABoAPTgYIBJCEMAHXxJDDkIYAC/AL8Av7/zT48AvwC/AL8AvwC//edwtQRGJUZoHrDxgH8B0wEgD+BoHk/w4CFIYQ8hT/D/MP/3Yv8AIE/w4CGIYQcgCGEAIHC9ELUA8Mn4EL0t6fBFBEYgRgAoCNpjTwDwDwys8QQMF/gMcD8JAuBgTz9cPwk9Rg5GBvAHAMDxBwi48QQPAtlP8AQIAeDA8QcIxEYA8QQIuPEHDwLST/AACAHgoPEDCEdGJfoH+E/wAQoK+gz6qvEBCgjqCgjC+ACAT/ABCAj6B/io8QEICOoFCMP4AIAAv73o8IUAvwDwHwIBIZFAREqAMkMJQvgjEAC/cEcQtQFGCEY/SoAyQwlS+CMgAPAfBAEjo0AaQAqxASIA4AAiEEYQvQC/APAfAgEhkUA2SkMJQvgjEAC/cEcQtQFGCEYxSoAyQwlS+CMgAPAfBAEjo0AaQAqxASIA4AAiEEYQvQQoCNFP8OAhCWlB8AQBT/DgIhFhB+BP8OAhCWkh8AQBT/DgIhFhcEdwRxC1//f8/xC9QXgYSoAyEWABePmxEh1BaBFgAXsJB8J6QeoCYYJ6QerCQUJ7QeqCQYJ7QepCQcJ7QeoCQUJ6QeoCIQJ6QepCAQJ4EUMISogyEWAF4AAhBUqEMhFgEh0RYHBHAkgMOABowPMCIHBHGO0A4ADkAOAAAPoFgOEA4IDiAOAt6fBHBEYORhdGmEYInf/3nP2CRhPgaByIsS2x//eV/aDrCACoQgrZT/QAcKT4RACgbEDwAQCgZAEgvejwhyBoAGowQAixASAA4AAguELi0QAg8ucCRtFkACBwR3BH+LUERgAl//dx/QZGDLkBJY/gACCgZLT4RABAuSBGBPD4+k/w/zEgRv/35f8FRgAtf9HU6QMQQB5P9PgSkvqi8rL6gvKQQAhDYWlJHk/04GKS+qLysvqC8pFACEOhaQhD4WkIQyFoiWj+ShFACEMhaIhgIGjAaCD04CAhaghDIWjIYE/0+BGR+qHxsfqB8SBriEAhaAhhIGgAaCD0+FFgaEAeT/T4UpL6ovKy+oLykEABQyBoAWDgbDNGACIgIQCQIEb/927/BUZ9uyBowGgg8P8BYGpAHv8ikvqi8rL6gvKQQAFDIGjBYCBoAGgg8EAAoWgIQyFoCGDU6QoBCEMhaNH4CBEh8KBBCEMhaMH4CAEgaABoQPABACFoCGDgaLDxgG8D0QEgpPhEAALgAiCk+EQAKEb4vXBHcLUERgAlDLkBJQvgIGgAaCDwAQAhaAhgIEYE8I77ACCk+EQAKEZwvXBHcEdwtQVGrGoAIOBjtPhEALD1gH8P0QIgIWhIYiBoAGhA9AAwIWgIYCBoAGhA8AIAIWgIYAXgAiCk+EQAIEb/99//cL1wR3BHcEdwR3BHcEct6fBBBEYgaADxUAggaAVqIGgHaLT4RGAF8AQAKLMH9IAgELMYLgnRYWtIHGBjCHiI+AAA4GtAHuBjCuAoLgjRmPgAEGJrUBxgYxFw4GtAHuBj4GsouSBoAGgg9IAgIWgIYCBG//fL/6LgBfACAAAoTNAH9AAwAChI0CguIdEF9HxQWLHga0ixmPgAEGJrUBxgYxFw4GtAHuBjieDgawAo4tECICFoSGIgaABoIPTgICFoCGACIKT4RAAgRv/3nv924AIgIWhIYiBoAGgg9OAgIWgIYAIgpPhEABguA9EgRv/3i/9k4AguA9EgRv/3hP9e4Lb1gH9b0aBsGLkgRv/3ev9V4CBG//dT/1HgBfAIALixB/QAIKCxCCAhaEhiIGgAaAD0gABAsSBoAGgg9BAgIWgIYAIgpPhEACBG//da/zbgBfABADizB/SAMCCzASAhaEhiIGgAaCD0+BAhaAhgAiCgZCBoAGgA8AQAaLEgaABoIPAEACFoCGBOSHhEIWyIYyBsA/Cs/xLgAiCk+EQAIEb/9w3/C+AF8BAAQLEH9IAQKLEQICFoSGIgRv/3//696PCBLenwQQNGACAfaD9oJ/BAV9P4AMDM+ABwn2hfuR9oP2gn8IAH0fgEwEfqDAfT+ADAzPgAcA9oAi8M0B9oB/WAch9oB/WEdB9oB/WIdR9oB/WQdgvgH2gH9cByH2gH9cR0H2gH9ch1H2gH9dB20ekSfEfqDAcXYM9qj7GPajdg0fg0wM9qR+oMB9H4MMBH6gwH0vgAwCz0fBxH6gwHF2AnaCfwHwfR+ETAR+oMBydgj2s/sQ9oL7nPa38e0/gAwMz4QHDPaAAvfNDPae+zj2tfs9H4FMDPaEfqDAfR+BDAR+oMB9H4HMBH6gwH0fgkwEfqDAfR+CDAR+oMBwPg/Pjg+DP+///R+DjAR+oMB9H4QMBH6gwH0vgAwN/4YIoM6ggMR+oMBxdgKuDR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMAA4CHgR+oMB9H4IMBH6gwH0vgAwEP2P3gs6ggMR+oMBxdg32q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2CPadP4AMDM+Ehwd+CPa+ex0fgUwM9oR+oMB9H4EMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+MSJDOoIDADgIeBH6gwHF2Aa4NH4FMDPaEfqDAfR+BDAR+oMB9L4AMAs8D8MR+oMBxdg32q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2A64M9pp7OPa+ex0fgkwM9pR+oMB9H4IMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+ESJCPE/CAzqCAxH6gwHF2AP4NH4JMDPaUfqDAfR+CDAR+oMB9L4AMAs9HxcR+oMBxdgj2nT+ADAzPhIcAPg/+cBIAgnn2S96PCBLen4QwRGDUYWRgAn//d6+oBGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsYsShoALkAvwC/tPhEAAIoA9HgaLDxgG8N0bT4RAAUKALRKGgCKAbQtPhEACQoQtEoaAEoP9FDRgAiICEgRgCW//el/AdGL7sAIKBkKUYgRv/3f/4HRu+5qGtYuUNGASICISBGAJb/95L8B0YCICFoSGIj4ChoGLkEIKT4RAAd4ChoASgL0bT4RAAkKAPRBCCk+EQAEuAUIKT4RAAO4LT4RAAUKAPRBCCk+EQABuAkIKT4RAAC4AEnECCgZDhGvej4g/i1BEYNRgAm//cF+gdGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsAsQC/tPhEAAIoJtEoaCC7qGsQu+BosPGAbx7Q4Gw7RgAiICEAkCBG//c8/AZGvrkAIKBkAyAhaEhiKUYgRv/3E/4GRma5CCCk+EQAIGgAaED0QDAhaAhgAuABJhAgoGQwRvi9Len4QwRGDUYWRgAn//e9+YBGtPhEAAEoA9C0+EQAAigk0UNGACIgISBGAJb/9wj8B0b3uU/0fwGR+qHxsfqB8ShoiEBP9H9Ckvqi8rL6gvJpaJFACEOpaAhD6WgIQyFowfgAAgIgpPhEAALgAScQIKBkOEa96PiDLen4QwRGDUYWRgAn//eB+YBGtPhEAAIoOdHgaLDxgG810UNGACIgISBGAJb/98z7B0ZfuyBoAGgg8EBQIWgIYCBogGgg8IBwKWgIQyFoiGAoaUDwQGCpaAhDQPRAYCFowfgAAShpQPBAYKloCENA9EBgIWjB+IAB6GhAHiFoCGRoaCFoiGQEIKT4RAAC4AEnECCgZDhGvej4gy3p+EUERg5GF0YAJf/3NPmARiBoAPFQCh65ASUIIKBkO+C0+EQABCg00SBoAGxAHOBj4GugY2ZjIGgAaCDwQFAhaAhgAL9DRgEiBCEgRgCX//dt+wVGBbEL4GFrSBxgYwh4ivgAAOBrQB7gY+BrACjp0QC/jblDRgEiAiEgRgCX//dV+wVGRbkCICFoSGKk+EQAAuABJRAgoGQoRr3o+IUt6fxNBEYORhdGACX/9+T4AZAgaADxUAogaND4SIAgaND4ELEeuQElCCCgZFLgtPhEAAQoS9EgaABsQBzgY+BroGNmYyBoAGgg8EBQQPCAUCFoCGDgaLDxgG8D0SBowPhIgAzgIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4ELEAvwCXASIGISBGAZv/9wD7BUYFsQvgmvgAEGJrUBxgYxFw4GtAHuBj4GsAKOnRAL+NuQCXASICISBGAZv/9+j6BUZFuQIgIWhIYqT4RAAC4AElECCgZChGvej8jRC1AkYAIBm5ASAII5NkIOCy+EQwBCsZ0RNoG2xbHNNj02uTY1FjE2gbaCPwQFMUaCNgAyMUaGNiGCOi+EQwE2gbaEP04CMUaCNgAuABIBAjk2QQvXC1AkYAIBVoq2wVaNX4EEEZuQEgCCWVZDXgsvhEUAQtLtEVaC1sbRzVY9VrlWNRYxVoLWgl8EBVRfCAVRZoNWADJRZodWIoJaL4RFAVaC1oRfTgJRZoNWDVaLXxgG8C0RVoq2QP4BVo1fgAUQX04GUVsRVoq2QG4BVoxfgQQQLgASAQJZVkcL1wtQRGACW0+EQAAPAIACC5tPhEAADwBABgsyBoAGgg9PgQIWgIYE/0gHCk+EQAIGgAaADwBABosSBoAGgg8AQAIWgIYPZIeEQhbIhjIGwD8Lv7EuACICFoSGIgaABoQPQAMCFoCGAgaABoQPACACFoCGAC4AElECCgZChGcL1wtQVGrGoAIOBjBCCgZCBoAGgg8AQAIWgIYCBG//ex/3C9cEdwR3C1BUasauBrQAjgY7T4RAAoKAPRIEb/9/L/AuAgRv/37f9wvQFGiGoAIsJjAmgSaCLwBAIDaBpgCmgSaCLwAQILaBpgAmgSaEL0ADIDaBpgcEct6fNBBEYAJiBoAGxFHAGYGLkBJgggoGR34LT4RAAEKHDRIGxAaQi55WMk4CBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggoGQBJhTgaAjgYxHgIGxAabD1AH8M0QXwAwAYuSB5APADABixCCCgZAEmAeCoCOBjAC5H0eBroGMBmGBjIGgAaCDwQFAhaAhgAyAhaEhiGCCk+EQApEh4RCFsyGKjSHhEIWwIY6JIeEQhbEhjACAhbIhjECEgbIFgIGwAaABoIPAQACFsiWgIQyFsCWgIYAGvo2vU+ADADPFQAjloIGwD8F/6IGgAaED0gDAhaAhgIGgAaEDwBAAhaAhgA+D/5wEmECCgZDBGvej8gS3p80cERgAmIGgAbEUcIGjQ+EiAIGjQ+BChAZgYuQEmCCCgZI7gtPhEAAQoctEgbEBpCLnlYyTgIGxAabD1gH8N0QXwAQAYuSB5APABABixCCCgZAEmFOBoCOBjEeAgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIIKBkASYB4KgI4GMALl7R4GugYwGYYGMgaABoIPBAUEDwgFAhaAhgAyAhaEhiKCCk+EQAX0h4RCFsyGJeSHhEIWwIY11IeEQhbEhjACAhbIhjACEgbIFgIGwAaABoIPAQACFsiWgIQyFsCWgIYAGvo2s6aNT4AMAM8VABIGwD8M/5IGgAaED0gDAhaAhg4Giw8YBvBNEgaMD4SIAN4BPgIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4EKEgaABoQPAEACFoCGAC4AEmECCgZDBGvej8hy3p+E8ERg1GFkYAJ/73Yf6CRiBo0PhIgCBo0PgQsbT4RAAEKErR6Giw9YAPRtFTRgAiICEgRgCW//em+AdGAC8/0ShoIWjB+IgAaGghaMH4gAAoaSFowfiQANXpAgEIQ0DwAFAhaAloIfBDUQhDIWgIYOBosPGAbwPRIGjA+EiADOAgaND4AAEA9OBgGLEgaMD4SIAC4CBowPgQsVNGASIIISBGAJb/92/4B0ZPuQggIWhIYgIgpPhEAALgAScQIKBkOEa96PiPwMD/8MD///BR9v//M////wf////Z/v//E/7//+f9//+5/f//Len4RQRGDUYAJv737P2ARiBoh2wgaND4EKG0+EQABChB0eBsQ0YAIiAhAJAgRv/3NfgGRk67KGghaMH4iABoaCFowfiAAChpIWjB+JAA1ekCAQhDQPAAUCFoCWgh8ENRCEMhaAhgCSAhaEhiSCCk+EQAIGgAaED0ECAhaAhg4Giw8YBvAtEgaIdkD+AgaND4AAEA9OBgELEgaIdkBuAgaMD4EKEC4AEmECCgZDBGvej4hfi1BEYNRgAm/veU/QdGtPhEAAQoJ9HgbDtGACIgIQCQIEb+9+L/BkYGu4ggpPhEAChoCCgM0WhoIWjB+DABECAhaEhiIGgAaED0gBAhaAhgIGgAaP5JCEApaEHwQFEIQyFoCGAC4AEmECCgZDBG+L34tQRGACX+9139Bka0+EQAAPAIACC5tPhEAADwBACQsyBoAGgA8AQAYLEgaABoIPAEACFoCGAgbAPw4vgFRg2xBCCgZCBoAGhA8AIAIWgIYOBsM0YBIgIhAJAgRv73jf8FRqW5AiAhaEhi4GwzRgAiICEAkCBG/veA/wVGPbkCIKT4RAAD4P/nASUQIKBkKEb4vTC1AkYAILL4RDAD8AgDi7lRYBNoG2gj9PhUU2hbHk/0+FWV+qX1tfqF9atAHEMTaBxgAuABIBAjk2QwvQFGCGgAaAD0+FBP9PhSkvqi8rL6gvLQQEAccEcBRohscEcBRrH4RABwR/C1BEYAIAAiACUAIxSxAiwA3Am5ASBg4AAmDmHOYI5gTmAOYAEsAdEAJQLgAiwA0a5NACNP4K1OVvgjIALwAQY+sQLwAgYF8AIHvkIB0V4cDmAC8BAGPrEC8CAGBfAgB75CAdFeHE5gAvSAdj6xAvQAdgX0AHe+QgHRXhyOYAL0gDaOsQL0gCYF9IAnvkIL0QL0ADYmuV4cRvSANs5gA+BeHEbwgHbOYALwgHaOsQLwgGYF8IBnvkIL0QLwAHYmuV4cRvSANg5hA+BeHEbwgHYOYV4c87ICK63b8L0t6fBNjLCCRgxGT/AAC/73b/wLkAAnuEYAJQAmfkna+AAAiEIC0QC/ASYB4AElACYAJxDgB+uHAgGrA+uCAXoc0LL/92//ILFP8AELCCDK+EgAeBzHsgIv7Nu78QAPftFtSABoAPABADixakgAaCDwAQBoSQhgSPABCGdIAGgA8AEAOLFlSABoIPABAGNJCGBI8AIIBeuFAAGpUfggAAAobdBbSAXrhQEBqlL4IRBJHlD4IQAg8AECVkgF64UBAatT+CEQSR5A+CEgBeuFAQGqAuuBAUloSR5Q+CEAIPAQAkxIBeuFAQPrgQFJaEkeQPghIAXrhQEBqgLrgQGJaEkeUPghACD0gHJCSAXrhQED64EBiWhJHkD4ISAF64UBAaoC64EBCXsB8A8BSR5Q+CEAIPSAMjdIBeuFAQPrgQEJewHwDwFJHkD4ISAF64UBAaoC64EBCXwB8A8BSR4A4HjhUPghACDwgHIqSAXrhQED64EBCXwB8A8BSR5A+CEgBuuGAQGqUvghECBoiEIf0AbrhgEC64EBYGhJaIhCF9AG64YBAuuBAaBoiWiIQg/QBuuGAQLrgQHgaMloiEIH0AbrhgEC64EBIGkJaYhCdtEQSAbrhgEBqlL4IRBJHlD4IQAg8AECC0gG64YBAatT+CEQSR5A+CEgBuuGAQGqAuuBAUloSR5Q+CEACeD3///PIgIEBAQcBlAAEACgABQAoCDwEAKNSAbrhgED64EBSWhJHkD4ISAG64YBAaoC64EBiWhJHlD4IQAg9IByg0gG64YBA+uBAYloSR5A+CEgBuuGAQGqAuuBAQl7AfAPAUkeUPghACD0gDJ4SAbrhgED64EBCXsB8A8BSR5A+CEgBuuGAQGqAuuBAQl8AfAPAUkeUPghACDwgHJsSAbrhgED64EBCXwB8A8BSR5A+CEgZ0ghaEkeUPghACDwAwACIZH6ofGx+oHxBfoB8UHwAQEIQ15JImhSHkH4IgAIRmFoSR5Q+CEAIPAwACAhkfqh8bH6gfEF+gHxQfAQAQhDU0liaFIeQfgiAAhGoWhJHlD4IQAg9EBxT/QAcJD6oPCw+oDwBfoA8ED0gHABQ0hIomhSHkD4IhDgaAD0gDDYsUNIIXsB8A8BSR5Q+CEAIPTgIE/0gCGR+qHxsfqB8QX6AfFB9IAxCEM5SSJ7AvAPAlIeQfgiABrgNUghewHwDwFJHlD4IQAg8OBhT/CAYJD6oPCw+oDwBfoA8EDwgHABQytIInsC8A8CUh5A+CIQIGkA9IAw2LEmSCF8AfAPAUkeUPghACD04CBP9IAhkfqh8bH6gfEF+gHxQfRAMQhDHEkifALwDwJSHkH4IgAa4BhIIXwB8A8BSR5Q+CEAIPDgYE/wgGGR+qHxsfqB8QX6AfFB8EBxCEMOSSJ8AvAPAlIeQfgiAAjwAQAosQpIAGhA8AEACEkIYAjwAgAosQZIAGhA8AEABEkIYFhGDLC96PCNBBwGUAAQAKAAFACgELWasARGACAGkAeQQPL5YAiQBCAJkBAgCpAAIA2QEZAUkBeQGJAZkAggC5BP8P8yBqn+SEhE/vem/xCxASAasBC9AiABkAKQACADkBAgBZCABASQQPL6UAiQACAMkE/0gGANkE/0QFAOkE/wgGAUkAIgFZCAAg+QAAQWkIAAGJAEIBeQAL8BIP73CPpP8P8yBqnmSEhE/vd2/wixASDO50/w/zJpRuFISET/9wL5CLEBIMTnnfgAAAKZCEABmYhC4dEAILvnMLWbsARGDUYAIAeQCJBA8vpQCZAEIAqQECALkAAgDZBP9IBgDpBP9EBQD5AAIBKQT/CAYBWQAiAWkAYgGJAAIBqQCCAMkAACEJAABBeQgAAZkAAgApABIAOQACAEkBAgBpCABAWQAL8BIP73tPlP8P8yB6m8SEhE/vci/xCxASAbsDC9T/D/MgGptkhIRP/3rfgIsQEg8+ed+AQAA5kIQAKZiELg0QAg6ucwtZuwBUYMRgAgB5AIkAyQT/RAUA+QACAQkBKQF5AZkBqQBJAQIAaQgAQFkAEsddEGIAmQASAKkAAgC5AOkBWQGJBCHgepnUhIRP735P4QsQEgG7AwvQIgApADkAUgCZBP8IBwFZABIBaQgh4HqZNISET+99D+CLEBIOrnT/D/MgKpjkhIRP/33/oIsQEg4OdyIAmQT/RAcA2QT/SAcA6QByCN+AQAT/D/Mgepg0hIRP73sf4IsQEgy+dP8P8yAal+SEhE/vft/wixASDB5wYgCZAAIA6QFZBCHgepd0hIRP73mf4IsQEgs+cFIAmQT/CAcBWQT/D/MgepcEhIRP73iv4IsQEgpOdP8P8yAqlrSEhE//eZ+hCxASCa51zgciAJkAAgDZBP9IBwDpACII34BADCHgepYUhIRP73bP4IsQEghudP8P8yAalcSEhE/veo/wixASB85ygg/vfn+E/w/zFWSEhE//f2/gixASBw50fyjhAJkAQgCpAQIAuQgAEOkAAEFZAGIBiQAiAWkAAgjfgEAAggDJAAAhCQAAQXkIAAGZBP8P8yB6lESEhE/vcy/gixASBM50/w/zIBqT9ISET+977/CLEBIELnnfgEAAIoddABIDznOEhIRP/3WP4IsQEgNedH8o0gCZAEIAqQECALkAAgDZBP9IBgDpAABBWQAiAWkAAgGJCN+AQAjfgFAAggDJAAAhCQAAQXkE/w/zIHqSVISET+9/X9CLEBIA/nT/D/MgGpIEhIRP73Mf8IsQEgBecoIP73cPgFIAmQASAKkAAgC5AOkE/wgHAVkAEgFpAAIBiQDJAQkBeQApABIAOQgh4HqRBISET+98v9CLEBIOXmT/D/MgKpC0hIRP/32vkIsQEg2+ZxIAmQACANkE/0gHAOkE/w/zIHqQNISET+97D9ILEBIMrmEAAAAA7gT/D/MgGp/khIRP73Of8IsQEgvead+AQACLEBILjmACC25hC1mrAERgAgBpAHkGYgCJABIAmQACAKkAuQDZARkBSQF5AYkBmQQh4Gqe1ISET+94D9ELEBIBqwEL2ZIAiQT/D/Mgap5khIRP73c/0IsQEg8ecFIAiQT/CAcBSQASAVkAAgFpABkAEgApAAIAOQECAFkIAEBJBP8P8yBqnYSEhE/vdX/QixASDV50/w/zIBqdNISET/92b5CLEBIMvnACDJ5wC1h7AAv85IwGxA9IAQzEnIZAhGwGwA9IAQAZAAvwC/AL8IRgBtQPSAcAhlCEYAbQD0gHABkAC/AL8IRgBrQPSAcAhjCEYAayD0gHAIYwC/CEaAbUDwgFCIZQhGgG0A8IBQAZAAvwC/t0hAaED0AHC1SUhgAL+ySMBsQPBAALBJyGQIRsBsAPBAAAGQAL8AvwC/CEbAbEDwgADIZAhGwGwA8IAAAZAAvwC/AL8IRsBsQPSAcMhkCEbAbAD0gHABkAC/AL+IFAKQAiADkAEgBJADIAWQBSAGkAKpm0gB8J3/T/QAQAKQAqmYSAHwlv9P9GRgApAAIASQAqmUSAHwjf9P9OBgApACqZJIAfCG/0/0wGACkAKpjEgB8H//B7AAvQC1hbCMSIVJSUQIYAhG/vdX+hCxASAFsAC9//dh/wQgf0lJREhgACF9SEhEgWBP8IBgkPqg8LD6gPF4SEhEAWECIUFhACGBYcFhAWICIUFiACGBYk/wgHHBYAkBwWIAIQFj/veR+QixASDU5wIgAJABkHFIBJBxSAOQAiACkMIeaUZmSEhE//d9+gixASDC52NISET/99P+CLEEILvnASFfSEhE//dZ/QixASCz5wAgsecAtYWwT/QWQVtIAvAE+E/04GFbSAHw//9P9GRhV0gB8Pr/ACABkE/0gFAAkAAgApADkGlGUEgB8Af/ASABkAAgApBP9ABAAJBpRktIAfD8/gAiT/QAQUhIAvB2+ERIAGtA9IBwQkkIYwhGAGsg9IBwCGMIRgBtIPSAcAhlBbAAvRC1QEg5SUlECGAIRv/3r/kCKAbQNUhIRP/3MfkIsQEgEL0AITFISET/9/78CLEBIPbnLkhIRP73qvkIsQEg7+f/957/ACDr53C1lLAERg1GFkYAIACQAZAEIAOQECAEkAaVgAEHkE/0QFAIkAAgC5BP8IBgDpAPlgYgEZAAIBOQTvYRYAKQCCAFkAACCZAABBCQgAASkE/w/zJpRhNISET+9837ELEBIBSwcL1P8P8yIUYOSEhE/vdY/QixASDz5wAg8ect6fBFlbCCRg1GkEbossD1gHZGRQDZRkYsRgXrCAcAIAGQApAS4AAAEAAAAAAQAkAAcABAABgASAAgAEgAHABIABAAoAIAAAECAAEAQfLtIAOQBCAEkBAgBZCAAQiQT/RAUAmQACAMkE/wgGAPkAAgEpAUkAggBpAAAgqQAAQRkIAAE5AAvweUEJb5SEhE//ex+xixASAVsL3o8IVP8P8yAanzSEhE/vdo+wixASDy50/w/zJRRu5ISET+96T8CLEBIOjnT/D/MelISET/9/X7CLEBIN/nNESyRAT1gHC4QgHZOBsB4E/0gHAGRrxCytMAINDnELWUsARGACAAkAGQTfYjQAKQBCADkBAgBJAGlIABB5BP9EBQCJAAIAuQDpARkBKQE5AIIAWQAAIJkNBISET/91/7ELEBIBSwEL1P8P8yaUbKSEhE/vcX+wixASDz50/0+mHGSEhE//eu+wixASDq5wAg6OcQtZSwBEa09YBPAtMBIBSwEL0AIACQAZBC8t4QApAEIAOQECAEkCADBpBP9IBgB5BP9EBQCJAAIAuQDpARkBKQE5AIIAWQAAIJkK9ISET/9x37CLEBINrnT/D/MmlGqkhIRP731voIsQEg0OcAIM7nALWVsAAgAZACkEbynwADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQm0hIRP/39foQsQEgFbAAvU/w/zIBqZVISET+9636CLEBIPPnk0mRSEhE//dF+wixASDr5wAg6ecAtZWwACABkAKQQvbUMAOQBCAEkBAgBZAAIAeQT/SAYAiQT/RAUAmQACAMkE/wgGAPkAIgEJAGIBKQACAUkAggBpAAAgqQAAQRkIAAE5BP8P8yAal4SEhE/vdy+hCxASAVsAC9T/D/MmlGckhIRP73/fsIsQEg8+ed+AAAAPBgAAixASDs5534AAAA8AwACLEIIOXnQPL6UAOQT/D/MgGpZUhIRP73TPoIsQEg2OdP8P8yaUZgSEhE/vfY+wixASDO5534AAAA8AEACLECIMfnACDF5wFGT/CAYAhggBJIYIARiGCAEMhggAIIYQAgcEcAtZewUEhIRP/3X/oQsQEgF7AAvQEgA5AAIASQBCAGkBAgB5CAAQqQT/RAUAuQACAOkE/wgGARkAYgFJAAIBaQTvYRYAWQCCAIkAACDJAABBOQgAAVkE/w/zIDqTpISET+9/b5CLEBINLnAiADkEHy7SAFkAAgFJBCHgOpMkhIRP735vkIsQEgwucAIAGQAaktSEhE/vfE/gixASC45wAgtucAtZWw//cz/wIoJdEAIAGQApBL8k8AA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkE/w/zIBqRpISET+97f5ELEBIBWwAL3/9xH/CCgB0QAg9+cBIPXnACDz5wC1lbD/9wX/CCgp0QAgAZACkEPyzwADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQT/D/MgGpA0hIRP73ifkwsQEgFbAAvRAAAADgkwQA//ff/gIoAdEAIPPnASDx5wAg7+cAtZWwACABkAKQS/ZGEAOQBCAEkBAgBZAAIAiQDJAPkBKQE5AUkAggBpBP8P8yAakVSEhE/vdb+RCxASAVsAC9ACD75wC1lbAAIAGQApD/IAOQBCAEkBAgBZAAIAiQDJAPkBKQE5AUkAggBpBP8P8yAakFSEhE/vc6+RCxASAVsAC9ACD75wAAEAAAAPtIAGgA9MBgsPWAbwLRT/SAYHBH9kiAMABoAPSAcLD1gH8C0U/0AHDz5wAg8ecCRgAhirvuSABoAPTAYLD1gG8r0etIgDAAaCD0gHDoS8P4gAAYRgBoIPTAYED0AHAYYORISEQAaORLsPvz8DIjAPsD8QDgSR4xsd1IQGkA9IBgsPWAb/bQ2khAaQD0gGCw9YBvUdEDIHBHCODVSIAwAGgg9IBw0kvD+IAAReCy9QB/OtHPSABoAPTAYLD1gG8q0ctIgDAAaED0gHDJS8P4gAAYRgBoIPTAYED0AHAYYMVISEQAaMRLsPvz8DIjAPsD8QDgSR4xsb5IQGkA9IBgsPWAb/bQukhAaQD0gGCw9YBvEtEDIL/ntkiAMABoQPSAcLNLw/iAAAfgsUgAaCD0wGBA9IBgrksYYAAgrOesScloIfQAcQFDqkrRYBFGyWhB9IBx0WBwR6ZIwGgg9IBwpEnIYHBHokhAaED0gGCgSUhgcEefSEBoIPSAYJ1JSGBwR5tIQGhA9ABwmUlIYHBHmEhAaCD0AHCWSUhgcEeUSIBoQPQAQJJJiGBwR5FIgGgg9ABAj0mIYHBHAkYJKnHS3+gC8AUUISs1P0lTYACISABqIfSAQxhDhksYYhhGQGoh9CBDmEOCS1hiXeCBSIBqCEN/S5hiGEbAaiHwEAOYQ3xL2GJQ4HpIAGsIQ3lLGGMYRkBriENYY0bgdUiAawhDdEuYYxhGwGuIQ9hjPOBwSABsCENvSxhkGEZAbIhDWGQy4GtIgGwIQ2pLmGQYRsBsiEPYZCjgZkgAbQhDZUsYZRhGQG2IQ1hlHuBhSIBti7IYQ19LmGUYRsBti7KYQ1xL2GUR4FtIAG7B8wsDGENYSxhmGEZAbsHzCwOYQ1VLWGYC4P/nASBwRwC/ACD75wJGCSpB0t/oAvAFDRMZHyUrMTgAS0gAaiH0gEOYQ0lLGGI04EdIgGqIQ0ZLmGIu4ERIAGuIQ0NLGGMo4EFIgGuIQ0BLmGMi4D5IAGyIQz1LGGQc4DtIgGyIQzpLmGQW4DhIAG2IQzdLGGUQ4DVIgG2LsphDM0uYZQngMkgAbsHzCwOYQy9LGGYB4AEgcEcAvwAg++cCRgkqd9Lf6ALwBRQgKjQ+SFlmACZIQGoh9CBDGEMkS1hiGEYAaiH0gEOYQyBLGGJj4B9IwGoh8BADGEMcS9hiGEaAaohDmGJX4BlIQGsIQxdLWGMYRgBriEMYY03gFEjAawhDEkvYYxhGgGuIQ5hjQ+APSEBsCEMNS1hkGEYAbIhDGGQ54ApIwGwIQwhL2GQYRoBsiEOYZC/gBUhAbQhDA0tYZRhGAG2IQxhlJeAAAABwAEAEAAAAQEIPAP5IwG2LshhD/EvYZRhGgG2LsphD+UuYZRHg+EhAbsHzCwMYQ/VLWGYYRgBuwfMLA5hD8ksYZgLg/+cBIHBHAL8AIPvnAkYJKkPS3+gC8AUNFRshJy0zOgDoSEBqIfQgQ5hD5ktYYjbg5EjAaiHwEAOYQ+JL2GIu4OBIQGuIQ99LWGMo4N1IwGuIQ9xL2GMi4NpIQGyIQ9lLWGQc4NdIwGyIQ9ZL2GQW4NRIQG2IQ9NLWGUQ4NFIwG2LsphDz0vYZQngzkhAbsHzCwOYQ8tLWGYB4AEgcEcAvwAg++fHSIBoQPSAYMVJiGBwR8RIgGgg9IBgwkmIYHBHwEiAaED0gHC+SYhgcEe9SIBoIPSAcLtJiGBwR7lIAGhA8BAAt0kIYHBHtkgAaCDwEAC0SQhgcEeySEBoQPAQALBJSGBwR69IQGgg8BAArUlIYHBHq0hAaEDwIACpSUhgcEeoSEBoIPAgAKZJSGBwR6RIQGhA8EAAoklIYHBHoUhAaCDwQACfSUhgcEedSEBoQPCAAJtJSGBwR5pIQGgg8IAAmElIYHBHAUYIaBAoBtAgKFLQQCh80IAoe9Hs4JJIAGgg8AgAkEoQYBAfAGgg8AgAEh8QYIxICDAAaCDwCACJSggyEGAQHwBoIPAIABIfEGBIaAD0gDCw9YA/B9GCSAAfAGhA8AgAf0oSHxBgSGgA9AAwsPUAPwXRe0gAaEDwCAB5ShBgCHkA8AEAOLF2SAAdAGhA8AgAc0oSHRBgCHkA8AIAAigH0W9ICDAAaEDwCABtSggyEGDx4GtIAGgg8BAAaUoQYBAfAGgg8BAAEh8QYGVICDAAaCDwEABiSggyEGAQHwBoIPAQABIfEGBIaAD0gDCw9YA/B9FbSAAfAGhA8BAAWEoSHxBgSGgA9AAwAeAj4MHgsPUAPwXRUkgAaEDwEABQShBgCHkA8AEAOLFNSAAdAGhA8BAAS0oSHRBgCHkA8AIAAigH0UdICDAAaEDwEABESggyEGCg4EJIAGgg8CAAQEoQYBAfAGgg8CAAEh8QYDxICDAAaCDwIAA6SggyEGAQHwBoIPAgABIfEGBIaAD0gDCw9YA/B9EySAAfAGhA8CAAMEoSHxBgSGgA9AAwsPUAPwXRK0gAaEDwIAApShBgCHkA8AEAOLEmSAAdAGhA8CAAJEoSHRBgCHkA8AIAAigH0SBICDAAaEDwIAAdSggyEGBS4BtIAGgg8EAAGUoQYBAfAGgg8EAAEh8QYBVICDAAaCDwQAATSggyEGAQHwBoIPBAABIfEGBIaAD0gDCw9YA/B9ELSAAfAGhA8EAACUoSHxBgSGgA9AAwsPUAPwXRBEgAaEDwQAACShBgCHkD4ABwAEAkBAFAAPABACixdEgAaEDwQAByShBgCHkA8AIAAigH0W5IAB0AaEDwQABsShIdEGAB4AEgcEcAvwAg++doSABoQPSAQGZJCGBwRwC/ZEgAaCD0gEBiShBgYkhIRABoYkqw+/LwMiIA+wLxAOBJHjGxW0hAaQD0AHCw9QB/9tBYSEBpAPQAcLD1AH8B0QMgcEcAIPznUkkJaCHwBwFQShFgUkkJaEHwBAFQShFgASgB0TC/AuBAvyC/IL9MSQloIfAEAUpKEWBwR0VJCWgh8AcBSRxDShFgRUkJaEHwBAFDShFgASgB0TC/AuBAvyC/IL8+SQloIfAEATxKEWBwRzhJCWgh8AcBiRw1ShFgN0kJaEHwBAE1ShFgASgB0TC/AuBAvyC/IL8xSQloIfAEAS9KEWBwRypIAGgg8AcAAB0oSQhgKkgAaEDwBAAoSQhgAL8AvzC/cEdwR3BHcEdwRxC1HkgUOABoAPSAMDCx/Per/k/0gDAZSRQ5CGAYSAwwAGgA8AgAKLH/9+n/CCATSQwxCGASSAwwAGgA8BAAKLH/99z/ECANSQwxCGAMSAwwAGgA8CAAKLH/98//ICAHSQwxCGAGSAwwAGgA8EAAKLH/98L/QCABSQwxCGAQvSgEAUAAcABABAAAAEBCDwAQ7QDg+kgAaEDwAQD4SQhgAOAAv/ZIAGgA8AIAACj40PNIAGgg8PAAQPBgAPBJCGAAIIhgCEYAaO5JCEDsSQhgACDIYAhGwGhA9IBQyGAAIAhhCEYAaUD0gFAIYQAgSGEIRkBpQPSAUEhhCEYAaCD0gCAIYAAgiGHfSOBJSUQIYHBH8LUAIQAjACQCJQIiACDXTrZoBvAMBl6x1U62aAbwDAYMLh/R0k72aAbwAwYBLhnRz042aAbwCAYuucxOlDY2aMbzAyED4MlONmjG8wMRy05+RFb4IRDFTrZoBvAMBoa5CEYO4MJOtmgG8AwGBC4B0cRIBuC+TrZoBvAMBgguANHBSLpOtmgG8AwGDC420bdO9mgG8AMEtU72aMbzAxZyHAEsGdACLALQAywU0QngtE62+/L2rk//aMfzBicG+wfzE+CwTrb78vapT/9ox/MGJwb7B/MJ4AC/sfvy9qRP/2jH8wYnBvsH8wC/AL+gTvZoxvNBZnYcdQCz+/Xw8L34tQRGACYAJZlIgG0A8IBQGLH/90H6BkYW4AC/lEiAbUDwgFCSSYhlCEaAbQDwgFAAkAC/AL//9y/6BkaMSIBtIPCAUIpJiGW29QB/B9GALAzZoCwB2QIlCOABJQbggCwB0wIlAuBwLADRASWHSABoIPAPAChDhUkIYAhGAGgA8A8AqEIB0AEg+L0AIPzn+LUERgAlIHgA8BAAEChw0XRIgGgA8AwAAChr0XFIAGgA8AIAGLGgaQi5ASD4vWxIIWoAaADwCAAgsWlIAGgA8PAABeBnSJQwAGgA9HBgAAmBQh/ZIGr/94z/CLEBIOXnAL9fSABoQPAIAF1JCGAIRgBoIPDwACFqCENZSQhgAL8IRkBoIPR/QOFpQOoBIFRJSGAe4AC/UkgAaEDwCABQSQhgCEYAaCDw8AAhaghDTEkIYAC/CEZAaCD0f0DhaUDqASBHSUhgIGr/91P/CLEBIKzn//fP/kJJiWjB8wMRSEp6RFFcyEBBSUlECGAPIAHwB/1K4KBpgLM6SABoQPABADhJCGD89zT9BUYG4Pz3MP1AGwIoAdkDIIjnMUgAaADwAgAAKPLQAL8uSABoQPAIACxJCGAIRgBoIPDwACFqCEMoSQhgAL8IRkBoIPR/QOFpQOoBICNJSGAX4P/nIUgAaCDwAQAfSQhg/PcC/QVGBuD89/78QBsCKAHZAyBW5xhIAGgA8AIAACjy0SB4APABAAAoftATSIBoAPAMAAgoC9AQSIBoAPAMAAwoDtENSMBoAPADAAMoCNEKSABoAPQAMIizYGh4uwEgMOcAv2BosPWAPxjRA0gAaED0gDABSQhgLeAAEAJA//T+6gAJPQAEAAAArhwAAAAk9AAAEnoAACACQHoaAABgaLD1oC8M0f1IAGhA9IAg+0kIYAhGAGhA9IAwCGAL4DTg90gAaCD0gDD1SQhgCEYAaCD0gCAIYAC/YGiYsfz3lPwFRgjg/PeQ/EAbQfKIMYhCAdkDIObm6UgAaAD0ADAAKPDQEuD894D8BUYI4Pz3fPxAG0HyiDGIQgHZAyDS5t9IAGgA9AAwACjw0SB4APACAAIoXtHaSIBoAPAMAAQoC9DXSIBoAPAMAAwoGNHUSMBoAPADAAIoEtHRSABoAPSAYBix4GgIuQEgrObMSEBoIPD+QCF8QOoBYMlJSGA54OBoALPGSABoQPSAcMRJCGD89zv8BUYG4Pz3N/xAGwIoAdkDII/mvkgAaAD0gGAAKPLQu0hAaCDw/kAhfEDqAWC3SUhgFuC2SABoIPSAcLRJCGD89xr8BUYG4Pz3FvxAGwIoAdkDIG7mrUgAaAD0gGAAKPLRIHgA8AgACCg20WBp0LGnSJQwAGhA8AEApEnB+JQA/Pf6+wVGBuD89/b7QBsCKAHZAyBO5p1IlDAAaADwAgAAKPHQGeCZSJQwAGgg8AEAl0nB+JQA/Pff+wVGBuD899v7QBsCKAHZAyAz5pBIlDAAaADwAgAAKPHRIHgA8AQABChv0QAmiUiAbQDwgFBwuQC/hkiAbUDwgFCESYhlCEaAbQDwgFAAkAC/AL8BJoBIAGgA9IBwsLl+SABoQPSAcHxJCGD896j7BUYG4Pz3pPtAGwIoAdkDIPzldUgAaAD0gHAAKPLQAL+gaAEoCNFvSJAwAGhA8AEAbUnB+JAAIeCgaAUoD9FpSJAwAGhA8AQAZ0nB+JAACEbQ+JAAQPABAMH4kAAO4GFIkDAAaCDwAQBfScH4kAAIRtD4kAAg8AQAwfiQAAC/oGiosfz3ZfsFRgng/Pdh+0AbQfKIMYhCAtkDILflJOBRSJAwAGgA8AIAACju0BPg/PdP+wVGCOD890v7QBtB8ogxiEIB2QMgoeVHSJAwAGgA8AIAACjv0QEuBdFCSIBtIPCAUEBJiGUAvyB4APAgACAoNtFgatCxO0iYMABoQPABADlJwfiYAPz3I/sFRgbg/Pcf+0AbAigB2QMgd+UySJgwAGgA8AIAACjx0BngLkiYMABoIPABACtJwfiYAPz3CPsFRgbg/PcE+0AbAigB2QMgXOUkSJgwAGgA8AIAACjx0aBq8LMgSIBoAPAMAAwoddCgagIoU9EbSABoIPCAcBlJCGD89+X6BUYG4Pz34fpAGwIoAdkDIDnlE0gAaADwAHAAKPLRIGtAHgEBYGtB6gAg4WoIQ6GPASLC61EBQOpBUUAgAF3C61AAQepAYTggAF1B6sBgBEnIYAhGAGhA8IBwBeBM4AAAABACQABwAEAIYAhGwGhA8IBwyGD896n6BUYG4Pz3pfpAGwIoAdkDIP3k90gAaADwAHAAKPLQL+DzSABoIPCAcPFJCGAIRgBoAPAAYEi5CEYAaADwAFAguQhGwGgg8AMAyGDpSMBo6UkIQOdJyGD893z6BUYH4A3g/Pd3+kAbAigB2QMgz+TgSABoAPAAcAAo8tEB4AEgxuQAIMTk8LUAIgAjACQCJQIhACDXTvZoBvADBgEuEtHUTjZoBvAIBi650U6UNjZoxvMDIgPgzk42aMbzAxLOTn5EVvgiIMpO9mgG8AMEyE72aMbzAxZxHAEsGdACLALQAywU0QngxU62+/H2wU//aMfzBicG+wfzE+DBTrb78fa8T/9ox/MGJwb7B/MJ4AC/svvx9rdP/2jH8wYnBvsH8wC/AL+zTvZoxvNBZnYcdQCz+/Xw8L0t6fBBBEYNRgAmACewRrBIAGgA8A8AqEIP0q1IAGgg8A8AKEOqSQhgCEYAaADwDwCoQgLQASC96PCBIHgA8AEAAChu0GBoAygj0ZxIAGgA8ABwCLkBIO7n//d6/wdGnUiHQgbZIHgA8AIAAigB0aBoILGSSIBoAPDwAKC7j0iAaCDw8ABA8IAAjEmIYE/wgAgp4GBoAigG0YhIAGgA9AAwiLkBIMfnYGgwuYRIAGgA8AIAQLkBIL7ngEgAaAD0gGAIuQEgt+f/9yz7B0aBSIdCCdl6SIBoIPDwAEDwgAB3SYhgT/CACHVIgGgg8AMAYWgIQ3JJiGD895L5BkZgaAMoENEI4Pz3i/mAG0HyiDGIQgHZAyCP52lIgGgA8AwADCjw0TbgYGgCKBDRCOD893f5gBtB8ogxiEIB2QMge+dfSIBoAPAMAAgo8NEi4GBogLkI4Pz3ZPmAG0HyiDGIQgHZAyBo51VIgGgA8AwAACjw0Q/gCOD891P5gBtB8ogxiEIB2QMgV+dNSIBoAPAMAAQo8NEgeADwAgACKAjRR0iAaCDw8AChaAhDREmIYAjguPGADwXRQUiAaCDw8AA/SYhgQ0gAaADwDwCoQg7ZQEgAaCDwDwAoQz5JCGAIRgBoAPAPAKhCAdABICXnIHgA8AQABCgH0TFIgGgg9OBg4WgIQy5JiGAgeADwCAAIKAjRK0iAaCD0YFAhaUDqwQAnSYhg//d/+iVJiWjB8wMRKkp6RFFcyEApSUlECGAPIAHwt/gAIPjmcLWGsAZGDUYURgC/GkjAbEDwAQAYSchkCEbAbADwAQAAkAC/AL+IFQGQAiACkASQACADkAWQAalP8JBAAPAQ+Q1IgGgg8P5AReoEAQhDCkmIYAawcL0QSEhEAGhwRwC1//f5/wRJiWjB8wIhC0p6RFFcyEAAvQAAABACQP//7v6WFAAAACT0AAASegAAIAJAALTEBNoRAAAEAAAAZhEAAAC1//fY/2tJiWjB88Ihakp6RFFcyEAAvT8hAWBlSQloAfSAIbH1gC8D0U/0oCFBYAzgYEkJaAH0gDGx9YA/A9FP9IAxQWAB4AAhQWBZSQloAfABARGxASGBYQHgACGBYVRJSWjB8wchwWFSSQloAfDwAQFiT0kJaAH0gHGx9YB/A9FP9IBxwWAB4AAhwWBJSUlowfMGYQFhRkmQMQloAfAEAQQpAtEFIYFgCuBBSZAxCWgB8AEBEbEBIYFgAeAAIYFgPEmUMQloAfABARGxASFBYQHgACFBYTZJmDEJaAHwAQERsQEhQWIB4AAhQWIxSQloAfCAcbHxgH8C0QIhgWIB4AEhgWIrScloAfADAsJiKEnJaMHzAxFJHAFjJUnJaMHzBiJCYyNJyWjB80FRSRxKAMJjH0nJaMHzQWFJHEoAAmQcScloyg6CY3BHDyICYBhKkmgC8AMCQmAWSpJoAvDwAoJgE0qSaAL04GLCYBFKkmgC9GBS0ggCYRBKEmgC8A8CCmBwRwtIAGhA9AAgCUkIYHBHcEcQtQZIwGkA9IBwsPWAfwXR//f1/0/0gHABSQhiEL0AEAJAJBEAAAAgAkB4tQJGACMAJAAg2uABJp5ADWgF6gYEACxy0E1oAi0C0E1oEi0T0d4IAvEgBVX4JgBdB+4ODyW1QKhDXgf2Dg1ptUAoQ94IAvEgBUX4JgAQaF4AAyW1QKhDDXkF8AMFXgC1QChDEGBNaAEtCNBNaAItBdBNaBEtAtBNaBItE9GQaF4AAyW1QKhDXgDNaLVAKEOQYFBoASWdQKhDDXnF8wAVnUAoQ1Bg0GheAAMltUCoQ14AjWi1QChD0GBNaAXwgFW18YBffNEAv6VNLW5F8AEFo041ZjVGLW4F8AEFAJUAvwC/T+q2NZ4IVfgmAJ0HLg8PJbVAqEOy8ZBPAtEAJSTgXuCYTapCAdEBJR7glk2qQgHRAiUZ4JVNqkIB0QMlFOCTTapCAdEEJQ/gkk2qQgHRBSUK4JBNqkIB0QYlBeCPTapCAdEHJQDgCCWeBzYPtUAoQ4tNnghF+CYAik0oaKBDTWgF9IA1tfWAPwDRIEOFTShgLR0oaKBDTWgF9AA1tfUAPwDRIEN/TS0dKGAtHShooENNaAX0gBW19YAfANEgQ3hNCDUoYC0dKGigQ01oBfQAFbX1AB8A0SBDck0MNShgWxwNaN1AAC1/9CCveL3wtQtGACEAIgAkhOABJY1ABeoDAgAqfdAFaE8AAya+QDVDBWDOCADxIAVV+CZQTgf3Dg8mvkC1Q88IAPEgBkb4J1CFaE8AAya+QLVDhWBFaAEmjkC1Q0VgxWhPAAMmvkC1Q8VgU02OCFX4JkCNBy4PDyW1QCxAsPGQTwHRACUj4EVNqEIB0QElHuBDTahCAdECJRngQk2oQgHRAyUU4EBNqEIB0QQlD+A/TahCAdEFJQrgPU2oQgHRBiUF4DxNqEIB0QclAOAIJY4HNg+1QKVCINGNBy4PDyUF+gb0NU2OCFX4JmCmQ48IRfgnYDJNLWiVQzBONWA1HS1olUM2HTVgNR0taJVDNh01YDUdLWiVQzYdNWBJHCP6AfUALX/0dq/wvQJGE2kLQAuxASAA4AAgcEcKsYFhAOCBYnBHQmlKQEJhcEcItQJGT/SAMACQAJgIQwCQAJjQYdFhAJjQYdBpAJDQaQD0gDAIsQAgCL0BIPzncEcQtQRGD0gUMABoIEAosQxIFDAEYCBG//fy/xC9AAAAEAJAAAQASAAIAEgADABIABAASAAUAEgAGABIABwASAgAAUAABAFAAXlKHv5LA+uCAkJl/EpAMoJlSh4BI5NAw2VwRxC1ACL4TANoo0IB0vdJAeD2SRwxA3gIOxQks/v08kNsmwgB64MDg2TuS4A7w2QBI5NAA2UQvXC1BEYAJQy5ASBwvelJIGiIQgvS6UkgaEAaFCGw+/HwgABgZOVICDggZArg4UkgaEAaFCGw+/HwgABgZN1ICDggZAIghPglACBoBWhH9vBwhUPU6QIBCEMhaQhDYWkIQ6FpCEPhaQhDIWoIQwVDIGgFYCBG//ep/6BosPWATwHRACBgYCB5oWwIYNTpExBIYGBoYLFgaAQoCdggRv/3h/8AIGFtCGDU6RYQSGAD4AAgYGWgZeBlACDgYiBjYGOgY+BjASCE+CUAACCE+CQAAL+b5xC1BEYMuQEgEL0gaABoIPABACFoCGCySSBoiEIL0rJJIGhAGhQhsPvx8IAAYGSuSAg4IGQK4KpJIGhAGhQhsPvx8IAAYGSmSAg4IGQAICFoCGCU+EQQASCIQCFsSGAgRv/3Sv8AIKFsCGDU6RMQSGBgbSixACBhbQhg1OkWEEhgACBgZaBl4GXgY4T4JQAAv4T4JAAAvwC/tucwtdDpE1RsYERtFLHQ6RZUbGCQ+ERQASSsQAVsbGAEaGNghGgQLATRBGiiYARo4WAD4ARooWAEaOJgML0t6fBBBEYNRhZGH0ZP8AAIAL+U+CQAASgC0QIgvejwgQEghPgkAAC/lPglAAEoF9ECIIT4JQAAIOBjIGgAaCDwAQAhaAhgO0YyRilGIEb/97n/IGgAaEDwAQAhaAhgBuAAvwAghPgkAAC/T/ACCEBG1Oct6fBBBEYNRhZGH0ZP8AAIAL+U+CQAASgC0QIgvejwgQEghPgkAAC/lPglAAEoP9ECIIT4JQAAIOBjIGgAaCDwAQAhaAhgO0YyRilGIEb/94D/IGswsSBoAGhA8A4AIWgIYAvgIGgAaCDwBAAhaAhgIGgAaEDwCgAhaAhgoGwAaAD0gDAosaBsAGhA9IBwoWwIYGBtKLFgbQBoQPSAcGFtCGAgaABoQPABACFoCGAG4AC/ACCE+CQAAL9P8AIIQEas5wFGACIJuQEgcEcIaABoIPAOAAtoGGCIbABoIPSAcItsGGAIaABoIPABAAtoGGCR+EQwASCYQAtsWGDR6RMwWGBIbUCxSG0AaCD0gHBLbRhg0ekWMFhgASCB+CUAAL8AIIH4JAAAvxBGzudwtQRGACWU+CUAAigD0AQg4GMBJTzgIGgAaCDwDgAhaAhgIGgAaCDwAQAhaAhgoGwAaCD0gHChbAhglPhEEAEgiEAhbEhg1OkTEEhgYG1AsWBtAGgg9IBwYW0IYNTpFhBIYAEgCOAAAAAJAkAIBAJAAAgCQAgAAkCE+CUAAL8AIIT4JAAAv6BrELEgRqFriEcoRnC9LenwQQRGDkYVRk/wAAiU+CUAAigJ0AQg4GMAvwAghPgkAAC/ASC96PCBIGgAaADwIAAgsU/0gHDgYwEg8+cuuZT4RBACIAD6AfcE4JT4RBAEIAD6Aff797b7gEYt4CBsAGiU+EQgCCGRQAhAgLGU+EQQASCIQCFsSGABIOBjhPglAAC/ACCE+CQAAL8BIMrnaByQsS2x+/eW+6DrCACoQgvZICDgYwEghPglAAC/ACCE+CQAAL8BILXnIGwAaDhAACjM0GBtiLGgbQBo4W0IQGCxYG0AaED0gHBhbQhg1OkWEEhg4GtA9IBg4GPgbABoIW0IQDCx1OkTEEhg4GtA9ABw4GNOuZT4RBACIIhAIWxIYAEghPglAAXglPhEEAQgiEAhbEhgAL8AIIT4JAAAvwC/eOdwtQRGIGwFaCBoBmiU+EQQBCCIQChA0LEG8AQAuLEgaABoAPAgACi5IGgAaCDwBAAhaAhglPhEEAQgiEAhbEhgIGsAKE7QIEYha4hHSuCU+EQQAiCIQChACLMG8AIA8LEgaABoAPAgAEC5IGgAaCDwCgAhaAhgASCE+CUAlPhEEAIgiEAhbEhgAL8AIIT4JAAAv+BqMLMgRuFqiEci4JT4RBAIIIhAKEDgsQbwCADIsSBoAGgg8A4AIWgIYJT4RBABIIhAIWxIYAEg4GOE+CUAAL8AIIT4JAAAv2BrELEgRmFriEdwvRC1A0YAJAC/k/gkAAEoAdECIBC9ASCD+CQAAL+T+CUAASgS0TGxASkG0AIpBtADKQjRBeDaYgfgGmMF4FpjA+CaYwHgASQAvwDgASQAvwAgg/gkAAC/IEbb5wJGACMAv5L4JAABKAHRAiBwRwEggvgkAAC/kvglAAEoG9EFKRbS3+gB8AMGCQwPAAAg0GIQ4AAgEGMN4AAgUGMK4AAgkGMH4AAg0GIQY1BjkGMB4AEjAL8A4AEjAL8AIIL4JAAAvxhG0ucBRpH4JQBwRwFGyGtwRxC1jLAERgC/vkgAbUD0AHC8SQhlCEYAbQD0AHABkAC/AL8AvwhGwGxA9IAQyGQIRsBsAPSAEAGQAL8AvwhGAGtA9ABwCGMIRgBrIPQAcAhjAL8IRoBtQPCAUIhlCEaAbQDwgFABkAC/AL+nSEBoQPQAcKVJSGAAv6JIwGxA8EAAoEnIZAhGwGwA8EAAAZAAvwC/AL8IRsBsQPSAcMhkCEbAbAD0gHABkAC/AL8AvwhGwGxA9IBwyGQIRsBsAPSAcAGQAL8AvwC/CEbAbED0gHDIZAhGwGwA9IBwAZAAvwC/AL8IRsBsQPSAcMhkCEbAbAD0gHABkAC/AL8AvwhGwGxA8IAAyGQIRsBsAPCAAAGQAL8AvwC/CEbAbEDwgADIZAhGwGwA8IAAAZAAvwC/AL8IRsBsQPCAAMhkCEbAbADwgAABkAC/AL8AvwhGwGxA8EAAyGQIRsBsAPBAAAGQAL8AvwC/CEbAbEDwQADIZAhGwGwA8EAAAZAAvwC/AL8IRsBsQPBAAMhkCEbAbADwQAABkAC/AL+IFAeQAiAIkAEgCZACIAqQBSALkAepV0j/99f5QCAHkAAgCZAHqVRI//fP+U/0AGAHkAepUUj/98j5T/SAYAeQB6lNSP/3wflP9ABwB5AHqUpI//e6+U/0gHAHkAepR0j/97P5T/QAcAeQB6lESP/3rPlP9IBgB5AHqUBI//el+U/0AHAHkAepO0j/9575T/SAYAeQB6k3SP/3l/lP9ABAB5AHqTRI//eQ+QIgApADkDRIBpA0SAWQAiAEkMIeAqkgRvz3x/wMsBC9ELUERkwg+/dy+k/0gFEnSP/3XfpAISZI//dZ+k/0AGEjSP/3VPpP9IBhIUj/90/6T/QAcR5I//dK+k/0gHEdSP/3RfpP9ABxGkj/90D6T/SAYRhI//c7+k/0AHETSP/3NvpP9IBhEUj/9zH6T/QAQQ5I//cs+gtIAGtA9ABwCUkIYwhGAGsg9ABwCGMIRgBtIPQAcAhlCEbAbCD0gBDIZBC9AAAAEAJAAHAAQAAYAEgAIABIABwASAIAAAECAAEAALWXsBQhEqgA8Kb4RCEBqADwovgQIAGQASAHkAAgCJACIAuQASEMkWAgCZANkTchDpECIRGREJEHIQ+RAaj+9wT7CLEXsAC9DyASkAMgE5CAIBSQACAVkBaQAyESqP73nf4Ase7nAiASkAAgFJAFIRKo/veT/gCx5OcAv+LnfLUERg1GFkZQITFISEQA8GT4UCEwSEhEAPBf+AAgAJABkPv3Vvj/96z/AiAqSUlECGBB8u0giGBP8IBgiGMBIMhjCGBO9hNAiGAIIEhkAJAgIAGQ/fc4+QixASB8vQAg/OdwtQRGACUk8HBFKEb996D6ACBwvQFGACBwRxC1/fcK+wAgEL1wtQRGDUYWRipGIUYwRv33E/oAIHC9cLUERg5GFUb996D7B+AU+AEbFfgBK5FCAdAgRnC9MB6m8QEG89EgRvjnA0YBIHBHAUYAIHBHEAAAAGAAAABP8AACALUTRpRGlkYgOSK/oOgMUKDoDFCx8SABv/T3rwkHKL+g6AxQSL8MwF34BOuJACi/QPgEKwi/cEdIvyD4AisR8IBPGL8A+AErcEcAAAAAAAAAAAAAAQIDBAYHCAkAAAAAAQIDBKCGAQBADQMAgBoGAAA1DABAQg8AgIQeAAAJPQAAEnoAACT0AAA2bgEASOgBAGzcAgAAAAAACT0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 21331
-    pc_uninit: 21449
-    pc_program_page: 21465
-    pc_erase_sector: 21429
-    pc_erase_all: 21455
-    data_section_offset: 21700
+    pc_init: 0x5353
+    pc_uninit: 0x53c9
+    pc_program_page: 0x53d9
+    pc_erase_sector: 0x53b5
+    pc_erase_all: 0x53cf
+    data_section_offset: 0x54c4
     flash_properties:
       address_range:
-        start: 2415919104
-        end: 2483027968
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x90000000
+        end: 0x94000000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 65536
-          address: 0
-  mx25lm51245g_stm32l4p5-disco:
-    name: mx25lm51245g_stm32l4p5-disco
+        - size: 0x10000
+          address: 0x0
+  - name: mx25lm51245g_stm32l4p5-disco
     description: MX25LM51245G_STM32L4P5-Disco
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwR3C1BEYNRhZGAPCt+AixACBwvQEg/OcBRgAgcEcQtQfwu/gQvXC1BUYAJAX1gDEoRgDwxfgERgEsAdEAIHC9IEb853C1BEYNRhZGMkYpRiBGAPCm+AixACBwvQEg/Oct6fBBBEYORhVGACcA8Hz4B0YXuQEgvejwgQfgFPgBGxX4ASuRQgHQIEb05zAepvEBBvPRIEbu5wFGACAAvwDgQByw9YBf+9twRwEgcEcAv/7nAUYAIHBHALWZsBQhFKgH8CT6SCECqAfwIPoAv0pIgG1A8IBQSEmIZQhGgG0A8IBQAZAAvwC/ACAD8Mr4QkiAbSDwgFBASYhlECACkAEgCZAAIAqQAiANkAEhDpFgIAuQD5E3IRCRAiETkRKRByERkQKoA/AK/wix//fA/w8gFJADIBWQgCAWkAAgF5AYkAMhFKgE8NH6CLH/97D/AiAUkAAgFpAFIRSoBPDG+gix//el/xmwAL0QtQAkBvDo+gDwbvj/96D/BvAV/gixACAQvQfwufgERgyxIEb45wEg9ucQtQRGBvAG/gbw/v8BIBC9cLUERg1GFkYk8HBEBvD6/SpGIUYwRgbwAf8BIHC9cLUERg1GJPBwRCXwcEWgsiQaDeAmRjBGBvBZ/wixACBwvQC/B/AU+AAo+9EE9YA0pULv0gEg8+cAEAJAcEdwtQRGACWcSEhEAGjwsZpISEQAaE/0enGx+/DwmElJRAlosfvw9jBGAPDs+WC5ECwI0gAiIUZQHgDwV/mRSEhEBGAE4AElAuABJQDgASUoRnC9ELUAJAMgAPA1+Q8g//cp/wixASQB4P/3yf8gRhC9cEcQtU/w/zCDSYhjACCIY0AeCGQAIAhkQB6IYgAgiGJAHshiACDIYkAeCGMAIAhj//fm/wAgEL14SEhEAGhySUlECWgIRHRJSUQIYHBHckhIRABocEduSEhEAGhwR3C1BEYAJWlISEQAaKBCCdBoSEhEAGj/9+b+BUYVuWNISEQEYChGcL1gSEhEAGhwR3C1BEb/99P+BkYlRmgcGLFaSEhEAGgFRAC///fI/oAbqEL603C9T/DgIABpIPACAE/w4CEIYXBHT/DgIABpQPACAE/w4CEIYXBHUUhwR1FIAGgADHBHT0gAaMDzCwBwR01IAGhwR0xIAB0AaHBHSkgIMABocEdHSEBoQPABAEVJSGBwR0NIQGgg8AEAQUlIYHBHQEhAaEDwAgA+SUhgcEc8SEBoIPACADpJSGBwRzlIQGhA8AQAN0lIYHBHNUhAaCDwBAAzSUhgcEfKIDNJSGJTIEhiASAySQhgcEcBIDFJCGJwRwAgL0kIYnBHK0kJayHwBAEBQylKEWNwRydJCWsh8AIBAUMlShFjcEcjSUlrIfA/AQFDIUpRY3BHELUfSABrQPABAB1JCGP/90D+BEYG4P/3PP4AGwooAdkDIBC9FkgAawDwCAAAKPLQACD25xJIAGsg8AEAEEkIY3BHD0hAaED0gHANSUhgcEcLSEBoIPSAcAlJSGBwRwAAFAAAABgAAAAQAAAAABACQAwAAAADAAsBACAE4JB1/x8AAAFAAAMgQgAAIEIQtQAoBNsKBxMO5EoTVAbgCgcUDuJKAPAPAxsf1FQQvQC/APAHAt5LDDsZaE/2/wMZQNxLC0ND6gIh2UsMOxlgAL9wRy3p8E2ARg1GFkYAJwDwnvkHRjlGKkYzRgHwBwDA8QcLu/EEDwLZT/AECwHgwPEHC9pGAPEEC7vxBw8C0k/wAAsB4KDxAwvcRk/wAQsL+gr7q/EBCwvqAgsL+gz7T/ABDg76DP6u8QEODuoDDkvqDgQhRkBG//ei/73o8I0BRghGACgJ2wDwHwMBIppAQwmbAAPx4CPD+AAhAL9wRxC1AUYIRgAoF9sA8B8DASKaQK1LRAlD+CQgAL8AvwC/v/NPjwC/AL8AvwC/AL8Av7/zb48AvwC/AL8AvxC9AL8AvwC/AL8Av7/zT48AvwC/AL+bSAw4AGgA9OBgmUkIQwAdl0kMOQhgAL8AvwC/v/NPjwC/AL8AvwC/AL/953C1BEYlRmgesPGAfwHTASAP4GgeT/DgIUhhDyFP8P8w//c//wAgT/DgIYhhByAIYQAgcL0QtQDw/PgQvS3p8EUERiBGACgD231PP1w/CQfgfE8A8A8MrPEEDBf4DHA/CT1GDkYG8AcAwPEHCLjxBA8C2U/wBAgB4MDxBwjERgDxBAi48QcPAtJP8AAIAeCg8QMIR0Yl+gf4T/ABCgr6DPqq8QEKCOoKCML4AIBP8AEICPoH+KjxAQgI6gUIw/gAgAC/vejwhRC1AUYIRgAoCNsA8B8DASKaQFxLgDNECUP4JCAAvxC9ELUBRghGACgO21ZKgDJDCVL4IyAA8B8EASOjQBpACrEBIgLgACIA4AAiEEYQvRC1AUYIRgAoB9sA8B8DASKaQElLRAlD+CQgAL8QvRC1AUYIRgAoDttESoAyQwlS+CMgAPAfBAEjo0AaQAqxASIC4AAiAOAAIhBGEL0EKAjRT/DgIQlpQfAEAU/w4CIRYQfgT/DgIQlpIfAEAU/w4CIRYXBHcEcQtf/3/P8QvUDwAQEqSnwyEWAAvwC/AL+/80+PAL8AvwC/AL8AvwC/v/NvjwC/AL8Av3BHAL8AvwC/v/NfjwC/AL8AvwAgHEl8MQhgcEdBeBlKgDIRYAF4+bESHUFoEWABewkHwnpB6gJhgnpB6sJBQntB6oJBgntB6kJBwntB6gJBQnpB6gIhAnpB6kIBAngRQwlKiDIRYAXgACEGSoQyEWASHRFgcEcDSAw4AGjA8wIgcEcA5ADgGO0A4AAA+gWA4QDggOIA4AF5Sh74SwPrggJCZfZKQDKCZUoeAvADAwEimkDCZXBH8ksCaJpCBtJCbJII8EsD64ICgmQG4EJskgjtSxwzA+uCAoJkAngIOhQjsvvz8eZKgDrCZAHwHAMBIppAAmVwR3C1BEYMuQEgcL3gSSBoiEIL0uBJIGhAGhQhsPvx8IAAYGTcSAg4IGQK4NhJIGhAGhQhsPvx8IAAYGTUSAg4IGQCIIT4JQAgaAVoR/bwcIVD1OkCAQhDIWkIQ2FpCEOhaQhD4WkIQyFqCEMFQyBoBWAgRv/3pf+gaLD1gE8B0QAgYGAgeaFsCGDU6RMQSGBgaGCxYGgEKAnYIEb/94H/ACBhbQhg1OkWEEhgA+AAIGBloGXgZQAg4GMBIIT4JQAAIIT4JAAAv5/nELUERgy5ASAQvSBoAGgg8AEAIWgIYKtJIGiIQgvSq0kgaEAaFCGw+/HwgABgZKdICDggZArgo0kgaEAaFCGw+/HwgABgZJ9ICDggZAAgIWgIYJT4RAAA8BwBASCIQCFsSGAgRv/3SP8AIKFsCGDU6RMQSGBgaFixYGgEKAjYIEb/9yr/ACBhbQhg1OkWEEhgACBgZaBl4GXgYiBjYGOgY+BjhPglAAC/hPgkAAC/AL+q5zC10OkTVGxgRG0UsdDpFlRsYJD4REAE8BwFASSsQAVsbGAEaGNghGgQLATRBGiiYARo4WAD4ARooWAEaOJgML0t6fBBBEYNRhZGH0ZP8AAIAL+U+CQAASgC0QIgvejwgQEghPgkAAC/lPglAAEoF9ECIIT4JQAAIOBjIGgAaCDwAQAhaAhgO0YyRilGIEb/97f/IGgAaEDwAQAhaAhgBuAAvwAghPgkAAC/T/ACCEBG1Oct6fBBBEYNRhZGH0ZP8AAIAL+U+CQAASgC0QIgvejwgQEghPgkAAC/lPglAAEoP9ECIIT4JQAAIOBjIGgAaCDwAQAhaAhgO0YyRilGIEb/937/IGswsSBoAGhA8A4AIWgIYAvgIGgAaCDwBAAhaAhgIGgAaEDwCgAhaAhgoGwAaAD0gDAosaBsAGhA9IBwoWwIYGBtKLFgbQBoQPSAcGFtCGAgaABoQPABACFoCGAG4AC/ACCE+CQAAL9P8AIIQEas5wFGACKR+CUAAigI0AQgyGMAvwAggfgkAAC/ASBwRwhoAGgg8A4AC2gYYIhsAGgg9IBwi2wYYAhoAGgg8AEAC2gYYJH4RAAA8BwDASCYQAtsWGDR6RMwWGBIbUCxSG0AaCD0gHBLbRhg0ekWMFhgASCB+CUAAL8AIIH4JAAAvxBGzOdwtQRGACWU+CUAAigM0AQg4GMBJT3gAAAACQJACAQCQAAIAkAIAAJAIGgAaCDwDgAhaAhgIGgAaCDwAQAhaAhgoGwAaCD0gHChbAhglPhEAADwHAEBIIhAIWxIYNTpExBIYGBtQLFgbQBoIPSAcGFtCGDU6RYQSGABIIT4JQAAvwAghPgkAAC/oGsQsSBGoWuIRyhGcL0t6fBBBEYORhVGlPglAAIoCdAEIOBjAL8AIIT4JAAAvwEgvejwgSBoAGgA8CAAILFP9IBw4GMBIPPnPrmU+EQAAPAcAQIgAPoB+AbglPhEAADwHAEEIAD6Afj/98n5B0Yw4CBsAGiU+EQQAfAcAgghkUAIQJCxlPhEAADwHAEBIIhAIWxIYAEg4GOE+CUAAL8AIIT4JAAAvwEgwudoHIix//em+cAbqEIA2F25ICDgYwEghPglAAC/ACCE+CQAAL8BIK7nIGwAaADqCAAAKMjQYG2IsaBtAGjhbQhAYLFgbQBoQPSAcGFtCGDU6RYQSGDga0D0gGDgY+BsAGghbQhAMLHU6RMQSGDga0D0AHDgY165lPhEAADwHAECIIhAIWxIYAEghPglAAfglPhEAADwHAEEIIhAIWxIYAC/ACCE+CQAAL8Av2zncLUERiBsBWggaAZolPhEAADwHAEEIIhAKEDgsQbwBADIsSBoAGgA8CAAKLkgaABoIPAEACFoCGCU+EQAAPAcAQQgiEAhbEhgIGsAKFbQIEYha4hHUuCU+EQAAPAcAQIgiEAoQBizBvACAACzIGgAaADwIABAuSBoAGgg8AoAIWgIYAEghPglAJT4RAAA8BwBAiCIQCFsSGAAvwAghPgkAAC/4GpQsyBG4WqIRybglPhEAADwHAEIIIhAKEDwsQbwCADYsSBoAGgg8A4AIWgIYJT4RAAA8BwBASCIQCFsSGABIOBjhPglAAC/ACCE+CQAAL9gaxCxIEZha4hHcL0QtQNGACQAv5P4JAABKAHRAiAQvQEgg/gkAAC/k/glAAEoEtExsQEpBtACKQbQAykI0QXg2mIH4BpjBeBaYwPgmmMB4AEkAL8A4AEkAL8AIIP4JAAAvyBG2+cCRgAjAL+S+CQAASgB0QIgcEcBIIL4JAAAv5L4JQABKBvRBSkW0t/oAfADBgkMDwAAINBiEOAAIBBjDeAAIFBjCuAAIJBjB+AAINBiEGNQY5BjAeABIwC/AOABIwC/ACCC+CQAAL8YRtLnAUaR+CUAcEcBRshrcEcCRpL4JQABKCTRAL+S+CQAASgB0QIgcEcBIIL4JAAAvwh4AwaIiUAeQ+rAQEtoGEMLekDqA0BLekDqQyCTbBto27IYQ5NsGGAAvwAggvgkAAC/4OcBIN7nAkaS+CUAASgb0VBtyLEAv5L4JAABKAHRAiBwRwEggvgkAAC/CIlAHgtoQ+rAQEtoGENTbRhgAL8AIIL4JAAAv+vnASDp5wFGkfglAEixSG04sUhtAGhA9IAwSm0QYAAgcEcBIPznAUaR+CUASLFIbTixSG0AaCD0gDBKbRBgACBwRwEg/OcQtQRG4GwAaCFtCECIsaBsAGgg9IBwoWwIYNTpExBIYOBrQPQAcOBjYGsQsSBGYWuIR2BtsLGgbQBo4W0IQIixYG0AaCD0gHBhbQhg1OkWEEhg4GtA9IBg4GNgaxCxIEZha4hHEL0AAHi1AkYAI9rgASaeQA1oBeoGBAAsctBNaAItAtBNaBItE9HeCALxIAVV+CYAXQfuDg8ltUCoQ14H9g4NabVAKEPeCALxIAVF+CYAEGheAAMltUCoQw15BfADBV4AtUAoQxBgTWgBLQjQTWgCLQXQTWgRLQLQTWgSLRPRkGheAAMltUCoQ14AzWi1QChDkGBQaAElnUCoQw15xfMAFZ1AKENQYNBoXgADJbVAqENeAI1otUAoQ9BgTWgF8IBVtfGAX3zRAL+nTS1uRfABBaVONWY1Ri1uBfABBQCVAL8Av0/qtjWeCFX4JgCdBy4PDyW1QKhDsvGQTwLRACUk4F7gmk2qQgHRASUe4JhNqkIB0QIlGeCXTapCAdEDJRTglU2qQgHRBCUP4JRNqkIB0QUlCuCSTapCAdEGJQXgkU2qQgHRByUA4Aglngc2D7VAKEONTZ4IRfgmAIxNKGigQ01oBfSANbX1gD8A0SBDh00oYC0dKGigQ01oBfQANbX1AD8A0SBDgU0tHShgLR0oaKBDTWgF9IAVtfWAHwDRIEN6TQg1KGAtHShooENNaAX0ABW19QAfANEgQ3RNDDUoYFscDWjdQAAtf/Qgr3i98LULRgAhh+ABJY1ABeoDAgAqftBpTY4IVfgmQI0HLg8PJbVALECw8ZBPAdEAJSPgW02oQgHRASUe4FlNqEIB0QIlGeBYTahCAdEDJRTgVk2oQgHRBCUP4FVNqEIB0QUlCuBTTahCAdEGJQXgUk2oQgHRByUA4Agljgc2D7VApUIh0U5NLWiVQ01ONWA1HS1olUM2HTVgNR0taJVDNh01YDUdLWiVQzYdNWCNBy4PDyUF+gb0QU2OCFX4JlClQz5OjwhG+CdQBWhPAAMmvkA1QwVgzggA8SAFVfgmUE4H9w4PJr5AtUPPCADxIAZG+CdQhWhPAAMmvkC1Q4VgRmgBJY1ArkNGYMVoTwADJr5AtUMA4ADgxWBJHCP6AfUALX/0c6/wvQJGE2kLQAuxASAA4AAgcEcKsYFhAOCBYnBHQmkKQAqxgWIA4IFhcEcItQJGT/SAMACQAJgIQwCQAJjQYdFhAJjQYdBpAJDQaQD0gDAIsQAgCL0BIPzncEcQtQRGD0gUMABoIEAosQxIFDAEYCBG//fy/xC9AAAAEAJAAAQASAAIAEgADABIABAASAAUAEgAGABIABwASAgAAUAABAFAELWGsARGAiACkAMgBJAAIAOQAL/ISMBsQPSAEMZJyGQIRsBsAPSAEACQAL8AvwC/CEaAbUDwgFCIZQhGgG0A8IBQAJAAvwC/vEhAaED0AHC6SUhgAL+4SMBsQPAQALZJyGQIRsBsAPAQAACQAL8AvwC/CEbAbEDwEADIZAhGwGwA8BAAAJAAvwC/AL8IRsBsQPAQAMhkCEbAbADwEAAAkAC/AL8AvwhGwGxA8BAAyGQIRsBsAPAQAACQAL8AvwC/CEbAbEDwEADIZAhGwGwA8BAAAJAAvwC/AL8IRsBsQPABAMhkCEbAbADwAQAAkAC/AL8AvwhGwGxA8AEAyGQIRsBsAPABAACQAL8AvwC/CEbAbEDwCADIZAhGwGwA8AgAAJAAvwC/AL8IRsBsQPAIAMhkCEbAbADwCAAAkAC/AL8AvwhGwGxA8AQAyGQIRsBsAPAEAACQAL8AvwC/CEbAbEDwCADIZAhGwGwA8AgAAJAAvwC/AL8IRsBsQPBAAMhkCEbAbADwQAAAkAC/AL8KIAWQASADkMACAZABqWhI//dp/QAgA5BP9IBgAZABqWRI//dg/QAgA5BP9ABwAZABqV9I//dX/U/0gFABkAGpXEj/91D9T/QAUAGQAalYSP/3Sf2AIAGQAalP8JBA//dC/UAgAZABqU/wkED/9zv9CCABkAGpT0j/9zX9gCABkAGpTUj/9y/9ECABkAGpSkj/9yn9ICABkAGpR0j/9yP9AyAFkEAgAZABqURI//cb/QC/PUgAbUD0gHA7SQhlCEYAbQD0gHAAkAC/AL8IRgBrQPSAcAhjCEYAayD0gHAIYwAiDyFHIP735v5HIP73If8GsBC9OLUERkcg/vcq/0/0AGErSP/31P1P9IBhKUj/98/9T/QAcSZI//fK/U/0gFEkSP/3xf1P9ABRIUj/98D9gCFP8JBA//e7/UAhT/CQQP/3tv0QIRxI//ey/SAhGkj/9679CCEXSP/3qv2AIRZI//em/UAhFUj/96L9D0gAa0D0gHANSQhjCEYAayD0gHAIYwC/CEYAbUD0gHAIZQhGAG0A9IBwAJAAvwC/CEbAbCD0gBDIZDi9AAAAEAJAAHAAQAAQAEgACABIAAwASAAYAEgt6fBBBEYORhdGmEYGnRLgaByAsf73T/yg6wgAqEIA2E25T/QAcKBk4GxA8AEA4GQBIL3o8IEgaABqMEAIsQEgAOAAILhC49EAIPLnAkYRZQAgcEdwR/i1BEYAJf73K/wGRgy5ASV44AAg4GSgbEC5IEb/9x3+QfKIMSBG//fm/wVGAC1p0SCKQB7haEHqAEFgaUAeQeoAIOFpCEMhaIlo/koRQAhDIWiIYCBowGgg9OAgIWoIQyFoyGAgjgAEIWgIYSFoYGtIYSBoAGgg9PhRYGhAHkHqACAhaAhgIG0zRgAiICEAkCBG//eK/wVGjbsgaMBoIPD/AGFqSR4IQyFoyGAgaABoIPBAAKFoCEMhaAhg1OkKAQhDIWjR+AgRIfCgQQhDIWjB+AgBIGgAaEDwAQAhaAhgoGkCKAXRIGiAaEDwAgAhaIhg4Giw8YBvAtEBIKBkAeACIKBkKEb4vXBHcLUERgAlDLkBJRDgIGgAaCDwAQAhaAhgIGiAaCDwAgAhaIhgIEb/99T+ACCgZChGcL1wR3BHcEdwtQVGrGoAICBkoGyw9YB/GtEgaABqwPNAEHixAiAhaEhiIGgAaED0ADAhaAhgIGgAaEDwAgAhaAhgCuACIKBkIEb/99z/BOACIKBkIEb/99X/cL1wR3BHcEdwR3BHLenwQQRGIGgA8VAIIGgFaiBoB2imbAXwBAA4swf0gCAgsxguCtGgawB4iPgAAKBrQBygYyBsQB4gZAvgKC4J0Zj4AAChawhwoGtAHKBjIGxAHiBkIGwouSBoAGgg9IAgIWgIYCBG//fK/6XgBfACAAAoS9AH9AAwAChH0CguIdEgbGixBfR8UFCxmPgAAKFrCHCga0AcoGMgbEAeIGSL4CBsACjh0QIgIWhIYiBoAGgg9OAgIWgIYAIgoGQgRv/3nf954AIgIWhIYiBoAGgg9OAgIWgIYAIgoGQYLgPRIEb/94v/aOAILgPRIEb/94T/YuC29YB/X9HgbBi5IEb/90//WeAgRv/3Sv9V4AXwCACwsQf0ACCYsQggIWhIYiBoAGgA9IAAOLEgaABoIPQQICFoCGACIKBkIEb/91z/O+AF8AEAYLMH9IAwSLMBICFoSGIgaABoIPT4ECFoCGACIOBkIGgAaADwBACYsSBoAGgg8AQAIWgIYExIeERhbIhjYGz/91r4uLECIKBkIEb/9wb/EeACIKBkIEb/9wD/C+AF8BAAQLEH9IAQKLEQICFoSGIgRv/38v696PCBLenwQQNGACAfaD9oJ/BAV9P4AMDM+ABwn2hfuR9oP2gn8IAH0fgEwEfqDAfT+ADAzPgAcA9oAi8M0R9oB/XAch9oB/XEdB9oB/XIdR9oB/XQdgvgH2gH9YByH2gH9YR0H2gH9Yh1H2gH9ZB20ekSfEfqDAcXYM9qj7GPajdg0fg0wM9qR+oMB9H4MMBH6gwH0vgAwCz0fBxH6gwHF2AnaCfwHwfR+ETAR+oMBydgj2s/sQ9oL7nPa38e0/gAwMz4QHDPaAAvfdDPafezj2tns9H4FMDPaEfqDAfR+BDAR+oMB9H4HMAE4AAA/Pjg+CX+//9H6gwH0fgkwEfqDAfR+CDAR+oMB9H4OMBH6gwH0fhAwEfqDAfS+ADA3/gYigzqCAxH6gwHF2Aq4NH4FMDPaEfqDAfR+BDAR+oMB9H4HMBH6gwH0fgkwADgIeBH6gwH0fggwEfqDAfS+ADAQ/Y/eCzqCAxH6gwHF2DfarfxgF8G0U9pCC8D0RdoR/AAZxdgj2gvYI9p0/gAwMz4SHB34I9r57HR+BTAz2hH6gwH0fgQwEfqDAfR+DjAR+oMB9H4QMBH6gwH0vgAwN/4fIkM6ggMAOAh4EfqDAcXYBrg0fgUwM9oR+oMB9H4EMBH6gwH0vgAwCzwPwxH6gwHF2DfarfxgF8G0U9pCC8D0RdoR/AAZxdgj2gvYDrgz2mns49r57HR+CTAz2lH6gwH0fggwEfqDAfR+DjAR+oMB9H4QMBH6gwH0vgAwN/4/IgI8T8IDOoIDEfqDAcXYA/g0fgkwM9pR+oMB9H4IMBH6gwH0vgAwCz0fFxH6gwHF2CPadP4AMDM+EhwA+D/5wEgCCffZL3o8IEt6fhFBEYNRpBG/vc5+YJGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsYsShoALkAvwC/p2wCLwPR4Giw8YBvCdEULwLRKGgCKATQJC890ShoASg60VNGACIgISBGzfgAgP/3svwGRh67ACDgZClGIEb/94P+BkbeuahrYLlTRgEiAiEgRs34AID/9578BkYCICFoSGIc4ChoELkEIKBkF+AoaAEoCNGgbCQoAtEEIKBkDuAUIKBkC+CgbBQoAtEEIKBkBeAkIKBkAuABJhAg4GQwRr3o+IX4tQRGDUb+98/4B0agaAC5AL/oaACxAL/oaQCxAL/oagCxAL+oawCxAL+gbAIoJdEoaBi7qGsIu+BosPGAbx3QIG07RgAiICEAkCBG//dR/AZGtrkAIOBkAyAhaEhiKUYgRv/3H/4GRl65CCCgZCBoAGhA9EAwIWgIYALgASYQIOBkMEb4vS3p+EUERg1GF0b+94r4gkbU+EiAuPEBDwLQuPECDxfRU0YAIiAhIEYAl//3H/wGRo65KIgABGloQOoBIKloCEPpaAhDIWjB+AACAiCgZALgASYQIOBkMEa96PiFLen4QwRGDUYXRv73XPiARqBsAig40eBosPGAbzTRQ0YAIiAhIEYAl//38vsGRla7IGgAaCDwQFAhaAhgIGiAaCDwgHApaAhDIWiIYChpQPBAYKloCENA9EBgIWjB+AABKGlA8EBgqWgIQ0D0QGAhaMH4gAHoaEAeIWgIZGhoIWiIZAQgoGQC4AEmECDgZDBGvej4gy3p+EUERg5GF0b+9xL4gEYgaADxUAoeuQElCCDgZDrgoGwEKDTRIGgAbEAcIGQgbOBjpmMgaABoIPBAUCFoCGAAv0NGASIEISBGAJf/95b7BUYFsQzgoGsAeIr4AACga0AcoGMgbEAeIGQgbAAo6NEAv4W5Q0YBIgIhIEYAl//3ffsFRj25AiAhaEhioGQC4AElECDgZChGvej4hS3p/E0ERg5GF0b998T/AZAgaADxUAogaND4SIAgaND4ELEeuQElCCDgZFHgoGwEKEvRIGgAbEAcIGQgbOBjpmMgaABoIPBAUEDwgFAhaAhg4Giw8YBvA9EgaMD4SIAM4CBo0PgAAQD04GAYsSBowPhIgALgIGjA+BCxAL8AlwEiBiEgRgGb//cr+wVGBbEM4Jr4AAChawhwoGtAHKBjIGxAHiBkIGwAKOjRAL+FuQCXASICISBGAZv/9xL7BUY9uQIgIWhIYqBkAuABJRAg4GQoRr3o/I0QtQJGACAZuQEgCCPTZB7gk2wEKxjRE2gbbFscE2QTbNNjkWMTaBtoI/BAUxRoI2ADIxRoY2IYI5NkE2gbaEP04CMUaCNgAuABIBAj02QQvXC1AkYAIBVoq2wVaNX4EEEZuQEgCCXVZDPglWwELS3RFWgtbG0cFWQVbNVjkWMVaC1oJfBAVUXwgFUWaDVgAyUWaHViKCWVZBVoLWhF9OAlFmg1YNVotfGAbwLRFWirZA/gFWjV+ABRBfTgZRWxFWirZAbgFWjF+BBBAuABIBAl1WRwvXC1BEYAJqVsBfAIABi5BfAEAAAoPNAgaABoIPT4ECFoCGBP9IBwoGQgaABoAPAEAJixIGgAaCDwBAAhaAhg+Uh4RGFsiGNgbP73jfz4sQIgoGQgRv/3Ovsd4CBoAGrA80AQeLECICFoSGIgaABoQPQAMCFoCGAgaABoQPACACFoCGAI4AIgoGQgRv/3H/sC4AEmECDgZDBGcL1wtQVGrGoAICBkBCDgZCBoAGgg8AQAIWgIYCBG//ej/1CxIGgAaCD04CAhaAhgAiCgZCBG//f8+nC9cEdwR3C1BUasaiBsQAggZKBsKCgD0SBG//fz/wLgIEb/9+7/cL0BRohqACICZAJoEmgi8AQCA2gaYApoEmgi8AECC2gaYAJoEmhC9AAyA2gaYHBHLenwQQRGDkYAJyBoAGxFHB65AScIIOBkeeCgbAQoc9FgbEBpCLklZCTgYGxAabD1gH8N0QXwAQAYuSB5APABABixCCDgZAEnFOBoCCBkEeBgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIIOBkAScB4KgIIGQAL0rRIGzgY6ZjIGgAaCDwQFAhaAhgAyAhaEhiGCCgZJtIeERhbMhimkh4RGFsCGOZSHhEYWxIYwAgYWyIYxAhYGyBYGBsAGgAaCDwEABhbIloCENhbAloCGDjayFoAfFQAjFGYGz+9w77YLkgaABoQPSAMCFoCGAgaABoQPAEACFoCGAJ4AEnBCDgZAIgoGQD4P/nAScQIOBkOEa96PCBLenwRwRGDkYAJyBoAGxFHCBo0PhIgCBo0PgQoR65AScIIOBkkOCgbAQob9FgbEBpCLklZCTgYGxAabD1gH8N0QXwAQAYuSB5APABABixCCDgZAEnFOBoCCBkEeBgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIIOBkAScB4KgIIGQAL2HRIGzgY6ZjIGgAaCDwQFBA8IBQIWgIYAMgIWhIYiggoGRVSHhEYWzIYlRIeERhbAhjU0h4RGFsSGMAIGFsiGMAIWBsgWBgbABoAGgg8BAAYWyJaAhDYWwJaAhg42siaALxUAEyRmBs/vd8+hC7IGgAaED0gDAhaAhg4Giw8YBvBNEgaMD4SIAN4BngIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4EKEgaABoQPAEACFoCGAI4AEnBCDgZAIgoGQC4AEnECDgZDhGvejwhy3p+E8ERg1GF0b99yr9gkYgaND4SIAgaND4ELGgbAQoXNHoaLD1gA9Y0VNGACIgISBGAJf/97r4BkYALlHRKGghaMH4iABoaCFowfiAAChpIWjB+JAA1ekCAQhDQPAAUCFoCWgh8ENRCEMhaAhg4Giw8YBvA9EgaMD4SIAf4CBo0PgAAQD04GCwsSBowPhIgBXgAADAwP/wwP//8Iv2//85////D////8n+//8V/v//6/3//6X9//8gaMD4ELFTRgEiCCEgRgCX//dw+AZGJrkIICFoSGICIKBkAuABJhAg4GQwRr3o+I8t6fhFBEYNRv33t/yARiBoh2wgaND4EKGgbAQoQNEgbUNGACIgIQCQIEb/90v4BkZGuyhoIWjB+IgAaGghaMH4gAAoaSFowfiQANXpAgEIQ0DwAFAhaAloIfBDUQhDIWgIYAkgIWhIYkggoGQgaABoQPQQICFoCGDgaLDxgG8C0SBoh2QP4CBo0PgAAQD04GAQsSBoh2QG4CBowPgQoQLgASYQIOBkMEa96PiF+LUERg1G/fdi/AdGoGwEKCbRIG07RgAiICEAkCBG/vf7/wZG/rmIIKBkKGgIKAzRaGghaMH4MAEQICFoSGIgaABoQPSAECFoCGAgaABo/UkIQCloQfBAUQhDIWgIYALgASYQIOBkMEb4vfi1BEYAJf33LfwHRqZsBvAIABi5BvAEAAAoOdAgaABoAPAEAGCxIGgAaCDwBAAhaAhgYGz+95L5BUYNsQQg4GQgaABqwPNAEPixIGgAaEDwAgAhaAhgIG07RgEiAiEAkCBG/vek/wVGrbkCICFoSGIgbTtGACIgIQCQIEb+95f/BUZFuQIgoGQF4AIgoGQC4AElECDgZChG+L0QtQJGACCTbAPwCANbuVFgE2gbaCP0+FRTaFseROoDIxRoI2AC4AEgECPTZBC9AUYIaABowPMEIEAccEcBRshscEcBRohscEfwtQVGACAAJBWxAi0A2Am5ASBk4AAmDmBOYI5gzmAOYQItCNG1TjZoBvABBg65tEwB4E/0AHQAI0/gsE42HVb4IyAC8AEGPrEC8AIGBPACB75CAdFeHA5gAvAQBj6xAvAgBgTwIAe+QgHRXhxOYAL0gHY+sQL0AHYE9AB3vkIB0V4cjmAC9IA2jrEC9IAmBPSAJ75CC9EC9AA2JrleHEb0gDbOYAPgXhxG8IB2zmAC8IB2jrEC8IBmBPCAZ75CC9EC8AB2JrleHEb0gDYOYQPgXhxG8IB2DmFbHAIrrdPwvS3p8E2MsIJGDEZP8AAL2EaESdr4AACIQgLRACYBJQHgASYAJQAnEOAH60cCa0YD68IBehzQsv/3c/8gsU/wAQsIIMr4TAB4HMeyAi/s07vxAA990XNIAGgA8AEAOLFxSABoIPABAG9JCGBI8AEIbkgAaADwAQA4sWtIAGgg8AEAaUkIYEjwAghkSAAdButGAWpGAuvBAYloSR5Q+CEAIPSAcl5IAB0G60YBa0YD68EBiWhJHkD4ISAAHwBoAPABAAAoZNBVSABoIPABAFNJCGABLVvRCB0F60UBXfgxEEkeUPghAEDwAgJMSAAdBetFAV34MRBJHkD4ISAF60UBakYC68EBSWhJHlD4IQBA8CACQkgAHQXrRQED68EBSWhJHkD4ISAF60UBakYC68EBCXtJHgHwAQFQ+CEAQPSAIjdIAB0F60UBA+vBAQl7SR4A4HDiAfABAUD4ISAF60UBakYC68EBCXxJHgHwAQFQ+CEAQPCAYilIAB0F60UBA+vBAQl8SR4B8AEBQPghIGzgButGAF34MADosyBIAB0G60YBXfgxEEkeUPghACDwAQIbSAAdButGAV34MRBJHkD4ISAG60YBakYC68EBSWhJHlD4IQAg8BACEUgAHQbrRgFrRgPrwQFJaEkeQPghIAbrRgFqRgLrwQEJe0keAfABAVD4IQAg9IAyBUgAHQbrRgED68EBC+Ao4AAA9///zwAcBlAiAgQEABAAoAAUAKAJe0keAfABAUD4ISAG60YBakYC68EBCXxJHgHwAQFQ+CEAIPCAcvpIButGAQPrwQEJfEkeAfABAUD4ISAF60UBXfgxECBoiEIg0AXrRQFqRgLrwQFgaEloiEIX0AXrRQEC68EBoGiJaIhCD9AF60UBAuvBAeBoyWiIQgfQBetFAQLrwQEgaQlpiEIn0QXrRQFd+DEQIGiIQiHRBetFAWpGAuvBAWBoSWiIQhjRBetFAQLrwQHgaMloiEIQ0QXrRQEC68EBIGkJaYhCCNHQSAAfAGhA8AEAzkkJHwhgauDMSAXrRQFd+DEQSR5Q+CEAIPABAsdIBetFAV34MRBJHkD4ISAF60UBakYC68EBSWhJHlD4IQAg8BACvUgF60UBa0YD68EBSWhJHkD4ISAF60UBakYC68EBiWhJHlD4IQAg9IBys0gF60UBA+vBAYloSR5A+CEgBetFAWpGAuvBAQl7SR4B8AEBUPghACD0gDKoSAXrRQED68EBCXtJHgHwAQFA+CEgBetFAWpGAuvBAQl8SR4B8AEBUPghACDwgHKcSAXrRQED68EBCXxJHgHwAQFA+CEglkihaEkeUPghACD0QHBP9IBxQepGIQhDkEmiaFIeQfgiAGBpQB4JHwlowfMHQYhCC9mKSAAfAGgg9H8BoIpAHkHqAECFSQkfCGCESAAfAGgA8AEAACht0IBIIWhJHlD4IQAg8AMAQBx8SSJoUh5B+CIACEZhaEkeUPghACDwMABA8BACdUhhaEkeQPghIOBoAPSAMJCxcUghe0keAfABAVD4IQAg9OAgQPSAMmtIIXtJHgHwAQFA+CEgEeBnSCF7SR4B8AEBUPghACDw4GBA8IByYkghe0keAfABAUD4ISAgaQD0gDCQsVxIIXxJHgHwAQFQ+CEAIPTgIED0QDJXSCF8SR4B8AEBQPghIJDgU0ghfEkeAfABAVD4IQAg8OBgQPBAck1IIXxJHgHwAQFA+CEgfeBJSCFoSR5Q+CEAIPADAAEhQepGAQhDREkiaFIeQfgiAAhGYWhJHlD4IQAg8DAAECFB6kYRCEM8SWJoUh5B+CIA4GgA9IAwqLEIRiF7SR4B8AEBUPghACD04CBP9IAxQeqGQQhDMEkie1IeAvABAkH4IgAU4CxIIXtJHgHwAQFQ+CEAIPDgYU/wgHBA6oZgAUMlSCJ7Uh4C8AECQPgiECBpAPSAMKixIEghfEkeAfABAVD4IQAg9OAgT/RAMUHqhkEIQxlJInxSHgLwAQJB+CIAFOAVSCF8SR4B8AEBUPghACDw4GBP8EBxQeqGYQhDDkkifFIeAvABAkH4IgAI8AEAKLEKSABoQPABAAhJCGAI8AIAKLEGSABoQPABAARJCGBYRgywvejwjQQcBlAAEACgABQAoHxIgGtA8IBQekmIYwhGgGsg8IBQiGNwR3dIAGhA9IBwdUkIYHBHdEgAaCD0gHBySQhgcEcBRnBIQGgg8A4ACmgQQ21KUGBtSABoIPSAMGtKEGAQHwBoIPSAMBIfEGBnSAgwAGgg9IAwZEoIMhBgEB8AaCD0gDASHxBgSGgA9IAwsPWAPwfRXUgAHwBoQPSAMFpKEh8QYEhoAPQAMLD1AD8F0VZIAGhA9IAwVEoQYAh5APABADixUUgAHQBoQPSAME5KEh0QYAh5APACAAIoB9FKSAgwAGhA9IAwSEoIMhBgACBwR0RIQGhA8AEAQklIYHBHQUhAaCDwAQA/SUhgcEc9ScloAPAfApFDQepQETpK0WARRoloAPAfAhFDNkqRYHBHNUmJaADwHwKRQzJKkWBwR3C1BEYNRlS5L0hAaQD0AHCw9QB/CtEA8MT8OLFwvSlIQGnA80AgCLkA8LT8KEgAaCDwBAAmSQhgAS0B0TC/AuBAvyC/IL8Av+jncLUFRgxGtfWATwPRIEYA8OL8AuAgRgDwxPxwvRdIAGgg8AcAwBwVSQhgFkgAaEDwBAAUSQhgAL8AvzC/cEcRSABoQPACAA9JCGBwRw1IAGgg8AIAC0kIYHBHCkgAaEDwEAAISQhgcEcGSABoIPAQAARJCGBwR3BHABACQABwAEAEBAFAEO0A4PhIAGgA9MBgsPWAbwLRT/SAYHBH80iAMABoAPSAcLD1gH8C0U/0AHDz5wAg8ecCRpK77EgAaAD0wGCw9YBvLNHoSIAwAGgg9IBw5kvD+IAAGEYAaCD0wGBA9ABwGGDiSEhEAGgyI1hD4Euw+/PwQRwA4Eke20hAaQD0gGCw9YBvAdEAKfXR10hAaQD0gGCw9YBvUtEDIHBHCODSSIAwAGgg9IBwz0vD+IAARuCy9QB/O9HMSABoAPTAYLD1gG8r0chIgDAAaED0gHDGS8P4gAAYRgBoIPTAYED0AHAYYMJISEQAaDIjWEPAS7D78/BBHADgSR67SEBpAPSAYLD1gG8B0QAp9dG3SEBpAPSAYLD1gG8S0QMgvueySIAwAGhA9IBwsEvD+IAAB+CuSABoIPTAYED0gGCrSxhgACCr56lJyWgh9ABxAUOmStFgEUbJaEH0gHHRYHBHokjAaCD0gHCgSchgcEefSEBoQPSAYJ1JSGBwR5tIQGgg9IBgmUlIYHBHmEhAaED0AHCWSUhgcEeUSEBoIPQAcJJJSGBwR5FIgGhA9ABAj0mIYHBHjUiAaCD0AECLSYhgcEcQtQJGACAJKnHS3+gC8AUUISs1P0lTYACESxtqIfSARCNDgUwjYiNGW2oh9CBEo0N+TGNiXeB8S5tqC0N7TKNiI0bbaiHwEASjQ3dM42JQ4HZLG2sLQ3RMI2MjRltri0NjY0bgcUubawtDb0yjYyNG22uLQ+NjPOBsSxtsC0NqTCNkI0ZbbItDY2Qy4GdLm2wLQ2VMo2QjRttsi0PjZCjgYksbbQtDYEwjZSNGW22LQ2NlHuBdS5ttjLIjQ1tMo2UjRtttjLKjQ1hM42UR4FZLG27B8wsEI0NUTCNmI0ZbbsHzCwSjQ1BMY2YC4P/nASAAvwC/EL0QtQJGACAJKkHS3+gC8AUNExkfJSsxOABGSxtqIfSARKNDREwjYjTgQkubaotDQUyjYi7gP0sba4tDPkwjYyjgPEuba4tDO0yjYyLgOUsbbItDOEwjZBzgNkubbItDNUyjZBbgM0sbbYtDMkwjZRDgMEubbYyyo0MuTKNlCeAtSxtuwfMLBKNDKkwjZgHgASAAvwC/EL0QtQJGACAJKnbS3+gC8AUUICo0Pk5YZQAhS1tqIfQgRCNDHkxjYiNGG2oh9IBEo0MbTCNiYuAZS9tqIfAQBCNDF0zjYiNGm2qLQ6NiVuATS1trC0MSTGNjI0Yba4tDI2NM4A5L22sLQw1M42MjRptri0OjY0LgCUtbbAtDCExjZCNGG2yLQyNkOOAES9tsC0MDTONkI0abbItDo2Qu4ABwAEAYAAAAQEIPAP5LW20LQ/1MY2UjRhtti0MjZR7g+UvbbYyyI0P3TONlI0abbYyyo0P0TKNlEeDzS1tuwfMLBCND8ExjZiNGG27B8wsEo0PtTCNmAuD/5wEgAL8AvxC9ELUCRgAgCSpD0t/oAvAFDRUbISctMzoA40tbaiH0IESjQ+BMY2I24N9L22oh8BAEo0PcTONiLuDbS1tri0PZTGNjKODYS9tri0PWTONjIuDVS1tsi0PTTGNkHODSS9tsi0PQTONkFuDPS1tti0PNTGNlEODMS9ttjLKjQ8pM42UJ4MhLW27B8wsEo0PGTGNmAeABIAC/AL8QvcJIgGhA9IBgwEmIYHBHv0iAaCD0gGC9SYhgcEcBRjG5ukiAaCD0QHC4SpBgGeCx9YB/CNG1SIBoIPRAcED0gHCySpBgDeCx9QB/CNGvSIBoIPRAcED0AHCsSpBgAeABIHBHACD85wC1T/SAcP/31v8AvQC1ACD/99H/AL2jSIBoQPQAYKFJiGBwR6BIgGgg9ABgnkmIYHBHnEjAaED0AFCaSchgcEeZSMBoIPQAUJdJyGBwR5VIAGhA8BAAk0kIYHBHkkgAaCDwEACQSQhgcEeOSEBoQPAQAIxJSGBwR4tIQGgg8BAAiUlIYHBHh0hAaEDwIACFSUhgcEeESEBoIPAgAIJJSGBwR4BIQGhA8EAAfklIYHBHfUhAaCDwQAB7SUhgcEd5SEBoQPCAAHdJSGBwR3ZIQGgg8IAAdElIYHBHAUYAIApoECoG0CAqUtBAKn7QgCp90fDgbUoSaCLwCAJrSxpgGh8SaCLwCAIbHxpgZ0oIMhJoIvAIAmVLCDMaYBofEmgi8AgCGx8aYEpoAvSAMrL1gD8H0V1KEh8SaELwCAJbSxsfGmBKaAL0ADKy9QA/BdFWShJoQvAIAlRLGmAKeQLwAQI6sVFKEh0SaELwCAJPSxsdGmAKeQLwAgICKgfRS0oIMhJoQvAIAkhLCDMaYPTgRkoSaCLwEAJESxpgGh8SaCLwEAIbHxpgQEoIMhJoIvAQAj5LCDMaYBofEmgi8BACGx8aYEpoAvSAMrL1gD8H0TZKEh8SaELwEAI0SxsfGmBKaAL0ADKy9QA/AeAh4MLgBdEuShJoQvAQAixLGmAKeQLwAQI6sSlKEh0SaELwEAImSxsdGmAKeQLwAgICKgfRIkoIMhJoQvAQAiBLCDMaYKPgHkoSaCLwIAIcSxpgGh8SaCLwIAIbHxpgGEoIMhJoIvAgAhVLCDMaYBofEmgi8CACGx8aYEpoAvSAMrL1gD8H0Q5KEh8SaELwIAILSxsfGmBKaAL0ADKy9QA/BdEHShJoQvAgAgVLGmAKeQLwAQJasQJKEh0D4ABwAEAkBAFAEmhC8CACmksaYAp5AvACAgIqB9GWShIdEmhC8CAClEsbHRpgUeCSShIfEmgi8EACj0sbHxpgGh8SaCLwQAIbHxpgi0oSHRJoIvBAAohLGx0aYBofEmgi8EACGx8aYEpoAvSAMrL1gD8H0YFKCDoSaELwQAJ+Swg7GmBKaAL0ADKy9QA/B9F6ShIfEmhC8EACd0sbHxpgCnkC8AECKrF0ShJoQvBAAnJLGmAKeQLwAgICKgfRbkoSHRJoQvBAAmxLGx0aYAHgASAAvwC/cEdpSABoQPSAQGdJCGBwR2VIAGgg9IBAY0oQYGNISEQAaDIiUENiSrD78vBBHADgSR5dSEBpAPQAcLD1AH8B0QAp9dFYSEBpAPQAcLD1AH8B0QMgcEcAIPznU0kJaCHwBwFRShFgU0kJaEHwBAFRShFgASgB0TC/AuBAvyC/IL9MSQloIfAEAUpKEWBwR0ZJCWgh8AcBSRxDShFgRUkJaEHwBAFDShFgASgB0TC/AuBAvyC/IL8/SQloIfAEAT1KEWBwRzhJCWgh8AcBiRw2ShFgOEkJaEHwBAE2ShFgASgB0TC/AuBAvyC/IL8xSQloIfAEAS9KEWBwRytIAGgg8AcAAB0oSQhgKkgAaEDwBAAoSQhgAL8AvzC/cEdwR3BHcEdwRxC1H0gUOABoAPSAMDCx//f8+k/0gDAaSRQ5CGAYSAwwAGgA8AgAKLH/9+n/CCAUSQwxCGASSAwwAGgA8BAAKLH/99z/ECAOSQwxCGAMSAwwAGgA8CAAKLH/98//ICAISQwxCGAGSAwwAGgA8EAAKLH/98L/QCACSQwxCGAQvQAAKAQBQABwAEAYAAAAQEIPABDtAOAQtf5IAGhA8AEA/EkIYPz35vkERgbg/Pfi+QAbAigB2QMgEL31SABoAPACAAAo8tDySABoIPDwAEDwYADvSQhgACCIYO5I70lJRAhg7khIRABo/PfI+QixASDi5/z3v/kERgjg/Pe7+QAbQfKIMYhCAdkDINXn4UiAaADwDAAAKPDR3kgAaOFJCEDcSQhg/Pem+QRGBuD896L5ABsCKAHZAyC+59VIAGgA8ChQACjy0dJJyGAIRsBoQPSAUMhgACAIYQhGAGlA9IBQCGEAIEhhCEZAaUD0gFBIYQhGAGgg9IAgCGAAIIhhQB4IYsNIlDAAaED0AADB+JQAACCR5/C1ACMAIN/49MLc+AjADPAMAd/46MLc+AzADPADBxmxDCkf0QEvHdHf+NTC3PgAwAzwCAy88QAPBtHf+MDC3PiUwMzzAyMF4N/4tMLc+ADAzPMDE9/4vML8RFz4IzBBuRhGBuAEKQHRq0gC4AgpANGpSAwpMtHf+ITC3PgMwAzwAwQBLAnQAiwC0AMsBNEB4KFKBOCgSgLgAL8aRgC/AL/f+FzC3PgMwMzzAxwM8QEG3/hMwtz4DMDM8wYsDPsC/Lz79vLf+DjC3PgMwMzzQWwM8QEMT+pMBbL79fDwvfi1BEYAJoZIgG0A8IBQGLH/98z5BUYW4AC/gUiAbUDwgFB/SYhlCEaAbQDwgFAAkAC/AL//97r5BUZ5SIBtIPCAUHdJiGW19QB/B9GALBDZoCwB2QImDOABJgrggCwB2QMmBuCALAHRAiYC4HAsANEBJnJIAGgg8A8AMENvSQhgCEYAaADwDwCwQgHQASD4vQAg/Oct6fhFBEYUuQEgvej4hV9IgGgA8AwHXUjAaADwAwYgeADwEAAQKHrRH7EML3nRAS530VZIAGgA8AIAGLHgaQi5ASDi51FIYWoAaADwCAAgsU5IAGgA8PAABeBMSJQwAGgA9HBgAAmBQh/ZYGr/937/CLEBIMnnAL9ESABoQPAIAEJJCGAIRgBoIPDwAGFqCEM+SQhgAL8IRkBoIPR/QCFqQOoBIDlJSGAf4AC/N0gAaEDwCAA1SQhgCEYAaCDw8ABhaghDMUkIYAC/CEZAaCD0f0AhakDqASAsSUhgL7lgav/3RP8IsQEgj+f/99D+J0mJaMHzAxEtSnpEUVwB8B8ByEAkSUlECGAjSEhEAGj89zL4gka68QAPYdBQRnXnXuD/5+BpgLMZSABoQPABABdJCGD89xz4BUYG4Pz3GPhAGwIoAdkDIGDnEEgAaADwAgAAKPLQAL8NSABoQPAIAAtJCGAIRgBoIPDwAGFqCEMHSQhgAL8IRkBoIPR/QCFqQOoBIAJJSGAq4BLgAAAAEAJAAAk9ABgAAAAQAAAA//T+6k43AAAAJPQAACACQCQ1AAD+SABoIPABAPxJCGD799f/BUYG4Pv30/9AGwIoAdkDIBvn9kgAaADwAgAAKPLRIHgA8AEAAChc0AgvA9AMLwrRAy4I0e1IAGgA9AAwiLNgaHi7ASAB5wC/YGiw9YA/BtHmSABoQPSAMORJCGAa4GBosPWgLwvR4UgAaED0gCDfSQhgCEYAaED0gDAIYArg20gAaCD0gDDZSQhgCEYAaCD0gCAIYAC/YGiQsfv3iP8FRgfgHuD794P/QBtkKAHZAyDL5s5IAGgA9AAwACjy0BDg+/d1/wVGBuD793H/QBtkKAHZAyC55sVIAGgA9AAwACjy0SB4APACAAIoUtEELwPQDC8U0QIuEtG8SABoAPSAYBix4GgIuQEgn+a4SEBoIPD+QCF8QOoBYLRJSGA54OBoALOySABoQPSAcLBJCGD79z7/BUYG4Pv3Ov9AGwIoAdkDIILmqUgAaAD0gGAAKPLQpkhAaCDw/kAhfEDqAWCjSUhgFuChSABoIPSAcJ9JCGD79x3/BUYG4Pv3Gf9AGwIoAdkDIGHmmUgAaAD0gGAAKPLRIHgA8AgACChx0WBp4LOSSJQw0PgAgAjwEAGgaYhCL9AI8AIAAigE0QjwAQAIuQEgQuYI8AEAyLGISJQwAGgg8AEAhUnB+JQA+/fo/gVGBuD79+T+QBsRKAHZAyAs5n5IlDAAaADwAgAAKPHRe0iUMABoIPAQAKFpCEN3ScH4lAB2SJQwAGgA4BfgQPABAHJJwfiUAPv3wv4FRgbg+/e+/kAbESgB2QMgBuZrSJQwAGgA8AIAACjx0BngZ0iUMABoIPABAGVJwfiUAPv3p/4FRgbg+/ej/kAbESgB2QMg6+VeSJQwAGgA8AIAACjx0SB4APAEAAQoc9FP8AAIV0iAbQDwgFB4uQC/VEiAbUDwgFBSSYhlCEaAbQDwgFAAkAC/AL9P8AEITUgAaAD0gHCwuUtIAGhA9IBwSUkIYPv3bv4FRgbg+/dq/kAbAigB2QMgsuVCSABoAPSAcAAo8tAgegDwAQA4szxIkDAAaCDwgAAhegHwgAEIQzhJkDEIYCB6APAEAHCxCEYAaEDwBAAyScH4kAAIRtD4kABA8AEAwfiQABfgLUiQMABoQPABACpJwfiQAA7gKEiQMABoIPABACZJwfiQAAhG0PiQACDwBADB+JAAoGiosfv3IP4FRgngNuD79xv+QBtB8ogxiEIB2QMgYeUZSJAwAGgA8AIAACjv0Bvg+/cK/gVGCOD79wb+QBtB8ogxiEIB2QMgTOUOSJAwAGgA8AIAACjv0QtIkDAAaCDwgAAIScH4kAC48QEPBdEFSIBtIPCAUANJiGUAvyB4APAgACAoA+AAEAJAAHAAQDTRoGrIsfdIAGhA8AEA9UmYOcH4mAD799D9BUYG4Pv3zP1AGwIoAdkDIBTl7UgAaADwAgAAKPLQGODqSABoIPABAOhJmDnB+JgA+/e2/QVGBuD797L9QBsCKAHZAyD65OBIAGgA8AIAACjy0eBq6LMML3vQ4GoCKFrR2kiYOABoIPCAcNdJmDkIYPv3lv0FRgbg+/eS/UAbAigB2QMg2uTQSJg4AGgA8ABwACjx0dTpDBBAHkHqABGga0HqACFAIABbASLC61AAQepAUUQgAF3C61AAQepAYTwgAF1B6sBgwEmYOclowEoRQADgg+AIQ7xJmDnIYAhGAGhA8IBwCGAIRsBoQPCAcMhg+/dW/QVGBuD791L9QBsCKAHZAyCa5LBImDgAaADwAHAAKPHQYuCsSJg4AGgg8IBwqkmYOQhgCEYAaADwIFAguQhGwGgg8AMAyGCjSJg4wGikSQhAoUmYOchg+/cp/QVGB+AO4Pv3JP1AGwIoAdkDIGzkmUiYOABoAPAAcAAo8dE04OBqASgA0WDkk0iYOMZoBvADASBrgUIm0Qbw8AFga0AesesAHx/RBvT+QaBrsesALxnRBvB4QTwgAF2x68BvEtEG9MABQCAAWwEiwutQALHrQF8I0QbwwGFEIABdwutQALHrQG8B0AEgL+QAIC3kLenwQQRGDUYUuQEgvejwgXlIAGgA8A8AqEIO0nZIAGgg8A8AKENzSQhgCEYAaADwDwCoQgHQASDo5yB4APABAAAoR9BgaAMoB9FnSJg4AGgA8ABw8LkBINjnYGgCKAfRYkiYOABoAPQAMJi5ASDN52BoOLldSJg4AGgA8AIASLkBIMPnWUiYOABoAPSAYAi5ASC751VImDiAaCDwAwBhaAhDUUmYOYhg+/eK/AZGCOD794b8gBtB8ogxiEIB2QMgpOdJSJg4gGgA8AwAYWiw64EP7dEgeADwAgACKAnRQkiYOIBoIPDwAKFoCEM/SZg5iGBASABoAPAPAKhCDtk9SABoIPAPAChDO0kIYAhGAGgA8A8AqEIB0AEgd+cgeADwBAAEKAnRMEiYOIBoIPTgYOFoCEMtSZg5iGAgeADwCAAIKArRKUiYOIBoIPRgUCFpQOrBACVJmDmIYP/3wfoiSZg5iWjB8wMRJEp6RFFcAfAfAchAIklJRAhgIUhIRABo+/ci/AdGOEZA53C1hrAGRg1GFEYAvxRImDjAbEDwAQASSZg5yGQIRsBsAPABAACQAL8Av4gVAZACIAKQBJAAIAOQBZABqU/wkED89zD8BkiYOIBoIPD+QEXqBAEIQwJJmDmIYAawcL0AAJgQAkAMgJ0B///u/gAgAkAELQAAGAAAABAAAACGSEhEAGhwRwC1//f5/4RJiWjB8wIhg0p6RFFcAfAfAchAAL0Atf/36/99SYlowfPCIXxKekQcOlFcAfAfAchAAL0/IQFgdkkJaAH0gCGx9YAvA9FP9KAhQWAM4HBJCWgB9IAxsfWAPwPRT/SAMUFgAeAAIUFgakkJaAHwAQERsQEhwWEB4AAhwWFlSUlowfMHIQFiYkkJaAHw8AFBYmBJCWgB9IBxsfWAfwPRT/SAccFgAeAAIcFgWUlJaMHzBmEBYVdJkDEJaAHwBAEEKQzRU0mQMQloAfCAAYApAtGFIYFgF+AFIYFgFOBNSZAxCWgB8AEBYbFKSZAxCWgB8IABgCkC0YEhgWAE4AEhgWAB4AAhgWBCSZQxCWgB8AEBEbEBIUFhAeAAIUFhPUmUMQloAfAQARApAdGBYQHgACGBYTdJmDEJaAHwAQERsQEhgWIB4AAhgWIySQloAfCAcbHxgH8C0QIhwWIB4AEhwWIsScloAfADAgJjKUnJaMHzAxFJHEFjJknJaMHzBiKCYyRJyWjB80FRSRxKAAJkIEnJaMHzQWFJHEoAQmQdScloyg7CY3BHDyICYBlKkmgC8AMCQmAXSpJoAvDwAoJgFEqSaAL04GLCYBJKkmgC9GBS0ggCYRFKEmgC8A8CCmBwRwxIAGhA9AAgCkkIYHBHcEcQtQdIwGkA9IBwsPWAfwXR//f1/0/0gHACSQhiEL0YAAAAABACQGAsAAAAIAJALenwQQRGD0YAJf5IwGgA8AMAULH7SMBoAPADACFoiEIB0SBoeLsBJS3gIGgBKATQAigJ0AMoGtEN4PJIAGgA8AIAALkBJRTg7kgAaAD0gGAAuQElDeDrSABoAPQAMCi56EgAaAD0gCAAuQElAeABJQC/AL89ueNIwGgg8AMAIWgIQ+BJyGAALXPR3kgAaCDwgFDcSQhg+/d6+gZGBuD793b6gBsCKAHZAyUF4NVIAGgA8ABQACjy0QC/AC1Z0Ye5oGgAAiF7QOrBYWBoQB5B6gAQzElJacxKEUAIQ8lJSGEo4AEvE9GgaAACIYoBIsLrUQFA6kFRYGhAHkHqABDBSUlpwkoRQAhDvklIYRLgoGgAAiF9ASLC61EBQOpBYWBoQB5B6gAQt0lJablKEUAIQ7RJSGGzSABoQPCAULFJCGD79yX6BkYG4Pv3IfqAGwIoAdkDJQXgq0gAaADwAFAAKPLQAL8tuadIQGmhaQhDpUlIYShGvejwgS3p8EEERg9GACWgSMBoAPADAFCxnUjAaADwAwAhaIhCAdEgaHi7ASUt4CBoASgE0AIoCdADKBrRDeCUSABoAPACAAC5ASUU4JBIAGgA9IBgALkBJQ3gjUgAaAD0ADAouYpIAGgA9IAgALkBJQHgASUAvwC/PbmFSMBoIPADACFoCEOCSchgAC1z0YBIAGgg8IBgfkkIYPv3vvkGRgbg+/e6+YAbAigB2QMlBeB3SABoAPAAYAAo8tEAvwAtWdGHuaBoAAIhe0DqwWFgaEAeQeoAEG5JCWluShFACENrSQhhKOABLxPRoGgAAiGKASLC61EBQOpBUWBoQB5B6gAQY0kJaWRKEUAIQ2BJCGES4KBoAAIhfQEiwutRAUDqQWFgaEAeQeoAEFlJCWlbShFACENWSQhhVUgAaEDwgGBTSQhg+/dp+QZGBuD792X5gBsCKAHZAyUF4E1IAGgA8ABgACjy0AC/LblJSABpoWkIQ0dJCGEoRr3o8IEt6fhFBEYAJahGIIgA9ABgsPUAbzLR4G5AKAnQA9xwsSAoG9ER4GAoFtCAKBbRFOA4SMBoQPSAMDZJyGAQ4AAhIB3/9yH/BUYK4AAhBPEgAP/3Xv4FRgPgAL8B4AElAL8Av1W5K0icMABoIPDgAOFuCEMoScH4nAAA4KhGIIgA9IBQsPWAXzbRIG+w9QB/DNAE3IixsPWAfx3RE+Cw9UB/F9Cw9YBvFtEU4BpIwGhA9IAwGEnIYBDgACEgHf/35P4FRgrgACEE8SAA//ch/gVGA+AAvwHgASUAvwC/VbkNSJwwAGgg9OBgIW8IQwlJwficAADgqEYgaAD0ADCw9QA/a9FP8AAKA0iAbQEhIeoQcMCxB+AAEAJAD4D/Bw+An/8PgP/5AL/+SIBtQPCAUPxJiGUIRoBtAPCAUACQAL8Av0/wAQr3SABoQPSAcPVJCGD796X4B0YG4Pv3ofjAGwIoAdkDJQXg70gAaAD0gHAAKPLQAL+Fu+pIkDAAaAD0QHbWsdT4lACwQhbQ5UiQMABoIPRAduJI0PiQAED0gDDgScH4kAAIRtD4kAAg9IAwwfiQAAhGwPiQYAbwAQCwsfv3bvgHRgrg+/dq+MAbQfKIMYhCA9kDJQjgF+Ah4NBIkDAAaADwAgAAKO3QAL9ducxIkDAAaCD0QHDU+JQQCEPIScH4kAAC4KhGAOCoRrrxAQ8F0cNIgG0g8IBQwUmIZQC/IHgA8AEASLG9SIgwAGgg8AMA4WsIQ7pJwfiIACB4APACAAIoCdG2SIgwAGgg8AwAIWwIQ7JJwfiIACB4APAEAAQoCdGuSIgwAGgg8DAAYWwIQ6tJwfiIACB4APAIAAgoCdGnSIgwAGgg8MAAoWwIQ6NJwfiIACB4APAQABAoCdGfSIgwAGgg9EBw4WwIQ5xJwfiIACB4APAgACAoCdGYSIgwAGgg9EBgIW0IQ5RJwfiIACCIAPQAcLD1AH8J0ZBIiDAAaCD0QCBhbghDjEnB+IgAIIgA9IBgsPWAbwnRiEiIMABoIPRAEKFuCEOEScH4iAAgeADwQABAKAnRgEiIMABoIPRAUGFtCEN9ScH4iAAgeADwgACAKAnReUiIMABoIPRAQKFtCEN1ScH4iAAgiAD0gHCw9YB/CdFxSIgwAGgg9EAw4W0IQ21JwfiIACBoAPSAELD1gB8J0WlInDAAaCDwAwAhbghDZUnB+JwAIIgA9ABQsPUAXx/RYUiIMABoIPBAYGFvCENdSYgxCGBgb7DxAG8G0VpIwGhA9IAQWEnIYArgYG+w8YBvBtEBISAd//da/QVGBbGoRiBoAPQAILD1AC9B0QC/oG+w9YBPCNFLSJwwAGhA9IBASUnB+JwAEeBHSJwwAGgg9IBAREnB+JwAQ0iIMABoIPBAYKFvCEM/ScH4iAAAv6BvsPEAbwbRO0jAaED0gBA5SchgFeCgb7D1gE8G0TZIwGhA9IAwNEnIYArgoG+w8YBvBtEBISAd//cS/QVGBbGoRiBoAPSAILD1gC8f0SpIiDAAaCDwQGDhbwhDJkmIMQhg4G+w8QBvBtEjSMBoQPSAECFJyGAK4OBvsPGAbwbRASEgHf/37PwFRgWxqEYgiAD0gECw9YBPFtEXSIgwAGgg8EBQ1PiAEAhDE0mIMQhg1PiAALDxgF8G0QIhIB3/98/8BUYFsahGIGgA9IAwsPWAPwrRCEicMABoIPAEANT4hBAIQwRJwficACBoAPQAELD1AB8P0QPgABACQABwAED+SJwwAGgg8BgA1PiIEAhD+knB+JwAIGgA9IAAsPWADyvR9kgAaCDwgFD0SQhg+vei/gdGBuD6957+wBsCKAHZAyUF4O1IAGgA8ABQACjy0QC/hbnpSJwwAGgg9EAw1PiMEAhD5UnB+JwAAiEE8SAA//e6+wVGBbGoRiBoAPCAcLDxgH8V0d1InDAAaCD0QBDU+JAQCEPZSZwxCGDU+JAAsPUAHwXR1UjAaED0gBDTSchgQEa96PiF0EnJaAHwAwFBYM5JCWnB8wMRSRyBYMtJCWnB8wYiwmDISQlpwfNAQQciAusBEgJhxEkJacHzQVFJHEoAQmHBSQlpwfNBYUkcSgCCYUFoAWK8SUlpwfMDEUkcQWK5SUlpwfMGIoJit0lJacHzQEEHIgLrARLCYrNJSWnB80FRSRxKAAJjr0lJacHzQWFJHEoAQmOsSYgxCWgB8AMBwWOpSYgxCWgB8AwBAWSmSYgxCWgB8DABQWSjSYgxCWgB8MABgWSgSYgxCWgB9EBxwWSdSYgxCWgB9EBhAWWaSYgxCWgB9EBRQWWXSYgxCWgB9EBBgWWUSYgxCWgB9EAxwWWRSZwxCWgB8AMBAWaOSYgxCWgB9EAhQWaLSYgxCWgB9EARgWaISZwxCWgB8OABwWaFSZwxCWgB9OBhAWeCSZAxCWgB9EBxwPiUEH5JiDEJaAHwQGFBZ3tJnDEJaAH0gEERsU/0gEEE4HdJiDEJaAHwQGFA+Hgfc0nR+IgQAfBAYUFgcEnR+IgQAfBAUYFgbUnR+JwQAfAEAcFgaknR+JwQAfRAMUFhZ0nR+JwQAfRAEYFheDhwR/C1BUYORgAgACEAJLX1AG8J0V9PnDc/aAfw4AFgKQ/RS/aAMAzgtfWAXwnRWE+cNz9oB/TgYbH1QH8B0Uv2gDAAKC3RMkZAKQLQsfUAfyjRT08/aAfwAHe38QB/8dFMT/9oB/SANwAvf9BJT/9ox/MDF38csvv38kVP/2jH8wYjQ0//aPwOPLlBT/9oB/QANw+xESQA4AckAvsD97f79PBj4EG7Ok8/aAfwAGe38QBvW9E3Tz9pB/SANwAvVdA0Tz9px/MDF38csvv38jBPP2nH8wYjLk8/afwOPLksTz9pB/QANw+xESQA4AckAvsD97f79PA54IApAtCx9YBvCNEjTz9oB/SAZ7f1gG8t0SFIK+AgKQLQsfWAfybRHE8/aAfwAFe38QBfH9EZT39pB/SAN9exFk9/acfzAxd/HLL79/ITT39px/MGIxFPf2n8Djy5D09/aQf0ADcPsREkAOAHJAL7A/e3+/Tw8L0t6fBNB0ZP8AALt/UAPz7RBEiQMABoAPRAdLT1gH8M0ATgAAAAEAJAACT0ALT1AH8M0LT1QH8o0Rzg+UgAaADwAgACKAHRT/QASx/g9EgAHQBoAPACAAIoC9HxSAAdAGgA8BAAECgC0U/w+gsB4E/0+ksL4OpIkDgAaAD0ADCw9QA/AdHf+JyzAOAAv/Xj5EiQOMBoAPADCrrxAQ8G0LrxAg8k0LrxAw850Szg3EiQOABoAPACAAIoF9HZSJA4AGgA8AgAKLHWSJA4AGgA8PAABeDTSAAdAGgA9HBgAAkACdFJeURR+CBQAOAAJRngzEiQOABoAPSAYLD1gG8B0ctNAOAAJQ3gxkiQOABoAPQAMLD1AD8B0cVNAOAAJQHgACUAvwC/t/WAb3bQGtwgL3TQDNwEL3LQBNwBL3DQAi9v0drhCC9t0BAv+dFZ4kAvatCAL2nQt/WAf2fQt/UAf+7Re+O39YA/fNAM3Lf1AG8W0Lf1gF8a0Lf1AF8e0Lf1gE/d0Zvit/WALxjQt/UAL2nQt/WAH2fQt/GAf9DR3OMpRk/0AGD/93b+g0Yo4ilGT/SAUP/3b/6DRiHiAL+YSAg4AGgA8EBkbLO08YBvW9C08QBvK9C08UBvftGRSJA4AGgA8AIAAigW0Y1IkDgAaADwCAAosYpIkDgAaADw8AAF4IdIAB0AaAD0cGAACQAJiEl5RFH4ILBr4F/jIOKY4T/h7uPB4Vngi+Ks4s3ifEiQOABoAPAAcLDxAH8j0XhIkDjAaAD0gBCw9YAfG9F0SJA4wGjA8wYmBfsG8HFJkDnJaALgX+JG4NHiwfMDEUkcsPvx9WtIkDjAaMDzQVBAHEAAtfvw+zTgZkiQOABoAPAAYLDxAG8f0WJIkDgAaQD0gBCw9YAfF9FeSJA4AGnA8wYmBfsG8FpJkDkJacHzAxFJHLD78fVWSJA4AGnA80FQQBxAALX78PsL4AngUUgIMABoAPACAAIoAdHf+EixAOAAvwC/huNKSAwwAGgA9IBAsPWATzTRRkiQOABoAPAAcLDxAH8r0UJIkDjAaAD0gDCw9YA/I9E+SJA4wGjA8wYmBfsG8DtJkDnJaMHzAxFJHLD78fU3SJA4wGhP6tBouPEADwrRM0iQOMBoAPQAMBCxT/ARCAHgT/AHCLX7+PuX4CxICDgAaADwQGTss7TxgG9d0LTxAG8h0LTxQG970SRIkDgAaADwAgACKBbRIUiQOABoAPAIACixHkiQOABoAPDwAAXgG0gAHQBoAPRwYAAJAAkdSXlEUfggsGjgFUiQOABoAPAAcLDxAH8h0RFIkDjAaAD0gBCw9YAfGdENSJA4wGjA8wYmAOBG4AX7BvAISZA5yWjB8wMRSRyw+/H1BEiQOMBowPNBUEAcQAC1+/D7PeCQEAJAIKEHAIIdAAAAJPQAVBwAAABs3AKiGgAA+UgAaADwAGCw8QBvG9H2SABpAPSAELD1gB8U0fJIAGnA8wYmBfsG8O9JCWnB8wMRSRyw+/H17EgAacDzQVBAHEAAtfvw+wvgCeDnSJgwAGgA8AIAAigB0d/4kLMA4AC/AL+w4uBIiDAAaADwAwQ0sQEsCNACLArQAywc0RHg/vel/oNGGOD+9/z4g0YU4NZIAGgA9IBgsPWAbwHR3/hQswrg0UiQMABoAPACAAIoAdFP9ABLAOAAvwC/hOLKSIgwAGgA8AwENLEELAjQCCwK0AwsHNER4P73a/6DRhjg/vfQ+INGFODASABoAPSAYLD1gG8B0d/4+LIK4LtIkDAAaADwAgACKAHRT/QASwDgAL8Av1jitEiIMABoAPAwBDSxECwI0CAsCtAwLBzREeD+9z/+g0YY4P73pPiDRhTgqkgAaAD0gGCw9YBvAdHf+KCyCuClSJAwAGgA8AIAAigB0U/0AEsA4AC/AL8s4p5IiDAAaADwwAQ0sUAsCNCALArQwCwc0RHg/vcT/oNGGOD+93j4g0YU4JRIAGgA9IBgsPWAbwHR3/hIsgrgj0iQMABoAPACAAIoAdFP9ABLAOAAvwC/AOKISIgwAGgA9EB0TLG09YB/CtC09QB/C9C09UB/HNER4P735P2DRhjg/vdJ+INGFOB8SABoAPSAYLD1gG8B0d/47LEK4HdIkDAAaADwAgACKAHRT/QASwDgAL8Av9HhcUiIMABoAPRAZEyxtPWAbwrQtPUAbwvQtPVAbxzREeD+97X9g0YY4P73GviDRhTgZUgAaAD0gGCw9YBvAdHf+IyxCuBgSJAwAGgA8AIAAigB0U/0AEsA4AC/AL+i4VlIiDAAaADwQFS08YBfBtC08UBfJdH99/T/g0Yi4FJIAGgA8ABgsPEAbxnRTkgAaQDwgHCgsUxIAGnA8wYmBfsG8ElJCWnB8wMRSRyw+/H1RUgAacDzQWBAHEAAtfvw+wDgAL8Av27hP0icMABoAPAEBBy5/vdq/YNGAuD998H/g0Zg4ThIiDAAaAD0QFQ0sbT1gF8H0LT1AF8S0Qfg/vdH/YNGDuD996z/g0YK4C5IAGgA9IBgsPWAbwHR3/iwsADgAL8Avz7hJ0iIMABoAPRARDSxtPWATwfQtPUATxLRB+D+9yX9g0YO4P33iv+DRgrgHUgAaAD0gGCw9YBvAdHf+GywAOAAvwC/HOEWSIgwAGgA9EA0NLG09YA/B9C09QA/EtEH4P73A/2DRg7g/fdo/4NGCuAMSABoAPSAYLD1gG8B0d/4KLAA4AC/AL/64AVInDAAaADwAwRcsQEsDdACLBnRDuAAAAAQAkAAbNwCACT0AP733PyDRg7g/fdB/4NGCuD5SABoAPSAYLD1gG8B0d/43LMA4AC/AL/T4PNIiDAAaAD0QCRUsbT1gC8L0LT1AC8c0LT1QC8t0SLgw+D+97b8g0Yo4OhIlDAAaADwAgACKAvR5UiUMABoAPAQABAoAtFP8PoLAeBP9PpLFODeSABoAPSAYLD1gG8B0d/4cLMK4NlIkDAAaADwAgACKAHRT/QASwDgAL8Av5Pg00iIMABoAPRAFEyxtPWAHwrQtPUAHxvQtPVAHyzRIeD+93f8g0Yo4MlIlDAAaADwAgACKAvRxUiUMABoAPAQABAoAtFP8PoLAeBP9PpLFOC/SABoAPSAYLD1gG8B0d/48LIK4LpIkDAAaADwAgACKAHRT/QASwDgAL8Av1Tgs0icMABoAPRAFDSxtPWAHwfQtPUAH0TRH+D996T+g0ZA4KtIAGgA8AIAAigU0ahIAGgA8AgAILGlSABoAPDwAAXgo0iUMABoAPRwYAAJAAmhSXlEUfggsCTgnUgAaADwAHCw8QB/G9GZSMBoAPSAELD1gB8U0ZZIwGjA8wYmBfsG8JNJyWjB8wMRSRyw+/H1j0jAaMDzQVBAHEAAtfvw+wDgAL8AvwDgAL8Av1hGvejwjXC1BEYAJoVIAGgg8IBgg0kIYPn3v/8FRgbg+fe7/0AbAigB2QMmBeB9SABoAPAAYAAo8tEAv4a7YGhAHgABoWhA6gEgIYoBIsLrUQFA6kFQIX3C61EBQOpBYCF7QOrBYG9JCWlxShFACENsSQhhCEYAaaFpCENpSQhhCEYAaEDwgGAIYPn3hv8FRgfg+feC/0AbAigC2QMmBuAG4GBIAGgA8ABgACjx0AC/MEZwvXC1ACVaSABoIPCAYFhJCGD592n/BEYG4Pn3Zf8AGwIoAdkDJQXgUkgAaADwAGAAKPLRAL9OSABpUUkIQExJCGEIRgBoAPAIUCC5CEbAaCDwAwDIYChGcL1wtQRGACZESABoIPCAUEJJCGD59zz/BUYG4Pn3OP9AGwIoAdkDJgXgO0gAaADwAFAAKPLRAL+Gu2BoQB4AAaFoQOoBICGKASLC61EBQOpBUCF9wutRAUDqQWAhe0DqwWAtSUlpL0oRQAhDK0lIYQhGQGmhaQhDKElIYQhGAGhA8IBQCGD59wP/BUYH4Pn3//5AGwIoAtkDJgbgBuAeSABoAPAAUAAo8dAAvzBGcL1wtQAlGUgAaCDwgFAXSQhg+ffm/gRGBuD59+L+ABsCKAHZAyUF4BBIAGgA8ABQACjy0QC/DUhAaRBJCEALSUhhCEYAaADwIGAguQhGwGgg8AMAyGAoRnC9BEmJaCH0AEEBQwFKkWBwRwAAABACQAAk9AC6FAAAD4CdAf//7v75SQloIfRwYUHqABH2SpQ6wviUEHBH9EgAHwBoQPAgAPFJlDnB+JAAcEfvSAAfAGgg8CAA7EmUOcH4kAAIRoBpIPQAcIhhcEfnSAAfAGhA8CAA5UmUOcH4kAAIRoBpQPQAcIhh4UgAaED0ACDfSQhg3kgIMABoQPQAINxJCDEIYHBHcEcQtdhIlDjAaQD0AHCw9QB/BtH/9/T/T/QAcNJJlDkIYhC9cLWGsARGACUAJgC/zUiUOMBsQPABAMpJlDnIZAhGwGwA8AEAAJAAvwC/BCABkAMgApACIASQACADkAGpT/CQQPr3c/6/SJQ4gG0A8IBQgLkAv7tIlDiAbUDwgFC5SZQ5iGUIRoBtAPCAUACQAL8AvwEltUgAaAD0gHAQufz3/f0BJq9IAB8AaCDwQHBE8IBxCEOrSZQ5wfiQAAEuAdH89/P9AS0H0aZIlDiAbSDwgFCkSZQ5iGUGsHC9OLUAJAAloEiUOIBtAPCAUIC5AL+cSJQ4gG1A8IBQmkmUOYhlCEaAbQDwgFAAkAC/AL8BJJZIAGgA9IBwELn897/9ASWQSAAfAGgg8IBwjkmUOcH4kAABLQHR/Pe4/QEsB9GJSJQ4gG0g8IBQhkmUOYhlOL2ESJQ4AGhA8AQAgkmUOQhgcEeASJQ4AGgg8AQAfUmUOQhgcEd7ShAyEmgi8P8CQOoBExpDd0uUO8P4pCBwR3VKlDqSa0LwgHJyS5Q7mmMaRpJrIvCAcppj0OkAIxpDg2hC6gMBwmgRQwKKQeoCQWxKUWASaCL0fFJDaULqAyJoSxpgGkYSaELwYAIaYHBHZEgAaEDwgABiSQhgcEdgSUloibIBYF5JCWjB8wUhQWBcSYloCQyBYFpJiWgB9ABBwWBwR3C1BUYAJPn3Yf0GRgC/aBwwsfn3W/2AG6hCANgFuQEkT0iAaADwAQAwsUTwAgQAvwEgSknIYAC/SUiAaADwAgACKAXRRPAEBAC/REnIYAC/Q0iAaAD0gGCw9YBvBtFE8CAEAL8EID1JyGAAvzxIgGgA9IBwsPWAfwbRRPAIBAC/BCA2SchgAL81SIBoAPQAcLD1AH8G0UTwEAQAvwQgL0nIYAC/LkiAaADwCAAIKAPRAL8qSchgAL8ALKjQIEZwvXBHcEdwR3BHcLUAJSRIhGgGaATwAQBAsQbwAQAosQEgH0nIYP/37/8y4ATwAgBAsQbwAgAosQIgGUnIYP/34v8m4ATwCABAsQbwCAAosQggE0nIYP/31f8a4ATwBAC4sQbwBACgsQT0gHAIsUXwCAUE9ABwCLFF8BAFBPSAYAixRfAgBQQgBUnIYChG//e4/3C9lBACQAAEAUAAcABAAGAAQEZIAGhA8AEAREkIYAAgiGAIRgBoQkkIQEBJCGCIFMhgCEYAaCD0gCAIYAAgiGHIAzxJCGBwR/C1ACMAIAAiAiQAJQIhNU42aAbwCAYuuTNOlDY2aMbzAyAD4DBONmjG8wMQMU5+RFb4IAAsTrZoBvAMBjaxBC4I0AguC9AMLjnRDeAqTk5EMGA44ClOJ09PRD5gM+AmTiVPT0Q+YC7gH072aAbwAwUdTvZoxvMDFnEcAi0C0AMtCNED4B1Otvvx8gbgG062+/HyAuCw+/HyAL8AvxJO9mjG8wYmckMPTvZoxvNBZnYcdACy+/T2D09PRD5gA+ANTk5EMGAAvwC/B062aMbzAxYLT39Eu10HTk5ENmjeQAVPT0Q+YPC9ABACQP//9uoI7QDgzA0AABgAAAAAJPQAEA0AABC1lrAERgAgApADkEDy+WAEkAQgBZAQIAaQACAHkAmQDZAQkBOQFJAVkEHyiDICqSBG+/e++hCxASAWsBC9QPL6UASQACAIkE/0gGAJkE/0QFAKkAAgC5BP8IBgEJAAIBKQASARkAQgE5AAv0HyiDICqSBG+/ed+gixASDd50HyiDIBqSBG+/cJ/AixASDU5534BAAA8AIAAijn0QAgzOcwtZWwBUYMRgAgAZACkEDy+lADkAQgBJAQIAWQACAGkAeQT/SAYAiQT/RAUAmQACAKkAyQT/CAYA+QACARkAEgEJAEIBKQACATkBSQAL8iRgGpKEb79136ELEBIBWwML0iRmlGKEb798n7CLEBIPXnnfgAAADwAQAAKOjRAL/t5zC1m7AFRgxGACAHkAiQDJBP9EBQD5AAIBCQEpAXkBmQGpAEkBAgBpCABAWQASx50QYgCZABIAqQACALkA6QFZAYkEHyiDIHqShG+/ci+hCxASAbsDC9BSAJkE/wgHAVkAAgF5ABIBaQQfKIMgepKEb79w/6CLEBIOvnAiACkAOQQfKIMgKpKEb79xL+CLEBIN/nciAJkE/0QHANkE/0gHAOkE/0QFAPkAAgEJBB8ogyB6koRvv37fkIsQEgyecHIAGQQfKIMgGpKEb79wn7CLEBIL7nBiAJkAAgDpAVkEHyiDIHqShG+/fU+QixASCw5wUgCZBP8IBwFZBB8ogyB6koRvv3xvkIsQEgoucCIAKQA5BB8ogyAqkoRvv3yf0QsQEgludO4HIgCZAAIA2QT/SAcA6QQfKIMgepKEb796n5CLEBIIXnASABkEHyiDIBqShG+/fF+gixASB65ygg+ffP+kHyiDEoRv/3Cv8IsQEgb+dH8o4QCZAEIAqQECALkIABDpAABBWQBiAYkAIgFpBB8ogyB6n3SEhE+/d6+QixASBW50HyiDJpRvJISET79+X6CLEBIEznnfgAAAEoe9ABIEbn60hIRP/3iv4IsQEgP+dH8o0gCZAEIAqQECALkAAgDZBP9IBgDpAABBWQAiAWkAAgGJCN+AAAjfgBAEHyiDIHqdtISET790P5CLEBIB/nQfKIMmlG1khIRPv3YPoIsQEgFecoIPn3avoFIAmQASAKkAAgC5AOkE/wgHAVkAEgFpAAIBiQApABIAOQQfKIMgepx0hIRPv3G/kIsQEg9+ZB8ogyAqnCSEhE+/cg/QixASDt5nEgCZAAIA2QT/SAcA6QQfKIMgepukhIRPv3APkIsQEg3OZB8ogyaUa1SEhE+/dr+hCxASDS5gTgnfgAAAixASDM5gAgyuYQtZSwBEYAIACQAZABIAOQACAEkAWQB5ALkBCQEZASkBOQDpBmIAKQQfKIMmlGIEb799H4ELEBIBSwEL2ZIAKQQfKIMmlGIEb798X4CLEBIPLnKCD59/b5ACDt5wC1h7AAv5ZIwGxA9IAQlEnIZAhGwGwA9IAQAZAAvwC/AL8IRgBtQPQAcAhlCEYAbQD0AHABkAC/AL8IRgBrQPQAcAhjCEYAayD0AHAIYwC/CEaAbUDwgFCIZQhGgG0A8IBQAZAAvwC/fkhAaED0AHB8SUhgAL96SMBsQPAgAHhJyGQIRsBsAPAgAAGQAL8AvwC/CEbAbEDwQADIZAhGwGwA8EAAAZAAvwC/iBQCkAIgA5ABIASQAyAFkAUgBpACqWlI+vfR+U/0gFACkAKpZ0j698r5PyACkAAgBJACqWNI+vfC+UDyA2ACkAKpXkj697v5B7AAvQC1h7BdSFdJSUQIYAhG+vfO/RCxASAHsAC9//d2/wQgUUlJREhgACFPSEhEgWBP8IBxwWAaIQFhAiFBYQAhgWHBYQFiAiFBYgAhgWJP8IBRwWIAIQFj+vcl/QixASDa5wIgAZACkEVIBZBFSASQAiADkAEgBpBB8ogyAak6SEhE+/fv/QixASDF5zZISET/9w7/CLEBIL7nASD59yr5ASExSEhE//el/QixASCz5wAgsecAtYWwQfI/AS5I+vc++kHyA2ErSPr3OfoAIAGQT/SAUACQACACkAOQaUYlSPr3SPkBIAGQACACkE/0gFAAkGlGIEj69z35ACJP9IBRHUj697b6GUgAa0D0AHAXSQhjCEYAayD0AHAIYwhGAG0g9ABwCGUIRsBsIPSAEMhkBbAAvRC1EUgLSUlECGAIRvv3Hf0CKAbQB0hIRPv3qfwIsQEgEL0AIQNISET/90r9kLEBIPbnAADsAAAAABACQABwAEAAGABIABQASAAUAKACAAABAgABAPdISET69xD9CLEBIN7n//eN/wAg2udwtZSwBEYNRhZGACAAkAGQBCADkBAgBJAAIAWQCZAKkAuQDJANkBCQBiARkAAgEpATkE72E0ACkE/0gGAHkE/0QFAIkE/wgGAOkAaVD5ZB8ogyaUbdSEhE+vdG/xCxASAUsHC9QfKIMiFG10hIRPv3sPgIsQEg8+cAIPHnLenwRZWwgkYNRhZG6LLA9YB4sEUA2bBGLEavGQAgAZACkEHy7SADkAQgBJAQIAWQACAGkAqQC5AMkA2QDpARkBKQE5AUkEHy7SADkE/0gGAIkE/0QFAJkE/wgGAPkAC/B5TN+ECAuUhIRP/3JvwYsQEgFbC96PCFQfKIMgGps0hIRPr38/4IsQEg8udB8ogyUUauSEhE+/cQ+AixASDo50HyiDGqSEhE//dX/AixASDf50REwkQE9YBwuEIB2TgbAeBP9IBwgEa8QsnTACDQ5xC1lLAERgAgAJABkAQgA5AQIASQACAFkAmQCpALkAyQDZAQkBGQEpATkAWQCZBN9iNAApBP9IBgB5BP9EBQCJAGlAAgDpCNSEhE//fO+xCxASAUsBC9QfKIMmlGiEhIRPr3nP4IsQEg8+dP9Pphg0hIRP/3CvwIsQEg6ucAIOjnELWUsARGACAAkAGQBCADkBAgBJAAIAWQCZAKkAuQDJANkBCQEZASkBOQBZAJkLT1gE8C0wEgFLAQvULy3hACkE/0gGAHkE/0QFAIkCADBpAAIA6QakhIRP/3h/sIsQEg6edB8ogyaUZlSEhE+vdW/gixASDf50HyiDFgSEhE//fE+wixASDW5wAg1OcAtZWwACABkAKQBCAEkBAgBZAAIAaQCpALkAyQDZAOkBGQEpATkBSQRvKfAAOQACAIkE/0AFAJkAAgB5APkExISET/90z7ELEBIBWwAL1B8ogyAalHSEhE+vca/gixASDz50RJQ0hIRP/3ifsIsQEg6+cAIOnnALWVsAAgAZACkEL21DADkAQgBJAQIAWQACAHkE/0gGAIkE/0QFAJkAAgDJBP8IBgD5ACIBCQBiASkAAgFJAGkAqQEZATkEHyiDIBqStISET69+P9ELEBIBWwAL1B8ogyaUYmSEhE+vdN/wixASDz5534AAAA8GAACLEBIOznnfgAAADwDAAIsQgg5edA8vpQA5BB8ogyAakYSEhE+ve9/QixASDY50HyiDJpRhNISET69yj/CLEBIM7nnfgAAADwAQAIsQIgx+cAIMXnAUZP8IBgCGCAEkhggBGIYIAQyGCAAghhACBwRwC1l7ADSEhE//e6+jCxASAXsAC97AAAAOCTBAACIAOQACAEkAQgBpAQIAeQACAIkAyQDZAOkA+QEJATkBSQFZAWkAiQDJBB8u0gBZBP9IBgCpBP9EBQC5AAIAmQT/CAYBGQASASkEAHFZBB8ogyA6lnSEhE+vdd/QixASDI5072E0AFkAEgA5AGIBSQACAVkEHyiDIDqV5ISET690r9CLEBILXnCCABkCAgApABqVhISET79xf6CLEBIKnnACCn5wC1lbD/9yj/Aigk0QAgAZACkEvyTwADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAGkEHyiDIBqUZISET69xr9ELEBIBWwAL3/9wf/CCgB0QAg9+cBIPXnACDz5wC1lbD/9/v+CCgk0QAgAZACkEPyzwADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAGkEHyiDIBqS9ISET69+38ELEBIBWwAL3/99r+AigB0QAg9+cBIPXnACDz5wC1lbAAIAGQApAEIASQECAFkAAgBpAKkAuQDJANkA6QEZASkBOQFJBL9kYQA5AAIAiQD5BB8ogyAakYSEhE+ve+/BCxASAVsAC9ACD75wC1lbAAIAGQApAEIASQECAFkAAgBpAKkAuQDJANkA6QEZASkBOQFJD/IAOQACAIkA+QQfKIMgGpBUhIRPr3mPwQsQEgFbAAvQAg++cAAOwAAABP8AACALUTRpRGlkYgOSK/oOgMUKDoDFCx8SABv/T3rwkHKL+g6AxQSL8MwF34BOuJACi/QPgEKwi/cEdIvyD4AisR8IBPGL8A+AErcEcAAAAAAAAAAAAAAQIDBAYHCAkAAAAAAQIDBKCGAQBADQMAgBoGAAA1DABAQg8AgIQeAAAJPQAAEnoAACT0AAA2bgEASOgBAGzcAgAAAAAAAAAAAAAAAAAAAAAQAAAAAQAAAAAJPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 239
-    pc_uninit: 261
-    pc_program_page: 305
-    pc_erase_sector: 275
-    pc_erase_all: 267
-    data_section_offset: 30352
+    pc_init: 0xef
+    pc_uninit: 0x105
+    pc_program_page: 0x131
+    pc_erase_sector: 0x113
+    pc_erase_all: 0x10b
+    data_section_offset: 0x7690
     flash_properties:
       address_range:
-        start: 1879048192
-        end: 1946157056
-      page_size: 4096
-      erased_byte_value: 255
-      program_page_timeout: 10000
-      erase_sector_timeout: 6000
+        start: 0x70000000
+        end: 0x74000000
+      page_size: 0x1000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x2710
+      erase_sector_timeout: 0x1770
       sectors:
-        - size: 65536
-          address: 0
-  stm32l4rx_2048_dual:
-    name: stm32l4rx_2048_dual
-    description: "STM32L4Rx 2MB Flash Dual "
-    cores: [main]
+        - size: 0x10000
+          address: 0x0
+  - name: stm32l4rx_2048_dual
+    description: 'STM32L4Rx 2MB Flash Dual '
+    cores:
+      - main
     default: true
     instructions: ZkllSIhgZkiIYGZIA2hmSkpEk2ADaEP0AHMDYANoI/SAYwNgCGpAAgTVT/ABYBBgASBQYAhqwAMI1FxIRfJVUQFgBiFBYED2/3GBYAAgcEdSSEFpQfAAQUFhACBwRwEgcEdK9qohUUpMSADgEWADadsD+9RM8vszA2FI8gQDQ2FDaUP0gDNDYQDgEWADadsD+9QCaUTy+jEKQgLQAWEBIHBHQWkh8AQBQWFBaSH0AEFBYQAgcEdwtTtOPEpORDdJdGig8QBlSvaqIwEsAtDF80c0CuDF8wc0NWioQgXTSGlA9ABgSGEA4BNgCGnAA/vUTPL7MAhhSGkg9P9gSGFIaQIlBevEBCBDSGFIaUD0gDBIYQDgE2AIacAD+9QKaUTy+jACQgLQCGEBIHC9SGkg9IAwSGFIaSDwAgBIYUhpIPQAYEhhACBwvRC1yR0TSyHwBwEcaeQD/NRcaUTwAQRcYRHgFGgEYFRoRGAcaeQD/NQcaeQHBNBE8vowGGEBIBC9CDAIOQgyACnr0VhpIPABAFhhACAQvQAAIwFnRQAgAkCrie/NAHAAQAQAAAAAMABAAAAAAAAAEAgAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 81
-    pc_program_page: 329
-    pc_erase_sector: 183
-    pc_erase_all: 99
-    data_section_offset: 432
+    pc_init: 0x1
+    pc_uninit: 0x51
+    pc_program_page: 0x149
+    pc_erase_sector: 0xb7
+    pc_erase_all: 0x63
+    data_section_offset: 0x1b0
     flash_properties:
       address_range:
-        start: 134217728
-        end: 136314880
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8200000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 4096
-          address: 0
-  stm32l4xx_64:
-    name: stm32l4xx_64
+        - size: 0x1000
+          address: 0x0
+  - name: stm32l4xx_64
     description: STM32L4xx 64 KB Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: v/NPj3BHX0gAaMDzCwCg9YBgNTgA0AEgcEdbSABqwPNAUHBHALUBRv/37f8BKAjR//fz/wEoBNFUSIFCAdMBIAC9ACAAvQC1AUb/99z/ASgC0MHzySAAvUDy3zAA6tEgyQP41QD1gHAAvUdISEmBYEhJgWAAIQFgTPL6MQFhAGrAAwjUREhF8lVRAWAGIUFgQPb/cYFgACBwRztJT/AAQEhhACBwRwEgcEc3SEzy+jEBYcETQWFBaUH0gDFBYUr2qiE1SgDgEWADadsD+9QAIUFhCEZwRxC1A0b/96P/AkYYRv/3sP8oSUzy+jQMYQIjA+vAAEDqwiBIYUhpQPSAMEhhv/NPj0r2qiAjSgDgEGALadsD+9QAIEhhCGkgQAHQDGEBIBC98LUXTMkdTPL6NyHwBwEnYU/wAAzE+BTAT/ABDkr2qiUUThfgxPgU4BNoA2BTaENgv/NPjwDgNWAjadsD+9TE+BTAI2k7QgLQJ2EBIPC9CDAIOQgyACnl0QAg8L0AAAAgBOAAIAJAAAABCCMBZ0Wrie/NADAAQAAAAAA=
-    pc_init: 107
-    pc_uninit: 155
-    pc_program_page: 295
-    pc_erase_sector: 215
-    pc_erase_all: 171
-    data_section_offset: 412
+    pc_init: 0x6b
+    pc_uninit: 0x9b
+    pc_program_page: 0x127
+    pc_erase_sector: 0xd7
+    pc_erase_all: 0xab
+    data_section_offset: 0x19c
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134283264
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8010000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32l4rx_db_opt:
-    name: stm32l4rx_db_opt
+        - size: 0x800
+          address: 0x0
+  - name: stm32l4rx_db_opt
     description: STM32L4Rx Flash Options Dual Bank
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHekh4SYFgeUmBYHlJwWB5ScFgACEBYHhJAWEAasADBtR4SHZJAWAGIUFgdkmBYAAgcEcBIW1IyQdBYUEEQWEAIHBHASBwRxC1aEhrTARhbkkBYksVQ2JtSYFibUnBYgFjYkpAMlNgSwSTYNFgEWFZQkFhv/NPj2dJYkoA4BFgA2nbA/vUAWkhQgTQAWkhQwFhASAQvQAgEL0AIHBH+LWgytZovEaXaBRovkYXaVNoAJdRaU1IkmlQTwdhV089QAViZ0b9A+0LRWJRTe1DLECEYlNMI0DDYndGJ0AHY/UDQkvtC0AzXWAAn/0D7QudYCFA2WAiQBphASFJBEFhv/NPj0VJP0oA4BFgA2nbA/vUAWk6ShFCBNABaRFDAWEBIPi9ACD4vfe1UWiCsIxGkWgVaI5G1GgTaVFpAZGRaQCRKk7RaRJqN2o0TjdANUCvQgfRJk99amZGrbK2srVCAtBAHAWw8L0hTa5qKU13Ru1DLkAvQL5CAdCAHPLnG0/9aidONUA0QKVCAdDAHOnnPGszQDRAnEIB0AAd4ucTTEA0Y2idsgGbm7KdQgHQQB3Y56No3QMAm+0L2wPbC51CAdCAHc7n42gxQDNAi0IB0MAdx+chaTJAMUCRQgHQCDDA5wOZQBi95wAAIwFnRQAgAkCrie/NOyoZCH9uXUz6wwAAVVUAAAAwAED/DwAAqvjv/wAA/n///wD/qqoAAP93/w//AP8AAAAAAA==
-    pc_init: 7
-    pc_uninit: 57
-    pc_program_page: 163
-    pc_erase_sector: 159
-    pc_erase_all: 77
-    data_section_offset: 552
+    pc_init: 0x7
+    pc_uninit: 0x39
+    pc_program_page: 0xa3
+    pc_erase_sector: 0x9f
+    pc_erase_all: 0x4d
+    data_section_offset: 0x228
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535822372
-      page_size: 36
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ff00000
+        end: 0x1ff00024
+      page_size: 0x24
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 36
-          address: 0
-  stm32l4xx_sb_opt:
-    name: stm32l4xx_sb_opt
+        - size: 0x24
+          address: 0x0
+  - name: stm32l4xx_sb_opt
     description: STM32L4xx single bank Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHUkhQSYFgUUmBYFFJwWBRScFgACEBYFBJAWEAasADBtRQSE5JAWAGIUFgTkmBYAAgcEcBIUVIyQdBYUEEQWEAIHBHASBwRxC1QEhDTARhRkkBYkkVQWIJBIFiREnBYgFjASFJBEFhv/NPj0FJPUoA4BFgA2nbA/vUAWkhQgTQAWkhQwFhASAQvQAgEL0AIHBH8LWUiBVok2jRaCtIEmkuTwdhNE41QAVipLJEYjNMI0CDYjJLGUDBYhpAAmMBIUkEQWG/80+PKkkmSgDgEWADadsD+9QBaTlCBNABaTlDAWEBIPC9ACDwvfC1jEaUaNNoYMoVSZJoD2ofSQ9ADUCvQgbREU1parayibKxQgHQQBzwvalqGU4xQDRAoUIB0IAc8L3sahZJDEALQJxCAdDAHPC9K2sKQAtAk0IB0AAd8L1gRPC9AAAjAWdFACACQKuJ7807KhkIf25dTPrDAABVVQAAADAAQP8PAACq+O////8A/6qqAAD/d/8P//8AgP8A/wAAAAAA
-    pc_init: 7
-    pc_uninit: 57
-    pc_program_page: 151
-    pc_erase_sector: 147
-    pc_erase_all: 77
-    data_section_offset: 392
+    pc_init: 0x7
+    pc_uninit: 0x39
+    pc_program_page: 0x97
+    pc_erase_sector: 0x93
+    pc_erase_all: 0x4d
+    data_section_offset: 0x188
     flash_properties:
       address_range:
-        start: 536836096
-        end: 536836116
-      page_size: 20
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fff7800
+        end: 0x1fff7814
+      page_size: 0x14
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 20
-          address: 0
-  stm32l4rx_2048:
-    name: stm32l4rx_2048
+        - size: 0x14
+          address: 0x0
+  - name: stm32l4rx_2048
     description: STM32L4Rx 2MB Flash
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: Y0liSIhgY0iIYGNIA2hjSkpEk2ADaEP0AHMDYANoI/SAYwNgCGpAAgTVT/ABYBBgASBQYAhqwAMI1FlIRfJVUQFgBiFBYED2/3GBYAAgcEdPSEFpQfAAQUFhACBwRwEgcEdK9qohTkpJSADgEWADadsD+9RM8vszA2FI8gQDQ2FDaUP0gDNDYQDgEWADadsD+9QCaUTy+jEKQgLQAWEBIHBHQWkh8AQBQWFBaSH0AEFBYQAgcEcwtcDzRzRK9qohN0ozSADgEWADadsD+9RM8vszA2FDaSP0/2NDYUNpAiUF68QEI0NDYUNpQ/SAM0NhAOARYANp2wP71AJpRPL6MQpCAtABYQEgML1BaSH0gDFBYUFpIfACAUFhACAwvXC1yR0h8AcBSvaqIx1MGE0A4CNgLmn2A/vUTPL7Ni5hbmlG8AEGbmET4BZoBmBWaEZgAOAjYC5p9gP71C5p9gcE0ETy+jAoYQEgcL0IMAg5CDIAKenRaGkg8AEAaGEHSAZJSESAaAhgACBwvQAAIwFnRQAgAkCrie/NAHAAQAQAAAAAMABAAAAAAAAAIAgAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 81
-    pc_program_page: 287
-    pc_erase_sector: 183
-    pc_erase_all: 99
-    data_section_offset: 420
+    pc_init: 0x1
+    pc_uninit: 0x51
+    pc_program_page: 0x11f
+    pc_erase_sector: 0xb7
+    pc_erase_all: 0x63
+    data_section_offset: 0x1a4
     flash_properties:
       address_range:
-        start: 134217728
-        end: 136314880
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8200000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 8192
-          address: 0
-  stm32l4rx_sb_opt:
-    name: stm32l4rx_sb_opt
+        - size: 0x2000
+          address: 0x0
+  - name: stm32l4rx_sb_opt
     description: STM32L4Rx Flash Options Single Bank
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHU0hRSYFgUkmBYFJJwWBSScFgACEBYFFJAWEAasADBtRRSE9JAWAGIUFgT0mBYAAgcEcBIUZIyQdBYUEEQWEAIHBHASBwRxC1QUhETARhR0kBYkkVQWJGSYFiRknBYgFjASFJBEFhv/NPj0NJPkoA4BFgA2nbA/vUAWkhQgTQAWkhQwFhASAQvQAgEL0AIHBH8LUVaFRok2jRaCxIEmkvTwdhNk41QAVi5APkC0RiMEzkQyNAg2IySxlAwWIaQAJjASFJBEFhv/NPjytJJkoA4BFgA2nbA/vUAWk5QgTQAWk5QwFhASDwvQAg8L3wtYxGlGjTaGDKFUmSaA9qIEkPQA1Ar0IG0RFNaWq2somysUIB0EAc8L2pahZO9kMxQDRAoUIB0IAc8L3sahVJDEALQJxCAdDAHPC9K2sKQAtAk0IB0AAd8L1gRPC9IwFnRQAgAkCrie/NOyoZCH9uXUz6wwAAVVUAAAAwAED/DwAAqvjv/wAA/n///wD/qqoAAP93/w//AP8AAAAAAA==
-    pc_init: 7
-    pc_uninit: 57
-    pc_program_page: 151
-    pc_erase_sector: 147
-    pc_erase_all: 77
-    data_section_offset: 396
+    pc_init: 0x7
+    pc_uninit: 0x39
+    pc_program_page: 0x97
+    pc_erase_sector: 0x93
+    pc_erase_all: 0x4d
+    data_section_offset: 0x18c
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535822356
-      page_size: 20
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ff00000
+        end: 0x1ff00014
+      page_size: 0x14
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 20
-          address: 0
-  stm32l4p5xx_1m:
-    name: stm32l4p5xx_1m
+        - size: 0x14
+          address: 0x0
+  - name: stm32l4p5xx_1m
     description: STM32L4P5xx_1M Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: aEkQtWZKimBnSopgCmrSsqoqGNBlSspgZUrKYApqIvD/AgpiCmpC8KoCCmJKaUL0ADJKYUppQvAAYkphv/NPj0ppEgH81App0gP81FlMTEQgYFlIAIgABIAJYGBACKBgAPCY+AEoBNBP9ABQ4GAAIBC9T/SAUPnnSkhBaUHwAEFBYb/zT48AIHBHASBwR0VITPL6MQFhwRNBYUFpQfSAMUFhv/NPjwFpyQP81AAgcEdwtQZGAPBu+D5NAShNRAbRqWgoaAFEsUIB2AEkAOAAJADwYPgBKB7QaGhAHgZAcgswSEzy+jMDYQIhAevCAUHqBDFBYUFpQfSAMUFhv/NPjwFpyQP81AFpGUIc0elosfWAXwXQGuCoaEAeBkAyC9/nA2EKIQHrwgFB6gQxQWFBaUH0gDFBYb/zT48BackD/NQBaRlCAtADYQEgcL0AIHC9MLUUS8kdTPL6NSHwBwEdYQEkXGER4BRoBGBUaERgv/NPjxxp5AP81BxpLEIC0B1hASAwvQgwCDkIMgAp69EAIFhhML0DSABqwPOAUHBHAAAjAWdFACACQKuJ7807KhkIf25dTAQAAADgdf8fAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 121
-    pc_program_page: 337
-    pc_erase_sector: 177
-    pc_erase_all: 143
-    data_section_offset: 444
+    pc_init: 0x1
+    pc_uninit: 0x79
+    pc_program_page: 0x151
+    pc_erase_sector: 0xb1
+    pc_erase_all: 0x8f
+    data_section_offset: 0x1bc
     flash_properties:
       address_range:
-        start: 134217728
-        end: 135266304
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8100000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 8192
-          address: 0
-  stm32l4xx_db_opt:
-    name: stm32l4xx_db_opt
+        - size: 0x2000
+          address: 0x0
+  - name: stm32l4xx_db_opt
     description: STM32L4xx dual bank Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: v/NPj3BHdkh0SYFgdUmBYHVJwWB1ScFgACEBYHRJAWEAasADBtR0SHJJAWAGIUFgckmBYAAgcEcBIWlIyQdBYUEEQWEAIHBHASBwRzC1ZEhnTARhakkBYksVQ2IdBIViaEnBYgFjXkpAMlNglWDRYBFhASFJBEFhv/NPj2JJXkoA4BFgA2nbA/vUAWkhQgTQAWkhQwFhASAwvQAgML0AIHBH+LWXiBZovEYXaZVovkaXitRoAJeTadFpSUgSakxPB2FSTz5ABmJnRr6yRmJQTjVAhWJPTSxAxGJ3Ri9AB2MAnz9Mv7JANGdgM0CjYClA4WAqQCJhASFJBEFhv/NPj0FJPUoA4BFgA2nbA/vUAmk3SQpCBNACaQpDAmEBIPi9ACD4vfe1UWiCsI5GFWiUaNFoAZERaSpOjEZRaQCRk2nRaRJqN2oxTjdANUCvQgfRI099anZGrbK2srVCAtBAHAWw8L29aipONUA0QKVCAdCAHPXn/monTAGdJkAlQK5CAdDAHOznPmtlRiZAJUCuQgHQAB3k5xJNQDVuaLeyAJ62srdCAdBAHdrnrmgYTz5AO0CeQgHQgB3S5+toIUAjQItCAdDAHcvnKWkiQCFAkUIB0AgwxOcDmUAYwecjAWdFACACQKuJ7807KhkIf25dTPrDAABVVQAAADAAQP8PAACq+O////8A/6qqAAD/d/8P//8AgP8A/wAAAAAA
-    pc_init: 7
-    pc_uninit: 57
-    pc_program_page: 163
-    pc_erase_sector: 159
-    pc_erase_all: 77
-    data_section_offset: 536
+    pc_init: 0x7
+    pc_uninit: 0x39
+    pc_program_page: 0xa3
+    pc_erase_sector: 0x9f
+    pc_erase_all: 0x4d
+    data_section_offset: 0x218
     flash_properties:
       address_range:
-        start: 536836096
-        end: 536836132
-      page_size: 36
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1fff7800
+        end: 0x1fff7824
+      page_size: 0x24
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 36
-          address: 0
+        - size: 0x24
+          address: 0x0

--- a/probe-rs/targets/STM32L5_Series.yaml
+++ b/probe-rs/targets/STM32L5_Series.yaml
@@ -1,4 +1,3 @@
----
 name: STM32L5 Series
 variants:
   - name: STM32L552CCTx
@@ -7,21 +6,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -33,21 +34,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -59,21 +62,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -85,21 +90,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -111,21 +118,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -137,21 +146,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -163,21 +174,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -189,21 +202,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -215,21 +230,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -241,21 +258,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -267,21 +286,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -293,21 +314,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -319,21 +342,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -345,21 +370,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -371,21 +398,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -397,21 +426,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -423,21 +454,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -449,21 +482,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -475,21 +510,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -501,21 +538,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -527,21 +566,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -553,21 +594,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -579,21 +622,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -605,21 +650,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -631,21 +678,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -657,21 +706,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -683,21 +734,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -709,21 +762,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -735,21 +790,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -761,21 +818,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -787,21 +846,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -813,21 +874,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -839,21 +902,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -865,21 +930,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -891,21 +958,23 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
@@ -917,116 +986,118 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32l5x_512_0c00
       - stm32l5x_512_0800
       - mx25l51245g_stm32l5_ospi
       - stm32l5x_opt
 flash_algorithms:
-  stm32l5x_512_0c00:
-    name: stm32l5x_512_0c00
+  - name: stm32l5x_512_0c00
     description: STM32L5x_512_Secure_Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: LenwQWpMB0YgbGxNaUlqSsAPTUQb0GZILDCoYGRIJDDoYOFg4mC/80+PYGrAA/zUT/D/NsT4gGDE+IRgxPiIYMT4jGAA8K74ASgO0BLgWEgoMKhgVkggMOhgoWCiYL/zT48gasAD/NQE4ET4oG9mYKZg5mDoaAFoyQP81FBIL2AAaAAEgAloYAAgvejwgUtIT/AAQUhEgmgRYL/zT4/AaAFoyQP81AAgcEdESULy+gJJRMhoAmCJaEjyBAIKYApoQvSAMgpgv/NPjwFoyQP81AAgcEdwtSDwd0UA8GP4N04BKE5EB9HW6QABAOtRAalCAdgBJADgACQA8FT4AShwaBzQQB4FQCkL8GhC8voCAmACIwPrwQFB6sQjsWgLYAtoQ/SAMwtgv/NPjwFoyQP81AFoEUIJ0AJgASBwvU/w/zEB61AAKEDBCt7nACBwvfC1GkzJHUxEQvL6BeNoIfAHAR1gpmgBJzdgF+DXeBRoZ/MfZARg13lUaGfzH2REYL/zT48caOQD/NQcaCxCAtAdYAEg8L0IMAg5CDIAKeXRACAwYPC9AkgAbMDzgFBwRwAAACACQCMBZ0Wrie/NBAAAAOAF+gsAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 143
-    pc_program_page: 335
-    pc_erase_sector: 213
-    pc_erase_all: 171
-    data_section_offset: 452
+    pc_init: 0x1
+    pc_uninit: 0x8f
+    pc_program_page: 0x14f
+    pc_erase_sector: 0xd5
+    pc_erase_all: 0xab
+    data_section_offset: 0x1c4
     flash_properties:
       address_range:
-        start: 201326592
-        end: 201850880
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0xc000000
+        end: 0xc080000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32l5x_512_0800:
-    name: stm32l5x_512_0800
+        - size: 0x800
+          address: 0x0
+  - name: stm32l5x_512_0800
     description: STM32L5x_512_NSecure_Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: LenwQWpMB0YgbGxNaUlqSsAPTUQb0GZILDCoYGRIJDDoYOFg4mC/80+PYGrAA/zUT/D/NsT4gGDE+IRgxPiIYMT4jGAA8K74ASgO0BLgWEgoMKhgVkggMOhgoWCiYL/zT48gasAD/NQE4ET4oG9mYKZg5mDoaAFoyQP81FBIL2AAaAAEgAloYAAgvejwgUtIT/AAQUhEgmgRYL/zT4/AaAFoyQP81AAgcEdESULy+gJJRMhoAmCJaEjyBAIKYApoQvSAMgpgv/NPjwFoyQP81AAgcEdwtSDwd0UA8GP4N04BKE5EB9HW6QABAOtRAalCAdgBJADgACQA8FT4AShwaBzQQB4FQCkL8GhC8voCAmACIwPrwQFB6sQjsWgLYAtoQ/SAMwtgv/NPjwFoyQP81AFoEUIJ0AJgASBwvU/w/zEB61AAKEDBCt7nACBwvfC1GkzJHUxEQvL6BeNoIfAHAR1gpmgBJzdgF+DXeBRoZ/MfZARg13lUaGfzH2REYL/zT48caOQD/NQcaCxCAtAdYAEg8L0IMAg5CDIAKeXRACAwYPC9AkgAbMDzgFBwRwAAACACQCMBZ0Wrie/NBAAAAOAF+gsAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 143
-    pc_program_page: 335
-    pc_erase_sector: 213
-    pc_erase_all: 171
-    data_section_offset: 452
+    pc_init: 0x1
+    pc_uninit: 0x8f
+    pc_program_page: 0x14f
+    pc_erase_sector: 0xd5
+    pc_erase_all: 0xab
+    data_section_offset: 0x1c4
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134742016
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8080000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  mx25l51245g_stm32l5_ospi:
-    name: mx25l51245g_stm32l5_ospi
+        - size: 0x800
+          address: 0x0
+  - name: mx25l51245g_stm32l5_ospi
     description: MX25L51245G_STM32L5_OSPI
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: ML9wRyC/cEdAv3BHv/Nvj3BHv/NPj3BHv/Nfj3BHAd9wR+/zFIBwR4DzFIi/82+PcEfv8wmAcEeA8wmIcEfv8wiAcEeA8wiIcEditnBHcrZwR+/zEIBwR2G2cEdxtnBH7/MTgHBHgPMRiHBH7/MSgHBHQLpwRwC6cEeQ+qDwcEfSsgHgAPgBK0ke+9JwRwAi9ucQtRNGCkYERhlG//fw/yBGEL2A6gECELUC8ABDQAAi0EoAH9ABDgHrEmHA81YAwvNWAkD0AABC9AACoPsCIAAEfzkUBADQQBxQ6hJAAdRAAEkewrIMBgTr0BBAHEAIgCoC0APgACAQvSDwAQAAKQDaACAYQxC9MLSA6gECAvAARTDwAEIh8ABAE9CQscMN1A3C8xYBwPMWAOQaQfQAAUD0AAJ9NJFCAdNkHADgSQAALALaMLwAIHBHT/QAAAAjkUIB04kaA0NACE/qQQH30VGxkUIC0U/wAEEF4ALST/ABAQHgb/ABAQPrxFAoRDC8APA1uAAoAdvA8QBAACkB28HxAEGBQgHYASBwRwAgcEcAKAHbwPEAQAApAdvB8QBBgUIB2QEgcEcAIHBHliMAIhFGAPAduCDwAEDBDcDzFgBA9AAAfykB2gAgcEeWKQPcwfGWAchAcEeWOYhAcEcAKai/cEdAHEkACL8g8AEAcEcQtLD6gPwA+gzwUOoBBAS/ELxwR0mxzPEgBCH6BPQR+gzxGL8BISFDCEOj6wwByx1P6gBhT+oQIEK/ACAQvHBHAOvDUBBEACmkvxC8cEdAHEkACL8g8AEAELxwR4OwAUaN+AsAAkYHKAGSAJFO2AGZ3+gB8AQNFh8oMTpDnfgLACNJSkYRRApcATIKVD7gnfgLAB9JSkYRRApcATIKVDXgnfgLABpJSkYRRApcATIKVCzgnfgLABZJSkYRRApcATIKVCPgnfgLABFJSkYRRApcATIKVBrgnfgLAA1JSkYRRApcATIKVBHgnfgLAAhJSkYRRApcATIKVAjgnfgLAARJSkYRRApcATIKVP/nA7BwRwkMAACAtYawE0aMRoZGBZAEkY34DyABIAKTzfgEwM34AOAGsIC9AAD/5/7nhbAKRgNGBJADkQAgApAEmAKQAZIAk//nApgDmYhCCNL/5wKYACEBYP/nApgEMAKQ8ucFsHBHAACAtYiwAUat+B4AEkhKRhNYBpAYRgWRBJIA8Lj+BJgGmUBYCCEAIgOSAPDo/wSYBplAWGpGA5tTYBNgT/SAcQIiAyMA8BX/T/CAcAOZCfAs+QiwgL2EDAAALenwQYqw3fhIwN34ROAQnB1GFkYPRoBGCZCN+CMQjfgiII34ITAHlM34GOCN+BfAACAEkAmZnfgiIFH4IhAEkQSQnfgjAJ34FxBA6gFgB5kIQwaZCENA6sFABJAJmZ34IiBB+CIAA5UClgGXzfgAgAqwvejwgQAAgLWEsAFGA5AEIgKQEEYCmgGREUYI8F78BLCAvXBHAABwtYmw3fg0wJ5GFEYNRgZGCJCN+B8QjfgeIAaTzfgUwAAgBJAImZ34HyAB64IB0fgAEQSRBJCd+B4ABpkIQwWZQOrBQASQCJmd+B8gAeuCAcH4AAHN+AzgApQBlQCWCbBwvQAAgLWGsApGA0YFkASRBZgIIcTyAgGIQgOSApMBkGLQ/+ccIMTyAgABmYFCW9D/5zAgxPICAAGZgUJU0P/nRCDE8gIAAZmBQk3Q/+dYIMTyAgABmYFCRtD/52wgxPICAAGZgUI/0P/ngCDE8gIAAZmBQjjQ/+dA8ghAxPICAAGZgUI10P/nQPIcQMTyAgABmYFCLdD/50DyMEDE8gIAAZmBQiXQ/+dA8kRAxPICAAGZgUId0P/nQPJYQMTyAgABmYFCFdD/50DybEDE8gIAAZmBQg3Q/+dA8oBAxPICAAGZgUIF0AngBJkBIAjwsvsG4ASZAiAI8K37AeD/5/7nBrCAvYWwAUYEkAAgjfgPAASaApITaCPwAQMTYAKaEGACmlBgApqQYAKa0GAEmgAjy/b+cxpEsOuSLwGRC9H/5wSYT/b4ccv2/XEIRMDzAxCN+A8ADeAEmE/2+DHL9v1xCEQA8PAAByEB6xAQjfgPAP/nc0hJRghYnfgPEAAiQPghIASYCCHE8gIBiEIAkGLQ/+ccIMTyAgAAmYFCY9D/5zAgxPICAACZgUJk0P/nRCDE8gIAAJmBQmXQ/+dYIMTyAgAAmYFCZtD/52wgxPICAACZgUJn0P/ngCDE8gIAAJmBQmjQ/+dA8ghAxPICAACZgUJo0P/nQPIcQMTyAgAAmYFCaND/50DyMEDE8gIAAJmBQmjQ/+dA8kRAxPICAACZgUJo0P/nQPJYQMTyAgAAmYFCaND/50DybEDE8gIAAJmBQmjQ/+dA8oBAxPICAACZgUJo0G/gPEhJRghYQWhB8A8BQWBp4DhISUYIWEFoQfDwAUFgYeA0SElGCFhBaEH0cGFBYFngMEhJRghYQWhB9HBBQWBR4CxISUYIWEFoQfRwIUFgSeAoSElGCFhBaEH0cAFBYEHgJEhJRghYQWhB8HBhQWA54B9ISUYIWEFoQfAPAUFgMeAbSElGCFhBaEHw8AFBYCngF0hJRghYQWhB9HBhQWAh4BNISUYIWEFoQfRwQUFgGeAPSElGCFhBaEH0cCFBYBHgC0hJRghYQWhB9HABQWAJ4AdISUYIWEFoQfBwYUFgAeD/5/7nBbBwRwC/cAwAAFAMAAAwDAAAg7ABRgKQAZAAaAJoIvABAgJgAJEDsHBHg7ABRgKQAZAAaAJoQvABAgJgAJEDsHBHg7ABRgKQAZAAaEBogLIAkQOwcEct6fBNpLDd+LTA3fiw4BxGFUYORjif3fjcgN342KDd+NSwD5A0mA6QM5gNkDKYDJAxmAuQMJgKkC+YCZAumAiQD5jN+IzAzfiI4CGTIJIfkQ+ZHpEImh2SCZsck934KMDN+GzA3fgs4M34aOAMmRmRDZkYkQ6ZF5HN+FiwzfhUoM34UIATlwAnEpeN+Edw3fh4gM34QIDd+HiAQPIACsv2/nrQRLfrmC8HlgaQBZQElQvR/+cemE/2+HHL9v1xCETA8wMQjfhHAA3gHphP9vgxy/b9cQhEAPDwAAchAesQEI34RwD/5wEg//eC/R+Y3fiE4CKZnfiBMJ34RyCd+IDAnfiMQG1GrGBpYMX4AOBhRv/3Mv0QmABoEpBH9vBxiEMSkBuZFZoRQxmaEUMYmhFDF5oRQxaaEUMUmhFDE5oRQwhDEpAQmQhgGpgQmUhgHZgQmYhgHJgQmchgJLC96PCNLenwTaSw3fi0wN34sOAcRhVGDkYHRiOQIpEhkiCTzfh84M34eMAjmB2QACAckBuQGpAZkBiQQPYAAcTyAgEYkR2ZCXmN+GQQHZkJaCKaIZvd+HjA3fiA4N34fIDd+GCg3fhksBeQGpgWkBuYFZAcmBSQaEYTkBeYEpETmQhjT/QAUMhiF5iIYsH4JIDB+CDgT/CADsH4HOCIYcH4FMBP8BAMwfgQwMtgimAUmkpgFZoKYBKYUUZaRhabEZQQlQ+WDpf/9+3+JLC96PCNLenwTaSw3fi0wN34sOAcRhVGDkYHRiOQIpEhkiCTzfh84M34eMAjmB2QACAckBuQGpAZkBiQQPYAAcTyAgEYkR2ZCXmN+GQQHZkJaCKaIZvd+HjA3fiA4N34fIDd+GCg3fhksBeQGpgWkBuYFZAcmBSQaEYTkE/0gEASkROZCGNP9ABQyGIXmIhiwfgkgMH4IOBP8IAOwfgc4IhhwfgUwAhhy2CKYBSaSmAVmgpgEphRRlpGFpsRlBCVD5YOl//3if4ksL3o8I1wRwAAgrABRgGQAJH/5wGYACgF0P/n/+cBmAE4AZD25wKwcEeAtQRISUYIWAghACIA8ET8gL0Av4QMAAAAIHBHgLWGsAFGBZAA8eBABJAHSktGGkQDkBBGA5oCkRFGBPDr/QAhAZAIRgawgL3sDAAAgrABRgGQAJECsHBHcEcAAHBHAACCsAFGAZAAKACRCND/5wlISUYIWAFoQfSAcQFgB+AFSElGCFgBaCH0gHEBYP/nArBwRwC/gAwAAIKwAUYBkAAoAJEI0P/nCUhJRghYAWhB9IBxAWAH4AVISUYIWAFoIfSAcQFg/+cCsHBHAL+ADAAAgrABRgGQQvIAAsTyAgIQcACRArBwRwAAg7ABRo34BwCd+AcAHygAkQfc/+ed+AcAASEB+gDwApAU4J34BwA/KAjc/+ed+AcAIDgBIQH6APACkAfgnfgHAEA4ASEB+gDwApD/5wKYA7BwRwAAg7ABRgKQACCN+AcAAJH/5534BwAHKAzc/+cCmJ34BxAAIkJU/+ed+AcAATCN+AcA7ucDsHBHAACDsAFGjfgLAAJGBygBkgCRTtgBmd/oAfAEDRYfKDE6Q534CwAjSUpGEUQKXAE6ClQ+4J34CwAfSUpGEUQKXAE6ClQ14J34CwAaSUpGEUQKXAE6ClQs4J34CwAWSUpGEUQKXAE6ClQj4J34CwARSUpGEUQKXAE6ClQa4J34CwANSUpGEUQKXAE6ClQR4J34CwAISUpGEUQKXAE6ClQI4J34CwAESUpGEUQKXAE6ClT/5wOwcEcJDAAAgLWGsApGA0at+BYAjfgVEL34FgACkgGTAPAk/gAoDtH/5734FgAN8Q8BAPCn+ASQnfgPEJ34FSAH8G7/AeD/5/7nBrCAvQAAgLWMsAFGC5ACRgAjxPICI5hCCpIJkTjQ/+dA8gBAxPICIAqZgUI60P/nQPYAAMTyAiAKmYFCPND/50D2AEDE8gIgCpmBQj7Q/+dB8gAAxPICIAqZgUJA0P/nQfIAQMTyAiAKmYFCQtD/50H2AADE8gIgCpmBQkTQ/+dB9gBAxPICIAqZgUJG0E/gASAIkAiZB/Dy/wAhCJgH8O7/R+ABIAeQB5kH8Oj/AiAAIQfw5P894AQgASEGkAfw3v8AIQaYB/Da/zPgCCABIQWQB/DU/wAhBZgH8ND/KeAQIAEhBJAH8Mr/ACEEmAfwxv8f4CAgASEDkAfwwP8AIQOYB/C8/xXgQCABIQKQB/C2/wAhApgH8LL/C+CAIAEhAZAH8Kz/ACEBmAfwqP8B4P/n/ucMsIC9AACAtYiwCkYDRq34HgAGkb34HgABkgCT//dH+U/wg0H/9+n4BZBP8H5R//cw+QAoENH/5wWYACH/9xv5ACgJ0f/nACDE8gIgApCd+B4AjfgTAP/nBZhP8IBB//cY+QAoE9H/5wWYT/B+Uf/3AvkAKAvR/+dA8gBAxPICIAKQvfgeABA4jfgTAP/nBZgAIcTyQAH/9/z4ACgT0f/nBZhP8IBB//fm+AAoC9H/50D2AADE8gIgApC9+B4AIDiN+BMA/+cFmE/wgUH/9+H4ACgU0f/nBZgAIcTyQAH/98r4ACgL0f/nQPYAQMTyAiACkL34HgAwOI34EwD/5wWYACHE8qAB//fE+AAoE9H/5wWYT/CBQf/3rvgAKAvR/+dB8gAAxPICIAKQvfgeAEA4jfgTAP/nBZgAIcTywAH/96j4ACgU0f/nBZgAIcTyoAH/95H4ACgL0f/nQfIAQMTyAiACkL34HgBQOI34EwD/5wWYACHE8uAB//eL+AAoFNH/5wWYACHE8sAB//d0+AAoC9H/50H2AADE8gIgApC9+B4AYDiN+BMA/+cFmE/wgkH/92/4ACgU0f/nBZgAIcTy4AH/91j4ACgL0f/nQfYAQMTyAiACkL34HgBwOI34EwD/5534EwABOAaZCHACmAiwgL2AtYSwAUYDkAJGACPE8gIjmEICkgGROND/50DyAEDE8gIgApmBQjbQ/+dA9gAAxPICIAKZgUIz0P/nQPYAQMTyAiACmYFCMND/50HyAADE8gIgApmBQi3Q/+dB8gBAxPICIAKZgUIq0P/nQfYAAMTyAiACmYFCJ9D/50H2AEDE8gIgApmBQiTQKOABIACQAJkH8CL+JOACIAEhB/Ad/h/gBCABIQfwGP4a4AggASEH8BP+FeAQIAEhB/AO/hDgICABIQfwCf4L4EAgASEH8AT+BuCAIAEhB/D//QHg/+f+5wSwgL3wtY2w3fhMwN34SOAcRhVGDkYHRgyQC5EKkgmTzfgg4M34HMAAIAaQBZAEkAaQA5QClQGWAJf/5waYDyhl2P/nBpgBIQH6APAFkAuZCEAEkAWZiEJU0f/nBphAAAMhAfoA8AyZCmgi6gAACGAKmAaZSQCIQAyZCmgQQwhgCpgBKATQ/+cKmAIoJtH/5waYQAADIQH6APAMmYpoIuoAAIhgCZgGmUkAiEAMmYpoEEOIYL34GAABIQH6APAMmYqIIuoAAIiAvfggAL34GBCIQAyZiogQQ4iA/+e9+BgAQAADIQH6APAMmcpoIuoAAMhgB5gGmUkAiEAMmcpoEEPIYP/n/+cGmAEwBpCW5w2w8L0AAIC1hrAKRgNGBZCt+BIQACADkAWYApIBk//3+P69+BIAQAADIQH6APAFmcpoIuoAAMhgA5i9+BIQSQCIQAWZymgQQ8hgBrCAvYC1hrAKRgNGrfgWAI34FRC9+BYADfEPAQKSAZP/99z9BJCd+A8QnfgVIAfwr/oGsIC9AAAQtYewE0aMRoZGBpCt+BYQjfgVIAAgBJADkJ34FQC9+BYQAfAHAYkAiEAEkL34FgAA8AcBiQAPIgL6AfEGmkf2/HQE6lAAEEQCaiLqAQEBYgaYvfgWEATqUQEIRABqBJkIQwOQnfgVAAAoApPN+ATAzfgA4AvQ/+cDmAaZvfgWIEf2/HMD6lICEUQIYv/nB7AQvQAAgLWKsBNGjEaGRgmQrfgiEAeSACCt+BoACZgFk834EMDN+Azg//dq/r34IgBP9v9xiEII0P/nvfgiAAEhAfoA8K34GgD/5wmYvfgaEAeaa0ZaYAAiGmACI//3wv4KsIC9hbAKRgNGBJCt+A4QT/SAMAKQvfgOAED0gDACkASZyGG9+A4ABJnIYQKYBJnIYQSYwGkCkASYwGkCkAGSAJMFsHBHAACAtYqwE0aMRoZGCZCt+CIQB5IAIK34GgAJmAWTzfgQwM34DOD/9xj+vfgiAE/2/3GIQgjQ/+e9+CIAASEB+gDwrfgaAP/nCZi9+BoQB5prRk/wAAzD+ATAGmABIgIj//dt/gqwgL0AAIKwAUYBkACKAJECsHBHAACEsApGA0YDkK34ChAAII34CQADmACKvfgKEAhAT/b/cQhCAZIAkwTQ/+cBII34CQAD4AAgjfgJAP/nnfgJAASwcEcAAIKwAUYBkICKAJECsHBHAACEsApGA0YDkK34ChAAII34CQADmICKvfgKEAhAT/b/cQhCAZIAkwTQ/+cBII34CQAD4AAgjfgJAP/nnfgJAASwcEcAAIC1hrABRq34FgC9+BYAApEA8Bj6ACgX0f/nvfgWAA3xDwH/95v8BJCd+A8QT/AADnJGzfgE4P/3Cf8EmJ34DxABmv/3uf7/5wawgL2AtYSwAUat+AwAvfgMAA3xBwIAkRFG//d7/AKQAIqd+AcQASIC+gHxCEIE0P/nASCN+A8AA+AAII34DwD/5534DwAEsIC9AACEsApGA0YDkK34ChADmEGDAZIAkwSwcEeAtYawCkYDRgWQrfgSEAAgA5AFmAKSAZP/90D9vfgSAEAAAyEB+gDwBZnKaCLqAADIYAOYvfgSEEkAiEAFmcpoEEPIYAawgL2AtYSwAUat+A4AvfgOAA3xBwIAkRFG//cn/AKQnfgHEP/3yv8EsIC9gLWEsAFGrfgOAL34DgAN8QcCAJERRv/3E/wCkJ34BxAAIv/31/6d+AcAASEB+gDwAplIgwSwgL2EsApGA0YDkK34ChADmAGDAZIAkwSwcEeAtYawCkYDRgWQrfgSEAIgA5AFmAKSAZP/9+D8vfgSAEAAAyEB+gDwBZnKaCLqAADIYAOYvfgSEEkAiEAFmcpoEEPIYAawgL2AtYSwAUat+A4AvfgOAA3xBwIAkRFG//fH+wKQnfgHEP/3yv8EsIC9gLWGsApGA0YFkK34EhABIAOQBZgCkgGT//eo/L34EgBAAAMhAfoA8AWZymgi6gAAyGADmL34EhBJAIhABZnKaBBDyGAGsIC9gLWEsAFGrfgOAL34DgAN8QcCAJERRv/3j/sCkJ34BxD/98r/BLCAvYC1hLABRq34DgC9+A4ADfEHAgCREUb/93v7ApCd+AcQACL/9z/+nfgHAAEhAfoA8AKZCIMEsIC9hLAKRgNGA5Ct+AoQA5iBggGSAJMEsHBHgLWGsBNGjEaGRgWQrfgSEAOSACoCk834BMDN+ADgBdD/5734EgAFmQiDBOC9+BIABZlIg//nBrCAvQAAg7ABRo34CwCd+AsAATgCRgMoAZEAkgjYAJnf6AHwAgMEBQPgAuAB4ADg/+cDsHBH/+f+54C1CUhJRghcASgG0P/nBkhJRghcACgG0f/nBEhJRghYCvBk+v/ngL3ADAAAqAMAAIC1CUhJRghcASgG0P/nBkhJRghcACgG0f/nBEhJRghYCvCO+v/ngL3ADAAAqAMAAIC1BkhJRghcAigG0f/nBEhJRghYCvA6+v/ngL3ADAAAqAMAAIC1BkhJRghcAigG0f/nBEhJRghYCvBq+v/ngL3ADAAAqAMAAIC1BkhJRghcAygG0f/nBEhJRghYCvAW+v/ngL3ADAAAqAMAAIC1BkhJRghcAygG0f/nBEhJRghYCvBG+v/ngL3ADAAAqAMAAIC1BkhJRghcBCgG0f/nBEhJRghYCvDy+f/ngL3ADAAAqAMAAIC1BkhJRghcBCgG0f/nBEhJRghYCvAi+v/ngL3ADAAAqAMAAIOwAUat+AgAACCt+AYAAJH/5734BgATSUpGEUQx+BAAACgX0P/nvfgIAL34BhANSktGGkQy+BEQiEIE0f/nASCN+AsACuD/5734BgABMK34BgDe5wAgjfgLAP/nnfgLAAOwcEdwAgAAgLWasBNGjEaGRhmQGJEXkqMgjfhaAAmTzfggwM34HOAA8ET4BPDW/R1ISUYAIgpQHEgIRAaQBZIEkQXwmfgBIE/0QFEGmgOQEEYDmwKRGUYCmgbwc/sUSASZCEQDmQKaBvBs+waYA/Ab+k/0QHAGmQGQCEYBmQPwd/yN+FsAByEGmAPw8/4GmAGZA/Bt/I34WwAIIQaYA/AL/wWYGrCAveQLAADsDAAAvA0AAIC1hrBmSElGTvIAEs7yAAIKUGRITvYAUs7yAAIKUGJIQfIAAsTyAgIKUGBIQvIAAsTyAgIKUF5IR/IAAsTyAAIKUFxIACLE8gECClBaSE7yEALO8gACClBYSAAixPICIgpQV0hA8gBCxPICIgpQVUhA9gACxPICIgpQU0hA9gBCxPICIgpQUUhB8gACxPICIgpQT0hB8gBCxPICIgpQTUhB9gACxPICIgpQS0hB9gBCxPICIgpQSUgAIsTyAgIKUEdIQPIAQsTyAgIKUEVIQPYAAsTyAgIKUENICCLE8gICClBCSBwixPICAgpQQEgwIsTyAgIKUD9IRCLE8gICClA9SFgixPICAgpQPEhsIsTyAgIKUDpIgCLE8gICClA5SEDyCELE8gICClA3SEDyHELE8gICClA1SEDyMELE8gICClAzSEDyRELE8gICClAxSEDyWELE8gICClAvSEDybELE8gICClAtSEDygELE8gICClArSEHyAALE8gJCClACqAGRB/AR+wOYJkkBmlBQUFgAKALR/+f/5/7nBrCAvQC/6AwAAMQTAADQDgAAgAwAAMgOAAD0EwAAABQAAIQMAACIDAAAjAwAAJAMAACUDAAAmAwAAJwMAACgDAAAMAwAAFAMAABwDAAANAwAADgMAAA8DAAAQAwAAEQMAABIDAAATAwAAFQMAABYDAAAXAwAAGAMAABkDAAAaAwAAGwMAACMDgAA+BMAAHC1OkhJRghEQHgBKCvR/+c3SElGBCIKVDZIAiMLVDZIT/AADAH4AMA0SE/wAQ4B+ADgM0gDJAxUMkgFJAxUMkgKVDJIByIKVDFIBiIKVDFIAfgAwDBIC1QwSAH4AOAwSAH4AMD/5yFISUYIREB4Aig60f/nHkhJRgQiClQdSAIjC1QdSE/wAAwB+ADAG0hP8AEOAfgA4BpIAyQMVBlIC1QZSAxUGUgB+ADgGUgB+ADAGEgGJQ1UGEgFJQ1UF0gLVBdIByYOVBdIDVQXSApUF0gB+ADAFkgB+ADgFkgLVBZIDFQWSApU/+dwvQC/xAwAADsYAAA+GAAAPxgAADwYAAA9GAAA7RMAAO4TAADwEwAA7xMAAMIMAADBDAAAwwwAAMwOAAAIDAAAyBMAAL8TAADAEwAAvhMAAL0TAAC8EwAAgLWOsAFGjfg3AAEoDJEF0P/nnfg3AAAoGtH/5xggBCELkAqRCfAW+xcgCZAKmQnwEftESElGT/ABDgH4AOBCSN34LOAh+ADgCEQJmUGA/+ed+DcAAigY0f/nHCAEIQiQB5EJ8Pf6GyAGkAeZCfDy+jVISUbd+CDgIfgA4AhEBppCgDBIAiMLVP/nnfg3AAMoGNH/5yIgBCEFkASRCfDa+iEgA5AEmQnw1fonSElG3fgU4CH4AOAIRAOaQoAhSAMjC1T/5534NwAEKBjR/+cYIAYhApABkQnwvfoXIACQAZkJ8Lj6GEhJRt34COAh+ADgCEQAmkKAE0gEIwtU/+cB8C373/hI4EhGEPgOAAEoEdH/5//nAvAC+wAoAdD/5/nn/+cC8L35ACgB0P/n+ef/98f+BOAFSElGASIKVP/nDrCAvQC/wAwAAHACAABUBAAAELWIsApGA0aN+B4ABpF6SElGCFgEkHlIT/AADAH4AMCN+A7ArfgMwI34C8B0SFH4AMDc+ATgLvQAbsz4BOBR+ADA3PgE4E70gG7M+ATgUfgAwNz4BOBO8AB+zPgE4FH4AMDc+ATgQPL/NC7qBA7M+ATgnfgewFH4AODe+ARAROpMDM74BMBR+ADA3PgE4C70fw7M+ATgUfgAwNz4BOBO9EA+zPgE4AhYQWhB9ABRQWBP9HFABJABkgCT/+dQSElGCFhAaBD0AF8P0P/nBJgBOASQSkhJRghcASgE0P/nBJgAKAHR/+dy4OjnQ0hJRghYBJD/5534CwACKCbc/+f/5z9ISUYIWIBpEPAEDw/R/+cEmAE4BJA5SElGCFwBKATQ/+cEmAAoAdH/51Dg6Oc0SElGCFhAap34CxADqlBUnfgLAAEwjfgLANTnK0hJRghYBJD/5ypISUYIWIBpEPAgDw/R/+cEmAE4BJAkSElGCFwBKATQ/+cEmAAoAdH/5ybg6OcfSElGCFjBaUHwIAHBYf/nG0hJRghYgGkQ8CAPAdD/5/bnBpgBIQFwnfgMAAaZSHCd+A0AnfgOEEDqASAGmUiAAfAj+gAgjfgfAA/g/+cB8Bz6/+cKSElGCFiAaRD0AE/10f/nASCN+B8A/+ed+B8ACLAQvQC/rAMAAAkZAACoAwAAELWMsApGA0aN+C4ACpGRSElGCFgIkJBIT/AADAH4AMCN+B7ArfgcwM34GMDN+BTAjfgTwIlIUfgAwNz4BOAu9ABuzPgE4FH4AMDc+ATgTvSAbsz4BOBR+ADA3PgE4E7wAH7M+ATgUfgAwNz4BOBA8v80LuoEDsz4BOCd+C7AUfgA4N74BEBE6kwMzvgEwFH4AMDc+ATgLvR/Dsz4BOBR+ADA3PgE4E70MC7M+ATgCFhBaEH0AFFBYE/0cUAIkAOSApP/52VISUYIWEBoEPQAXw/Q/+cImAE4CJBfSElGCFwBKATQ/+cImAAoAdH/55zg6OdYSElGCFgIkP/nnfgTAAooJtz/5//nVEhJRghYgGkQ8AQPD9H/5wiYATgIkE5ISUYIXAEoBND/5wiYACgB0f/neuDo50lISUYIWEBqnfgTEAWqUFSd+BMAATCN+BMA1OdCSElGCFhCaEL0gEJCYDxICFgIkP/nPEhJRghYgGkQ8CAPD9H/5wiYATgIkDZISUYIXAEoBND/5wiYACgB0f/nSuDo5zFISUYIWMFpQfAgAcFh/+ctSElGCFiAaRDwIA8B0P/n9ucKmAEhAXAKmAAhQXAKmEGAnfgVAJ34FiBA6gIgCpqQgJ34FwCd+BggnfgZMJ34GsBP6gxsTOoDQ0PqAiIQQwqakGCd+BsAnfgcIJ34HTCd+B7AT+oMbEzqA0ND6gIiEEMKmtBgAZEB8PP4AZiN+C8AD+D/5wHw7Pj/5wpISUYIWIBpEPQAT/XR/+cBII34LwD/5534LwAMsBC9AL+sAwAACRkAAKgDAADwtY+w3fhQwJ5GFEYNRgZGzfg0wAyTC5IKkY34JwC9+CoAjfgmAL34KgAACo34JQBP9v9wwPIBAAeQk0hJRgAiClSN+BsgkUgKWNNpT/D/PML4HMAKWNL4BMAs9ABswvgEwApY0vgEwCz0gGzC+ATACljS+ATAQPL/NyzqBwzC+ATAnfgnIFH4AMDc+ARwR+pCAsz4BCAKWNL4BMAs9H8MwvgEwApY0vgEwEz0QDzC+ATACljS+ATATPAAfML4BMAIWEFoQfQAUUFgT/IAEMDyAgAHkAWVBJTN+AzgApYBk//nakhJRghYQGgQ9ABfEtD/5weYATgHkGNISUYIXAAoBNH/5weYACgE0f/nASCN+BsApODl5//nXEhJRghYgGkQ8AIPDtH/51dISUYIXAAoB9D/5534GwBA8AIAjfgbAI3g6eed+CkAUElKRlFYiGJP9HFAB5D/50xISUYIWIBpEPACDw7R/+dHSElGCFwAKAfQ/+ed+BsAQPAEAI34GwBt4OnnnfgmAEBJSkZRWIhiQPb/cAeQ/+c8SElGCFiAaRDwAg8O0f/nN0hJRghcACgH0P/nnfgbAEDwCACN+BsATeDp5534JQAwSUpGUViIYv/nLkhJRghYgGkQ8CAPDtH/5ylISUYIXAAoB9D/5534GwBA8BAAjfgbADDg6ecjSElGCFjBaUHwIAHBYf/nH0hJRghYgGkQ8CAPAdD/5/bnT/JvIAeQ/+cYSElGCFhAaBD0gE8P0P/nB5gBOAeQEkhJRghcACgE0f/nB5gAKAHR/+cE4P/nACCt+DoAD+D/5wDwov//5wlISUYIWIBpEPQAT/XR/+cBIK34OgD/5734OgAPsPC9AL8JGQAAqAMAAPC1jbDd+EjAnkYURg1GBkbN+CzACpMJkgiRjfgfAE/2/3DA8gEABpDf+GwESUYAIgpUjfgXIN/4ZAQKWNNpT/D/PML4HMAKWNL4BMAs9ABswvgEwApY0vgEwCz0gGzC+ATACljS+ATAQPL/NyzqBwzC+ATAnfgfIFH4AMDc+ARwR+pCAsz4BCAKWNL4BMAs9H8MwvgEwApY0vgEwEz0MCzC+ATACljS+ATATPAAfML4BMAIWEFoQfQAUUFgT/IAEMDyAgAGkASVA5TN+AjgAZYAk//n3/jEA0lGCFhAaBD0AF8T0P/nBpgBOAaQ3/ioA0lGCFwAKATR/+cGmAAoBNH/5wEgjfgXALLh4+f/59/4jANJRghYgGkQ8AIPD9H/59/4dANJRghcACgH0P/nnfgXAEDwAgCN+BcAmeHn59/4XANJRghY/yGBYk/0cUAGkP/n3/hIA0lGCFiAaRDwAg8P0f/n3/gwA0lGCFwAKAfQ/+ed+BcAQPAEAI34FwB34efnvfgkAMCy3/gQE0pGUViIYkD2/3AGkP/nwEhJRghYgGkQ8AIPDtH/57tISUYIXAAoB9D/5534FwBA8AgAjfgXAFXh6ee9+CQAAAqzSUpGUViIYkD2/3AGkP/nr0hJRghYgGkQ8AIPDtH/56pISUYIXAAoB9D/5534FwBA8AgAjfgXADTh6ecKmMCyo0lKRlFYiGJA9v9wBpD/559ISUYIWIBpEPACDw7R/+eaSElGCFwAKAfQ/+ed+BcAQPAIAI34FwAU4ennCpjA8wcgk0lKRlFYiGJA9v9wBpD/549ISUYIWIBpEPACDw7R/+eKSElGCFwAKAfQ/+ed+BcAQPAIAI34FwDz4OnnCpjA8wdAgklKRlFYiGJA9v9wBpD/535ISUYIWIBpEPACDw7R/+d5SElGCFwAKAfQ/+ed+BcAQPAIAI34FwDS4OnnCpgADnJJSkZRWIhiQPb/cAaQ/+duSElGCFiAaRDwAg8O0f/naUhJRghcACgH0P/nnfgXAEDwCACN+BcAsuDp5wuYwLJiSUpGUViIYkD2/3AGkP/nXkhJRghYgGkQ8AIPDtH/51lISUYIXAAoB9D/5534FwBA8AgAjfgXAJLg6ecLmMDzByBSSUpGUViIYkD2/3AGkP/nTkhJRghYgGkQ8AIPDtH/50lISUYIXAAoB9D/5534FwBA8AgAjfgXAHHg6ecLmMDzB0BBSUpGUViIYkD2/3AGkP/nPUhJRghYgGkQ8AIPDtH/5zhISUYIXAAoB9D/5534FwBA8AgAjfgXAFDg6ecLmAAOMUlKRlFYiGJA9v9wBpD/5y1ISUYIWIBpEPAgDw7R/+coSElGCFwAKAfQ/+ed+BcAQPAQAI34FwAw4OnnIkhJRghYwWlB8CABwWH/5x5ISUYIWIBpEPAgDwHQ/+f250/ybyAGkP/nGEhJRghYQGgQ9IBPD9D/5waYATgGkBFISUYIXAAoBNH/5waYACgB0f/nBOD/5wAgrfgyAA/g/+cA8FH9/+cISElGCFiAaRD0AE/10f/nASCt+DIA/+e9+DIADbDwvQkZAACoAwAAgLWGsAFGrfgUAAAgjfgSAB9ISkYTGE/w0gyD+AHAvfgUwKP4AsABIxNUA5H/5xhISUYKWAhEQWiDaMBo7EbM+AAAViACkRFGApr/90H8jfgTAH8gCPAO+534EgABMMGyjfgSAAQpBNH/5wEgjfgXAAng/+ed+BMAASjY0P/nACCN+BcA/+ed+BcABrCAvQC/6AsAAIC1hLAKRgNGrfgMAK34ChC9+AwAACEBkgCTAPBN/I34CQAAKATQ/+cBII34DwAR4L34CgAAIQDwP/yN+AkAACgE0P/nASCN+A8AA+AAII34DwD/5534DwAEsIC9gLWEsApGA0at+AwArfgKEL34DAAAIQGSAJMA8Dn9jfgJAAAoBND/5wEgjfgPABHgvfgKAAAhAPAr/Y34CQAAKATQ/+cBII34DwAD4AAgjfgPAP/nnfgPAASwgL2AtYSwCkYDRq34DACt+AoQCEYBkgCT/fd9+kTyAAHE8k5R/fcd+gAhxPJ/Mf335vn993X6jfgIAL34DAAAIQDw3/uN+AkAACgE0P/nASCN+A8AEeCd+AgQACAB8HX9jfgJAAAoBND/5wEgjfgPAAPgACCN+A8A/+ed+A8ABLCAvYC1hLAKRgNGrfgMAK34ChC9+AwAASEBkgCTAPCx+434CQAAKATQ/+cBII34DwAR4L34CgABIQDwo/uN+AkAACgE0P/nASCN+A8AA+AAII34DwD/5534DwAEsIC9gLWEsApGA0at+AwArfgKEL34DAABIQGSAJMA8J38jfgJAAAoBND/5wEgjfgPABHgvfgKAAEhAPCP/I34CQAAKATQ/+cBII34DwAD4AAgjfgPAP/nnfgPAASwgL2AtYSwCkYDRq34DACt+AoQCEYBkgCT/ffh+UTyAAHE8k5R/feB+QAhxPJ/Mf33Svn999n5jfgIAL34DAABIQDwQ/uN+AkAACgE0P/nASCN+A8AEeCd+AgQASAB8Nn8jfgJAAAoBND/5wEgjfgPAAPgACCN+A8A/+ed+A8ABLCAvYC1hLAKRgNGrfgMAK34ChC9+AwAAiEBkgCTAPAV+434CQAAKATQ/+cBII34DwAR4L34CgACIQDwB/uN+AkAACgE0P/nASCN+A8AA+AAII34DwD/5534DwAEsIC9gLWEsApGA0at+AwArfgKEL34DAACIQGSAJMA8AH8jfgJAAAoBND/5wEgjfgPABHgvfgKAAIhAPDz+434CQAAKATQ/+cBII34DwAD4AAgjfgPAP/nnfgPAASwgL2AtYSwCkYDRq34DACt+AoQvfgMAAMhAZIAkwDwufqN+AkAACgE0P/nASCN+A8AEeC9+AoAAyEA8Kv6jfgJAAAoBND/5wEgjfgPAAPgACCN+A8A/+ed+A8ABLCAvYC1hLAKRgNGrfgMAK34ChC9+AwAAyEBkgCTAPCl+434CQAAKATQ/+cBII34DwAR4L34CgADIQDwl/uN+AkAACgE0P/nASCN+A8AA+AAII34DwD/5534DwAEsIC9gLWEsApGA0at+AwArfgKEL34DAAEIQGSAJMA8F36jfgJAAAoBND/5wEgjfgPABHgvfgKAAQhAPBP+o34CQAAKATQ/+cBII34DwAD4AAgjfgPAP/nnfgPAASwgL2AtYSwCkYDRq34DACt+AoQvfgMAAUhAZIAkwDwL/qN+AkAACgE0P/nASCN+A8AEeC9+AoABSEA8CH6jfgJAAAoBND/5wEgjfgPAAPgACCN+A8A/+ed+A8ABLCAvYC1hLAKRgNGrfgMAK34ChC9+AwABiEBkgCTAPAB+o34CQAAKATQ/+cBII34DwAR4L34CgAGIQDw8/mN+AkAACgE0P/nASCN+A8AA+AAII34DwD/5534DwAEsIC9gLWEsApGA0at+AwArfgKEL34DAAHIQGSAJMA8NP5jfgJAAAoBND/5wEgjfgPABHgvfgKAAchAPDF+Y34CQAAKATQ/+cBII34DwAD4AAgjfgPAP/nnfgPAASwgL2AtYSwACCN+A4AjfgNABtJSkYRRFMiSnBIgP/nF0hJRgpYCERBaINowGjsRsz4AAA0IAKREUYCmv/3WPmN+A4AfyAI8CX4nfgNAAEwjfgNABDw/w8E0f/nASCN+A8ACeD/5534DgABKNjQ/+cAII34DwD/5534DwAEsIC96AsAAIC1hLAAII34DQAbSUpGEURUIkpwSID/5xdISUYKWAhEQWiDaMBo7EbM+AAANCACkRFGApr/9xr5jfgOAH8gB/Dn/534DQABMMGyjfgNAAQpBNH/5wEgjfgPAAng/+ed+A4AASjY0P/nACCN+A8A/+ed+A8ABLCAvegLAACAtYSwACCN+A0AG0lKRhFEayJKcEiA/+cXSElGClgIREFog2jAaOxGzPgAADQgApERRgKa//fc+I34DgB/IAfwqf+d+A0AATDBso34DQAEKQTR/+cBII34DwAJ4P/nnfgOAAEo2ND/5wAgjfgPAP/nnfgPAASwgL3oCwAAgLWEsAAgjfgNABtJSkYRRFYiSnBIgP/nF0hJRgpYCERBaINowGjsRsz4AAA0IAKREUYCmv/3nviN+A4AfyAH8Gv/nfgNAAEwwbKN+A0ABCkE0f/nASCN+A8ACeD/5534DgABKNjQ/+cAII34DwD/5534DwAEsIC96AsAAIC1hLAAII34DQAbSUpGEURYIkpwSID/5xdISUYKWAhEQWiDaMBo7EbM+AAANCACkRFGApr/92D4jfgOAH8gB/At/534DQABMMGyjfgNAAQpBNH/5wEgjfgPAAng/+ed+A4AASjY0P/nACCN+A8A/+ed+A8ABLCAvegLAACAtYSwACCN+A0AG0lKRhFEVSJKcEiA/+cXSElGClgIREFog2jAaOxGzPgAADQgApERRgKa//ci+I34DgB/IAfw7/6d+A0AATDBso34DQAEKQTR/+cBII34DwAJ4P/nnfgOAAEo2ND/5wAgjfgPAP/nnfgPAASwgL3oCwAAgLWEsAAgjfgNABtJSkYRRFciSnBIgP/nF0hJRgpYCERBaINowGjsRsz4AAA0IAKREUYCmv735P+N+A4AfyAH8LH+nfgNAAEwwbKN+A0ABCkE0f/nASCN+A8ACeD/5534DgABKNjQ/+cAII34DwD/5534DwAEsIC96AsAAIC1hrAKRgNGrfgUAI34ExAAII34EgCN+BEAnfgTAKAwHknMRmFESHC9+BQASICd+BMAA5ICk/z3vf7/5xdISUYKWAhEQWiDaMBo7EbM+AAANCABkRFGAZr+95T/jfgSAH8gB/Bh/p34EQABMI34EQAQ8P8PBNH/5wEgjfgXAAng/+ed+BIAASjY0P/nACCN+BcA/+ed+BcABrCAvegLAACAtYSwAUaN+A4AACCN+AwAHUpLRhpEWCNTcFCAnfgOAAKR/Pd3/v/nF0hJRgpYCERBaINowGjsRsz4AAA0IAGREUYBmv73Tv+N+A0AfyAH8Bv+nfgMAAEwwbKN+AwABykE0f/nASCN+A8ACeD/5534DQABKNjQ/+cAII34DwD/5534DwAEsIC96AsAAIC1jLA+SElGCFwBKAbQ/+c7SElGCFwAKAjR/+c5SElGRfIAQsTyAAIKUP/nNEhJRghcAigI0f/nMkhJRkX2AALE8gACClD/5y1ISUYIXAMoCNH/5ytISUZF9gBCxPIAAgpQ/+cnSElGClgCkBBGAZEI8ND6AZgCmUBYCPAp+k/0gFAKkAAgrfgsAE/0AEEFkQaQZSGt+BwQCJCt+CQArfgmAA4hjfgMEBMhjfgNEBIhjfgOEI34DwABII34EAABmAKZQFgKqQWqA6sI8NH6AZgCmUBYCPBk+gGYAplAWAjwJfoBmAKZQlgTaEPwgAMTYEJYE2hD8BADE2AMsIC9AL/ADAAAqAMAAIC1hrAKRgNGrfgUAI34ExAAII34EgCN+BEAnfgTAOAwHknMRmFESHC9+BQASICd+BMAA5ICk/335fr/5xdISUYKWAhEQWiDaMBo7EbM+AAANCABkRFGAZr+93r+jfgSAH8gB/BH/Z34EQABMI34EQAQ8P8PBNH/5wEgjfgXAAng/+ed+BIAASjY0P/nACCN+BcA/+ed+BcABrCAvegLAACAtYawCkYDRq34FACN+BMQACCN+BIAjfgRAJ34EwDgMB5JzEZhREhwvfgUAEiAnfgTAAOSApP995X6/+cXSElGClgIREFog2jAaOxGzPgAADQgAZERRgGa/vcq/o34EgB/IAfw9/yd+BEAATCN+BEAEPD/DwTR/+cBII34FwAJ4P/nnfgSAAEo2ND/5wAgjfgXAP/nnfgXAAawgL3oCwAAsLWKsJxGlkYMRgVGrfgkAI34IxCt+CAgjfgfMAAgjfgeAI34HQApSElGCEQQIYGAvfgkEJ34IyBB6gJBgWC9+CAQnfgfIEHqAkHBYJ34IwDN+BjAzfgU4ASUA5X89/D8nfgfAPz37Pz/5xhISUYKWAhEQWiDaMBo7EbM+AAANCACkRFGApr+9wv/jfgeAH8gB/CQ/J34HQABMMGyjfgdAAcpBNH/5wEgjfgnAArg/+ed+B4AASjY0P/nnfgeAI34JwD/5534JwAKsLC96AsAAIC1hrABRq34FAAAII34EgAcSEpGEESkIkJwvfgUIEKAA5H/5xdISUYKWAhEQWiDaMBo7EbM+AAAViACkRFGApr+9379jfgTAH8gB/BL/J34EgABMMGyjfgSAAQpBNH/5wEgjfgXAAng/+ed+BMAASjY0P/nACCN+BcA/+ed+BcABrCAvegLAACAtYKwAUat+AYAAJH/5wHwhfiN+AUA/+ed+AUAASj20P/n/+f/5534BQABKPrQ/+f/5734BgAAIf/3fP2N+AUA/+ed+AUAASjz0P/nACACsIC9AACAtYSwACCN+A0AHElKRhFEDyJKcEiA/+cYSElGClgIREFog2jAaOxGzPgAAFYgApERRgKa/vcW/Y34DgB/IAfw4/ud+A0AATDBso34DQAHKQTR/+cBII34DwAK4P/nnfgOAAEo2ND/5534DgCN+A8A/+ed+A8ABLCAvQC/6AsAAIC1hrAAII34FQAySElGCET+IUFwASFBgP/nLkhJRgpYCERBaINowGjsRsz4AABWIASREUYEmv731fyN+BYAfyAH8KL7nfgVAAEwwbKN+BUABykE0f/nASCN+BcANeD/5534FgABKNjQ/+f/5xpISUYKGFYjA5AYRgKREUb+94D6jfgWAAKYA5lCXAEqBdH/5xFISUYAIgpUEuCd+BUAATDBso34FQAFKQTR/+cBII34FwAK4P/nnfgWAAEo1tD/5534FgCN+BcA/+ed+BcABrCAvQC/6AsAAPgLAACAtYiwAUYGkAAgjfgWADZISkYQRP4iQnADIkKABJH/5zFISUYKWAhEQWiDaMBo7EbM+AAAViADkRFGA5r+92T8jfgXAEHy/3AH8DD7nfgWAAEwwbKN+BYABykE0f/nASCN+B8APOD/5534FwABKNfQ/+cAII34FgD/5xxISUYKGFYjApAYRgGREUb+9wv6jfgXAAGYAplCXAEqCdH/5xNISUYKGFKIBpsagAAiClQS4J34FgABMMGyjfgWAAUpBNH/5wEgjfgfAArg/+ed+BcAASjS0P/nnfgXAI34HwD/5534HwAIsIC96AsAAPgLAACAtYSwAUaN+A4AACCN+A0AjfgMAB9ISkYQREEiQnCd+A4gQoCd+A4AApH990/4/+cYSElGClgIREFog2jAaOxGzPgAADQgAZERRgGa/vfk+434DQB/IAfwsfqd+AwAATDBso34DAAHKQTR/+cBII34DwAK4P/nnfgNAAEo2ND/5534DQCN+A8A/+ed+A8ABLCAvQC/6AsAAIC1hLABRo34DgAAII34DQCN+AwAH0hKRhBEQCJCcJ34DiBCgJ34DgACkf33A/j/5xhISUYKWAhEQWiDaMBo7EbM+AAANCABkRFGAZr+95j7jfgNAH8gB/Bl+p34DAABMMGyjfgMAAcpBNH/5wEgjfgPAArg/+ed+A0AASjY0P/nnfgNAI34DwD/5534DwAEsIC9AL/oCwAAgLWQsApGA0at+DwADpEAII34NgBfScxGYURP8GAOgfgB4EiACagIkgeTzfgYwAXwofpZSAaZCFwAKATR/+cHIPz3avr/51RISUYKXAEyClT/51BISUYKWAhEQWiDaMBo7EbM+AAANCAFkRFGBZr+9zv7jfg3AH8gB/AI+p34NgABMMGyjfg2AAcpBNH/5wEgjfg/AHng/+ed+DcAASjY0P/nvfg8AAch//dc+534NxAIRI34NwA3SElGCETmIUFw/+c0SElGClgIREFog2jAaOxGzPgAAFYgBJERRgSa/vcD+434NwB/IAfw0Pmd+DYAATDBso34NgAHKQTR/+cBII34PwBB4P/nnfg3AAEo2ND/5yJISUYAIgpU/+cfSElGChhWIwOQGEYCkRFG/veq+I34NwACmAOZQlwBKgnR/+cWSElGACIKVAhEQIgOmQhwF+B/IAfwmvmd+DYAATBf+oD+jfg2AL7xBQ8E0f/nASCN+D8ACeD/5534NwABKM3Q/+cAII34PwD/5534PwAQsIC9AL/oCwAA3AwAAPgLAACAtZKwCkYDRq34RAAQkQAgjfg+AJZJzEZhRE/wYA6B+AHgSIALqAqSCZPN+CDABfDR+ZBICJkIXAAoBNH/5wcg/Pea+f/ni0hJRgpcATIKVP/nh0hJRgpYCERBaINowGjsRsz4AAA0IAeREUYHmv73a/qN+D8AfyAH8Dj5nfg+AAEwwbKN+D4ABykE0f/nASCN+EcA6OD/5534PwABKNjQ/+e9+EQAByH/94z6nfg/EAhEjfg/AG5ISUYIROQhQXD/52tISUYKWAhEQWiDaMBo7EbM+AAAViAGkRFGBpr+9zP6jfg/AH8gB/AA+Z34PgABMMGyjfg+AAcpBNH/5wEgjfhHALDg/+ed+D8AASjY0P/nV0hJRghE5SFBcP/nVEhJRgpYCERBaINowGjsRsz4AABWIAWREUYFmv73BfqN+D8AfyAH8NL4nfg+AAEwwbKN+D4ABykE0f/nASCN+EcAguD/5534PwABKNjQ/+dCSElGACIKVP/nP0hJRgoYViMEkBhGA5ERRv33rP+N+D8AA5gEmUJcASoJ0f/nNkhJRgAiClQIRECIEJkIYBfgfyAH8Jz4nfg+AAEwX/qA/o34PgC+8QUPBNH/5wEgjfhHAErg/+ed+D8AASjN0P/n/+clSElGChhWIwKQGEYBkRFG/fd4/434PwABmAKZQlwBKgzR/+ccSElGACIKVAhEQIgQmQpoQuoAQAhgF+B/IAfwZfid+D4AATBf+oD+jfg+AL7xBQ8E0f/nASCN+EcAE+D/5534PwABKMrQ/+e9+EQAByH/99H6nfg/EAhEjfg/AAAgjfhHAP/nnfhHABKwgL3oCwAA3QwAAPgLAACAtYawAUat+BQAACCN+BIAHEhKRhBEsiJCcL34FCBCgAOR/+cXSElGClgIREFog2jAaOxGzPgAAFYgApERRgKa/vdE+Y34EwB/IAfwEfid+BIAATDBso34EgAEKQTR/+cBII34FwAJ4P/nnfgTAAEo2ND/5wAgjfgXAP/nnfgXAAawgL3oCwAAgLWKsApGA0aN+CYACJEAII34HwCd+CYQ0DHf+ATBzkb0RIz4ARCs+AIAPkkO+AEAnfgmAAaSBZPN+BDg/Pca+DlIT/b/ccDyDwEEmhFQ/+czSElGClgIRENo0PgIwMBo7kbO+AAANCADkRFGGkZjRv736PgtSQOaUFR/IAbwtP+d+B8AATDBso34HwAFKQTR/+cBII34JwA94P/nI0hJRghcASjU0P/n/+ceSElGChg0IwKQGEYBkRFG/feR/htJAZpQVAKYEVwBKQHR/+cY4H8gBvCJ/534HwABMF/6gP6N+B8AvvEFDwTR/+cBII34JwAQ4P/nDUhJRghcASjU0P/nCEhJRghEQIgImQiAACCN+CcA/+ed+CcACrCAvQC/6AsAAPgLAACsAwAA3gwAAIC1irB4SElGCETIIUFwACFBgI34JhCN+CUQjfgkEI34IxD/53BISUYKWAhEQWiDaMBo7EbM+AAANCAHkRFGB5r+92j4jfgjAH8gBvA1/534JAABMMGyjfgkAAcpBNH/5wEgjfgnALrg/+ed+CMAASjY0P/nACCN+CQA/+dbSElGChg0IwaQGEYFkRFG/fcQ/o34IwAFmAaZQlwBKgnR/+dSSElGACIKVAhEQIiN+CYAF+B/IAbwAP+d+CQAATBf+oD+jfgkAL7xBQ8E0f/nASCN+CcAg+D/5534IwABKM3Q/+cAII34JAD/5z9ISUYKWAhEQWiDaMBo7EbM+AAAViAEkRFGBJr+9wX4jfgjAH8gBvDS/p34JAABMMGyjfgkAAcpBNH/5wEgjfgnAFfg/+ed+CMAASjY0P/nACCN+CQA/+cqSElGChhWIwOQGEYCkRFG/fet/Y34IwACmAOZQlwBKgnR/+chSElGACIKVAhEQIiN+CUAF+B/IAbwnf6d+CQAATBf+oD+jfgkAL7xBQ8E0f/nASCN+CcAIOD/5534IwABKM3Q/+cRSElGASIKVAhEnfgmEEFwnfglEIFwQSkJ0P/nCkhJRghEgHhAKALQ/+f/5/7nACCN+CcA/+ed+CcACrCAvQC/6AsAAPgLAADEDAAAgLWEsAAgjfgNAB1JSkYRRMYjS3BIgBtIEET897/7/+cXSElGClgIREFog2jAaOxGzPgAADQgApERRgKa/fdw/434DgB/IAbwPf6d+A0AATDBso34DQAEKQTR/+cBII34DwAJ4P/nnfgOAAEo2ND/5wAgjfgPAP/nnfgPAASwgL3oCwAACQwAAIC1hLAAII34DQAySUpGEUTFI0twSIAwSBBE/Pd7+//nLEhJRgpYCERBaINowGjsRsz4AAA0IAKREUYCmv33LP+N+A4AfyAG8Pn9nfgNAAEwwbKN+A0ABykE0f/nASCN+A8AMuD/5534DgABKNjQ/+f/5xhISUYKWAhEQWiDaMBo7EbM+AAAViABkRFGAZr99wP/jfgOAH8gBvDQ/Z34DQABMMGyjfgNAAcpBNH/5wEgjfgPAAng/+ed+A4AASjY0P/nACCN+A8A/+ed+A8ABLCAvQC/6AsAAAkMAACAtYSwACCN+A0AMklKRhFExyJKcEiA/+cuSElGClgIREFog2jAaOxGzPgAADQgApERRgKa/ffC/o34DgB/IAbwj/2d+A0AATDBso34DQAHKQTR/+cBII34DwA34P/nnfgOAAEo2ND/5xpISUYIRMUhQXD/5xdISUYKWAhEQWiDaMBo7EbM+AAAViABkRFGAZr995T+jfgOAH8gBvBh/Z34DQABMMGyjfgNAAcpBNH/5wEgjfgPAAng/+ed+A4AASjY0P/nACCN+A8A/+ed+A8ABLCAvegLAACAtYawCkYDRq34FACt+BIQACCN+BEAjfgQAL34FAAEIQOSApP+95z+nfgREAhEjfgRABxISUYIRLMhQXC9+BIQQYD/5xdISUYKWAhEQWiDaMBo7EbM+AAAViABkRFGAZr990D+jfgRAH8gBvAN/Z34EAABMMGyjfgQAAQpBNH/5wEgjfgXAAng/+ed+BEAASjY0P/nACCN+BcA/+ed+BcABrCAvegLAACAtYawCkYDRo34FgCt+BQQACCN+BIAnfgWALAwJUnMRmFESHC9+BQASIAjSBz4AAAAKAOSApMM0f/nnfgWAPv3Ff0dSM5GHvgAEAExDvgAEP/n/+cXSElGClgIREFog2jAaOxGzPgAADQgAZERRgGa/ffk/Y34EwB/IAbwsfyd+BIAATDBso34EgAEKQTR/+cBII34FwAJ4P/nnfgTAAEo2ND/5wAgjfgXAP/nnfgXAAawgL3oCwAA3wwAABC1jLATRoxGhkat+CwACpGN+CcgACCN+CUAcElKRhFEZCRMcEiAbkgQXAAoCJPN+BzAzfgY4ATR/+cEIPv3uPz/5//nZUhJRgpYCERBaINowGjsRsz4AAA0IAWREUYFmv33jv2N+CYAfyAG8Fv8nfglAAEwwbKN+CUABykE0f/nASCN+C8ApeD/5534JgABKNjQ/+dRSElGCEThIUFwCplBgP/nTUhJRgpYCERBaINowGjsRsz4AABWIASREUYEmv33Xv2N+CYAfyAG8Cv8nfglAAEwwbKN+CUABykE0f/nASCN+C8AdeD/5534JgABKNjQ/+c5SElGCETiIUFwvfgqEEGA/+c1SElGClgIREFog2jAaOxGzPgAAFYgA5ERRgOa/fct/Y34JgB/IAbw+vud+CUAATDBso34JQAHKQTR/+cBII34LwBE4P/nnfgmAAEo2ND/5yFISUYIROMhQXCd+CcQQYD/5xxISUYKWAhEQWiDaMBo7EbM+AAAViACkRFGApr99/z8jfgmAH8gBvDJ+534JQABMMGyjfglAAcpBNH/5wEgjfgvABPg/+ed+CYAASjY0P/nvfgsAAQh/vcd/Z34JhAIRI34JgAAII34LwD/5534LwAMsBC96AsAAOAMAACAtYSwACCN+A0ANUlKRhFEWCJKcEiAByD799j7/+cwSElGClgIREFog2jAaOxGzPgAADQgApERRgKa/fev/I34DgB/IAbwfPud+A0AATDBso34DQAHKQTR/+cBII34DwA54P/nnfgOAAEo2ND/5xxISUYIRKIhQXAAIUGA/+cYSElGClgIREFog2jAaOxGzPgAAFYgAZERRgGa/fd//I34DgB/IAbwTPud+A0AATDBso34DQAHKQTR/+cBII34DwAJ4P/nnfgOAAEo2ND/5wAgjfgPAP/nnfgPAASwgL0Av+gLAACAtYawAUat+BQAACCN+BIAHEhKRhBE0CJCcL34FCBCgAOR/+cXSElGClgIREFog2jAaOxGzPgAAFYgApERRgKa/fc6/I34EwB/IAbwB/ud+BIAATDBso34EgAEKQTR/+cBII34FwAJ4P/nnfgTAAEo2ND/5wAgjfgXAP/nnfgXAAawgL3oCwAAgLWGsAFGBJCAaAgoApEF0P/nBJiAaAkoD9H/5wSYQGgIKAXQ/+cEmEBoCSgF0f/nQ/bHAK34DgAW4ASYgGgBKA/R/+cEmEBoASgK0f/nxyCt+A4ABJjQ+MwAACHA+AgRAeD/5/7n/+f/5wSYAfDC+AAoAdH/5/jnBJi9+A4QA/Br+QSZT/ABDhkiAZAIRnFGAPDk/gAoBNH/5wAgjfgXABTgBJgAaCAhGSJP9v9zwPIPAwPwe/0AKATR/+cAII34FwAD4AEgjfgXAP/nnfgXAAawgL2wtYywnEaWRgxGBUYKkAmRCJKt+B4wACAGkI34FwAKmIBoCCjN+BDAzfgM4AKUAZUT0f/nCphAaAgoDtH/5072E0Ct+BQACpjQ+MwABiHA+AgRASCN+BcAOuAKmIBoCSgc0f/nCphAaAkoF9H/5072EWCt+BQACpjQ+MwABiHA+AgRCpjQ+MwA0PgAEUHwAFHA+AARASCN+BcAGOAKmIBoASgR0f/nCphAaAEoDNH/5xMgrfgUAAqY0PjMAAAhwPgIEY34FxAB4P/n/uf/5//nCpgAaCAhGSJP9v9zwPIPAwPw+vwAKATR/+cAII34LwCb4AqYAGi9+B4QATkD8Er5CpgCIU/wgFIB8Er9CpkJaL34FCAAkAhGEUYC8L3+CpgAaAmZA/AM+QqY0Pi4AAAoSdH/5534FwAAKB7R/+f/5wqY0PjMAABqEPAgDxTQ/+cKmND4zAAAahDwBA8L0P/nCpjQ+MwAkPhQAAiZBppTHAaTiFT/5+PnJOCd+BcAASgf0f/n/+cKmND4zAAAahDwIA8V0P/nCpjQ+MwAAGoQ8AQPDND/5wqY0PjMALD4UAAImQaaUxwGkyH4EgD/5+Ln/+f/5wXgCpgAaAEhAfBS/v/nCpgAaAAhAfBM/gqYAGggIRkiT/b/c8DyDwMD8HT8ACgE0f/nACCN+C8AFeAKmND4zAAAIQFgCpjQ+MwAQPb/cUFiDyD79zH+CpjQ+MwAASEBYI34LxD/5534LwAMsLC9AACAtYawAUYFkIBoCCgDkQXQ/+cFmIBoCSgZ0f/nBZhAaAgoBdD/5wWYQGgJKA/R/+dG8plgrfgSAEn2ZhCt+BAABZjQ+MwAACHA+AgRGeAFmIBoASgS0f/nBZhAaAEoDdH/52YgrfgSAJkgrfgQAAWY0PjMAAAhwPgIEQHg/+f+5//nBZi9+BIQAvDi/yIhApAIRvv32f0FmL34EBAC8Nj/BZnR+MwQT/AADsH4AOAFmdH4zBBA9v9+wfgk4A8hAZAIRvv3wf0FmND4zAABIQFgBZiBYAWYQWAGsIC9gLWKsBNGjEaGRgiQB5EGkgAgrfgWAI34EwAImIBoCCgDk834CMDN+ATgBdD/5wiYgGgJKBjR/+cImEBoCCgF0P/nCJhAaAkoDtH/50Hy7SCt+BQACJjQ+MwAACHA+AgRASCN+BMAGOAImIBoASgR0f/nCJhAaAEoDNH/5xIgrfgUAAiY0PjMAAAhwPgIEY34ExAB4P/n/uf/5//nCJgA8Lf+ACgB0f/n+OcImABoICEZIk/2/3PA8g8DA/CF+wAoBNH/5wAgjfgnAI7gCJgAaP8hAvDX/wiYAiEAIgHw2PsImQlovfgUIACQCEYRRgLwS/0ImABoB5kC8Jr/CJjQ+LgAAChF0f/nnfgTAAAoHNH/5//nvfgWAP8oFdz/5wiY0PjMAABqEPAEDwzQ/+cImABoBpm9+BYgUxyt+BYwiVwD8KT7/+fl5yLgnfgTAAEoHdH/5//nvfgWAH8oFtz/5wiY0PjMAABqEPAEDw3Q/+cImABoBpm9+BYgUxyt+BYwMfgSEAPwkvv/5+Tn/+f/5wDg/+cImABoAfAu+wiYAGggIRkiT/b/c8DyDwMD8Az7ACgE0f/nACCN+CcAFeAImAEhGSIA8Fj8ACgE0f/nACCN+CcACeAImND4zABA9v9xQWIBII34JwD/5534JwAKsIC9AACwtZCwnEaWRgxGBUYOkA2RDJILkwAgrfgqAI34JwAOmIBoCCjN+BTAzfgQ4AOUApUF0P/nDpiAaAkoGNH/5w6YQGgIKAXQ/+cOmEBoCSgO0f/nQfLtIK34KAAOmND4zAAAIcD4CBEBII34JwAY4A6YgGgBKBHR/+cOmEBoASgM0f/nEiCt+CgADpjQ+MwAACHA+AgRjfgnEAHg/+f+5//n/+cOmADwuv0AKAHR/+f45w6YAGggIRkiT/b/c8DyDwMD8Ij6ACgE0f/nACCN+D8AjuAOmABoC5kC8Nr+DpgCIQAiAfDb+g6ZCWi9+CggAZAIRhFGAvBO/A6YAGgNmQLwnf4OmND4uAAAKEXR/+ed+CcAACgc0f/n/+e9+CoA/ygV3P/nDpjQ+MwAAGoQ8AQPDND/5w6YAGgMmb34KiBTHK34KjCJXAPwp/r/5+XnIuCd+CcAASgd0f/n/+e9+CoAfygW3P/nDpjQ+MwAAGoQ8AQPDdD/5w6YAGgMmb34KiBTHK34KjAx+BIQA/CV+v/n5Of/5//nAOD/5w6YAGgB8DH6DpgAaCAhGSJP9v9zwPIPAwPwD/oAKATR/+cAII34PwAV4A6YASEZIgDwW/sAKATR/+cAII34PwAJ4A6Y0PjMAED2/3FBYgEgjfg/AP/nnfg/ABCwsL2AtYiwCkYDRgeQBpEAII34EwAHmIBoCCgDkgKTBdD/5weYgGgJKBXR/+cHmEBoCCgF0P/nB5hAaAkoC9H/50fyjhCt+BAAB5jQ+MwABCHA+AgRFuAHmIBoASgP0f/nB5hAaAEoCtH/53EgrfgQAAeY0PjMAAAhwPgIEQHg/+f+5//nB5gAaAEhAvAG/geYAiFP8IBSAfAG+geZCWi9+BAgAZAIRhFGAvB5+weYAGgGmQLwyP3/5weY0PjMAABqEPAEDwHR/+f25weY0PjMAJD4UACd+BMQShyN+BMgBapQVP/nB5jQ+MwAAGoQ8AIPAdH/5/bnB5jQ+MwAACEBYAeY0PjMAED2/3FBYg8g+/c4+weY0PjMAAEhAWCd+BQACLCAvQAAgLWIsApGB5EAIY34EBAHmYloCCkCkAGSBdD/5weYgGgJKA/R/+cHmEBoCCgF0P/nB5hAaAkoBdH/50L21DCt+A4AEOAHmIBoASgJ0f/nB5hAaAEoBNH/5ysgrfgOAAHg/+f+5//nB5gAaAEhAvCC/QeYACEBZQeYAiFP8IBSAfB/+QeZCWi9+A4gAJAIRhFGAvDy+v/nB5jQ+MwAAGoQ8CAPF9D/5weY0PjMAABqEPAEDw7Q/+cHmND4zACQ+FAAnfgQEEocjfgQIA3xEQJQVP/n4OcHmE/0gHEBZZ34EQAA8AEAjfgUAJ34EQAA8AIAjfgVAJ34EQAA8AQAjfgWAJ34EQAA8AgAjfgXAJ34EQAA8CAAjfgYAJ34EQAA8EAAjfgZAJ34GgACmYhxvfgYAIiABZgIYAiwgL0AAIC1iLABRgaQACCN+BAABpiAaAgoAZEF0P/nBpiAaAkoFdH/5waYQGgIKAXQ/+cGmEBoCSgL0f/nSfZgcK34DgAGmND4zAAEIcD4CBEW4AaYgGgBKA/R/+cGmEBoASgK0f/nnyCt+A4ABpjQ+MwAACHA+AgRAeD/5/7n/+cGmABoASEC8Nn8BpgDIU/wgFIB8Nn4BpkJaL34DiAAkAhGEUYC8Ez6BpgAaAAhAvCb/P/nBpjQ+MwAAGoQ8CAPF9D/5waY0PjMAABqEPAEDw7Q/+cGmND4zACQ+FAAnfgQEEocjfgQIA3xEQJQVP/n4OcGmND4zAAAIQFgBpjQ+MwAQPb/cUFiDyD79wv6BpjQ+MwAASEBYJ34EQCN+BQAnfgSAI34FQCd+BMAjfgWAJ34FgCN+B4AvfgUAK34HACd+B4AjfgKAL34HACt+AgAApgIsIC9AACAtYiwCkYDRgaQBZEGmIBoCCgDkgKTBdD/5waYgGgJKA/R/+cGmEBoCCgF0P/nBphAaAkoBdH/50Ly3hCt+BIAFuAGmIBoASgP0f/nBphAaAEoCtH/5yEgrfgSAAaY0PjMAAAhwPgIEQHg/+f+5//n/+cGmADw/PoAKAHR/+f45waYvfgSEAWaAvDW+gaZASJP8BkOAZAIRhFGckYA8Bz5ACgE0f/nACCN+B8AGuAGmABoICEZIk/2/3PA8g8DAvCz/wAoBNH/5wAgjfgfAAngBpjQ+MwAQPb/cUFiASCN+B8A/+ed+B8ACLCAvYC1iLAKRgNGBpGd+BoQjfgeEL34GBCt+BwQBZCd+B0AnfgeEAhDnfgcEAhDjfgTAAWYT/QAcQORApMBkv/3kP2N+BIABZid+BMgA5kA8Pj5BZkAkAhGA5n/94L9jfgSAAiwgL2AtYawCkYDRgWQjfgTEAWYT/RAcQORApIBk//3b/2N+BIABZid+BMgA5kA8Nf5BZkAkAhGA5n/92H9jfgSAAawgL0AAIC1jrAKRgNGDZAMkQhGASkKkAmTCJII0P/nCpgIKDDQ/+cKmAkoUtB34A2YCCFBYA2YgWD/5wAgjfgvAA2ZnfgvIAeQCEYHmQDwpvkNmQaQCEYHmf/3MP2N+C4A/+ed+C4AnfgvEIhC5dH/5w2YASFP9EBSBZEC8An8DZgFmYFgS+ABII34LwD/5w2YASFBYA2YgWANmJ34LyAAIQSRAPB7+Q2ZCCKKYA2ZSmANmQOQCEYEmf/3AP2N+C4A/+ed+C4AnfgvEIhC39H/5yXgAiCN+C8A/+cNmAEhQWANmIFgDZid+C8gACECkQDwVfkNmQkiimANmUpgDZkBkAhGApn/99r8jfguAP/nnfguAJ34LxCIQt/R/+f/5w2Y0PjMAAAhAWANmND4zABA9v9xQWIPIPv3gfgNmND4zAABIQFgDrCAvYC1jrATRoxGhkYMkAuRCpJP9v9wwPIPAAiQDJjQ+MwAACHA+AARDJjQ+MwAAWgh8AEBAWAMmIBoCCgHk834GMDN+BTgBdD/5wyYgGgJKBXR/+cMmEBoCCgF0P/nDJhAaAkoC9H/50Dy+lCt+CYADJjQ+MwABiHA+AgRFuAMmIBoASgP0f/nDJhAaAEoCtH/5wUgrfgmAAyY0PjMAAAhwPgIEQHg/+f+5//nCphjKA7R/+cMmABoC5lqRgAjE2AEIgSREUYEmgSbAPBm/gngDJgAaAuaaUYAIwtgBCEA8Fz+/+cMmABoACEC8JD6DJgDIU/wAFIA8JD+DJnR+MwQCmhC8AECCmADkP/nDJjQ+MwAAGgBIQApApAB0f/n9ecMmABovfgmEAHw8/8MmIBoCCgF0P/nDJiAaAkoENH/5wyYQGgIKAXQ/+cMmEBoCSgG0f/nDJgAaAAhAvAu+v/nC5gBKAPR/+cAIAiQ/+cMmABoCJsIIWMiAvDr/QAoD9H/5wyYAGgA8Pz9DJjQ+MwAQPb/fsD4JOAAII34NwBW4AyYAGgIIWMiT/b/c8DyDwMC8M/9ACgE0f/nACCN+DcAReAMmABoAPDc/QyYAGgCIWMiT/b/c8DyDwMC8Lr9ACgE0f/nACCN+DcAMOAMmABoICEZIk/2/3PA8g8DAvCp/QAoBNH/5wAgjfg3AB/gDJgAaAIhAPDt/QyYAGgIIQDw6P0MmND4zAAAIQFgDJjQ+MwAQPb/cUFiDyD691z/DJjQ+MwAASEBYI34NxD/5534NwAOsIC9gLWKsBNGjEaGRgiQB5GN+BsgACCt+BgACJiAaAgoBJPN+AzAzfgI4AXQ/+cImIBoCSgP0f/nCJhAaAgoBdD/5wiYQGgJKAXR/+dH8o0grfgWABDgCJiAaAEoCdH/5wiYQGgBKATR/+dyIK34FgAB4P/n/uf/5//nCJgA8GP4jfgVAL34GAAA8QEOrfgY4AUoBNH/5wAgjfgnAE/g/+ed+BUAACjo0P/nCJgAaAAhAZEC8IL5CJgCIQGaAPCD/QiZCWi9+BYgAJAIRhFGAfD2/giYAGgHmQLwRfn/5wiY0PjMAABqEPAEDwHR/+f25534GwAImdH4zBCB+FAA/+cImND4zAAAahDwAg8B0f/n9ucImND4zAAAIQFgCJjQ+MwAQPb/cUFiDyD697r+CJjQ+MwAASEBYI34JxD/5534JwAKsIC9gLWGsAFGBJCAaAgoApEF0P/nBJiAaAkoD9H/5wSYQGgIKAXQ/+cEmEBoCSgF0f/nQPL5YK34DgAQ4ASYgGgBKAnR/+cEmEBoASgE0f/nBiCt+A4AAeD/5/7n/+cEmND4zAAAIQFgBJjQ+MwAQPb/cUFiDyD693L+BJjQ+MwAASEBYASYGSL/9+/9ACgE0f/nACCN+BcAPOAEmL34DhAC8GH4AZD/5wSY0PjMAABqEPACDwHR/+f25wSY0PjMAED2/3FBYgSYAiFjIv/3zf0AKATR/+cAII34FwAa4ASY0PjMAAAhwPgIEQSY0PjMAAFgBJjQ+MwAQPb/cUFiDyD69y3+BJjQ+MwAASEBYI34FxD/5534FwAGsIC9AAD/5/7n/+f+54C1grABRgGQAAEAkfr3ofgCsIC9grABRo34BwCd+AcAAPAfAgEjA/oC8gZLzEZc+AMwwPNCEAPrgADA+IAhAJECsHBH6AwAAIOwAUYCkAAgAZACmADwHwABkAE4ASIC+gDwBEpLRppYU2gYQ1BgAJEDsHBHxBMAAIC1gbAAIACQE0lKRlNYT/D/PMP4gMBTWG/wcE7D+ITgU1jD+IDBUVjB+IThAJD/5wCYDigN2P/nB0hJRghYAJkIRAAhgPgAE//nAJgBMACQ7ucBsIC9AL/oDAAAA0hJRghYASHA8vpRwWBwR8QTAAADSElGCFgEIcDy+lHBYHBHxBMAAIC1+vcr+IC9AkhJRghYAGhwRwC/xBMAAANISUYIWEBob/OfIHBHAL/EEwAAA0hJRghYQGjA8wkwcEcAv8QTAACEsAFGA5AAIAKQAZADmMDzgFABkAAoAJEG0f/nB0hJRghYQGsCkAXgBEhJRghYgGsCkP/nApgEsHBHAL/EEwAAhbABRgSQACADkAKQAZAEmMDzgUACkASYwPMBUAGQApgAKACRBtH/5xRISUYIWMBqA5Ag4AKYASgW0f/nD0hJRghYgGoBmckAyEADkAGYAigF0P/nA5gA8A8AA5AD4J34DAADkP/nBeAESElGCFgAawOQ/+f/5wOYBbBwR8QTAACEsAFGjfgPAAAgApABkJ34DwAA8B8AASIC+gDwAZANSEpGEFid+A8gwvNCEgDrggDQ+AACAZoQQJBCAJED0f/nASACkALgACACkP/nApgEsHBHAL/oDAAAhLABRo34DwAAIAKQAZCd+A8AAPAfAAEiAvoA8AGQDUhKRhBYnfgPIMLzQhIA64IA0PgAAQGaEECQQgCRA9H/5wEgApAC4AAgApD/5wKYBLBwRwC/6AwAAIWwAUYEkAAgA5ACkAGQBJjA84MwAZABIgL6APABkApISkYQWEBqAZoQQAKQAZqQQgCRA9H/5wEgA5AC4AAgA5D/5wOYBbBwR8QTAACFsAFGBJAAIAOQApABkASYggoBksDzgyABkAEiAvoA8AGQCkhKRhBYQGoBmhBAApABmpBCAJED0f/nASADkALgACADkP/nA5gFsHBHxBMAALC1i7CcRpZGDEYFRo34KwCN+CoQjfgpIAmTACAIkAeQBpAFkA8gBJAJmAAozfgMwM34COABlACVWND/5zZISUYIWMBoAPTgYMD14GACCgiSBCKi6xAgBZAEmAia0EAEkJ34KgAFmpBACJCd+CkgBJsaQBBDCJAAAQiQnfgrIALwAwLSAJBACJAiSApYnfgrMALrkwKS+AAjB5Kd+CsgAvADAtIA/yMD+gLyBpIHmyPqAgIHkgaaCJsaQAiSB5saQweSC1id+CvAA+ucA4P4ACOd+CsgAvAfA0/wAQwM+gPzCFjC80IRQPghMBDgnfgrAADwHwEBIgL6AfEGSktGmljA80IQAuuAAMD4gBD/5wuwsL0Av+gMAADEEwAAgrABRgGQACLA8vpSEEMDSktGmljQYACRArBwR8QTAACAtfn3Xf6AvYC1+fdS/oC9gbAAIACQGklKRlNYT/AgbMP4BMBTWJhgU1hA8gAMwPL6XMP4DMBTWBhhUVhIYQCQ/+cAmAIoDNj/5w1ISUYIWACZCEQAIQF2/+cAmAEwAJDv5wdISUYKWAAjU2IKWE/w/zOTYgpY02IIWANjAbBwR8QTAACAtfn3Hf6AvYC1+fcS/oC9grABRo34BwCd+AcATvYAcs7yAAIQYACRArBwR4SwCkYDRgOQApEDmLDx/z8BkgCTC9z/5wKYAAEDmQHwDwFO9hRSzvIAAohUCOACmAABA5lO8gBCzvIAAohU/+cEsHBHg7ABRgKQACABkAKYAPAfAAGQASIC+gDwBEpLRppYU2gYQ1BgAJEDsHBHAL/EEwAAhLAKRgNGA5ACkQOYT/aAfMH2/3wB6gwBCEMEScxGXPgBEIhgAZIAkwSwcEfEEwAAhbAKRgNGBJADkQAgApAEmADwHwABIQH6APACkAOYACgBkgCTCND/5wKYCUlKRlFYSmoQQ0hiCOACmAVJSkZRWEpqIuoAAEhi/+cFsHBHAL/EEwAAcLWJsBNGjEaGRgiQjfgfEI34HiAAIAaQ/yEFkQSQA5AjSEpGFFjkaAT04GTE9eBkJQoDlQQlpesUJAaUBZwDnexABZSd+B9ABp2sQAOUnfgeUAWeNUAsQwOUJAEDlAicBPDABQaVxPOBFAaUCJzE8wEkBZQDneQABfoE9AOUBZzkAKFABJEUWAadLEQlfiXqAQEhdgOZEFgGmhBEAn4RQwF2ApPN+ATAzfgA4AmwcL3EEwAAhLAKRgNGjfgPAAKRACkBkgCTCdD/5534DwAJSUpGUVgKaRBDCGEJ4J34DwAESUpGUVgKaSLqAAAIYf/nBLBwR8QTAAAQtYqwVUhJRgAiClRUSApUVEgKVAMgCZAIkRFGB5IE8P/4T/b/cPr3dfoCIQmYBPD3+E1ICJkIWkxKiFKIGN/4MOEx+A7goPgC4N/4KOEx+A7goPgE4N/4IOEx+A7goPgG4N/4GOEx+A7goPgI4N/4EOEx+A7goPgK4N/4COEx+A7goPgM4N/4AOEx+A7goPgO4N/4+OAx+A7goPgQ4N/48OAx+A7goPgS4N/46OAx+A7goPgU4N/44OAx+A7goPgW4IpYQWjQ+Ajgw2jQ+BDAQGlsRmBgxPgAwBBGckYA8G/7LkgImQoY0CEGkBBGBZL597H8QfIAAMTyAkAEkADwH/oEmAiZBpqIUAeb3fgUwMz4DDDM+BgwzPgUMMz4EDDM+BwwzPgoMMz4LDBP9MgezPgk4Mz4MDBP8IB+zPgg4AUkzPg8QMz4OODM+DQwYEYB8KL4A5AKsBC9AL8LGQAAChkAAAwZAACzBAAAkA4AAF0EAACrBAAAZwQAAHEEAAB5BAAAgQQAAIkEAACRBAAAlwQAAJ8EAAClBAAA7AwAAIOwAUYCkAGQAmhC8AICAmAAkQOwcEcAAHC1irDd+DjAnkYURg1GBkYJkAiRB5IGk834FMAJmASQCJnA+JAQBJgBaCH0AAEBYAWYBJkKaBBDCGAGmASZwfiIAAeYBJnB+IAAzfgM4AKUAZUAlgqwcL2FsApGA0YEkI34DxAEmAKQnfgPEND4JMBB6gwBQWIBkgCTBbBwRwAALenwTbCwE0aMRoZGLpAtkSySLpgRRh6Tzfh0wM34cOAB8Er8LphAaAAoBtD/5y6YQWhCbQHwfPz/5y6YQWyCbMNs0PhQwND4VOCEbSSUzfiM4M34iMAhkyCSH5HBbQJuQ27Q+GjA0Phs4ARvKpTN+KTgzfigwCeTJpIlkUBvK5AtmAMoG5AA8vKAG5nf6AHwAkG5ewAgIpAfkCWQLpnR+MwQwfgIAS6YAGgfmSCaIZvd+IjA3fiM4CScJZ0mnief3figgN34pKDd+KiwGpArmBmQaEYYkBmYF5EYmUhiwfggsMH4HKDB+BiAT2EOYc1gjGDB+ATgwfgAwBqYF5kA8En5ACgE0f/nACCN+L8AsuCt4AAgH5AlkC6ZCWgfmiCb3fiEwN34iOAjnCSdJp4nn934oIDd+KSg3fiosBaQK5gVkGhGFJAVmBORFJlIYsH4ILDB+BygwfgYgE9hDmEWmMhgjWBMYMH4AOATmBFGGkZjRgDwD/kAKATR/+cAII34vwB44HPgKJgBKAPR/+cAICKQ/+cAIB+QLpkJaCCaIZvd+IjA3fiM4CScJZ0mnief3figgN34pKDd+KiwEpArmBGQaEYQkBGYD5EQmUhiwfggsMH4HKDB+BiAT2EOYc1gjGDB+ATgwfgAwA+YEpkA8NH4ACgE0f/nACCN+L8AOuA14C6YAGgfmSCaIZvd+IjA3fiM4CScJZ0mnief3figgN34pKDd+KiwDpArmA2QaEYMkA2YC5EMmUhiwfggsMH4HKDB+BiAT2EOYc1gjGDB+ATgwfgAwA6YC5kA8Jv4ACgE0f/nACCN+L8ABOD/5wEgjfi/AP/nnfi/ADCwvejwjXC1i7Dd+DzAnkYURg1GBkbN+CjACZMIkgeRBpAEkAeYCJkJmgqbEUMIQxhDBZAEmAFoQfbIcpFDAWAFmASZCmgQQwhgA5UClM34BOAAlguwcL0AAIWwCkYDRgSQA5EEmAKQAWgh8AQBAWADmAEoAZIAkwbR/+cCmAFoQfAEAQFg/+cFsHBHAACAtYSwAUYDkEHyAALE8gJCkEICkQvR/+dP9IBwASEBkALwvvkAIQGYAvC6+f/nBLCAvQAAgLWCsAFGAZBB8gACxPICQpBCAJEG0f/nT/SAcAEhAvBl+f/nArCAvYC1hLABRgOQAyAAIgKQAZERRgPwN/5P9v9w+fet/wIhApgD8C/+A5gBIYFgBLCAvS3p8E2YsN34pMDd+KDgJ5wmnSWeJJ/d+IyA3fiIoN34hLAFkCCYBJAYRgOQEEYCkAhGAZAFmM34WMDN+FTgFJQTlRKWEZfN+ECAzfg8oM34OLDd+BDAzfg0wAyTC5IKkQWZCZFP9v9yCJIJmgaS0vgAIQeSTPLAA8/ywAMaQAeSD5vd+CjgC5wMnQ2eM0MOnjNDK0ND6g4DI0Pd+EjgQ+oOA934QOBD6g4D3fhU4EPqDgPd+EzgQ+oOA934UOBD6g4D3fhY4EPqDgMaQweSAJD/5waYAGoQ8CAPC9D/5wiYQR4IkQAoBND/5wAgjfhfAAjg7ucHmAaZwfgAAQEgjfhfAP/nnfhfABiwvejwjQAALenwTZiw3fikwN34oOAnnCadJZ4kn934jIDd+Iig3fiEsAWQIJgEkBhGA5AQRgKQCEYBkAWYzfhYwM34VOAUlBOVEpYRl834QIDN+Dygzfg4sN34EMDN+DTADJMLkgqRBZkJkU/2/3IHkgmaBpIPmgqb3fgs4AycDZ0qQw6dKkMiQxpDQuoOAhKbGkMQmxpDEZsaQxWbGkMTmxpDFJsaQwiSAJD/5waYAGoQ8CAPC9D/5weYQR4HkQAoBND/5wAgjfhfAAjg7ucImAaZwfiAAQEgjfhfAP/nnfhfABiwvejwjQAA8LWLsN34RMDd+EDgHEYVRg5GB0bN+CjAzfgk4AiTB5IGkQWQnfgUAJ34FRAElQOUApYBl/n3tP+d+BYAnfgXEPn3rv+d+BgAnfgZEPn3qP+d+BoAnfgbEPn3ov+d+BwAnfgdEPn3nP+d+B4AnfgfEPn3lv+d+CAAnfghEPn3kP+d+CIAnfgjEPn3iv+d+CQAnfglEPn3hP+d+CYAnfgnEPn3fv+d+CgAnfgpEPn3eP+d+CoAnfgrEPn3cv8LsPC9cLWKsN34OMCeRhRGDUYGRs34JMAIkweSBpEFkASQBpkHmgib3fgkwEzqAiJC6gFBGUPA+AASA5UClM34BOAAlgqwcL0QtYiwE0aMRoZGB5AGkQWSB5gAaCAhGSJv8H9EBJMjRs34DODN+AjAAfBA/AeZT/CAUgGQCEYRRgHw+PgHmND4zACBaCHw4GGBYAeY0PjMAIFoQfCgYYFgB5jQ+MwA0PgAEUHwAFHA+AARB5jQ+MwAAWgh9PhRAWAHmND4zAABaEH0gHEBYAeY0PiEEND4zAAJAsD4ABIHmABoASEB8GT4B5gAaAaZSQAB8DT4/+cHmND4zAAAahDwBA8B0f/n9ucHmND4zACw+FAABZkIgP/nB5jQ+MwAAGoQ8AIPAdH/5/bnB5gAaAIh//cw/AEgCLAQvQAAELWIsBNGjEaGRgeQBpEFkgeYAGggIRkib/B/RASTI0bN+AzgzfgIwAHwxvsHmU/wgFIBkAhGEUYB8H74B5jQ+MwAgWgh8OBhgWAHmND4zACBaEHwgGGBYAeY0PjMAND4ABFB8ABRwPgAEQeY0PjMAAFoIfT4UQFgB5jQ+MwAAWhB9IBxAWAHmND4hBDQ+MwACQLA+AASB5gAaAEhAPDq/weYAGgGmUkAAPC6///nB5jQ+MwAAGoQ8AQPAdH/5/bnB5jQ+MwAsPhQAAWZCID/5weY0PjMAABqEPACDwHR/+f25weYAGgCIf/3tvsBIAiwEL0AABC1iLATRoxGhkYHkAaRrfgWIAeYAGggIRkib/B/RASTI0bN+AzgzfgIwAHwS/sHmQAiAZAIRhFGAJIB8AP4B5jQ+MwAgWgh8OBhgWAHmND4zACBaEHwoGGBYAeY0PjMAND4ABFB8ABRwPgAEQeY0PjMAACZwPgAEgeYAGgA8ID/B5gAaAaZSQAA8FD//+cHmND4zAAAahDwBA8B0f/n9ue9+BYAB5nR+MwQofhQAP/nB5jQ+MwAAGoQ8AIPAdH/5/bnB5gAaAIh//dM+wEgCLAQvQAAELWIsBNGjEaGRgeQBpGt+BYgB5gAaCAhGSJv8H9EBJMjRs34DODN+AjAAfDh+geZACIBkAhGEUYAkgDwmf8HmND4zACBaCHw4GGBYAeY0PjMAIFoQfCAYYFgB5jQ+MwA0PgAEUHwAFHA+AARB5jQ+MwAAJnA+AASB5gAaADwFv8HmABoBplJAADw5v7/5weY0PjMAABqEPAEDwHR/+f25734FgAHmdH4zBCh+FAA/+cHmND4zAAAahDwAg8B0f/n9ucHmABoAiH/9+L6ASAIsBC9AACAtZSwCkYDRhKQEZFv8H9AD5ASmEDyVVFP8KoMDpENkmJGzfgwwAuT//cW/xKZQPKqIlUjCpAIRhFGCZIaRgiT//cK/xKZgCIHkAhGDpn/9wP/EpkGkAhGDpkMmv/3/P4SmQWQCEYJmQia//f1/hKZEZowIwSQCEYRRhpG//fs/gOQ/+cSmEDyVVFwIv/35P4SmRGaDfFCDgKQCEYRRnJG//fm/Q+ZSh4PkgApAZAE0f/nACCN+E8ACeD/5734QgCAKN/R/+cBII34TwD/5534TwAUsIC9AACwtZawnEaWRgxGBUYUkBORrfhKIBGTb/B/QA+QE5gNkBSYQPJVUaoizfgwwM34LOAKlAmV//ek/hSZQPKqIlUjCJAIRhFGGkb/95r+FJkTmiUjB5AIRhFGGkb/95H+FJkTmr34SjABO5uyBpAIRhFGGkb/94X+ACEOkQWQ/+cOmL34ShCIQhHa/+cUmA2ZEZoOmzL4EyD/993+DZkCMQ2RBJD/5w6YATAOkOjnFJgTmSki//dl/gOQ/+cUmEDyVVFwIv/3Xf4UmROaDfFCDgKQCEYRRnJG//df/Q+ZSh4PkgApAZAE0f/nACCN+FcACeD/5734QgCAKN/R/+cBII34VwD/5534VwAWsLC9gLWQsBNGjEaGRg6QDZGt+DIgb/B/QAuQDphA8lVRqiIJkQiTzfgcwM34GOD/9yL+DplA8qoiVSMFkAhGEUYaRv/3GP4OmaAiBJAIRgmZ//cR/g6ZDZq9+DIwA5AIRhFGGkb/93H+ApD/5w6YQPJVUXAi//f//Q6ZDZoN8TAOAZAIRhFGckb/9wH9C5lKHguSACkAkATR/+cAII34PwAJ4P/nvfgwAIAo39H/5wEgjfg/AP/nnfg/ABCwgL2wtY6wnEaWRgxGBUYNkAyRC5Kt+CowACAJkK34IgANmdH4zBAIYED2/3DN+BzAzfgY4AWUBJX59/P6DZjQ+MwAASEBYA2Y0Pi4AAEoJNH/5w2Y0PjEAAEh+Peg/w2YAPHEAdD4zABQMAuavfgq4E/qXg5rRsP4BOBP9IBuw/gA4E/0gHMDkAhGA5n592P6DZjEMPn3M/n/5w2YAGggIRkib/B/QwHw6vgNmU/wgFICkAhGEUYA8KL9T/DgYAmQDZjQ+MwAgWgh8OBhgWANmND4zACBaEHwgGGBYA2Y0PjMAAFoIfT4UQFgDZjQ+MwAAWhB9IBxAWANmND4zADQ+AARQfAAUcD4ABENmND4hBDQ+MwACQLA+AASDZgAaL34KhABOQDwCf0NmABoDJlJAADw2fwNmND4uAAAKCDR/+f/5734IgBBHK34IhC9+CoQsOtRDxPa/+cNmND4zAAAahDwBA8B0P/n/+cNmND4zACw+FAAC5mKHAuSCIDh5xLgDZgAaAEh//dI+v/nDZjEMPn3wfgAKAHQ/+f35w2YxDD596H4/+cNmABoICH/97f4ASAOsLC9sLWMsJxGlkYMRgVGC5AKkQmSrfgiMAAgrfggAAuZ0fjMEAhgQPb/cM34HMDN+BjgBZQElfn3GvoLmND4zAABIQFgT/b/cPn3EfoLmND4uAABKCTR/+cLmND4vAABIfj3w/4LmADxvAHQ+MwAUDAJmr34IuBP6l4Oa0bD+ATgT/SAbsP4AOBP9IBzA5AIRgOZ+fcg+QuYvDD591b4/+cLmABoICEZIm/wf0MB8A34C5nR+IQg0fjMEBICwfgAIguZACICkAhGEUYA8L78C5jQ+MwAgWgh8OBhgWALmND4zACBaEHwgGGBYAuYAGi9+CIQATkA8Ef8C5gAaAqZSQAA8Bf8C5jQ+LgAACgi0f/n/+cLmND4zAAAahDwAg8Y0f/n/+cLmND4zAAAahDwBA8B0f/n9ucJmL34IBBKHK34ICAw+BEAC5nR+MwQofhQAN/nE+ALmABoASH/94T5/+cLmND4zAAAahDwAg8B0f/n9ucLmLww+Pfc///nC5gAaAIh/vfy/wEgDLCwvQAALenwQY2w3fhUwN34UOATnB1GFkYPRoBGzfgwwM34LOAKlAmTCJIHkQaQBZAImAmZCpoLmxpDDJsaQxFDCEMEkAWYAWgh9PgRAWAEmAWZCmgQQwhgA5UClgGXzfgAgA2wvejwgS3p8E2qsAFGKJAAaEHyAALE8gJCkEIZkQPR/+dMICeQAeD/5/7nKJgBaMD4zBAomABo//dT+SiYAGj/9zX5KJjAaADwRfkomAFo0Pgg4EJqg2rQ+CzABGtFa4ZrwGtvRjhh/mC9YHxgx/gAwAhGcUYA8GT5KJgBaAJpQ2nQ+BjAwGnuRs74AAAIRhFGGkZjRv/3xvgomAFo0Pi4ABiQCEYYmf/35/gomND4oDCd+JwAACEXkRea/vdp/CiYAWjQ+KAg0PikMND4qMDQ+Kzg0PiwQND4tABtRqhgbGDF+ADgCEYRRhpGY0b/91j/KJjAbwEoQPC1gP/nKJgKIU/0QFIA8Ob7KJgBaEJs0PhI4MNs0PhQwERthW3GbQdu0PhkgND4aKDQ+GywFpAAbxWQFphAbxSQaEYTkBSYEpETmUhiFZgIYsH4HLDB+BigwfgUgA9hzmCNYExgwfgAwBKYEUZyRv/35/gAKATR/+cAII34pwCM4CiYAWjQ+IAg0PiEMND4iMDQ+IwA7kbO+AAACEYRRhpGY0b/9yf6KJjQ+JAAAShc0f/nKJgBaND4lAARkAhGEZkA8HD4KJgBaND4mAAQkAhGEJkA8HX4KJjAaQgoCtH/5yiYAWiw+JwAD5AIRg+ZAPAz/f/nKJhP8EBRAPAz+yiYAGgamRuaHJvd+HTg3fh4wB+cIJ0hniKf3fiMgN34kKDd+JSwDpAmmA2QaEYMkA2YC5EMmUhiwfggsMH4HKDB+BiAT2EOYc1gjGDB+ATAwfgA4A6YC5n/9/v4ACgE0f/nACCN+KcAGOD/5wngKJjAbwAoBNH/5yiYASEBZP/n/+comAEhgWAomND4zAACaELwAQICYI34pxD/5534pwAqsL3o8I2FsApGA0YEkAORBJgCkAOZwPgQEQGSAJMFsHBHhbAKRgNGBJADkQSYApADmcD4kBEBkgCTBbBwR4C1hLABRgOQF0hKRhBY0PicIAL0QBLA+JwgA5gAKAGRAJAI0P/nAJgBKAfQ/+cAmAIoB9AN4AAgApAK4E/0gBACkAbgAyAB8BH/T/QAEAKQ/+cCmARJSkZRWNH4nCAQQ8H4nAAEsIC90A4AAC3p8E2QsN34cMDd+GzgGpwZnRieH0aQRopGg0bN+DzAzfg44A2UDJULlgqTCZIIkQeQBpAImAmZCpoLmxpDEUMIQwyZCEMFkA2YDpkPmhFDCEMEkAaYgWhP9vwCz/bgAhFAgWAFmAaZimgQQ4hgBpjBaCHw/wHBYASYBpnKaBBDyGADl834CIDN+ASgzfgAsBCwvejwjQAAg7ABRgKQAZCQ+FAAAJEDsHBHAABwtZGwCkYDRhCRD5HR+AARAfAHAQuRD5nR+AARAfAIAQ2RD5nR+AARAfAwAQyRD5nR+AARAfTgYQWRD5nR+AARAfQAYQeRD5nR+AARAfRAUQaRD5nR+AARAfTgIQKRD5nR+AARAfQAIQSRD5nR+AARAfRAEQORD5nR+AARAfDgYQiRD5nR+AARAfAAYQqRApnd+AzA3fgQ4AWcBp0HnkZhBWHEYMD4CODA+ATAAWAImd34JMDd+CjgC5wMnQ2exmKFYkRiwPgg4MD4HMCBYQ6ZAWMBkwCSEbBwvQAAg7ABRgKQAZCw+FAAAJEDsHBHAACDsAFGApABkABtAJEDsHBHELWKsBNGjEaGRgmQCJEHkgmYAGggIRkib/B/RAaTI0bN+BTgzfgQwADw4vwJmQloACIDkAhGEUYCkgDwN/kJmND4zAABaCH0+FEBYAmYASECmv73Mf0JmQloCJoBkAhGEUb/96X+CZgAaAeZAPD0+P/nCZjQ+MwAAGoQ8AIPAdH/5/bnCZgAaCAhGSJv8H9DAPCu/AAhAJAIRgqwEL0AAHC1jrDd+EjAnkYURg1GBkYNkAyRC5IKk634JsAAIK34JAANmQloICIZI2/wf0wIkAhGEUYaRmNGzfgc4AaUBZUElgDwhfwNmQlovfgmIAE6A5AIRhFGAPDZ+A2Y0PjMAAFoIfT4UQFgDZgCIQia/vfT/A2ZCWgMmgKQCEYRRv/3R/4NmABoC5kA8Jb4DZjQ+LgAACgf0f/n/+e9+CQAvfgmEIhCFtr/5w2Y0PjMAABqEPAEDw3Q/+cKmL34JBBKHK34JCBAXA2Z0fjMEIH4UAD/5+Ln/+cNmABoICEZIm/wf0MA8DX8DZkJaAIiAZAIRhFG/vd9/AAgDrBwvYC1irAKRgNGCZAIkQmY0PjMAAAhAWBA9v9wB5IGkwWR+Pfq/QmY0PjMAAWZAWIJmND4zABP9v9yQmIJmND4zAABIwNgCZgAaCAhGSMEkhpGBJsA8P/7CZkJaAOQCEYFmQDwVvgJmND4zAABaCH0+FEBYAmYBZkFmv73UPwJmQloCJoCkAhGEUb/98T9/+cJmND4zAAAahDwAg8B0f/n9ucJmABoICEZIm/wf0MA8NL7ASEBkAhGCrCAvQAAhbAKRgNGBJADkQSYApADmYFkAZIAkwWwcEcAAIWwCkYDRgSQA5EEmAKQA5nA+CARAZIAkwWwcEeFsApGA0YEkAORBJgCkAOZwPggEQGSAJMFsHBHhbAKRgNGBJADkQSYApADmQFkAZIAkwWwcEcAAC3p8E2UsN34lMDd+JDgI5winSGeIJ/d+HyA3fh4oN34dLAFkByYBJAYRgOQEEYCkAhGAZAFmM34TMDN+EjgEZQQlQ+WDpfN+DSAzfgwoM34LLDd+BDAzfgowAmTCJIHkQWZBpEHmgib3fgk4AqcC50Mno5lTWUMZcH4TOCLZEpkDZoOm934POAQnBGdEp4OZ81mjGbB+GTgC2bKZROaSmcAkBSwvejwjYWwCkYDRgSQA5EIRgApApABkwCSD9D/5wKYsPGAXw7Q/+cCmLDxAF8N0P/nApiw8UBfDNAP4ASYACGBZwvgBJgBIYFnB+AEmAIhgWcD4ASYAyGBZ//nBJjQ+MwAAWgh8EBRAWADmASZ0fjMEApoEEMIYAWwcEcAALC1lLATRoxGhkYTkBKREZIEqDQhA5PN+AjAzfgE4Pf3Zv8SmAE4AUYJKACRAPKjgQCZ3+gR8AoAPwB1AHkArwDsAPAA9AArAWYBACAJkE/0gHEHkRGZCJEPkAEhDZEOkAyQT/CAcAqQE5gEmgWb3fgYwN34HOAInAmdhWVEZcD4UODA+EzAg2RCZAqaC5vd+DDA3fg04A6cD50FZ8RmwPho4MD4ZMADZsJlEJpCZxOYQWBg4QAgCZBP9ABxB5ERmQiRD5ABIQ2RDpAMkE/wAHAKkBOYBJkFmgab3fgcwN34IOAJnIRlwPhU4MD4UMDDZIJkQWQKmQuaDJvd+DTA3fg44A+cBGfA+GzgwPhowENmAmbBZRCZQWcTmAIhQWAq4ROYAyFBYCbhACAJkE/0QHEHkRGZCJEPkAEhDZEOkAyQT/BAcAqQE5gEmQWaBpvd+BzA3fgg4AmchGXA+FTgwPhQwMNkgmRBZAqZC5oMm934NMDd+DjgD5wEZ8D4bODA+GjAQ2YCZsFlEJlBZxOYBCFBYPDgT/QAYAmQT/RAcAeQEZgIkE/0ACAGkAAgD5ABIQ2RDpBP8ABgDJBP8EBwCpATmASZBZoGm934HMDd+CDgCZyEZcD4VODA+FDAw2SCZEFkCpkLmgyb3fg0wN34OOAPnARnwPhs4MD4aMBDZgJmwWUQmUFnE5gFIUFgs+ATmAghQWCv4BOYCSFBYKvgACAJkE/0gGEHkRGZCJEPkAQhDZEQIQ6RDJBP8IBgCpATmASZBZoGm934HMDd+CDgCZyEZcD4VODA+FDAw2SCZEFkCpkLmgyb3fg0wN34OOAPnARnwPhs4MD4aMBDZgJmwWUQmUFnE5gIIUFgdOBP9ABgCZBP9IBgB5ARmAiQCCAPkAQgDZAQIA6QT/AAYAyQT/CAYAqQE5gEmQWaBpvd+BzA3fgg4AmchGXA+FTgwPhQwMNkgmRBZAqZC5oMm934NMDd+DjgD5wEZ8D4bODA+GjAQ2YCZsFlEJlBZxOYCSFBYDngT/QAYAmQT/SAYAeQEZgIkAAgDZBP8ABgDJBP8IBgCpBP8ABQEJATmASZBZoGm934HMDd+CDgCZyEZcD4VODA+FDAw2SCZEFkCpkLmgyb3fg0wN34OOAPnARnwPhs4MD4aMBDZgJmwWUQmUFnE5gKIUFg/+cUsLC9AACFsApGA0YEkAORBJgCkAOZwPgwEQGSAJMFsHBHLenwTaqw3fjswN346OA5nDidN542n9341IDd+NCg3fjMsBqQMpgZkBhGGJAQRheQCEYWkBqYzfigwM34nOAmlCWVJJYjl834iIDN+ISgzfiAsN34ZMDN+HzAHpMdkhqaHJIbkRybHZoVkBhG//f8/RyYAWhCbINs0PhMwND4UOBEbYVtxm0HbtD4ZIDQ+Gig0PhssBSQAG8TkBSYQG8SkGhGEZASmBCREZlIYhOYCGLB+BywwfgYoMH4FIAPYc5gjWBMYMH4AOAQmBFGGkZjRv73/PoAKATR/+cAII34pwCE4ByYAGgjmSSaJZsA8IT4HJgAaB6Z//eb+hyYAGgfmf/3+PwcmAFoQmyDbND4TODQ+FDARG2FbcZtB27Q+GSA0PhooND4bLAPkABvDpAPmEBvDZBoRgyQDZgLkQyZSGIOmAhiwfgcsMH4GKDB+BSAD2HOYI1gTGDB+ADAC5gRRhpGc0b+9zr7ACgE0f/nACCN+KcAOuAcmABoJpknmiibAPBY+ByYAGggmf/3X/ocmABoIZn/97z8HJjAaQgoDtH/5xyY0PjMAAFoQfAIAQFgHJgAaL34iBD/9xT//+cbmAkoCtH/5xyY0PjMAND4ABFB8ABRwPgAEf/nHJhP8EBR//cG/QEgjfinAP/nnfinACqwvejwjQAAsLWKsJxGlkYMRgVGCZMIkgeRBpAEkAmYnfgcEAhDCJkIQwWQBJnB+AgBA5UClM34BODN+ADACrCwvQAAsLWKsJxGlkYMRgVGCZMIkgeRBpAEkAmYnfgcEAhDCJkIQwWQBJnB+IgBA5UClM34BODN+ADACrCwvQAAsLWLsJxGlkYMRgVGCZAIkY34HyAGkwmYBJAAao34FwCd+B8AGSjN+AzAzfgI4AGUAJUc0f/n/+ed+BcACJkIQhTQ/+cEmABqjfgXAAaYACgL0P/nBphBHgaRASgE0f/nACCN+CsAKOD/5+Xn/+ed+B8AYygd0f/n/+ed+BcACJkIQIhCFND/5wSYAGqN+BcABpgAKAvQ/+cGmEEeBpEBKATR/+cAII34KwAG4P/n5Of/5wEgjfgrAP/nnfgrAAuwsL0AAIWwCkYDRgSQjfgPEASYApCd+A8QgPhQEAGSAJMFsHBHhbAKRgNGBJCt+A4QBJgCkL34DhCg+FAQAZIAkwWwcEeFsApGA0YEkAORBJgCkAOZAWUBkgCTBbBwRwAAgLWKsBNGjEaGRgmQrfgiEI34ISAAIK34HgAJmQaQCEYFk834EMDN+Azg+PcF/AmYnfghIL34IhD49zb9vfgiAAEhAfoA8K34HgAJmL34HiBrRt34GMDD+ATAGWACIQKREUYCmgKb+PdZ/AqwgL0AAIKwAUYBkAAoAJEI0P/nCUhJRghYAWhB9IBxAWAH4AVISUYIWAFoIfSAcQFg/+cCsHBHAL/IDgAAgLWCsE/wgFABIQGQAPCM+wAhAZgA8Ij7ArCAvYC1grABRo34BwAWSEpGE1jT+BjASPIfHkzqDgzD+BjAE1jT+ADALPAHDMP4AMAQWAJoQvACAgJgTvYQUM7yAAACaELwBAICYJ34BwABKACRA9H/5/f3DvsC4Pf3Dfv/5wKwgL3IDgAAgLUMSElGCliTaUjyHxxD6gwDk2EIWAFoQfAHAQFgTvYQUM7yAAABaEHwBAEBYPf37fqAvcgOAACAtQxISUYKWJNpSPIfHEPqDAOTYQhYAWhB8AMBAWBO9hBQzvIAAAFoQfAEAQFg9/fR+oC9yA4AAIC1hrAKRgNGBZCN+BMQACADkBZISUZR+ADA3PgAwM34DMAs8AcMzfgMwN34FOBM6g4MzfgMwAhYwPgAwE72EFDO8gAAAWhB8AQBAWCd+BMAASgCkgGTA9H/5/f3n/oC4Pf3nvr/5wawgL0Av8gOAACAtYewE0aMRoZGjfgbAI34GhCN+BkgR/IAAMTyAAAFkAAgBJADkJ34GQABKAKTzfgEwM34AOAO0f/nBZid+BsQQFgEkJ34GhAIQwSQBZmd+BsgiFAO4AWYnfgbEEBYA5Cd+BoQCEMDkAWZnfgbIBFESGD/5wewgL2CsAFGAZAAKACRCND/5wlISUYIWEFoQfABAUFgB+AFSElGCFhBaCHwAQFBYP/nArBwRwC/yA4AAIOwAUYCkAAgAZAJSEpGE1hbaAGTI/DgAwGT3fgIwEPqDAMBkxBYQ2AAkQOwcEcAv8gOAACAtYKwAUaN+AcACkhKRhNY0/gYwEjyHx5M6g4Mw/gYwJ34BzAQWAJoQuqDMgJgAJECsIC9yA4AAIC1hrATRoxGhkYFkASRA5IWSElGCFiBaUjyHxIRQ4FhA5gAKAKTzfgEwM34AOAI0P/nBZgNSUpGUViKaBBDiGAI4AWYCUlKRlFYimgi6gAAiGD/5wSYBZkBOYhAA0lKRlFYymgQQ8hgBrCAvcgOAABwRwAAsLWKsBNGjEaGRgmQCJEHkgmYAPHgQAaQB5oImQpMTUYsRAWQIEYFnASRIUYEnQOTK0bN+AjAzfgE4Pz3mfoAIQCQCEYKsLC97AwAAIC1irATRoxGhkYJkK34IhCN+CEgACCt+B4ACZkGkAhGBZPN+BDAzfgM4Pj3Efq9+CIAASEB+gDwrfgeAAmYvfgeEGpGBptTYBNgAiICkgKb+Pdw+gmYnfghIL34IhD49y/7CrCAvQAAhLAKRgNGA5ACkQApAZIAkwjQ/+cDmAlJSkZRWIpsEEOIZAjgA5gFSUpGUViKbCLqAACIZP/nBLBwRwC/0A4AAISwCkYDRgOQApEAKQGSAJMI0P/nA5gJSUpGUViKbhBDiGYI4AOYBUlKRlFYim4i6gAAiGb/5wSwcEcAv9AOAACEsApGA0YDkAKRACkBkgCTCND/5wOYCUlKRlFYimoQQ4hiCOADmAVJSkZRWIpqIuoAAIhi/+cEsHBHAL/QDgAAhLAKRgNGA5ACkQApAZIAkwjQ/+cDmAlJSkZRWMpsEEPIZAjgA5gFSUpGUVjKbCLqAADIZP/nBLBwRwC/0A4AAISwCkYDRgOQApEAKQGSAJMI0P/nA5gJSUpGUVjKbhBDyGYI4AOYBUlKRlFYym4i6gAAyGb/5wSwcEcAv9AOAACEsApGA0YDkAKRACkBkgCTCND/5wOYCUlKRlFYymoQQ8hiCOADmAVJSkZRWMpqIuoAAMhi/+cEsHBHAL/QDgAAhLAKRgNGA5ACkQApAZIAkwjQ/+cDmAlJSkZRWAptEEMIZQjgA5gFSUpGUVgKbSLqAAAIZf/nBLBwRwC/0A4AAISwCkYDRgOQApEAKQGSAJMI0P/nA5gJSUpGUVgKbxBDCGcI4AOYBUlKRlFYCm8i6gAACGf/5wSwcEcAv9AOAACEsApGA0YDkAKRACkBkgCTCND/5wOYCUlKRlFYCmsQQwhjCOADmAVJSkZRWAprIuoAAAhj/+cEsHBHAL/QDgAAhLAKRgNGA5ACkQApAZIAkwjQ/+cDmAlJSkZRWMptEEPIZQjgA5gFSUpGUVjKbSLqAADIZf/nBLBwRwC/0A4AAISwCkYDRgOQApEAKQGSAJMI0P/nA5gJSUpGUVjKbxBDyGcI4AOYBUlKRlFYym8i6gAAyGf/5wSwcEcAv9AOAACEsApGA0YDkAKRACkBkgCTCND/5wOYCUlKRlFYymsQQ8hjCOADmAVJSkZRWMprIuoAAMhj/+cEsHBHAL/QDgAAhLAKRgNGA5ACkQApAZIAkwjQ/+cDmAlJSkZRWIptEEOIZQjgA5gFSUpGUViKbSLqAACIZf/nBLBwRwC/0A4AAISwCkYDRgOQApEAKQGSAJMI0P/nA5gJSUpGUViKbxBDiGcI4AOYBUlKRlFYim8i6gAAiGf/5wSwcEcAv9AOAACEsApGA0YDkAKRACkBkgCTCND/5wOYCUlKRlFYimsQQ4hjCOADmAVJSkZRWIprIuoAAIhj/+cEsHBHAL/QDgAAhLAKRgNGA5ACkQApAZIAkwjQ/+cDmAlJSkZRWApuEEMIZgjgA5gFSUpGUVgKbiLqAAAIZv/nBLBwRwC/0A4AAISwCkYDRgOQApEAKQGSAJMK0P/nA5gLSUpGUVjR+IAgEEPB+IAACuADmAZJSkZRWNH4gCAi6gAAwfiAAP/nBLBwRwC/0A4AAISwCkYDRgOQApEAKQGSAJMI0P/nA5gJSUpGUVgKbBBDCGQI4AOYBUlKRlFYCmwi6gAACGT/5wSwcEcAv9AOAAAQtYWwCkYDRgSQA5EAIAKQDUhJRlH4AMDc+AjAzfgIwCzw/kzN+AjA3fgQ4AOcTuoEDkzqDgzN+AjACFjA+AjAAZIAkwWwEL3QDgAAQfIAAMTyAgABaEH0gDEBYP/nQfIAAMTyAgAAaBD0AD8B0f/n9edC8gAAxPICAAFoQfAHAQFgQfIIAMTyAgABaCHw8AEBYAFoAWABaCH04GEBYAFoAWABaCH0YFEBYAFoAWABaEHwAgEBYP/nQfIIAMTyAgAAaADwDAAIKAHQ/+f053BHgLUQSElGClgTaEPwAQMTYApYACOTYApY0vgAwE/2/37O9v5uDOoODML4AMAKWNNgCljS+ADALPSALML4AMAIWINhgL3QDgAAh7ABRgaQACAFkASQA5ACIAKQQfIIAMTyAgAAaADwDAAFkAJGDCgBkQCSOdgAmd/oAfAHNzc3Djc3NxU3NzccAAaYQPYAEcDyPQEBYC/gBphC8gBBwPL0AQFgKOAGmET2AAHA8ugRAWAh4EHyDADE8gIAAWgB9H9BiQkDkQBoAPQAMAIhQerQMAKQA5mx+/DwRPJAIcDyDwFIQwaZCGAG4AaYQvIAQcDy9AEBYP/nQfIIAMTyAgABaAHw8AIFksHzAxEFkUL2cGLA8gACekRRXASRBpvT+ADALPoB8VlgAWgB9OBjBZPB8wIhBZFRXASRBpvT+ATALPoB8ZlgAGgA9GBRBZHA88IgBZAQXASQBplKaCL6APDIYAewcEcDSElGCFiAaADwDABwRwC/0A4AAIOwAUYCkB5ISkYTWNP4AMAs9IA8w/gAwBBYAmgi9IAiAmACmAAoAZEAkCTQ/+cAmLD1gD8F0P/nAJiw9YAvEtAa4A9ISUYIWAFoQfSAMQFg/+cLSElGCFgAaBD0AD8B0f/n9ucK4AZISUYIWAFoQfSgIQFgAuAB4P/n/ucDsHBH0A4AAIGwDUhJRghYAWhB9EBxAWD/5wlISUYIWABoACEAKQCQAdD/5/XnBEhJRghYgWhB9ABBgWABsHBH0A4AAISwCkYDRgOQApEDmBJJzEZc+AEQ0fiQwEDqDADB+JAAApgAKAGSAJMK0P/nCkhJRghY0PiQEEHwgHHA+JAQCeAFSElGCFjQ+JAQIfCAccD4kBD/5wSwcEfQDgAAgLWCsAFGAZABIACRAPAW+E/0gHAA8PT6AZgBKArR/+cFSElGCFjQ+JAQQfAgAcD4kBD/5wKwgL3QDgAAgLWEsAFGjfgPAE/wgFABIgKREUb/92D9IUhJRghYAmhC9IByAmAfSApY0viQ4C7wAQ7C+JDgCFjQ+JAQIfAEAcD4kBCd+A8AAUYBKAGRBND/5wGYBCgV0B7gEkhJRghY0PiQEEHwAQHA+JAQ/+cNSElGCFjQ+JAAEPACDwHR/+f15wvgB0hJRghY0PiQEEHwBQHA+JAQAeD/5/7nBLCAvcgOAADQDgAAgbALSElGCFjQ+JQQQfABAcD4lBD/5wZISUYIWND4lAAAIQApAJAB0P/n9OcBsHBH0A4AABC1hbAKRgNGBJADkQAgApANSElGUfgAwNz4CMDN+AjALPD+TM34CMDd+BDgA5xO6gQOTOoODM34CMAIWMD4CMABkgCTBbAQvdAOAACwtYmwnEaWRgxGBUYIkAeRBpIFkwAgBJAcSUpGU1gbaASTBJAImASQUVgKaBBDCGAFmAAozfgMwM34COABlACVCND/5xFISUYIWAFoQfAEAQFgB+ANSElGCFgBaCHwBAEBYP/nB5gJSUpGU1jT+ADATOoAEBhgBphRWNH4lCBC6gAgwfiUAAmwsL0Av9AOAACCsAFGAZABKACREtH/5xNISUYIWAFoQfABAQFg/+cPSElGCFgAaBDwAg8B0f/n9ucR4ApISUYIWAFoIfABAQFg/+cGSElGCFgAaBDwAg8B0P/n9uf/5wKwcEcAv9AOAACAtYSwAUYDkAAgApABkf/3x/8OSElGUfgA4N74ACBC8AgCzvgAIApYEmgCkiLw8AICkt34DOBC6g4CApIIWAJgASD/963/BLCAvQC/0A4AAISwCkYDRgOQApEAKQGSAJMZ0P/nA5gBIQH6APAYSUpGUVgKaBBDCGD/5xVISUYIWABoA5kBMQEiAvoB8QhCAdH/5/LnGeADmAEhAfoA8AxJSkZRWApoIuoAAAhg/+cISElGCFgAaAOZATEBIgL6AfEIQgHQ/+fy5//nBLBwRwC/0A4AAIC1hrABRgWQACAEkBoiA5AQRgObApEZRgGS//ev/w9ISUYKWBJpBJIi9IAyBJIFmxpDQvSAMghYAmEBIQGY//ed///nBUhJRghYAGgQ8ABvAdH/5/bnBrCAvQC/0A4AAIC1hrABRgWQACAEkBoiA5AQRgObApEZRgGS//d//w9ISUYKWBJpBJIi9MACBJIFmxpDQvSAEghYAmEBIQGY//dt///nBUhJRghYAGgQ8ABvAdH/5/bnBrCAvQC/0A4AAIC1hrABRgWQACAEkBoiA5AQRgObApEZRgGS//dP/w9ISUYKWBJpBJIi8MBiBJIFmxpDQvCAcghYAmEBIQGY//c9///nBUhJRghYAGgQ8ABvAdH/5/bnBrCAvQC/0A4AAIC1hrABRgWQACAEkBwiA5AQRgObApEZRgGS//cf/w9ISUYKWFJpBJIi9IAyBJIFmxpDQvSAMghYQmEBIQGY//cN///nBUhJRghYAGgQ8ABfAdH/5/bnBrCAvQC/0A4AAIC1hrABRgWQACAEkBgiA5AQRgObApEZRgGS//fv/g9ISUYKWNJoBJIi8HhCBJIFmxpDQvSAMghYwmABIQGY//fd/v/nBUhJRghYAGgQ8AB/AdH/5/bnBrCAvQC/0A4AAIC1hrABRgWQACAEkBgiA5AQRgObApEZRgGS//e//hBISUYKWNJoBJIi9MACBJIFmxpDQfYAA8DyEAMaQwhYwmABIQGY//eq/v/nBUhJRghYAGgQ8AB/AdH/5/bnBrCAvdAOAACAtYawAUYFkAAgBJAYIgOQEEYDmwKRGUYBkv/3jf4PSElGCljSaASSIvDAYgSSBZsaQ0LwgHIIWMJgASEBmP/3e/7/5wVISUYIWABoEPAAfwHR/+f25wawgL0Av9AOAACBsAtISUYIWND4mBBB8AEBwPiYEP/nBkhJRghYAGgAIQApAJAB0P/n9ecBsHBHAL/QDgAAgLWEsAFGA5A3SEpGE1jT+JDATPSAPMP4kMAQWND4kCAi9IAywPiQIAOYsPWAfwKRAZAg0P/nAZiw9QB/BdD/5wGYsPVAfyzQQuD/90v93/iY4EhGUPgOENH4kCAi9EBywfiQIFD4DgDQ+JAQQfQAccD4kBAt4AEg//fg/BpIzkZe+AAQ0fiQICL0QHLB+JAgXvgAAND4kBBB9IBxwPiQEBfgT/SAMP/3HfwPSM5GXvgAENH4kCAi9EBywfiQIF74AADQ+JAQQfRAccD4kBAA4P/nBUhJRghY0PiQEEH0AEHA+JAQBLCAvdAOAACDsAFGApAAIAGQCUhKRhNYm2gBkyPwAwMBk934CMBD6gwDAZMQWINgAJEDsHBHAL/QDgAAhLABRo34DwBP9vxwwvIDAAKQnfgPIAojzvIAA0PqAhICYL/zT48CmABoAZC/80+PApgFIs7yAAICYL/zT48BmACRBLBwRwAAgLWGsAFGBJADkQDwo/wAKATR/+cAII34FwA24P/nBJjQ+MwAAGoQ8CAPAdD/5/bnBJjQ+MwAACHA+AgRBJgCkQKa/Pff/QSZCWhgIgGQCEYRRv33U///5wSY0PjMAABqEPACDwHR/+f25wSYASEZIgDwlPsAKATR/+cAII34FwAD4AEgjfgXAP/nnfgXAAawgL0AALC1krCcRpZGDEYFRhCQD5EOkq34NjAQmAIhT/CAUs34LMDN+CjgCZQIlfz3of0QmUloASkHkATR/+cLII34NQCQ4BCYQGgCKBPR/+e7II34NQAQmND4zACoIcD4IBEQmND4zADQ+AARQfQAMcD4ABF34BCYQGgEKDXR/+cQmAEhQWAQmADwBvqN+DQAEJgAIU/wAg5yRs34GOAA8FP8EJkFkAhGAPD2+Y34NAAQmAQhQWAQmE/wgFIGmfz3Wf3rIY34NRAQmdH4zBCoIsH4ICEQmdH4zBDR+AAhQvRAMsH4ACEEkDzgEJhAaAUoNdH/5xCYASFBYBCYAPDM+Y34NAAQmAAhT/ACDnJGzfgM4ADwGfwQmQKQCEYA8Lz5jfg0ABCYBSFBYBCYT/CAUgOZ/Pcf/e0hjfg1EBCZ0fjMEKUiwfggIRCZ0fjMENH4ACFC9EAywfgAIQGQAeD/5/7n/+f/5//nEJjQ+MwACCHA+AgREJgAaL34NhABOf738/gQmABonfg1EP33b/4QmABoD5n+9774ACCt+DIAEJjQ+LgAACgh0f/n/+cQmND4zAAAahDwIA8X0P/nEJjQ+MwAAGoQ8AQPDtD/5xCY0PjMAJD4UAAOmb34MiBTHK34MjAh+BIA/+fg5wrgEJgAaAEh/Pcp/hCYAGgAIfz3JP7/5xCYAGggIRkiT/b/c8DyDwP+90v8ACgE0f/nACCN+EcAFeAQmND4zAAAIQFgEJjQ+MwAQPb/cUFiDyD29wj+EJjQ+MwAASEBYI34RxD/5534RwASsLC9gLWEsAFGApDQ+MwAACLA+AghApgBIhkjAZERRhpGAPBJ+gAoBNH/5wAgjfgPACTgApjwIf335P8AkP/nApjQ+MwAAGoQ8AIPAdH/5/bnApjQ+MwAQPb/cUFiApgBIRkiAPAo+gAoBNH/5wAgjfgPAAPgASCN+A8A/+ed+A8ABLCAvQAAELWOsBNGjEaGRgyQC5EKkgyYwG2w8YB/CJPN+BzAzfgY4ATR/+cCII34JwAS4AyYwG2w8UB/CtH/5zIgjfgnAAyYACECIgDwEfsFkAHg/+f+5//nDJgA8Mf6ACgE0f/nACCN+DcApOAMmABoICEZIk/2/3P+96z7DJkCIgAjBJAIRhFGGkYDk/z3BvwMmQpoC2nR+BTg0fgYwMlpbEYhYAKQEEYZRnJGY0b89zX9DJjQ+MwAA5nA+AgRDJgAaP8h/ffk/wyYAGid+CcQ/fdg/QyYAGgLmf33r///5wyY0PjMAABqEPAEDwHR/+f25wqYQRwKkQB4DJnR+MwQgfhQAAAgjfgmAP/nDJjQ+MwAAGoAIRDwIA8BkQPQ/+cBIAGQ/+cBmBDwAQ8Y0P/nDJjQ+MwAAGoQ8AQPD9D/5wqYQRwKkQB4DJnR+MwQgfhQAJ34JgABMI34JgD/59XnDJgAaPz3TvsMmABoICEZIk/2/3PA8g8D/vcs+wAoBNH/5wAgjfg3ABXgDJgBIRkiAPBQ+QAoBNH/5wAgjfg3AAngDJjQ+MwAQPb/cUFiASCN+DcA/+ed+DcADrAQvQAAgLWIsAFGB5DQ+MwAACLA+AghB5gAaAEjBZEZRgSTA5L991b/B5gDIU/wgFL891b7B5kJaDUiApAIRhFG/ffK/AeYAGgEIWMiT/b/c/734voHmdH4zBCR+FAQjfgbEP8hAZAIRvb3qPwHmND4zAADmQFgB5jQ+MwAQPb/ckJiDyD295r8B5jQ+MwABJkBYJ34GwAIsIC9AACAtYSwAUYDkND4zAAIIsD4CCEDmABoASICkRFG/fcM/wOYAiFP8IBS/PcM+wOZCWhlIgGQCEYRRv33gPwDmABoAyHA8oAB/ffN/gOYAGgEIWMiT/b/c/73kfoDmdH4zBCR+FAQAJAIRgSwgL2AtYawAUYEkAAgjfgIAASa0vjMIML4CAEEmABoASIBkRFG/ffT/gSYAyFP8IBS/PfT+gSZCWifIgCQCEYRRv33R/z/5wSY0PjMAABqEPAgDxfQ/+cEmND4zAAAahDwBA8O0P/nBJjQ+MwAkPhQAJ34CBBKHI34CCAN8QkCUFT/5+DnBJjQ+MwAACEBYASY0PjMAED2/3FBYg8g9vcL/ASY0PjMAAEhAWCd+AkAjfgMAJ34CgCN+A0AvfgMAK34FAC9+BQABrCAvYC1iLAKRgNGBpAFkQaYBJIDkwDwJfkAKATR/+cAII34HwA94P/nBpjQ+MwAAGoQ8CAPAdD/5/bnBpjQ+MwAACHA+AgRBpgBIgKREUYCmvz3X/oGmQlo2CIBkAhGEUb999P7BpgAaAWZ/fci/v/nBpjQ+MwAAGoQ8AIPAdH/5/bnBpgBIRkiAPAP+AAoBNH/5wAgjfgfAAPgASCN+B8A/+ed+B8ACLCAvXC1jLATRoxGhkYKkAmRCJJP9v9wwPIPAAeQCpjQ+MwAACHA+AARCpjQ+MwAAmgi8AECAmAKmND4zADA+AgRCpgBaAJpRGmFacBpbkYwYAhGEUYiRgaTK0bN+BTgzfgQwPz3QvsImGMoDtH/5wqYAGgJmWpGACMTYAQiA5ERRgOaA5v897H5CeAKmABoCZppRgAjC2AEIfz3p/n/5wqYAGgAIf332/0KmAMhT/AAUvz32/kKmdH4zBAKaELwAQIKYAKQ/+cKmND4zAAAaAEhACkBkAHR/+f15wqYAGgFIf33P/sJmAEoA9H/5wAgB5D/5wqYAGgHmwghYyL+91H5ACgP0f/nCpgAaPz3YvkKmND4zABA9v9+wPgk4AAgjfgvAEXgCpgAaPz3U/kKmABoAiFjIk/2/3PA8g8D/vcx+QAoBNH/5wAgjfgvADDgCpgAaCAhGSJP9v9zwPIPA/73IPkAKATR/+cAII34LwAf4AqYAGgCIfz3ZPkKmABoCCH891/5CpjQ+MwAACEBYAqY0PjMAED2/3FBYg8g9vfT+gqY0PjMAAEhAWCN+C8Q/+ed+C8ADLBwvQAAgLWEsAFGApDQ+MwAACLA+AghApgBIhkjAZERRhpG//cT/wAoBNH/5wAgjfgPACTgApgGIf33rvwAkP/nApjQ+MwAAGoQ8AIPAdH/5/bnApjQ+MwAQPb/cUFiApgCIWMi//fy/gAoBNH/5wAgjfgPAAPgASCN+A8A/+ed+A8ABLCAvQAAgLWQsBNGjEaGRg6Qjfg3EI34NiAOmAyTzfgswM34KOD/96z/ACgE0f/nACCN+D8AWeAOmND4zAAAIcD4CBEOmAMiCZERRgma/Pfw+A6ZCWgBIgiQCEYRRgeS/fdj+g6YAGgHmf333PwOmABoBCFjIk/2/34GkQWSc0bN+BDg/vdx+J34NxAOmtL4zCCC+FAQDpkJaAOQCEYGmQWaBJv+92H4nfg2EA6a0vjMIIL4UBAOmQloICIZIwKQCEYRRhpGBJv+90/4DpkBkAhG//dW/wAoBNH/5wAgjfg/AAPgASCN+D8A/+ed+D8AELCAvQAAcEcAAIC1grABIAGQAZn+9w39ACEBmP73Cf0CsIC9AAAQtYSwCkYDRo34DwCN+A4QACACkJ34DgAA8AMAgAAPIQH6APACkBJJzEZc+AHgnfgOQATw/ASmRN74CEAk6gAAzvgIAJ34DwCd+A7gDvADBKQAoEBc+AEQDvD8DGFE0fgIwEDqDACIYAGSAJMEsBC99BMAAIC1grABIAGQAZn+94H8ArCAvQAAgrABRo34BwAHSEpGE1hP8AcMw/gAwJ34BzAQWAJoGkMCYACRArBwR/QTAACCsAFGjfgHAJ34BwAfKACRDNz/5534BwABIQH6APALSUpGUVgKahBDCGIM4J34BwAgOAEhAfoA8ARJSkZRWIpqEEOIYv/nArBwRwC/9BMAAIawCkYDRo34FwAEkU/2/HDC8gMAA5AAaAKQA5gAaAKQnfgXAASZQepAcAOZCGC/80+PA5hP8P8xAWC/80+PAZIAkwawcEcAAIC1hLABRgKQsPGAfwGRA9P/5wEgA5Ad4AKYIPB/QAE4TvIUAc7yAAEIYE/w/zAPIfv3uv1O8hgAzvIAAAAhAWBO8hAAzvIAAE/wBw7A+ADgA5H/5wOYBLCAvQAAcEcAAIC1/vdz/E72CF7O8gAOT/BgYM74AACAvYOwAUYCkAAgAZACmAAiwvICAhBgAZCd+AYAwPOAEACRA7BwR4KwAUYBkAAgAJECsHBHAAD/5/7nLenwTaCwE0aMRoZGHpAdkRySEKgwIQ+Tzfg4wM34NOD19437L0hJRghEDJD698L6CCAMmQuQCEYLmfr3w/9O9hNAEZBP9EBQEJAAIBiQFCGN+FgQF5AQmhGbEpnd+EzA3fhQ4BWcFp0Ynhmf3fhogN34bKDrRsv4JKDL+CCAy/gccMv4GGDL+BQAy/gQUMv4DEDL+Ajgy/gEwMv4ABAMmAuZ/feh/QqQ/+cdmEEeHZEAKA/Q/+cemEEcHpEAeByZShwckgl4iEID0P/nHpgfkAPg6ucemB+Q/+cfmCCwvejwjQC/7AwAAIC1hrAKRgNGBZAEkQWYA5AAaAghxPICAYhCApIBkwCQYtD/5xwgxPICAACZgUJb0P/nMCDE8gIAAJmBQlTQ/+dEIMTyAgAAmYFCTdD/51ggxPICAACZgUJG0P/nbCDE8gIAAJmBQj/Q/+eAIMTyAgAAmYFCOND/50DyCEDE8gIAAJmBQjXQ/+dA8hxAxPICAACZgUIt0P/nQPIwQMTyAgAAmYFCJdD/50DyREDE8gIAAJmBQh3Q/+dA8lhAxPICAACZgUIV0P/nQPJsQMTyAgAAmYFCDdD/50DygEDE8gIAAJmBQgXQCeAEmQEg/vf4+AbgBJkCIP738/gB4P/n/ucGsIC9hrABRgWQBJAAaAOQACCN+AsAA5oTaCPwAQMTYAOaEGADmlBgA5qQYAOa0GAEmhJoACPL9v5zGkSw65IvAZEM0f/nBJgAaE/2+HHL9v1xCETA8wMQjfgLAA7gBJgAaE/2+DHL9v1xCEQA8PAAByEB6xAQjfgLAP/nckhJRghYnfgLEAAiQPghIAOYCCHE8gIBiEIAkGLQ/+ccIMTyAgAAmYFCY9D/5zAgxPICAACZgUJk0P/nRCDE8gIAAJmBQmXQ/+dYIMTyAgAAmYFCZtD/52wgxPICAACZgUJn0P/ngCDE8gIAAJmBQmjQ/+dA8ghAxPICAACZgUJo0P/nQPIcQMTyAgAAmYFCaND/50DyMEDE8gIAAJmBQmjQ/+dA8kRAxPICAACZgUJo0P/nQPJYQMTyAgAAmYFCaND/50DybEDE8gIAAJmBQmjQ/+dA8oBAxPICAACZgUJo0G/gO0hJRghYQWhB8A8BQWBp4DdISUYIWEFoQfDwAUFgYeAzSElGCFhBaEH0cGFBYFngL0hJRghYQWhB9HBBQWBR4CtISUYIWEFoQfRwIUFgSeAnSElGCFhBaEH0cAFBYEHgI0hJRghYQWhB8HBhQWA54B5ISUYIWEFoQfAPAUFgMeAaSElGCFhBaEHw8AFBYCngFkhJRghYQWhB9HBhQWAh4BJISUYIWEFoQfRwQUFgGeAOSElGCFhBaEH0cCFBYBHgCkhJRghYQWhB9HABQWAJ4AZISUYIWEFoQfBwYUFgAeD/5/7nBrBwR3AMAABQDAAAMAwAAIawCkYDRgWQBJEFmAOQAGgCkASYASgBkgCTBtH/5wKYAWhB8AEBAWAF4AKYAWgh8AEBAWD/5wawcEcAAISwAUYDkAKQAGgBkEBogLIAkQSwcEcAAC3p8E2ksN34tMDd+LDgHEYVRg5GOJ/d+NyA3fjYoN341LAOkDSYDZAzmAyQMpgLkDGYCpAwmAmQL5gIkC6YB5AOmM34jMDN+IjgIZMgkh+RDpkekQeaHZIImxyT3fgkwM34bMDd+Cjgzfho4AuZGZEMmRiRDZkXkc34WLDN+FSgzfhQgBOXHp8Slz9oEZcAJxCXjfg/cN34SIDY+ACAQPIACsv2/nrQRLfrmC8GlgWQBJQDlQzR/+cSmABoT/b4ccv2/XEIRMDzAxCN+D8ADuASmABoT/b4Mcv2/XEIRADw8AAHIQHrEBCN+D8A/+cBIPX3uPofmN34hOAimZ34gTCd+D8gnfiAwJ34jEBtRqxgaWDF+ADgYUb192j6EZgAaBCQR/bwcYhDEJAbmRWaEUMZmhFDGJoRQxeaEUMWmhFDFJoRQxOaEUMIQxCQEZkIYBqYEZlIYB2YEZmIYByYEZnIYCSwvejwjS3p8E2ksN34tMDd+LDgHEYVRg5GB0YjkCKRIZIgk834fODN+HjAI5gdkAAgHJAbkBqQGZAYkED2AAHE8gIBGJEdmQl5jfhkECOZIpohm934eMDd+IDg3fh8gN34YKDd+GSwF5AamBaQG5gVkByYFJBoRhOQF5gSkROZCGNP9ABQyGIXmIhiwfgkgMH4IOBP8IAOwfgc4IhhwfgUwE/wEAzB+BDAy2CKYBSaSmAVmgpgEphRRlpGFpsRlBCVD5YOl//36v4ksL3o8I0AAC3p8E2ksN34tMDd+LDgHEYVRg5GB0YjkCKRIZIgk834fODN+HjAI5gdkAAgHJAbkBqQGZAYkED2AAHE8gIBGJEdmQl5jfhkECOZIpohm934eMDd+IDg3fh8gN34YKDd+GSwF5AamBaQG5gVkByYFJBoRhOQF5gSkROZCGNP9ABQyGIXmIhiwfgkgMH4IOBP8IAOwfgc4IhhwfgUwAhhy2CKYBSaSmAVmgpgEphRRlpGFpsRlBCVD5YOl//3h/4ksL3o8I2AtYSwAUYDkAKQAGgIIsTyAgKQQgGRAJBi0P/nHCDE8gIAAJmBQlvQ/+cwIMTyAgAAmYFCVND/50QgxPICAACZgUJN0P/nWCDE8gIAAJmBQkbQ/+dsIMTyAgAAmYFCP9D/54AgxPICAACZgUI40P/nQPIIQMTyAgAAmYFCNND/50DyHEDE8gIAAJmBQizQ/+dA8jBAxPICAACZgUIk0P/nQPJEQMTyAgAAmYFCHND/50DyWEDE8gIAAJmBQhTQ/+dA8mxAxPICAACZgUIM0P/nQPKAQMTyAgAAmYFCBNAH4AOY//e//AXgA5j/97v8AeD/5/7nBLCAvYKwAUYBkACR/+cBmAAoBdD/5//nAZgBOAGQ9ucCsHBHibAKRgNGrfgiAAeRvfgiAAAJA5C9+CIAAPAPAAE4jfgaAAOYBygCkgGTAJBc2ACZ3+gB8AQNGCMuOURPACDE8gIgBJCd+CIAjfgbAEzgQPIAQMTyAiAEkL34IgAQOI34GwBB4ED2AADE8gIgBJC9+CIAIDiN+BsANuBA9gBAxPICIASQvfgiADA4jfgbACvgQfIAAMTyAiAEkL34IgBAOI34GwAg4EHyAEDE8gIgBJC9+CIAUDiN+BsAFeBB9gAAxPICIASQvfgiAGA4jfgbAArgQfYAQMTyAiAEkL34IgBwOI34GwD/5534GgAHmQhwBJgJsHBHAACAtYSwAUYDkAJGACPE8gIjmEICkgGROND/50DyAEDE8gIgApmBQjTQ/+dA9gAAxPICIAKZgUIw0P/nQPYAQMTyAiACmYFCLND/50HyAADE8gIgApmBQijQ/+dB8gBAxPICIAKZgUIk0P/nQfYAAMTyAiACmYFCIND/50H2AEDE8gIgApmBQhzQH+ABIADw4v4d4AIgAPDe/hngAyAA8Nr+FeAEIADw1v4R4AUgAPDS/g3gBiAA8M7+CeAHIADwyv4F4AggAPDG/gHg/+f+5wSwgL0AAPC1jbDd+EzA3fhI4BxGFUYORgdGDJALkQqSCZPN+CDgzfgcwAAgBpAFkASQBpADlAKVAZYAl//nBpgPKGXY/+cGmAEhAfoA8AWQC5kIQASQBZmIQlTR/+cGmEAAAyEB+gDwDJkKaCLqAAAIYAqYBplJAIhADJkKaBBDCGAKmAEoBND/5wqYAigm0f/nBphAAAMhAfoA8AyZimgi6gAAiGAJmAaZSQCIQAyZimgQQ4hgvfgYAAEhAfoA8AyZiogi6gAAiIC9+CAAvfgYEIhADJmKiBBDiID/5734GABAAAMhAfoA8AyZymgi6gAAyGAHmAaZSQCIQAyZymgQQ8hg/+f/5waYATAGkJbnDbDwvQAAgLWGsApGA0at+BYAjfgVEL34FgAN8Q8BApIBk//3gv4EkJ34DxCd+BUgAPBJ/QawgL0AABC1h7ATRoxGhkYGkK34FhCN+BUgACAEkAOQnfgVAL34FhAB8AcBiQCIQASQvfgWAADwBwGJAA8iAvoB8QaaR/b8dATqUAAQRAJqIuoBAQFiBpi9+BYQBOpRAQhEAGoEmQhDA5AGmb34FiAE6lICEUQIYgKTzfgEwM34AOAHsBC9gLWOsAFGDZAAIAyQCKgHkf33kv4NmETyAEHE8gABiEIGkE7Q/+dE9gAAxPIAAAaZgUIA8GyA/+dE9gBAxPIAAAaZgUIA8IyA/+dF8gAAxPIAAAaZgUIA8KyA/+dI8gAAxPIAAAaZgUIA8M+A/+dD9gAAxPIBAAaZgUJA8PKA/+d5SElGCFjQ+IgAAPADAAFGAygFkRTYBZnf6AHwAgUIDguYDJAM4AmYDJAJ4ELyAEDA8vQADJAD4E/0+kAMkP/nz+BpSElGCFjQ+IgAAPAMAAFGDCgEkRnYBJnf6AHwBxcXFwoXFxcNFxcXEwAKmAyQDOAJmAyQCeBC8gBAwPL0AAyQA+BP9PpADJD/56ngVkhJRghY0PiIAADwMAABRgAoA5EM0P/nA5gQKAvQ/+cDmCAoCtD/5wOYMCgM0A/gCpgMkAzgCZgMkAngQvIAQMDy9AAMkAPgT/T6QAyQ/+eA4EFISUYIWND4iAAA8MAAAUYAKAKRDND/5wKYQCgL0P/nApiAKArQ/+cCmMAoDNAP4AqYDJAM4AmYDJAJ4ELyAEDA8vQADJAD4E/0+kAMkP/nV+AtSElGCFjQ+IgAAPRAcAFGACgBkQ/Q/+cBmLD1gH8N0P/nAZiw9QB/C9D/5wGYsPVAfwzQD+AKmAyQDOAJmAyQCeBC8gBAwPL0AAyQA+BP9PpADJD/5yvgF0hJRghY0PiIAAD0QGABRgAoAJEP0P/nAJiw9YBvDdD/5wCYsPUAbwvQ/+cAmLD1QG8M0A/gCpgMkAzgCZgMkAngQvIAQMDy9AAMkAPgT/T6QAyQ/+f/5wyYDrCAvdAOAACAtYawAUYFkAJGRfIAQ8TyAAOYQgSSA5EQ0P/nRfYAAMTyAAAEmYFCEND/50X2AEDE8gAABJmBQhDQF+AgIAAhASMCkQKaAPAZ+xHgIiAAIQEjAZEBmgDwEfsJ4EkgACEBIwCRAJoA8An7AeD/5/7nBrCAvYC1hrABRgWQAkZF8gBDxPIAA5hCBJIDkRDQ/+dF9gAAxPIAAASZgUIQ0P/nRfYAQMTyAAAEmYFCENAX4B8gACEBIwKRApoA8N/6EeAhIAAhASMBkQGaAPDX+gngSCAAIQEjAJEAmgDwz/oB4P/n/ucGsIC9LenwQZSw3fhwwN34bOAanB1GFkYPRoBGE5Ct+EoQrfhIIK34RjCt+ERArfhC4M34PMAAIK34OgCt+DgABCGt+DYQQfIAIcDyegEMkROZiogi8D8CioAIqQeQCEYGlQWWBJfN+AyA/fe9/AqYDJBN9oNhxPIbMaD7AQGJDK34OBC9+DgQE5qTiBlDkYATmQqIIvABAgqAB5mt+DoQD5pI8qBjwPIBA5pCApAd2P/nDJgPmUkAsPvx8K34NgC9+DYAAygE3P/nBCCt+DYA/+e9+DYAvfg6EAhDrfg6AL34OAABMBOZCIRH4L34SABL9v9xiEIJ0f/nDJgPmQHrQQGw+/Hwrfg2AA7gDJgPmRkiUUOw+/Hwrfg2AL34NgBA9IBArfg2AP/nvfg2AED2/3EIQgfR/+e9+DYAQPABAK34NgD/5734NgC9+DoQCENA9ABArfg6AL34OABP9JZxSENE9tNRwfJiAaD7AQEBIgLrkRETmhGEAZD/5734OgATmYiDE5gBiEHwAQEBgBOYAIit+DoAvfg6AE/29TEIQK34OgC9+EoAvfhEEAhDgLK9+DoQCEOt+DoAE5kIgL34QgC9+EYQCEMTmQiBFLC96PCBAACAtYSwAUYDkAJGRfIAQ8TyAAOYQgKSAZEQ0P/nRfYAAMTyAAACmYFCDND/50X2AEDE8gAAApmBQgjQC+AUIADwi/oJ4BUgAPCH+gXgFiAA8IP6AeD/5/7nBLCAvYC1hrABRgWQAkZF8gBDxPIAA5hCBJIDkRDQ/+dF9gAAxPIAAASZgUIQ0P/nRfYAQMTyAAAEmYFCENAX4CAgACEBIwKRApoA8I/5EeAiIAAhASMBkQGaAPCH+QngSSAAIQEjAJEAmgDwf/kB4P/n/ucGsIC9gLWGsAFGBZACRkXyAEPE8gADmEIEkgOREND/50X2AADE8gAABJmBQhDQ/+dF9gBAxPIAAASZgUIQ0BfgHyAAIQEjApECmgDwVfkR4CEgACEBIwGRAZoA8E35CeBIIAAhASMAkQCaAPBF+QHg/+f+5wawgL2AtYSwAUYDkAJGRfIAQ8TyAAOYQgKSAZEQ0P/nRfYAAMTyAAACmYFCDND/50X2AEDE8gAAApmBQgjQC+AUIADwifoJ4BUgAPCF+gXgFiAA8IH6AeD/5/7nBLCAvbC1ibCcRpZGDEYFRgiQB5EGkgWTACAEkAiZCmgi8AECCmAImQpoIvT4UgpgB5kKaImIEUMImhNoGUMRYAiZimgi9ABCimAImYhgBplKaAmJEUMImpFgBpkJaAiak2gZQ5FgCJnKaCL0AELKYAiZyGAGmUqKCYoRQ4myCJrRYAaZyWgImtNoGUPRYAiZCGEFmAB4AAcEkAWZCXlA6gFQBJAFmcl4QOoBQASQBZmJeEDqASAEkAWZSXgIQwSQCJkIYQiYAWhB8AEBAWDN+AzAzfgI4AGUAJUJsLC9AACDsAFGApCAihD0gG8AkQzQ/+cCmIGKIfSAYYGCGEhJRgpcQvABAgpU/+cCmICKEPSAfwzQ/+cCmIGKIfSAcYGCD0hJRgpcQvACAgpU/+cCmICKEPQAbxDQ/+cJSElGClxC8AMCClQCmIGKIfQAYYGCApgAio34BwD/5wOwcEcAvwkZAACDsAFGApAAkQOwcEeDsAFGApCAaRD0AH8AkQzQ/+cCmMFpQfQAccFhGEhJRgpcQvACAgpU/+cCmIBpEPSAfwzQ/+cCmMFpQfSAccFhD0hJRgpcQvACAgpU/+cCmIBpEPSAbxDQ/+cJSElGClxC8AMCClQCmEBqjfgHAAKYwWlB9IBhwWH/5wOwcEcAvwkZAACDsAFGApCAaRDwEA8AkQzQ/+cCmMFpQfAQAcFhBEhJRgpcQvABAgpU/+cDsHBHAL8JGQAAsLWKsJxGlkYMRgVGjfgnAI34JhCN+CUgjfgkMAAgCJAHkAaQBZAPIASQnfgkAAAozfgMwM34COABlACVXND/507yDADO8gAAAGgA9OBgwPXgYAEKCJEEIaHrECAFkASYCJnIQASQnfgmAAWZiEAIkJ34JRAEmhFACEMIkAABCJCd+CcQAfADAckAiEAIkJ34JwCACE7yAEHO8gABQFwHkJ34JwAA8AMAwAD/IgL6APAGkAeaIuoAAAeQBpgImhBACJAHmhBDB5Cd+CcgkghQVJ34JwAA8B8BASIC+gHxTvIAEs7yAAJC6tAATvIcEs7yAAIQQAFgE+Cd+CcAAPAfAQEiAvoB8U7ygBLO8gACQurQAE7ynBLO8gACEEABYP/nCrCwvYC1irATRoxGhkYJkK34IhCN+CEgACCt+B4ACZkGkAhGBZPN+BDAzfgM4P/3l/kJmJ34ISC9+CIQ//ec+r34IgABIQH6APCt+B4ACZi9+B4ga0bd+BjAw/gEwBlgAiECkRFGApoCm//34/kKsIC9AACAtYiwAUat+B4AvfgeABQ4AkYDKAaRBZIv2AWZ3+gB8AINGCNP9AAQASEEkP33NvgAIQSY/fcy+CHgT/SAAAEhA5D99yv4ACEDmP33J/gW4E/0AAABIQKQ/fcg+AAhApj99xz4C+ACIAEhAZD897b/ACEBmPz3sv8B4P/n/ucIsIC9AACAtYSwAUYDkAJGRPIAQ8TyAAOYQgKSAZEu0P/nRPYAAMTyAAACmYFCLND/50T2AEDE8gAAApmBQirQ/+dF8gAAxPIAAAKZgUIo0P/nSPIAAMTyAAACmYFCJtD/50P2AADE8gEAApmBQiTR/+dP9IBAASH89/H/H+BP9AAwASH894v/GeBP9IAgASH894X/E+BP9AAgASH893//DeBP9IAQASH893n/B+ABIACQAJn89xP/AeD/5/7nBLCAvYC1hLABRq34DgC9+A4AATgCRhYoApEBkk7YAZnf6AHwDBIXHCEmKzA1NTVMTExMTExMTDU7QUcAASAAkACZ/Pct/jngAiABIfz3KP404AQgASH89yP+L+AIIAEh/Pce/irgECABIfz3Gf4l4CAgASH89xT+IOBAIAEh/PcP/hvggCABIfz3Cv4W4E/0ABABIfz3JP8Q4E/0gAABIfz3Hv8K4E/0AAABIfz3GP8E4AIgASH897P+/+cEsIC9AAAAAAECAwQBAgMEBgcICQAAAAAIAAJABQAAAAAAAAAAAAAANQlBCW8JCgkAABkJMQkMCQAANglCCXAJCwkAABoJMgkNCQAAARsMEQwAABwMFgwAAAAAAAgAAkAHAAAAAAAAAAAAAAAIBAJACAAAAAAAAAAAAAAACAACQFYAAAAcAAJAVgAAADAAAkBWAAAACAQCQFYAAAAcBAJAVgAAADAEAkBWAAAAAAAAAAAAAAA1BhMGAAA4Bh4GAABJBiAGAABGBicGAAAjBkoGWwZoBhkFAAA0BhIGAAA3Bh0GAABIBh8GAABFBigGAAAIAAJAVwAAABwAAkBXAAAAMAACQFcAAAAIBAJAVwAAABwEAkBXAAAAMAQCQFcAAAAAAAAAAAAAAAgAAkBYAAAAHAACQFgAAAAwAAJAWAAAAAgEAkBYAAAAHAQCQFgAAAAwBAJAWAAAAAAAAAAAAAAACAACQFkAAAAcAAJAWQAAADAAAkBZAAAACAQCQFkAAAAcBAJAWQAAADAEAkBZAAAAAAAAAAAAAABRDAAAYQwAAGIMAABjDAAAZAwAAGUMAABmDAAAPAwAAD0MAAA+DAAARAwAAFIMAABFDAAARgwAAEcMAABDDAAAbgwAAG8MAABTDAAAVAwAAFUMAABWDAAAXQwAAF4MAABfDAAAYAwAADQMAAA/DAAATgwAAE8MAABQDAAAOQwAADoMAAA7DAAAQAwAADEMAAAyDAAASAwAAEkMAABKDAAASwwAAEwMAABNDAAACAACQAAAAAAAAAAAAAAAAGgMAABBDAAAQgwAAGoMAAA4DAAAagwAAGsMAABtDAAAGAwAADUMAAA3DAAANgwAAAAAAAAOAA8AEAAUABUAAAAIAAJAEQAAAAgEAkARAAAAAAAAAAAAAAAIAAJAEgAAAAgEAkASAAAAAAAAAAAAAAAZBG8EFwQAABoEbgQYBAAADwQWBHAEAgQAAAAACAACQBMAAAAIBAJAEwAAAAAAAAAAAAAACAACQBQAAAAIBAJAFAAAAAAAAAAAAAAAHgRSBBsEAAAfBFEEHAQAAFMEHQQAAAAACAACQBUAAAAIBAJAFQAAAAAAAAAAAAAACAACQBYAAAAIBAJAFgAAAAAAAAAAAAAAIQRoBAgEAAAiBCoGaQQVBAAAZwQTBAAACAACQBcAAAAIBAJAFwAAAAAAAAAAAAAACAACQBgAAAAIBAJAGAAAAAAAAAAAAAAAPQQbA18EFwUAAD4EHANgBBgFAAA8BF4EDwUAAABUAEAA8QAAGgEOAQAADwAAABAAAAAUAAAADgAAACQBbQEXAQAAIQFrARYBAAAjAWwBGAEAABMBIgFwAQ8BAAAkDjwOBg4AACEOPQ4SDgAACQ4+DgUOAAAeCGYIBwgAAAgAAkAjAAAACAQCQCMAAAAAAAAAAAAAAAgAAkAkAAAACAQCQCQAAAAAAAAAAAAAAB0IZwgSCAAAIQgbCGkIBAgAACIIHAhoCAMIAAABCQAAABUAAAAEChsKSwpbAwAAEwpEA2cDAgoAABIKTQpZCgAAEQpOCloKAAAICk8KWAoAAAcKUApXCgAAIgo1CgAAIwo2CmwDAAAkCjcKAAAlCjgKAAAdCkoKXAMAAAMKBQMcCiwFTAoAABMAAAAgAAAAAAgEAkAlAAAAHAACQCUAAAAAAAAAAAAAAAgEAkAmAAAAHAACQCYAAAAAAAAAAAAAABoNRQ0KDQAAGQ1DDWgNBA0AABsNRg0JDQAAIg0kDTcNRw0LDQAABQ0PDRcNSg1aDQAASw1YDRUNAABJDVkNFA0AABYNRA1IDVcNDg0AABkDQwNoAwQDAABGAwkDAAAkAzcDRwMLAwAARQMaAwAAWw0mAwAAEQ0BDQAAAAAIBAJAJwAAABwAAkAnAAAAAAAAAAAAAAAIBAJAKAAAABwAAkAoAAAAAAAAAAAAAAAdDSENPQ1rDQAAHw0nDToNbA0AAB4NOw1qDQAAIA08DW0NAABkDRANAAAsDWUNKA0AAGMNKw0AAGYNLQ0AACoNAw0AABoIAAAZCAAALQwAADMMAAAnCAAAKQwAACgIAAAqDAAAKwwAACwMAAAZDAAAGgwAACcMAAAoDAAAHAACQAsAAAAcBAJACwAAAAAAAAAAAAAACAACQAwAAAAIBAJADAAAAAAAAAAAAAAADAUVBU8FZAUHBQAADQUWBVAFZQUIBQAAEQUQBU0FZgUFBQAABgUUBU4FYwUCBQAACAACQA0AAAAIBAJADQAAAAAAAAAAAAAACAACQA4AAAAIBAJADgAAAAAAAAAAAAAAIwU0BR8FAAAiAyQFNQUgBQAAHQUxBRoFAAAbBR4FMgU0AwoDAAAAAAgAAkAPAAAACAQCQA8AAAAAAAAAAAAAAAgAAkAQAAAACAQCQBAAAAAAAAAAAAAAACwGawYVBgAALQY3BWwGFgYAAG0GEAYFBgAAKwZqBhQGAAAPAAAADgAAAB0OCg4AAB4Oag4CDgAAHw5aDmsOAw4AACAOWw5sDgQOAAAWDgAAFw4AABkOQQ4HDgAAFQ4LDgAAGA4AABoOQg4IDgAADAxPAk8DDAIAAAcMHQEdA1ABUAMHAQAAHgFJAQgBAABKAQkBAAAfAUsBEQEAAEwBCgEAACABTQESAQAATgELAQAATwEMAQAASAENAQAABgEQAQEBAAAUAQIBAAAbAQMBAAAcAQQBAAAGAhACAQ4AABUCJwJEAgcCAAAWAigCRQIIAgAAKQJGAhECAAAqAkcCEgIAAEMCMwIAAD0CFwIAAD4CGAIAAD8CGQIAAEACGgIAAEECAABXAgECAABYAgICAABZAgMCAABaAgQCAABXAQAAFwwqASoOFwMAAAcNGAMYDQcDAAAIAwYDAAAnAwAAHwMRAwAAKAMAACADEgMAACkDAAAqAwAAAQMAAEMAAAAqAEQAIgAAAEUAKwAAAEYAMwAAAEcALQAAABQAAAAdCQAAHgkAAB8JAAAVCQAAFgkAABcJAAAYCQAAKwkAACwJAAAtCQAAJwkAACgJAAApCQAAKgkAAEsJAABMCQAATQkAAE4JAAA7CQAAPAkAAD0JAAA+CQAAQwkAAEQJAABFCQAARgkAAF8JAABgCQAAYQkAAGIJAAAzCRsJAAAAAQIDBAUGBwkKDA0OD3MRDxARDxESAQgVNlcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYCAAAAAAACAACQB8AAAAIBAJAHwAAAAAAAAAAAAAACAACQCAAAAAIBAJAIAAAAAAAAAAAAAAACwgQCAAALAgCCAAAKwgBCAAAFggAAAAACAACQCEAAAAIBAJAIQAAAAAAAAAAAAAACAACQCIAAAAIBAJAIgAAAAAAAAAAAAAAEQgVCAAAMwgAAC0IAAAWB24HCQcAAGwHFQcMBwAAAAAIAAJAGQAAAAgEAkAZAAAAAAAAAAAAAAAIAAJAGgAAAAgEAkAaAAAAAAAAAAAAAABtBxQHDQcAABgHawcLBwAAFwdqBwoHAAA4BwUHAAA0BwEHAAAIBAJAGwAAAAgAAkAbAAAAAAAAAAAAAAAIAAJAHAAAAAgEAkAcAAAAAAAAAAAAAAA1BwIHAAA3BxADBAcAADYHAwcAAB0HLQc7BxEHAAAeBzwHBwcAAAAACAACQB0AAAAIBAJAHQAAAAAAAAAAAAAACAACQB4AAAAIBAJAHgAAAAAAAAAAAAAAEgcfBzMHPQcQBwAAJgcsBzoHHAcAACUHKwc5BxsHAAAQCwAAIAsAABYLAAAfCwAAFAoLCgAADAoAAA0KAAAqCg4KAAAKCgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-    pc_init: 6757
-    pc_uninit: 43325
-    pc_program_page: 35941
-    pc_erase_sector: 2953
-    pc_erase_all: 2949
-    data_section_offset: 49672
+    pc_init: 0x1a65
+    pc_uninit: 0xa93d
+    pc_program_page: 0x8c65
+    pc_erase_sector: 0xb89
+    pc_erase_all: 0xb85
+    data_section_offset: 0xc208
     flash_properties:
       address_range:
-        start: 2415919104
-        end: 2483027968
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x90000000
+        end: 0x94000000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 4096
-          address: 0
-  stm32l5x_opt:
-    name: stm32l5x_opt
+        - size: 0x1000
+          address: 0x0
+  - name: stm32l5x_opt
     description: STM32L5xx Flash Options
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: 1EjTSYFg1EmBYL/zT48BaskD/NTRSQFh0UkBYb/zT48BaskD/NQAIHBHykhP8IBBgWK/80+PgWrJA/zUT/AAQYFiv/NPj4FqyQP81AAgcEcAIHBHcLW/TELy+gUlYiBswEkA8ABACEMgZL9IYGS/SKBkb/T+AKBl4GWgZuBmAPBj+QEoCNG6SOBkukhgZWBmb/B/ACBlIGZP9AAwoGK/80+PIGrAA/zUIGooQAHQJWIBIHC9ACBwRy3p/E3ReBBo03lh8x9gUWhj8x9hAZHRepRo0vgMwGHzH2TRexNpYfMfbNF8Vmlh8x9j0X3VfmHzH2aRaWXzH2EAkdF/0vgcgJL4I1Bh8x9oEWqS+CdwZfMfYVVqwkZn8x9lkvgrcNL4KIBn8x9okvgvcNJqw0Zn8x9iiE+WRkLy+gI6Yo5KEEM4ZEzwfwB4ZEPwfwC4ZGrwfxC4ZWHwfxD4ZWvwfxC4Zm7wfxD4ZgDw7/gBKA/RRvB8APhkgUkBmAhDeGUMQ3xmAJhg8H8QOGVl8H8QOGa/80+PT/QAMLhiv/NPjzhqwAP81DhqQvL6AQhAA9A4aghDOGIBIL3o/I0t6fdNBEbReBBoVmhh8x9g0XmVaGHzH2bRetNoYfMfZdF713xh8x9jEWmS+BfAZ/MfYVdpkvgfgGzzH2e6RpL4G8CXaYOwbPMfZ9L4HMBo8x9szfgEwJL4I4DS+CDAaPMfbOZGkvgngNL4JMBo8x9szfgAwJL4K4DS+CjAaPMfbONGkvgvwNJqbPMfYt/4DMHc+EDA3/gogW/qCAgM6ggMAOoIAIRFA9AgRgawvejwjTpI0PhEwE/q7By86+MfAdDgHPLng2zbEbPr4R8B0CAd6+eBbQHwfxMBmQHwfxGLQgHQ4B3h58FtAfB/Ew7wfxGLQgLQBPEIANfngW4B8H8TC/B/EYtCAtAE8QoAzeeARsBuAvB/EQDwfxCIQgLQBPELAMLnAPA0+AEoLtHY+EwAQUYg8HwCKvB8AIJCAdBgHbPnSm0fSMBDAkAGQLJCAdBgHKrnSm4FQAJAqkIB0KAco+cIbQfwfxIA8H8QkEIB0KAdmucIbgDwfxEAmADwfxCBQgLQBPEJAI/nBJggRIznAkgAbMAPcEcjAWdFACACQKuJ7807KhkIf25dTKr4739/AAAIfwD5C3wAAAyAf4B/AIiAYP//gH8AAAAA
-    pc_init: 1
-    pc_uninit: 43
-    pc_program_page: 185
-    pc_erase_sector: 181
-    pc_erase_all: 85
-    data_section_offset: 896
+    pc_init: 0x1
+    pc_uninit: 0x2b
+    pc_program_page: 0xb9
+    pc_erase_sector: 0xb5
+    pc_erase_all: 0x55
+    data_section_offset: 0x380
     flash_properties:
       address_range:
-        start: 535822336
-        end: 535822384
-      page_size: 48
-      erased_byte_value: 255
-      program_page_timeout: 3000
-      erase_sector_timeout: 3000
+        start: 0x1ff00000
+        end: 0x1ff00030
+      page_size: 0x30
+      erased_byte_value: 0xff
+      program_page_timeout: 0xbb8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 48
-          address: 0
+        - size: 0x30
+          address: 0x0

--- a/probe-rs/targets/STM32WB_Series.yaml
+++ b/probe-rs/targets/STM32WB_Series.yaml
@@ -1,8 +1,7 @@
----
 name: STM32WB Series
 manufacturer:
   id: 0x20
-  cc: 0x00
+  cc: 0x0
 variants:
   - name: STM32WB30CEUx
     cores:
@@ -10,21 +9,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb3x_512_m4
   - name: STM32WB35CCUx
@@ -33,21 +34,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb3x_256_m4
   - name: STM32WB35CEUx
@@ -56,21 +59,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb3x_512_m4
   - name: STM32WB50CGUx
@@ -79,21 +84,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
   - name: STM32WB55CCUx
@@ -103,21 +110,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
   - name: STM32WB55CEUx
@@ -127,21 +136,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
   - name: STM32WB55CGUx
@@ -151,21 +162,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
   - name: STM32WB55RCVx
@@ -175,21 +188,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
   - name: STM32WB55REVx
@@ -199,21 +214,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
   - name: STM32WB55RGVx
@@ -223,21 +240,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
   - name: STM32WB55VCQx
@@ -246,21 +265,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
   - name: STM32WB55VCYx
@@ -270,21 +291,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537001984
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
   - name: STM32WB55VEQx
@@ -293,21 +316,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
   - name: STM32WB55VEYx
@@ -317,21 +342,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134742016
+            start: 0x8000000
+            end: 0x8080000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
   - name: STM32WB55VGQx
@@ -340,21 +367,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
   - name: STM32WB55VGYx
@@ -364,90 +393,92 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 135266304
+            start: 0x8000000
+            end: 0x8100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wb_m4
 flash_algorithms:
-  stm32wb3x_256_m4:
-    name: stm32wb3x_256_m4
+  - name: stm32wb3x_256_m4
     description: STM32WB3_M4 256 Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: YUhBaQApA9pgSYFgYEmBYAAgcEdcSEFpQgQRQ0FhACBwRxC1WEhbSVtKAOARYANp2wP71FlKAmEBackD/NQBaQkD/NQBaUkD/NQBaVRLGUMBYUFpBCMZQ0FhQWmcAyFDQWEBackD/NQBaUkD/NQBaQkD/NRBaZlDQWEAIUFhAWkRQgLQAmEBIBC9ACAQvRC1PUlCSgphS2lCTCNAS2FACuNDGEALadsD/NQLaVsD/NQLaRsD/NRMaQIjGEMEQ0xhSGncAyBDSGEAvwC/CGnAA/zUCGlAA/zUCGkAA/zUSGmYQ0hhACBIYQhpEEIC0AphASAQvQEgwAYAaEAcAtEIaCBDCGAAIBC9cLXJHR5LyQgjTckAHWFcaQEmNENcYRpOQDYe4B1hHGnkA/zUHGlkA/zUHGkkA/zUFGgEYFRoRGAcaeQD/NQcaWQD/NQcaSQD/NQ0aggwCDkIMuQHAdABIHC9ACne0VhpQAhAAFhhASDABgBoQBwE0BhoASEJBIhDGGAAIHC9AAAAQABYIwFnRauJ782qqgAAADAAQPpDAAD/AQAAB+D//wAAAAA=
-    pc_init: 1
-    pc_uninit: 21
-    pc_program_page: 265
-    pc_erase_sector: 143
-    pc_erase_all: 35
-    data_section_offset: 424
+    pc_init: 0x1
+    pc_uninit: 0x15
+    pc_program_page: 0x109
+    pc_erase_sector: 0x8f
+    pc_erase_all: 0x23
+    data_section_offset: 0x1a8
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134479872
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8040000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 4096
-          address: 0
-  stm32wb3x_512_m4:
-    name: stm32wb3x_512_m4
+        - size: 0x1000
+          address: 0x0
+  - name: stm32wb3x_512_m4
     description: STM32WB3_M4 512 Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: YUhBaQApA9pgSYFgYEmBYAAgcEdcSEFpQgQRQ0FhACBwRxC1WEhbSVtKAOARYANp2wP71FlKAmEBackD/NQBaQkD/NQBaUkD/NQBaVRLGUMBYUFpBCMZQ0FhQWmcAyFDQWEBackD/NQBaUkD/NQBaQkD/NRBaZlDQWEAIUFhAWkRQgLQAmEBIBC9ACAQvRC1PUlCSgphS2lCTCNAS2FACuNDGEALadsD/NQLaVsD/NQLaRsD/NRMaQIjGEMEQ0xhSGncAyBDSGEAvwC/CGnAA/zUCGlAA/zUCGkAA/zUSGmYQ0hhACBIYQhpEEIC0AphASAQvQEgwAYAaEAcAtEIaCBDCGAAIBC9cLXJHR5LyQgjTckAHWFcaQEmNENcYRpOQDYe4B1hHGnkA/zUHGlkA/zUHGkkA/zUFGgEYFRoRGAcaeQD/NQcaWQD/NQcaSQD/NQ0aggwCDkIMuQHAdABIHC9ACne0VhpQAhAAFhhASDABgBoQBwE0BhoASEJBIhDGGAAIHC9AAAAQABYIwFnRauJ782qqgAAADAAQPpDAAD/AQAAB+D//wAAAAA=
-    pc_init: 1
-    pc_uninit: 21
-    pc_program_page: 265
-    pc_erase_sector: 143
-    pc_erase_all: 35
-    data_section_offset: 424
+    pc_init: 0x1
+    pc_uninit: 0x15
+    pc_program_page: 0x109
+    pc_erase_sector: 0x8f
+    pc_erase_all: 0x23
+    data_section_offset: 0x1a8
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134742016
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8080000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 4096
-          address: 0
-  stm32wb_m4:
-    name: stm32wb_m4
+        - size: 0x1000
+          address: 0x0
+  - name: stm32wb_m4
     description: STM32WB_M4 Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: Qfb4cQHqUCBwR0pISEmBYElJgWAAIHBHRkhBaUHwAEFBYQAgcEcBIHBHELVK9qoiQklASADgCmADadsD+9RE8vo0BGFI8gQDQ2FDaUP0gDNDYQDgCmADadsD+9QAIUFhAWkhQgLQBGEBIBC9ACAQvUH2+HEB6lAiELUuSAFpEfRAP/vRAWlJA/zUAWkJA/zURPL6NARhQvACAUFhQWlB9IAxQWFK9qohJEoA4BFgA2nbA/vUACFBYQFpIUIC0ARhASAQvQAgEL0QtRpLyR1A8v8UIfAHARxhASRcYR/gHGkU9EA/+9EcaWQD/NQcaSQD/NQUaARgVGhEYBxpFPRAP/vRHGlkA/zUHGkkA/zUHGmkBwHVASAQvQgwCDkIMgAp3dFYaSDwAQBYYQAgEL0AACMBZ0UAQABYq4nvzQAwAEAAAAAA
-    pc_init: 11
-    pc_uninit: 25
-    pc_program_page: 201
-    pc_erase_sector: 113
-    pc_erase_all: 43
-    data_section_offset: 320
+    pc_init: 0xb
+    pc_uninit: 0x19
+    pc_program_page: 0xc9
+    pc_erase_sector: 0x71
+    pc_erase_all: 0x2b
+    data_section_offset: 0x140
     flash_properties:
       address_range:
-        start: 134217728
-        end: 135266304
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8100000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 4096
-          address: 0
+        - size: 0x1000
+          address: 0x0

--- a/probe-rs/targets/STM32WL_Series.yaml
+++ b/probe-rs/targets/STM32WL_Series.yaml
@@ -1,6 +1,5 @@
----
 name: STM32WL Series
-manufacturer: ~
+manufacturer: null
 variants:
   - name: STM32WLE5J8Ix
     cores:
@@ -8,21 +7,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536891392
+            start: 0x20000000
+            end: 0x20005000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134283264
+            start: 0x8000000
+            end: 0x8010000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wlexx_64
   - name: STM32WLE5JBIx
@@ -31,21 +32,23 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536920064
+            start: 0x20000000
+            end: 0x2000c000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134348800
+            start: 0x8000000
+            end: 0x8020000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wlexx_128
   - name: STM32WLE5JCIx
@@ -54,90 +57,92 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536936448
+            start: 0x20000000
+            end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 134217728
-            end: 134479872
+            start: 0x8000000
+            end: 0x8040000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - stm32wlxx_cm4
 flash_algorithms:
-  stm32wlexx_64:
-    name: stm32wlexx_64
+  - name: stm32wlexx_64
     description: STM32WLE4x Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: kUhBaQApA9qQSYFgkEmBYAAgcEeMSEFpQfAAQUFhACBwR4lISvaqIYpKAOARYANp2wP71EDy/xICYQFpyQP81AFpCQP81AFpSQP81AFpEUMBYUFpQfAEAUFhQWlB9IAxQWEBackD/NQBaUkD/NQBaQkD/NRBaSHwBAFBYQAgcEdxSUDy/xIKYQphS2lB9vhyk0NLYQLqECMIacAD/NQIaUAD/NQIaQAD/NRIaUPwAgMYQ0hhSGlA9IAwSGEAvwC/CGnAA/zUCGlAA/zUCGkAA/zUSGkg8AIASGFIaSDwAgBIYUhpkENIYUhpIPSAMEhhT/AAYABoQBwD0QhoQPSAMAhgACBwRy3p/E3f+DyByR1A8v8bAPAHAyHwBwHI+BCw2PgUQETwAQTI+BRAbkZ04AgpQtPI+BCwW7PFGqpGACQD4BX4AXs3VWQcnEL50wAkw/EIBQbgBOsDDBL4AXsG+AxwZBylQvbYU0bY+BBA5AP71Nj4EEBkA/vU2PgQQCQD+9QAnBxgXGAAvwC/SRsoRAAj2PgQQOQD+9TY+BBAZAP71Nj4EEAkA/vUEMoQwBDKEMAIOQC/AL8j4AAkA+AS+AFbNVVkHIxC+dMAJP8lwfEIBwTgBOsBDGQcBvgMUKdC+NjY+BAQyQP71Nj4EBBJA/vU2PgQEAkD+9QAmQFgQWAAIdj4EEDkA/vU2PgQQGQD+9TY+BBAJAP71AApiNHY+BQAIPABAMj4FABP8ABgAGhAHAXQ2PgAACD0gDDI+AAAACC96PyNAAAAQABYIwFnRauJ780AMABAAAAAAA==
-    pc_init: 1
-    pc_uninit: 21
-    pc_program_page: 263
-    pc_erase_sector: 129
-    pc_erase_all: 35
-    data_section_offset: 600
+    pc_init: 0x1
+    pc_uninit: 0x15
+    pc_program_page: 0x107
+    pc_erase_sector: 0x81
+    pc_erase_all: 0x23
+    data_section_offset: 0x258
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134283264
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8010000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32wlexx_128:
-    name: stm32wlexx_128
+        - size: 0x800
+          address: 0x0
+  - name: stm32wlexx_128
     description: STM32WLE5x Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: kUhBaQApA9qQSYFgkEmBYAAgcEeMSEFpQfAAQUFhACBwR4lISvaqIYpKAOARYANp2wP71EDy/xICYQFpyQP81AFpCQP81AFpSQP81AFpEUMBYUFpQfAEAUFhQWlB9IAxQWEBackD/NQBaUkD/NQBaQkD/NRBaSHwBAFBYQAgcEdxSUDy/xIKYQphS2lB9vhyk0NLYQLqECMIacAD/NQIaUAD/NQIaQAD/NRIaUPwAgMYQ0hhSGlA9IAwSGEAvwC/CGnAA/zUCGlAA/zUCGkAA/zUSGkg8AIASGFIaSDwAgBIYUhpkENIYUhpIPSAMEhhT/AAYABoQBwD0QhoQPSAMAhgACBwRy3p/E3f+DyByR1A8v8bAPAHAyHwBwHI+BCw2PgUQETwAQTI+BRAbkZ04AgpQtPI+BCwW7PFGqpGACQD4BX4AXs3VWQcnEL50wAkw/EIBQbgBOsDDBL4AXsG+AxwZBylQvbYU0bY+BBA5AP71Nj4EEBkA/vU2PgQQCQD+9QAnBxgXGAAvwC/SRsoRAAj2PgQQOQD+9TY+BBAZAP71Nj4EEAkA/vUEMoQwBDKEMAIOQC/AL8j4AAkA+AS+AFbNVVkHIxC+dMAJP8lwfEIBwTgBOsBDGQcBvgMUKdC+NjY+BAQyQP71Nj4EBBJA/vU2PgQEAkD+9QAmQFgQWAAIdj4EEDkA/vU2PgQQGQD+9TY+BBAJAP71AApiNHY+BQAIPABAMj4FABP8ABgAGhAHAXQ2PgAACD0gDDI+AAAACC96PyNAAAAQABYIwFnRauJ780AMABAAAAAAA==
-    pc_init: 1
-    pc_uninit: 21
-    pc_program_page: 263
-    pc_erase_sector: 129
-    pc_erase_all: 35
-    data_section_offset: 600
+    pc_init: 0x1
+    pc_uninit: 0x15
+    pc_program_page: 0x107
+    pc_erase_sector: 0x81
+    pc_erase_all: 0x23
+    data_section_offset: 0x258
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134348800
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8020000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
-  stm32wlxx_cm4:
-    name: stm32wlxx_cm4
+        - size: 0x800
+          address: 0x0
+  - name: stm32wlxx_cm4
     description: STM32WLxx_CM4 Flash
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: kUhBaQApA9qQSYFgkEmBYAAgcEeMSEFpQfAAQUFhACBwR4lISvaqIYpKAOARYANp2wP71EDy/xICYQFpyQP81AFpCQP81AFpSQP81AFpEUMBYUFpQfAEAUFhQWlB9IAxQWEBackD/NQBaUkD/NQBaQkD/NRBaSHwBAFBYQAgcEdxSUDy/xIKYQphS2lB9vhyk0NLYQLqECMIacAD/NQIaUAD/NQIaQAD/NRIaUPwAgMYQ0hhSGlA9IAwSGEAvwC/CGnAA/zUCGlAA/zUCGkAA/zUSGkg8AIASGFIaSDwAgBIYUhpkENIYUhpIPSAMEhhT/AAYABoQBwD0QhoQPSAMAhgACBwRy3p/E3f+DyByR1A8v8bAPAHAyHwBwHI+BCw2PgUQETwAQTI+BRAbkZ04AgpQtPI+BCwW7PFGqpGACQD4BX4AXs3VWQcnEL50wAkw/EIBQbgBOsDDBL4AXsG+AxwZBylQvbYU0bY+BBA5AP71Nj4EEBkA/vU2PgQQCQD+9QAnBxgXGAAvwC/SRsoRAAj2PgQQOQD+9TY+BBAZAP71Nj4EEAkA/vUEMoQwBDKEMAIOQC/AL8j4AAkA+AS+AFbNVVkHIxC+dMAJP8lwfEIBwTgBOsBDGQcBvgMUKdC+NjY+BAQyQP71Nj4EBBJA/vU2PgQEAkD+9QAmQFgQWAAIdj4EEDkA/vU2PgQQGQD+9TY+BBAJAP71AApiNHY+BQAIPABAMj4FABP8ABgAGhAHAXQ2PgAACD0gDDI+AAAACC96PyNAAAAQABYIwFnRauJ780AMABAAAAAAA==
-    pc_init: 1
-    pc_uninit: 21
-    pc_program_page: 263
-    pc_erase_sector: 129
-    pc_erase_all: 35
-    data_section_offset: 600
+    pc_init: 0x1
+    pc_uninit: 0x15
+    pc_program_page: 0x107
+    pc_erase_sector: 0x81
+    pc_erase_all: 0x23
+    data_section_offset: 0x258
     flash_properties:
       address_range:
-        start: 134217728
-        end: 134479872
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 400
-      erase_sector_timeout: 400
+        start: 0x8000000
+        end: 0x8040000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x190
+      erase_sector_timeout: 0x190
       sectors:
-        - size: 2048
-          address: 0
+        - size: 0x800
+          address: 0x0

--- a/probe-rs/targets/fe310.yaml
+++ b/probe-rs/targets/fe310.yaml
@@ -1,8 +1,7 @@
----
 name: fe310
-manufacturer: ~
+manufacturer: null
 variants:
-  - name: "fe310-g002"
+  - name: fe310-g002
     cores:
       - name: main
         type: riscv
@@ -14,36 +13,38 @@ variants:
             start: 0x20000000
             end: 0x40000000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
       - Ram:
           range:
             start: 0x80000000
             end: 0x80004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - hifive-flashloader
 flash_algorithms:
-  hifive-flashloader:
-    name: hifive-flashloader
-    description: "Flashloader for HiFive1 Rev B"
-    cores: [main]
+  - name: hifive-flashloader
+    description: Flashloader for HiFive1 Rev B
+    cores:
+      - main
     default: true
     instructions: t0UBELBF408G/rdFARAThoUEmUYUwvBF408G/rdFARAThoUBiUYUwrBF408G/rdFARAThoUEkwZwDRTC8EXjTwb+k1WFAEFmEwYG8PGNE1aFAdGNExaFALcG/wB1jmIFUY1NjbdFARCwReNPBv6TVQUBE1aFAJN29g83RgEQNMZ0RuPPBv5hgTdGARA0RuPPBv4T9vUPt0UBEJOGhQSQwvBF408G/rdFARCwReNPBv63RQEQE4aFBAjC6EXjTwX+N0UBEJMFhQEjoAUACUaTBoUEFUeQwTxF488H/pjCfEXjzwf+PEXjzwf+I6AGAHxF488H/oWLIywFAOn/AUWCgDdFARAjIAUGAUWCgLdGARC4RuNPB/63RgEQE4eGBJlHHMP4RuNPB/63RgEQE4eGAYlHHMO4RuNPB/63RgEQE4eGBIlHHMP4RuNPB/6TVoUAQWcTBwfw+Y4TV4UB2Y4TF4UAtwf/AH2PYgVZjVWNt0YBELhG408H/pNWBQETV4UAk3f3DzdHARA8x3xH488H/mGBN0cBEDxH488H/hP39g+3RgEQk4eGBJjD+EbjTwf+t0YBELhG408H/rdGARATh4YECMPoRuNPBf6FxTMItgC3RQEQk4aFBH1Xg0cGAKhF408F/pzC6EXjX6f+BQbjFgb/N0UBEJMFhQEjoAUACUaTBoUEFUeQwTxF488H/pjCfEXjzwf+PEXjzwf+I6AGAHxF488H/oWLIywFAOn/AUWCgAFFgoAAAA==
-    pc_init: 256
-    pc_uninit: 562
-    pc_program_page: 268
-    pc_erase_sector: 0
-    pc_erase_all: ~
-    data_section_offset: 568
+    pc_init: 0x100
+    pc_uninit: 0x232
+    pc_program_page: 0x10c
+    pc_erase_sector: 0x0
+    pc_erase_all: null
+    data_section_offset: 0x238
     flash_properties:
       address_range:
         start: 0x20000000
         end: 0x40000000
-      page_size: 256
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 2000
+      page_size: 0x100
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0x7d0
       sectors:
-        - size: 4096
-          address: 0
+        - size: 0x1000
+          address: 0x0

--- a/probe-rs/targets/nRF51_Series.yaml
+++ b/probe-rs/targets/nRF51_Series.yaml
@@ -1,7 +1,6 @@
----
 name: nRF51 Series
 manufacturer:
-  cc: 0x02
+  cc: 0x2
   id: 0x44
 variants:
   - name: nRF51422_xxAA
@@ -10,21 +9,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf51xxx
       - nrf51xxx_sde
@@ -35,21 +36,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf51xxx
       - nrf51xxx_sde
@@ -60,21 +63,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf51xxx
       - nrf51xxx_sde
@@ -85,21 +90,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 196608
+            start: 0x0
+            end: 0x30000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf51xxx
       - nrf51xxx_sde
@@ -110,21 +117,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf51xxx
       - nrf51xxx_sde
@@ -135,21 +144,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf51xxx
       - nrf51xxx_sde
@@ -160,21 +171,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 131072
+            start: 0x0
+            end: 0x20000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf51xxx
       - nrf51xxx_sde
@@ -185,21 +198,23 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536903680
+            start: 0x20000000
+            end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf51xxx
       - nrf51xxx_sde
@@ -210,92 +225,94 @@ variants:
         type: armv6m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 536887296
+            start: 0x20000000
+            end: 0x20004000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 262144
+            start: 0x0
+            end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf51xxx
       - nrf51xxx_sde
       - nrf51xxx_ecb
 flash_algorithms:
-  nrf51xxx_sde:
-    name: nrf51xxx_sde
+  - name: nrf51xxx_sde
     description: nRF51xxx SoftDevice Erase
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: sLUURgxNSEYAIUFRQBlBYIFgwWAQRgDwK/oAKATQSUZJGYhgzGCwvUhGQBkBIUFgAkgBYAAgsL0EAAAACAYAQBC1BEYAIADwE/oNSUpGURgAKALQiGDMYALgiWgAKQ3QCEkBIgpgBkpLRpxYTGCaGFNoi2CTaMtg0mgKYRC9wEYEAAAAAEAAILC1DUhJRgEiClAIGAAkRGCEYMRgBeAgRgDwFvoA8I75BBkA8Iv5BUYA8I75aEOEQvHTACCwvcBGBAAAAPi1BEYXTkhGAieHUYAZACFBYIFgwWAA8HP5AUYgRgDwD/pIRgApAtCAGQMhFeCAGQEhQWAA8GT5BUYA8Gf5aEOgQgfZSEaAGUdgIEYA8N75ACAF4EhGgBkEIYFgxGABIAGw8L0EAAAA/rUORgdGNExIRgMlBVEAGQAhQWCBYMFguAcE0EhGABkDIYFgCuBIRgAZASFBYLAHC9BIRgAZAyGBYDdGSEYAGcdgASYwRgOw8L0CkkhGABkCIUFgAPAg+QGQAPAj+QGZSEO4QhTZSEYAGUVgJUb0GQDwEvkBkADwFfkBmUhDhEIK2UhGQBkEIYFgJ0YsRtXnSEYAGQQhxOdIRkAZBCFBYLAIAZAAJjxGNUYJ4CBoQBwK0QKZAckCkQHEAPBf+W0cAZiFQvLTvedIRgNMABkFIYFgfxmy58BGBAAAAP61FUYERjVKSEYEJ4dQgBgAJkZghmDGYKAHW9GIBwXQSEaAGAMhgWDEYFPgApFIRoAYASFBYADwwfgBkADwxPgBmUhDoEIe2UhGJElAGAIhQWACmAAZAZAA8LD4AJAA8LP4AZkAmlBDgUIU2UhGG0qAGIdgwWAA8KH4BUYA8KT4BEZsQybgSEYUSUAYAyGBYAKZwWAe4EhGEElAGEdg8EOBAGIYApmJCEAcFB0rHYhCCtItaFJoqkIiRh1G9NBIRgZJQBgGIa7nSEYESUAYBSFBYAGcIEYDsPC9wEYEAAAA/rUWRg1GBEYtT0hGBSHBUcAZACFBYIFgwWCgBwTQSEbAGQMhgWAK4EhGwBkBIUFgqAcK0EhGwBkDIYFgLEZIRsAZxGABIAOw8L1IRsAZAyFBYADwQ/gCkADwRvgCmUhDoEIW2UhGwBkEIQCRQWAoGQKQAPAz+AGQAPA2+AKaAZlIQ4JCCdlIRsAZBCGBYBRG1edIRsAZBCHE50hGwBkAmUFgYR4AIAJGqkLM0kwcUhxJeLFCIUb30EhGwBkFIbHnBAAAAA8gAAIDSUpoEgICQAh4EENwR8BG4A8A8AFIAGhwR8BGEAAAEAFIAGhwR8BGFAAAEAZIQWj/IhFCBtAFSQpoACBSHADQCGhwRwBocEcoAAAQABAAEP8gAAIDSQloAUAAIEAaSEFwR8BGBBAAEBC1EUlKaP8jGkIG0A9JCmhSHArQC2gBIQ/gC2gAIQMig0IA2BFGCEYQvQlKE2gDIQhMo0IF0VNoAiEDIoNCANgRRsiyEL3ARigAABAAEAAQBDAAANvlsVEBRgEgAykJ2IgABaEIWAhJCGAISQpoACAAKvvQcEfARgAAAAACAAAAAQAAAAAAAAAE5QFAAOQBQAJIAWgAKfzQcEfARgDkAUADSAEhAWADSAFoACn80HBHDOUBQADkAUADSQhgA0gBaAAp/NBwR8BGCOUBQADkAUAESAEhAWAESAFoACn80AAgcEfARhTlAUAA5AFAACIDCYtCLNMDCotCEdMAI5xGTuADRgtDPNQAIkMIi0Ix0wMJi0Ic0wMKi0IB05RGP+DDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkFDCItCAdNLAMAaUkFBGgDSAUZSQRBGcEdd4MoPANBJQgMQANNAQlNAnEYAIgMJi0It0wMKi0IS04kB/CISugMKi0IM04kBkhGLQgjTiQGSEYtCBNOJATrQkhEA4IkJwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJB2dJDCItCAdNLAMAaUkFBGgDSAUZSQRBGY0ZbEAHTQEIAKwDVSUJwR2NGWxAA00BCAbUAIMBGwEYCvQAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 65
-    pc_program_page: 301
-    pc_erase_sector: 197
-    pc_erase_all: 137
-    data_section_offset: 1632
+    pc_init: 0x1
+    pc_uninit: 0x41
+    pc_program_page: 0x12d
+    pc_erase_sector: 0xc5
+    pc_erase_all: 0x89
+    data_section_offset: 0x660
     flash_properties:
       address_range:
-        start: 0
-        end: 2097152
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x200000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1024
-          address: 0
-  nrf51xxx:
-    name: nrf51xxx
+        - size: 0x400
+          address: 0x0
+  - name: nrf51xxx
     description: nRF51xxx
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: sLUURgxNSEYAIUFRQBlBYIFgwWAQRgDwxfoAKATQSUZJGYhgzGCwvUhGQBkBIUFgAkgBYAAgsL0EAAAACAYAQBC1BEYAIADwrfoNSUpGURgAKALQiGDMYALgiWgAKQ3QCEkBIgpgBkpLRpxYTGCaGFNoi2CTaMtg0mgKYRC9wEYEAAAAAEAAIPC1gbAnT0hGASbGUcAZACREYIRgxGAA8EX6ACgG0EhGwBkCIYFgASABsPC9SEbAGUZgIEYA8EL6AigJ0AEoC9AAKCVGC9EA8Bv6BUY0RgbgFUgFaAAkAuAA8BL6BUZIRsAZAiFBYAXgKEYA8If6APD7+UUZAPD4+QZGAPD7+XBDhULx00hGwBkDIUFgACwB0ADwgPpIRsAZBCFBYAAgAbDwvcBGBAAAAAgwAADwtYGwBEYhTkhGAieHUYAZACFBYIFgwWAA8ND5AUYgRgDwcPpIRgApBtCAGQMhgWDEYAEgAbDwvYAZASFBYADwvfkFRgDwwPloQ6BCDdlIRoAZR2AgRgDw2/kDKA3RIEYA8Db6ACABsPC9SEaAGQQhgWDEYAEgAbDwvUhGgBkDIUFgh2ABIAGw8L3ARgQAAADwtYWwBEZPTUhGAydHUUAZACZGYIZgxmCgBwXQSEZAGYdgxGABJorgSEZAGQEjQ2CIBwXQSEZAGYdgwWABJn7gApEDkkhGQBkCIQGRQWAA8G35BJAA8HD5BJlIQ6BCFtlIRkAZR2ACmAAZBJAA8F75AJAA8GH5BJoAmUhDgkIN2UhGQBkEIYFgwmABJlfgSEZAGQQhgWDEYAEmUOBIRkAZBCFBYADwYPkAKAXQSEZAGQGZgWABJkLgSEZAGQUhAJFBYCBGAPBc+QIoBtJIRkAZAZmBYMRgASYx4A3R/yIgRgKZAPAx+AAoBtBIRkdRQBkAmUFgASYi4EhGR1FAGQYhQWACmIAIBJAZ0AAhJ0Y4aEAcDdEORgOZAckDkQHHAPB7+TFGcRwAJgSYgULv0wbgSEZAGWEYAJqCYMFgASYwRgWw8L0EAAAA8LWFsARGNE5IRgUlhVGAGQAnR2CHYMdgoAcG0EhGgBkDIYFgxGABJzngSEaAGQEjQ2CIBwbQSEaAGQMigmDBYAEnLOAEkgKRSEaAGQIhQWAA8Mj4A5AA8Mv4A5lIQ6BCF9lIRoAZAyFBYAKYABkBkADwuPgDkADwu/gBmgOZSEOCQg/ZSEaAGQQhgWDCYAEnBeBIRoAZBCGBYMRgASc4RgWw8L1IRoAZBCFBYAKYACgDRvTQACAiXEEcBJ+6QgTRACeZQghG9tPp50lGiRkgGI1gyGABJ+LnBAAAAPC1g7AVRgRGOEpIRgQnh1CAGAAjQ2CDYMNgoAcG0EhGgBgDIYFgxGAmRlzgSEaAGAEjQ2CIBwbQSEaAGAMigmDBYCZGT+ACkUhGgBgCIUFgAPBa+AZGAPBd+HBDoEIc2UhGIklAGAMhQWACmAYZAPBL+AGQAPBO+AGZSEOGQhTZSEYaSUAYh2DGYADwPfgERgDwQPgGRmZDJeBIRhNJQBgEIYFgxGAmRh3gSEYPSUAYR2ACmIAICdAAIUkcKmgjaJNCCdEtHSQdgUL200hGB0lAGAUhQWAG4EhGBElAGAYhgWDEYCZGMEYDsPC9BAAAAA8gAAIDSUpoEgICQAh4EENwR8BG4A8A8AFIAGhwR8BGEAAAEAFIAGhwR8BGFAAAEAZIQWj/IhFCBtAFSQpoACBSHADQCGhwRwBocEcoAAAQABAAEP8gAAIDSQloAUAAIEAaSEFwR8BGBBAAEBC1E0lKaP8jGkIK0BFJCmhSHA7QC2gBIQMig0IV2NCyEL0LaAAhAyKDQgDYEUYIRhC9CUoTaAMhCEyjQgXRU2gCIQMig0IA2BFGyLIQvcBGKAAAEAAQABAEMAAA2+WxUQFGASADKQnYiAAFoQhYCEkIYAhJCmgAIAAq+9BwR8BGAAAAAAIAAAABAAAAAAAAAATlAUAA5AFAAkgBaAAp/NBwR8BGAOQBQANIASEBYANIAWgAKfzQcEcM5QFAAOQBQANJCGADSAFoACn80HBHwEYI5QFAAOQBQARIASEBYARIAWgAKfzQACBwR8BGFOUBQADkAUAAIgMJi0Jz0wMKi0JY0wMLi0I80wMMi0Ih0xLgA0YLQ3/UACJDCItCdNMDCYtCX9MDCotCRNMDC4tCKNMDDItCDdMJAv8iEroDDItCAtMSEgkCZdADC4tCGdMA4AkKwwuLQgHTywPAGlJBgwuLQgHTiwPAGlJBQwuLQgHTSwPAGlJBAwuLQgHTCwPAGlJBwwqLQgHTywLAGlJBgwqLQgHTiwLAGlJBQwqLQgHTSwLAGlJBAwqLQgHTCwLAGlJBzdLDCYtCAdPLAcAaUkGDCYtCAdOLAcAaUkFDCYtCAdNLAcAaUkEDCYtCAdMLAcAaUkHDCItCAdPLAMAaUkGDCItCAdOLAMAaUkFDCItCAdNLAMAaUkFBGgDSAUZSQRBGcEdd4MoPANBJQgMQANNAQlNAnEYAIgMJi0It0wMKi0IS04kB/CISugMKi0IM04kBkhGLQgjTiQGSEYtCBNOJATrQkhEA4IkJwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJB2dJDCItCAdNLAMAaUkFBGgDSAUZSQRBGY0ZbEAHTQEIAKwDVSUJwR2NGWxAA00BCAbUAIMBGwEYCvQAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 1
-    pc_uninit: 65
-    pc_program_page: 453
-    pc_erase_sector: 309
-    pc_erase_all: 137
-    data_section_offset: 2080
+    pc_init: 0x1
+    pc_uninit: 0x41
+    pc_program_page: 0x1c5
+    pc_erase_sector: 0x135
+    pc_erase_all: 0x89
+    data_section_offset: 0x820
     flash_properties:
       address_range:
-        start: 0
-        end: 2097152
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x200000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1024
-          address: 0
-  nrf51xxx_ecb:
-    name: nrf51xxx_ecb
+        - size: 0x400
+          address: 0x0
+  - name: nrf51xxx_ecb
     description: nRF51xxx External Connectivity Board
-    cores: [main]
+    cores:
+      - main
     default: false
     instructions: QLpwR8C6cEdVSAEjASoF0AIqBdADKgXQASBwRwIhAuBDYAHgACFBYE5IAWgAKfzQTUiDYAAgcEdJSQAgSGBJSAFoACn80AAgcEdFSQEgyGBESAFoACn80AAgcEdwtQElLQcERilpAPCB+AApBNEoaWlpSEOgQgHYASBwvThIhGA4SAFoACn80AAgcL1wtYMHFtGLBxTRASMbBxxpXWlsQ4RCDdkcaVtpXENDGJxCB9MAIyxMjQgL4JkARlh2HAHQASBwvVZYRlAhaAAp/NBbHJ1C8dgAIHC9cLUERoMHEdGLBw/RASMbBx1pXml1Q4VCCNkdaV5pQBh1Q4VCA9IYaVlpSENwvQAjjQgI4JkAZlhRWI5CAtCYAAAZcL1bHJ1C9NhwvTC1gwcT0YsHEdEBIxsHHGldaWxDhEIK2RxpW2lcQ0MYnEIE0wAjBeDEXJRCAdABIDC9WxyLQvfTACAwvQDlAUAA5AFAAAYAQAAiAwmLQizTAwqLQhHTACOcRk7gA0YLQzzUACJDCItCMdMDCYtCHNMDCotCAdOURj/gwwmLQgHTywHAGlJBgwmLQgHTiwHAGlJBQwmLQgHTSwHAGlJBAwmLQgHTCwHAGlJBwwiLQgHTywDAGlJBgwiLQgHTiwDAGlJBQwiLQgHTSwDAGlJBQRoA0gFGUkEQRnBHXeDKDwDQSUIDEADTQEJTQAAinEYDCYtCLdMDCotCEtP8IokBEroDCotCDNOJAZIRi0II04kBkhGLQgTTiQE60JIRAOCJCcMJi0IB08sBwBpSQYMJi0IB04sBwBpSQUMJi0IB00sBwBpSQQMJi0IB0wsBwBpSQcMIi0IB08sAwBpSQYMIi0IB04sAwBpSQdnSQwiLQgHTSwDAGlJBQRoA0gFGY0ZSQVsQEEYB00BCACsA1UlCcEdjRlsQANNAQgG1ACDARsBGAr0AAAAAAAA=
-    pc_init: 9
-    pc_uninit: 57
-    pc_program_page: 141
-    pc_erase_sector: 93
-    pc_erase_all: 75
-    data_section_offset: 712
+    pc_init: 0x9
+    pc_uninit: 0x39
+    pc_program_page: 0x8d
+    pc_erase_sector: 0x5d
+    pc_erase_all: 0x4b
+    data_section_offset: 0x2c8
     flash_properties:
       address_range:
-        start: 0
-        end: 2097152
-      page_size: 1024
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x200000
+      page_size: 0x400
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 1024
-          address: 0
+        - size: 0x400
+          address: 0x0

--- a/probe-rs/targets/nRF52_Series.yaml
+++ b/probe-rs/targets/nRF52_Series.yaml
@@ -1,7 +1,6 @@
----
 name: nRF52 Series
 manufacturer:
-  cc: 0x02
+  cc: 0x2
   id: 0x44
 variants:
   - name: nRF52805_xxAA
@@ -10,27 +9,30 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x30000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x10001000
             end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf52
   - name: nRF52810_xxAA
@@ -39,27 +41,30 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x30000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x10001000
             end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf52
   - name: nRF52811_xxAA
@@ -68,27 +73,30 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20006000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x30000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x10001000
             end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf52
   - name: nRF52820_xxAA
@@ -97,27 +105,30 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x40000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x10001000
             end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf52
   - name: nRF52832_xxAA
@@ -126,27 +137,30 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20010000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x10001000
             end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf52
   - name: nRF52832_xxAB
@@ -155,27 +169,30 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20008000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x10001000
             end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf52
   - name: nRF52833_xxAA
@@ -184,27 +201,30 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20020000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x80000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x10001000
             end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf52
   - name: nRF52840_xxAA
@@ -213,34 +233,37 @@ variants:
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
+            start: 0x0
             end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
             start: 0x10001000
             end: 0x10002000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf52
 flash_algorithms:
-  nrf52:
-    name: nrf52
+  - name: nrf52
     description: nrf52
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: AL4K4A14LQZoQAgkQAAA01hAZB760UkcUh4AKvLRcEcAIHBHACBwR3C1JkwCIGBgASDgYCRNKGjABwLQACBgYHC9APAs+PbncLUeTAIhYWAeSYhCAtMBIGBhAOCgYBpNAPAd+ChowAf60AAgYGBwvfi1BUaOCBNIASEURkFgEk8BzAHFOGjABwbQdh740Q1IACFBYAhG+L0A8AH48ucMSEBoAAYADgvQCklJaAApB9AJSQpKwwcA0ApgCR1ACPnRcEcAAADlAUAA5AFAABAAEAAEAUAABQFAAAYBQDVGUm4AAAAA
     pc_init: 0x21
@@ -251,12 +274,12 @@ flash_algorithms:
     data_section_offset: 0x170
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x10002000
       page_size: 0x1000
-      erased_byte_value: 0xFF
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0xbb8
       sectors:
         - size: 0x1000
-          address: 0
+          address: 0x0

--- a/probe-rs/targets/nRF53_Series.yaml
+++ b/probe-rs/targets/nRF53_Series.yaml
@@ -1,4 +1,3 @@
----
 name: nRF53 Series
 variants:
   - name: nRF5340_xxAA
@@ -7,134 +6,138 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
       - name: network
         type: armv8m
         core_access_options:
           Arm:
-            ap: 1
-            psel: 0
+            ap: 0x1
+            psel: 0x0
     memory_map:
       - Ram:
           range:
             start: 0x20000000
             end: 0x20040000
           is_boot_memory: false
-          cores: [application]
+          cores:
+            - application
       - Ram:
           range:
             start: 0x21000000
             end: 0x21020000
           is_boot_memory: false
-          cores: [network]
+          cores:
+            - network
       - Nvm:
           range:
-            start: 0x00000000
-            end: 0x00100000
+            start: 0x0
+            end: 0x100000
           is_boot_memory: true
-          cores: [application]
+          cores:
+            - application
       - Nvm:
           range:
-            start: 0x01000000
-            end: 0x01040000
+            start: 0x1000000
+            end: 0x1040000
           is_boot_memory: true
-          cores: [network]
+          cores:
+            - network
     flash_algorithms:
       - nrf53xx_application
       - nrf53xx_application_uicr
       - nrf53xx_network
       - nrf53xx_network_uicr
 flash_algorithms:
-  nrf53xx_application:
-    name: nrf53xx_application
+  - name: nrf53xx_application
     description: nRF53xxx_app
-    cores: [application]
+    cores:
+      - application
     default: true
     instructions: sLVA8gQFwPIABQAgCesFAUn4BQDB6QEAyGDQshRGAPA9+iCxCesFAcHpAgSwvQnrBQABIUFgAPAr+gAgsL0AvxC1BEYAIADwKfo4sUDyBAHA8gABSUTB6QIEEL1A8gQAwPIAAAnrAAGJaAApBL8AIBC9RPIAAcLyAAEBIgpgWfgAIEhESmBCaIpggmjKYMBoCGEAIBC9AL9A8gQAwPIAAAEhSfgAEEhEACHA6QERwWAA8Ci6sLVA8gQFBEbA8gAFAiBJ+AUACesFAAAhwOkBEcFgAPCl+bT78PEB+xBAMLEJ6wUAAyHA6QIUZSCwvQnrBQABIUFgAPCt+aBCE9gA8Kv5oEIP2QnrBQACIUFgIEYA8ML5Aygcv2cgsL0gRgDw5/kAILC9CesFAAQhwOkCFGYgsL0t6fBBQPIEBwRGwPIABxVGDkYDIAnrBwEAIqMHSfgHAMHpASLKYAbQCesHAcHpAgRlIL3o8IEJ6wcAASFBYADwb/mgQhXYAPBt+aBCEdkJ6wcAAyFBYAbrBAgA8GP5gEUP2QnrBwAEIcDpAhhmIL3o8IEJ6wcABCHA6QIUZiC96PCBCesHAAQhQWAA8Gn5MLEJ6wcAAiGBYGcgvejwgQnrBwAFIUFgIEYA8Fz5AigH0gnrBwACIcDpAhRnIL3o8IEP0f8iIEYxRgDwNvhIsQMgSfgHAAnrBwAFIUFgZyC96PCBAyBJ+AcAACCw65YPCesHAU/wBgJKYAi/vejwgU/qlggAJlT4JgABMAzRVfgmAET4JgAA8EL5ATZGRU/wAADw073o8IEJ6wcABSGiGcDpAhJoIL3o8IEt6fBBQPIEBw1GBEbA8gAHBSAWRkn4BwAJ6wcAACGqB8DpARHBYAfQCesHAAMhwOkCFWUgvejwgQnrBwACIUFgAPDS+KBCFdgA8ND4oEIR2QnrBwADIUFgBesECADwxviARQ/ZCesHAAQhwOkCGGYgvejwgQnrBwAEIcDpAhRmIL3o8IEJ6wcABCEALUFgBL8AIL3o8IEAIQfgAL8BMalCT/AAACi/vejwgWBcsEL10GAYCesHAQUiwekCIAEgvejwgQC/LenwQUDyBAUERsDyAAUEIJBGD0ZJ+AUACesFAAAhogfA6QERwWAI0AnrBQADIWUmwOkCFDBGvejwgQnrBQABIUFgAPBv+KBCEtgA8G34oEIO2QnrBQADIUFgPhkA8GT4hkIO2QnrBQAEIcDpAhYE4AnrBQAEIcDpAhRmJjBGvejwgQAhseuXDwnrBQBP8AQBQWAL0LgIACEiaFj4ITCaQgvRATGBQgTxBAT10wnrBQAFIUFgMEa96PCBCesFAAYhwOkCFCBGvejwgQAAQPIwEMDy/wABaAExHL8AaHBHQPbgcc/yAAEIeEloYfMLIHBHQPIgIMDy/wABaAExFL8AaE/0gFBwRwC/QPIkIMDy/wABaAExFL8AaE/0AHBwRwC/ACBwRwAgcEcQtf/34f8ERv/36v8A+wTwEL0AvwFEgUKcvwEgcEcD4IhCJL8BIHBHUPgEKwEyHL8AIHBH9OcAv3BHAL8AIHBHAyBwRwMohL9pIHBHgLVAsgWhUfggAEnyBFHF8gMBCGAA8Ar4ACCAvQAAAAACAAAAAQAAAAAAAABJ8gBAxfIDAAFoACn80HBHSfIMUMXyAwABIQFg8OcAv4GwAJAAmE/w/zEBYAGw5+dpIHBHsLX/96f/BEZAsQAlKEb/9+3///eD/wVEpUL30wAgsL0AAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 65
-    pc_program_page: 309
-    pc_erase_sector: 181
-    pc_erase_all: 153
-    data_section_offset: 1316
+    pc_init: 0x1
+    pc_uninit: 0x41
+    pc_program_page: 0x135
+    pc_erase_sector: 0xb5
+    pc_erase_all: 0x99
+    data_section_offset: 0x524
     flash_properties:
       address_range:
-        start: 0
+        start: 0x0
         end: 0x200000
       page_size: 0x1000
-      erased_byte_value: 0xFF
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0xbb8
       sectors:
         - size: 0x1000
-          address: 0
-  nrf53xx_application_uicr:
-    name: nrf53xx_application_uicr
+          address: 0x0
+  - name: nrf53xx_application_uicr
     description: nRF53xxx_app UICR Erase
-    cores: [application]
+    cores:
+      - application
     default: false
     instructions: cLVA8gQGwPIABgAlCesGAEn4BlDA6QFVxWDQshRGAPCZ+gAoHr8J6wYBwekCBAVGKEZwvRC1BEYAIADwi/pA8gQBwPIAAUlEELHB6QIEA+CJaAApCL8QvUTyAAHC8gABASIKYEDyBALA8gACWfgCMEpES2BTaItgk2jLYNJoCmEQvQC/gLVA8gQAwPIAAAEhSfgAEEhEACHA6QERwWAA8I/6ACCAvQC/cLVA8gQEwPIABAIgCesEBQAmSfgEAMXpAWbuYADw4PkFIUn4BBABIRDwAw/F6QEW7mAE0AnrBAEDIopgE+BI8gAMwPL/DADrDAEM9YBTCesEAplCT/ADA1NgENkJ6wQABCKCYAhGCesEAchgAPB++gFGaSgUvwApACEIRnC98LEAIxz4AxD/KSPRWRyBQhbSDOsDAUp4/yoU0ZocgkIO0op4/yoR0docgkII0sl4/ykO0QQzg0JP8AAB4tPd5wAhCEZwvUPwAQMD4EPwAgMA4BNGDOsDAAnrBAEFIq3nAL9wtUDyBAzA8gAMBSNJ+AwwCesMA0/wAA6EB8PpAe7D+AzgBdAJ6wwBAyLB6QIgDOAJ6wwDT/ABDowHw/gE4AfQCesMAAMiwOkCIWUjGEZwvUj2/37A8v8OCesMAwIkcEVcYAXZCesMAQQiwekCIA3gCxgO8QEFCesMBAMmq0JmYAfZCesMAAQhwOkCE2YjGEZwvRmzT/AADhD4DjCTQifRDvEBA4tCGdIA6w4DXHiUQhfRDvECBIxCENKceJRCE9EO8QMEjEIJ0tt4k0IP0Q7xBA6ORU/wAAPe0xDgACMYRnC9TvABDgPgTvACDgDgpkZwRAnrDAEFIgEjwekCIBhGcL0Avy3p8EFA8gQGwPIABhVGBEYDIAnrBgIAI48HSfgGAMLpATPTYAbQCesGAsLpAgFlIL3o8IFI9v9wwPL/AAnrBgICI4RCU2AH2QnrBgAEIcDpAhRmIL3o8IEKGQEwCesGAwMngkJfYAfZCesGAAQhwOkCEmYgvejwgQAgsOuRDxvQT+qRCAAnDOBV+CcARPgnAADwQPkBN0dFT/AAACi/vejwgVT4JwABMO7QCesGAAUh4hnA6QISaCC96PCBLenwQUDyBAzA8gAMBCNJ+AwwCesMAwAmhQfD6QFm3mAF0AnrDAEDIsHpAiAK4AnrDAMBJo0HXmAI0AnrDAADIsDpAiFlIxhGvejwgUj2/3TA8v8ECesMAwImoEJeYAXZCesMAQQiwekCIAzgCxgBNAnrDAYDJaNCdWAI2QnrDAAEIcDpAhNmIxhGvejwgQAlteuRDwnrDAZP8AQFdWA50E/qkQ4AIQwkBRkWGVX4DFxW+AxstUIm0U0cdUUq0gDrgQUC64EG1fgEgHdouEUT0Y8cd0Ue0q1otmi1Qg/RzRx1RRfSBlkXWb5CC9EEMXFFBPEQBNjTDeBB8AEBA+BB8AIBAOApRgDrgQMJ6wwABiHA6QITGEa96PCBAABA8jAQwPL/AAFoATEcvwBocEdA9uBxz/IAAQh4SWhh8wsgcEdA8iAgwPL/AAFoATEUvwBoT/SAUHBHAL9A8iQgwPL/AAFoATEUvwBoT/QAcHBHAL8AIHBHACBwR0DyICHA8v8BCGgBMBS/CGhP9IBQSmgBMhS/SWhP9ABxAfsA8HBHAL8BRIFCnL8BIHBHAL8CaAEyHL8AIHBHBDCIQiS/ASBwRwJoATIcvwAgcEcEMIhCJL8BIHBHAmgBMhy/ACBwRwQwiEIkvwEgcEcCaAEyHL8AIHBHBDCIQiS/ASBwR9bnAL9wRwC/ACBwRwMgcEcDKIS/aSBwR0CyDKFR+CAQSfIAQMXyAwDA+AQRBeAAvwFoACkcvwAgcEcBaCG5AWgRuQFoACnz0AAgcEcAAAAAAgAAAAEAAAAAAAAASfIAQMXyAwABaEG5AWgxuQFoACkYv3BHAWgAKfTQcEdJ8gBAxfIDAAEhwPgMEQC/AWhBuQFoMbkBaAApGL9wRwFoACn00HBHgbAAkEnyAEEAmMXyAwFP8P8yAmAIaDC5CGgguQhoELkIaAAo9tABsHBHAL9pIHBHgLWBsEDyIC7A8v8O3vgAAAEwFL/e+AAQT/SAUd74BAABMBS/3vgEIE/0AHIC+wHx8bFJ8gBDACLF8gMDT/D/PACSAJjA+ADAGGgwuRhoILkYaBC5GGgAKPbQ3vgAAAEwFL/e+AAAT/SAUAJEikLn0wAgAbCAvQAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-    pc_init: 1
-    pc_uninit: 53
-    pc_program_page: 653
-    pc_erase_sector: 169
-    pc_erase_all: 133
-    data_section_offset: 1680
+    pc_init: 0x1
+    pc_uninit: 0x35
+    pc_program_page: 0x28d
+    pc_erase_sector: 0xa9
+    pc_erase_all: 0x85
+    data_section_offset: 0x690
     flash_properties:
       address_range:
         start: 0xff8000
         end: 0xff9000
       page_size: 0x1000
-      erased_byte_value: 0xFF
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0xbb8
       sectors:
         - size: 0x1000
-          address: 0
-  nrf53xx_network:
-    name: nrf53xx_network
+          address: 0x0
+  - name: nrf53xx_network
     description: nRF53xxx_net
-    cores: [network]
+    cores:
+      - network
     default: true
     instructions: sLVA8gQFwPIABQAgCesFAUn4BQDB6QEAyGDQshRGAPA/+iCxCesFAcHpAgSwvQnrBQABIUFgAPAt+gAgsL0AvxC1BEYAIADwK/o4sUDyBAHA8gABSUTB6QIEEL1A8gQAwPIAAAnrAAGJaAApBL8AIBC9RPIAAcLyABEBIgpgWfgAIEhESmBCaIpggmjKYMBoCGEAIBC9AL9A8gQAwPIAAAEhSfgAEEhEACHA6QERwWAA8Cq6sLVA8gQFBEbA8gAFAiBJ+AUACesFAAAhwOkBEcFgAPCl+bT78PEB+xBAMLEJ6wUAAyHA6QIUZSCwvQnrBQABIUFgAPCr+aBCE9gA8Kv5oEIP2QnrBQACIUFgIEYA8MT5Aygcv2cgsL0gRgDw6fkAILC9CesFAAQhwOkCFGYgsL0t6fBBQPIEBwRGwPIABxVGDkYDIAnrBwEAIqMHSfgHAMHpASLKYAbQCesHAcHpAgRlIL3o8IEJ6wcAASFBYADwbfmgQhXYAPBt+aBCEdkJ6wcAAyFBYAbrBAgA8GP5gEUP2QnrBwAEIcDpAhhmIL3o8IEJ6wcABCHA6QIUZiC96PCBCesHAAQhQWAA8Gv5MLEJ6wcAAiGBYGcgvejwgQnrBwAFIUFgIEYA8F75AigH0gnrBwACIcDpAhRnIL3o8IEP0f8iIEYxRgDwNvhIsQMgSfgHAAnrBwAFIUFgZyC96PCBAyBJ+AcAACCw65YPCesHAU/wBgJKYAi/vejwgU/qlggAJlT4JgABMAzRVfgmAET4JgAA8ET5ATZGRU/wAADw073o8IEJ6wcABSGiGcDpAhJoIL3o8IEt6fBBQPIEBw1GBEbA8gAHBSAWRkn4BwAJ6wcAACGqB8DpARHBYAfQCesHAAMhwOkCFWUgvejwgQnrBwACIUFgAPDQ+KBCFdgA8ND4oEIR2QnrBwADIUFgBesECADwxviARQ/ZCesHAAQhwOkCGGYgvejwgQnrBwAEIcDpAhRmIL3o8IEJ6wcABCEALUFgBL8AIL3o8IEAIQfgAL8BMalCT/AAACi/vejwgWBcsEL10GAYCesHAQUiwekCIAEgvejwgQC/LenwQUDyBAUERsDyAAUEIJBGD0ZJ+AUACesFAAAhogfA6QERwWAI0AnrBQADIWUmwOkCFDBGvejwgQnrBQABIUFgAPBt+KBCEtgA8G34oEIO2QnrBQADIUFgPhkA8GT4hkIO2QnrBQAEIcDpAhYE4AnrBQAEIcDpAhRmJjBGvejwgQAhseuXDwnrBQBP8AQBQWAL0LgIACEiaFj4ITCaQgvRATGBQgTxBAT10wnrBQAFIUFgMEa96PCBCesFAAYhwOkCFCBGvejwgQAAQPIwEMDy/xABaAExHL8AaHBHQPbgcc/yAAEIeEloYfMLIHBHQPIgIMDy/xABaAExFL8AaE/0AGBwRwC/QPIkIMDy/xABaAExFL8AaIAgcEcAIHBHT/CAcHBHAL8Qtf/34f8ERv/36v8A+wTwAPGAcBC9AL8BRIFCnL8BIHBHA+CIQiS/ASBwR1D4BCsBMhy/ACBwR/TnAL9wRwC/ACBwRwMgcEcDKIS/aSBwR4C1QLIFoVH4IABA8gRRxPIIEQhgAPAK+AAggL0AAAAAAgAAAAEAAAAAAAAAQPIAQMTyCBABaAAp/NBwR0DyDFDE8ggQASEBYPDnAL+BsACQAJhP8P8xAWABsOfnaSBwR7C1//el/wRGsPGAfwrZT/CAdQC/KEb/9+n///d9/wVEpUL30wAgsL0AAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 65
-    pc_program_page: 309
-    pc_erase_sector: 181
-    pc_erase_all: 153
-    data_section_offset: 1328
+    pc_init: 0x1
+    pc_uninit: 0x41
+    pc_program_page: 0x135
+    pc_erase_sector: 0xb5
+    pc_erase_all: 0x99
+    data_section_offset: 0x530
     flash_properties:
       address_range:
         start: 0x1000000
         end: 0x1040000
       page_size: 0x800
-      erased_byte_value: 0xFF
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0xbb8
       sectors:
         - size: 0x800
-          address: 0
-  nrf53xx_network_uicr:
-    name: nrf53xx_network_uicr
+          address: 0x0
+  - name: nrf53xx_network_uicr
     description: nRF53xxx_net UICR Erase
-    cores: [network]
+    cores:
+      - network
     default: false
     instructions: cLVA8gQGwPIABgAlCesGAEn4BlDA6QFVxWDQshRGAPDl+QAoHr8J6wYBwekCBAVGKEZwvRC1BEYAIADw1/lA8gQBwPIAAUlEELHB6QIEA+CJaAApCL8QvUTyAAHC8gARASIKYEDyBALA8gACWfgCMEpES2BTaItgk2jLYNJoCmEQvQC/gLVA8gQAwPIAAAEhSfgAEEhEACHA6QERwWAA8Mf5ACCAvQC/ELVA8gQAwPIAAAIhSfgAEEhEACTA6QFExGAA8FP5AUZI8gAAwPL/EP8iAPAL+DCxAPC6+QRGaSgUvwAsACQgRhC9AL9wtUDyBAzA8gAMBSNJ+AwwCesMA0/wAA6EB8PpAe7D+AzgBdAJ6wwBAyLB6QIgDOAJ6wwDT/ABDowHw/gE4AjQCesMAAMiwOkCIU/wZQ5wRnC9SPb/fsDy/x4J6wwDAiRwRVxgBdkJ6wwBBCLB6QIgDeALGA7xAQUJ6wwEAyarQmZgCNkJ6wwABCHA6QITT/BmDnBGcL1RsQAjT/AADgC/xlyWQgfRATOLQvnTC+BP8AAOcEZwvRhECesMAQUiT/ABDsHpAiBwRnC9AL8t6fBBQPIEBsDyAAYVRgRGAyAJ6wYCACOPB0n4BgDC6QEz02AG0AnrBgLC6QIBZSC96PCBSPb/cMDy/xAJ6wYCAiOEQlNgB9kJ6wYABCHA6QIUZiC96PCBChkBMAnrBgMDJ4JCX2AH2QnrBgAEIcDpAhJmIL3o8IEAILDrkQ8b0E/qkQgAJwzgVfgnAET4JwAA8Or4ATdHRU/wAAAov73o8IFU+CcAATDu0AnrBgAFIeIZwOkCEmggvejwgXC1QPIEDMDyAAwEI0n4DDAJ6wwDT/AADoQHw+kB7sP4DOAF0AnrDAEDIsHpAiAM4AnrDANP8AEOjAfD+ATgB9AJ6wwAAyLA6QIhZSMYRnC9SPb/fsDy/x4J6wwDAiRwRVxgBdkJ6wwBBCLB6QIgDeALGA7xAQUJ6wwEAyarQmZgB9kJ6wwABCHA6QITZiMYRnC9ACW165EPCesMBk/wBAV1YBTQT+qRDgAhAL8EaFL4IVCsQgXRATFxRQDxBAD10wXgCesMAQYiA0bB6QIgGEZwvQAAQPIwEMDy/xABaAExHL8AaHBHQPbgcc/yAAEIeEloYfMLIHBHQPIgIMDy/xABaAExFL8AaE/0AGBwRwC/QPIkIMDy/xABaAExFL8AaIAgcEcAIHBHT/CAcHBHAL8Qtf/34f8ERv/36v8A+wTwAPGAcBC9AL8BRIFCnL8BIHBHA+CIQiS/ASBwR1D4BCsBMhy/ACBwR/TnAL9wRwC/ACBwRwMgcEcDKIS/aSBwR4C1QLIFoVH4IABA8gRRxPIIEQhgAPAK+AAggL0AAAAAAgAAAAEAAAAAAAAAQPIAQMTyCBABaAAp/NBwR0DyDFDE8ggQASEBYPDnAL+BsACQAJhP8P8xAWABsOfnaSBwR7C1//el/wRGsPGAfwrZT/CAdQC/KEb/9+n///d9/wVEpUL30wAgsL0AAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 53
-    pc_program_page: 441
-    pc_erase_sector: 169
-    pc_erase_all: 133
-    data_section_offset: 1148
+    pc_init: 0x1
+    pc_uninit: 0x35
+    pc_program_page: 0x1b9
+    pc_erase_sector: 0xa9
+    pc_erase_all: 0x85
+    data_section_offset: 0x47c
     flash_properties:
       address_range:
         start: 0x1ff8000
         end: 0x1ff9000
       page_size: 0x800
-      erased_byte_value: 0xFF
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0xbb8
       sectors:
         - size: 0x800
-          address: 0
+          address: 0x0

--- a/probe-rs/targets/nRF91_Series.yaml
+++ b/probe-rs/targets/nRF91_Series.yaml
@@ -1,4 +1,3 @@
----
 name: nRF91 Series
 variants:
   - name: nRF9160_xxAA
@@ -7,69 +6,71 @@ variants:
         type: armv8m
         core_access_options:
           Arm:
-            ap: 0
-            psel: 0
+            ap: 0x0
+            psel: 0x0
     memory_map:
       - Ram:
           range:
-            start: 536870912
-            end: 537133056
+            start: 0x20000000
+            end: 0x20040000
           is_boot_memory: false
-          cores: [main]
+          cores:
+            - main
       - Nvm:
           range:
-            start: 0
-            end: 1048576
+            start: 0x0
+            end: 0x100000
           is_boot_memory: true
-          cores: [main]
+          cores:
+            - main
     flash_algorithms:
       - nrf91xx
       - nrf91xx_uicr
 flash_algorithms:
-  nrf91xx:
-    name: nrf91xx
+  - name: nrf91xx
     description: nRF91xxx
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: sLVA8gQFwPIABQAgCesFAUn4BQDB6QEAyGDQshRGAPA9+iCxCesFAcHpAgSwvQnrBQABIUFgAPAr+gAgsL0AvxC1BEYAIADwKfo4sUDyBAHA8gABSUTB6QIEEL1A8gQAwPIAAAnrAAGJaAApBL8AIBC9RPIAAcLyAAEBIgpgWfgAIEhESmBCaIpggmjKYMBoCGEAIBC9AL9A8gQAwPIAAAEhSfgAEEhEACHA6QERwWAA8Ci6sLVA8gQFBEbA8gAFAiBJ+AUACesFAAAhwOkBEcFgAPCl+bT78PEB+xBAMLEJ6wUAAyHA6QIUZSCwvQnrBQABIUFgAPCt+aBCE9gA8Kv5oEIP2QnrBQACIUFgIEYA8ML5Aygcv2cgsL0gRgDw5/kAILC9CesFAAQhwOkCFGYgsL0t6fBBQPIEBwRGwPIABxVGDkYDIAnrBwEAIqMHSfgHAMHpASLKYAbQCesHAcHpAgRlIL3o8IEJ6wcAASFBYADwb/mgQhXYAPBt+aBCEdkJ6wcAAyFBYAbrBAgA8GP5gEUP2QnrBwAEIcDpAhhmIL3o8IEJ6wcABCHA6QIUZiC96PCBCesHAAQhQWAA8Gn5MLEJ6wcAAiGBYGcgvejwgQnrBwAFIUFgIEYA8Fz5AigH0gnrBwACIcDpAhRnIL3o8IEP0f8iIEYxRgDwNvhIsQMgSfgHAAnrBwAFIUFgZyC96PCBAyBJ+AcAACCw65YPCesHAU/wBgJKYAi/vejwgU/qlggAJlT4JgABMAzRVfgmAET4JgAA8EL5ATZGRU/wAADw073o8IEJ6wcABSGiGcDpAhJoIL3o8IEt6fBBQPIEBw1GBEbA8gAHBSAWRkn4BwAJ6wcAACGqB8DpARHBYAfQCesHAAMhwOkCFWUgvejwgQnrBwACIUFgAPDS+KBCFdgA8ND4oEIR2QnrBwADIUFgBesECADwxviARQ/ZCesHAAQhwOkCGGYgvejwgQnrBwAEIcDpAhRmIL3o8IEJ6wcABCEALUFgBL8AIL3o8IEAIQfgAL8BMalCT/AAACi/vejwgWBcsEL10GAYCesHAQUiwekCIAEgvejwgQC/LenwQUDyBAUERsDyAAUEIJBGD0ZJ+AUACesFAAAhogfA6QERwWAI0AnrBQADIWUmwOkCFDBGvejwgQnrBQABIUFgAPBv+KBCEtgA8G34oEIO2QnrBQADIUFgPhkA8GT4hkIO2QnrBQAEIcDpAhYE4AnrBQAEIcDpAhRmJjBGvejwgQAhseuXDwnrBQBP8AQBQWAL0LgIACEiaFj4ITCaQgvRATGBQgTxBAT10wnrBQAFIUFgMEa96PCBCesFAAYhwOkCFCBGvejwgQAAQPIwEMDy/wABaAExHL8AaHBHQPbgcc/yAAEIeEloYfMLIHBHQPIgIMDy/wABaAExFL8AaE/0gFBwRwC/QPIkIMDy/wABaAExFL8AaE/0AHBwRwC/ACBwRwAgcEcQtf/34f8ERv/36v8A+wTwEL0AvwFEgUKcvwEgcEcD4IhCJL8BIHBHUPgEKwEyHL8AIHBH9OcAv3BHAL8AIHBHAyBwRwMohL9pIHBHgLVAsgWhUfggAEnyBFHF8gMBCGAA8Ar4ACCAvQAAAAACAAAAAQAAAAAAAABJ8gBAxfIDAAFoACn80HBHSfIMUMXyAwABIQFg8OcAv4GwAJAAmE/w/zEBYAGw5+dpIHBHsLX/96f/BEZAsQAlKEb/9+3///eD/wVEpUL30wAgsL0AAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 65
-    pc_program_page: 309
-    pc_erase_sector: 181
-    pc_erase_all: 153
-    data_section_offset: 1316
+    pc_init: 0x1
+    pc_uninit: 0x41
+    pc_program_page: 0x135
+    pc_erase_sector: 0xb5
+    pc_erase_all: 0x99
+    data_section_offset: 0x524
     flash_properties:
       address_range:
-        start: 0
-        end: 2097152
-      page_size: 4096
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
+        start: 0x0
+        end: 0x200000
+      page_size: 0x1000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 4096
-          address: 0
-  nrf91xx_uicr:
-    name: nrf91xx_uicr
+        - size: 0x1000
+          address: 0x0
+  - name: nrf91xx_uicr
     description: nRF91xxx UICR Erase
-    cores: [main]
+    cores:
+      - main
     default: true
     instructions: cLVA8gQGwPIABgAlCesGAEn4BlDA6QFVxWDQshRGAPDj+QAoHr8J6wYBwekCBAVGKEZwvRC1BEYAIADw1flA8gQBwPIAAUlEELHB6QIEA+CJaAApCL8QvUTyAAHC8gABASIKYEDyBALA8gACWfgCMEpES2BTaItgk2jLYNJoCmEQvQC/gLVA8gQAwPIAAAEhSfgAEEhEACHA6QERwWAA8MX5ACCAvQC/ELVA8gQAwPIAAAIhSfgAEEhEACTA6QFExGAA8FP5AUZI8gAAwPL/AP8iAPAL+DCxAPC4+QRGaSgUvwAsACQgRhC9AL9wtUDyBAzA8gAMBSNJ+AwwCesMA0/wAA6EB8PpAe7D+AzgBdAJ6wwBAyLB6QIgDOAJ6wwDT/ABDowHw/gE4AjQCesMAAMiwOkCIU/wZQ5wRnC9SPb/fsDy/w4J6wwDAiRwRVxgBdkJ6wwBBCLB6QIgDeALGA7xAQUJ6wwEAyarQmZgCNkJ6wwABCHA6QITT/BmDnBGcL1RsQAjT/AADgC/xlyWQgfRATOLQvnTC+BP8AAOcEZwvRhECesMAQUiT/ABDsHpAiBwRnC9AL8t6fBBQPIEBsDyAAYVRgRGAyAJ6wYCACOPB0n4BgDC6QEz02AG0AnrBgLC6QIBZSC96PCBSPb/cMDy/wAJ6wYCAiOEQlNgB9kJ6wYABCHA6QIUZiC96PCBChkBMAnrBgMDJ4JCX2AH2QnrBgAEIcDpAhJmIL3o8IEAILDrkQ8b0E/qkQgAJwzgVfgnAET4JwAA8Oj4ATdHRU/wAAAov73o8IFU+CcAATDu0AnrBgAFIeIZwOkCEmggvejwgXC1QPIEDMDyAAwEI0n4DDAJ6wwDT/AADoQHw+kB7sP4DOAF0AnrDAEDIsHpAiAM4AnrDANP8AEOjAfD+ATgB9AJ6wwAAyLA6QIhZSMYRnC9SPb/fsDy/w4J6wwDAiRwRVxgBdkJ6wwBBCLB6QIgDeALGA7xAQUJ6wwEAyarQmZgB9kJ6wwABCHA6QITZiMYRnC9ACW165EPCesMBk/wBAV1YBTQT+qRDgAhAL8EaFL4IVCsQgXRATFxRQDxBAD10wXgCesMAQYiA0bB6QIgGEZwvQAAQPIwEMDy/wABaAExHL8AaHBHQPbgcc/yAAEIeEloYfMLIHBHQPIgIMDy/wABaAExFL8AaE/0gFBwRwC/QPIkIMDy/wABaAExFL8AaE/0AHBwRwC/ACBwRwAgcEcQtf/34f8ERv/36v8A+wTwEL0AvwFEgUKcvwEgcEcD4IhCJL8BIHBHUPgEKwEyHL8AIHBH9OcAv3BHAL8AIHBHAyBwRwMohL9pIHBHgLVAsgWhUfggAEnyBFHF8gMBCGAA8Ar4ACCAvQAAAAACAAAAAQAAAAAAAABJ8gBAxfIDAAFoACn80HBHSfIMUMXyAwABIQFg8OcAv4GwAJAAmE/w/zEBYAGw5+dpIHBHsLX/96f/BEZAsQAlKEb/9+3///eD/wVEpUL30wAgsL0AAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 1
-    pc_uninit: 53
-    pc_program_page: 441
-    pc_erase_sector: 169
-    pc_erase_all: 133
-    data_section_offset: 1136
+    pc_init: 0x1
+    pc_uninit: 0x35
+    pc_program_page: 0x1b9
+    pc_erase_sector: 0xa9
+    pc_erase_all: 0x85
+    data_section_offset: 0x470
     flash_properties:
       address_range:
-        start: 16744448
-        end: 16748544
-      page_size: 4096
-      erased_byte_value: 255
-      program_page_timeout: 1000
-      erase_sector_timeout: 3000
+        start: 0xff8000
+        end: 0xff9000
+      page_size: 0x1000
+      erased_byte_value: 0xff
+      program_page_timeout: 0x3e8
+      erase_sector_timeout: 0xbb8
       sectors:
-        - size: 4096
-          address: 0
+        - size: 0x1000
+          address: 0x0
 core: M33


### PR DESCRIPTION
This makes it consistent with all other lists of stuff in the
YAMLs, which all are arrays with "name" fields if applicable.