### PR TITLE
debugger: Show progress message while flashing is in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added STM32U5 series target.
 - Added all RAM regions to most STM32H7 parts. (#864)
 - Added name field to memory regions. (#864)
-- debugger: Show progress notification while device is being flashed. (#xxx)
+- debugger: Show progress notification while device is being flashed. (#871)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added STM32U5 series target.
 - Added all RAM regions to most STM32H7 parts. (#864)
 - Added name field to memory regions. (#864)
+- debugger: Show progress notification while device is being flashed. (#xxx)
 
 ### Removed
 


### PR DESCRIPTION
Add basic support to show a progress message while flashing is in progress. The `supports_progress_reporting`  flag of the client is respected.

Currently, only a notification that flashing is in progress is shown. This could be enhanced with additional information, like a proper progress bar.
