### PR TITLE
Add all RAM regions to STM32H7 parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add esp32.yaml with esp32c3 variant. (#846)
 - Added target definition validation to make handling inside probe-rs easier by making some basic assumptions about the validity of the used `ChipFamily` without always checking again. (#848)
 - Added STM32U5 series target.
+- Added all RAM regions to most STM32H7 parts. (#864)
+- Added name field to memory regions. (#864)
 
 ### Removed
 

--- a/probe-rs-target/src/memory.rs
+++ b/probe-rs-target/src/memory.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 /// Represents a region in non-volatile memory (e.g. flash or EEPROM).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NvmRegion {
+    /// A name to describe the region
+    pub name: Option<String>,
     /// Address range of the region
     pub range: Range<u32>,
     /// True if the chip boots from this memory
@@ -24,6 +26,8 @@ impl NvmRegion {
 /// Represents a region in RAM.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RamRegion {
+    /// A name to describe the region
+    pub name: Option<String>,
     /// Address range of the region
     pub range: Range<u32>,
     /// True if the chip boots from this memory
@@ -35,6 +39,8 @@ pub struct RamRegion {
 /// Represents a generic region.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GenericRegion {
+    /// A name to describe the region
+    pub name: Option<String>,
     /// Address range of the region
     pub range: Range<u32>,
     /// List of cores that can access this region

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -387,6 +387,7 @@ mod tests {
         };
 
         let region = NvmRegion {
+            name: Some("FLASH".into()),
             is_boot_memory: true,
             range: 0..1 << 16,
             cores: vec!["main".into()],
@@ -412,6 +413,7 @@ mod tests {
         };
 
         let region = NvmRegion {
+            name: Some("FLASH".into()),
             is_boot_memory: true,
             range: 0..1 << 16,
             cores: vec!["main".into()],

--- a/probe-rs/targets/STM32H7_Series.yaml
+++ b/probe-rs/targets/STM32H7_Series.yaml
@@ -10,18 +10,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -84,18 +84,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -158,18 +158,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -232,18 +232,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -306,18 +306,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -380,18 +380,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -454,18 +454,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -528,18 +528,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -602,18 +602,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -676,18 +676,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -750,18 +750,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -824,18 +824,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -898,18 +898,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -972,18 +972,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -1046,18 +1046,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -1120,18 +1120,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -1194,18 +1194,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -1276,18 +1276,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -1358,18 +1358,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -1440,18 +1440,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -1522,18 +1522,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -1604,18 +1604,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -1686,18 +1686,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -1768,18 +1768,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -1850,18 +1850,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -1932,18 +1932,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2014,18 +2014,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2096,18 +2096,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2178,18 +2178,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2260,18 +2260,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2342,18 +2342,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2424,18 +2424,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2506,18 +2506,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2588,18 +2588,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2670,18 +2670,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2752,18 +2752,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2834,18 +2834,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2916,18 +2916,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -2998,18 +2998,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -3080,18 +3080,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -3162,18 +3162,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -3244,18 +3244,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -3326,18 +3326,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -3408,18 +3408,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -3490,18 +3490,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -3572,18 +3572,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -3654,18 +3654,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -3736,18 +3736,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -3818,18 +3818,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -3900,18 +3900,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -3982,18 +3982,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -4064,18 +4064,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -4146,18 +4146,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -4228,18 +4228,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -4310,18 +4310,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -4392,18 +4392,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -4474,18 +4474,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -4556,18 +4556,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -4638,18 +4638,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -4720,18 +4720,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -4802,18 +4802,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -4884,18 +4884,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -4966,18 +4966,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -5048,18 +5048,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -5130,18 +5130,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -5212,18 +5212,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -5294,18 +5294,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -5376,18 +5376,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -5458,18 +5458,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -5540,18 +5540,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -5622,18 +5622,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -5704,18 +5704,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -5786,18 +5786,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main
@@ -5868,18 +5868,18 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
-          name: DTCM
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - Ram:
           name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
           is_boot_memory: false
           cores:
             - main

--- a/probe-rs/targets/STM32H7_Series.yaml
+++ b/probe-rs/targets/STM32H7_Series.yaml
@@ -10,9 +10,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -35,9 +84,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -60,9 +158,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -85,9 +232,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -110,9 +306,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -135,9 +380,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -160,9 +454,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -185,9 +528,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -210,9 +602,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -235,9 +676,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -260,9 +750,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -285,9 +824,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -310,9 +898,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -335,9 +972,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -360,9 +1046,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -385,9 +1120,58 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24060000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30008000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -410,9 +1194,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -435,9 +1276,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -460,9 +1358,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -485,9 +1440,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -510,9 +1522,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -535,9 +1604,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -560,9 +1686,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -585,9 +1768,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -610,9 +1850,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -635,9 +1932,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -660,9 +2014,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -685,9 +2096,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -710,9 +2178,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -735,9 +2260,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -760,9 +2342,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -785,9 +2424,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -810,9 +2506,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -835,9 +2588,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -860,9 +2670,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -885,9 +2752,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -910,9 +2834,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -935,9 +2916,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -960,9 +2998,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -985,9 +3080,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1010,9 +3162,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1035,9 +3244,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1060,9 +3326,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1085,9 +3408,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1110,9 +3490,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1135,9 +3572,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1160,9 +3654,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1185,9 +3736,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1210,9 +3818,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1235,9 +3900,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1260,9 +3982,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1285,9 +4064,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1310,9 +4146,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1335,9 +4228,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1360,9 +4310,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1385,9 +4392,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1410,9 +4474,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1435,9 +4556,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1460,9 +4638,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1485,9 +4720,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1510,9 +4802,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1535,9 +4884,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1560,9 +4966,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1585,9 +5048,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1610,9 +5130,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1635,9 +5212,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1660,9 +5294,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1685,9 +5376,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1710,9 +5458,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1735,9 +5540,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1760,9 +5622,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1785,9 +5704,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1810,9 +5786,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main
@@ -1835,9 +5868,66 @@ variants:
             psel: 0x0
     memory_map:
       - Ram:
+          name: DTCM
+          range:
+            start: 0x20000000
+            end: 0x20020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: AXI-SRAM
           range:
             start: 0x24000000
             end: 0x24080000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM1
+          range:
+            start: 0x30000000
+            end: 0x30020000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM2
+          range:
+            start: 0x30020000
+            end: 0x30040000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM3
+          range:
+            start: 0x30040000
+            end: 0x30048000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: SRAM4
+          range:
+            start: 0x38000000
+            end: 0x38010000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: BSRAM
+          range:
+            start: 0x38800000
+            end: 0x38801000
+          is_boot_memory: false
+          cores:
+            - main
+      - Ram:
+          name: ITCM
+          range:
+            start: 0x00000000
+            end: 0x00010000
           is_boot_memory: false
           cores:
             - main


### PR DESCRIPTION
Covers all of them except for the H7A3/H7B3 parts. ST didn't put the memory map into the reference manual so I didn't bother.

One issue I ran into is that [`Flasher::new()` uses the first RAM region found](https://github.com/probe-rs/probe-rs/blob/4ba46f40f436e8cec452ce4a5ae570b21d26d156/probe-rs/src/flashing/flasher.rs#L69-L83). When DTCM was the first RAM in the list, flashing would fail sporadically or the program would fail soon after startup. I moved the AXI-SRAM back to the start of the list to work around this. I'm not familiar enough with the flashing algorithms to know if there's a more principled solution. Should the flash algo specify which RAM region it wants to use? 