### PR TITLE
Improve flash data load times

### DIFF
--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -50,6 +50,9 @@ pub enum FlashError {
     )]
     InvalidFlashAlgorithmLoadAddress { addr: u32 },
 
+    #[error("Invalid page size {size:08X?}. Must be a multiple of 4 bytes.")]
+    InvalidPageSize { size: u32 },
+
     // TODO: Warn at YAML parsing stage.
     // TODO: 1 Add information about flash (name, address)
     // TODO: 2 Add source of target definition (built-in, yaml)

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -186,6 +186,13 @@ impl FlashAlgorithm {
     ) -> Result<Self, FlashError> {
         use std::mem::size_of;
 
+        if raw.flash_properties.page_size % 4 != 0 {
+            // TODO move to yaml validation
+            return Err(FlashError::InvalidPageSize {
+                size: raw.flash_properties.page_size,
+            });
+        }
+
         let assembled_instructions = raw.instructions.chunks_exact(size_of::<u32>());
 
         if !assembled_instructions.remainder().is_empty() {

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -805,11 +805,22 @@ impl<'p> ActiveFlasher<'p, Program> {
         );
 
         // TODO: Prevent security settings from locking the device.
-
         // Transfer the buffer bytes to RAM.
+        let words: Vec<u32> = bytes
+            .chunks_exact(core::mem::size_of::<u32>())
+            .map(|a| u32::from_le_bytes([a[0], a[1], a[2], a[3]]))
+            .collect();
+
+        let t1 = std::time::Instant::now();
         self.core
-            .write_8(algo.page_buffers[buffer_number], bytes)
+            .write_32(algo.page_buffers[buffer_number], &words)
             .map_err(FlashError::Core)?;
+
+        log::info!(
+            "Took {:?} to download {} byte page into ram",
+            t1.elapsed(),
+            bytes.len()
+        );
 
         Ok(())
     }


### PR DESCRIPTION
I was trying to improve my flash loading algorithm for the esp32c3 and found even when boosting clocks, switching to qio mode for the spi flash the speed would not improve. It took me a while to track down, because I assumed everything in probe-rs was okay, as running the `ram_download` example yielded good results.

Eventually I spotted that the flash data (note: not algorithm) was loaded one byte at a time instead of words. This PR changes that to write words.

Time to load 256byte page _before_: 250ms~
Time to load 256byte page _after_: 25ms~