### PR TITLE
Forbid ambiguous chip names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Information on whether a rebuild was necessary is included in the artefact (nothing changed if
  `fresh == true`) (#795).
 - `Debug` was reimplemented on `Session` (#795).
+- Reject ambiguous chip selection.
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -186,7 +186,7 @@ impl Registry {
                     }
                 }
             }
-            if exact_matches > 1 || ( exact_matches == 0 && partial_matches > 1 ) {
+            if exact_matches > 1 || (exact_matches == 0 && partial_matches > 1) {
                 log::warn!(
                     "Ignoring ambiguous matches for specified chip name {}",
                     name,

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -339,24 +339,28 @@ mod tests {
     #[test]
     fn try_fetch1() {
         let registry = Registry::from_builtin_families();
-        assert!(registry.get_target_by_name("nrf51").is_ok());
+        // ambiguous: partially matches STM32G081KBUx and STM32G081KBUxN
+        assert!(registry.get_target_by_name("STM32G081KBU").is_err());
     }
 
     #[test]
     fn try_fetch2() {
         let registry = Registry::from_builtin_families();
-        assert!(registry.get_target_by_name("nrf5182").is_ok());
+        // ok: matches both STM32G081KBUx and STM32G081KBUxN, but the first one is an exact match
+        assert!(registry.get_target_by_name("stm32G081KBUx").is_ok());
     }
 
     #[test]
     fn try_fetch3() {
         let registry = Registry::from_builtin_families();
-        assert!(registry.get_target_by_name("nrF51822_x").is_ok());
+        // ok: unique substring match
+        assert!(registry.get_target_by_name("STM32G081RBI").is_ok());
     }
 
     #[test]
     fn try_fetch4() {
         let registry = Registry::from_builtin_families();
+        // ok: unique exact match
         assert!(registry.get_target_by_name("nrf51822_Xxaa").is_ok());
     }
 }

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -163,6 +163,8 @@ impl Registry {
         let (family, chip) = {
             // Try get the corresponding chip.
             let mut selected_family_and_chip = None;
+            let mut exact_matches = 0;
+            let mut partial_matches = 0;
             for family in &self.families {
                 for variant in family.variants.iter() {
                     if variant
@@ -171,18 +173,32 @@ impl Registry {
                         .starts_with(&name.to_ascii_lowercase())
                     {
                         if variant.name.to_ascii_lowercase() != name.to_ascii_lowercase() {
-                            log::warn!(
-                                "Found chip {} which matches given partial name {}. Consider specifying its full name.",
-                                variant.name,
-                                name,
-                            );
-                            if selected_family_and_chip.is_some() {
+                            log::debug!("Partial match for chip name: {}", variant.name);
+                            partial_matches += 1;
+                            if exact_matches > 0 {
                                 continue;
                             }
+                        } else {
+                            log::debug!("Exact match for chip name: {}", variant.name);
+                            exact_matches += 1;
                         }
                         selected_family_and_chip = Some((family, variant));
                     }
                 }
+            }
+            if exact_matches > 1 || ( exact_matches == 0 && partial_matches > 1 ) {
+                log::warn!(
+                    "Ignoring ambiguous matches for specified chip name {}",
+                    name,
+                );
+                return Err(RegistryError::ChipNotFound(name.to_owned()));
+            }
+            if exact_matches == 0 && partial_matches == 1 {
+                log::warn!(
+                    "Found chip {} which matches given partial name {}. Consider specifying its full name.",
+                    selected_family_and_chip.unwrap().1.name,
+                    name,
+                );
             }
             let (family, chip) = selected_family_and_chip
                 .ok_or_else(|| RegistryError::ChipNotFound(name.to_owned()))?;

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -385,6 +385,6 @@ mod test {
 
         let probe = fake_probe.into_probe();
 
-        probe.attach("nrf51822").unwrap();
+        probe.attach("nrf51822_xxAC").unwrap();
     }
 }


### PR DESCRIPTION
As suggested by dirbaio: Forbid ambiguous chip names.
(But ignore partial matches if exactly one exact match exists.)