### PR TITLE
Reduce panics caused by `unwrap()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed logic errors and timing of RTT initialization in `probe-rs-debugger`. (#847)
 - Debugger: Do not crash the CLI when pressing enter without a command. (#875)
 - Fixed panic in CLI debugger when using a command without arguments. (#873)
+- Debugger: Reduce panics caused by `unwrap()` usage. (#886) 
 
 ## [0.11.0]
 

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -1444,7 +1444,7 @@ pub fn debug(debugger_options: DebuggerOptions, dap: bool, vscode: bool) {
         );
         match &debugger.debugger_options.port.clone() {
             Some(port) => {
-                let addr = match format!("{}:{:?}", Ipv4Addr::LOCALHOST.to_string(), port)
+                let addr =  SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
                     .to_socket_addrs()
                 {
                     Ok(mut socket_addr) => {

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -20,7 +20,7 @@ use serde::Deserialize;
 use std::{
     env::{current_dir, set_current_dir},
     fs::File,
-    net::{Ipv4Addr, TcpListener, ToSocketAddrs},
+    net::{Ipv4Addr, TcpListener},
     path::PathBuf,
     str::FromStr,
     thread,
@@ -1444,26 +1444,10 @@ pub fn debug(debugger_options: DebuggerOptions, dap: bool, vscode: bool) {
         );
         match &debugger.debugger_options.port.clone() {
             Some(port) => {
-                let addr =  SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
-                    .to_socket_addrs()
-                {
-                    Ok(mut socket_addr) => {
-                        if let Some(addr) = socket_addr.next() {
-                            addr
-                        } else {
-                            log::error!(
-                                "Unable to create a socket address from {}:{:?}",
-                                Ipv4Addr::LOCALHOST.to_string(),
-                                port
-                            );
-                            return;
-                        }
-                    }
-                    Err(error) => {
-                        log::error!("{:?}", error);
-                        return;
-                    }
-                };
+                let addr = std::net::SocketAddr::new(
+                    std::net::IpAddr::V4(Ipv4Addr::LOCALHOST),
+                    port.to_owned(),
+                );
 
                 loop {
                     let listener = match TcpListener::bind(addr) {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -434,11 +434,12 @@ impl DebugProbe for JLink {
             }
         };
 
-        let actual_speed_khz = speed_khz;
-
-        self.handle
-            .set_speed(SpeedConfig::khz(speed_khz as u16).unwrap())?;
-        self.speed_khz = speed_khz;
+        if let Some(expected_speed) = SpeedConfig::khz(speed_khz as u16) {
+            self.handle.set_speed(expected_speed)?;
+            self.speed_khz = speed_khz;
+        } else {
+            return Err(DebugProbeError::UnsupportedSpeed(speed_khz));
+        }
 
         Ok(speed_khz)
     }


### PR DESCRIPTION
Improved user experience, by handling and forwarding errors that would previously cause the debugger to panic. This gives the user the feedback needed to either correct something and proceed, or to report bugs with better information.