### PR TITLE
Permissions & nRF53 unlocking sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a permissions system that allows the user to specify if a full chip erase is allowed (#918)
+- Added debug sequence for the nRF5340 that turns on the network core can unlock both cores by erasing them if that is permitted (#918)
+
 ## [0.12.0]
 
 - Added support for `chip-erase` flag under the `probe-rs-cli download` command. (#898)

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -14,8 +14,8 @@ use probe_rs::{
     ProbeCreationError,
 };
 use probe_rs::{
-    Core, CoreStatus, DebugProbeError, DebugProbeSelector, MemoryInterface, Probe, Session,
-    WireProtocol,
+    Core, CoreStatus, DebugProbeError, DebugProbeSelector, MemoryInterface, Permissions, Probe,
+    Session, WireProtocol,
 };
 use probe_rs_rtt::{Rtt, ScanRegion};
 use serde::Deserialize;
@@ -141,6 +141,11 @@ pub struct DebuggerOptions {
     #[structopt(long, conflicts_with("dap"))]
     #[serde(default)]
     pub(crate) connect_under_reset: bool,
+
+    /// Allow the chip to be fully erased
+    #[structopt(long, conflicts_with("dap"))]
+    #[serde(default)]
+    pub(crate) allow_erase_all: bool,
 
     /// IP port number to listen for incoming DAP connections, e.g. "50000"
     #[structopt(long, requires("dap"), required_if("dap", "true"))]
@@ -306,16 +311,23 @@ pub fn start_session(debugger_options: &DebuggerOptions) -> Result<SessionData, 
         }
     }
 
+    let mut permissions = Permissions::new();
+    if debugger_options.allow_erase_all {
+        permissions = permissions.allow_erase_all();
+    }
+
     // Attach to the probe.
     let target_session = if debugger_options.connect_under_reset {
-        target_probe.attach_under_reset(target_selector)?
+        target_probe.attach_under_reset(target_selector, permissions)?
     } else {
-        target_probe.attach(target_selector).map_err(|err| {
-            anyhow!(
-                "Error attaching to the probe: {:?}.\nTry the --connect-under-reset option",
-                err
-            )
-        })?
+        target_probe
+            .attach(target_selector, permissions)
+            .map_err(|err| {
+                anyhow!(
+                    "Error attaching to the probe: {:?}.\nTry the --connect-under-reset option",
+                    err
+                )
+            })?
     };
 
     // Change the current working directory if `debugger_options.cwd` is `Some(T)`.

--- a/gdb-server/src/bin.rs
+++ b/gdb-server/src/bin.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use colored::*;
+use probe_rs::Permissions;
 use std::sync::Mutex;
 use std::{
     process::{self},
@@ -118,7 +119,7 @@ fn main_try() -> Result<()> {
         None => TargetSelector::Auto,
     };
 
-    let session = Mutex::new(probe.attach(target_selector)?);
+    let session = Mutex::new(probe.attach(target_selector, Permissions::default())?);
 
     if opt.reset_halt {
         session

--- a/probe-rs-cli-util/src/common_options.rs
+++ b/probe-rs-cli-util/src/common_options.rs
@@ -38,7 +38,8 @@ use std::{fs::File, io::Write, path::Path, path::PathBuf};
 use probe_rs::{
     config::{RegistryError, TargetSelector},
     flashing::{FileDownloadError, FlashError, FlashLoader},
-    DebugProbeError, DebugProbeSelector, FakeProbe, Probe, Session, Target, WireProtocol,
+    DebugProbeError, DebugProbeSelector, FakeProbe, Permissions, Probe, Session, Target,
+    WireProtocol,
 };
 use structopt::StructOpt;
 
@@ -149,6 +150,12 @@ pub struct ProbeOptions {
     pub speed: Option<u32>,
     #[structopt(long = "dry-run")]
     pub dry_run: bool,
+    #[structopt(
+        long = "allow-erase-all",
+        help = "Use this flag to allow all memory, including security keys and 3rd party firmware, to be erased \
+        even when it has read-only protection."
+    )]
+    pub allow_erase_all: bool,
 }
 
 impl ProbeOptions {
@@ -246,10 +253,15 @@ impl ProbeOptions {
         probe: Probe,
         target: TargetSelector,
     ) -> Result<Session, OperationError> {
+        let mut permissions = Permissions::new();
+        if self.allow_erase_all {
+            permissions = permissions.allow_erase_all();
+        }
+
         let session = if self.connect_under_reset {
-            probe.attach_under_reset(target)
+            probe.attach_under_reset(target, permissions)
         } else {
-            probe.attach(target)
+            probe.attach(target, permissions)
         }
         .map_err(|error| OperationError::AttachingFailed {
             source: error,

--- a/probe-rs/examples/benchmark.rs
+++ b/probe-rs/examples/benchmark.rs
@@ -1,3 +1,4 @@
+use probe_rs::Permissions;
 use probe_rs::{config::TargetSelector, MemoryInterface, Probe, WireProtocol};
 
 use std::{env, num::ParseIntError, time::SystemTime};
@@ -69,7 +70,7 @@ fn main() -> Result<(), &'static str> {
     let probe_name = probe.get_name();
 
     let mut session = probe
-        .attach(target_selector)
+        .attach(target_selector, Permissions::default())
         .map_err(|_| "Failed to attach probe to target")?;
 
     let chip_name = session.target().name.clone();

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -1,4 +1,4 @@
-use probe_rs::{config::TargetSelector, MemoryInterface, Probe, WireProtocol};
+use probe_rs::{config::TargetSelector, MemoryInterface, Permissions, Probe, WireProtocol};
 
 use std::num::ParseIntError;
 use std::time::{Duration, Instant};
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
     }
 
     let mut session = probe
-        .attach(target_selector)
+        .attach(target_selector, Permissions::default())
         .context("Failed to attach probe to target")?;
     let mut core = session.core(0).context("Failed to attach to core")?;
 

--- a/probe-rs/examples/tcp_itm.rs
+++ b/probe-rs/examples/tcp_itm.rs
@@ -1,5 +1,5 @@
 use probe_rs::architecture::arm::swo::SwoConfig;
-use probe_rs::Error;
+use probe_rs::{Error, Permissions};
 
 use itm_decode::{Decoder, DecoderOptions, TracePacket};
 
@@ -21,7 +21,7 @@ fn main() -> Result<(), Error> {
     let probe = probes[0].open()?;
 
     // Attach to a chip.
-    let mut session = probe.attach("stm32f407")?;
+    let mut session = probe.attach("stm32f407", Permissions::default())?;
 
     // Create a new SwoConfig with a system clock frequency of 16MHz
     let cfg = SwoConfig::new(16_000_000)

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -1,3 +1,4 @@
+pub mod nrf53;
 pub mod nxp;
 
 use std::{
@@ -270,7 +271,11 @@ pub trait ArmDebugSequence: Send + Sync {
     ///
     /// [ARM SVD Debug Description]: http://www.keil.com/pack/doc/cmsis/Pack/html/debug_description.html#debugDeviceUnlock
     #[doc(alias = "DebugDeviceUnlock")]
-    fn debug_device_unlock(&self, _interface: &mut crate::Memory) -> Result<(), crate::Error> {
+    fn debug_device_unlock(
+        &self,
+        _interface: &mut crate::Memory,
+        _permissions: &crate::Permissions,
+    ) -> Result<(), crate::Error> {
         // Empty by default
         Ok(())
     }

--- a/probe-rs/src/architecture/arm/sequences/nrf53.rs
+++ b/probe-rs/src/architecture/arm/sequences/nrf53.rs
@@ -90,7 +90,11 @@ impl ArmDebugSequence for Nrf5340 {
                 "Core {} is locked. Erase procedure will be started to unlock it.",
                 core_ahb_ap
             );
-            self.unlock_core(interface.get_arm_interface()?, core_ctrl_ap_address, permissions)?;
+            self.unlock_core(
+                interface.get_arm_interface()?,
+                core_ctrl_ap_address,
+                permissions,
+            )?;
 
             if !self.is_core_unlocked(interface.get_arm_interface()?, core_ahb_ap_address)? {
                 return Err(crate::Error::ArchitectureSpecific(

--- a/probe-rs/src/architecture/arm/sequences/nrf53.rs
+++ b/probe-rs/src/architecture/arm/sequences/nrf53.rs
@@ -1,0 +1,107 @@
+use std::sync::Arc;
+
+use super::ArmDebugSequence;
+use crate::architecture::arm::ap::CSW;
+use crate::architecture::arm::{
+    communication_interface::Initialized, ApAddress, ArmCommunicationInterface, DapAccess,
+};
+
+pub struct Nrf5340(());
+
+impl Nrf5340 {
+    const ERASEALL: u8 = 0x04;
+    const ERASEALLSTATUS: u8 = 0x08;
+
+    const APPLICATION_RESET_S_NETWORK_FORCEOFF_REGISTER: u32 = 0x50005614;
+    const RELEASE_FORCEOFF: u32 = 0;
+
+    pub fn create() -> Arc<dyn ArmDebugSequence> {
+        Arc::new(Self(()))
+    }
+
+    /// Returns true when the core is unlocked and false when it is locked.
+    /// The `ap_address` must be of the ahb ap of the core.
+    fn is_core_unlocked(
+        &self,
+        arm_interface: &mut ArmCommunicationInterface<Initialized>,
+        ap_address: ApAddress,
+    ) -> Result<bool, crate::Error> {
+        let csw: CSW = arm_interface.read_raw_ap_register(ap_address, 0x00)?.into();
+        Ok(csw.DeviceEn != 0)
+    }
+
+    /// Unlocks the core by performing an erase all procedure.
+    /// The `ap_address` must be of the ctrl ap of the core.
+    fn unlock_core(
+        &self,
+        arm_interface: &mut ArmCommunicationInterface<Initialized>,
+        ap_address: ApAddress,
+    ) -> Result<(), crate::Error> {
+        arm_interface.write_raw_ap_register(ap_address, Self::ERASEALL, 1)?;
+        while arm_interface.read_raw_ap_register(ap_address, Self::ERASEALLSTATUS)? != 0 {}
+        Ok(())
+    }
+
+    /// Sets the network core to active running.
+    /// The `ap_address` must be of the ahb ap of the application core.
+    fn set_network_core_running(&self, interface: &mut crate::Memory) -> Result<(), crate::Error> {
+        interface.write_32(
+            Self::APPLICATION_RESET_S_NETWORK_FORCEOFF_REGISTER,
+            &[Self::RELEASE_FORCEOFF],
+        )?;
+        Ok(())
+    }
+}
+
+impl ArmDebugSequence for Nrf5340 {
+    fn debug_device_unlock(
+        &self,
+        interface: &mut crate::Memory,
+        permissions: &crate::Permissions,
+    ) -> Result<(), crate::Error> {
+        // TODO: Eraseprotect is not considered. If enabled, the debugger must set up the same keys as the firmware does
+        // TODO: Approtect and Secure Approtect are not considered. If enabled, the debugger must set up the same keys as the firmware does
+        // These keys should be queried from the user if required and once that mechanism is implemented
+
+        if !permissions.erase_all() {
+            return Err(crate::Error::MissingPermissions(String::from("erase_all")));
+        }
+
+        let ap_address = interface.get_ap();
+
+        let core_aps = [(0, 2), (1, 3)];
+
+        for (core_ahb_ap, core_ctrl_ap) in core_aps {
+            let core_ahb_ap_address = ApAddress {
+                ap: core_ahb_ap,
+                ..ap_address
+            };
+            let core_ctrl_ap_address = ApAddress {
+                ap: core_ctrl_ap,
+                ..ap_address
+            };
+
+            log::info!("Checking if core {} is unlocked", core_ahb_ap);
+            if self.is_core_unlocked(interface.get_arm_interface()?, core_ahb_ap_address)? {
+                log::info!("Core {} is already unlocked", core_ahb_ap);
+                continue;
+            }
+
+            log::warn!(
+                "Core {} is locked. Erase procedure will be started to unlock it.",
+                core_ahb_ap
+            );
+            self.unlock_core(interface.get_arm_interface()?, core_ctrl_ap_address)?;
+
+            if !self.is_core_unlocked(interface.get_arm_interface()?, core_ahb_ap_address)? {
+                return Err(crate::Error::ArchitectureSpecific(
+                    format!("Could not unlock core {}", core_ahb_ap).into(),
+                ));
+            }
+        }
+
+        self.set_network_core_running(interface)?;
+
+        Ok(())
+    }
+}

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -2,6 +2,7 @@ use probe_rs_target::{Architecture, ChipFamily};
 
 use super::{Core, MemoryRegion, RawFlashAlgorithm, RegistryError, TargetDescriptionSource};
 
+use crate::architecture::arm::sequences::nrf53::Nrf5340;
 use crate::architecture::arm::sequences::nxp::LPC55S69;
 use crate::architecture::arm::sequences::ArmDebugSequence;
 use crate::architecture::riscv::sequences::esp32c3::ESP32C3;
@@ -95,6 +96,9 @@ impl Target {
         } else if chip.name.starts_with("esp32c3") {
             log::warn!("Using custom sequence for ESP32c3");
             debug_sequence = DebugSequence::Riscv(ESP32C3::create());
+        } else if chip.name.starts_with("nRF5340") {
+            log::warn!("Using custom sequence for nRF5340");
+            debug_sequence = DebugSequence::Arm(Nrf5340::create());
         }
 
         Ok(Target {

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     ChipNotFound(#[from] RegistryError),
     #[error("This feature requires one of the following architectures: {0:?}")]
     ArchitectureRequired(&'static [&'static str]),
+    #[error("An operation couldn't be done because it lacked the permission to do so: {0}")]
+    MissingPermissions(String),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/probe-rs/src/flashing/mod.rs
+++ b/probe-rs/src/flashing/mod.rs
@@ -16,9 +16,9 @@
 //! and looks like this:
 //!
 //! ```no_run
-//! use probe_rs::{Session, flashing};
+//! use probe_rs::{Session, flashing, Permissions};
 //!
-//! let mut session = Session::auto_attach("nrf51822")?;
+//! let mut session = Session::auto_attach("nrf51822", Permissions::default())?;
 //!
 //! flashing::download_file(&mut session, "binary.hex", flashing::Format::Hex)?;
 //!
@@ -28,10 +28,10 @@
 //! ### Adding data manually
 //!
 //! ```no_run
-//! use probe_rs::{Session, flashing::{FlashLoader, DownloadOptions}};
+//! use probe_rs::{Session, flashing::{FlashLoader, DownloadOptions}, Permissions};
 //!
 //!
-//! let mut session = Session::auto_attach("nrf51822")?;
+//! let mut session = Session::auto_attach("nrf51822", Permissions::default())?;
 //!
 //! let mut loader = session.target().flash_loader();
 //!

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -87,7 +87,7 @@ pub use crate::probe::{
     AttachMethod, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType,
     Probe, ProbeCreationError, WireProtocol,
 };
-pub use crate::session::Session;
+pub use crate::session::{Permissions, Session};
 
 // TODO: Hide behind feature
 pub use crate::probe::fake_probe::FakeProbe;

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -12,7 +12,7 @@
 //! ## Halting the attached chip
 //! ```no_run
 //! # use probe_rs::Error;
-//! use probe_rs::Probe;
+//! use probe_rs::{Probe, Permissions};
 //!
 //! // Get a list of all available debug probes.
 //! let probes = Probe::list_all();
@@ -21,7 +21,7 @@
 //! let mut probe = probes[0].open()?;
 //!
 //! // Attach to a chip.
-//! let mut session = probe.attach("nrf52")?;
+//! let mut session = probe.attach("nrf52", Permissions::default())?;
 //!
 //! // Select a core.
 //! let mut core = session.core(0)?;
@@ -35,10 +35,10 @@
 //!
 //! ```no_run
 //! # use probe_rs::Error;
-//! use probe_rs::Session;
+//! use probe_rs::{Session, Permissions};
 //! use probe_rs::MemoryInterface;
 //!
-//! let mut session = Session::auto_attach("nrf52")?;
+//! let mut session = Session::auto_attach("nrf52", Permissions::default())?;
 //! let mut core = session.core(0)?;
 //!
 //! // Read a block of 50 32 bit words.

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -379,6 +379,7 @@ impl DapAccess for FakeArmInterface<Initialized> {
 #[cfg(test)]
 mod test {
     use super::FakeProbe;
+    use crate::Permissions;
 
     #[test]
     fn create_session_with_fake_probe() {
@@ -386,6 +387,8 @@ mod test {
 
         let probe = fake_probe.into_probe();
 
-        probe.attach("nrf51822_xxAC").unwrap();
+        probe
+            .attach("nrf51822_xxAC", Permissions::default())
+            .unwrap();
     }
 }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -623,8 +623,12 @@ impl Permissions {
         }
     }
 
-    pub(crate) fn erase_all(&self) -> bool {
-        self.erase_all
+    pub(crate) fn erase_all(&self) -> Result<(), crate::Error> {
+        if self.erase_all {
+            Ok(())
+        } else {
+            Err(crate::Error::MissingPermissions("erase_all".into()))
+        }
     }
 }
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -115,6 +115,7 @@ impl Session {
         probe: Probe,
         target: TargetSelector,
         attach_method: AttachMethod,
+        permissions: Permissions,
     ) -> Result<Self, Error> {
         let (mut probe, target) = get_target_from_selector(target, attach_method, probe)?;
 
@@ -178,7 +179,7 @@ impl Session {
                     let mut memory_interface = interface.memory_interface(default_memory_ap)?;
 
                     // Enable debug mode
-                    sequence_handle.debug_device_unlock(&mut memory_interface)?;
+                    sequence_handle.debug_device_unlock(&mut memory_interface, &permissions)?;
 
                     // Enable debug mode
                     sequence_handle.debug_core_start(&mut memory_interface)?;
@@ -280,7 +281,10 @@ impl Session {
     }
 
     /// Automatically creates a session with the first connected probe found.
-    pub fn auto_attach(target: impl Into<TargetSelector>) -> Result<Session, Error> {
+    pub fn auto_attach(
+        target: impl Into<TargetSelector>,
+        permissions: Permissions,
+    ) -> Result<Session, Error> {
         // Get a list of all available debug probes.
         let probes = Probe::list_all();
 
@@ -291,7 +295,7 @@ impl Session {
             .open()?;
 
         // Attach to a chip.
-        probe.attach(target)
+        probe.attach(target, permissions)
     }
 
     /// Lists the available cores with their number and their type.
@@ -581,4 +585,51 @@ fn get_target_from_selector(
     };
 
     Ok((probe, target))
+}
+
+/// The `Permissions` struct represents what a [Session] is allowed to do with a target.
+/// Some operations can be irreversable, so need to be explicitly allowed by the user.
+///
+/// # Example
+///
+/// ```
+/// use probe_rs::Permissions;
+///
+/// let permissions = Permissions::new().allow_erase_all();
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct Permissions {
+    /// When set to true, all memory of the chip may be erased or reset to factory default
+    erase_all: bool,
+}
+
+impl Permissions {
+    /// Constructs a new permissions object with the default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allow the session to erase all memory of the chip or reset it to factory default.
+    ///
+    /// # Warning
+    /// This may irreversibly remove otherwise read-protected data from the device like security keys and 3rd party firmware.
+    /// What happens exactly may differ per device and per probe-rs version.
+    #[must_use]
+    pub fn allow_erase_all(self) -> Self {
+        Self {
+            erase_all: true,
+            ..self
+        }
+    }
+
+    pub(crate) fn erase_all(&self) -> bool {
+        self.erase_all
+    }
+}
+
+impl Default for Permissions {
+    fn default() -> Self {
+        Self { erase_all: false }
+    }
 }

--- a/probe-rs/tests/flash_dry_run.rs
+++ b/probe-rs/tests/flash_dry_run.rs
@@ -1,11 +1,11 @@
-use probe_rs::{flashing::DownloadOptions, FakeProbe, Probe};
+use probe_rs::{flashing::DownloadOptions, FakeProbe, Permissions, Probe};
 
 #[test]
 fn flash_dry_run() {
     let probe = Probe::from_specific_probe(Box::new(FakeProbe::new()));
 
     let mut session = probe
-        .attach("stm32wb55ccux")
+        .attach("stm32wb55ccux", Permissions::default())
         .expect("Failed to attach with 'fake' probe.");
 
     let mut flasher = session.target().flash_loader();

--- a/rtt/src/lib.rs
+++ b/rtt/src/lib.rs
@@ -12,12 +12,12 @@
 //!
 //! ```no_run
 //! use std::sync::{Arc, Mutex};
-//! use probe_rs::Probe;
+//! use probe_rs::{Probe, Permissions};
 //! use probe_rs_rtt::Rtt;
 //!
 //! // First obtain a probe-rs session (see probe-rs documentation for details)
 //! let probe = Probe::list_all()[0].open()?;
-//! let mut session = probe.attach("somechip")?;
+//! let mut session = probe.attach("somechip", Permissions::default())?;
 //! let memory_map = session.target().memory_map.clone();
 //! // Select a core.
 //! let mut core = session.core(0)?;

--- a/rtthost/src/main.rs
+++ b/rtthost/src/main.rs
@@ -1,3 +1,4 @@
+use probe_rs::Permissions;
 use probe_rs::{config::TargetSelector, DebugProbeInfo, Probe};
 use probe_rs_rtt::{Channels, Rtt, RttChannel, ScanRegion};
 use std::io::prelude::*;
@@ -140,7 +141,7 @@ fn run() -> i32 {
         .map(TargetSelector::Unspecified)
         .unwrap_or(TargetSelector::Auto);
 
-    let mut session = match probe.attach(target_selector) {
+    let mut session = match probe.attach(target_selector, Permissions::default()) {
         Ok(session) => session,
         Err(err) => {
             eprintln!("Error creating debug session: {}", err);

--- a/smoke-tester/src/main.rs
+++ b/smoke-tester/src/main.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 
 use clap::{App, Arg};
-use probe_rs::Error;
+use probe_rs::{Error, Permissions};
 
 mod dut_definition;
 mod macros;
@@ -81,7 +81,7 @@ fn main() -> Result<()> {
         println_dut_status!(tracker, blue, "Chip:  {:?}", &definition.chip.name);
 
         let mut session = probe
-            .attach(definition.chip.clone())
+            .attach(definition.chip.clone(), Permissions::default())
             .context("Failed to attach to chip")?;
         let target = session.target();
         let memory_regions = target.memory_map.clone();
@@ -137,7 +137,8 @@ fn main() -> Result<()> {
         if definition.reset_connected {
             let probe = definition.open_probe()?;
 
-            let _session = probe.attach_under_reset(definition.chip.clone())?;
+            let _session =
+                probe.attach_under_reset(definition.chip.clone(), Permissions::default())?;
         }
 
         Ok(())


### PR DESCRIPTION
Added a permissions system to tell the session what it is allowed to do.
Currently only one permission is present: `erase_all`
This permission allows the debug sequence to use erase the entire device, including secure keys and 3rd party firmware that is read-only locked. This is required for the nRF53 for which a debug sequence has been added.

The permissions are passed through the Session::attach method.

In relevant places, a CLI option has been added.
Everywhere else, the default permissions are passed which does not allow anything.

I've also made a branch for cargo-flash to add a diagnostic for the new error: https://github.com/diondokter/cargo-flash/commit/d0d075db48d0eaa033ec8932d11d5ce609ace107