### PR TITLE
Fall back to older version of futures, version 0.3.18 was yanked

### DIFF
--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -34,7 +34,7 @@ anyhow = "1.0.51"
 reqwest = { version = "0.11.7", features = ["json", "blocking"] }
 serde = { version = "1.0.131", features = ["derive"] }
 # chrono = { version = "0.4.0", features = ["serde"] }
-futures = "0.3.18"
+futures = "0.3.17"
 tokio = { version = "1.14.0", features = ["macros", "rt", "rt-multi-thread"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Revert futures to version 0.3.17 in target-gen, version 0.3.18 was yanked.

See rust-lang/futures-rs#2529.﻿
