### PR TITLE
Export core::RegisterFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved when RTT is initialized/retried, and removed `rtt_timeout` from recognized options of `probe-rs-debugger`. (#850)
 - Refactor `probe-rs-debugger` code as per `launch` vs. `attach` changes documented in [VS Code extension PR # 12](https://github.com/probe-rs/vscode/pull/12) (#854)
 - Breaking change: `probe-rs-debugger` and the associated [VSCode extension PR #21](https://github.com/probe-rs/vscode/pull/21) now uses camelCase for all `launch.json` properties (#885)
+- Publicly export `core::RegisterFile` type.
 
 ### Fixed
 - Detect proper USB HID interface to use for CMSIS-DAP v1 probes. Without this, CMSIS-DAP probes with multiple HID interfaces, e.g. MCUlink, were not working properly on MacOS (#722).

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -79,7 +79,7 @@ pub use crate::config::{CoreType, Target};
 pub use crate::core::{
     Architecture, Breakpoint, BreakpointId, CommunicationInterface, Core, CoreInformation,
     CoreInterface, CoreList, CoreRegister, CoreRegisterAddress, CoreState, CoreStatus, HaltReason,
-    SpecificCoreState,
+    RegisterFile, SpecificCoreState,
 };
 pub use crate::error::Error;
 pub use crate::memory::{Memory, MemoryInterface};


### PR DESCRIPTION
I think this is probably just an oversight since the `pub fn core::registers()` returns a `&'static RegisterFile`, but that type isn't currently publically visible (despite itself being `pub`).