### PR TITLE
msp, psp, and extra register added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for core registers `msp`, `psp` and `extra`, extra containing:
+  - Bits[31:24] CONTROL.
+  - Bits[23:16] FAULTMASK.
+  - Bits[15:8]  BASEPRI.
+  - Bits[7:0]   PRIMASK.
+
 ### Fixed
 
 - Fixed a panic when cmsisdap probes return more transfers than requested (#922, #923)

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -55,6 +55,28 @@ pub(crate) mod register {
         _kind: RegisterKind::General,
         address: CoreRegisterAddress(14),
     };
+
+    pub const MSP: RegisterDescription = RegisterDescription {
+        name: "MSP",
+        _kind: RegisterKind::General,
+        address: CoreRegisterAddress(0b10001),
+    };
+
+    pub const PSP: RegisterDescription = RegisterDescription {
+        name: "PSP",
+        _kind: RegisterKind::General,
+        address: CoreRegisterAddress(0b10010),
+    };
+
+    // CONTROL bits [31:24], FAULTMASK bits [23:16],
+    // BASEPRI bits [15:8], and PRIMASK bits [7:0]
+    pub const EXTRA: RegisterDescription = RegisterDescription {
+        name: "EXTRA",
+        _kind: RegisterKind::General,
+        address: CoreRegisterAddress(0b10100),
+    };
+
+    // TODO: Floating point support
 }
 
 static ARM_REGISTER_FILE: RegisterFile = RegisterFile {
@@ -180,6 +202,11 @@ static ARM_REGISTER_FILE: RegisterFile = RegisterFile {
             address: CoreRegisterAddress(1),
         },
     ],
+
+    msp: Some(&register::MSP),
+    psp: Some(&register::PSP),
+    extra: Some(&register::EXTRA),
+    // TODO: Floating point support
 };
 
 bitfield! {

--- a/probe-rs/src/architecture/riscv/register.rs
+++ b/probe-rs/src/architecture/riscv/register.rs
@@ -310,4 +310,8 @@ pub(super) static RISCV_REGISTERS: RegisterFile = RegisterFile {
             address: CoreRegisterAddress(0x100B),
         },
     ],
+
+    psp: None,
+    msp: None,
+    extra: None,
 };

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -81,7 +81,15 @@ pub struct RegisterFile {
     pub(crate) return_address: &'static RegisterDescription,
 
     pub(crate) argument_registers: &'static [RegisterDescription],
+
     pub(crate) result_registers: &'static [RegisterDescription],
+
+    pub(crate) msp: Option<&'static RegisterDescription>,
+
+    pub(crate) psp: Option<&'static RegisterDescription>,
+
+    pub(crate) extra: Option<&'static RegisterDescription>,
+    // TODO: floating point support
 }
 
 impl RegisterFile {
@@ -124,6 +132,34 @@ impl RegisterFile {
     pub fn get_platform_register(&self, index: usize) -> Option<&RegisterDescription> {
         self.platform_registers.get(index)
     }
+
+    pub fn msp(&self) -> Option<&RegisterDescription> {
+        self.msp
+    }
+
+    pub fn psp(&self) -> Option<&RegisterDescription> {
+        self.psp
+    }
+
+    // ARM DDI 0403E.d (ID070218)
+    // C1.6.3 Debug Core Register Selector Register, DCRSR
+    // Bits[31:24] CONTROL.
+    // Bits[23:16] FAULTMASK.
+    // Bits[15:8]  BASEPRI.
+    // Bits[7:0]   PRIMASK.
+    // In each field, the valid bits are packed with leading zeros. For example,
+    // FAULTMASK is always a single bit, DCRDR[16], and DCRDR[23:17] is 0b0000000.
+    pub fn extra(&self) -> Option<&RegisterDescription> {
+        self.extra
+    }
+
+    // TODO: support for floating point registers
+    // 0b0100001            Floating-point Status and Control Register, FPSCR.
+    // 0b1000000-0b1011111  FP registers S0-S31.
+    // For example, 0b1000000 specifies S0, and 0b1000101 specifies S5.
+    // All other values are Reserved.
+    // If the processor does not implement the FP extension the REGSEL field is bits[4:0], and
+    // bits[6:5] are Reserved, SBZ.
 }
 
 pub trait CoreInterface: MemoryInterface {


### PR DESCRIPTION
Added support for core registers:
- msp
- psp
- extra 
   // ARM DDI 0403E.d (ID070218)
    // C1.6.3 Debug Core Register Selector Register, DCRSR
    // Bits[31:24] CONTROL.
    // Bits[23:16] FAULTMASK.
    // Bits[15:8]  BASEPRI.
    // Bits[7:0]   PRIMASK.
  
 Added notes for debug access for floating point, if anyone feels like having a go.