### PR TITLE
Complete 'lazy load' of variables in `probe-rs-debugger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chip names are now matched treating an 'x' as a wildcard. (#964)
 - GDB server is now available as a subcommand in the probe-rs-cli, not as a separate binary in the `gdb-server` package anymore . (#972)
 - `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals (#999)
-  - Removed `StackFrameIterator` and incorporated its logic into `DebugInfo::unwind()`
-  - `StackFrame` now has `VariableCache` entries for locals, statics and registers
-  - Modify `DebugSession` and `CoreData` to handle multiple cores.
-  - Modify `Variable::parent_key` to be `Option<i64>` and use `None` rather than `0` values to control logic.
-  - WIP: Use the updated `VariableCache` to facilitate 'lazy' loading of all variables during stack trace operations. VSCode and MS DAP will request one 'level' of variables at a time, and there is no need to resolve and cache variable data unless the user is going to view/use it.
+  - Removed StackFrameIterator and incorporated its logic into DebugInfo::unwind()
+  - StackFrame now has VariableCache entries for locals, statics and registers
+  - Modify DebugSession and CoreData to handle multiple cores.
+  - Modify Variable::parent_key to be Option<i64> and use None rather than 0 values to control logic.
+  - [WIP] Use the updated StackFrame, and new VariableNodeType to facilitate 'lazy' loading of variables during stack trace operations. VSCode and MS DAP will request one 'level' of variables at a time, and there is no need to resolve and cache variable data unless the user is going to view/use it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Chip names are now matched treating an 'x' as a wildcard. (#964)
 - GDB server is now available as a subcommand in the probe-rs-cli, not as a separate binary in the `gdb-server` package anymore . (#972)
-- `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals
+- `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals (#999)
   - `VariableCache` structure now models the tree stucture of the MS DAP Specification for `Threads -> StackTrace -> Scopes -> Variables`
   - Modify `DebugSession` and `CoreData` to handle multiple cores.
   - WIP: Modify `Variable::parent_key` to be `Option<i64>` and use `None` rather than `0` values to control logic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GDB server is now available as a subcommand in the probe-rs-cli, not as a separate binary in the `gdb-server` package anymore . (#972)
 - `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals
   - `VariableCache` structure now models the tree stucture of the MS DAP Specification for `Threads -> StackTrace -> Scopes -> Variables`
-  - 
+  - Modify `DebugSession` and `CoreData` to handle multiple cores.
+  - WIP: Modify `Variable::parent_key` to be `Option<i64>` and use `None` rather than `0` values to control logic.
+  - WIP: Use the updated `VariableCache` to facilitate 'lazy' loading of all variables during stack trace operations. VSCode and MS DAP will request one 'level' of variables at a time, and there is no need to resolve and cache variable data unless the user is going to view/use it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chip names are now matched treating an 'x' as a wildcard. (#964)
 - GDB server is now available as a subcommand in the probe-rs-cli, not as a separate binary in the `gdb-server` package anymore . (#972)
 - `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals (#999)
-  - `VariableCache` structure now models the tree stucture of the MS DAP Specification for `Threads -> StackTrace -> Scopes -> Variables`
+  - Removed `StackFrameIterator` and incorporated its logic into `DebugInfo::unwind()`
+  - `StackFrame` now has `VariableCache` entries for locals, statics and registers
   - Modify `DebugSession` and `CoreData` to handle multiple cores.
-  - WIP: Modify `Variable::parent_key` to be `Option<i64>` and use `None` rather than `0` values to control logic.
+  - Modify `Variable::parent_key` to be `Option<i64>` and use `None` rather than `0` values to control logic.
   - WIP: Use the updated `VariableCache` to facilitate 'lazy' loading of all variables during stack trace operations. VSCode and MS DAP will request one 'level' of variables at a time, and there is no need to resolve and cache variable data unless the user is going to view/use it.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Chip names are now matched treating an 'x' as a wildcard. (#964)
 - GDB server is now available as a subcommand in the probe-rs-cli, not as a separate binary in the `gdb-server` package anymore . (#972)
+- `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals
+  - `VariableCache` structure now models the tree stucture of the MS DAP Specification for `Threads -> StackTrace -> Scopes -> Variables`
+  - 
 
 ### Fixed
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -262,7 +262,7 @@ impl DebugCli {
                     let program_counter = cli_data.core.read_core_reg(regs.program_counter())?;
 
                     // TODO: Cache this, should only be cleared when core is running
-                    let mut cache = VariableCache::new();
+                    let mut cache = VariableCache::new(cli_data.core.id());
 
                     if let Some(di) = &mut cli_data.debug_info {
                         let frames = di.try_unwind(

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -261,7 +261,7 @@ impl DebugCli {
                     let program_counter = cli_data.core.read_core_reg(regs.program_counter())?;
 
                     // TODO: Cache this, should only be cleared when core is running
-                    let mut cache = VariableCache::new(cli_data.core.id());
+                    let mut cache = VariableCache::new();
 
                     if let Some(di) = &mut cli_data.debug_info {
                         let _frames =

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -5,7 +5,6 @@ use num_traits::Num;
 use probe_rs::architecture::arm::Dump;
 use probe_rs::debug::{DebugInfo, VariableCache};
 use probe_rs::{Core, CoreRegisterAddress, MemoryInterface};
-
 use std::fs::File;
 use std::{io::prelude::*, time::Duration};
 
@@ -265,14 +264,8 @@ impl DebugCli {
                     let mut cache = VariableCache::new(cli_data.core.id());
 
                     if let Some(di) = &mut cli_data.debug_info {
-                        let frames = di.try_unwind(
-                            &mut cache,
-                            &mut cli_data.core,
-                            u64::from(program_counter),
-                        );
-                        for _stack_frame in frames {
-                            // Iterate all the stack frames, so that `debug_info.variable_cache` gets populated.
-                        }
+                        let _frames =
+                            di.unwind(&mut cache, &mut cli_data.core, u64::from(program_counter))?;
                         println!("{}", cache);
                     } else {
                         println!("No debug information present!");

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -432,7 +432,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         _core_data: &mut CoreData,
         request: Request,
     ) -> Result<()> {
-        self.send_response::<()>(request.clone(), Ok(None))
+        self.send_response::<()>(request, Ok(None))
     }
 
     pub(crate) fn threads(&mut self, core_data: &mut CoreData, request: Request) -> Result<()> {
@@ -1130,13 +1130,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                             self.send_response(
                                 request,
                                 Ok(Some(ContinueResponseBody {
-                                    all_threads_continued: if self.last_known_status
-                                        == CoreStatus::Running
-                                    {
-                                        Some(false) // TODO: Implement multi-core logic here
-                                    } else {
-                                        Some(false)
-                                    },
+                                    all_threads_continued: Some(false), // TODO: Implement multi-core logic here
                                 })),
                             )?;
                         }

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -949,7 +949,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             let dap_variables: Vec<Variable> = if let Some(variable_cache) = variable_cache {
                 if let Some(parent_variable) = parent_variable.as_mut() {
                     if parent_variable.variable_node_type.is_deferred()
-                        && !variable_cache.has_children(&parent_variable)?
+                        && !variable_cache.has_children(parent_variable)?
                     {
                         core_data.debug_info.cache_deferred_variables(
                             variable_cache,

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -647,11 +647,11 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
         *core_data.variable_cache = VariableCache::new(core_data.target_core.id());
 
-        let current_stackframes = core_data.debug_info.try_unwind(
+        let current_stackframes = core_data.debug_info.unwind(
             core_data.variable_cache,
             &mut core_data.target_core,
             u64::from(pc),
-        );
+        )?;
 
         match self.adapter_type() {
             DebugAdapterType::CommandLine => {
@@ -664,6 +664,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             }
             DebugAdapterType::DapClient => {
                 let mut frame_list: Vec<StackFrame> = current_stackframes
+                    .iter()
                     .map(|frame| {
                         let column = frame
                             .source_location

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -645,7 +645,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
         log::debug!("Replacing variable cache!");
 
-        *core_data.variable_cache = VariableCache::new(core_data.target_core.id());
+        *core_data.variable_cache = VariableCache::new();
 
         let current_stackframes = core_data.debug_info.unwind(
             core_data.variable_cache,
@@ -783,7 +783,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             if let Some(static_root_variable) =
                 core_data.variable_cache.get_variable_by_name_and_parent(
                     &VariableName::StaticScope,
-                    stackframe_root_variable.variable_key,
+                    Some(stackframe_root_variable.variable_key),
                 )
             {
                 let (static_variables_reference, static_named_variables, static_indexed_variables) =
@@ -806,7 +806,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             if let Some(register_root_variable) =
                 core_data.variable_cache.get_variable_by_name_and_parent(
                     &VariableName::Registers,
-                    stackframe_root_variable.variable_key,
+                    Some(stackframe_root_variable.variable_key),
                 )
             {
                 let (
@@ -831,7 +831,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             if let Some(locals_root_variable) =
                 core_data.variable_cache.get_variable_by_name_and_parent(
                     &VariableName::LocalScope,
-                    stackframe_root_variable.variable_key,
+                    Some(stackframe_root_variable.variable_key),
                 )
             {
                 let (locals_variables_reference, locals_named_variables, locals_indexed_variables) =
@@ -927,7 +927,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
             let dap_variables: Vec<Variable> = core_data
                 .variable_cache
-                .get_children(arguments.variables_reference)?
+                .get_children(Some(arguments.variables_reference))?
                 .iter()
                 // Filter out requested children, then map them as DAP variables
                 .filter(|variable| match &arguments.filter {
@@ -1086,7 +1086,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
     ) -> (i64, i64, i64) {
         let mut named_child_variables_cnt = 0;
         let mut indexed_child_variables_cnt = 0;
-        if let Ok(children) = cache.get_children(parent_variable.variable_key) {
+        if let Ok(children) = cache.get_children(Some(parent_variable.variable_key)) {
             for child_variable in children {
                 if child_variable.is_indexed() {
                     indexed_child_variables_cnt += 1;

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -645,7 +645,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
         log::debug!("Replacing variable cache!");
 
-        *core_data.variable_cache = VariableCache::new();
+        *core_data.variable_cache = VariableCache::new(core_data.target_core.id());
 
         let current_stackframes = core_data.debug_info.try_unwind(
             core_data.variable_cache,

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -781,7 +781,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         {
             if let Some(static_root_variable) =
                 core_data.variable_cache.get_variable_by_name_and_parent(
-                    &VariableName::Statics,
+                    &VariableName::StaticScope,
                     stackframe_root_variable.variable_key,
                 )
             {
@@ -829,7 +829,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             };
             if let Some(locals_root_variable) =
                 core_data.variable_cache.get_variable_by_name_and_parent(
-                    &VariableName::Locals,
+                    &VariableName::LocalScope,
                     stackframe_root_variable.variable_key,
                 )
             {

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -113,7 +113,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     thread_id: Some(core_data.target_core.id() as i64),
                     preserve_focus_hint: Some(false),
                     text: None,
-                    all_threads_stopped: Some(true),
+                    all_threads_stopped: Some(false), // TODO: Implement multi-core logic here
                     hit_breakpoint_ids: None,
                 });
                 self.send_event("stopped", event_body)?;
@@ -348,7 +348,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 Ok(_) => {
                     self.last_known_status = CoreStatus::Running;
                     let event_body = Some(ContinuedEventBody {
-                        all_threads_continued: Some(true),
+                        all_threads_continued: Some(false), // TODO: Implement multi-core logic here
                         thread_id: core_data.target_core.id() as i64,
                     });
 
@@ -391,7 +391,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                             thread_id: Some(core_data.target_core.id() as i64),
                             preserve_focus_hint: None,
                             text: None,
-                            all_threads_stopped: Some(true),
+                            all_threads_stopped: Some(false), // TODO: Implement multi-core logic here
                             hit_breakpoint_ids: None,
                         });
                         self.send_event("stopped", event_body)?;
@@ -416,59 +416,88 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         }
     }
 
+    /// NOTE: VSCode sends a 'threads' request when it receives the response from this request, irrespective of target state.
+    /// This can lead to duplicate `threads->stacktrace->etc.` sequences if & when the target halts and sends a 'stopped' event.
+    /// See [https://github.com/golang/vscode-go/issues/940] for more info.
+    /// In order to avoid overhead and duplicate responses, we will implement the following logic.
+    /// - `configuration_done` will ignore target status, and simply notify VSCode that we're done.
+    /// - `threads` will check for [DebugAdapter::last_known_status] and ...
+    ///   - If it is `Unknown`, it will ...
+    ///     - send back a threads response, with `all_threds_stopped=Some(false)`
+    ///     - check on actual core status, and update [DebugAdapter::last_known_status] as well as synch status with the VSCode client.
+    ///   - If it is `Halted`, it will respond with thread information as expected.
+    ///   - Any other status will send and error.
     pub(crate) fn configuration_done(
         &mut self,
-        core_data: &mut CoreData,
+        _core_data: &mut CoreData,
         request: Request,
     ) -> Result<()> {
-        // Make sure the DAP Client and the DAP Server are in sync with the status of the core.
-        match core_data.target_core.status() {
-            Ok(core_status) => {
-                self.last_known_status = core_status;
-                if core_status.is_halted() {
-                    if self.halt_after_reset
-                        || core_status == CoreStatus::Halted(HaltReason::Breakpoint)
-                    {
-                        self.send_response::<()>(request, Ok(None))?;
-
-                        let event_body = Some(StoppedEventBody {
-                            reason: core_status.short_long_status().0.to_owned(),
-                            description: Some(core_status.short_long_status().1.to_string()),
-                            thread_id: Some(core_data.target_core.id() as i64),
-                            preserve_focus_hint: None,
-                            text: None,
-                            all_threads_stopped: Some(true),
-                            hit_breakpoint_ids: None,
-                        });
-                        self.send_event("stopped", event_body)
-                    } else {
-                        self.r#continue(core_data, request)
-                    }
-                } else {
-                    self.send_response::<()>(request, Ok(None))
-                }
-            }
-            Err(error) => {
-                self.send_response::<()>(
-                    request,
-                    Err(DebuggerError::Other(anyhow!(
-                        "Could not read core status to synchronize the client and the probe. {:?}",
-                        error
-                    ))),
-                )?;
-                Err(anyhow!("Failed to get core status."))
-            }
-        }
+        self.send_response::<()>(request.clone(), Ok(None))
     }
+
     pub(crate) fn threads(&mut self, core_data: &mut CoreData, request: Request) -> Result<()> {
         // TODO: Implement actual thread resolution. For now, we just use the core id as the thread id.
-
-        let single_thread = Thread {
-            id: core_data.target_core.id() as i64,
-            name: core_data.target_name.clone(),
-        };
-
-        let threads = vec![single_thread];
+        let mut threads: Vec<Thread> = vec![];
+        match self.last_known_status {
+            CoreStatus::Unknown => {
+                // We are probably here because the `configuration_done` request just happened, so we can make sure the client and debugger are in synch.
+                match core_data.target_core.status() {
+                    Ok(core_status) => {
+                        self.last_known_status = core_status;
+                        // Make sure the DAP Client and the DAP Server are in sync with the status of the core.
+                        if core_status.is_halted() {
+                            if self.halt_after_reset
+                                || core_status == CoreStatus::Halted(HaltReason::Breakpoint)
+                            {
+                                let event_body = Some(StoppedEventBody {
+                                    reason: core_status.short_long_status().0.to_owned(),
+                                    description: Some(
+                                        core_status.short_long_status().1.to_string(),
+                                    ),
+                                    thread_id: Some(core_data.target_core.id() as i64),
+                                    preserve_focus_hint: None,
+                                    text: None,
+                                    all_threads_stopped: Some(false), // TODO: Implement multi-core logic here
+                                    hit_breakpoint_ids: None,
+                                });
+                                self.send_event("stopped", event_body)?;
+                            } else {
+                                self.send_response(
+                                    request.clone(),
+                                    Ok(Some(ThreadsResponseBody { threads })),
+                                )?;
+                                return self.r#continue(core_data, request);
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        return self.send_response::<()>(
+                            request,
+                            Err(DebuggerError::Other(anyhow!(
+                                "Could not read core status to synchronize the client and the probe. {:?}",
+                                error
+                            ))),
+                        );
+                    }
+                }
+            }
+            CoreStatus::Halted(_) => {
+                let single_thread = Thread {
+                    id: core_data.target_core.id() as i64,
+                    name: core_data.target_name.clone(),
+                };
+                threads.push(single_thread);
+            }
+            CoreStatus::Running | CoreStatus::LockedUp | CoreStatus::Sleeping => {
+                return self.send_response::<()>(
+                    request,
+                    Err(DebuggerError::Other(anyhow!(
+                        "Received request for `threads`, while last known core status was {:?}",
+                        self.last_known_status
+                    ))),
+                );
+            }
+        }
         self.send_response(request, Ok(Some(ThreadsResponseBody { threads })))
     }
 
@@ -614,7 +643,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             }
         };
 
-        let _arguments: StackTraceArguments = match self.adapter_type() {
+        let arguments: StackTraceArguments = match self.adapter_type() {
             DebugAdapterType::CommandLine => StackTraceArguments {
                 format: None,
                 levels: None,
@@ -649,16 +678,11 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             core_data.target_core.id()
         );
 
-        if core_data.pc_of_most_recent_unwind().unwrap_or(0) != pc {
-            // If the program_counter has changed since the last unwind, then refresh the stack frames.
-            // NOTE: We do this, because VSCode sometimes sends duplicate stack_trace requests, and that results in overhead, as well as different ID's for the new stackframes.
-            *core_data.stack_frames = core_data
-                .debug_info
-                .unwind(&mut core_data.target_core, u64::from(pc))?;
-        }
-
         match self.adapter_type() {
             DebugAdapterType::CommandLine => {
+                *core_data.stack_frames = core_data
+                    .debug_info
+                    .unwind(&mut core_data.target_core, u64::from(pc))?;
                 let mut body = "".to_string();
                 if core_data.stack_frames.is_empty() {
                     body.push_str(
@@ -676,103 +700,168 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 self.send_response(request, Ok(Some(body)))
             }
             DebugAdapterType::DapClient => {
-                let mut frame_list: Vec<StackFrame> = core_data
-                    .stack_frames
-                    .iter()
-                    .map(|frame| {
-                        let column = frame
-                            .source_location
-                            .as_ref()
-                            .and_then(|sl| sl.column)
-                            .map(|col| match col {
-                                ColumnType::LeftEdge => 0,
-                                ColumnType::Column(c) => c,
-                            })
-                            .unwrap_or(0);
-
-                        let source = if let Some(source_location) = &frame.source_location {
-                            let path: Option<PathBuf> =
-                                source_location.directory.as_ref().map(|path| {
-                                    let mut path = if path.is_relative() {
-                                        std::env::current_dir().unwrap().join(path)
-                                    } else {
-                                        path.to_owned()
-                                    };
-
-                                    if let Some(file) = &source_location.file {
-                                        path.push(file);
-                                    }
-
-                                    path
-                                });
-                            Some(Source {
-                                name: source_location.file.clone(),
-                                path: path.map(|p| p.to_string_lossy().to_string()),
-                                source_reference: None,
-                                presentation_hint: None,
-                                origin: None,
-                                sources: None,
-                                adapter_data: None,
-                                checksums: None,
-                            })
-                        } else {
-                            log::debug!("No source location present for frame!");
-                            None
-                        };
-
-                        let line = frame
-                            .source_location
-                            .as_ref()
-                            .and_then(|sl| sl.line)
-                            .unwrap_or(0) as i64;
-                        let function_display_name = if frame.inlined_call_site.is_some() {
-                            format!("{} #[inline]", frame.function_name)
-                        } else {
-                            format!("{} @{:#010x}", frame.function_name, frame.pc)
-                        };
-                        // TODO: Can we add more meaningful info to `module_id`, etc.
-                        StackFrame {
-                            id: frame.id as i64,
-                            name: function_display_name,
-                            source,
-                            line,
-                            column: column as i64,
-                            end_column: None,
-                            end_line: None,
-                            module_id: None,
-                            presentation_hint: Some("normal".to_owned()),
-                            can_restart: Some(false),
-                            instruction_pointer_reference: Some(format!("{:#010x}", frame.pc)),
+                if let Some(levels) = arguments.levels {
+                    if let Some(start_frame) = arguments.start_frame {
+                        if levels == 20 && start_frame == 0 {
+                            // This is a invalid stack_trace from VSCode, so let's respond in kind.
+                            let body = StackTraceResponseBody {
+                                stack_frames: vec![],
+                                total_frames: Some(0i64),
+                            };
+                            return self.send_response(request, Ok(Some(body)));
+                        } else if levels == 1 && start_frame == 0 {
+                            // This is a legit request for the first frame in a new stack_trace, so do a new unwind.
+                            *core_data.stack_frames = core_data
+                                .debug_info
+                                .unwind(&mut core_data.target_core, u64::from(pc))?;
                         }
-                    })
-                    .collect();
+                        // Determine the correct 'slice' of available [StackFrame]s to serve up ...
+                        let total_frames = core_data.stack_frames.len() as i64;
+                        let frame_slice = if levels == 1 && start_frame == 0 {
+                            // Just the first frame - use the LHS of the split at `levels`
+                            core_data.stack_frames.split_at(levels as usize).0.iter()
+                        } else if total_frames <= 20
+                            && start_frame >= 0
+                            && start_frame <= total_frames
+                        {
+                            // When we have less than 20 frames - use the RHS of of the split at `start_frame`
+                            core_data
+                                .stack_frames
+                                .split_at(start_frame as usize)
+                                .1
+                                .iter()
+                        } else if total_frames > 20 && start_frame + levels <= total_frames {
+                            // When we have more than 20 frames - we can safely split twice
+                            core_data
+                                .stack_frames
+                                .split_at(start_frame as usize)
+                                .1
+                                .split_at(levels as usize)
+                                .0
+                                .iter()
+                        } else {
+                            return self.send_response::<()>(
+                                request,
+                                Err(DebuggerError::Other(anyhow!(
+                                    "Request for stack trace failed with invalid arguments: {:?}",
+                                    arguments
+                                ))),
+                            );
+                        };
 
-                // If we get an empty stack frame list,
-                // add a frame so that something is visible in the
-                // debugger.
-                if frame_list.is_empty() {
-                    frame_list.push(StackFrame {
-                        can_restart: None,
-                        column: 0,
-                        end_column: None,
-                        end_line: None,
-                        id: pc as i64,
-                        instruction_pointer_reference: None,
-                        line: 0,
-                        module_id: None,
-                        name: format!("<unknown function @ {:#010x}>", pc),
-                        presentation_hint: None,
-                        source: None,
-                    })
+                        let mut frame_list: Vec<StackFrame> = frame_slice
+                            .map(|frame| {
+                                let column = frame
+                                    .source_location
+                                    .as_ref()
+                                    .and_then(|sl| sl.column)
+                                    .map(|col| match col {
+                                        ColumnType::LeftEdge => 0,
+                                        ColumnType::Column(c) => c,
+                                    })
+                                    .unwrap_or(0);
+
+                                let source = if let Some(source_location) = &frame.source_location {
+                                    let path: Option<PathBuf> =
+                                        source_location.directory.as_ref().map(|path| {
+                                            let mut path = if path.is_relative() {
+                                                std::env::current_dir().unwrap().join(path)
+                                            } else {
+                                                path.to_owned()
+                                            };
+
+                                            if let Some(file) = &source_location.file {
+                                                path.push(file);
+                                            }
+
+                                            path
+                                        });
+                                    Some(Source {
+                                        name: source_location.file.clone(),
+                                        path: path.map(|p| p.to_string_lossy().to_string()),
+                                        source_reference: None,
+                                        presentation_hint: None,
+                                        origin: None,
+                                        sources: None,
+                                        adapter_data: None,
+                                        checksums: None,
+                                    })
+                                } else {
+                                    log::debug!("No source location present for frame!");
+                                    None
+                                };
+
+                                let line = frame
+                                    .source_location
+                                    .as_ref()
+                                    .and_then(|sl| sl.line)
+                                    .unwrap_or(0) as i64;
+                                let function_display_name = if frame.inlined_call_site.is_some() {
+                                    format!("{} #[inline]", frame.function_name)
+                                } else {
+                                    format!("{} @{:#010x}", frame.function_name, frame.pc)
+                                };
+                                // TODO: Can we add more meaningful info to `module_id`, etc.
+                                StackFrame {
+                                    id: frame.id as i64,
+                                    name: function_display_name,
+                                    source,
+                                    line,
+                                    column: column as i64,
+                                    end_column: None,
+                                    end_line: None,
+                                    module_id: None,
+                                    presentation_hint: Some("normal".to_owned()),
+                                    can_restart: Some(false),
+                                    instruction_pointer_reference: Some(format!(
+                                        "{:#010x}",
+                                        frame.pc
+                                    )),
+                                }
+                            })
+                            .collect();
+
+                        // If we get an empty stack frame list,
+                        // add a frame so that something is visible in the
+                        // debugger.
+                        if frame_list.is_empty() {
+                            frame_list.push(StackFrame {
+                                can_restart: None,
+                                column: 0,
+                                end_column: None,
+                                end_line: None,
+                                id: pc as i64,
+                                instruction_pointer_reference: None,
+                                line: 0,
+                                module_id: None,
+                                name: format!("<unknown function @ {:#010x}>", pc),
+                                presentation_hint: None,
+                                source: None,
+                            })
+                        }
+
+                        let body = StackTraceResponseBody {
+                            stack_frames: frame_list,
+                            total_frames: Some(total_frames),
+                        };
+                        self.send_response(request, Ok(Some(body)))
+                    } else {
+                        self.send_response::<()>(
+                            request,
+                            Err(DebuggerError::Other(anyhow!(
+                                "Request for stack trace failed with invalid start_frame argument: {:?}",
+                                arguments.start_frame
+                            ))))
+                    }
+                } else {
+                    self.send_response::<()>(
+                        request,
+                        Err(DebuggerError::Other(anyhow!(
+                            "Request for stack trace failed with invalid levels argument: {:?}",
+                            arguments.levels
+                        ))),
+                    )
                 }
-
-                let frame_len = frame_list.len();
-
-                let body = StackTraceResponseBody {
-                    stack_frames: frame_list,
-                    total_frames: Some(frame_len as i64),
-                };
-                self.send_response(request, Ok(Some(body)))
             }
         }
     }
@@ -1036,18 +1125,21 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                         Ok(Some(self.last_known_status.short_long_status().1)),
                     ),
                     DebugAdapterType::DapClient => {
-                        self.send_response(
-                            request,
-                            Ok(Some(ContinueResponseBody {
-                                all_threads_continued: if self.last_known_status
-                                    == CoreStatus::Running
-                                {
-                                    Some(true)
-                                } else {
-                                    Some(false)
-                                },
-                            })),
-                        )?;
+                        if request.command.as_str() == "continue" {
+                            // If this continue was initiated as part of some other request, then do not respond.
+                            self.send_response(
+                                request,
+                                Ok(Some(ContinueResponseBody {
+                                    all_threads_continued: if self.last_known_status
+                                        == CoreStatus::Running
+                                    {
+                                        Some(false) // TODO: Implement multi-core logic here
+                                    } else {
+                                        Some(false)
+                                    },
+                                })),
+                            )?;
+                        }
                         // We have to consider the fact that sometimes the `run()` is successfull,
                         // but "immediately" after the MCU hits a breakpoint or exception.
                         // So we have to check the status again to be sure.
@@ -1063,7 +1155,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                                         thread_id: Some(core_data.target_core.id() as i64),
                                         preserve_focus_hint: None,
                                         text: None,
-                                        all_threads_stopped: Some(true),
+                                        all_threads_stopped: Some(false), // TODO: Implement multi-core logic here
                                         hit_breakpoint_ids: None,
                                     });
                                     self.send_event("stopped", event_body)?;
@@ -1112,7 +1204,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     thread_id: Some(core_data.target_core.id() as i64),
                     preserve_focus_hint: None,
                     text: None,
-                    all_threads_stopped: Some(true),
+                    all_threads_stopped: Some(false), // TODO: Implement multi-core logic here
                     hit_breakpoint_ids: None,
                 });
                 self.send_event("stopped", event_body)

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -414,11 +414,6 @@ pub struct CoreData<'p> {
 }
 
 impl<'p> CoreData<'p> {
-    /// The first [StackFrame]'s `pc` value, is the value of the program counter at the most recent unwind.
-    pub(crate) fn pc_of_most_recent_unwind(&'p self) -> Option<u32> {
-        self.stack_frames.first().map(|stack_frame| stack_frame.pc)
-    }
-
     /// Search available [StackFrame]'s for the given `id`
     pub(crate) fn get_stackframe(&'p self, id: i64) -> Option<&'p probe_rs::debug::StackFrame> {
         self.stack_frames
@@ -1009,8 +1004,7 @@ impl Debugger {
                     supports_read_memory_request: Some(true),
                     supports_restart_request: Some(true),
                     supports_terminate_request: Some(true),
-                    // TODO: In order to supports_delayed_stack_trace_loading: Some(false), we need to honor the `levels` parameter of the `stacktrace` request from VSCode - see https://github.com/Microsoft/vscode/issues/62908. However, despite setting this to `false`, VSCode still sends duplicate `StackTrace` requests for each halt.
-                    supports_delayed_stack_trace_loading: Some(false),
+                    supports_delayed_stack_trace_loading: Some(true),
                     // supports_value_formatting_options: Some(true),
                     // supports_function_breakpoints: Some(true),
                     // TODO: Use DEMCR register to implement exception breakpoints

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -244,7 +244,10 @@ pub struct DebugSession {
     pub(crate) session: Session,
     #[allow(dead_code)]
     pub(crate) capstone: Capstone,
+    /// [DebugSession] will manage one [DebugInfo] per [DebuggerOptions::program_binary]
     pub(crate) debug_infos: Vec<DebugInfo>,
+    /// [DebugSession] will manage one [VariableCache] per [Core] in [Session::cores].
+    /// NOTE: Logically, the relationship should be 'one [VariableCache] per [DebugInfo]', but the overhead of a recursive delete from [VariableCache] made it desireable to have a unique cache for each [Core], so that it can be recreated everytime a stacktrace is requested for a core.
     pub(crate) variable_caches: Vec<VariableCache>,
 }
 

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -414,6 +414,11 @@ pub struct CoreData<'p> {
 }
 
 impl<'p> CoreData<'p> {
+    /// The first [StackFrame]'s `pc` value, is the value of the program counter at the most recent unwind.
+    pub(crate) fn pc_of_most_recent_unwind(&'p self) -> Option<u32> {
+        self.stack_frames.first().map(|stack_frame| stack_frame.pc)
+    }
+
     /// Search available [StackFrame]'s for the given `id`
     pub(crate) fn get_stackframe(&'p self, id: i64) -> Option<&'p probe_rs::debug::StackFrame> {
         self.stack_frames

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -359,7 +359,7 @@ impl DebugSession {
         ];
 
         // Configure the [VariableCache].
-        let variable_caches = vec![VariableCache::new(debugger_options.core_index)];
+        let variable_caches = vec![VariableCache::new()];
 
         Ok(DebugSession {
             session: target_session,

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -452,7 +452,6 @@ impl DebugInfo {
         &self,
         core: &mut Core<'_>,
         unit_info: &UnitInfo,
-        stack_frame_registers: &Registers,
     ) -> Result<VariableCache, DebugError> {
         let mut static_variable_cache = VariableCache::new();
 
@@ -466,7 +465,6 @@ impl DebugInfo {
                 Some(unit_node.entry().offset()),
             );
             static_root_variable.variable_node_type = VariableNodeType::DirectLookup;
-            static_root_variable.stack_frame_registers = Some(stack_frame_registers.clone());
             static_root_variable.name = VariableName::StaticScope;
             static_variable_cache.cache_variable(None, static_root_variable, core)?;
         }
@@ -514,7 +512,6 @@ impl DebugInfo {
         core: &mut Core<'_>,
         die_cursor_state: &mut FunctionDie,
         unit_info: &UnitInfo,
-        stack_frame_registers: &Registers,
     ) -> Result<VariableCache, DebugError> {
         let mut function_variable_cache = VariableCache::new();
 
@@ -530,7 +527,6 @@ impl DebugInfo {
             Some(function_node.entry().offset()),
         );
         function_root_variable.variable_node_type = VariableNodeType::DirectLookup;
-        function_root_variable.stack_frame_registers = Some(stack_frame_registers.clone());
         function_root_variable.name = VariableName::LocalScope;
         function_variable_cache.cache_variable(None, function_root_variable, core)?;
         Ok(function_variable_cache)
@@ -542,35 +538,35 @@ impl DebugInfo {
         cache: &mut VariableCache,
         core: &mut Core<'_>,
         parent_variable: &mut Variable,
+        stack_frame_registers: &Registers,
     ) -> Result<(), DebugError> {
         match parent_variable.variable_node_type {
             VariableNodeType::Offset(reference_offset) => {
                 // Only attempt this part if the parent is a pointer and we have not yet resolved the referenced children.
                 if !cache.has_children(parent_variable)? {
-                    if let Some(ref stack_frame_registers) = parent_variable.stack_frame_registers {
-                        if let Some(header_offset) = parent_variable.header_offset {
-                            let unit_header =
-                                self.dwarf.debug_info.header_from_offset(header_offset)?;
-                            let unit_info = UnitInfo {
-                                debug_info: self,
-                                unit: gimli::Unit::new(&self.dwarf, unit_header)?,
-                            };
-                            // Reference to a type, or an node.entry() to another type or a type modifier which will point to another type.
-                            let mut type_tree = unit_info.unit.header.entries_tree(
-                                &unit_info.unit.abbreviations,
-                                Some(reference_offset),
-                            )?;
-                            let referenced_node = type_tree.root()?;
-                            let mut referenced_variable = cache.cache_variable(
-                                Some(parent_variable.variable_key),
-                                Variable::new(
-                                    unit_info.unit.header.offset().as_debug_info_offset(),
-                                    Some(referenced_node.entry().offset()),
-                                ),
-                                core,
-                            )?;
+                    if let Some(header_offset) = parent_variable.header_offset {
+                        let unit_header =
+                            self.dwarf.debug_info.header_from_offset(header_offset)?;
+                        let unit_info = UnitInfo {
+                            debug_info: self,
+                            unit: gimli::Unit::new(&self.dwarf, unit_header)?,
+                        };
+                        // Reference to a type, or an node.entry() to another type or a type modifier which will point to another type.
+                        let mut type_tree = unit_info
+                            .unit
+                            .header
+                            .entries_tree(&unit_info.unit.abbreviations, Some(reference_offset))?;
+                        let referenced_node = type_tree.root()?;
+                        let mut referenced_variable = cache.cache_variable(
+                            Some(parent_variable.variable_key),
+                            Variable::new(
+                                unit_info.unit.header.offset().as_debug_info_offset(),
+                                Some(referenced_node.entry().offset()),
+                            ),
+                            core,
+                        )?;
 
-                            match &parent_variable.name {
+                        match &parent_variable.name {
                                 VariableName::Named(name) => {
                                     if name.starts_with("Some") {
                                         referenced_variable.name =
@@ -583,27 +579,26 @@ impl DebugInfo {
                                 }
                                 other => referenced_variable.name = VariableName::Named(format!("ERROR: Unable to generate name, parent variable does not have a name but is special variable {:?}", other)),
                             }
-                            let mut buff = [0u8; 4];
-                            core.read(parent_variable.memory_location as u32, &mut buff)?;
-                            referenced_variable.memory_location = u32::from_le_bytes(buff) as u64;
-                            referenced_variable = cache.cache_variable(
-                                referenced_variable.parent_key,
-                                referenced_variable,
-                                core,
-                            )?;
-                            referenced_variable = unit_info.extract_type(
-                                referenced_node,
-                                parent_variable,
-                                referenced_variable,
-                                core,
-                                stack_frame_registers,
-                                cache,
-                            )?;
+                        let mut buff = [0u8; 4];
+                        core.read(parent_variable.memory_location as u32, &mut buff)?;
+                        referenced_variable.memory_location = u32::from_le_bytes(buff) as u64;
+                        referenced_variable = cache.cache_variable(
+                            referenced_variable.parent_key,
+                            referenced_variable,
+                            core,
+                        )?;
+                        referenced_variable = unit_info.extract_type(
+                            referenced_node,
+                            parent_variable,
+                            referenced_variable,
+                            core,
+                            stack_frame_registers,
+                            cache,
+                        )?;
 
-                            // Only use this, if it is NOT a unit datatype.
-                            if referenced_variable.type_name.contains("()") {
-                                cache.remove_cache_entry(referenced_variable.variable_key)?;
-                            }
+                        // Only use this, if it is NOT a unit datatype.
+                        if referenced_variable.type_name.contains("()") {
+                            cache.remove_cache_entry(referenced_variable.variable_key)?;
                         }
                     }
                 }
@@ -611,42 +606,40 @@ impl DebugInfo {
             VariableNodeType::DirectLookup => {
                 // Only attempt this if the children are not already resolved.
                 if !cache.has_children(parent_variable)? {
-                    if let Some(ref stack_frame_registers) = parent_variable.stack_frame_registers {
-                        if let Some(header_offset) = parent_variable.header_offset {
-                            let unit_header =
-                                self.dwarf.debug_info.header_from_offset(header_offset)?;
-                            let unit_info = UnitInfo {
-                                debug_info: self,
-                                unit: gimli::Unit::new(&self.dwarf, unit_header)?,
-                            };
-                            // Find the parent node
-                            let mut type_tree = unit_info.unit.header.entries_tree(
-                                &unit_info.unit.abbreviations,
-                                parent_variable.entries_offset,
-                            )?;
-                            let parent_node = type_tree.root()?;
+                    if let Some(header_offset) = parent_variable.header_offset {
+                        let unit_header =
+                            self.dwarf.debug_info.header_from_offset(header_offset)?;
+                        let unit_info = UnitInfo {
+                            debug_info: self,
+                            unit: gimli::Unit::new(&self.dwarf, unit_header)?,
+                        };
+                        // Find the parent node
+                        let mut type_tree = unit_info.unit.header.entries_tree(
+                            &unit_info.unit.abbreviations,
+                            parent_variable.entries_offset,
+                        )?;
+                        let parent_node = type_tree.root()?;
 
-                            // For process_tree we need to create a temporary parent that will later be eliminated with VariableCache::adopt_grand_children
-                            // TODO: Investigate if UnitInfo::process_tree can be modified to use `&mut parent_variable`, then we would not need this temporary variable.
-                            let mut temporary_variable = parent_variable.clone();
-                            temporary_variable.variable_key = 0;
-                            temporary_variable.parent_key = Some(parent_variable.variable_key);
-                            temporary_variable = cache.cache_variable(
-                                Some(parent_variable.variable_key),
-                                temporary_variable,
-                                core,
-                            )?;
+                        // For process_tree we need to create a temporary parent that will later be eliminated with VariableCache::adopt_grand_children
+                        // TODO: Investigate if UnitInfo::process_tree can be modified to use `&mut parent_variable`, then we would not need this temporary variable.
+                        let mut temporary_variable = parent_variable.clone();
+                        temporary_variable.variable_key = 0;
+                        temporary_variable.parent_key = Some(parent_variable.variable_key);
+                        temporary_variable = cache.cache_variable(
+                            Some(parent_variable.variable_key),
+                            temporary_variable,
+                            core,
+                        )?;
 
-                            temporary_variable = unit_info.process_tree(
-                                parent_node,
-                                temporary_variable,
-                                core,
-                                stack_frame_registers,
-                                cache,
-                            )?;
+                        temporary_variable = unit_info.process_tree(
+                            parent_node,
+                            temporary_variable,
+                            core,
+                            stack_frame_registers,
+                            cache,
+                        )?;
 
-                            cache.adopt_grand_children(parent_variable, &temporary_variable)?;
-                        }
+                        cache.adopt_grand_children(parent_variable, &temporary_variable)?;
                     }
                 }
             }
@@ -759,7 +752,7 @@ impl DebugInfo {
 
                 // Next, resolve the statics that belong to the compilation unit that this function is in.
                 let static_variables = self
-                    .create_static_scope_cache(core, &unit_info, &stack_frame_registers)
+                    .create_static_scope_cache(core, &unit_info)
                     .map_or_else(
                         |error| {
                             log::error!(
@@ -773,12 +766,7 @@ impl DebugInfo {
 
                 // Next, resolve and cache the function variables.
                 let local_variables = self
-                    .create_function_scope_cache(
-                        core,
-                        function_die,
-                        &unit_info,
-                        &stack_frame_registers,
-                    )
+                    .create_function_scope_cache(core, function_die, &unit_info)
                     .map_or_else(
                         |error| {
                             log::error!(
@@ -2395,14 +2383,13 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                     gimli::AttributeValue::UnitRef(unit_ref) => {
                                         child_variable.variable_node_type =
                                             VariableNodeType::Offset(unit_ref);
-                                        child_variable.stack_frame_registers =
-                                            Some(stack_frame_registers.clone());
                                         if child_variable.type_name.starts_with("*const") {
                                             // Resolve the children of this variable, because they contain essential information required to resolve the value
                                             self.debug_info.cache_deferred_variables(
                                                 cache,
                                                 core,
                                                 &mut child_variable,
+                                                stack_frame_registers,
                                             )?;
                                         } else if parent_variable.type_name == "Some" {
                                             // The parent `DW_TAG_structure_type` with name `Some` is an intermediate node that we only need for its children

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -30,6 +30,8 @@ use gimli::{
 };
 use object::read::{Object, ObjectSection};
 
+use self::variable::VariableNodeType;
+
 #[derive(Debug, thiserror::Error)]
 pub enum DebugError {
     #[error("IO Error while accessing debug data")]
@@ -446,7 +448,7 @@ impl DebugInfo {
     /// We do not actually resolve the children of `[VariableName::StaticScope]` automatically, and only create the necessary header in the `VariableCache`.
     /// This allows us to resolve the `[VariableName::StaticScope]` on demand/lazily, when a user requests it from the debug client.
     /// This saves a lot of overhead when a user only wants to see the `[VariableName::LocalScope]` or `[VariableName::Registers]` while stepping through code (the most common use cases)
-    fn cache_static_variables(
+    fn create_static_scope_cache(
         &self,
         core: &mut Core<'_>,
         unit_info: &UnitInfo,
@@ -463,7 +465,7 @@ impl DebugInfo {
                 unit_info.unit.header.offset().as_debug_info_offset(),
                 Some(unit_node.entry().offset()),
             );
-            static_root_variable.referenced_node_offset = Some(unit_node.entry().offset());
+            static_root_variable.variable_node_type = VariableNodeType::DirectLookup;
             static_root_variable.stack_frame_registers = Some(stack_frame_registers.clone());
             static_root_variable.name = VariableName::StaticScope;
             static_variable_cache.cache_variable(None, static_root_variable, core)?;
@@ -472,7 +474,7 @@ impl DebugInfo {
     }
 
     /// Resolves and then loads all the `Register` variables into the `DebugInfo::VariableCache`.
-    fn cache_register_variables(
+    fn create_register_scope_cache(
         &self,
         registers: &Registers,
         core: &mut Core<'_>,
@@ -506,8 +508,8 @@ impl DebugInfo {
         Ok(register_variable_cache)
     }
 
-    /// Resolves and then loads all the `function` variables into the `DebugInfo::VariableCache`.
-    fn cache_function_variables(
+    /// Creates the unpopulated cache for `function` variables
+    fn create_function_scope_cache(
         &self,
         core: &mut Core<'_>,
         die_cursor_state: &mut FunctionDie,
@@ -527,101 +529,132 @@ impl DebugInfo {
             unit_info.unit.header.offset().as_debug_info_offset(),
             Some(function_node.entry().offset()),
         );
+        function_root_variable.variable_node_type = VariableNodeType::DirectLookup;
+        function_root_variable.stack_frame_registers = Some(stack_frame_registers.clone());
         function_root_variable.name = VariableName::LocalScope;
-        function_root_variable =
-            function_variable_cache.cache_variable(None, function_root_variable, core)?;
-
-        unit_info.process_tree(
-            function_node,
-            function_root_variable,
-            core,
-            stack_frame_registers,
-            &mut function_variable_cache,
-        )?;
+        function_variable_cache.cache_variable(None, function_root_variable, core)?;
         Ok(function_variable_cache)
     }
 
-    /// This is a lazy/deffered resolves and loads all the 'child' `Variable`s for a given unit.
-    /// This is used for:
-    /// - pointer variables (`DW_TAG_pointer_type`) into the `DebugInfo::VariableCache`.
-    /// - [VariableName::StaticScope] : The load of static variables and their namespaces in the debugger.
-    pub fn cache_referenced_variables(
+    /// This effects the on-demand expansion of lazy/deffered load of all the 'child' `Variable`s for a given 'parent'.
+    pub fn cache_deferred_variables(
         &self,
         cache: &mut VariableCache,
         core: &mut Core<'_>,
-        parent_variable: &Variable,
+        parent_variable: &mut Variable,
     ) -> Result<(), DebugError> {
-        // Only do attempt this part if the parent is a pointer and we have not yet resolved the referenced children.
-        if parent_variable.referenced_node_offset.is_some()
-            && !cache.has_children(parent_variable)?
-        {
-            if let Some(ref stack_frame_registers) = parent_variable.stack_frame_registers {
-                if let Some(header_offset) = parent_variable.header_offset {
-                    let unit_header = self.dwarf.debug_info.header_from_offset(header_offset)?;
-                    let unit_info = UnitInfo {
-                        debug_info: self,
-                        unit: gimli::Unit::new(&self.dwarf, unit_header)?,
-                    };
-                    // Reference to a type, or an node.entry() to another type or a type modifier which will point to another type.
-                    let mut type_tree = unit_info.unit.header.entries_tree(
-                        &unit_info.unit.abbreviations,
-                        parent_variable.referenced_node_offset,
-                    )?;
-                    let referenced_node = type_tree.root()?;
-                    let mut referenced_variable = cache.cache_variable(
-                        Some(parent_variable.variable_key),
-                        Variable::new(
-                            unit_info.unit.header.offset().as_debug_info_offset(),
-                            Some(referenced_node.entry().offset()),
-                        ),
-                        core,
-                    )?;
+        match parent_variable.variable_node_type {
+            VariableNodeType::Offset(reference_offset) => {
+                // Only attempt this part if the parent is a pointer and we have not yet resolved the referenced children.
+                if !cache.has_children(parent_variable)? {
+                    if let Some(ref stack_frame_registers) = parent_variable.stack_frame_registers {
+                        if let Some(header_offset) = parent_variable.header_offset {
+                            let unit_header =
+                                self.dwarf.debug_info.header_from_offset(header_offset)?;
+                            let unit_info = UnitInfo {
+                                debug_info: self,
+                                unit: gimli::Unit::new(&self.dwarf, unit_header)?,
+                            };
+                            // Reference to a type, or an node.entry() to another type or a type modifier which will point to another type.
+                            let mut type_tree = unit_info.unit.header.entries_tree(
+                                &unit_info.unit.abbreviations,
+                                Some(reference_offset),
+                            )?;
+                            let referenced_node = type_tree.root()?;
+                            let mut referenced_variable = cache.cache_variable(
+                                Some(parent_variable.variable_key),
+                                Variable::new(
+                                    unit_info.unit.header.offset().as_debug_info_offset(),
+                                    Some(referenced_node.entry().offset()),
+                                ),
+                                core,
+                            )?;
 
-                    match &parent_variable.name {
-                        VariableName::Named(name) => {
-                            if name.starts_with("Some") {
-                                referenced_variable.name =
-                                    VariableName::Named(name.replacen("&", "*", 1));
-                            } else {
-                                referenced_variable.name =
-                                    VariableName::Named(format!("*{}", name));
-                                // Now, retrieve the location by reading the adddress pointed to by the parent variable.
+                            match &parent_variable.name {
+                                VariableName::Named(name) => {
+                                    if name.starts_with("Some") {
+                                        referenced_variable.name =
+                                            VariableName::Named(name.replacen("&", "*", 1));
+                                    } else {
+                                        referenced_variable.name =
+                                            VariableName::Named(format!("*{}", name));
+                                        // Now, retrieve the location by reading the adddress pointed to by the parent variable.
+                                    }
+                                }
+                                other => referenced_variable.name = VariableName::Named(format!("ERROR: Unable to generate name, parent variable does not have a name but is special variable {:?}", other)),
+                            }
+                            let mut buff = [0u8; 4];
+                            core.read(parent_variable.memory_location as u32, &mut buff)?;
+                            referenced_variable.memory_location = u32::from_le_bytes(buff) as u64;
+                            referenced_variable = cache.cache_variable(
+                                referenced_variable.parent_key,
+                                referenced_variable,
+                                core,
+                            )?;
+                            referenced_variable = unit_info.extract_type(
+                                referenced_node,
+                                parent_variable,
+                                referenced_variable,
+                                core,
+                                stack_frame_registers,
+                                cache,
+                            )?;
+
+                            // Only use this, if it is NOT a unit datatype.
+                            if referenced_variable.type_name.contains("()") {
+                                cache.remove_cache_entry(referenced_variable.variable_key)?;
                             }
                         }
-                        // Create a dummy variable, which is filtered out again in `adopt_grand_children`.
-                        VariableName::StaticScope => {
-                            referenced_variable.name = VariableName::Named("*<statics>".to_string());
-                        }
-                        other => referenced_variable.name = VariableName::Named(format!("ERROR: Unable to generate name, parent variable does not have a name but is special variable {:?}", other)),
-                    }
-
-                    let mut buff = [0u8; 4];
-                    core.read(parent_variable.memory_location as u32, &mut buff)?;
-                    referenced_variable.memory_location = u32::from_le_bytes(buff) as u64;
-                    referenced_variable = cache.cache_variable(
-                        referenced_variable.parent_key,
-                        referenced_variable,
-                        core,
-                    )?;
-                    referenced_variable = unit_info.extract_type(
-                        referenced_node,
-                        parent_variable,
-                        referenced_variable,
-                        core,
-                        stack_frame_registers,
-                        cache,
-                    )?;
-
-                    // Only use this, if it is NOT a unit datatype.
-                    if referenced_variable.type_name.contains("()") {
-                        cache.remove_cache_entry(referenced_variable.variable_key)?;
-                    } else if parent_variable.name == VariableName::StaticScope {
-                        // If we are lazily resolving `[VariableName::StaticScope]`, then we need to eliminate the intermediate node
-                        cache.adopt_grand_children(parent_variable, &referenced_variable)?;
                     }
                 }
             }
+            VariableNodeType::DirectLookup => {
+                // Only attempt this if the children are not already resolved.
+                if !cache.has_children(parent_variable)? {
+                    if let Some(ref stack_frame_registers) = parent_variable.stack_frame_registers {
+                        if let Some(header_offset) = parent_variable.header_offset {
+                            let unit_header =
+                                self.dwarf.debug_info.header_from_offset(header_offset)?;
+                            let unit_info = UnitInfo {
+                                debug_info: self,
+                                unit: gimli::Unit::new(&self.dwarf, unit_header)?,
+                            };
+                            // Find the parent node
+                            let mut type_tree = unit_info.unit.header.entries_tree(
+                                &unit_info.unit.abbreviations,
+                                parent_variable.entries_offset,
+                            )?;
+                            let parent_node = type_tree.root()?;
+
+                            // For process_tree we need to create a temporary parent that will later be eliminated with VariableCache::adopt_grand_children
+                            // TODO: Investigate if UnitInfo::process_tree can be modified to use `&mut parent_variable`, then we would not need this temporary variable.
+                            let mut temporary_variable = parent_variable.clone();
+                            temporary_variable.variable_key = 0;
+                            temporary_variable.parent_key = Some(parent_variable.variable_key);
+                            temporary_variable = cache.cache_variable(
+                                Some(parent_variable.variable_key),
+                                temporary_variable,
+                                core,
+                            )?;
+
+                            temporary_variable = unit_info.process_tree(
+                                parent_node,
+                                temporary_variable,
+                                core,
+                                stack_frame_registers,
+                                cache,
+                            )?;
+
+                            cache.adopt_grand_children(parent_variable, &temporary_variable)?;
+                        }
+                    }
+                }
+            }
+            VariableNodeType::DoNotRecurse | VariableNodeType::RecurseToBaseType => {
+                // Do nothing. These have already been recursed to their maximum.
+            }
         }
+
         Ok(())
     }
 
@@ -712,7 +745,7 @@ impl DebugInfo {
                 // Now that we have the function_name and function_source_location, we can create the appropriate variable caches for this stack frame.
 
                 let register_variables = self
-                    .cache_register_variables(&stack_frame_registers, core)
+                    .create_register_scope_cache(&stack_frame_registers, core)
                     .map_or_else(
                         |error| {
                             log::error!(
@@ -726,7 +759,7 @@ impl DebugInfo {
 
                 // Next, resolve the statics that belong to the compilation unit that this function is in.
                 let static_variables = self
-                    .cache_static_variables(core, &unit_info, &stack_frame_registers)
+                    .create_static_scope_cache(core, &unit_info, &stack_frame_registers)
                     .map_or_else(
                         |error| {
                             log::error!(
@@ -740,7 +773,7 @@ impl DebugInfo {
 
                 // Next, resolve and cache the function variables.
                 let local_variables = self
-                    .cache_function_variables(
+                    .create_function_scope_cache(
                         core,
                         function_die,
                         &unit_info,
@@ -776,7 +809,7 @@ impl DebugInfo {
 
         // Before returning `unknown_function` [StackFrame], make sure we at least cache the Register values.
         let register_variables = self
-            .cache_register_variables(&stack_frame_registers, core)
+            .create_register_scope_cache(&stack_frame_registers, core)
             .map_or_else(
                 |error| {
                     log::warn!(
@@ -2360,15 +2393,16 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                             Some(data_type_attribute) => {
                                 match data_type_attribute.value() {
                                     gimli::AttributeValue::UnitRef(unit_ref) => {
-                                        child_variable.referenced_node_offset = Some(unit_ref);
+                                        child_variable.variable_node_type =
+                                            VariableNodeType::Offset(unit_ref);
                                         child_variable.stack_frame_registers =
                                             Some(stack_frame_registers.clone());
                                         if child_variable.type_name.starts_with("*const") {
                                             // Resolve the children of this variable, because they contain essential information required to resolve the value
-                                            self.debug_info.cache_referenced_variables(
+                                            self.debug_info.cache_deferred_variables(
                                                 cache,
                                                 core,
-                                                &child_variable,
+                                                &mut child_variable,
                                             )?;
                                         } else if parent_variable.type_name == "Some" {
                                             // The parent `DW_TAG_structure_type` with name `Some` is an intermediate node that we only need for its children

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -899,9 +899,9 @@ impl DebugInfo {
         None
     }
 
-    /// We do not actually resolve the children of `<statics>` automatically, and only create the necessary header in the `VariableCache`.
-    /// This allows us to resolve the `<statics>` on demand/lazily, when a user requests it from the debug client.
-    /// This saves a lot of overhead when a user only wants to see the `<locals>` or `<registers>` while stepping through code (the most common use cases)
+    /// We do not actually resolve the children of `[VariableName::StaticScope]` automatically, and only create the necessary header in the `VariableCache`.
+    /// This allows us to resolve the `[VariableName::StaticScope]` on demand/lazily, when a user requests it from the debug client.
+    /// This saves a lot of overhead when a user only wants to see the `[VariableName::LocalScope]` or `[VariableName::Registers]` while stepping through code (the most common use cases)
     fn cache_static_variables(
         &self,
         cache: &mut VariableCache,
@@ -921,7 +921,7 @@ impl DebugInfo {
             );
             static_root_variable.referenced_node_offset = Some(unit_node.entry().offset());
             static_root_variable.stack_frame_registers = Some(stack_frame_registers.clone());
-            static_root_variable.name = VariableName::Statics;
+            static_root_variable.name = VariableName::StaticScope;
             cache.cache_variable(
                 stackframe_root_variable.variable_key,
                 static_root_variable,
@@ -987,7 +987,7 @@ impl DebugInfo {
             unit_info.unit.header.offset().as_debug_info_offset(),
             Some(function_node.entry().offset()),
         );
-        function_root_variable.name = VariableName::Locals;
+        function_root_variable.name = VariableName::LocalScope;
         function_root_variable = cache.cache_variable(
             stackframe_root_variable.variable_key,
             function_root_variable,
@@ -1007,7 +1007,7 @@ impl DebugInfo {
     /// This is a lazy/deffered resolves and loads all the 'child' `Variable`s for a given unit.
     /// This is used for:
     /// - pointer variables (`DW_TAG_pointer_type`) into the `DebugInfo::VariableCache`.
-    /// - <statics> : The load of static variables and their namespaces in the debugger.
+    /// - [VariableName::StaticScope] : The load of static variables and their namespaces in the debugger.
     pub fn cache_referenced_variables(
         &self,
         cache: &mut VariableCache,
@@ -1052,7 +1052,7 @@ impl DebugInfo {
                             }
                         }
                         // Create a dummy variable, which is filtered out again in `adopt_grand_children`.
-                        VariableName::Statics => {
+                        VariableName::StaticScope => {
                             referenced_variable.name = VariableName::Named("*<statics>".to_string());
                         }
                         other => referenced_variable.name = VariableName::Named(format!("ERROR: Unable to generate name, parent variable does not have a name but is special variable {:?}", other)),
@@ -1078,8 +1078,8 @@ impl DebugInfo {
                     // Only use this, if it is NOT a unit datatype.
                     if referenced_variable.type_name.contains("()") {
                         cache.remove_cache_entry(referenced_variable.variable_key)?;
-                    } else if parent_variable.name == VariableName::Statics {
-                        // If we are lazily resolving `<statics>`, then we need to eliminate the intermediate node
+                    } else if parent_variable.name == VariableName::StaticScope {
+                        // If we are lazily resolving `[VariableName::StaticScope]`, then we need to eliminate the intermediate node
                         cache.adopt_grand_children(parent_variable, &referenced_variable)?;
                     }
                 }
@@ -1173,7 +1173,7 @@ impl DebugInfo {
 
                 log::debug!("UNWIND: Function name: {}", function_name);
 
-                // Now that we have the function_name and function_source_location, we can cache the in-scope `Variable`s (`<statics>` and `<locals>`) in `DebugInfo::VariableCache`
+                // Now that we have the function_name and function_source_location, we can cache the in-scope `Variable`s (`[VariableName::StaticScope]` and `[VariableName::LocalScope]`) in `DebugInfo::VariableCache`
                 // We need an empty parent variable for the next operation, but do not need to store it in the cache.
                 let parent_variable = Variable::new(None, None);
                 let mut stackframe_root_variable = Variable::new(
@@ -2671,7 +2671,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 }
             }
             gimli::DW_TAG_compile_unit => {
-                // This only happens when we do a 'lazy' load of <statics>
+                // This only happens when we do a 'lazy' load of [VariableName::StaticScope]
                 child_variable =
                     self.process_tree(node, child_variable, core, stack_frame_registers, cache)?;
             }

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -53,7 +53,7 @@ impl VariableCache {
             // The caller is telling us this is definitely a new `Variable`
             variable_to_add.variable_key = get_sequential_key();
 
-            log::debug!(
+            log::trace!(
                 "VariableCache: Add Variable: key={}, parent={:?}, name={:?}",
                 variable_to_add.variable_key,
                 variable_to_add.parent_key,
@@ -70,7 +70,7 @@ impl VariableCache {
             new_entry_key
         } else {
             // Attempt to update an existing `Variable` in the cache
-            log::debug!(
+            log::trace!(
                 "VariableCache: Update Variable, key={}, name={:?}",
                 variable_to_add.variable_key,
                 &variable_to_add.name
@@ -168,15 +168,17 @@ impl VariableCache {
 
     /// Sometimes DWARF uses intermediate nodes that are not part of the coded variable structure.
     /// When we encounter them, the children of such intermediate nodes are assigned to the parent of the intermediate node, and we discard the intermediate nodes from the `DebugInfo::VariableCache`
+    ///
+    /// Similarly, while resolving [VariableNodeType::is_deferred()], i.e. 'lazy load' of variables, we need to create intermediate variables that are eliminated here.
+    ///
+    /// NOTE: For all other situations, this function will silently do nothing.
     pub fn adopt_grand_children(
         &mut self,
         parent_variable: &Variable,
         obsolete_child_variable: &Variable,
     ) -> Result<(), Error> {
-        // If the `obsolete_child_variable` has a type other than `Some`, then silently do nothing.
         if obsolete_child_variable.type_name.is_empty()
-            || obsolete_child_variable.type_name == "Some"
-            || obsolete_child_variable.name == VariableName::Named("*<statics>".to_string())
+            || obsolete_child_variable.variable_node_type.is_deferred()
         {
             // Make sure we pass children up, past any intermediate nodes.
             self.variable_hash_map
@@ -263,10 +265,6 @@ impl Default for VariantRole {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum VariableName {
-    /// Every [`Core`] will have it's own set of hierarchy of entries in the cache.
-    CoreId,
-    /// Top-level variable for a stack frame (usually a function or inlined subroutine).
-    StackFrame,
     /// Top-level variable for static variables, child of a stack frame variable, and holds all the static scoped variables which are directly visible to the compile unit of the frame.
     StaticScope,
     /// Top-level variable for registers, child of a stack frame variable.
@@ -292,8 +290,6 @@ impl Default for VariableName {
 impl std::fmt::Display for VariableName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            VariableName::CoreId => write!(f, "<core_id>"),
-            VariableName::StackFrame => write!(f, "<stack_frame>"),
             VariableName::StaticScope => write!(f, "<static_scope>"),
             VariableName::Registers => write!(f, "<registers>"),
             VariableName::LocalScope => write!(f, "<local_scope>"),
@@ -312,9 +308,11 @@ pub enum VariableNodeType {
     /// For pointer values, their referenced variables are found at an [gimli::UnitOffset] in the [DebugInfo].
     /// - Rule: Pointers to `struct` variables WILL NOT BE recursed, because  this may lead to infinite loops/stack overflows in `struct`s that self-reference.
     /// - Rule: Pointers to "base" datatypes SHOULD BE, but ARE NOT resolved, because it would keep the UX simple, but DWARF doesn't make it easy to determine when a pointer points to a base data type. We can read ahead in the DIE children, but that feels rather inefficient.
-    Offset(UnitOffset),
+    ReferenceOffset(UnitOffset),
+    /// Use the `header_offset` and `type_offset` as direct references for recursing the variable children.
+    /// - Rule: For structured variables, we WILL NOT automatically expand their children, but we have enough information to expand it on demand. Except if they fall into one of the special cases handled by [VariableNodeType::RecurseAsIntermediate]
+    TypeOffset(UnitOffset),
     /// Use the `header_offset` and `entries_offset` as direct references for recursing the variable children.
-    /// - Rule: For structured variables, we WILL NOT automatically expand their children, but we have enough information to expand it on demand.
     /// - Rule: All top level variables in a [StackFrame] are automatically deferred, i.e [VariableName::StaticScope], [VariableName::Registers], [VariableName::LocalScope].
     DirectLookup,
     /// Sometimes it doesn't make sense to recurse the children of a specific node type
@@ -324,17 +322,21 @@ pub enum VariableNodeType {
     DoNotRecurse,
     /// Unless otherwise specified, always recurse the children of every node until we get to the base data type.
     /// - Rule: (Default) Unless it is prevented by any of the other rules, we always recurse the children of these variables.
+    /// - Rule: Certain structured variables (e.g. `&str`, `Some`, `Ok`, `Err`, etc.) are set to [VariableNodeType::RecurseToBaseType] to improve the debugger UX.
     /// - Rule: Pointers to `const` variables WILL ALWAYS BE recursed, because they provide essential information, for example about the length of strings, or the size of arrays.
+    /// - Rule: Enumerated types WILL ALWAYS BE recursed, because we only ever want to see the 'active' child as the value.
+    /// - Rule: For now, Array types WILL ALWAYS BE recursed. TODO: Evaluate if it is beneficial to defer these.
+    /// - Rule: For now, Union types WILL ALWAYS BE recursed. TODO: Evaluate if it is beneficial to defer these.
     RecurseToBaseType,
 }
 
 impl VariableNodeType {
     pub fn is_deferred(&self) -> bool {
         match self {
-            VariableNodeType::Offset(_) => true,
-            VariableNodeType::DirectLookup => true,
-            VariableNodeType::DoNotRecurse => false,
-            VariableNodeType::RecurseToBaseType => false,
+            VariableNodeType::ReferenceOffset(_)
+            | VariableNodeType::TypeOffset(_)
+            | VariableNodeType::DirectLookup => true,
+            _other => false,
         }
     }
 }
@@ -362,16 +364,14 @@ pub struct Variable {
     /// The source location of the declaration of this variable, if available.
     pub source_location: Option<SourceLocation>,
     pub type_name: String,
+    /// The unit_header_offset and variable_unit_offset are cached to allow on-demand access to the variable's gimli::Unit, through functions like:
+    ///   `gimli::Read::DebugInfo.header_from_offset()`, and   
+    ///   `gimli::Read::UnitHeader.entries_tree()`
+    pub unit_header_offset: Option<DebugInfoOffset>,
+    pub variable_unit_offset: Option<UnitOffset>,
     /// For 'lazy loading' of certain variable types we have to determine if the variable recursion should be deferred, and if so, how to resolve it when the request for further recursion happens.
     /// See [VariableNodeType] for more information.
     pub variable_node_type: VariableNodeType,
-    /// The header_offset and entries_offset are cached to allow on-demand access to the gimli::Unit, through functions like:
-    ///   `gimli::Read::DebugInfo.header_from_offset()`, and   
-    ///   `gimli::Read::UnitHeader.entries_tree()`
-    ///
-    /// TODO: Is there a more efficient method to get on demand access to gimli::Unit through stored references to it?
-    pub header_offset: Option<DebugInfoOffset>,
-    pub entries_offset: Option<UnitOffset>,
     /// The starting location/address in memory where this Variable's value is stored.
     pub memory_location: u64,
     pub byte_size: u64,
@@ -391,8 +391,8 @@ impl Variable {
         entries_offset: Option<UnitOffset>,
     ) -> Variable {
         Variable {
-            header_offset,
-            entries_offset,
+            unit_header_offset: header_offset,
+            variable_unit_offset: entries_offset,
             ..Default::default()
         }
     }
@@ -425,8 +425,8 @@ impl Variable {
                         self.formatted_variable_value(variable_cache)
                     } else if self.type_name.is_empty() || self.memory_location.is_zero() {
                         if self.variable_node_type.is_deferred() {
-                            // When we will do a lazy-load of variable children, and they have not yet been requested by the user
-                            "".to_string()
+                            // When we will do a lazy-load of variable children, and they have not yet been requested by the user, just display the type_name as the value
+                            self.type_name.clone()
                         } else {
                             // This condition should only be true for intermediate nodes from DWARF. These should not show up in the final `VariableCache`
                             // If a user sees this error, then there is a logic problem in the stack unwind
@@ -470,54 +470,88 @@ impl Variable {
             return;
         }
 
-        log::debug!(
+        log::trace!(
             "Extracting value for {:?}, type={}",
             self.name,
             self.type_name
         );
 
         // This is the primary logic for decoding a variable's value, once we know the type and memory_location.
-        let string_value = match self.type_name.as_str() {
-            "!" => "<Never returns>".to_string(),
-            "()" => "()".to_string(),
-            "bool" => bool::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "char" => char::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "&str" => String::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value),
-            "i8" => i8::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "i16" => i16::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "i32" => i32::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "i64" => i64::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "i128" => i128::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "isize" => isize::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "u8" => u8::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "u16" => u16::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "u32" => u32::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "u64" => u64::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "u128" => u128::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "usize" => usize::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "f32" => f32::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "f64" => f64::get_value(self, core, variable_cache)
-                .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
-            "None" => "None".to_string(),
-            _undetermined_value => "".to_owned(),
+        let known_value = match self.type_name.as_str() {
+            "!" => Some("<Never returns>".to_string()),
+            "()" => Some("()".to_string()),
+            "bool" => Some(
+                bool::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "char" => Some(
+                char::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "&str" => Some(
+                String::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value),
+            ),
+            "i8" => Some(
+                i8::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "i16" => Some(
+                i16::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "i32" => Some(
+                i32::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "i64" => Some(
+                i64::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "i128" => Some(
+                i128::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "isize" => Some(
+                isize::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "u8" => Some(
+                u8::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "u16" => Some(
+                u16::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "u32" => Some(
+                u32::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "u64" => Some(
+                u64::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "u128" => Some(
+                u128::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "usize" => Some(
+                usize::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "f32" => Some(
+                f32::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "f64" => Some(
+                f64::get_value(self, core, variable_cache)
+                    .map_or_else(|err| format!("ERROR: {:?}", err), |value| value.to_string()),
+            ),
+            "None" => Some("None".to_string()),
+            _undetermined_value => None,
         };
-        self.value = Some(string_value);
+        self.value = known_value;
     }
 
     /// The variable is considered to be an 'indexed' variable if the name starts with two underscores followed by a number. e.g. "__1".

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -32,41 +32,22 @@ impl Default for VariableCache {
 }
 
 impl VariableCache {
-    pub fn new(_core_index: usize) -> Self {
-        // This is WIP ... please leave commented code.
-        //let variable_cache =
-        VariableCache {
+    pub fn new(core_index: usize) -> Self {
+        let variable_cache = VariableCache {
             variable_cache_key: 0,
             variable_hash_map: HashMap::new(),
-        }
-        //;
+        };
         // The variable_cache will always be pre-populated with a [VariableName::CoreId] variable for the specified core.
-        // TODO: Implement this.
-        // let mut core_id_variable = Variable::new(None, None);
-        // core_id_variable.name = VariableName::CoreId;
-        // core_id_variable.source_location = function_source_location.clone();
-        // let function_display_name = if function_die.is_inline {
-        //     format!("{} #[inline]", &function_name)
-        // } else {
-        //     format!("{} @{:#010x}", &function_name, address)
-        // };
+        let mut core_id_variable = Variable::new(None, None);
+        core_id_variable.name = VariableName::CoreId;
+        core_id_variable.variable_key = core_index as i64;
+        
+        // TODO: set the value to be something human readable form ...
         // core_id_variable.set_value(function_display_name);
-        // core_id_variable = unit_info.extract_location(
-        //     &unit_info
-        //         .unit
-        //         .entries_tree(Some(function_die.function_die.offset()))?
-        //         .root()?,
-        //     &parent_variable,
-        //     core_id_variable,
-        //     core,
-        //     &stack_frame_registers,
-        //     cache,
-        // )?;
-
         //
         // core_id_variable =
         //     cache.cache_variable(parent_variable.variable_key, core_id_variable, core)?;
-        // variable_cache
+        variable_cache
     }
 
     /// Performs an *add* or *update* of a `probe_rs::debug::Variable` to the cache, consuming the input and returning a Clone.

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -22,32 +22,19 @@ use num_traits::Zero;
 ///           - This structure is recursive until a base type is encountered.
 #[derive(Debug)]
 pub struct VariableCache {
-    variable_cache_key: i64,
     variable_hash_map: HashMap<i64, Variable>,
 }
 impl Default for VariableCache {
     fn default() -> Self {
-        Self::new(0)
+        Self::new()
     }
 }
 
 impl VariableCache {
-    pub fn new(core_index: usize) -> Self {
-        let variable_cache = VariableCache {
-            variable_cache_key: 0,
+    pub fn new() -> Self {
+        VariableCache {
             variable_hash_map: HashMap::new(),
-        };
-        // The variable_cache will always be pre-populated with a [VariableName::CoreId] variable for the specified core.
-        let mut core_id_variable = Variable::new(None, None);
-        core_id_variable.name = VariableName::CoreId;
-        core_id_variable.variable_key = core_index as i64;
-        
-        // TODO: set the value to be something human readable form ...
-        // core_id_variable.set_value(function_display_name);
-        //
-        // core_id_variable =
-        //     cache.cache_variable(parent_variable.variable_key, core_id_variable, core)?;
-        variable_cache
+        }
     }
 
     /// Performs an *add* or *update* of a `probe_rs::debug::Variable` to the cache, consuming the input and returning a Clone.
@@ -56,62 +43,55 @@ impl VariableCache {
     /// - *Update* operation: If the `Variable::variable_key` is > 0
     ///   - If the key value exists in the cache, update it, Return an updated Clone of the variable.
     ///   - If the key value doesn't exist in the cache, Return an error.
-    /// - For all operations, update the `parent_key`. A value of 0 means there are no parents for this variable.
+    /// - For all operations, update the `parent_key`. A value of None means there are no parents for this variable.
     ///   - Validate that the supplied `Variable::parent_key` is a valid entry in the cache.
     /// - If appropriate, the `Variable::value` is updated from the core memory, and can be used by the calling function.
     pub fn cache_variable(
         &mut self,
-        parent_key: i64,
+        parent_key: Option<i64>,
         cache_variable: Variable,
         core: &mut Core<'_>,
     ) -> Result<Variable, Error> {
         let mut variable_to_add = cache_variable.clone();
 
         // Validate that the parent_key exists ...
-        variable_to_add.parent_key = parent_key;
-        if variable_to_add.parent_key > 0
-            && (!self
-                .variable_hash_map
-                .contains_key(&variable_to_add.parent_key))
-        {
-            return Err(anyhow!("VariableCache: Attempted to add a new variable: {} with non existent `parent_key`: {}. Please report this as a bug", variable_to_add.name, variable_to_add.parent_key).into());
+        if let Some(new_parent_key) = parent_key {
+            if self.variable_hash_map.contains_key(&new_parent_key) {
+                variable_to_add.parent_key = parent_key;
+            } else {
+                return Err(anyhow!("VariableCache: Attempted to add a new variable: {} with non existent `parent_key`: {}. Please report this as a bug", variable_to_add.name, new_parent_key).into());
+            }
         }
 
         // Is this an *add* or *update* operation?
         let stored_key = if variable_to_add.variable_key == 0 {
             // The caller is telling us this is definitely a new `Variable`
-            let new_cache_key: i64 = self.variable_cache_key + 1;
-            variable_to_add.variable_key = new_cache_key;
+            variable_to_add.variable_key = get_sequential_key();
 
             log::debug!(
-                "VariableCache: Add Variable: key={}, parent={}, name={:?}",
-                new_cache_key,
+                "VariableCache: Add Variable: key={}, parent={:?}, name={:?}",
+                variable_to_add.variable_key,
                 variable_to_add.parent_key,
                 &variable_to_add.name
             );
 
-            match self
+            let new_entry_key = variable_to_add.variable_key;
+            if let Some(old_variable) = self
                 .variable_hash_map
                 .insert(variable_to_add.variable_key, variable_to_add)
             {
-                Some(old_variable) => {
-                    return Err(anyhow!("Attempt to insert a new `Variable`:{:?} with a duplicate cache key: {}. Please report this as a bug.", cache_variable.name, old_variable.variable_key).into());
-                }
-                None => {
-                    self.variable_cache_key = new_cache_key;
-                }
+                return Err(anyhow!("Attempt to insert a new `Variable`:{:?} with a duplicate cache key: {}. Please report this as a bug.", cache_variable.name, old_variable.variable_key).into());
             }
-            self.variable_cache_key
+            new_entry_key
         } else {
             // Attempt to update an existing `Variable` in the cache
-            let reused_cache_key = variable_to_add.variable_key;
-
             log::debug!(
                 "VariableCache: Update Variable, key={}, name={:?}",
-                reused_cache_key,
+                variable_to_add.variable_key,
                 &variable_to_add.name
             );
 
+            let updated_entry_key = variable_to_add.variable_key;
             if let Some(prev_entry) = self
                 .variable_hash_map
                 .get_mut(&variable_to_add.variable_key)
@@ -123,10 +103,10 @@ impl VariableCache {
 
                 *prev_entry = variable_to_add
             } else {
-                return Err(anyhow!("Attempt to update and existing `Variable`:{:?} with a non-existent cache key: {}. Please report this as a bug.", cache_variable.name, reused_cache_key).into());
+                return Err(anyhow!("Attempt to update and existing `Variable`:{:?} with a non-existent cache key: {}. Please report this as a bug.", cache_variable.name, variable_to_add.variable_key).into());
             }
 
-            reused_cache_key
+            updated_entry_key
         };
 
         // As the final act, we need to update the variable with an appropriate value.
@@ -161,7 +141,7 @@ impl VariableCache {
     pub fn get_variable_by_name_and_parent(
         &self,
         variable_name: &VariableName,
-        parent_key: i64,
+        parent_key: Option<i64>,
     ) -> Option<Variable> {
         let child_variables = self
             .variable_hash_map
@@ -175,33 +155,29 @@ impl VariableCache {
             0 => None,
             1 => child_variables.first().cloned(),
             child_count => {
-                log::error!("Found {} variables with parent_key={} and name={}. Please report this as a bug.", child_count, parent_key, variable_name);
+                log::error!("Found {} variables with parent_key={:?} and name={}. Please report this as a bug.", child_count, parent_key, variable_name);
                 child_variables.last().cloned()
             }
         }
     }
 
     /// Retrieve `clone`d version of all the children of a `Variable`.
-    /// This also validates that the parent exists in the cache, before attempting to retrieve children.
-    pub fn get_children(&self, parent_key: i64) -> Result<Vec<Variable>, Error> {
-        if parent_key == 0 && (!self.variable_hash_map.contains_key(&parent_key)) {
-            return Err(anyhow!("VariableCache: Attempted to retrieve children for a non existent `variable_key`: {}.", parent_key).into());
-        } else {
-            let mut children: Vec<Variable> = self
-                .variable_hash_map
-                .values()
-                .filter(|child_variable| child_variable.parent_key == parent_key)
-                .cloned()
-                .collect::<Vec<Variable>>();
-            // We have to incur the overhead of sort(), or else the variables in the UI are not in the same order as they appear in the source code.
-            children.sort_by_key(|var| var.variable_key);
-            Ok(children)
-        }
+    /// If `parent_key == None`, it will return all the top level variables (no parents) in this cache.
+    pub fn get_children(&self, parent_key: Option<i64>) -> Result<Vec<Variable>, Error> {
+        let mut children: Vec<Variable> = self
+            .variable_hash_map
+            .values()
+            .filter(|child_variable| child_variable.parent_key == parent_key)
+            .cloned()
+            .collect::<Vec<Variable>>();
+        // We have to incur the overhead of sort(), or else the variables in the UI are not in the same order as they appear in the source code.
+        children.sort_by_key(|var| var.variable_key);
+        Ok(children)
     }
 
     // Check if a `Variable` has any children. This also validates that the parent exists in the cache, before attempting to check for children.
     pub fn has_children(&self, parent_variable: &Variable) -> Result<bool, Error> {
-        self.get_children(parent_variable.variable_key)
+        self.get_children(Some(parent_variable.variable_key))
             .map(|children| !children.is_empty())
     }
 
@@ -221,9 +197,11 @@ impl VariableCache {
             self.variable_hash_map
                 .values_mut()
                 .filter(|search_variable| {
-                    search_variable.parent_key == obsolete_child_variable.variable_key
+                    search_variable.parent_key == Some(obsolete_child_variable.variable_key)
                 })
-                .for_each(|grand_child| grand_child.parent_key = parent_variable.variable_key);
+                .for_each(|grand_child| {
+                    grand_child.parent_key = Some(parent_variable.variable_key)
+                });
             // Remove the intermediate variable from the cache
             self.remove_cache_entry(obsolete_child_variable.variable_key)?;
         }
@@ -235,7 +213,7 @@ impl VariableCache {
         let children: Vec<Variable> = self
             .variable_hash_map
             .values()
-            .filter(|search_variable| search_variable.parent_key == parent_variable_key)
+            .filter(|search_variable| search_variable.parent_key == Some(parent_variable_key))
             .cloned()
             .collect();
         for child in children {
@@ -262,7 +240,7 @@ impl std::fmt::Display for VariableCache {
             .values()
             .cloned()
             .filter(|child_variable| {
-                child_variable.name == VariableName::StackFrame && child_variable.parent_key == 0
+                child_variable.name == VariableName::StackFrame && child_variable.parent_key == None
             })
             .collect::<Vec<Variable>>();
         stack_frames.sort_by_key(|variable| variable.variable_key);
@@ -326,7 +304,7 @@ fn _fmt_recurse_variables(
         parent_variable.value.as_ref().unwrap_or(&"".to_string()),
         parent_variable.type_name
     );
-    if let Ok(children) = variable_cache.get_children(parent_variable.variable_key) {
+    if let Ok(children) = variable_cache.get_children(Some(parent_variable.variable_key)) {
         for variable in &children {
             _fmt_recurse_variables(variable_cache, variable, new_level, f)?;
         }
@@ -403,8 +381,8 @@ impl std::fmt::Display for VariableName {
 pub struct Variable {
     /// Every variable must have a unique key value assigned to it. The value will be zero until it is stored in VariableCache, at which time its value will be set to the same as the VariableCache::variable_cache_key
     pub variable_key: i64,
-    /// Every variable must have a unique parent assigned to it when stored in the VariableCache. A parent_key of 0 in the cache simply implies that this variable doesn't have a parent, i.e. it is the root of a tree.
-    pub parent_key: i64,
+    /// Every variable must have a unique parent assigned to it when stored in the VariableCache. A parent_key of None in the cache simply implies that this variable doesn't have a parent, i.e. it is the root of a tree.
+    pub parent_key: Option<i64>,
 
     /// The variable name refers to the name of any of the types of values described in the [VariableCache]
     pub name: VariableName,
@@ -604,7 +582,7 @@ impl Variable {
         } else {
             let mut compound_value = "".to_string();
             // Only do this if we do not already have a value assigned.
-            if let Ok(children) = variable_cache.get_children(self.variable_key) {
+            if let Ok(children) = variable_cache.get_children(Some(self.variable_key)) {
                 // Make sure we can safely unwrap() children.
                 if self.type_name.starts_with('&') {
                     // Pointers
@@ -711,7 +689,7 @@ impl Value for String {
         variable_cache: &VariableCache,
     ) -> Result<Self, DebugError> {
         let mut str_value: String = "".to_owned();
-        if let Ok(children) = variable_cache.get_children(variable.variable_key) {
+        if let Ok(children) = variable_cache.get_children(Some(variable.variable_key)) {
             if !children.is_empty() {
                 let mut string_length = match children.iter().find(|child_variable| {
                     child_variable.name == VariableName::Named("length".to_string())
@@ -728,7 +706,7 @@ impl Value for String {
                 }) {
                     Some(location_value) => {
                         if let Ok(child_variables) =
-                            variable_cache.get_children(location_value.variable_key)
+                            variable_cache.get_children(Some(location_value.variable_key))
                         {
                             if let Some(first_child) = child_variables.first() {
                                 first_child.memory_location as u32

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -372,8 +372,6 @@ pub struct Variable {
     /// TODO: Is there a more efficient method to get on demand access to gimli::Unit through stored references to it?
     pub header_offset: Option<DebugInfoOffset>,
     pub entries_offset: Option<UnitOffset>,
-    /// The register values are needed to resolve the debug information and calculate memory locations and run-time data values. This is only needed for referenced nodes of variables with `DW_TAG_pointer_type`
-    pub stack_frame_registers: Option<Registers>,
     /// The starting location/address in memory where this Variable's value is stored.
     pub memory_location: u64,
     pub byte_size: u64,
@@ -387,7 +385,7 @@ pub struct Variable {
 }
 
 impl Variable {
-    /// In most cases, Variables will be initialized with their ELF references, so that we resolve their data types and values on demand.
+    /// In most cases, Variables will be initialized with their ELF references so that we resolve their data types and values on demand.
     pub(crate) fn new(
         header_offset: Option<DebugInfoOffset>,
         entries_offset: Option<UnitOffset>,

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -27,16 +27,46 @@ pub struct VariableCache {
 }
 impl Default for VariableCache {
     fn default() -> Self {
-        Self::new()
+        Self::new(0)
     }
 }
 
 impl VariableCache {
-    pub fn new() -> Self {
-        Self {
+    pub fn new(_core_index: usize) -> Self {
+        // This is WIP ... please leave commented code.
+        //let variable_cache =
+        VariableCache {
             variable_cache_key: 0,
             variable_hash_map: HashMap::new(),
         }
+        //;
+        // The variable_cache will always be pre-populated with a [VariableName::CoreId] variable for the specified core.
+        // TODO: Implement this.
+        // let mut core_id_variable = Variable::new(None, None);
+        // core_id_variable.name = VariableName::CoreId;
+        // core_id_variable.source_location = function_source_location.clone();
+        // let function_display_name = if function_die.is_inline {
+        //     format!("{} #[inline]", &function_name)
+        // } else {
+        //     format!("{} @{:#010x}", &function_name, address)
+        // };
+        // core_id_variable.set_value(function_display_name);
+        // core_id_variable = unit_info.extract_location(
+        //     &unit_info
+        //         .unit
+        //         .entries_tree(Some(function_die.function_die.offset()))?
+        //         .root()?,
+        //     &parent_variable,
+        //     core_id_variable,
+        //     core,
+        //     &stack_frame_registers,
+        //     cache,
+        // )?;
+
+        //
+        // core_id_variable =
+        //     cache.cache_variable(parent_variable.variable_key, core_id_variable, core)?;
+        // variable_cache
     }
 
     /// Performs an *add* or *update* of a `probe_rs::debug::Variable` to the cache, consuming the input and returning a Clone.

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -623,7 +623,7 @@ impl Variable {
                             child.formatted_variable_value(variable_cache)
                         );
                     }
-                    format!("{}", compound_value)
+                    compound_value
                 } else if self.type_name.as_str() == "Some"
                     || self.type_name.as_str() == "Ok"
                     || self.type_name.as_str() == "Err"
@@ -681,7 +681,7 @@ impl Variable {
                     if let Some(post_fix) = &post_fix {
                         compound_value = format!("{}{}", compound_value, post_fix);
                     };
-                    format!("{}", compound_value)
+                    compound_value
                 }
             } else {
                 // We don't have a value, and we can't generate one from children values, so use the type_name


### PR DESCRIPTION
Various `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals
- [x] Removed `StackFrameIterator` and incorporated its logic into `DebugInfo::unwind()`
- [x] `StackFrame` now has `VariableCache` entries for locals, statics and registers
- [x] Modify `DebugSession` and `CoreData` to handle multiple cores.
- [x] Modify `Variable::parent_key` to be `Option<i64>` and use `None` rather than `0` values to control logic.
- [x] Use the updated `StackFrame`, and new `VariableNodeType` to facilitate 'lazy' loading of variables during stack trace operations. VSCode and MS DAP will request one 'level' of variables at a time, and there is no need to resolve and cache variable data unless the user is going to view/use it.
