### PR TITLE
Add `probe-rs-cli run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for the built in JTAG on the ESP32C3 and other ESP32 devices (#863).
 - Added name field to memory regions. (#864)
 - debugger: Show progress notification while device is being flashed. (#871, #884)
+- Add optional ability to load fixed address flashing algorithms (non PIC). (#822)
+- Added `probe-rs-cli run` command, to flash and run a binary showing RTT output.
 
 ### Removed
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,6 +2,7 @@ mod common;
 mod debugger;
 mod gdb;
 mod info;
+mod run;
 
 use debugger::CliState;
 
@@ -128,7 +129,21 @@ enum Cli {
         #[structopt(flatten)]
         common: ProbeOptions,
     },
+    /// Flash and run an ELF program
+    #[structopt(name = "run")]
+    Run {
+        #[structopt(flatten)]
+        common: ProbeOptions,
+
+        /// The path to the ELF file to flash and run
+        path: String,
+
+        /// Whether to erase the entire chip before downloading
+        #[structopt(long)]
+        chip_erase: bool,
+    },
     /// Trace a memory location on the target
+    #[structopt(name = "trace")]
     Trace {
         #[structopt(flatten)]
         shared: CoreOptions,
@@ -210,6 +225,11 @@ fn main() -> Result<()> {
             chip_erase,
             disable_progressbars,
         ),
+        Cli::Run {
+            common,
+            path,
+            chip_erase,
+        } => run::run(common, &path, chip_erase),
         Cli::Erase { common } => erase(&common),
         Cli::Trace {
             shared,

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -1,0 +1,44 @@
+use anyhow::{Context, Result};
+use probe_rs::flashing::FileDownloadError;
+use probe_rs_cli_util::common_options::{CargoOptions, FlashOptions, ProbeOptions};
+use probe_rs_cli_util::flash::run_flash_download;
+use std::fs::File;
+use std::path::Path;
+
+pub fn run(common: ProbeOptions, path: &str, chip_erase: bool) -> Result<()> {
+    let mut session = common.simple_attach()?;
+
+    let mut file = match File::open(path) {
+        Ok(file) => file,
+        Err(e) => return Err(FileDownloadError::IO(e)).context("Failed to open binary file."),
+    };
+
+    let mut loader = session.target().flash_loader();
+    loader.load_elf_data(&mut file)?;
+
+    run_flash_download(
+        &mut session,
+        Path::new(path),
+        &FlashOptions {
+            version: false,
+            list_chips: false,
+            list_probes: false,
+            disable_progressbars: false,
+            reset_halt: false,
+            log: None,
+            restore_unwritten: false,
+            flash_layout_output_path: None,
+            elf: None,
+            work_dir: None,
+            cargo_options: CargoOptions::default(),
+            probe_options: common,
+        },
+        loader,
+        chip_erase,
+    )?;
+
+    let mut core = session.core(0)?;
+    core.reset()?;
+
+    Ok(())
+}

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "probe-rs-debugger"
 version = "0.12.0"
-authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Dominik Boehi <dominik.boehi@gmail.ch>", "Jack Noppe <noppej@hotmail.com>"]
+authors = [
+    "Noah Hüsser <yatekii@yatekii.ch>",
+    "Dominik Boehi <dominik.boehi@gmail.ch>",
+    "Jack Noppe <noppej@hotmail.com>",
+]
 edition = "2021"
 description = "An interface (CLI or DAP Server) on top of the debug probe capabilities provided by probe-rs."
 documentation = "https://docs.rs/probe-rs/"
@@ -16,8 +20,8 @@ license = "MIT OR Apache-2.0"
 ftdi = ["probe-rs/ftdi"]
 
 [dependencies]
-probe-rs = { version = "0.12.0", path = "../probe-rs"}
-probe-rs-rtt = { version = "0.12.0", path = "../rtt"}
+probe-rs = { version = "0.12.0", path = "../probe-rs" }
+probe-rs-cli-util = { version = "0.12.0", path = "../probe-rs-cli-util" }
 
 env_logger = "0.9.0"
 log = "0.4.6"
@@ -37,7 +41,6 @@ serde = { version = "^1.0", features = ["derive"] }
 schemafy = "^0.6"
 chrono = { version = "0.4", features = ["serde"] }
 goblin = "0.4.1"
-defmt-decoder = { version = "0.2.1", features = ["unstable"] }
 
 [dev-dependencies]
 insta = "1.8.0"

--- a/debugger/src/dap_types.rs
+++ b/debugger/src/dap_types.rs
@@ -2,6 +2,7 @@
 use crate::DebuggerError;
 use num_traits::Num;
 use parse_int::parse;
+use probe_rs_cli_util::rtt;
 use schemafy::schemafy;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -29,7 +30,7 @@ pub struct QuitRequest {
 pub struct RttChannelEventBody {
     pub channel_number: usize,
     pub channel_name: String,
-    pub data_format: crate::rtt::DataFormat,
+    pub data_format: rtt::DataFormat,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -1,7 +1,7 @@
+use crate::dap_types;
 use crate::debugger::ConsoleLog;
 use crate::debugger::CoreData;
 use crate::DebuggerError;
-use crate::{dap_types, rtt::DataFormat};
 use anyhow::{anyhow, Result};
 use dap_types::*;
 use parse_int::parse;
@@ -9,6 +9,7 @@ use probe_rs::{
     debug::{ColumnType, VariableKind},
     CoreStatus, HaltReason, MemoryInterface,
 };
+use probe_rs_cli_util::rtt;
 use serde::{de::DeserializeOwned, Serialize};
 
 use std::{collections::HashMap, string::ToString};
@@ -1211,7 +1212,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         &mut self,
         channel_number: usize,
         channel_name: String,
-        data_format: DataFormat,
+        data_format: rtt::DataFormat,
     ) -> bool {
         if self.adapter_type() == DebugAdapterType::DapClient {
             let event_body = match serde_json::to_value(RttChannelEventBody {

--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -4,7 +4,6 @@ mod debug_adapter;
 mod debugger;
 mod info;
 mod protocol;
-mod rtt;
 
 use anyhow::Result;
 use clap::{crate_authors, crate_description, crate_name, crate_version, Parser};

--- a/probe-rs-cli-util/Cargo.toml
+++ b/probe-rs-cli-util/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "probe-rs-cli-util"
 version = "0.12.0"
-authors = ["Noah Hüsser <yatekii@yatekii.ch", "Dominik Boehi <dominik.boehi@gmail.com>"]
+authors = [
+    "Noah Hüsser <yatekii@yatekii.ch",
+    "Dominik Boehi <dominik.boehi@gmail.com>",
+]
 edition = "2021"
 description = "Helper library for CLI applications based on probe-rs."
 documentation = "https://docs.rs/probe-rs-cli-util/"
@@ -16,6 +19,9 @@ license = "MIT OR Apache-2.0"
 default = ["anyhow"]
 
 [dependencies]
+probe-rs-rtt = { path = "../rtt" }
+probe-rs = { version = "0.12.0", path = "../probe-rs" }
+
 thiserror = "1.0"
 anyhow = { version = "1.0", optional = true }
 indicatif = "0.16.0"
@@ -23,9 +29,8 @@ env_logger = "0.9.0"
 log = "0.4.0"
 once_cell = "1.7.2"
 colored = "2.0.0"
-probe-rs = { version = "0.12.0", path = "../probe-rs" }
 cargo_toml = "0.11.1"
-serde = { version = "1.0.115", features = [ "derive" ] }
+serde = { version = "1.0.115", features = ["derive"] }
 cargo_metadata = "0.14.0"
 dunce = "1.0.1"
 sentry = { version = "0.23.0", features = ["anyhow"], optional = true }
@@ -33,3 +38,7 @@ simplelog = "0.11.0"
 terminal_size = "0.1.13"
 clap = { version = "3.0", features = ["derive"] }
 byte-unit = "4.0.13"
+chrono = { version = "0.4", features = ["serde"] }
+goblin = "0.4.1"
+num-traits = "0.2.14"
+defmt-decoder = { version = "0.2.1", features = ["unstable"] }

--- a/probe-rs-cli-util/src/lib.rs
+++ b/probe-rs-cli-util/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod common_options;
 pub mod flash;
 pub mod logging;
+pub mod rtt;
 
 use cargo_toml::Manifest;
 use serde::Deserialize;


### PR DESCRIPTION
Add a `probe-rs-cli run` command.

The goal is a simpler-to-use `cargo-embed` alternative that doesn't require a configuration file.

Coming in future PRs:

- Break on HardFault
- Stack trace on HardFault or Control+C
- RTT input support (keystrokes are sent to the target).

[relevant XKCD](https://xkcd.com/927/)