### PR TITLE
Add flash algo for GD32VF1_Series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial support for batched commands for J-Link (#515).
 - Added support for the STM32F2 family (#675).
 - Added support for FE310-G002 (HiFive1 Rev. B).
+- Added flash algorithm for GD32VF1 family (#830).
 
 ### Changed
 

--- a/probe-rs/targets/GD32VF1_Series.yaml
+++ b/probe-rs/targets/GD32VF1_Series.yaml
@@ -21,5 +21,30 @@ variants:
           is_boot_memory: true
           cores:
             - main
-    flash_algorithms: []
-flash_algorithms: []
+    flash_algorithms:
+      - gd32vf103
+flash_algorithms:
+  - name: gd32vf103
+    description: GD32VF103 128 KB internal flash
+    cores:
+      - main
+    default: true
+    instructions: tyUCQAlGkMnIyYhJE2UFBBOGBQEIwshFBYl1/bclAkAjqAUAyEURiRHlyEUTdgUBAUUBxlFFyMUFRYKANxUCQAxBk+UVAAzBDEGJifXdNxUCQExB8ZkTBkUADMJMQbGJ9f03FQJADEE3BgD/fRbxjQzBTEE3xsLfPQbxjTcGKCATBgZA0Y1MwQxBNwYAAdGNDMG3BQACEEFtjnXeNxUCQExB8ZmT5SUAEwZFAAzCoUVQQTGK4x62/jclAkAMSZP1BQiZybcFZ0WThTUSTMG3le/Nk4W1mkzBAUWCgIFGNycCQIVHHMuT98X/Mwj2AIXNYwsGA4MoBgD9FZOXJgCqlyOgFwFcR4WL9f9cR5GLkedcRxEGwYuFBvnbNyUCQCMiBQAFRYKAAUWCgDclAkCTBQAIDMkBRYKAAAAAAA==
+    pc_init: 60
+    pc_uninit: 298
+    pc_program_page: 220
+    pc_erase_sector: 0
+    pc_erase_all: ~
+    data_section_offset: 312
+    flash_properties:
+      address_range:
+        start: 0x8000000
+        end: 0x8020000
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 100
+      erase_sector_timeout: 6000
+      sectors:
+        - size: 1024
+          address: 0
+


### PR DESCRIPTION
This is a very basic flash algorithm for the GD32VF1 series.
The source for the algo is here: https://github.com/9names/gd32vf103-flashloader
It was only (briefly) tested on the GD32VF103CBT6 as found on the longan-nano.
Flash and verify was confirmed using both probe-rs and segger's tools.
probe-rs needed patching to ignore failure when attempting to reset the chip, since this microcontroller does not conform to the riscv debug spec and we haven't added the sequences to reset it yet.