### PR TITLE
cmsisdap: Check for DAP_Transfer response with more transfers than requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a panic when cmsisdap probes return more transfers than requested (#922, #923)
+
 ## [0.12.0]
 
 - Added support for `chip-erase` flag under the `probe-rs-cli download` command. (#898)

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
@@ -166,7 +166,14 @@ impl Request for TransferRequest {
     }
 
     fn from_bytes(&self, mut buffer: &[u8]) -> Result<Self::Response, SendError> {
+        if buffer.len() < 2 {
+            return Err(SendError::NotEnoughData);
+        }
         let transfer_count = buffer[0];
+        if transfer_count as usize > self.transfers.len() {
+            log::error!("Transfer count larger than requested number of transfers");
+            return Err(SendError::UnexpectedAnswer);
+        }
 
         let last_transfer_response = LastTransferResponse {
             ack: match buffer[1] & 0x7 {


### PR DESCRIPTION
In #922 it looks like `transfer_count` which is read from the response data could be larger than `self.transfers.len()`, so we try and access `self.transfers` out of bounds. This isn't expected from a probe (it shouldn't be able to execute _more_ transfers than we asked...) but at least makes sense to emit a useful error log and return an Error instead of panicking.

Still a draft because there might be more we can do to fix #922.