### PR TITLE
Fixed address flashing flash algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved number parsing on all the `probe-rs-cli` commands. They now all accept normal (`01234`), hex (`0x1234`), octal (`0o1234`) and binary (`0b1`) formats. (#774)
 - Added progress bars to the probe-rs-cli download command. (#776)
 - Improve reliability of communication with the RISCV debug module by recovering from busy errors in batch operations. (#802)
+- Add optional ability to load fixed address flashing algorithms (non PIC). (#822)
 
 ### Removed
 

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -16,7 +16,7 @@ pub struct RawFlashAlgorithm {
     pub description: String,
     /// Whether this flash algorithm is the default one or not.
     pub default: bool,
-    /// List of 32-bit words containing the code for the algo.
+    /// List of 32-bit words containing the code for the algo. If `load_address` is not specified, the code must be position indepent (PIC).
     #[serde(deserialize_with = "deserialize")]
     #[serde(serialize_with = "serialize")]
     pub instructions: Vec<u8>,

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -16,10 +16,12 @@ pub struct RawFlashAlgorithm {
     pub description: String,
     /// Whether this flash algorithm is the default one or not.
     pub default: bool,
-    /// List of 32-bit words containing the position-independent code for the algo.
+    /// List of 32-bit words containing the code for the algo.
     #[serde(deserialize_with = "deserialize")]
     #[serde(serialize_with = "serialize")]
     pub instructions: Vec<u8>,
+    /// Address to load algo into RAM. Optional.
+    pub load_address: Option<u32>,
     /// Address of the `Init()` entry point. Optional.
     pub pc_init: Option<u32>,
     /// Address of the `UnInit()` entry point. Optional.

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -45,6 +45,10 @@ pub enum FlashError {
         "The RAM contents did not match the expected contents after loading the flash algorithm."
     )]
     FlashAlgorithmNotLoaded,
+    #[error(
+        "Failed to load flash algorithm into RAM at address {addr:08X?}. Is there space for the algorithm header?"
+    )]
+    InvalidFlashAlgorithmLoadAddress { addr: u32 },
 
     // TODO: Warn at YAML parsing stage.
     // TODO: 1 Add information about flash (name, address)

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -208,37 +208,37 @@ impl FlashAlgorithm {
         let mut addr_stack = 0;
         let mut addr_load = 0;
         let mut addr_data = 0;
+        let mut code_start = 0;
 
         // Try to find a stack size that fits with at least one page of data.
         for i in 0..Self::FLASH_ALGO_STACK_SIZE / Self::FLASH_ALGO_STACK_DECREMENT {
-            offset = Self::FLASH_ALGO_STACK_SIZE - Self::FLASH_ALGO_STACK_DECREMENT * i;
-            // Stack address
-            addr_stack = ram_region.range.start + offset;
             // Load address
-            addr_load = addr_stack;
+            addr_load = raw.load_address.unwrap_or(ram_region.range.start);
+            offset += (header.len() * size_of::<u32>()) as u32;
+            code_start = addr_load + offset;
             offset += (instructions.len() * size_of::<u32>()) as u32;
 
+            addr_stack = addr_load + offset + (Self::FLASH_ALGO_STACK_SIZE - Self::FLASH_ALGO_STACK_DECREMENT * i);
+
             // Data buffer 1
-            addr_data = ram_region.range.start + offset;
+            addr_data = addr_stack;
             offset += raw.flash_properties.page_size;
 
-            if offset <= ram_region.range.end - ram_region.range.start {
+            if offset <= ram_region.range.end - addr_load {
                 break;
             }
         }
 
         // Data buffer 2
-        let addr_data2 = ram_region.range.start + offset;
+        let addr_data2 = addr_data + raw.flash_properties.page_size;
         offset += raw.flash_properties.page_size;
 
         // Determine whether we can use double buffering or not by the remaining RAM region size.
-        let page_buffers = if offset <= ram_region.range.end - ram_region.range.start {
+        let page_buffers = if offset <= ram_region.range.end - addr_load {
             vec![addr_data, addr_data2]
         } else {
             vec![addr_data]
         };
-
-        let code_start = addr_load + (header.len() * size_of::<u32>()) as u32;
 
         let name = raw.name.clone();
 

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -215,8 +215,11 @@ impl FlashAlgorithm {
             // Load address
             addr_load = raw
                 .load_address
-                .map(|a| a - (header.len() * size_of::<u32>()) as u32) // adjust the raw load address to account for the algo header
-                .unwrap_or(ram_region.range.start);
+                .map(|a| {
+                    a.checked_sub((header.len() * size_of::<u32>()) as u32) // adjust the raw load address to account for the algo header
+                        .ok_or(FlashError::InvalidFlashAlgorithmLoadAddress { addr: addr_load })
+                })
+                .unwrap_or(Ok(ram_region.range.start))?;
             if addr_load < ram_region.range.start {
                 return Err(FlashError::InvalidFlashAlgorithmLoadAddress { addr: addr_load });
             }


### PR DESCRIPTION
* Add optional `load_address` to the raw yaml target def to allow for non PIC flash loaders.
* Modify stack size finding algo, to place stack after instruction code.

### Questions

- `load_address` currently includes the arch header - so in my WIP flash loader, I have to offset to account for this (riscv is 8byte long), perhaps it should be `code_start` and probe-rs will load the header before it (if it can, what happens if you specify the beginning of ram as the code start?)
- Should this be limited to RISCV? I think the cmsis spec for arm flash loaders dictates that they must be PIC.