### PR TITLE
Fix a typo in debugger help text

### DIFF
--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -224,7 +224,7 @@ impl DebugCli {
 
         cli.add_command(Command {
             name: "break",
-            help_text: "Set a breakpoint at a specifc address",
+            help_text: "Set a breakpoint at a specific address",
 
             function: |cli_data, args| {
                 let address = get_int_argument(args, 0)?;

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -422,7 +422,7 @@ impl Debugger {
                 DebugCommand {
                     dap_cmd: "",
                     cli_cmd: "set_breakpoint",
-                    help_text: "Set a breakpoint at a specifc address",
+                    help_text: "Set a breakpoint at a specific address",
                     function_name: "set_breakpoint",
                 },
                 DebugCommand {


### PR DESCRIPTION
Just a lttle tpo 🙂