### PR TITLE
probe-rs-cli: download: add erase option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Added support for `chip-erase` flag under the `probe-rs-cli download` command. (#898)
+- Added support for `disable-progressbars` flag under the `probe-rs-cli download` command. (#898)
+- Fixed bug in `FlashLoader` not emitting `ProgressEvent::FinishedErasing` when using `do_chip_erase`. (#898)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added support for `erase` flag under the `probe-rs-cli download` command. (#898)
+- Added support for `chip-erase` flag under the `probe-rs-cli download` command. (#898)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added support for `erase` flag under the `probe-rs-cli download` command. (#898)
+
 ### Added
 
 - Added LPC5516 targets. (#853)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -110,6 +110,10 @@ enum Cli {
         /// Whether to erase the entire chip before downloading
         #[structopt(long)]
         chip_erase: bool,
+
+        /// Whether to disable fancy progress reporting
+        #[structopt(long)]
+        disable_progressbars: bool,
     },
     /// Erase all nonvolatile memory of attached target
     #[structopt(name = "erase")]
@@ -170,11 +174,13 @@ fn main() -> Result<()> {
             skip_bytes,
             path,
             chip_erase,
+            disable_progressbars,
         } => download_program_fast(
             common,
             format.into(base_address, skip_bytes),
             &path,
             chip_erase,
+            disable_progressbars,
         ),
         Cli::Erase { common } => erase(&common),
         Cli::Trace {
@@ -241,6 +247,7 @@ fn download_program_fast(
     format: Format,
     path: &str,
     do_chip_erase: bool,
+    disable_progressbars: bool,
 ) -> Result<()> {
     let mut session = common.simple_attach()?;
 
@@ -264,7 +271,7 @@ fn download_program_fast(
             version: false,
             list_chips: false,
             list_probes: false,
-            disable_progressbars: false,
+            disable_progressbars,
             reset_halt: false,
             log: None,
             restore_unwritten: false,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -106,6 +106,10 @@ enum Cli {
 
         /// The path to the file to be downloaded to the flash
         path: String,
+
+        /// Whether to erase before downloading
+        #[structopt(short, long)]
+        erase: bool,
     },
     /// Erase all nonvolatile memory of attached target
     #[structopt(name = "erase")]
@@ -165,8 +169,14 @@ fn main() -> Result<()> {
             base_address,
             skip_bytes,
             path,
-        } => download_program_fast(common, format.into(base_address, skip_bytes), &path),
-        Cli::Erase { common } => erase(&common),
+            erase,
+        } => {
+            if erase {
+                erase_device(&common)?;
+            }
+            download_program_fast(common, format.into(base_address, skip_bytes), &path)
+        }
+        Cli::Erase { common } => erase_device(&common),
         Cli::Trace {
             shared,
             common,
@@ -265,7 +275,7 @@ fn download_program_fast(common: ProbeOptions, format: Format, path: &str) -> Re
     Ok(())
 }
 
-fn erase(common: &ProbeOptions) -> Result<()> {
+fn erase_device(common: &ProbeOptions) -> Result<()> {
     let mut session = common.simple_attach()?;
 
     erase_all(&mut session)?;

--- a/probe-rs-cli-util/src/flash.rs
+++ b/probe-rs-cli-util/src/flash.rs
@@ -19,6 +19,7 @@ pub fn run_flash_download(
     path: &Path,
     opt: &FlashOptions,
     loader: FlashLoader,
+    do_chip_erase: bool,
 ) -> Result<(), OperationError> {
     // Start timer.
     let instant = Instant::now();
@@ -26,6 +27,7 @@ pub fn run_flash_download(
     let mut download_option = DownloadOptions::default();
     download_option.keep_unwritten_bytes = opt.restore_unwritten;
     download_option.dry_run = opt.probe_options.dry_run;
+    download_option.do_chip_erase = do_chip_erase;
 
     if !opt.disable_progressbars {
         // Create progress bars.

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -316,6 +316,10 @@ impl FlashLoader {
             if do_chip_erase {
                 log::debug!("    Doing chip erase...");
                 flasher.run_erase(|active| active.erase_all())?;
+
+                if let Some(progress) = options.progress {
+                    progress.finished_erasing();
+                }
             }
 
             for region in regions {


### PR DESCRIPTION
Stuff like softdevice needs to erase before flashing, wwhich means were replacing 1 command with 2, and if its not noticed the binary cant start with any decent error meessage

So add -e --erase flag to the download

- `probe-rs-cli erase --chip nRF52840_xxAA`
- `probe-rs-cli download --format hex s140_nrf52_7.2.0_softdevice.hex --chip nRF52840_xxAA`
becomes
- `probe-rs-cli download --format hex s140_nrf52_7.2.0_softdevice.hex --chip nRF52840_xxAA -e`
