### PR TITLE
debugger: Improve register handling for RISCV

### DIFF
--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -696,6 +696,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                             // Extract all the variables from the `StackFrame` for later MS DAP calls to retrieve.
                             let (variables_reference, named_variables_cnt, indexed_variables_cnt) =
                                 self.create_variable_map(&frame.variables);
+
                             scopes.push(Scope {
                                 line: Some(line),
                                 column: frame.source_location.as_ref().and_then(|l| {
@@ -740,41 +741,35 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                             // Build the registers scope and add its variables.
                             // TODO: Consider expanding beyond core registers to add other architectue registers.
                             let register_scope_reference = self.new_variable_map_key();
-                            let mut register_count: i64 = 0;
-                            self.variable_map.insert(
-                                register_scope_reference,
-                                frame
-                                    .registers
-                                    .into_iter()
-                                    .map(|register| {
-                                        register_count += 1;
-                                        let register_position = register_count - 1;
-                                        Variable {
-                                            name: match register_position {
-                                                7 => "R7: THUMB Frame Pointer".to_owned(),
-                                                11 => "R11: ARM Frame Pointer".to_owned(),
-                                                13 => "SP".to_owned(),
-                                                14 => "LR".to_owned(),
-                                                15 => "PC".to_owned(),
-                                                other => format!("R{}", other),
-                                            },
-                                            value: match register {
-                                                None | Some(0) => "<not available>".to_owned(),
-                                                Some(register) => {
-                                                    format!("0x{:08x}", register)
-                                                }
-                                            },
-                                            type_: Some("Core Register".to_owned()),
-                                            presentation_hint: None,
-                                            evaluate_name: None,
-                                            variables_reference: 0,
-                                            named_variables: None,
-                                            indexed_variables: None,
-                                            memory_reference: None,
-                                        }
-                                    })
-                                    .collect(),
-                            );
+
+                            // TODO: This is ARM specific, but should be generalized
+                            let variables: Vec<Variable> = frame
+                                .registers
+                                .registers()
+                                .map(|(register_number, value)| Variable {
+                                    name: match register_number {
+                                        7 => "R7: THUMB Frame Pointer".to_owned(),
+                                        11 => "R11: ARM Frame Pointer".to_owned(),
+                                        13 => "SP".to_owned(),
+                                        14 => "LR".to_owned(),
+                                        15 => "PC".to_owned(),
+                                        other => format!("R{}", other),
+                                    },
+                                    value: format!("0x{:08x}", value),
+                                    type_: Some("Core Register".to_owned()),
+                                    presentation_hint: None,
+                                    evaluate_name: None,
+                                    variables_reference: 0,
+                                    named_variables: None,
+                                    indexed_variables: None,
+                                    memory_reference: None,
+                                })
+                                .collect();
+
+                            let register_count = variables.len();
+
+                            self.variable_map
+                                .insert(register_scope_reference, variables);
                             scopes.push(Scope {
                                 line: None,
                                 column: None,
@@ -784,7 +779,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                                 indexed_variables: Some(0),
                                 name: "Registers".to_string(),
                                 presentation_hint: Some("registers".to_string()),
-                                named_variables: Some(register_count),
+                                named_variables: Some(register_count as i64),
                                 source: None,
                                 variables_reference: if register_count > 0 {
                                     register_scope_reference

--- a/debugger/src/protocol.rs
+++ b/debugger/src/protocol.rs
@@ -617,8 +617,6 @@ fn get_content_len(header: &str) -> Option<usize> {
 mod test {
     use std::io::{self, ErrorKind, Read};
 
-    
-
     use crate::protocol::{get_content_len, ProtocolAdapter};
 
     use super::DapAdapter;

--- a/debugger/src/protocol.rs
+++ b/debugger/src/protocol.rs
@@ -441,24 +441,22 @@ impl ProtocolAdapter for CliAdapter {
     fn listen_for_request(&mut self) -> Request {
         let line = match self.get_line() {
             Ok(line) => line,
-            Err(error) => match error {
-                actual_error => {
-                    let request = Request {
-                        seq: self.seq,
-                        arguments: None,
-                        command: "error".to_owned(),
-                        type_: "request".to_owned(),
-                    };
-                    self.send_response::<Request>(
-                        &request,
-                        Err(DebuggerError::Other(anyhow!(
-                            "Error handling input: {:?}",
-                            actual_error
-                        ))),
-                    );
-                    return request;
-                }
-            },
+            Err(error) => {
+                let request = Request {
+                    seq: self.seq,
+                    arguments: None,
+                    command: "error".to_owned(),
+                    type_: "request".to_owned(),
+                };
+                self.send_response::<Request>(
+                    &request,
+                    Err(DebuggerError::Other(anyhow!(
+                        "Error handling input: {:?}",
+                        error
+                    ))),
+                );
+                return request;
+            }
         };
 
         let history_entry: &str = line.as_ref();
@@ -619,7 +617,7 @@ fn get_content_len(header: &str) -> Option<usize> {
 mod test {
     use std::io::{self, ErrorKind, Read};
 
-    use insta;
+    
 
     use crate::protocol::{get_content_len, ProtocolAdapter};
 

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -69,11 +69,11 @@ pub(crate) enum RegisterKind {
 }
 
 /// Register description for a core.
-
 #[derive(Debug)]
 pub struct RegisterFile {
     pub(crate) platform_registers: &'static [RegisterDescription],
 
+    /// Register description for the program counter
     pub(crate) program_counter: &'static RegisterDescription,
 
     pub(crate) stack_pointer: &'static RegisterDescription,

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -219,45 +219,6 @@ impl Registers {
     }
 }
 
-/*
-impl<'a> IntoIterator for &'a Registers {
-    type Item = &'a Option<u32>;
-    type IntoIter = std::slice::Iter<'a, Option<u32>>;
-
-    fn into_iter(self) -> std::slice::Iter<'a, Option<u32>> {
-        self.values.values()
-    }
-}
-
-impl std::ops::Index<usize> for Registers {
-    type Output = Option<u32>;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.values[index]
-    }
-}
-
-impl std::ops::IndexMut<usize> for Registers {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.values[index]
-    }
-}
-
-impl std::ops::Index<std::ops::Range<usize>> for Registers {
-    type Output = [Option<u32>];
-
-    fn index(&self, index: std::ops::Range<usize>) -> &Self::Output {
-        &self.values[index]
-    }
-}
-
-impl std::ops::IndexMut<std::ops::Range<usize>> for Registers {
-    fn index_mut(&mut self, index: std::ops::Range<usize>) -> &mut Self::Output {
-        &mut self.values[index]
-    }
-}
-*/
-
 #[derive(Debug, PartialEq)]
 pub struct SourceLocation {
     pub line: Option<u64>,


### PR DESCRIPTION
This PR improves the register handling, so stack traces should work better on RISCV. It improves the register handling, so that program counter / stack frame address are no longer hardcoded, but architecture specific. `Registers::from_core` now handles both RISCV and ARM, which fixes #851.

There is more work to be done, which is tracked in #877

See also probe-rs/vscode#11.