### PR TITLE
Add STM32WL55JCIx target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added progress bars to the probe-rs-cli download command. (#776)
 - Improve reliability of communication with the RISCV debug module by recovering from busy errors in batch operations. (#802)
 - Add optional ability to load fixed address flashing algorithms (non PIC). (#822)
+- Added STM32WL55JCIx target. (#835)
 
 ### Removed
 

--- a/probe-rs/targets/STM32WL_Series.yaml
+++ b/probe-rs/targets/STM32WL_Series.yaml
@@ -76,6 +76,39 @@ variants:
             - main
     flash_algorithms:
       - stm32wlxx_cm4
+  - name: STM32WL55JCIx
+    cores:
+      - name: application
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0x0
+            psel: 0x0
+      - name: network
+        type: armv6m
+        core_access_options:
+          Arm:
+            ap: 0x1
+            psel: 0x0
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20010000
+          is_boot_memory: false
+          cores:
+            - application
+            - network
+      - Nvm:
+          range:
+            start: 0x8000000
+            end: 0x8040000
+          is_boot_memory: true
+          cores:
+            - application
+            - network
+    flash_algorithms:
+      - stm32wlxx_cm4
 flash_algorithms:
   - name: stm32wlexx_64
     description: STM32WLE4x Flash


### PR DESCRIPTION
Per [RM0453 Rev 2](https://www.st.com/resource/en/reference_manual/rm0453-stm32wl5x-advanced-armbased-32bit-mcus-with-subghz-radio-solution-stmicroelectronics.pdf) page 1331:


> 0x0: AP0 - CPU1 (Cortex-M4) debug access port (AHB-AP)
> 0x1: AP1 - CPU2 (Cortex-M0+) debug access port (AHB-AP)

I have confirmed that this can communicate with both cores.