### PR TITLE
Add .gitattributes with merge=union for changelog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
If you enforce changelog entries for every contribution, then every contribution submitted in parallel will lead to a merge conflict.

With the `.gitattribute` file, conflicts should be resolved automatically by accepting lines from both sides in a 3-way merge.

GitHub doesn't support this yet, I think, but bors may support it. Worth a try.