### PR TITLE
Support multiple inlined functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ARM:`Session::swo_reader` that returns a wrapping implementation of `std::io::Read` around `Session::read_swo`. (#916)
 - Added CortexM23 to Armv8m mapping for `target-gen`. (#966)
 - Added get_target_voltage to the Probe struct to access the inner DebugProbe method. (#991)
+- Debugger: Added support for showing multiple inlined functions in backtrace. (#1002)
 
 ### Changed
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -291,7 +291,22 @@ impl DebugCli {
                                         }
 
                                         if let Some(file) = &location.file {
-                                            print!("/{}", file)
+                                            print!("/{}", file);
+
+                                            if let Some(line) = location.line {
+                                                print!(":{}", line);
+
+                                                if let Some(col) = location.column {
+                                                    match col {
+                                                        probe_rs::debug::ColumnType::LeftEdge => {
+                                                            print!(":1")
+                                                        }
+                                                        probe_rs::debug::ColumnType::Column(c) => {
+                                                            print!(":{}", c)
+                                                        }
+                                                    }
+                                                }
+                                            }
                                         }
 
                                         println!();

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -274,10 +274,13 @@ impl DebugCli {
                                 frames.iter().map(|sf| sf.id as i64).collect();
 
                             for (i, frame) in frames.iter().enumerate() {
-                                println!(
-                                    "Frame {}: {} @ {:#010x}",
-                                    i, frame.function_name, frame.pc
-                                );
+                                print!("Frame {}: {} @ {:#010x}", i, frame.function_name, frame.pc);
+
+                                if frame.is_inlined {
+                                    print!(" inline");
+                                }
+
+                                println!();
 
                                 if let Some(location) = &frame.source_location {
                                     if location.directory.is_some() || location.file.is_some() {
@@ -371,7 +374,7 @@ impl DebugCli {
 
             function: |cli_data, _args| {
                 match &cli_data.state {
-                    &DebugState::Halted(ref halted_state) => {
+                    DebugState::Halted(ref halted_state) => {
                         if let Some(locals) =
                             halted_state.variable_cache.get_variable_by_name_and_parent(
                                 &VariableName::Locals,
@@ -393,7 +396,7 @@ impl DebugCli {
                             println!("No local variables available.")
                         }
                     }
-                    &DebugState::Running => println!("Core must be halted for this command."),
+                    DebugState::Running => println!("Core must be halted for this command."),
                 }
 
                 Ok(CliState::Continue)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -424,15 +424,13 @@ fn debug(shared_options: &CoreOptions, common: &ProbeOptions, exe: Option<PathBu
 
     let core = session.core(shared_options.core)?;
 
-    let mut cli_data = debugger::CliData {
-        core,
-        debug_info: di,
-        capstone: cs,
-    };
+    let mut cli_data = debugger::CliData::new(core, di, cs)?;
 
     let mut rl = Editor::<()>::new();
 
     loop {
+        cli_data.print_state()?;
+
         let readline = rl.readline(">> ");
         match readline {
             Ok(line) => {

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -710,7 +710,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                             .as_ref()
                             .and_then(|sl| sl.line)
                             .unwrap_or(0) as i64;
-                        let function_display_name = if frame.inlined_call_site.is_some() {
+                        let function_display_name = if frame.is_inlined {
                             format!("{} #[inline]", frame.function_name)
                         } else {
                             format!("{} @{:#010x}", frame.function_name, frame.pc)

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -1096,7 +1096,8 @@ impl DebugInfo {
         core: &mut Core<'_>,
         address: u64,
         unwind_registers: &Registers,
-        // If we encountered an abstract source location (the location in the caller function where it calls and inline function), during the previous iteration, it was stored on the `StackFrameIterator` for passing to this function in the `::next()` iteration. This function then uses this as the source location for the caller.
+        // If we encountered an abstract source location (the location in the caller function where it calls and inline function), during the previous iteration,
+        // it was stored on the `StackFrameIterator` for passing to this function in the `::next()` iteration. This function then uses this as the source location for the caller.
         abstract_source_location: Option<SourceLocation>,
     ) -> Result<StackFrame, DebugError> {
         let mut units = self.get_units();

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -69,11 +69,8 @@ pub struct StackFrame {
     pub source_location: Option<SourceLocation>,
     pub registers: Registers,
     pub pc: u32,
-    /// If this StackFrame was for an inlined function, then the call site addresss (the point where the calling function invoked this function) will be stored here, to be used as the PC value for the calling StackFrame. This allows us to create virtual StackFrames for inlined functions, and improves the logical flow of a stepping experience during debug.
-    /// TODO: This only works for one-level of inlined function. When we have nested inlined functions, it collapses them into a single logical `StackFrame`. We need to find a better mechanism to enable nesting.
-    pub inlined_call_site: Option<u32>,
-    /// If this function is an inlined function, we record the caller's [`SourceLocation`] here.
-    pub inlined_caller_source_location: Option<SourceLocation>,
+
+    pub is_inlined: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -236,8 +233,9 @@ pub struct StackFrameIterator<'debuginfo, 'probe, 'core> {
     unwind_context: Box<gimli::UnwindContext<DwarfReader>>,
     /// Register state as updated for every iteration (previous function) of the unwind process.
     unwind_registers: Registers,
-    /// If the most recent function in the unwind was an inlined function, we record the caller's [`SourceLocation`] here.
-    inlined_caller_source_location: Option<SourceLocation>,
+
+    // Used for handling inlined functions
+    cached_stack_frames: Vec<StackFrame>,
 }
 
 impl<'debuginfo, 'probe, 'core> StackFrameIterator<'debuginfo, 'probe, 'core> {
@@ -263,7 +261,7 @@ impl<'debuginfo, 'probe, 'core> StackFrameIterator<'debuginfo, 'probe, 'core> {
             unwind_bases,
             unwind_context,
             unwind_registers: current_registers,
-            inlined_caller_source_location: None,
+            cached_stack_frames: Vec::new(),
         }
     }
 }
@@ -313,21 +311,49 @@ impl<'debuginfo, 'probe, 'core> Iterator for StackFrameIterator<'debuginfo, 'pro
             frame_pc,
         );
 
-        // PART 1-a: Prepare the `StackFrame` that holds the current frame information
-        let return_frame = match self.debug_info.get_stackframe_info(
-            self.cache,
-            self.core,
-            frame_pc,
-            &self.unwind_registers,
-            self.inlined_caller_source_location.clone(),
-        ) {
-            Ok(frame) => frame,
-            Err(e) => {
-                log::error!("UNWIND: Unable to complete `StackFrame` information: {}", e);
-                // There is no point in continuing with the unwind, so let's get out of here.
-                self.unwind_registers.set_return_address(None);
-                return None;
+        // If we have cached stack frames (due to inlining), just return the cached frames
+        if self.cached_stack_frames.len() > 1 {
+            log::info!("Using cached stack frame for inlined function.");
+            return self.cached_stack_frames.pop();
+        }
+
+        let return_frame = if self.cached_stack_frames.is_empty() {
+            // PART 1-a: Prepare the `StackFrame` that holds the current frame information
+            let mut return_frames = match self.debug_info.get_stackframe_info(
+                self.cache,
+                self.core,
+                frame_pc,
+                &self.unwind_registers,
+            ) {
+                Ok(frame) => frame,
+                Err(e) => {
+                    log::error!("UNWIND: Unable to complete `StackFrame` information: {}", e);
+                    // There is no point in continuing with the unwind, so let's get out of here.
+                    self.unwind_registers.set_return_address(None);
+                    return None;
+                }
+            };
+
+            if return_frames.len() > 1 {
+                log::debug!("Multiple stack frames:");
+                for frame in &return_frames {
+                    log::debug!(" - name={}, pc={}", frame.function_name, frame.pc);
+                }
             }
+
+            let return_frame = return_frames.pop().unwrap();
+
+            self.cached_stack_frames = return_frames;
+
+            if !self.cached_stack_frames.is_empty() {
+                log::debug!("UNWIND: In inlined function, returning virtual frame.");
+                return Some(return_frame);
+            }
+
+            return_frame
+        } else {
+            log::info!("Last cached stack frame, current funtion is not inlined.");
+            self.cached_stack_frames.pop().unwrap()
         };
 
         // Part 1-b: When we encounter the starting (after reset) return address, we've reached the bottom of the stack, so no more unwinding after this ...
@@ -340,41 +366,6 @@ impl<'debuginfo, 'probe, 'core> Iterator for StackFrameIterator<'debuginfo, 'pro
                 );
                 return Some(return_frame);
             }
-        }
-
-        // PART 2: Setup the registers for the `next()` iteration (a.k.a. unwind previous frame, a.k.a. "callee", in the call stack).
-        log::debug!("UNWIND Registers for previous function ...");
-        // Part2-a: We check if the StackFrame just processed was an INLINED function, in which case the unwind process below will take a different path than the one for NON-INLINED functions.
-        if let Some(inlined_call_site) = return_frame.inlined_call_site {
-            self.inlined_caller_source_location =
-                return_frame.inlined_caller_source_location.clone();
-            log::debug!(
-                "UNWIND - Preparing `StackFrameIterator` to unwind INLINED function {:?} at {:?}",
-                return_frame.function_name,
-                return_frame.source_location
-            );
-            // The only `unwind` we need to do, is to update the PC with the call site address of the inline function. The `StackFrameIterator::next()` iteration will then create a virtual `StackFrame` for the call-site.
-            let register_number = self
-                .unwind_registers
-                .register_description
-                .program_counter()
-                .address
-                .0 as u32;
-            log::debug!(
-                "UNWIND - {:04?}: Caller: {:#010x}\tCallee: {:#010x}\tRule: {}",
-                self.unwind_registers
-                    .get_name_by_dwarf_register_number(register_number),
-                inlined_call_site,
-                self.unwind_registers
-                    .get_value_by_dwarf_register_number(register_number)
-                    .unwrap_or_default(),
-                "PC= Inlined function `inlined_call_site`'",
-            );
-            self.unwind_registers
-                .set_program_counter(Some(inlined_call_site));
-            return Some(return_frame);
-        } else {
-            self.inlined_caller_source_location = None;
         }
 
         log::debug!(
@@ -789,20 +780,35 @@ impl DebugInfo {
         &self.dwarf
     }
 
-    pub fn function_name(&self, address: u64, find_inlined: bool) -> Option<String> {
+    /// Get the name of the function at the given address.
+    ///
+    /// If no function is found, `None` will be returend.
+    ///
+    /// ## Inlined functions
+    /// Multiple nested inline functions could exist at the given address.
+    /// This function will currently return the innermost function in that case.
+    pub fn function_name(
+        &self,
+        address: u64,
+        find_inlined: bool,
+    ) -> Result<Option<String>, DebugError> {
         let mut units = self.dwarf.units();
 
         while let Some(unit_info) = self.get_next_unit_info(&mut units) {
-            if let Some(die_cursor_state) = &mut unit_info.get_function_die(address, find_inlined) {
+            let mut functions = unit_info.get_function_dies(address, find_inlined)?;
+
+            // Use the last functions from the list, this is the function which most closely
+            // corresponds to the PC in case of multiple inlined functions.
+            if let Some(die_cursor_state) = functions.pop() {
                 let function_name = die_cursor_state.function_name(&unit_info);
 
                 if function_name.is_some() {
-                    return function_name;
+                    return Ok(function_name);
                 }
             }
         }
 
-        None
+        Ok(None)
     }
 
     /// Try get the [`SourceLocation`] for a given address.
@@ -971,7 +977,7 @@ impl DebugInfo {
         &self,
         cache: &mut VariableCache,
         core: &mut Core<'_>,
-        die_cursor_state: &mut FunctionDie,
+        die_cursor_state: &FunctionDie,
         unit_info: &UnitInfo,
         stack_frame_registers: &Registers,
         stackframe_root_variable: &Variable,
@@ -1096,81 +1102,94 @@ impl DebugInfo {
         core: &mut Core<'_>,
         address: u64,
         unwind_registers: &Registers,
-        // If we encountered an abstract source location (the location in the caller function where it calls and inline function), during the previous iteration,
-        // it was stored on the `StackFrameIterator` for passing to this function in the `::next()` iteration. This function then uses this as the source location for the caller.
-        abstract_source_location: Option<SourceLocation>,
-    ) -> Result<StackFrame, DebugError> {
+    ) -> Result<Vec<StackFrame>, DebugError> {
         let mut units = self.get_units();
 
         let unknown_function = format!("<unknown function @ {:#010x}>", address);
         let stack_frame_registers = unwind_registers.clone();
 
+        let mut frames = Vec::new();
+
         let mut inlined_call_site: Option<u32> = None;
         let mut inlined_caller_source_location: Option<SourceLocation> = None;
+
         while let Some(unit_info) = self.get_next_unit_info(&mut units) {
-            if let Some(function_die) =
-                &mut unit_info.get_function_die(address, abstract_source_location.is_none())
-            {
+            let functions = unit_info.get_function_dies(address, true)?;
+
+            if functions.is_empty() {
+                continue;
+            }
+
+            // Debugging, remove afterwards
+            if functions.len() > 1 {
+                let function_names: Vec<_> = functions
+                    .iter()
+                    .map(|f| {
+                        f.function_name(&unit_info)
+                            .unwrap_or_else(|| "<err getting name>".to_string())
+                    })
+                    .collect();
+
+                log::info!("Multiple inlined functions: {:?}", function_names);
+            }
+
+            // Handle all functions which contain further inlined functions
+            for (index, function_die) in functions[0..functions.len() - 1].iter().enumerate() {
                 let function_name = function_die
                     .function_name(&unit_info)
-                    .unwrap_or(unknown_function);
+                    .unwrap_or_else(|| unknown_function.clone());
 
-                if function_die.is_inline {
-                    // Calculate the call site for this function, so that we can use it later to create an additional 'callee' `StackFrame` from that PC.
-                    let address_size =
-                        gimli::_UnwindSectionPrivate::address_size(&self.frame_section) as u64;
+                let next_function = &functions[index + 1];
 
-                    if function_die.low_pc > address_size && function_die.low_pc < u32::MAX.into() {
-                        inlined_call_site = Some(function_die.low_pc as u32);
-                        inlined_caller_source_location = if let Some(file_name_attr) =
-                            function_die.get_attribute(gimli::DW_AT_call_file)
-                        {
-                            if let Some((directory, file)) = extract_file(
-                                unit_info.debug_info,
-                                &unit_info.unit,
-                                file_name_attr.value(),
-                            ) {
-                                let line = function_die
-                                    .get_attribute(gimli::DW_AT_call_line)
-                                    .and_then(|line| line.udata_value());
-                                let column = function_die
-                                    .get_attribute(gimli::DW_AT_call_column)
-                                    .map(|column| match column.udata_value() {
-                                        None => ColumnType::LeftEdge,
-                                        Some(c) => ColumnType::Column(c),
-                                    });
-                                Some(SourceLocation {
-                                    line,
-                                    column,
-                                    file: Some(file),
-                                    directory: Some(directory),
-                                })
-                            } else {
-                                None
-                            }
-                        } else {
-                            log::warn!(
-                                "Failed to get `SourceLocation` for function {:?}",
-                                function_die.function_name(&unit_info)
+                assert!(next_function.is_inline);
+
+                // Calculate the call site for this function, so that we can use it later to create an additional 'callee' `StackFrame` from that PC.
+                let address_size =
+                    gimli::_UnwindSectionPrivate::address_size(&self.frame_section) as u64;
+
+                if next_function.low_pc > address_size && next_function.low_pc < u32::MAX.into() {
+                    // The first instruction of the inlined function is used as the call saite
+                    inlined_call_site = Some(function_die.low_pc as u32);
+
+                    inlined_caller_source_location = if let Some(file_name_attr) =
+                        next_function.get_attribute(gimli::DW_AT_call_file)
+                    {
+                        if let Some((directory, file)) = extract_file(
+                            unit_info.debug_info,
+                            &unit_info.unit,
+                            file_name_attr.value(),
+                        ) {
+                            let line = function_die
+                                .get_attribute(gimli::DW_AT_call_line)
+                                .and_then(|line| line.udata_value());
+                            let column = function_die.get_attribute(gimli::DW_AT_call_column).map(
+                                |column| match column.udata_value() {
+                                    None => ColumnType::LeftEdge,
+                                    Some(c) => ColumnType::Column(c),
+                                },
                             );
+                            Some(SourceLocation {
+                                line,
+                                column,
+                                file: Some(file),
+                                directory: Some(directory),
+                            })
+                        } else {
                             None
-                        };
+                        }
                     } else {
-                        log::error!(
-                            "UNWIND: Unable to calculate call site information for function {}",
-                            function_name
+                        log::warn!(
+                            "Failed to get `SourceLocation` for function {:?}",
+                            function_die.function_name(&unit_info)
                         );
-                    }
-                };
-
-                // Resolve either :
-                // - The 'origin' [`SourceLocation`] for a given `PC` address, or ...
-                // - The 'abstract' [`SourceLocation`] if it is available
-                let function_source_location = if abstract_source_location.is_some() {
-                    abstract_source_location
+                        None
+                    };
                 } else {
-                    self.get_source_location(address)
-                };
+                    log::error!(
+                        "UNWIND: Unable to calculate call site information for function {}",
+                        function_name
+                    );
+                }
 
                 log::debug!("UNWIND: Function name: {}", function_name);
 
@@ -1182,7 +1201,7 @@ impl DebugInfo {
                     Some(function_die.function_die.offset()),
                 );
                 stackframe_root_variable.name = VariableName::StackFrame;
-                stackframe_root_variable.source_location = function_source_location.clone();
+                stackframe_root_variable.source_location = inlined_caller_source_location.clone();
                 let function_display_name = if function_die.is_inline {
                     format!("{} #[inline]", &function_name)
                 } else {
@@ -1249,56 +1268,157 @@ impl DebugInfo {
                     &stackframe_root_variable,
                 )?;
 
-                // Ready to go ...
-                return Ok(StackFrame {
+                frames.push(StackFrame {
                     // MS DAP Specification requires the id to be unique accross all threads, so using  so using unique `Variable::variable_key` of the `stackframe_root_variable` as the id.
                     id: stackframe_root_variable.variable_key as u64,
                     function_name,
-                    source_location: function_source_location,
-                    registers: stack_frame_registers,
-                    pc: address as u32,
-                    inlined_call_site,
-                    inlined_caller_source_location,
+                    source_location: inlined_caller_source_location.clone(),
+                    registers: stack_frame_registers.clone(),
+                    pc: inlined_call_site.unwrap(),
+                    is_inlined: function_die.is_inline,
                 });
             }
+
+            // Handle last function, which contains no further inlined functions
+            let last_function = functions.last().unwrap(); //UNWRAP: Checked at beginning of loop, functions must contain at least one value
+
+            let function_name = last_function
+                .function_name(&unit_info)
+                .unwrap_or_else(|| unknown_function.clone());
+
+            let function_location = self.get_source_location(address);
+
+            // Now that we have the function_name and function_source_location, we can cache the in-scope `Variable`s (`<statics>` and `<locals>`) in `DebugInfo::VariableCache`
+            // We need an empty parent variable for the next operation, but do not need to store it in the cache.
+            let parent_variable = Variable::new(None, None);
+            let mut stackframe_root_variable = Variable::new(
+                unit_info.unit.header.offset().as_debug_info_offset(),
+                Some(last_function.function_die.offset()),
+            );
+            stackframe_root_variable.name = VariableName::StackFrame;
+            stackframe_root_variable.source_location = function_location.clone();
+            let function_display_name = if last_function.is_inline {
+                format!("{} #[inline]", &function_name)
+            } else {
+                format!("{} @{:#010x}", &function_name, address)
+            };
+            stackframe_root_variable.set_value(function_display_name);
+            stackframe_root_variable = unit_info.extract_location(
+                &unit_info
+                    .unit
+                    .entries_tree(Some(last_function.function_die.offset()))?
+                    .root()?,
+                &parent_variable,
+                stackframe_root_variable,
+                core,
+                &stack_frame_registers,
+                cache,
+            )?;
+
+            stackframe_root_variable = cache.cache_variable(
+                parent_variable.variable_key,
+                stackframe_root_variable,
+                core,
+            )?;
+
+            if let Some(error) = self
+                .cache_register_variables(
+                    cache,
+                    &stack_frame_registers,
+                    &stackframe_root_variable,
+                    core,
+                )
+                .err()
+            {
+                log::warn!(
+                    "Could not resolve register variables.{}. Continuing...",
+                    error
+                );
+            }
+
+            // Next, resolve the statics that belong to the compilation unit that this function is in.
+            if let Some(error) = self
+                .cache_static_variables(
+                    cache,
+                    core,
+                    &unit_info,
+                    &stack_frame_registers,
+                    &stackframe_root_variable,
+                )
+                .err()
+            {
+                log::warn!(
+                    "Error while resolving static variables.{}. Continuing...",
+                    error
+                );
+            }
+
+            // Next, resolve and cache the function variables.
+            self.cache_function_variables(
+                cache,
+                core,
+                last_function,
+                &unit_info,
+                &stack_frame_registers,
+                &stackframe_root_variable,
+            )?;
+
+            frames.push(StackFrame {
+                // MS DAP Specification requires the id to be unique accross all threads, so using  so using unique `Variable::variable_key` of the `stackframe_root_variable` as the id.
+                id: stackframe_root_variable.variable_key as u64,
+                function_name,
+                source_location: function_location,
+                registers: stack_frame_registers.clone(),
+                pc: address as u32,
+                is_inlined: last_function.is_inline,
+            });
+
+            break;
         }
 
         // If we get here, we were not able to identify/unwind the function information.
         // Before returning `unknown_function` [StackFrame], make sure we at least cache the Register values.
         // We need an empty parent variable for the next operation, but do not need to store it in the cache.
-        let parent_variable = Variable::new(None, None);
-        let mut stackframe_root_variable = Variable::new(None, None);
-        stackframe_root_variable.name = VariableName::StackFrame;
-        stackframe_root_variable.source_location = self.get_source_location(address);
-        stackframe_root_variable.set_value(unknown_function.clone());
-        stackframe_root_variable.memory_location = address;
 
-        stackframe_root_variable =
-            cache.cache_variable(parent_variable.variable_key, stackframe_root_variable, core)?;
+        if frames.is_empty() {
+            let parent_variable = Variable::new(None, None);
+            let mut stackframe_root_variable = Variable::new(None, None);
+            stackframe_root_variable.name = VariableName::StackFrame;
+            stackframe_root_variable.source_location = self.get_source_location(address);
+            stackframe_root_variable.set_value(unknown_function.clone());
+            stackframe_root_variable.memory_location = address;
 
-        if let Some(error) = self
-            .cache_register_variables(
-                cache,
-                &stack_frame_registers,
-                &stackframe_root_variable,
+            stackframe_root_variable = cache.cache_variable(
+                parent_variable.variable_key,
+                stackframe_root_variable,
                 core,
-            )
-            .err()
-        {
-            log::warn!(
-                "Could not resolve register variables.{}. Continuing...",
-                error
-            );
+            )?;
+
+            if let Some(error) = self
+                .cache_register_variables(
+                    cache,
+                    &stack_frame_registers,
+                    &stackframe_root_variable,
+                    core,
+                )
+                .err()
+            {
+                log::warn!(
+                    "Could not resolve register variables.{}. Continuing...",
+                    error
+                );
+            }
+            Ok(vec![StackFrame {
+                id: stackframe_root_variable.variable_key as u64,
+                function_name: unknown_function,
+                source_location: self.get_source_location(address),
+                registers: stack_frame_registers.clone(),
+                pc: address as u32,
+                is_inlined: false,
+            }])
+        } else {
+            Ok(frames)
         }
-        Ok(StackFrame {
-            id: stackframe_root_variable.variable_key as u64,
-            function_name: unknown_function,
-            source_location: self.get_source_location(address),
-            registers: stack_frame_registers,
-            pc: address as u32,
-            inlined_call_site,
-            inlined_caller_source_location,
-        })
     }
 
     pub fn try_unwind<'debuginfo, 'probe, 'core>(
@@ -1566,18 +1686,20 @@ struct UnitInfo<'debuginfo> {
 
 impl<'debuginfo> UnitInfo<'debuginfo> {
     /// Get the DIE for the function containing the given address.
-    fn get_function_die(&self, address: u64, find_inlined: bool) -> Option<FunctionDie> {
+    ///
+    /// If `find_inlined` is `false`, then the result will contain a single [`FunctionDie`]
+    fn get_function_dies(
+        &self,
+        address: u64,
+        find_inlined: bool,
+    ) -> Result<Vec<FunctionDie>, DebugError> {
         log::trace!("Searching Function DIE for address {:#010x}", address);
 
         let mut entries_cursor = self.unit.entries();
 
         while let Ok(Some((_depth, current))) = entries_cursor.next_dfs() {
             if current.tag() == gimli::DW_TAG_subprogram {
-                let mut ranges = self
-                    .debug_info
-                    .dwarf
-                    .die_ranges(&self.unit, current)
-                    .unwrap();
+                let mut ranges = self.debug_info.dwarf.die_ranges(&self.unit, current)?;
 
                 while let Ok(Some(ranges)) = ranges.next() {
                     if (ranges.begin <= address) && (address < ranges.end) {
@@ -1586,53 +1708,74 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                         let mut die = FunctionDie::new(current.clone());
                         die.low_pc = ranges.begin;
                         die.high_pc = ranges.end;
+
+                        let mut functions = vec![die];
+
                         if find_inlined {
                             log::debug!(
                                 "Found DIE, now checking for inlined functions: name={:?}",
-                                die.function_name(self)
+                                functions[0].function_name(self)
                             );
-                            return self
-                                .find_inlined_function(address, current.offset())
-                                .or_else(|| {
-                                    log::debug!("No inlined function found!");
-                                    Some(die)
-                                });
-                        } else {
-                            log::debug!("Found DIE: name={:?}", die.function_name(self));
 
-                            return Some(die);
+                            let inlined_functions =
+                                self.find_inlined_functions(address, current.offset())?;
+
+                            if inlined_functions.is_empty() {
+                                log::debug!("No inlined function found!");
+                            } else {
+                                log::debug!(
+                                    "{} inlined functions for address {:#010x}",
+                                    inlined_functions.len(),
+                                    address
+                                );
+                                functions.extend(inlined_functions.into_iter());
+                            }
+
+                            return Ok(functions);
+                        } else {
+                            log::debug!("Found DIE: name={:?}", functions[0].function_name(self));
                         }
+
+                        return Ok(functions);
                     }
                 }
             }
         }
-        None
+        Ok(vec![])
     }
 
-    /// Check if the function located at the given offset contains an inlined function at the
+    /// Check if the function located at the given offset contains inlined functions at the
     /// given address.
-    fn find_inlined_function(&self, address: u64, offset: UnitOffset) -> Option<FunctionDie> {
+    fn find_inlined_functions(
+        &self,
+        address: u64,
+        offset: UnitOffset,
+    ) -> Result<Vec<FunctionDie>, DebugError> {
         let mut current_depth = 0;
 
+        let mut abort_depth = 0;
+
         let mut cursor = self.unit.entries_at_offset(offset).unwrap();
+
+        let mut functions = Vec::new();
 
         while let Ok(Some((depth, current))) = cursor.next_dfs() {
             current_depth += depth;
 
-            if current_depth < 0 {
+            if current_depth < abort_depth {
                 break;
             }
 
             if current.tag() == gimli::DW_TAG_inlined_subroutine {
-                let mut ranges = self
-                    .debug_info
-                    .dwarf
-                    .die_ranges(&self.unit, current)
-                    .unwrap();
+                let mut ranges = self.debug_info.dwarf.die_ranges(&self.unit, current)?;
 
                 while let Ok(Some(ranges)) = ranges.next() {
                     if (ranges.begin <= address) && (address < ranges.end) {
                         // Check if we are actually in an inlined function
+
+                        // We don't have to search further up in the tree, if there are multiple inlined functions,
+                        // they will be children of the current function.
+                        abort_depth = current_depth;
 
                         // Find the abstract definition
                         if let Some(abstract_origin) =
@@ -1647,19 +1790,21 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                     );
                                     die.low_pc = ranges.begin;
                                     die.high_pc = ranges.end;
-                                    return Some(die);
+
+                                    functions.push(die);
                                 }
                                 other_value => panic!("Unsupported value: {:?}", other_value),
                             }
                         } else {
-                            return None;
+                            log::debug!("No abstract origin for inlined function, skipping.");
+                            return Ok(vec![]);
                         }
                     }
                 }
             }
         }
 
-        None
+        Ok(functions)
     }
 
     fn expr_to_piece(
@@ -2075,7 +2220,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 )));
             };
 
-        log::debug!("process_tree for parent {}", parent_variable.variable_key);
+        log::trace!("process_tree for parent {}", parent_variable.variable_key);
 
         let mut child_nodes = parent_node.children();
         while let Some(mut child_node) = child_nodes.next()? {

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -69,7 +69,7 @@ impl VariableCache {
             let new_cache_key: i64 = self.variable_cache_key + 1;
             variable_to_add.variable_key = new_cache_key;
 
-            log::debug!(
+            log::trace!(
                 "VariableCache: Add Variable: key={}, parent={}, name={:?}",
                 new_cache_key,
                 variable_to_add.parent_key,
@@ -92,7 +92,7 @@ impl VariableCache {
             // Attempt to update an existing `Variable` in the cache
             let reused_cache_key = variable_to_add.variable_key;
 
-            log::debug!(
+            log::trace!(
                 "VariableCache: Update Variable, key={}, name={:?}",
                 reused_cache_key,
                 &variable_to_add.name

--- a/probe-rs/tests/inlined_function.rs
+++ b/probe-rs/tests/inlined_function.rs
@@ -1,70 +1,82 @@
-use probe_rs::debug::DebugInfo;
+use probe_rs::debug::{DebugError, DebugInfo};
+
+type TestResult = Result<(), DebugError>;
 
 #[test]
-fn function_name_of_inlined_function_1() {
+fn function_name_of_inlined_function_1() -> TestResult {
     let di = DebugInfo::from_file("tests/inlined-function").unwrap();
 
     let address = 0x15e;
 
     let expected_name = "blink_on";
 
-    let name = di.function_name(address, true).unwrap();
+    let name = di.function_name(address, true)?.unwrap();
 
     assert_eq!(expected_name, name);
+
+    Ok(())
 }
 
 #[test]
-fn name_of_function_containing_inlined_function_1() {
+fn name_of_function_containing_inlined_function_1() -> TestResult {
     let di = DebugInfo::from_file("tests/inlined-function").unwrap();
 
     let address = 0x15e;
 
     let expected_name = "__cortex_m_rt_main";
 
-    let name = di.function_name(address, false).unwrap();
+    let name = di.function_name(address, false)?.unwrap();
 
     assert_eq!(expected_name, name);
+
+    Ok(())
 }
 
 #[test]
-fn function_name_of_inlined_function_2() {
+fn function_name_of_inlined_function_2() -> TestResult {
     let di = DebugInfo::from_file("tests/inlined-function").unwrap();
 
     let address = 0x154;
 
     let expected_name = "__cortex_m_rt_main";
 
-    let name = di.function_name(address, true).unwrap();
+    let name = di.function_name(address, true)?.unwrap();
 
     assert_eq!(expected_name, name);
+
+    Ok(())
 }
 
 #[test]
-fn name_of_function_containing_inlined_function_2() {
+fn name_of_function_containing_inlined_function_2() -> TestResult {
     let di = DebugInfo::from_file("tests/inlined-function").unwrap();
 
     let address = 0x154;
 
     let expected_name = "__cortex_m_rt_main";
 
-    let name = di.function_name(address, false).unwrap();
+    let name = di.function_name(address, false)?.unwrap();
 
     assert_eq!(expected_name, name);
+
+    Ok(())
 }
 
 #[test]
-fn function_name_of_non_inlined_function() {
+fn function_name_of_non_inlined_function() -> TestResult {
     let di = DebugInfo::from_file("tests/inlined-function").unwrap();
 
     let address = 0xf4;
 
     let expected_name = "blink_off";
 
-    let name = di.function_name(address, true).unwrap();
+    let name = di.function_name(address, true)?.unwrap();
 
     assert_eq!(expected_name, name);
 
     // The function is not inlined, so we should receive the same name in both cases
-    let name = di.function_name(address, false).unwrap();
+    let name = di.function_name(address, false)?.unwrap();
     assert_eq!(expected_name, name);
+
+    Ok(())
 }


### PR DESCRIPTION
This is both some in progress work on the CLI debugger, as well as support for multiple inlined functions.

This probably conflicts with #999 , since it changes the stack frame iterator as well. 

@noppej Do you think the approach in this PR would also work with your changes?

## Backtrace comparsion

### Current master

```
StackFrame data for copy_forward #[inline]
        /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.66/src/mem/impls.rs:76:29

StackFrame data for memcpy @0x08030a06
        /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.66/src/mem/mod.rs:25:5

StackFrame data for free<stm32wb55_homekit::ble::receive_event::{closure#0}, core::result::Result<bluetooth_hci::host::uart::Packet<stm32wb55::event::Stm32Wb5xEvent>, nb::Error<bluetooth_hci::host::uart::Error<(), stm32wb55::event::Stm32Wb5xError>>>> #[inline]
        /rustc/22e491ac7ed454d34669151a8b6464cb643c9b41/library/core/src/result.rs:2005:38

StackFrame data for receive_event @0x08004542
        stm32wb55-homekit/src/ble.rs:306:5

StackFrame data for run @0x0800b0fc
        /home/dominik/code/stm32wb55-homekit/stm32wb55-homekit/src/main.rs:185:31

StackFrame data for __cortex_m_rt_entry @0x0800d37c
        /home/dominik/code/stm32wb55-homekit/stm32wb55-homekit/src/main.rs:94:5

StackFrame data for __cortex_m_rt_entry_trampoline @0x0800d326
        /home/dominik/code/stm32wb55-homekit/stm32wb55-homekit/src/main.rs:84:1

StackFrame data for trampoline @0x08018b4c
        /home/dominik/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.15/src/lib.rs:547:26

StackFrame data for Reset @0x080001c2
        /home/dominik/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.15/src/lib.rs:550:13

```


### This PR
```
Frame 0: copy_forward_misaligned_words @ 0x08030a86 inline
       /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.66/src/mem/impls.rs
Frame 1: copy_forward @ 0x08030a06 inline
       /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.66/src/mem/impls.rs
Frame 2: memcpy @ 0x080309fe
       /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.66/src/mem/mod.rs
Frame 3: from_residual<bluetooth_hci::host::uart::Packet<stm32wb55::event::Stm32Wb5xEvent>, nb::Error<bluetooth_hci::host::uart::Error<(), stm32wb55::event::Stm32Wb5xError>>, nb::Error<bluetooth_hci::host::uart::Error<(), stm32wb55::event::Stm32Wb5xError>>> @ 0x080048ae inline
       /rustc/22e491ac7ed454d34669151a8b6464cb643c9b41/library/core/src/result.rs
Frame 4: read<(), stm32wb55::event::Stm32Wb5xEvent, stm32wb55::event::Stm32Wb5xError, stm32wb55::RadioCoprocessor<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>, typenum::bit::B0>, typenum::bit::B0>, typenum::bit::B0>, typenum::bit::B0>, typenum::bit::B0>, typenum::bit::B0>, typenum::bit::B0>, typenum::bit::B1>, typenum::bit::B0>>> @ 0x0800483a inline
       /home/dominik/.cargo/git/checkouts/bluetooth-hci-131d88e279548bee/d355813/src/host/uart.rs
Frame 5: {closure#0} @ 0x0800454c inline
       stm32wb55-homekit/src/ble.rs
Frame 6: free<stm32wb55_homekit::ble::receive_event::{closure#0}, core::result::Result<bluetooth_hci::host::uart::Packet<stm32wb55::event::Stm32Wb5xEvent>, nb::Error<bluetooth_hci::host::uart::Error<(), stm32wb55::event::Stm32Wb5xError>>>> @ 0x08004542 inline
       /home/dominik/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.3/src/interrupt.rs
Frame 7: receive_event @ 0x08004534
       stm32wb55-homekit/src/ble.rs
Frame 8: run @ 0x0800b0fc
       /home/dominik/code/stm32wb55-homekit/stm32wb55-homekit/src/main.rs
Frame 9: __cortex_m_rt_entry @ 0x0800d37c
       /home/dominik/code/stm32wb55-homekit/stm32wb55-homekit/src/main.rs
Frame 10: __cortex_m_rt_entry_trampoline @ 0x0800d326
       /home/dominik/code/stm32wb55-homekit/stm32wb55-homekit/src/main.rs
Frame 11: trampoline @ 0x08018b4c
       /home/dominik/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.15/src/lib.rs
Frame 12: Reset @ 0x080001c2
       /home/dominik/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.15/src/lib.rs
```