### PR TITLE
Add CortexM23 to Armv8m mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a command to print the list of all supported chips. (#946)
 - Added a command to print info about a chip, such as RAM and the number of cores. (#946)
 - ARM:`Session::swo_reader` that returns a wrapping implementation of `std::io::Read` around `Session::read_swo`. (#916)
+- Added CortexM23 to Armv8m mapping for `target-gen`. (#966)
 
 ### Changed
 

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -155,6 +155,7 @@ fn core_to_probe_core(value: &Core) -> Result<CoreType, Error> {
         Core::CortexM0Plus => CoreType::Armv6m,
         Core::CortexM4 => CoreType::Armv7em,
         Core::CortexM3 => CoreType::Armv7m,
+        Core::CortexM23 => CoreType::Armv8m,
         Core::CortexM33 => CoreType::Armv8m,
         Core::CortexM7 => CoreType::Armv7em,
         c => {


### PR DESCRIPTION
I suppose lack of this definition is just a mere oversight or something.

I needed this to process [Nuvoton.NuMicro_DFP.1.3.9.pack](https://github.com/OpenNuvoton/cmsis-packs/) by target-gen.

And I can report that at least basic operations are working fine with Cortex-M23 based Nuvoton chips, M252 series for example.