### PR TITLE
Prefer `read` over `read_8`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Debug` was reimplemented on `Session` (#795).
 - Target YAMLs: Changed `flash_algorithms` from a map to an array. (#813)
 - Reject ambiguous chip selection.
+- Prefer using `read` over `read_8` for better performance and compatibility. (#829)
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -57,7 +57,7 @@ impl DebugCli {
 
                 let mut code = [0u8; 16 * 2];
 
-                cli_data.core.read_8(cpu_info.pc, &mut code)?;
+                cli_data.core.read(cpu_info.pc, &mut code)?;
 
                 /*
                 let instructions = cli_data
@@ -313,7 +313,7 @@ impl DebugCli {
 
                 let mut stack = vec![0u8; (stack_top - stack_bot) as usize];
 
-                cli_data.core.read_8(stack_bot, &mut stack[..])?;
+                cli_data.core.read(stack_bot, &mut stack[..])?;
 
                 let mut dump = Dump::new(stack_bot, stack);
 

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -143,7 +143,7 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
         /*
         let mut code = [0u8; 16 * 2];
 
-        core_data.target_core.read_8(cpu_info.pc, &mut code)?;
+        core_data.target_core.read(cpu_info.pc, &mut code)?;
 
         let instructions = core_data
             .capstone
@@ -299,7 +299,7 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
 
         // let mut stack = vec![0u8; (stack_top - stack_bot) as usize];
 
-        // core_data.target_core.read_8(stack_bot, &mut stack[..])?;
+        // core_data.target_core.read(stack_bot, &mut stack[..])?;
 
         // let mut dump = Dump::new(stack_bot, stack);
 

--- a/gdb-server/src/handlers.rs
+++ b/gdb-server/src/handlers.rs
@@ -238,7 +238,7 @@ pub(crate) fn write_register(register: u32, hex_value: &str, mut core: Core) -> 
 
 pub(crate) fn read_memory(address: u32, length: u32, mut core: Core) -> Option<String> {
     let mut readback_data = vec![0u8; length as usize];
-    match core.read_8(address, &mut readback_data) {
+    match core.read(address, &mut readback_data) {
         Ok(_) => Some(
             readback_data
                 .iter()

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -414,7 +414,7 @@ impl<'debuginfo, 'probe, 'core> Iterator for StackFrameIterator<'debuginfo, 'pro
 
                         let mut buff = [0u8; 4];
 
-                        if let Err(e) = self.core.read_8(addr as u32, &mut buff) {
+                        if let Err(e) = self.core.read(addr as u32, &mut buff) {
                             log::info!(
                                 "Failed to read from address {:#010x} ({} bytes): {}",
                                 addr,
@@ -1110,7 +1110,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 Complete => break,
                 RequiresMemory { address, size, .. } => {
                     let mut buff = vec![0u8; size as usize];
-                    core.read_8(address as u32, &mut buff).map_err(|_| {
+                    core.read(address as u32, &mut buff).map_err(|_| {
                         DebugError::Other(anyhow::anyhow!("Unexpected error while reading debug expressions from target memory. Please report this as a bug."))
                     })?;
                     match size {
@@ -1718,7 +1718,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                         };
                                         // Now, retrieve the location by reading the adddress pointed to by the parent variable.
                                         let mut buff = [0u8; 4];
-                                        core.read_8(
+                                        core.read(
                                             child_variable.memory_location as u32,
                                             &mut buff,
                                         )?;
@@ -1790,7 +1790,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 };
                 // NOTE: hard-coding value of variable.byte_size to 1 ... replace with code if necessary.
                 let mut buff = [0u8; 1];
-                core.read_8(child_variable.memory_location as u32, &mut buff)?;
+                core.read(child_variable.memory_location as u32, &mut buff)?;
                 let this_enum_const_value = u8::from_le_bytes(buff).to_string();
                 let enumumerator_value =
                     match enumerator_values.into_iter().find(|enumerator_variable| {
@@ -2219,7 +2219,7 @@ pub(crate) fn _print_all_attributes(
                         Complete => break,
                         RequiresMemory { address, size, .. } => {
                             let mut buff = vec![0u8; size as usize];
-                            core.read_8(address as u32, &mut buff)
+                            core.read(address as u32, &mut buff)
                                 .expect("Failed to read memory");
                             match size {
                                 1 => evaluation

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -355,7 +355,7 @@ impl Value for String {
                     str_value = "ERROR: Failed to determine &str memory location".to_string();
                 } else {
                     let mut buff = vec![0u8; string_length];
-                    core.read_8(string_location as u32, &mut buff)?;
+                    core.read(string_location as u32, &mut buff)?;
                     str_value = core::str::from_utf8(&buff)?.to_owned();
                 }
             }
@@ -369,7 +369,7 @@ impl Value for String {
 impl Value for i8 {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 1];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = i8::from_le_bytes(buff);
         Ok(ret_value)
     }
@@ -377,7 +377,7 @@ impl Value for i8 {
 impl Value for i16 {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 2];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = i16::from_le_bytes(buff);
         Ok(ret_value)
     }
@@ -385,7 +385,7 @@ impl Value for i16 {
 impl Value for i32 {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 4];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = i32::from_le_bytes(buff);
         Ok(ret_value)
     }
@@ -393,7 +393,7 @@ impl Value for i32 {
 impl Value for i64 {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 8];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = i64::from_le_bytes(buff);
         Ok(ret_value)
     }
@@ -401,7 +401,7 @@ impl Value for i64 {
 impl Value for i128 {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 16];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = i128::from_le_bytes(buff);
         Ok(ret_value)
     }
@@ -409,7 +409,7 @@ impl Value for i128 {
 impl Value for isize {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 4];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         // TODO: how to get the MCU isize calculated for all platforms.
         let ret_value = i32::from_le_bytes(buff);
         Ok(ret_value as isize)
@@ -419,7 +419,7 @@ impl Value for isize {
 impl Value for u8 {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 1];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = u8::from_le_bytes(buff);
         Ok(ret_value)
     }
@@ -427,7 +427,7 @@ impl Value for u8 {
 impl Value for u16 {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 2];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = u16::from_le_bytes(buff);
         Ok(ret_value)
     }
@@ -435,7 +435,7 @@ impl Value for u16 {
 impl Value for u32 {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 4];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = u32::from_le_bytes(buff);
         Ok(ret_value)
     }
@@ -443,7 +443,7 @@ impl Value for u32 {
 impl Value for u64 {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 8];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = u64::from_le_bytes(buff);
         Ok(ret_value)
     }
@@ -451,7 +451,7 @@ impl Value for u64 {
 impl Value for u128 {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 16];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = u128::from_le_bytes(buff);
         Ok(ret_value)
     }
@@ -459,7 +459,7 @@ impl Value for u128 {
 impl Value for usize {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 4];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         // TODO: how to get the MCU usize calculated for all platforms.
         let ret_value = u32::from_le_bytes(buff);
         Ok(ret_value as usize)
@@ -468,7 +468,7 @@ impl Value for usize {
 impl Value for f32 {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 4];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = f32::from_le_bytes(buff);
         Ok(ret_value)
     }
@@ -476,7 +476,7 @@ impl Value for f32 {
 impl Value for f64 {
     fn get_value(variable: &Variable, core: &mut Core<'_>) -> Result<Self, DebugError> {
         let mut buff = [0u8; 8];
-        core.read_8(variable.memory_location as u32, &mut buff)?;
+        core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = f64::from_le_bytes(buff);
         Ok(ret_value)
     }

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -305,7 +305,7 @@ impl<'session> Flasher<'session> {
         self.run_verify(|active| {
             active
                 .core
-                .read_8(fill.address(), page_slice)
+                .read(fill.address(), page_slice)
                 .map_err(FlashError::Core)
         })
     }

--- a/rtt/src/channel.rs
+++ b/rtt/src/channel.rs
@@ -202,7 +202,7 @@ impl UpChannel {
                 break;
             }
 
-            core.read_8(self.0.buffer_ptr + read, &mut buf[..count])?;
+            core.read(self.0.buffer_ptr + read, &mut buf[..count])?;
 
             total += count;
             read += count as u32;
@@ -381,7 +381,7 @@ fn read_c_string(
 
     // Read up to 128 bytes not going past the end of the region
     let mut bytes = vec![0u8; min(128, (range.end - ptr) as usize)];
-    core.read_8(ptr, bytes.as_mut())?;
+    core.read(ptr, bytes.as_mut())?;
 
     let return_value = bytes
         .iter()

--- a/rtt/src/rtt.rs
+++ b/rtt/src/rtt.rs
@@ -54,7 +54,7 @@ impl Rtt {
             None => {
                 // If memory wasn't passed in, read the minimum header size
                 let mut mem = vec![0u8; Self::MIN_SIZE];
-                core.read_8(ptr, &mut mem)?;
+                core.read(ptr, &mut mem)?;
                 Cow::Owned(mem)
             }
         };
@@ -88,7 +88,7 @@ impl Rtt {
         if let Cow::Owned(mem) = &mut mem {
             // If memory wasn't passed in, read the rest of the control block
             mem.resize(cb_len, 0);
-            core.read_8(
+            core.read(
                 ptr + Self::MIN_SIZE as u32,
                 &mut mem[Self::MIN_SIZE..cb_len],
             )?;
@@ -187,7 +187,7 @@ impl Rtt {
 
             mem.resize(range.len(), 0);
             {
-                core.read_8(range.start, mem.as_mut())?;
+                core.read(range.start, mem.as_mut())?;
             }
 
             for offset in 0..(mem.len() - Self::MIN_SIZE) {


### PR DESCRIPTION
* Both API's allow the reading for target memory into a byte slice, however `read` will use Word access under the hood for better performance. 
* Not all targets have byte level access to system memory, however word access is pretty much guaranteed (this is the case for the esp32c3).