### PR TITLE
Prevent endless loops while unwinding, ensure PC changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debugger: Do not crash the CLI when pressing enter without a command. (#875)
 - Fixed panic in CLI debugger when using a command without arguments. (#873)
 - Debugger: Reduce panics caused by `unwrap()` usage. (#886) 
+- probe-rs: When unwinding, detect if the program counter does not change anymore and stop. (#893)
 
 ## [0.11.0]
 

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -319,7 +319,9 @@ where
         )?;
 
         remaining_data_len -= first_chunk_size_words;
-        address += (4 * first_chunk_size_words) as u32;
+        address = address
+            .checked_add((4 * first_chunk_size_words) as u32)
+            .ok_or(AccessPortError::OutOfBoundsError)?;
         data_offset += first_chunk_size_words;
 
         while remaining_data_len > 0 {


### PR DESCRIPTION
To avoid endless loops while unwinding the call stack, add a check to ensure that the PC changes.

This fixes #892.