### PR TITLE
Fix argument parsing in debugger

### DIFF
--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -100,7 +100,7 @@ pub struct DebuggerOptions {
     pub(crate) cwd: Option<PathBuf>,
 
     /// Binary to debug as a path. Relative to `cwd`, or fully qualified.
-    #[clap(long, parse(from_os_str), conflicts_with("dap"))]
+    #[clap(long, parse(from_os_str), required(true), conflicts_with("dap"))]
     pub(crate) program_binary: Option<PathBuf>,
 
     /// The number associated with the debug probe to use. Use 'list' command to see available probes
@@ -153,7 +153,7 @@ pub struct DebuggerOptions {
     /// Reset the target after flashing
     #[clap(
         long,
-        required_if_eq("flashing_enabled", "true"),
+        required_if_eq("flashing-enabled", "true"),
         conflicts_with("dap")
     )]
     #[serde(default)]
@@ -168,7 +168,7 @@ pub struct DebuggerOptions {
     #[clap(
         long,
         conflicts_with("dap"),
-        required_if_eq("flashing_enabled", "true")
+        required_if_eq("flashing-enabled", "true")
     )]
     #[serde(default)]
     pub(crate) full_chip_erase: bool,
@@ -177,7 +177,7 @@ pub struct DebuggerOptions {
     #[clap(
         long,
         conflicts_with("dap"),
-        required_if_eq("flashing_enabled", "true")
+        required_if_eq("flashing-enabled", "true")
     )]
     #[serde(default)]
     pub(crate) restore_unwritten_bytes: bool,

--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -78,19 +78,16 @@ fn parse_hex(src: &str) -> Result<u32, std::num::ParseIntError> {
 )]
 enum CliCommands {
     /// List all connected debug probes
-    #[clap(name = "list")]
     List {},
     /// List all probe-rs supported chips
     #[clap(name = "list-chips")]
     ListChips {},
     /// Gets infos about the selected debug probe and connected target
-    #[clap(name = "info")]
     Info {
         #[clap(flatten)]
         debugger_options: DebuggerOptions,
     },
     /// Resets the target attached to the selected debug probe
-    #[clap(name = "reset")]
     Reset {
         #[clap(flatten)]
         debugger_options: DebuggerOptions,
@@ -100,7 +97,6 @@ enum CliCommands {
     },
     /// Open target in debug mode and accept debug commands.
     /// By default, the program operates in CLI mode.
-    #[clap(name = "debug")]
     Debug {
         #[clap(flatten)]
         debugger_options: DebuggerOptions,
@@ -115,7 +111,6 @@ enum CliCommands {
         vscode: bool,
     },
     /// Dump memory from attached target
-    #[clap(name = "dump")]
     Dump {
         #[clap(flatten)]
         debugger_options: DebuggerOptions,
@@ -127,7 +122,6 @@ enum CliCommands {
         words: u32,
     },
     /// Download memory to attached target
-    #[clap(name = "download")]
     Download {
         #[clap(flatten)]
         debugger_options: DebuggerOptions,
@@ -136,7 +130,6 @@ enum CliCommands {
         path: String,
     },
     /// Begin tracing a memory address over SWV
-    #[clap(name = "trace")]
     Trace {
         #[clap(flatten)]
         debugger_options: DebuggerOptions,


### PR DESCRIPTION
Fix parsing, new clap seems to require that we specify the flags with a hyphen.

Also, some of the unnecessary clap attributes are removed.