### PR TITLE
Debugger: Do not crash CLI on empty lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use a more reliable JTAG IR length detection when there's only a single target in the chain. Fixes an issue with the esp32c3. (#796, #823).
 - Replaced `unreachable!` induced panic with logic to fix `probe-rs-debugger` failures. (#847)
 - Fixed logic errors and timing of RTT initialization in `probe-rs-debugger`. (#847)
+- Debugger: Do not crash the CLI when pressing enter without a command. (#875)
 
 ## [0.11.0]
 


### PR DESCRIPTION
When pressing enter without entering a command, simply call readline again in a loop instead of panicking.

This way, the empty command will not be added to the history either, the line will be fully ignored.

Without this fix:

![2021-11-07-180505_1043x630_scrot](https://user-images.githubusercontent.com/105168/140654536-5de4a94e-549f-432a-a47c-d6bbe8bf29b6.png)