### PR TITLE
Clean up a lot of comments.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "DAP-STDIO probe-rs-debugger", //Use this to test the dap server, in 'launch' mode
+            "name": "DAP-STDIO probe-rs-debugger", // Use this to test the dap server, in 'launch' mode.
             "cargo": {
                 "args": [
                     "build",
@@ -43,7 +43,7 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "DAP-Server probe-rs-debugger", //Use this to test the dap server in 'attach' mode
+            "name": "DAP-Server probe-rs-debugger", // Use this to test the dap server in 'attach' mode.
             "cargo": {
                 "args": [
                     "build",

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -121,9 +121,6 @@ fn show_arm_info(interface: &mut Box<dyn ArmProbeInterface>) -> Result<()> {
 
         let ap_information = interface.ap_information(access_port).unwrap();
 
-        //let idr = interface.read_ap_register(access_port, IDR::default())?;
-        //println!("{:#x?}", idr);
-
         match ap_information {
             ApInformation::MemoryAp(MemoryApInformation {
                 debug_base_address, ..

--- a/debugger/src/dap_types.rs
+++ b/debugger/src/dap_types.rs
@@ -97,7 +97,8 @@ fn get_string_argument(
                     argument_name: argument_name.to_string(),
                 });
             }
-            Ok(arguments[index].as_str().unwrap().to_string()) //convert this to RUST string
+            // Convert this to a Rust string.
+            Ok(arguments[index].as_str().unwrap().to_string())
         }
         _ => Err(DebuggerError::MissingArgument {
             argument_name: argument_name.to_string(),

--- a/debugger/src/info.rs
+++ b/debugger/src/info.rs
@@ -3,11 +3,11 @@ use crate::{DebuggerError, DebuggerOptions};
 use probe_rs::{
     architecture::{
         arm::{
-            ap::{GenericAp, MemoryAp},
+            ap::{GenericAp, MemoryAp, IDR},
             armv6m::Demcr,
             memory::Component,
             sequences::DefaultArmSequence,
-            ApAddress, ApInformation, ArmProbeInterface, DpAddress, MemoryApInformation,
+            ApAddress, ApInformation, ArmProbeInterface, DpAddress, MemoryApInformation, Register,
         },
         riscv::communication_interface::RiscvCommunicationInterface,
     },
@@ -138,10 +138,10 @@ fn show_arm_info(interface: &mut Box<dyn ArmProbeInterface>) -> Result<()> {
         };
         let access_port = GenericAp::new(ap);
 
-        let ap_information = interface.ap_information(access_port).unwrap();
+        let idr = interface.read_raw_ap_register(ap, IDR::ADDRESS)?;
+        println!("{:#x?}", idr);
 
-        //let idr = interface.read_ap_register(access_port, IDR::default())?;
-        //println!("{:#x?}", idr);
+        let ap_information = interface.ap_information(access_port).unwrap();
 
         match ap_information {
             ApInformation::MemoryAp(MemoryApInformation {

--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -1,6 +1,7 @@
-mod dap_types; //Uses Schemafy to generate DAP types from Json
+// Uses Schemafy to generate DAP types from Json
+mod dap_types;
 mod debug_adapter;
-mod debugger; //The probe-rs debugger.
+mod debugger;
 mod info;
 mod rtt;
 
@@ -105,7 +106,7 @@ enum CliCommands {
         #[structopt(flatten)]
         debugger_options: DebuggerOptions,
 
-        //TODO: Implement multi-session --server choices
+        // TODO: Implement multi-session --server choices
         /// Switch from using CLI to DAP Protocol debug commands. By default, the DAP communication for the first session is via STDIN and STDOUT. Adding the additional --port property will run as an IP server, listening to connections on the specified port.
         #[structopt(long)]
         dap: bool,

--- a/debugger/src/rtt.rs
+++ b/debugger/src/rtt.rs
@@ -311,7 +311,8 @@ impl RttActiveTarget {
                                     }
                                     DataFormat::BinaryLE => {
                                         for element in &active_channel.rtt_buffer.0[..bytes_read] {
-                                            write!(formatted_data, "{:#04x}", element).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r); //Width of 4 allows 0xFF to be printed.
+                                            // Width of 4 allows 0xFF to be printed.
+                                            write!(formatted_data, "{:#04x}", element).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
                                         }
                                     }
                                     DataFormat::Defmt => {

--- a/probe-rs/src/architecture/arm/component/dwt.rs
+++ b/probe-rs/src/architecture/arm/component/dwt.rs
@@ -105,7 +105,7 @@ bitfield! {
     pub cpievtena, set_cpievtena: 17;
     pub exctrcena, set_exctrcena: 16;
     pub pcsamplena, set_pcsamplena: 12;
-    ///00 Disabled. No Synchronization packets.
+    /// 00 Disabled. No Synchronization packets.
     /// 01 Synchronization counter tap at CYCCNT[24].
     /// 10 Synchronization counter tap at CYCCNT[26].
     /// 11 Synchronization counter tap at CYCCNT[28].

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -377,7 +377,7 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
     }
 
     fn run(&mut self) -> Result<(), Error> {
-        //before we run, we always perform a single instruction step, to account for possible breakpoints that might get us stuck on the current instruction
+        // Before we run, we always perform a single instruction step, to account for possible breakpoints that might get us stuck on the current instruction.
         self.step()?;
 
         let mut value = Dhcsr(0);
@@ -388,14 +388,14 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
         self.memory.write_word_32(Dhcsr::ADDRESS, value.into())?;
         self.memory.flush()?;
 
-        // We assume that the core is running now
+        // We assume that the core is running now.
         self.state.current_state = CoreStatus::Running;
 
         Ok(())
     }
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
-        //First check if we stopped on a breakpoint, because this requires special handling before we can continue
+        // First check if we stopped on a breakpoint, because this requires special handling before we can continue.
         let was_breakpoint =
             if self.state.current_state == CoreStatus::Halted(HaltReason::Breakpoint) {
                 log::debug!("Core was halted on breakpoint, disabling breakpoints");
@@ -418,7 +418,7 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
         self.memory.flush()?;
         self.wait_for_core_halted(Duration::from_millis(100))?;
 
-        //Re-enable breakpoints before we continue
+        // Re-enable breakpoints before we continue.
         if was_breakpoint {
             self.enable_breakpoints(true)?;
         }

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -504,12 +504,12 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
     }
 
     fn run(&mut self) -> Result<(), Error> {
-        //before we run, we always perform a single instruction step, to account for possible breakpoints that might get us stuck on the current instruction
+        // Before we run, we always perform a single instruction step, to account for possible breakpoints that might get us stuck on the current instruction.
         self.step()?;
 
         let mut dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
 
-        // First disable the DHCSR->C_MASKINTS
+        // First disable the DHCSR->C_MASKINTS.
         if dhcsr.c_maskints() {
             dhcsr.set_c_maskints(false);
             dhcsr.enable_write();
@@ -531,7 +531,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
     }
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
-        //First check if we stopped on a breakpoint, because this requires special handling before we can continue
+        // First check if we stopped on a breakpoint, because this requires special handling before we can continue.
         let was_breakpoint =
             if self.state.current_state == CoreStatus::Halted(HaltReason::Breakpoint) {
                 self.enable_breakpoints(false)?;
@@ -563,12 +563,12 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
 
         self.wait_for_core_halted(Duration::from_millis(100))?;
 
-        //Re-enable breakpoints before we continue
+        // Re-enable breakpoints before we continue.
         if was_breakpoint {
             self.enable_breakpoints(true)?;
         }
 
-        // try to read the program counter
+        // Try to read the program counter.
         let pc_value = self.read_core_reg(register::PC.address)?;
 
         // get pc
@@ -633,7 +633,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
     }
 
     fn set_hw_breakpoint(&mut self, bp_unit_index: usize, addr: u32) -> Result<(), Error> {
-        //First make sure they are asking for a breakpoint on a half-word boundary
+        // First make sure they are asking for a breakpoint on a half-word boundary.
         if (addr & 0x1) > 0 {
             return Err(Error::Other(anyhow!(
                 "The requested breakpoint address 0x{:08x} is not on a half-word boundary",
@@ -687,7 +687,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
         Architecture::Arm
     }
 
-    /// See docs on the [`CoreInterface::get_hw_breakpoints`] trait
+    /// See docs on the [`CoreInterface::get_hw_breakpoints`] trait.
     fn get_hw_breakpoints(&mut self) -> Result<Vec<Option<u32>>, Error> {
         let mut breakpoints = vec![];
         let num_hw_breakpoints = self.get_available_breakpoint_units()? as usize;
@@ -696,11 +696,12 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
             let ctrl_reg = FpCtrl::from(raw_val);
             // FpRev1 and FpRev2 needs different decoding of the register value, but the location where we read from is the same ...
             let reg_addr = FpRev1CompX::ADDRESS + (bp_unit_index * size_of::<u32>()) as u32;
-            // The raw breakpoint address as read from memory
+            // The raw breakpoint address as read from memory.
             let register_value = self.memory.read_word_32(reg_addr)?;
-            // The breakpoint address after it has been adjusted for FpRev 1 or 2
+            // The breakpoint address after it has been adjusted for FpRev 1 or 2.
             let breakpoint:u32;
-            if register_value & 0b1 == 0b1 { // We only care about `enabled` breakpoints
+            if register_value & 0b1 == 0b1 {
+                // We only care about `enabled` breakpoints.
                 if ctrl_reg.rev() == 0 {
                     breakpoint = FpRev1CompX::get_breakpoint_comparator(register_value)?;
                 } else if ctrl_reg.rev() == 1 {

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -121,7 +121,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
     }
 
     fn run(&mut self) -> Result<(), Error> {
-        //before we run, we always perform a single instruction step, to account for possible breakpoints that might get us stuck on the current instruction
+        // Before we run, we always perform a single instruction step, to account for possible breakpoints that might get us stuck on the current instruction.
         self.step()?;
 
         let mut value = Dhcsr(0);
@@ -168,7 +168,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
     }
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
-        //First check if we stopped on a breakpoint, because this requires special handling before we can continue
+        // First check if we stopped on a breakpoint, because this requires special handling before we can continue.
         let was_breakpoint =
             if self.state.current_state == CoreStatus::Halted(HaltReason::Breakpoint) {
                 log::debug!("Core was halted on breakpoint, disabling breakpoints");
@@ -192,7 +192,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
 
         self.wait_for_core_halted(Duration::from_millis(100))?;
 
-        //Re-enable breakpoints before we continue
+        // Re-enable breakpoints before we continue.
         if was_breakpoint {
             self.enable_breakpoints(true)?;
         }

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -79,24 +79,23 @@ pub trait ArmDebugSequence: Send + Sync {
 
         // TODO: Use atomic block
 
-        // todo!();
-
-        // Ensure current debug interface is in reset state
+        // Ensure current debug interface is in reset state.
         interface.swj_sequence(51, 0x0007_FFFF_FFFF_FFFF)?;
 
-        // Execute SWJ-DP Switch Sequence JTAG to SWD (0xE79E)
-        // Change if SWJ-DP uses deprecated switch code (0xEDB6)
+        // Execute SWJ-DP Switch Sequence JTAG to SWD (0xE79E).
+        // Change if SWJ-DP uses deprecated switch code (0xEDB6).
         interface.swj_sequence(16, 0xE79E)?;
 
-        interface.swj_sequence(51, 0x0007_FFFF_FFFF_FFFF)?; // > 50 cycles SWDIO/TMS High
-        interface.swj_sequence(3, 0x00)?; // At least 2 idle cycles (SWDIO/TMS Low)
+        interface.swj_sequence(51, 0x0007_FFFF_FFFF_FFFF)?; // > 50 cycles SWDIO/TMS High.
+        interface.swj_sequence(3, 0x00)?; // At least 2 idle cycles (SWDIO/TMS Low).
 
-        // End of atomic block
+        // End of atomic block.
 
-        // Read DPIDR to enable SWD interface
+        // Read DPIDR to enable SWD interface.
         let _ = interface.raw_read_register(PortType::DebugPort, DPIDR::ADDRESS);
 
-        //interface.read_dpidr()?;
+        // TODO: Figure a way how to do this.
+        // interface.read_dpidr()?;
 
         Ok(())
     }
@@ -122,8 +121,6 @@ pub trait ArmDebugSequence: Send + Sync {
         interface.write_dp_register(dp, abort)?;
 
         interface.write_dp_register(dp, Select(0))?;
-
-        //let powered_down = interface.read_dp_register::<Select>::()
 
         let ctrl = interface.read_dp_register::<Ctrl>(dp)?;
 

--- a/probe-rs/src/architecture/arm/sequences/nxp.rs
+++ b/probe-rs/src/architecture/arm/sequences/nxp.rs
@@ -35,8 +35,6 @@ impl ArmDebugSequence for LPC55S69 {
 
         interface.write_dp_register(dp, Select(0))?;
 
-        //let powered_down = interface.read_dp_register::<Select>::()
-
         let ctrl = interface.read_dp_register::<Ctrl>(dp)?;
 
         let powered_down = !(ctrl.csyspwrupack() && ctrl.cdbgpwrupack());
@@ -258,8 +256,6 @@ pub fn enable_debug_mailbox(
     let ap = ApAddress { dp, ap: 2 };
 
     let status: IDR = interface.read_ap_register(GenericAp::new(ap))?;
-
-    //let status = read_ap(interface, 2, 0xFC)?;
 
     log::info!("APIDR: {:?}", status);
     log::info!("APIDR: 0x{:08X}", u32::from(status));

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -954,7 +954,7 @@ impl<'probe> RiscvCommunicationInterface {
         log::debug!("abstractcs: {:?}", abstractcs_prev);
 
         if abstractcs_prev.cmderr() != 0 {
-            //clear previous command error
+            // Clear previous command error.
             let mut abstractcs_clear = Abstractcs(0);
             abstractcs_clear.set_cmderr(0x7);
 

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -492,10 +492,10 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         let mut breakpoints = vec![];
         let num_hw_breakpoints = self.get_available_breakpoint_units()? as usize;
         for bp_unit_index in 0..num_hw_breakpoints {
-            //select the trigger
+            // Select the trigger.
             self.write_csr(tselect, bp_unit_index as u32)?;
 
-            //Read the trigger "configuration" data
+            // Read the trigger "configuration" data.
             let tdata_value = Mcontrol(self.read_csr(tdata1)?);
 
             log::warn!("Breakpoint {}: {:?}", bp_unit_index, tdata_value);
@@ -506,7 +506,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
             let trigger_any_action_enabled =
                 tdata_value.execute() || tdata_value.store() || tdata_value.load();
 
-            //Only return if the trigger if it is for an execution debug action in all modes
+            // Only return if the trigger if it is for an execution debug action in all modes.
             if tdata_value.type_() == 0b10
                 && tdata_value.action() == 1
                 && tdata_value.match_() == 0

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -439,7 +439,7 @@ impl<'probe> Core<'probe> {
             self.enable_breakpoints(true)?;
         }
 
-        //If there is a breakpoint set already, return its bp_unit_index, else find the next free index
+        // If there is a breakpoint set already, return its bp_unit_index, else find the next free index.
         let breakpoint_comparator_index = match self
             .inner
             .get_hw_breakpoints()?

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -578,7 +578,8 @@ pub enum DebugProbeSelectorParseError {
 /// let selector: probe_rs::DebugProbeSelector = "1337:1337:SERIAL".try_into().unwrap();
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(try_from = "String")] //We need this so that serde will first converst from the string `PID:VID:<Serial>` to a struct before deserializing
+// We need this so that serde will first converst from the string `PID:VID:<Serial>` to a struct before deserializing.
+#[serde(try_from = "String")]
 pub struct DebugProbeSelector {
     pub vendor_id: u16,
     pub product_id: u16,

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
@@ -114,12 +114,17 @@ impl InnerTransferResponse {
 
 /// Read/write single and multiple registers.
 ///
-///The DAP_Transfer Command reads or writes data to CoreSight registers. Each CoreSight register is accessed with a single 32-bit read or write. The CoreSight registers are addressed with DPBANKSEL/APBANKSEL and address lines A2, A3 (A0 = 0 and A1 = 0). This command executes several read/write operations on the selected DP/AP registers. The Transfer Data in the Response are in the order of the Transfer Request in the Command but might be shorter in case of communication failures. The data transfer is aborted on a communication error:
+/// The DAP_Transfer Command reads or writes data to CoreSight registers.
+/// Each CoreSight register is accessed with a single 32-bit read or write.
+/// The CoreSight registers are addressed with DPBANKSEL/APBANKSEL and address lines A2, A3 (A0 = 0 and A1 = 0).
+/// This command executes several read/write operations on the selected DP/AP registers.
+/// The Transfer Data in the Response are in the order of the Transfer Request in the Command but might be shorter in case of communication failures.
+/// The data transfer is aborted on a communication error:
 ///
-///- Protocol Error
-///- Target FAULT response
-///- Target WAIT responses exceed configured value
-///- Value Mismatch (Read Register with Value Match)
+/// - Protocol Error
+/// - Target FAULT response
+/// - Target WAIT responses exceed configured value
+/// - Value Mismatch (Read Register with Value Match)
 #[derive(Debug)]
 pub struct TransferRequest {
     /// Zero based device index of the selected JTAG device. For SWD mode the value is ignored.

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -154,11 +154,6 @@ impl CmsisDap {
     }
 
     fn send_swj_sequences(&mut self, request: SequenceRequest) -> Result<(), CmsisDapError> {
-        /* 12 38 FF FF FF FF FF FF FF -> 12 00 // SWJ Sequence
-        12 10 9E E7 -> 12 00 // SWJ Sequence
-        12 38 FF FF FF FF FF FF FF -> 12 00 // SWJ Sequence */
-        //let sequence_1 = SequenceRequest::new(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
-
         commands::send_command::<SequenceRequest>(&mut self.device, request)
             .map_err(CmsisDapError::from)
             .and_then(|v| match v {
@@ -218,13 +213,13 @@ impl CmsisDap {
                     }
                     Ack::NoAck => {
                         log::trace!("Transfer status: NACK");
-                        //try a reset?
+                        // TODO: Try a reset?
                         return Err(DapError::NoAcknowledge.into());
                     }
                     Ack::Fault => {
                         log::trace!("Transfer status: FAULT");
 
-                        // Check the reason for the fault
+                        // Check the reason for the fault.
                         let response = RawDapAccess::raw_read_register(
                             self,
                             PortType::DebugPort,
@@ -236,7 +231,7 @@ impl CmsisDap {
                         if ctrl.sticky_err() {
                             let mut abort = Abort(0);
 
-                            // Clear sticky error flags
+                            // Clear sticky error flags.
                             abort.set_stkerrclr(ctrl.sticky_err());
 
                             RawDapAccess::raw_write_register(

--- a/probe-rs/src/probe/jlink/swd.rs
+++ b/probe-rs/src/probe/jlink/swd.rs
@@ -248,7 +248,6 @@ fn perform_transfers<P: RawSwdIo>(
         num_transfers += 1;
     }
 
-    //if need_ap_read || write_response_pending {
     if need_ap_read || write_response_pending {
         if write_response_pending {
             io_sequence.add_output_sequence(&vec![

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -529,9 +529,6 @@ fn get_target_from_selector(
                     Ok(interface) => {
                         let mut interface = interface.initialize(DefaultArmSequence::new())?;
 
-                        //let chip_result = try_arm_autodetect(interface);
-                        log::debug!("Autodetect: Trying DAP interface...");
-
                         // TODO:
                         let dp = DpAddress::Default;
 

--- a/smoke-tester/src/tests/stepping.rs
+++ b/smoke-tester/src/tests/stepping.rs
@@ -43,7 +43,6 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
 
     let core_status = core.status()?;
 
-    //assert_eq!(core_status, CoreStatus::Halted(HaltReason::Step));
     if core_status != CoreStatus::Halted(HaltReason::Step) {
         log::warn!("Unexpected core status: {:?}!", core_status);
     }


### PR DESCRIPTION
- Add spaces after the // or ///.
- Add full stops.
- Also quote some variable names with backticks.
- Remove dead code.
- Move comments that were on the same line as actual code (I consider it bad style and it breaks rustfmt https://github.com/rust-lang/rustfmt/issues/4119)