### PR TITLE
debugger: Initial refactoring of protocol specific code into module

### DIFF
--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -38,3 +38,6 @@ schemafy = "^0.6"
 chrono = { version = "0.4", features = ["serde"] }
 goblin = "0.4.1"
 defmt-decoder = { version = "0.2.1", features = ["unstable"] }
+
+[dev-dependencies]
+insta = "1.8.0"

--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -3,6 +3,7 @@ mod dap_types;
 mod debug_adapter;
 mod debugger;
 mod info;
+mod protocol;
 mod rtt;
 
 use anyhow::Result;
@@ -50,10 +51,7 @@ pub enum DebuggerError {
         original_error: std::io::Error,
     },
     #[error("IO error: '{original_error}'.")]
-    NonBlockingReadError {
-        os_error_number: i32,
-        original_error: std::io::Error,
-    },
+    NonBlockingReadError { original_error: std::io::Error },
     #[error(transparent)]
     StdIO(#[from] std::io::Error),
     #[error("Unable to open probe{}", .0.map(|s| format!(": {}", s)).as_deref().unwrap_or("."))]

--- a/debugger/src/protocol.rs
+++ b/debugger/src/protocol.rs
@@ -1,0 +1,743 @@
+use crate::debug_adapter::{DapStatus, DebugAdapterType};
+use crate::debugger::ConsoleLog;
+use crate::DebuggerError;
+use probe_rs::CoreStatus;
+use rustyline::error::ReadlineError;
+use rustyline::Editor;
+use serde::Serialize;
+use serde_json::json;
+use std::string::ToString;
+use std::{
+    io::{BufRead, BufReader, Read, Write},
+    str,
+};
+
+use crate::dap_types::{
+    Event, MessageSeverity, OutputEventBody, ProtocolMessage, Request, Response,
+    ShowMessageEventBody, StoppedEventBody,
+};
+
+use anyhow::anyhow;
+
+pub trait ProtocolAdapter {
+    /// Listen for a request. This call should be non-blocking, and if not request is available, it should
+    /// return a [`Request`] with the `command` field set to "process_next_request".
+    fn listen_for_request(&mut self) -> Request;
+
+    fn send_event<S: Serialize>(&mut self, event_type: &str, event_body: Option<S>) -> bool;
+    fn show_message(&mut self, severity: MessageSeverity, message: impl Into<String>) -> bool;
+    fn log_to_console<S: Into<String>>(&mut self, message: S) -> bool;
+    fn set_console_log_level(&mut self, log_level: ConsoleLog);
+
+    fn send_response<S: Serialize>(
+        &mut self,
+        request: &Request,
+        response: Result<Option<S>, DebuggerError>,
+    ) -> bool;
+
+    fn peek_seq(&self) -> i64;
+
+    const ADAPTER_TYPE: DebugAdapterType;
+}
+
+pub struct DapAdapter<R: Read, W: Write> {
+    input: BufReader<R>,
+    output: W,
+    console_log_level: ConsoleLog,
+    seq: i64,
+}
+
+impl<R: Read, W: Write> DapAdapter<R, W> {
+    pub(crate) fn new(reader: R, writer: W) -> Self {
+        Self {
+            input: BufReader::new(reader),
+            output: writer,
+            seq: 1,
+            console_log_level: ConsoleLog::Warn,
+        }
+    }
+
+    fn send_data(&mut self, raw_data: &[u8]) -> Result<(), std::io::Error> {
+        let response_body = raw_data;
+
+        let response_header = format!("Content-Length: {}\r\n\r\n", response_body.len());
+
+        self.output.write_all(response_header.as_bytes())?;
+
+        match self.output.write_all(response_body) {
+            Ok(_) => {}
+            Err(error) => {
+                log::error!("send_data - body: {:?}", error);
+                self.output.flush().ok();
+                return Err(error);
+            }
+        }
+
+        self.output.flush().ok();
+
+        self.seq += 1;
+
+        Ok(())
+    }
+
+    /// Receive data from `self.input`. Data has to be in the format specified by the Debug Adapter Protocol (DAP).
+    /// The returned data is the content part of the request, as raw bytes.
+    fn receive_data(&mut self) -> Result<Vec<u8>, DebuggerError> {
+        let mut header = String::new();
+
+        match self.input.read_line(&mut header) {
+            Ok(_data_length) => {}
+            Err(error) => {
+                // There is no data available, so do something else (like checking the probe status) or try again.
+                return Err(DebuggerError::NonBlockingReadError {
+                    original_error: error,
+                });
+            }
+        }
+
+        // We should read an empty line here.
+        let mut buff = String::new();
+        match self.input.read_line(&mut buff) {
+            Ok(_data_length) => {}
+            Err(error) => {
+                // There is no data available, so do something else (like checking the probe status) or try again.
+                return Err(DebuggerError::NonBlockingReadError {
+                    original_error: error,
+                });
+            }
+        }
+
+        let data_length = get_content_len(&header).ok_or_else(|| {
+            DebuggerError::Other(anyhow!(
+                "Failed to read content length from header '{}'",
+                header
+            ))
+        })?;
+
+        let mut content = vec![0u8; data_length];
+        let bytes_read = match self.input.read(&mut content) {
+            Ok(len) => len,
+            Err(error) => {
+                // There is no data available, so do something else (like checking the probe status) or try again.
+                return Err(DebuggerError::NonBlockingReadError {
+                    original_error: error,
+                });
+            }
+        };
+
+        if bytes_read == data_length {
+            Ok(content)
+        } else {
+            Err(DebuggerError::Other(anyhow!(
+                "Failed to read the expected {} bytes from incoming data",
+                data_length
+            )))
+        }
+    }
+
+    fn listen_for_request_and_respond(&mut self) -> Request {
+        match self.receive_msg_content() {
+            Ok(request) => {
+                if request.command != "process_next_request" {
+                    log::debug!("Received request: {:?}", request);
+
+                    // This is the SUCCESS request for new requests from the client.
+                    match self.console_log_level {
+                        ConsoleLog::Error => {}
+                        ConsoleLog::Info | ConsoleLog::Warn => {
+                            self.log_to_console(format!(
+                                "\nReceived DAP Request sequence #{} : {}",
+                                request.seq, request.command
+                            ));
+                        }
+                        ConsoleLog::Debug | ConsoleLog::Trace => {
+                            self.log_to_console(format!("\nReceived DAP Request: {:#?}", request));
+                        }
+                    }
+                }
+
+                request
+            }
+            Err(e) => {
+                let request = Request {
+                    seq: self.seq,
+                    arguments: None,
+                    command: "error".to_owned(),
+                    type_: "request".to_owned(),
+                };
+
+                self.send_response::<Request>(&request, Err(e));
+
+                request
+            }
+        }
+    }
+
+    fn receive_msg_content(&mut self) -> Result<Request, DebuggerError> {
+        match self.receive_data() {
+            Ok(message_content) => {
+                // Extract protocol message
+                match serde_json::from_slice::<ProtocolMessage>(&message_content) {
+                    Ok(protocol_message) if protocol_message.type_ == "request" => {
+                        match serde_json::from_slice::<Request>(&message_content) {
+                            Ok(request) => Ok(request),
+                            Err(error) => Err(DebuggerError::Other(anyhow!(
+                                "Error encoding ProtocolMessage to Request: {:?}",
+                                error
+                            ))),
+                        }
+                    }
+                    Ok(protocol_message) => Err(DebuggerError::Other(anyhow!(
+                        "Received an unexpected message type: '{}'",
+                        protocol_message.type_
+                    ))),
+                    Err(error) => Err(DebuggerError::Other(anyhow!("{}", error))),
+                }
+            }
+            Err(error) => {
+                match error {
+                    DebuggerError::NonBlockingReadError { original_error } => {
+                        if original_error.kind() == std::io::ErrorKind::WouldBlock {
+                            // Non-blocking read is waiting for incoming data that is not ready yet.
+                            // This is not a real error, so use this opportunity to check on probe status and notify the debug client if required.
+                            Ok(Request {
+                                arguments: None,
+                                command: "process_next_request".to_owned(),
+                                seq: self.seq,
+                                type_: "request".to_owned(),
+                            })
+                        } else {
+                            // This is a legitimate error. Tell the client about it.
+                            Err(DebuggerError::StdIO(original_error))
+                        }
+                    }
+                    _ => {
+                        // This is a legitimate error. Tell the client about it.
+                        Err(DebuggerError::Other(anyhow!("{}", error)))
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<R: Read, W: Write> ProtocolAdapter for DapAdapter<R, W> {
+    fn listen_for_request(&mut self) -> Request {
+        self.listen_for_request_and_respond()
+    }
+
+    fn send_event<S: Serialize>(&mut self, event_type: &str, event_body: Option<S>) -> bool {
+        let new_event = Event {
+            seq: self.seq,
+            type_: "event".to_string(),
+            event: event_type.to_string(),
+            body: event_body.map(|event_body| serde_json::to_value(event_body).unwrap_or_default()),
+        };
+
+        let encoded_event = match serde_json::to_vec(&new_event) {
+            Ok(encoded_event) => encoded_event,
+            Err(_) => {
+                return false;
+            }
+        };
+
+        if self.send_data(&encoded_event).is_err() {
+            return false;
+        }
+
+        if new_event.event != "output" {
+            // This would result in an endless loop.
+            match self.console_log_level {
+                ConsoleLog::Error => {}
+                ConsoleLog::Info | ConsoleLog::Warn => {
+                    self.log_to_console(format!("\nTriggered DAP Event: {}", new_event.event));
+                }
+                ConsoleLog::Debug | ConsoleLog::Trace => {
+                    self.log_to_console(format!("INFO: Triggered DAP Event: {:#?}", new_event));
+                }
+            }
+        }
+
+        true
+    }
+
+    fn show_message(&mut self, severity: MessageSeverity, message: impl Into<String>) -> bool {
+        log::debug!("show_message");
+        let event_body = match serde_json::to_value(ShowMessageEventBody {
+            severity,
+            message: format!("{}\n", message.into()),
+        }) {
+            Ok(event_body) => event_body,
+            Err(_) => {
+                return false;
+            }
+        };
+        self.send_event("probe-rs-show-message", Some(event_body))
+    }
+
+    fn log_to_console<S: Into<String>>(&mut self, message: S) -> bool {
+        log::debug!("log_to_console");
+        let event_body = match serde_json::to_value(OutputEventBody {
+            output: format!("{}\n", message.into()),
+            category: Some("console".to_owned()),
+            variables_reference: None,
+            source: None,
+            line: None,
+            column: None,
+            data: None,
+            group: Some("probe-rs-debug".to_owned()),
+        }) {
+            Ok(event_body) => event_body,
+            Err(_) => {
+                return false;
+            }
+        };
+        self.send_event("output", Some(event_body))
+    }
+
+    fn send_response<S: Serialize>(
+        &mut self,
+        request: &Request,
+        response: Result<Option<S>, DebuggerError>,
+    ) -> bool {
+        let mut resp = Response {
+            command: request.command.clone(),
+            request_seq: request.seq,
+            seq: request.seq,
+            success: false,
+            body: None,
+            type_: "response".to_owned(),
+            message: None,
+        };
+
+        match response {
+            Ok(value) => {
+                let body_value = match value {
+                    Some(value) => Some(match serde_json::to_value(value) {
+                        Ok(value) => value,
+                        Err(_) => {
+                            return false;
+                        }
+                    }),
+                    None => None,
+                };
+                resp.success = true;
+                resp.body = body_value;
+            }
+            Err(debugger_error) => {
+                resp.success = false;
+                resp.message = {
+                    let mut response_message = debugger_error.to_string();
+                    let mut offset_iterations = 0;
+                    let mut child_error: Option<&dyn std::error::Error> =
+                        std::error::Error::source(&debugger_error);
+                    while let Some(source_error) = child_error {
+                        offset_iterations += 1;
+                        response_message = format!("{}\n", response_message,);
+                        for _offset_counter in 0..offset_iterations {
+                            response_message = format!("{}\t", response_message);
+                        }
+                        response_message = format!(
+                            "{}{:?}",
+                            response_message,
+                            <dyn std::error::Error>::to_string(source_error)
+                        );
+                        child_error = std::error::Error::source(source_error);
+                    }
+                    Some(response_message)
+                };
+            }
+        };
+
+        log::debug!("send_response: {:?}", resp);
+
+        let encoded_resp = match serde_json::to_vec(&resp) {
+            Ok(encoded_resp) => encoded_resp,
+            Err(_) => return false,
+        };
+
+        if self.send_data(&encoded_resp).is_err() {
+            return false;
+        }
+
+        if !resp.success {
+            self.log_to_console(&resp.clone().message.unwrap());
+            self.show_message(MessageSeverity::Error, &resp.message.unwrap());
+        } else {
+            match self.console_log_level {
+                ConsoleLog::Error => {}
+                ConsoleLog::Info | ConsoleLog::Warn => {
+                    self.log_to_console(format!(
+                        "   Sent DAP Response sequence #{} : {}",
+                        resp.seq, resp.command
+                    ));
+                }
+                ConsoleLog::Debug | ConsoleLog::Trace => {
+                    self.log_to_console(format!("\nSent DAP Response: {:#?}", resp));
+                }
+            }
+        }
+
+        true
+    }
+
+    fn peek_seq(&self) -> i64 {
+        self.seq
+    }
+
+    const ADAPTER_TYPE: DebugAdapterType = DebugAdapterType::DapClient;
+
+    fn set_console_log_level(&mut self, log_level: ConsoleLog) {
+        self.console_log_level = log_level;
+    }
+}
+
+pub struct CliAdapter {
+    seq: i64,
+    rl: Editor<()>,
+    console_log_level: ConsoleLog,
+
+    // TODO: Remove this from here
+    pub(crate) last_known_status: CoreStatus,
+}
+
+impl CliAdapter {
+    pub fn new() -> Self {
+        Self {
+            seq: 1,
+            rl: Editor::new(),
+            console_log_level: ConsoleLog::Info,
+            last_known_status: CoreStatus::Unknown,
+        }
+    }
+
+    /// Call readline until a non-empty line is entered.
+    fn get_line(&mut self) -> Result<String, ReadlineError> {
+        loop {
+            match self.rl.readline(">> ") {
+                // Ignore empty lines
+                Ok(line) if line.trim().is_empty() => continue,
+
+                // Return non-empty lines
+                Ok(line) => return Ok(line),
+
+                // Handle errors
+                Err(error) => {
+                    match error {
+                        // For end of file and ctrl-c, we just quit
+                        ReadlineError::Eof | ReadlineError::Interrupted => {
+                            return Ok("quit".to_string())
+                        }
+                        // Propagate other errors
+                        actual_error => return Err(actual_error),
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl ProtocolAdapter for CliAdapter {
+    fn listen_for_request(&mut self) -> Request {
+        let line = match self.get_line() {
+            Ok(line) => line,
+            Err(error) => match error {
+                actual_error => {
+                    let request = Request {
+                        seq: self.seq,
+                        arguments: None,
+                        command: "error".to_owned(),
+                        type_: "request".to_owned(),
+                    };
+                    self.send_response::<Request>(
+                        &request,
+                        Err(DebuggerError::Other(anyhow!(
+                            "Error handling input: {:?}",
+                            actual_error
+                        ))),
+                    );
+                    return request;
+                }
+            },
+        };
+
+        let history_entry: &str = line.as_ref();
+        self.rl.add_history_entry(history_entry);
+
+        let mut command_arguments: Vec<&str> = line.split_whitespace().collect();
+        let command_name = command_arguments.remove(0);
+        let arguments = if !command_arguments.is_empty() {
+            Some(json!(command_arguments))
+        } else {
+            None
+        };
+
+        Request {
+            arguments,
+            command: command_name.to_string(),
+            seq: self.seq,
+            type_: "request".to_string(),
+        }
+    }
+
+    fn send_event<S: Serialize>(&mut self, event_type: &str, event_body: Option<S>) -> bool {
+        // Only report on continued or stopped events, so the user knows when the core halts.
+        match event_type {
+            "stopped" => {
+                if let Some(event_body) = event_body {
+                    let event_body_struct: StoppedEventBody = serde_json::from_value(
+                        serde_json::to_value(event_body).unwrap_or_default(),
+                    )
+                    .unwrap();
+                    let description = event_body_struct.description.unwrap_or_else(|| {
+                        "Received and unknown event from the debugger".to_owned()
+                    });
+                    println!("{}", description);
+                }
+            }
+            "continued" => {
+                println!(
+                    "{}",
+                    self.last_known_status.short_long_status().1.to_owned()
+                );
+            }
+            other => match self.console_log_level {
+                ConsoleLog::Error => {}
+                ConsoleLog::Info | ConsoleLog::Warn => {
+                    self.log_to_console(format!("Triggered Event: {}", other));
+                }
+                ConsoleLog::Debug | ConsoleLog::Trace => {
+                    self.log_to_console(format!(
+                        "Triggered Event: {:#?}",
+                        serde_json::to_value(event_body).unwrap_or_default()
+                    ));
+                }
+            },
+        }
+        true
+    }
+
+    fn show_message(&mut self, severity: MessageSeverity, message: impl Into<String>) -> bool {
+        println!("{:?}: {}", severity, message.into());
+        true
+    }
+
+    fn log_to_console<S: Into<String>>(&mut self, message: S) -> bool {
+        println!("{}", message.into());
+        true
+    }
+
+    fn send_response<S: Serialize>(
+        &mut self,
+        request: &Request,
+        response: Result<Option<S>, DebuggerError>,
+    ) -> bool {
+        let mut resp = Response {
+            command: request.command.clone(),
+            request_seq: request.seq,
+            seq: request.seq,
+            success: false,
+            body: None,
+            type_: "response".to_owned(),
+            message: None,
+        };
+
+        match response {
+            Ok(value) => {
+                let body_value = match value {
+                    Some(value) => Some(match serde_json::to_value(value) {
+                        Ok(value) => value,
+                        Err(_) => {
+                            return false;
+                        }
+                    }),
+                    None => None,
+                };
+                resp.success = true;
+                resp.body = body_value;
+            }
+            Err(debugger_error) => {
+                resp.success = false;
+                resp.message = {
+                    let mut response_message = debugger_error.to_string();
+                    let mut offset_iterations = 0;
+                    let mut child_error: Option<&dyn std::error::Error> =
+                        std::error::Error::source(&debugger_error);
+                    while let Some(source_error) = child_error {
+                        offset_iterations += 1;
+                        response_message = format!("{}\n", response_message,);
+                        for _offset_counter in 0..offset_iterations {
+                            response_message = format!("{}\t", response_message);
+                        }
+                        response_message = format!(
+                            "{}{:?}",
+                            response_message,
+                            <dyn std::error::Error>::to_string(source_error)
+                        );
+                        child_error = std::error::Error::source(source_error);
+                    }
+                    Some(response_message)
+                };
+            }
+        };
+
+        if resp.success {
+            if let Some(body) = resp.body {
+                println!("{}", body.as_str().unwrap());
+            }
+        } else {
+            println!("ERROR: {}", resp.message.unwrap());
+        }
+        true
+    }
+
+    fn peek_seq(&self) -> i64 {
+        self.seq
+    }
+
+    const ADAPTER_TYPE: DebugAdapterType = DebugAdapterType::CommandLine;
+
+    fn set_console_log_level(&mut self, log_level: ConsoleLog) {
+        self.console_log_level = log_level;
+    }
+}
+
+fn get_content_len(header: &str) -> Option<usize> {
+    let mut parts = header.trim_end().split_ascii_whitespace();
+
+    // discard first part
+    let first_part = parts.next()?;
+
+    if first_part == "Content-Length:" {
+        parts.next()?.parse::<usize>().ok()
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::{self, ErrorKind, Read};
+
+    use insta;
+
+    use crate::protocol::{get_content_len, ProtocolAdapter};
+
+    use super::DapAdapter;
+
+    struct TestReader {
+        response: Option<io::Result<usize>>,
+    }
+
+    impl Read for TestReader {
+        fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+            if let Some(response) = self.response.take() {
+                response
+            } else {
+                Err(io::Error::new(
+                    ErrorKind::Other,
+                    "Repeated use of test reader",
+                ))
+            }
+        }
+    }
+
+    #[test]
+    fn receive_valid_request() {
+        let content = "{ \"seq\": 3, \"type\": \"request\", \"command\": \"test\" }";
+
+        let input = format!("Content-Length: {}\r\n\r\n{}", content.len(), content);
+
+        let mut output = Vec::new();
+
+        let mut adapter = DapAdapter::new(input.as_bytes(), &mut output);
+
+        let request = adapter.listen_for_request();
+
+        let output_str = String::from_utf8(output).unwrap();
+
+        insta::assert_snapshot!(output_str);
+
+        assert_eq!(request.command, "test");
+        assert_eq!(request.seq, 3);
+    }
+
+    #[test]
+    fn receive_request_with_wrong_content_length() {
+        let content = "{ \"seq\": 3, \"type\": \"request\", \"command\": \"test\" }";
+
+        let input = format!("Content-Length: {}\r\n\r\n{}", content.len() + 10, content);
+
+        let mut output = Vec::new();
+
+        let mut adapter = DapAdapter::new(input.as_bytes(), &mut output);
+
+        let request = adapter.listen_for_request();
+
+        let output_str = String::from_utf8(output).unwrap();
+
+        insta::assert_snapshot!(output_str);
+
+        assert_eq!(request.command, "error");
+        // assert_eq!(request.seq, 1); -- not relevant
+        assert_eq!(request.type_, "request");
+    }
+
+    #[test]
+    fn receive_request_with_invalid_json() {
+        let content = "{ \"seq\": 3, \"type\": \"request\", \"command\": \"test }";
+
+        let input = format!("Content-Length: {}\r\n\r\n{}", content.len(), content);
+
+        let mut output = Vec::new();
+
+        let mut adapter = DapAdapter::new(input.as_bytes(), &mut output);
+
+        let request = adapter.listen_for_request();
+
+        let output_str = String::from_utf8(output).unwrap();
+
+        insta::assert_snapshot!(output_str);
+
+        assert_eq!(request.command, "error");
+        assert_eq!(request.type_, "request");
+    }
+
+    #[test]
+    fn receive_request_would_block() {
+        let input = TestReader {
+            response: Some(io::Result::Err(io::Error::new(
+                ErrorKind::WouldBlock,
+                "would block",
+            ))),
+        };
+
+        let mut output = Vec::new();
+
+        let mut adapter = DapAdapter::new(input, &mut output);
+
+        let request = adapter.listen_for_request();
+
+        let output_str = String::from_utf8(output).unwrap();
+
+        insta::assert_snapshot!(output_str);
+
+        assert_eq!(request.command, "process_next_request");
+        assert_eq!(request.seq, 1);
+        assert_eq!(request.type_, "request");
+    }
+
+    #[test]
+    fn parse_valid_header() {
+        let header = "Content-Length: 234\r\n";
+
+        assert_eq!(234, get_content_len(header).unwrap());
+    }
+
+    #[test]
+    fn parse_invalid_header() {
+        let header = "Content: 234\r\n";
+
+        assert!(get_content_len(header).is_none());
+    }
+}

--- a/debugger/src/snapshots/probe_rs_debugger__debug_adapter__test__receive_request_with_invalid_json.snap
+++ b/debugger/src/snapshots/probe_rs_debugger__debug_adapter__test__receive_request_with_invalid_json.snap
@@ -1,0 +1,14 @@
+---
+source: debugger/src/debug_adapter.rs
+expression: output_str
+
+---
+Content-Length: 136
+
+{"command":"error","message":"EOF while parsing a string at line 1 column 49","request_seq":1,"seq":1,"success":false,"type":"response"}Content-Length: 156
+
+{"body":{"category":"console","group":"probe-rs-debug","output":"EOF while parsing a string at line 1 column 49\n"},"event":"output","seq":2,"type":"event"}Content-Length: 145
+
+{"body":{"message":"EOF while parsing a string at line 1 column 49\n","severity":"error"},"event":"probe-rs-show-message","seq":3,"type":"event"}Content-Length: 154
+
+{"body":{"category":"console","group":"probe-rs-debug","output":"\nTriggered DAP Event: probe-rs-show-message\n"},"event":"output","seq":4,"type":"event"}

--- a/debugger/src/snapshots/probe_rs_debugger__debug_adapter__test__receive_request_with_wrong_content_length.snap
+++ b/debugger/src/snapshots/probe_rs_debugger__debug_adapter__test__receive_request_with_wrong_content_length.snap
@@ -1,0 +1,14 @@
+---
+source: debugger/src/debug_adapter.rs
+expression: output_str
+
+---
+Content-Length: 145
+
+{"command":"error","message":"Failed to read the expected 60 bytes from incoming data","request_seq":1,"seq":1,"success":false,"type":"response"}Content-Length: 165
+
+{"body":{"category":"console","group":"probe-rs-debug","output":"Failed to read the expected 60 bytes from incoming data\n"},"event":"output","seq":2,"type":"event"}Content-Length: 154
+
+{"body":{"message":"Failed to read the expected 60 bytes from incoming data\n","severity":"error"},"event":"probe-rs-show-message","seq":3,"type":"event"}Content-Length: 154
+
+{"body":{"category":"console","group":"probe-rs-debug","output":"\nTriggered DAP Event: probe-rs-show-message\n"},"event":"output","seq":4,"type":"event"}

--- a/debugger/src/snapshots/probe_rs_debugger__debug_adapter__test__receive_request_would_block.snap
+++ b/debugger/src/snapshots/probe_rs_debugger__debug_adapter__test__receive_request_would_block.snap
@@ -1,0 +1,6 @@
+---
+source: debugger/src/debug_adapter.rs
+expression: output_str
+
+---
+

--- a/debugger/src/snapshots/probe_rs_debugger__debug_adapter__test__receive_valid_request.snap
+++ b/debugger/src/snapshots/probe_rs_debugger__debug_adapter__test__receive_valid_request.snap
@@ -1,0 +1,8 @@
+---
+source: debugger/src/debug_adapter.rs
+expression: output_str
+
+---
+Content-Length: 151
+
+{"body":{"category":"console","group":"probe-rs-debug","output":"\nReceived DAP Request sequence #3 : test\n"},"event":"output","seq":1,"type":"event"}

--- a/debugger/src/snapshots/probe_rs_debugger__protocol__test__receive_request_with_invalid_json.snap
+++ b/debugger/src/snapshots/probe_rs_debugger__protocol__test__receive_request_with_invalid_json.snap
@@ -1,0 +1,14 @@
+---
+source: debugger/src/protocol.rs
+expression: output_str
+
+---
+Content-Length: 136
+
+{"command":"error","message":"EOF while parsing a string at line 1 column 49","request_seq":1,"seq":1,"success":false,"type":"response"}Content-Length: 156
+
+{"body":{"category":"console","group":"probe-rs-debug","output":"EOF while parsing a string at line 1 column 49\n"},"event":"output","seq":2,"type":"event"}Content-Length: 145
+
+{"body":{"message":"EOF while parsing a string at line 1 column 49\n","severity":"error"},"event":"probe-rs-show-message","seq":3,"type":"event"}Content-Length: 154
+
+{"body":{"category":"console","group":"probe-rs-debug","output":"\nTriggered DAP Event: probe-rs-show-message\n"},"event":"output","seq":4,"type":"event"}

--- a/debugger/src/snapshots/probe_rs_debugger__protocol__test__receive_request_with_wrong_content_length.snap
+++ b/debugger/src/snapshots/probe_rs_debugger__protocol__test__receive_request_with_wrong_content_length.snap
@@ -1,0 +1,14 @@
+---
+source: debugger/src/protocol.rs
+expression: output_str
+
+---
+Content-Length: 145
+
+{"command":"error","message":"Failed to read the expected 60 bytes from incoming data","request_seq":1,"seq":1,"success":false,"type":"response"}Content-Length: 165
+
+{"body":{"category":"console","group":"probe-rs-debug","output":"Failed to read the expected 60 bytes from incoming data\n"},"event":"output","seq":2,"type":"event"}Content-Length: 154
+
+{"body":{"message":"Failed to read the expected 60 bytes from incoming data\n","severity":"error"},"event":"probe-rs-show-message","seq":3,"type":"event"}Content-Length: 154
+
+{"body":{"category":"console","group":"probe-rs-debug","output":"\nTriggered DAP Event: probe-rs-show-message\n"},"event":"output","seq":4,"type":"event"}

--- a/debugger/src/snapshots/probe_rs_debugger__protocol__test__receive_request_would_block.snap
+++ b/debugger/src/snapshots/probe_rs_debugger__protocol__test__receive_request_would_block.snap
@@ -1,0 +1,6 @@
+---
+source: debugger/src/protocol.rs
+expression: output_str
+
+---
+

--- a/debugger/src/snapshots/probe_rs_debugger__protocol__test__receive_valid_request.snap
+++ b/debugger/src/snapshots/probe_rs_debugger__protocol__test__receive_valid_request.snap
@@ -1,0 +1,8 @@
+---
+source: debugger/src/protocol.rs
+expression: output_str
+
+---
+Content-Length: 151
+
+{"body":{"category":"console","group":"probe-rs-debug","output":"\nReceived DAP Request sequence #3 : test\n"},"event":"output","seq":1,"type":"event"}


### PR DESCRIPTION
Refactoring of the debug adapter code, so that code specific to CLI / DAP is now in separate structs. 

More work can be done to improve this, this is just initial work to gather some feedback if this goes into a useful direction.
