### PR TITLE
Make sure that an exactly matching chip name can't be overridden by substring matches

### DIFF
--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -175,7 +175,10 @@ impl Registry {
                                 "Found chip {} which matches given partial name {}. Consider specifying its full name.",
                                 variant.name,
                                 name,
-                            )
+                            );
+                            if selected_family_and_chip.is_some() {
+                                continue;
+                            }
                         }
                         selected_family_and_chip = Some((family, variant));
                     }


### PR DESCRIPTION
If there are two chip variants where one's name is a prefix of
the other's, without this change it's not possible to reliably
select the shorter one.

Eg. if there are RP2040 and RP2040_SELFDEBUG, `--chip RP2040` may
accidentally select RP2040_SELFDEBUG.

To avoid that, ignore a variant if it's only a substring match and
there was already some match.