### PR TITLE
arm: add `std::io::Read` wrapper around `read_swo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ARM: added `Session::swo_reader` that returns a wrapping implementation of `std::io::Read` around `Session::read_swo`. (#916)
+
 ## [0.12.0]
 
 - Added support for `chip-erase` flag under the `probe-rs-cli download` command. (#898)
@@ -71,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed logic errors and timing of RTT initialization in `probe-rs-debugger`. (#847)
 - Debugger: Do not crash the CLI when pressing enter without a command. (#875)
 - Fixed panic in CLI debugger when using a command without arguments. (#873)
-- Debugger: Reduce panics caused by `unwrap()` usage. (#886) 
+- Debugger: Reduce panics caused by `unwrap()` usage. (#886)
 - probe-rs: When unwinding, detect if the program counter does not change anymore and stop. (#893)
 
 ### Target Support

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -11,7 +11,7 @@ mod traits;
 pub use communication_interface::{
     ApInformation, ArmChipInfo, ArmCommunicationInterface, DapError, MemoryApInformation, Register,
 };
-pub use swo::{SwoAccess, SwoConfig, SwoMode};
+pub use swo::{SwoAccess, SwoConfig, SwoMode, SwoReader};
 pub use traits::*;
 
 pub use self::core::armv6m;

--- a/probe-rs/src/architecture/arm/swo/mod.rs
+++ b/probe-rs/src/architecture/arm/swo/mod.rs
@@ -1,3 +1,4 @@
+use crate::architecture::arm::communication_interface::ArmProbeInterface;
 use crate::Error;
 
 #[derive(Debug, Copy, Clone)]
@@ -147,4 +148,47 @@ pub(crate) fn poll_interval_from_buf_size(
 
     // Poll frequently enough to catch the buffer at 1/4 full
     Some(std::time::Duration::from_millis(time_to_full_ms as u64 / 4))
+}
+
+pub struct SwoReader<'a> {
+    interface: &'a mut Box<dyn ArmProbeInterface>,
+    buf: Vec<u8>,
+}
+
+impl<'a> SwoReader<'a> {
+    pub(crate) fn new(interface: &'a mut Box<dyn ArmProbeInterface>) -> Self {
+        Self {
+            interface,
+            buf: Vec::new(),
+        }
+    }
+}
+
+impl<'a> std::io::Read for SwoReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        use core::cmp;
+        use std::{
+            io::{Error, ErrorKind},
+            mem,
+        };
+
+        // Always buffer: this pulls data as quickly as possible from
+        // the target to clear it's embedded trace buffer, minimizing
+        // the chance of an overflow event during which packets are
+        // lost.
+        self.buf.append(
+            &mut self
+                .interface
+                .read_swo()
+                .map_err(|e| Error::new(ErrorKind::Other, e))?,
+        );
+
+        let swo = {
+            let next_buf = self.buf.split_off(cmp::min(self.buf.len(), buf.len()));
+            mem::replace(&mut self.buf, next_buf)
+        };
+
+        buf[..swo.len()].copy_from_slice(&swo);
+        Ok(swo.len())
+    }
 }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -10,7 +10,7 @@ use crate::{
             ap::{AccessPortError, GenericAp, MemoryAp},
             communication_interface::{ArmProbeInterface, MemoryApInformation},
             memory::Component,
-            ApInformation, SwoConfig,
+            ApInformation, SwoConfig, SwoReader,
         },
         riscv::communication_interface::RiscvCommunicationInterface,
     },
@@ -330,6 +330,17 @@ impl Session {
     pub fn read_swo(&mut self) -> Result<Vec<u8>, Error> {
         let interface = self.get_arm_interface()?;
         interface.read_swo()
+    }
+
+    /// Returns an implementation of [std::io::Read] that wraps [ArmProbeInterface::read_swo].
+    ///
+    /// The implementation buffers all available bytes from
+    /// [ArmProbeInterface::read_swo] on each [std::io::Read::read],
+    /// minimizing the chance of a target-side overflow event on which
+    /// trace packets are lost.
+    pub fn swo_reader(&mut self) -> Result<SwoReader, Error> {
+        let interface = self.get_arm_interface()?;
+        Ok(SwoReader::new(interface))
     }
 
     fn get_arm_interface(&mut self) -> Result<&mut Box<dyn ArmProbeInterface>, Error> {


### PR DESCRIPTION
An upcoming release of `itm` (queued to replace the now deprecated `itm-decode`) now takes an `std::io::Read` impl
instead of requiring the end-user to push bytes manually.