### PR TITLE
Debugger: Do not panic when using a command without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `unreachable!` induced panic with logic to fix `probe-rs-debugger` failures. (#847)
 - Fixed logic errors and timing of RTT initialization in `probe-rs-debugger`. (#847)
 - Debugger: Do not crash the CLI when pressing enter without a command. (#875)
+- Fixed panic in CLI debugger when using a command without arguments. (#873)
 
 ## [0.11.0]
 

--- a/debugger/src/dap_types.rs
+++ b/debugger/src/dap_types.rs
@@ -54,8 +54,8 @@ pub struct ShowMessageEventBody {
 
 impl TryFrom<&serde_json::Value> for ReadMemoryArguments {
     fn try_from(arguments: &serde_json::Value) -> Result<Self, Self::Error> {
-        let count = get_int_argument(arguments, "count", 1)?;
-        let memory_reference = get_string_argument(arguments, "memory_reference", 0)?;
+        let count = get_int_argument(Some(arguments), "count", 1)?;
+        let memory_reference = get_string_argument(Some(arguments), "memory_reference", 0)?;
         Ok(ReadMemoryArguments {
             count,
             memory_reference,
@@ -69,8 +69,11 @@ impl TryFrom<&serde_json::Value> for ReadMemoryArguments {
 // SECTION: For various helper functions
 
 /// Parse the argument at the given index.
+///
+/// Note: The function accepts an `Option` for `arguments` because this makes
+/// the usage easier if no arguments are present.
 pub fn get_int_argument<T: Num>(
-    arguments: &serde_json::Value,
+    arguments: Option<&serde_json::Value>,
     argument_name: &str,
     index: usize,
 ) -> Result<T, DebuggerError>
@@ -81,7 +84,7 @@ where
     <T as Num>::FromStrRadixErr: 'static,
 {
     match arguments {
-        serde_json::Value::Array(arguments) => {
+        Some(serde_json::Value::Array(arguments)) => {
             if arguments.len() <= index {
                 return Err(DebuggerError::MissingArgument {
                     argument_name: argument_name.to_string(),
@@ -102,12 +105,12 @@ where
 }
 
 fn get_string_argument(
-    arguments: &serde_json::Value,
+    arguments: Option<&serde_json::Value>,
     argument_name: &str,
     index: usize,
 ) -> Result<String, DebuggerError> {
     match arguments {
-        serde_json::Value::Array(arguments) => {
+        Some(serde_json::Value::Array(arguments)) => {
             if arguments.len() <= index {
                 return Err(DebuggerError::MissingArgument {
                     argument_name: argument_name.to_string(),

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -213,11 +213,11 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
         }
     }
     pub(crate) fn write(&mut self, core_data: &mut CoreData, request: &Request) -> bool {
-        let address = match get_int_argument(request.arguments.as_ref().unwrap(), "address", 0) {
+        let address = match get_int_argument(request.arguments.as_ref(), "address", 0) {
             Ok(address) => address,
             Err(error) => return self.send_response::<()>(request, Err(error)),
         };
-        let data = match get_int_argument(request.arguments.as_ref().unwrap(), "data", 1) {
+        let data = match get_int_argument(request.arguments.as_ref(), "data", 1) {
             Ok(data) => data,
             Err(error) => return self.send_response::<()>(request, Err(error)),
         };
@@ -232,7 +232,7 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
         }
     }
     pub(crate) fn set_breakpoint(&mut self, core_data: &mut CoreData, request: &Request) -> bool {
-        let address = match get_int_argument(request.arguments.as_ref().unwrap(), "address", 0) {
+        let address = match get_int_argument(request.arguments.as_ref(), "address", 0) {
             Ok(address) => address,
             Err(error) => return self.send_response::<()>(request, Err(error)),
         };
@@ -255,7 +255,7 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
         }
     }
     pub(crate) fn clear_breakpoint(&mut self, core_data: &mut CoreData, request: &Request) -> bool {
-        let address = match get_int_argument(request.arguments.as_ref().unwrap(), "address", 0) {
+        let address = match get_int_argument(request.arguments.as_ref(), "address", 0) {
             Ok(address) => address,
             Err(error) => return self.send_response::<()>(request, Err(error)),
         };
@@ -1371,7 +1371,10 @@ impl<R: Read, W: Write> DebugAdapter<R, W> {
         }
     }
 
-    /// Sends either the success response or an error response if passed a DebuggerError. For the DAP Client, it forwards the response, while for the CLI, it will print the body for success, or the message for failure.
+    /// Sends either the success response or an error response if passed a
+    /// DebuggerError. For the DAP Client, it forwards the response, while for
+    /// the CLI, it will print the body for success, or the message for
+    /// failure.
     pub fn send_response<S: Serialize>(
         &mut self,
         request: &Request,


### PR DESCRIPTION
Previously, calling a command in the CLI debugger (e.g.
`set_breakpoint`) without passing any arguments would lead to a panic
due to unwrapping of the arguments.

By passing an Option to the argument parsing helpers, this an be
avoided, and instead the help is shown.