### PR TITLE
treewide: occured → occurred

### DIFF
--- a/probe-rs-cli-util/src/lib.rs
+++ b/probe-rs-cli-util/src/lib.rs
@@ -25,7 +25,7 @@ pub enum ArtifactError {
         source: std::io::Error,
         work_dir: String,
     },
-    #[error("An IO error occured during the execution of 'cargo build'.")]
+    #[error("An IO error occurred during the execution of 'cargo build'.")]
     Io(#[source] std::io::Error),
     #[error("Unable to read the Cargo.toml at '{path}'.")]
     CargoToml {
@@ -151,7 +151,7 @@ pub fn build_artifact(work_dir: &Path, args: &[String]) -> Result<Artifact, Arti
     }
 
     // Check if the command succeeded, otherwise return an error.
-    // Any error messages occuring during the build are shown above,
+    // Any error messages occurring during the build are shown above,
     // when the compiler messages are rendered.
     if !output.status.success() {
         return Err(ArtifactError::CargoBuild(output.status.code()));

--- a/probe-rs/examples/tcp_itm.rs
+++ b/probe-rs/examples/tcp_itm.rs
@@ -266,7 +266,7 @@ impl SwoPublisher<Box<dyn Any + Send>> for TcpPublisher {
             h.0.join()
         }) {
             Some(Err(err)) => {
-                log::error!("An error occured during thread execution: {:?}", err);
+                log::error!("An error occurred during thread execution: {:?}", err);
                 Err(err)
             }
             _ => Ok(()),

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -24,7 +24,7 @@ use std::{
 
 #[derive(Debug, thiserror::Error, Clone, PartialEq)]
 pub enum DapError {
-    #[error("An error occured in the SWD communication between probe and device.")]
+    #[error("An error occurred in the SWD communication between probe and device.")]
     SwdProtocol,
     #[error("Target device did not respond to request.")]
     NoAcknowledge,

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -15,7 +15,7 @@ pub enum DebugPortError {
         register: &'static str,
         version: DebugPortVersion,
     },
-    #[error("A Debug Probe Error occured")]
+    #[error("A Debug Probe Error occurred")]
     DebugProbe(#[from] DebugProbeError),
 }
 

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -8,7 +8,7 @@ use num_traits::cast::FromPrimitive;
 pub enum RomTableError {
     #[error("Component is not a valid romtable")]
     NotARomtable,
-    #[error("An error with the access port occured during runtime")]
+    #[error("An error with the access port occurred during runtime")]
     AccessPort(
         #[from]
         #[source]

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -31,7 +31,7 @@ pub enum RiscvError {
     DebugProbe(#[from] DebugProbeError),
     #[error("Timeout during JTAG register access.")]
     Timeout,
-    #[error("Error occured during execution of an abstract command: {0:?}")]
+    #[error("Error occurred during execution of an abstract command: {0:?}")]
     AbstractCommand(AbstractCommandErrorKind),
     #[error("The core did not acknowledge a request for reset, resume or halt")]
     RequestNotAcknowledged,
@@ -619,14 +619,14 @@ impl<'probe> RiscvCommunicationInterface {
         for (out_index, &idx) in read_results.iter().enumerate() {
             data[out_index] = match result[idx] {
                 CommandResult::U32(data) => V::from_register_value(data),
-                _ => panic!("Internal error occured."),
+                _ => panic!("Internal error occurred."),
             };
         }
 
         // Check that the read was succesful
         let sbcs = match result[sbcs_result] {
             CommandResult::U32(res) => res,
-            _ => panic!("Internal error occured."),
+            _ => panic!("Internal error occurred."),
         };
 
         let sbcs = Sbcs(sbcs);
@@ -790,7 +790,7 @@ impl<'probe> RiscvCommunicationInterface {
         // Check that the write was succesful
         let sbcs = match result[ok_index] {
             CommandResult::U32(res) => res,
-            _ => panic!("Internal error occured."),
+            _ => panic!("Internal error occurred."),
         };
 
         let sbcs = Sbcs(sbcs);

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -29,10 +29,10 @@ pub enum RegistryError {
     /// in probe-rs.
     #[error("The core type '{0}' is not supported in probe-rs.")]
     UnknownCoreType(String),
-    /// An IO error which occured when trying to read a target description file.
+    /// An IO error which occurred when trying to read a target description file.
     #[error("An IO error was encountered")]
     Io(#[from] std::io::Error),
-    /// An error occured while deserializing a YAML target description file.
+    /// An error occurred while deserializing a YAML target description file.
     #[error("Deserializing the yaml encountered an error")]
     Yaml(#[from] serde_yaml::Error),
     /// Unable to lock the registry.

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -45,7 +45,7 @@ impl std::fmt::Debug for Target {
     }
 }
 
-/// An error occured while parsing the target description.
+/// An error occurred while parsing the target description.
 pub type TargetParseError = serde_yaml::Error;
 
 impl Target {

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -3,9 +3,9 @@ use crate::{architecture::arm::ap::AccessPortError, config::RegistryError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("An error with the usage of the probe occured")]
+    #[error("An error with the usage of the probe occurred")]
     Probe(#[from] DebugProbeError),
-    #[error("A core architecture specific error occured")]
+    #[error("A core architecture specific error occurred")]
     ArchitectureSpecific(#[from] Box<dyn std::error::Error + Send + Sync>),
     #[error("Probe could not be opened: {0}")]
     UnableToOpenProbe(&'static str),

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -53,7 +53,7 @@ impl FromStr for Format {
 /// OS permission issues as well as chip connectivity and memory boundary issues.
 #[derive(Debug, thiserror::Error)]
 pub enum FileDownloadError {
-    /// An error with the actual flashing procedure has occured.
+    /// An error with the actual flashing procedure has occurred.
     ///
     /// This is mostly an error in the communication with the target inflicted by a bad hardware connection or a probe-rs bug.
     #[error("Error while flashing")]
@@ -61,10 +61,10 @@ pub enum FileDownloadError {
     /// Reading and decoding the IHEX file has failed due to the given error.
     #[error("Could not read ihex format")]
     IhexRead(#[from] ihex::ReaderError),
-    /// An IO error has occured while reading the firmware file.
+    /// An IO error has occurred while reading the firmware file.
     #[error("I/O error")]
     IO(#[from] std::io::Error),
-    /// The given error has occured while reading the object file.
+    /// The given error has occurred while reading the object file.
     #[error("Object Error: {0}.")]
     Object(&'static str),
     /// Reading and decoding the given ELF file has resulted in the given error.

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -91,7 +91,7 @@ pub enum DebugProbeError {
     Usb(#[source] Option<Box<dyn std::error::Error + Send + Sync>>),
     #[error("The firmware on the probe is outdated")]
     ProbeFirmwareOutdated,
-    #[error("An error specific to a probe type occured")]
+    #[error("An error specific to a probe type occurred")]
     ProbeSpecific(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("Probe could not be created")]
     ProbeCouldNotBeCreated(#[from] ProbeCreationError),
@@ -100,11 +100,11 @@ pub enum DebugProbeError {
     // TODO: This is core specific, so should probably be moved there.
     #[error("Operation timed out")]
     Timeout,
-    #[error("An error specific to the selected architecture occured")]
+    #[error("An error specific to the selected architecture occurred")]
     ArchitectureSpecific(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("The connected probe does not support the interface '{0}'")]
     InterfaceNotAvailable(&'static str),
-    #[error("An error occured while working with the registry occured")]
+    #[error("An error occurred while working with the registry")]
     Registry(#[from] RegistryError),
     #[error("Tried to close interface while it was still in use")]
     InterfaceInUse,
@@ -140,7 +140,7 @@ pub enum ProbeCreationError {
     HidApi(#[from] hidapi::HidError),
     #[error("{0}")]
     Rusb(#[from] rusb::Error),
-    #[error("An error specific to a probe type occured: {0}")]
+    #[error("An error specific to a probe type occurred: {0}")]
     ProbeSpecific(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("{0}")]
     Other(&'static str),

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -707,7 +707,7 @@ impl JTAGAccess for FtdiProbe {
 
                         let data = match data {
                             CommandResult::VecU8(data) => data,
-                            _ => panic!("Internal error occured. Cannot have a transformer function for outputs other than Vec<u8>"),
+                            _ => panic!("Internal error occurred. Cannot have a transformer function for outputs other than Vec<u8>"),
                         };
                         results.push(
                             transformer(data)

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -467,7 +467,7 @@ impl<D: StLinkUsb> StLink<D> {
 
                     self.enter_idle()?;
                 }
-                // Other error occured, return it
+                // Other error occurred, return it
                 _ => return Err(e),
             }
         }


### PR DESCRIPTION
i encountered `Error: A core architecture specific error occured`
i went to look for the source of that typo, and found a few more occurrences