### PR TITLE
Improved the timing and reliability of when RTT is initialized in `probe-rs-debugger`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject ambiguous chip selection.
 - Prefer using `read` over `read_8` for better performance and compatibility. (#829)
 - Increased default RTT Timeout (retry waiting for RTT Control Block initialization) to 1000ms in `probe-rs-debugger`. (#847)
+- Improved when RTT is initialized/retried, and removed `rtt_timeout` from recognized options of `probe-rs-debugger`. (#850)
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).

--- a/debugger/src/rtt.rs
+++ b/debugger/src/rtt.rs
@@ -20,10 +20,6 @@ fn default_channel_formats() -> Vec<RttChannelConfig> {
     vec![]
 }
 
-fn default_rtt_timeout() -> usize {
-    1000
-}
-
 #[derive(Debug, Copy, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum DataFormat {
     String,
@@ -56,10 +52,6 @@ pub struct RttConfig {
     #[structopt(skip)]
     #[serde(default, rename = "rtt_enabled")]
     pub enabled: bool,
-    /// Connection timeout in ms.
-    #[structopt(skip)]
-    #[serde(default = "default_rtt_timeout", rename = "rtt_timeout")]
-    pub timeout: usize,
     /// Configure data_format and show_timestamps for select channels
     #[structopt(skip)]
     #[serde(default = "default_channel_formats", rename = "rtt_channel_formats")]


### PR DESCRIPTION
Improved the timing and reliability of when RTT is initialized/retried, and removed `rtt_timeout` from recognized options of `probe-rs-debugger`.

Previously, host side RTT initialization was retried with a timeout value, in an attempt to let the target processing proceed from startup until post target side RTT initialization.  This will ALWAYS fail if there are breakpoints or exceptions in the code ahead of RTT initialization.

To overcome this, host side RTT initialization now works as follows:
- Provided that the `launch.json` is set with `rtt_enabled:true` ...
- First attempt is after MS DAP "configuration_done" request.
- Try again, one attempt for every idle cycle of the debugger, when the target is NOT halted, and until it succeeds. 
- Failures are silently ignored and logged with a `log::warn!()`.

This strategy allows for various delays on the target side (exceptions, breakpoints, triggers, etc.) and will initialize host side on the first available opportunity after the client side RTT initialization is complete. 

Note: Any settings of `rtt_timeout` in `launch.json` will be silently ignored, and will be removed from the VS Code extension on next release.
