### PR TITLE
Add start sequence for lpc55s19.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bits[23:16] FAULTMASK.
   - Bits[15:8]  BASEPRI.
   - Bits[7:0]   PRIMASK.
+- Debug port start sequence for LPC55S16 (#944)
 
 ### Fixed
 

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -89,8 +89,8 @@ impl Target {
             Architecture::Riscv => DebugSequence::Riscv(DefaultRiscvSequence::create()),
         };
 
-        if chip.name.starts_with("LPC55S69") {
-            log::warn!("Using custom sequence for LPC55S69");
+        if chip.name.starts_with("LPC55S16") || chip.name.starts_with("LPC55S69") {
+            log::warn!("Using custom sequence for LPC55S16/LPC55S69");
             debug_sequence = DebugSequence::Arm(LPC55S69::create());
         } else if chip.name.starts_with("esp32c3") {
             log::warn!("Using custom sequence for ESP32c3");


### PR DESCRIPTION
The lpc55s19 seems to use the same start sequence as lpc55s69.
Enabling the same sequence allows erase/download operations to
appear to succeed.

FWIW, when I dump memory locations, it matches the contents of the binary I downloaded, so I think this is working. My guess that is we need to rework this into a more generic form for nxp (not just lpc55s69) since it's common code now.