### PR TITLE
Replace #999 - Complete 'lazy load' of variables in probe-rs-debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chip names are now matched treating an 'x' as a wildcard. (#964)
 - GDB server is now available as a subcommand in the probe-rs-cli, not as a separate binary in the `gdb-server` package anymore . (#972)
 - `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals (#999)
-  - Removed `StackFrameIterator` and incorporated its logic into `DebugInfo::unwind()`
-  - `StackFrame` now has `VariableCache` entries for locals, statics and registers
-  - Modify `DebugSession` and `CoreData` to handle multiple cores.
-  - Modify `Variable::parent_key` to be `Option<i64>` and use `None` rather than `0` values to control logic.
-  - WIP: Use the updated `VariableCache` to facilitate 'lazy' loading of all variables during stack trace operations. VSCode and MS DAP will request one 'level' of variables at a time, and there is no need to resolve and cache variable data unless the user is going to view/use it.
+  - Removed StackFrameIterator and incorporated its logic into DebugInfo::unwind()
+  - StackFrame now has VariableCache entries for locals, statics and registers
+  - Modify DebugSession and CoreData to handle multiple cores.
+  - Modify Variable::parent_key to be Option<i64> and use None rather than 0 values to control logic.
+  - [WIP] Use the updated StackFrame, and new VariableNodeType to facilitate 'lazy' loading of variables during stack trace operations. VSCode and MS DAP will request one 'level' of variables at a time, and there is no need to resolve and cache variable data unless the user is going to view/use it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chip names are now matched treating an 'x' as a wildcard. (#964)
 - GDB server is now available as a subcommand in the probe-rs-cli, not as a separate binary in the `gdb-server` package anymore . (#972)
 - `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals (#999)
-  - `VariableCache` structure now models the tree stucture of the MS DAP Specification for `Threads -> StackTrace -> Scopes -> Variables`
+  - Removed `StackFrameIterator` and incorporated its logic into `DebugInfo::unwind()`
+  - `StackFrame` now has `VariableCache` entries for locals, statics and registers
   - Modify `DebugSession` and `CoreData` to handle multiple cores.
-  - WIP: Modify `Variable::parent_key` to be `Option<i64>` and use `None` rather than `0` values to control logic.
+  - Modify `Variable::parent_key` to be `Option<i64>` and use `None` rather than `0` values to control logic.
   - WIP: Use the updated `VariableCache` to facilitate 'lazy' loading of all variables during stack trace operations. VSCode and MS DAP will request one 'level' of variables at a time, and there is no need to resolve and cache variable data unless the user is going to view/use it.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Chip names are now matched treating an 'x' as a wildcard. (#964)
 - GDB server is now available as a subcommand in the probe-rs-cli, not as a separate binary in the `gdb-server` package anymore . (#972)
+- `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals
+  - `VariableCache` structure now models the tree stucture of the MS DAP Specification for `Threads -> StackTrace -> Scopes -> Variables`
+  - 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GDB server is now available as a subcommand in the probe-rs-cli, not as a separate binary in the `gdb-server` package anymore . (#972)
 - `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals
   - `VariableCache` structure now models the tree stucture of the MS DAP Specification for `Threads -> StackTrace -> Scopes -> Variables`
-  - 
+  - Modify `DebugSession` and `CoreData` to handle multiple cores.
+  - WIP: Modify `Variable::parent_key` to be `Option<i64>` and use `None` rather than `0` values to control logic.
+  - WIP: Use the updated `VariableCache` to facilitate 'lazy' loading of all variables during stack trace operations. VSCode and MS DAP will request one 'level' of variables at a time, and there is no need to resolve and cache variable data unless the user is going to view/use it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Chip names are now matched treating an 'x' as a wildcard. (#964)
 - GDB server is now available as a subcommand in the probe-rs-cli, not as a separate binary in the `gdb-server` package anymore . (#972)
-- `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals
+- `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals (#999)
   - `VariableCache` structure now models the tree stucture of the MS DAP Specification for `Threads -> StackTrace -> Scopes -> Variables`
   - Modify `DebugSession` and `CoreData` to handle multiple cores.
   - WIP: Modify `Variable::parent_key` to be `Option<i64>` and use `None` rather than `0` values to control logic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - StackFrame now has VariableCache entries for locals, statics and registers
   - Modify DebugSession and CoreData to handle multiple cores.
   - Modify Variable::parent_key to be Option<i64> and use None rather than 0 values to control logic.
-  - [WIP] Use the updated StackFrame, and new VariableNodeType to facilitate 'lazy' loading of variables during stack trace operations. VSCode and MS DAP will request one 'level' of variables at a time, and there is no need to resolve and cache variable data unless the user is going to view/use it.
+  - Use the updated StackFrame, and new VariableNodeType to facilitate 'lazy' loading of variables during stack trace operations. VSCode and MS DAP will request one 'level' of variables at a time, and there is no need to resolve and cache variable data unless the user is going to view/use it.
+  - Improved `Variable` value formatting for complex variable types.
 
 ### Fixed
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -5,7 +5,6 @@ use num_traits::Num;
 use probe_rs::architecture::arm::Dump;
 use probe_rs::debug::{DebugInfo, Registers, VariableCache, VariableName};
 use probe_rs::{Core, CoreRegisterAddress, MemoryInterface};
-
 use std::fs::File;
 use std::{io::prelude::*, time::Duration};
 
@@ -288,14 +287,11 @@ impl DebugCli {
                     let mut cache = VariableCache::new(cli_data.core.id());
 
                     if let Some(di) = &mut cli_data.debug_info {
-                        let frames = di.try_unwind(
-                            &mut cache,
-                            &mut cli_data.core,
-                            u64::from(program_counter),
-                        );
-                        for _stack_frame in frames {
-                            // Iterate all the stack frames, so that `debug_info.variable_cache` gets populated.
-                        }
+                        let _frames =
+                            di.unwind(&mut cache, &mut cli_data.core, u64::from(program_counter))?;
+                        println!("{}", cache);
+                    } else {
+                        println!("No debug information present!");
                     }
                 }
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -283,13 +283,18 @@ impl DebugCli {
                     let regs = cli_data.core.registers();
                     let program_counter = cli_data.core.read_core_reg(regs.program_counter())?;
 
-                    // TODO: Cache this, should only be cleared when core is running
-                    let mut cache = VariableCache::new();
-
                     if let Some(di) = &mut cli_data.debug_info {
-                        let _frames =
-                            di.unwind(&mut cache, &mut cli_data.core, u64::from(program_counter))?;
-                        println!("{}", cache);
+                        let frames = di.unwind(&mut cli_data.core, u64::from(program_counter))?;
+                        if frames.is_empty() {
+                            println!(
+                                "No backtrace information available for program counter = {:#010x}!",
+                                program_counter
+                            );
+                        } else {
+                            for stack_frame in frames {
+                                println!("{}", stack_frame);
+                            }
+                        }
                     } else {
                         println!("No debug information present!");
                     }

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -284,7 +284,7 @@ impl DebugCli {
                     let program_counter = cli_data.core.read_core_reg(regs.program_counter())?;
 
                     // TODO: Cache this, should only be cleared when core is running
-                    let mut cache = VariableCache::new(cli_data.core.id());
+                    let mut cache = VariableCache::new();
 
                     if let Some(di) = &mut cli_data.debug_info {
                         let _frames =

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -949,7 +949,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             let dap_variables: Vec<Variable> = if let Some(variable_cache) = variable_cache {
                 if let Some(parent_variable) = parent_variable.as_mut() {
                     if parent_variable.variable_node_type.is_deferred()
-                        && !variable_cache.has_children(&parent_variable)?
+                        && !variable_cache.has_children(parent_variable)?
                     {
                         core_data.debug_info.cache_deferred_variables(
                             variable_cache,

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -432,7 +432,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         _core_data: &mut CoreData,
         request: Request,
     ) -> Result<()> {
-        self.send_response::<()>(request.clone(), Ok(None))
+        self.send_response::<()>(request, Ok(None))
     }
 
     pub(crate) fn threads(&mut self, core_data: &mut CoreData, request: Request) -> Result<()> {
@@ -1131,13 +1131,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                             self.send_response(
                                 request,
                                 Ok(Some(ContinueResponseBody {
-                                    all_threads_continued: if self.last_known_status
-                                        == CoreStatus::Running
-                                    {
-                                        Some(false) // TODO: Implement multi-core logic here
-                                    } else {
-                                        Some(false)
-                                    },
+                                    all_threads_continued: Some(false), // TODO: Implement multi-core logic here
                                 })),
                             )?;
                         }

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -647,11 +647,11 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
         *core_data.variable_cache = VariableCache::new(core_data.target_core.id());
 
-        let current_stackframes = core_data.debug_info.try_unwind(
+        let current_stackframes = core_data.debug_info.unwind(
             core_data.variable_cache,
             &mut core_data.target_core,
             u64::from(pc),
-        );
+        )?;
 
         match self.adapter_type() {
             DebugAdapterType::CommandLine => {
@@ -664,6 +664,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             }
             DebugAdapterType::DapClient => {
                 let mut frame_list: Vec<StackFrame> = current_stackframes
+                    .iter()
                     .map(|frame| {
                         let column = frame
                             .source_location

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -645,7 +645,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
         log::debug!("Replacing variable cache!");
 
-        *core_data.variable_cache = VariableCache::new(core_data.target_core.id());
+        *core_data.variable_cache = VariableCache::new();
 
         let current_stackframes = core_data.debug_info.unwind(
             core_data.variable_cache,
@@ -783,7 +783,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             if let Some(static_root_variable) =
                 core_data.variable_cache.get_variable_by_name_and_parent(
                     &VariableName::StaticScope,
-                    stackframe_root_variable.variable_key,
+                    Some(stackframe_root_variable.variable_key),
                 )
             {
                 let (static_variables_reference, static_named_variables, static_indexed_variables) =
@@ -806,7 +806,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             if let Some(register_root_variable) =
                 core_data.variable_cache.get_variable_by_name_and_parent(
                     &VariableName::Registers,
-                    stackframe_root_variable.variable_key,
+                    Some(stackframe_root_variable.variable_key),
                 )
             {
                 let (
@@ -831,7 +831,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             if let Some(locals_root_variable) =
                 core_data.variable_cache.get_variable_by_name_and_parent(
                     &VariableName::LocalScope,
-                    stackframe_root_variable.variable_key,
+                    Some(stackframe_root_variable.variable_key),
                 )
             {
                 let (locals_variables_reference, locals_named_variables, locals_indexed_variables) =
@@ -927,7 +927,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
             let dap_variables: Vec<Variable> = core_data
                 .variable_cache
-                .get_children(arguments.variables_reference)?
+                .get_children(Some(arguments.variables_reference))?
                 .iter()
                 // Filter out requested children, then map them as DAP variables
                 .filter(|variable| match &arguments.filter {
@@ -1086,7 +1086,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
     ) -> (i64, i64, i64) {
         let mut named_child_variables_cnt = 0;
         let mut indexed_child_variables_cnt = 0;
-        if let Ok(children) = cache.get_children(parent_variable.variable_key) {
+        if let Ok(children) = cache.get_children(Some(parent_variable.variable_key)) {
             for child_variable in children {
                 if child_variable.is_indexed() {
                     indexed_child_variables_cnt += 1;

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -645,7 +645,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
         log::debug!("Replacing variable cache!");
 
-        *core_data.variable_cache = VariableCache::new();
+        *core_data.variable_cache = VariableCache::new(core_data.target_core.id());
 
         let current_stackframes = core_data.debug_info.try_unwind(
             core_data.variable_cache,

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -781,7 +781,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         {
             if let Some(static_root_variable) =
                 core_data.variable_cache.get_variable_by_name_and_parent(
-                    &VariableName::Statics,
+                    &VariableName::StaticScope,
                     stackframe_root_variable.variable_key,
                 )
             {
@@ -829,7 +829,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             };
             if let Some(locals_root_variable) =
                 core_data.variable_cache.get_variable_by_name_and_parent(
-                    &VariableName::Locals,
+                    &VariableName::LocalScope,
                     stackframe_root_variable.variable_key,
                 )
             {

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -414,11 +414,6 @@ pub struct CoreData<'p> {
 }
 
 impl<'p> CoreData<'p> {
-    /// The first [StackFrame]'s `pc` value, is the value of the program counter at the most recent unwind.
-    pub(crate) fn pc_of_most_recent_unwind(&'p self) -> Option<u32> {
-        self.stack_frames.first().map(|stack_frame| stack_frame.pc)
-    }
-
     /// Search available [StackFrame]'s for the given `id`
     pub(crate) fn get_stackframe(&'p self, id: i64) -> Option<&'p probe_rs::debug::StackFrame> {
         self.stack_frames
@@ -1009,8 +1004,7 @@ impl Debugger {
                     supports_read_memory_request: Some(true),
                     supports_restart_request: Some(true),
                     supports_terminate_request: Some(true),
-                    // TODO: In order to supports_delayed_stack_trace_loading: Some(false), we need to honor the `levels` parameter of the `stacktrace` request from VSCode - see https://github.com/Microsoft/vscode/issues/62908. However, despite setting this to `false`, VSCode still sends duplicate `StackTrace` requests for each halt.
-                    supports_delayed_stack_trace_loading: Some(false),
+                    supports_delayed_stack_trace_loading: Some(true),
                     // supports_value_formatting_options: Some(true),
                     // supports_function_breakpoints: Some(true),
                     // TODO: Use DEMCR register to implement exception breakpoints

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -244,7 +244,10 @@ pub struct DebugSession {
     pub(crate) session: Session,
     #[allow(dead_code)]
     pub(crate) capstone: Capstone,
+    /// [DebugSession] will manage one [DebugInfo] per [DebuggerOptions::program_binary]
     pub(crate) debug_infos: Vec<DebugInfo>,
+    /// [DebugSession] will manage one [VariableCache] per [Core] in [Session::cores].
+    /// NOTE: Logically, the relationship should be 'one [VariableCache] per [DebugInfo]', but the overhead of a recursive delete from [VariableCache] made it desireable to have a unique cache for each [Core], so that it can be recreated everytime a stacktrace is requested for a core.
     pub(crate) variable_caches: Vec<VariableCache>,
 }
 

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -414,6 +414,11 @@ pub struct CoreData<'p> {
 }
 
 impl<'p> CoreData<'p> {
+    /// The first [StackFrame]'s `pc` value, is the value of the program counter at the most recent unwind.
+    pub(crate) fn pc_of_most_recent_unwind(&'p self) -> Option<u32> {
+        self.stack_frames.first().map(|stack_frame| stack_frame.pc)
+    }
+
     /// Search available [StackFrame]'s for the given `id`
     pub(crate) fn get_stackframe(&'p self, id: i64) -> Option<&'p probe_rs::debug::StackFrame> {
         self.stack_frames

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -359,7 +359,7 @@ impl DebugSession {
         ];
 
         // Configure the [VariableCache].
-        let variable_caches = vec![VariableCache::new(debugger_options.core_index)];
+        let variable_caches = vec![VariableCache::new()];
 
         Ok(DebugSession {
             session: target_session,

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -266,506 +266,6 @@ pub struct SourceLocation {
     pub directory: Option<PathBuf>,
 }
 
-// TODO: REBASE: Remove this after comparing next() functionality changes.
-
-/// `StackFrameIterator` stores the information required to iterate through (`::next()`) each of the frames (`StackFrame`) involved in a `DebugInfo::try_unwind()` operation.
-/// The most valuable of these are pointers into the core's [`DebugInfo`], as well as the register values for the current frame in the stack (per iteration).
-pub struct StackFrameIterator<'debuginfo, 'probe, 'core> {
-    debug_info: &'debuginfo DebugInfo,
-    cache: &'debuginfo mut VariableCache,
-    core: &'core mut Core<'probe>,
-    unwind_bases: gimli::BaseAddresses,
-    /// The `unwind_context` has the potential to be expensive, so storing it here allows it to be re-used for every iteration in the `next()` implementation.
-    unwind_context: Box<gimli::UnwindContext<DwarfReader>>,
-    /// Register state as updated for every iteration (previous function) of the unwind process.
-    unwind_registers: Registers,
-
-    /// Used for handling inlined functions. If inlined functions are found, stack frames for all inlined functions and the containing, non-inlined function are
-    /// generated at the same time.
-    cached_stack_frames: Vec<StackFrame>,
-}
-
-impl<'debuginfo, 'probe, 'core> StackFrameIterator<'debuginfo, 'probe, 'core> {
-    /// In addition to providing the handle for iterating available `StackFrame`s, this function will also populate the `DebugInfo::VariableCache` with available `static` `Variable`s
-    pub fn new(
-        debug_info: &'debuginfo DebugInfo,
-        cache: &'debuginfo mut VariableCache,
-        core: &'core mut Core<'probe>,
-        address: u64,
-    ) -> Self {
-        let mut current_registers = Registers::from_core(core);
-        if current_registers.get_program_counter().is_none() {
-            current_registers.set_program_counter(Some(address as u32));
-        }
-
-        let unwind_context: Box<UnwindContext<DwarfReader>> = Box::new(gimli::UnwindContext::new());
-        let unwind_bases = gimli::BaseAddresses::default();
-
-        Self {
-            debug_info,
-            cache,
-            core,
-            unwind_bases,
-            unwind_context,
-            unwind_registers: current_registers,
-            cached_stack_frames: Vec::new(),
-        }
-    }
-}
-
-impl<'debuginfo, 'probe, 'core> Iterator for StackFrameIterator<'debuginfo, 'probe, 'core> {
-    type Item = StackFrame;
-
-    /// Performs the logical unwind that is managed by the `StackFrameIterator`. The returned `StackFrame` is that of the **callee** (the frame at the top of the logical unwind process ), the ...
-    /// - First call to `::next()` returns the 'StackFrame' at the current PC (program counter), and ...
-    /// - Each subsequent call to `::next()` will unwind and return the **previous** `StackFrame` in the call stack.
-    /// - Every iteration of the `::next()` method will update the `StackFrameIterator` fields as needed, to ensure that the subsequent calls / iterations know how to correctly unwind the **caller** `StackFrame` (where the current iteration was called from)
-    /// - Iteration will continue until there are no more frames to unwind.
-    ///
-    /// [DWARF](https://dwarfstd.org) 6.4.4 - CIE defines the return register address used in the `gimli::RegisterRule` tables for unwind operations. Theoretically, if we encounter a function that has `Undefined` `gimli::RegisterRule` for the return register address, it means we have reached the bottom of the stack OR the function is a 'no return' type of function. I have found actual examples (e.g. local functions) where we get `Undefined` for register rule when we cannot apply this logic. Example 1: local functions in main.rs will have LR rule as `Undefined`. Example 2: main()-> ! that is called from a trampoline will have a valid LR rule.
-    /// The iterator will continue until we have an LR register value of `None`. This will be true under the following conditions:
-    /// - We encounter a LR register value of 0xFFFFFFFF which is the 'Reset` value for that register.
-    /// - TODO: Catch the situation where the PC value indicates a hard-fault or other non-recoverable exception
-    /// - We can not intelligently infer a valid LR register value from the other registers.
-    /// - We legitimately get an LR register value of None, indicating the bottom of the stack.
-    /// - Similarly, certain error conditions encountered in `StackFrameIterator` will also clear the LR register, to prevent further (likely faulty) iterations.
-    /// Note: In addition to populating the `StackFrame`s, this function will also populate the `DebugInfo::VariableCache` with `Variable`s for available Registers and function variables.
-    fn next(&mut self) -> Option<Self::Item> {
-        // PART 0-a: If we've encountered an error in the previous iteration, the `PC` will be `None`.
-        let frame_pc = if let Some(frame_pc) = self.unwind_registers.get_program_counter() {
-            frame_pc as u64
-        } else {
-            log::debug!(
-                "UNWIND: No available PC (program counter). Cannot continue stack unwinding."
-            );
-            return None;
-        };
-        // PART 0-b: If the LR is set to 0x0 or None, then we can't unwind anything further.
-        if self
-            .unwind_registers
-            .get_return_address()
-            .map_or(true, |lr_value| lr_value == 0x0)
-        {
-            log::warn!(
-                "UNWIND: We encountered an LR value of `None` or `0x0`, and cannot continue stack unwinding."
-            );
-            return None;
-        };
-
-        // PART 1: Construct the `StackFrame` for the current pc.
-        log::debug!(
-            "UNWIND: Will generate `StackFrame` for function at address (PC) {:#010x}",
-            frame_pc,
-        );
-
-        // If we have cached stack frames (due to inlining), just return the cached frames if there
-        // are multiple left. The last cached frame is from the non-inlined function, and will
-        // be unwound normally.
-        if self.cached_stack_frames.len() > 1 {
-            log::info!("Using cached stack frame for inlined function.");
-            return self.cached_stack_frames.pop();
-        }
-
-        let return_frame = if self.cached_stack_frames.is_empty() {
-            // PART 1-a: Prepare the `StackFrame` that holds the current frame information
-            let mut return_frames = match self.debug_info.get_stackframe_info(
-                self.cache,
-                self.core,
-                frame_pc,
-                &self.unwind_registers,
-            ) {
-                Ok(frame) => frame,
-                Err(e) => {
-                    log::error!("UNWIND: Unable to complete `StackFrame` information: {}", e);
-                    // There is no point in continuing with the unwind, so let's get out of here.
-                    self.unwind_registers.set_return_address(None);
-                    return None;
-                }
-            };
-
-            if return_frames.len() > 1 {
-                log::debug!("Multiple stack frames:");
-                for frame in &return_frames {
-                    log::debug!(" - name={}, pc={:#010x}", frame.function_name, frame.pc);
-                }
-            }
-
-            let return_frame = return_frames.pop().unwrap();
-
-            self.cached_stack_frames = return_frames;
-
-            if !self.cached_stack_frames.is_empty() {
-                log::debug!("UNWIND: In inlined function, returning virtual frame.");
-                return Some(return_frame);
-            }
-
-            return_frame
-        } else {
-            log::debug!("Last cached stack frame, current funtion is not inlined.");
-            self.cached_stack_frames.pop().unwrap()
-        };
-
-        // Part 1-b: When we encounter the starting (after reset) return address, we've reached the bottom of the stack, so no more unwinding after this ...
-        // TODO: Validate that this applies to RISCV also.s
-        if let Some(check_return_address) = self.unwind_registers.get_return_address() {
-            if check_return_address == u32::MAX {
-                self.unwind_registers.set_return_address(None);
-                log::debug!(
-                    "UNWIND: Stack unwind complete - Reached the 'Reset' value of the LR register."
-                );
-                return Some(return_frame);
-            }
-        }
-
-        // PART 2: Setup the registers for the `next()` iteration (a.k.a. unwind previous frame, a.k.a. "callee", in the call stack).
-        log::debug!(
-            "UNWIND - Preparing `StackFrameIterator` to unwind NON-INLINED function {:?} at {:?}",
-            return_frame.function_name,
-            return_frame.source_location
-        );
-        // PART 2-a: get the `gimli::FrameDescriptorEntry` for this address and then the unwind info associated with this row.
-        // TODO: The `gimli` docs for this function talks about cases where there might be more than one FDE for a function. Investigate if this affects RUST and how to solve.
-        use gimli::UnwindSection;
-        let frame_descriptor_entry = match self.debug_info.frame_section.fde_for_address(
-            &self.unwind_bases,
-            frame_pc,
-            gimli::DebugFrame::cie_from_offset,
-        ) {
-            Ok(frame_descriptor_entry) => frame_descriptor_entry,
-            Err(error) => {
-                log::error!(
-                    "UNWIND: Error reading FrameDescriptorEntry at PC={:#010x} : {}",
-                    frame_pc,
-                    error
-                );
-                self.unwind_registers.set_return_address(None);
-                return Some(return_frame);
-            }
-        };
-
-        match frame_descriptor_entry.unwind_info_for_address(
-            &self.debug_info.frame_section,
-            &self.unwind_bases,
-            &mut self.unwind_context,
-            frame_pc,
-        ) {
-            Ok(unwind_info) => {
-                // Because we will be updating the `self.unwind_registers` with previous frame unwind info, we need to keep a copy of the current frame's registers that can be used to resolve [DWARF](https://dwarfstd.org) expressions.
-                let callee_frame_registers = self.unwind_registers.clone();
-                // PART 2-b: Determine the CFA (canonical frame address) to use for this unwind row.
-                let unwind_cfa = match unwind_info.cfa() {
-                    gimli::CfaRule::RegisterAndOffset { register, offset } => {
-                        let reg_val = self
-                            .unwind_registers
-                            .get_value_by_dwarf_register_number(register.0 as u32);
-                        match reg_val {
-                            Some(reg_val) => {
-                                let unwind_cfa = (i64::from(reg_val) + offset) as u32;
-                                log::debug!(
-                                    "UNWIND - CFA : {:#010x}\tRule: {:?}",
-                                    unwind_cfa,
-                                    unwind_info.cfa()
-                                );
-                                Some(unwind_cfa)
-                            }
-                            None => {
-                                log::error!("UNWIND: `StackFrameIterator` unable to determine the unwind CFA: Missing value of register {}",register.0);
-                                self.unwind_registers.set_return_address(None);
-                                return Some(return_frame);
-                            }
-                        }
-                    }
-                    gimli::CfaRule::Expression(_) => unimplemented!(),
-                };
-
-                // PART 2-c: Unwind registers for the "previous/calling" frame.
-                // TODO: Test for RISCV ... This is only tested for ARM right now.
-                // TODO: Maybe do some cleanup on the `Registerfile` API, to make the following more ergonomic.
-                for register_number in 0..self
-                    .unwind_registers
-                    .register_description
-                    .platform_registers
-                    .len() as u32
-                {
-                    use gimli::read::RegisterRule::*;
-
-                    let register_rule =
-                        unwind_info.register(gimli::Register(register_number as u16));
-
-                    let mut register_rule_string = format!("{:?}", register_rule);
-
-                    let new_value = match register_rule {
-                        Undefined => {
-                            // In many cases, the DWARF has `Undefined` rules for variables like frame pointer, program counter, etc., so we hard-code some rules here to make sure unwinding can continue. If there is a valid rule, it will bypass these hardcoded ones.
-                            match register_number {
-                                _fp if register_number
-                                    == self
-                                        .unwind_registers
-                                        .register_description
-                                        .frame_pointer()
-                                        .address
-                                        .0 as u32 =>
-                                {
-                                    register_rule_string = "FP=CFA (dwarf Undefined)".to_string();
-                                    callee_frame_registers.get_frame_pointer()
-                                }
-                                _sp if register_number
-                                    == self
-                                        .unwind_registers
-                                        .register_description
-                                        .stack_pointer()
-                                        .address
-                                        .0 as u32 =>
-                                {
-                                    // TODO: ARM Specific - Add rules for RISCV
-                                    // NOTE: [ARMv7-M Architecture Reference Manual](https://developer.arm.com/documentation/ddi0403/ee), Section B.1.4.1: Treat bits [1:0] as `Should be Zero or Preserved`
-                                    register_rule_string = "SP=CFA (dwarf Undefined)".to_string();
-                                    unwind_cfa.map(|unwind_cfa| unwind_cfa & !0b11)
-                                }
-                                _lr if register_number
-                                    == self
-                                        .unwind_registers
-                                        .register_description
-                                        .return_address()
-                                        .address
-                                        .0 as u32 =>
-                                {
-                                    // This value is used to determine the Undefined PC value, and will be set correctly later on in this method.
-                                    register_rule_string =
-                                        "LR=current LR (dwarf Undefined)".to_string();
-                                    callee_frame_registers.get_return_address()
-                                }
-                                _pc if register_number
-                                    == self
-                                        .unwind_registers
-                                        .register_description
-                                        .program_counter()
-                                        .address
-                                        .0 as u32 =>
-                                {
-                                    // NOTE: [ARMv7-M Architecture Reference Manual](https://developer.arm.com/documentation/ddi0403/ee), Section A5.1.2: We have to clear the last bit to ensure the PC is half-word aligned. (on ARM architecture, when in Thumb state for certain instruction types will set the LSB to 1)
-                                    // NOTE: PC = Current instruction + 1 address, so to reverse this from LR return address, we have to subtract 4 bytes
-                                    // TODO: Ensure that this operation does not seem to have a negative effect on RISCV.
-                                    let address_size =
-                                        frame_descriptor_entry.cie().address_size() as u32;
-                                    register_rule_string = format!(
-                                        "PC=(unwound LR & !0b1) - {} (dwarf Undefined)",
-                                        address_size
-                                    );
-                                    self.unwind_registers.get_return_address().and_then(
-                                        |return_address| {
-                                            if return_address == u32::MAX {
-                                                // No reliable return is available.
-                                                None
-                                            } else if return_address.is_zero() {
-                                                Some(0)
-                                            } else {
-                                                Some((return_address - address_size) & !0b1)
-                                            }
-                                        },
-                                    )
-                                }
-                                _ => {
-                                    // This will result in the register value being cleared for the previous frame.
-                                    None
-                                }
-                            }
-                        }
-                        SameValue => callee_frame_registers
-                            .get_value_by_dwarf_register_number(register_number),
-                        Offset(address_offset) => {
-                            if let Some(unwind_cfa) = unwind_cfa {
-                                let previous_frame_register_address =
-                                    i64::from(unwind_cfa) + address_offset;
-                                let mut buff = [0u8; 4];
-                                if let Err(e) = self
-                                    .core
-                                    .read(previous_frame_register_address as u32, &mut buff)
-                                {
-                                    log::error!(
-                                                        "UNWIND: Failed to read from address {:#010x} ({} bytes): {}",
-                                                        previous_frame_register_address,
-                                                        4,
-                                                        e
-                                                    );
-                                    log::error!(
-                                        "UNWIND: Rule: Offset {} from address {:#010x}",
-                                        address_offset,
-                                        unwind_cfa
-                                    );
-                                    self.unwind_registers.set_return_address(None);
-                                    return Some(return_frame);
-                                }
-                                let previous_frame_register_value = u32::from_le_bytes(buff);
-                                Some(previous_frame_register_value as u32)
-                            } else {
-                                log::error!("UNWIND: Tried to unwind `RegisterRule` at CFA = None. Please report this as a bug.");
-                                self.unwind_registers.set_return_address(None);
-                                return Some(return_frame);
-                            }
-                        }
-                        //TODO: Implement the remainder of these `RegisterRule`s
-                        _ => unimplemented!(),
-                    };
-
-                    self.unwind_registers
-                        .set_by_dwarf_register_number(register_number, new_value);
-                    log::debug!(
-                        "UNWIND - {:04?}: Caller: {:#010x}\tCallee: {:#010x}\tRule: {}",
-                        self.unwind_registers
-                            .get_name_by_dwarf_register_number(register_number),
-                        self.unwind_registers
-                            .get_value_by_dwarf_register_number(register_number)
-                            .unwrap_or_default(),
-                        callee_frame_registers
-                            .get_value_by_dwarf_register_number(register_number)
-                            .unwrap_or_default(),
-                        register_rule_string,
-                    );
-                }
-            }
-            Err(error) => {
-                log::debug!("UNWIND: Stack unwind complete. No available debug info for program counter {:#x}: {}", frame_pc, error);
-                self.unwind_registers.set_return_address(None);
-                return Some(return_frame);
-            }
-        };
-
-        // PART 3: In order to set the correct value of the previous frame we need to peek one frame deeper in the stack.
-        // NOTE: ARM Specific.
-        // TODO: Investigate and document why and under which circumstances this extra step is necessary. It was added during PR#895.
-        // TODO: Test on RISCV and fix as needed
-        if let Some(previous_frame_pc) = self.unwind_registers.get_program_counter() {
-            let previous_frame_descriptor_entry =
-                match self.debug_info.frame_section.fde_for_address(
-                    &self.unwind_bases,
-                    previous_frame_pc as u64,
-                    gimli::DebugFrame::cie_from_offset,
-                ) {
-                    Ok(frame_descriptor_entry) => frame_descriptor_entry,
-                    Err(error) => {
-                        log::error!(
-                        "UNWIND: Error reading previous FrameDescriptorEntry at PC={:#010x} : {}",
-                        previous_frame_pc,
-                        error
-                    );
-                        self.unwind_registers.set_return_address(None);
-                        return Some(return_frame);
-                    }
-                };
-
-            match previous_frame_descriptor_entry.unwind_info_for_address(
-                &self.debug_info.frame_section,
-                &self.unwind_bases,
-                &mut self.unwind_context,
-                previous_frame_pc as u64,
-            ) {
-                Ok(previous_unwind_info) => {
-                    let previous_unwind_cfa = match previous_unwind_info.cfa() {
-                        gimli::CfaRule::RegisterAndOffset { register, offset } => {
-                            let reg_val = self
-                                .unwind_registers
-                                .get_value_by_dwarf_register_number(register.0 as u32);
-                            match reg_val {
-                                Some(reg_val) => {
-                                    let unwind_cfa = (i64::from(reg_val) + offset) as u32;
-                                    log::debug!(
-                                        "UNWIND - CFA : {:#010x}\tRule: Previous Function {:?}",
-                                        unwind_cfa,
-                                        previous_unwind_info.cfa()
-                                    );
-                                    Some(unwind_cfa)
-                                }
-                                None => {
-                                    log::error!(
-                                                        "UNWIND: `StackFrameIterator` unable to determine the previous frame unwind CFA: Missing value of register {}",
-                                                        register.0
-                                                    );
-                                    self.unwind_registers.set_return_address(None);
-                                    return Some(return_frame);
-                                }
-                            }
-                        }
-                        gimli::CfaRule::Expression(_) => unimplemented!(),
-                    };
-                    use gimli::read::RegisterRule::*;
-
-                    let return_register_number = previous_frame_descriptor_entry
-                        .cie()
-                        .return_address_register()
-                        .0 as u32;
-                    let register_rule = previous_unwind_info
-                        .register(gimli::Register(return_register_number as u16));
-
-                    let register_rule_string = format!("{:?}", register_rule);
-
-                    let new_return_value = match register_rule {
-                        Undefined => None,
-                        SameValue => self
-                            .unwind_registers
-                            .get_value_by_dwarf_register_number(return_register_number),
-                        Offset(address_offset) => {
-                            if let Some(unwind_cfa) = previous_unwind_cfa {
-                                let previous_frame_register_address =
-                                    i64::from(unwind_cfa) + address_offset;
-                                let mut buff = [0u8; 4];
-                                if let Err(e) = self
-                                    .core
-                                    .read(previous_frame_register_address as u32, &mut buff)
-                                {
-                                    log::error!(
-                                                        "UNWIND: Failed to read from address {:#010x} ({} bytes): {}",
-                                                        previous_frame_register_address,
-                                                        4,
-                                                        e
-                                                    );
-                                    log::error!(
-                                        "UNWIND: Rule: Offset {} from address {:#010x}",
-                                        address_offset,
-                                        unwind_cfa
-                                    );
-                                    self.unwind_registers.set_return_address(None);
-                                    return Some(return_frame);
-                                }
-                                let previous_frame_register_value = u32::from_le_bytes(buff);
-                                Some(previous_frame_register_value as u32)
-                            } else {
-                                log::error!("UNWIND: Tried to unwind `RegisterRule` at CFA = None. Please report this as a bug.");
-                                self.unwind_registers.set_return_address(None);
-                                return Some(return_frame);
-                            }
-                        }
-                        //TODO: Implement the remainder of these `RegisterRule`s
-                        _ => unimplemented!(),
-                    };
-                    self.unwind_registers
-                        .set_by_dwarf_register_number(return_register_number, new_return_value);
-                    log::debug!(
-                        "UNWIND - {:04?}: Caller: {:#010x}\tRule: Override with previous frame {}",
-                        self.unwind_registers
-                            .get_name_by_dwarf_register_number(return_register_number),
-                        self.unwind_registers
-                            .get_value_by_dwarf_register_number(return_register_number)
-                            .unwrap_or_default(),
-                        register_rule_string,
-                    );
-                }
-                Err(error) => {
-                    log::debug!("UNWIND: Stack unwind complete. No available debug info for program counter {:#x}: {}",frame_pc, error);
-                    self.unwind_registers.set_return_address(None);
-                    return Some(return_frame);
-                }
-            };
-        } else {
-            log::error!("UNWIND: Cannot read previous FrameDescriptorEntry without a valid PC");
-            self.unwind_registers.set_return_address(None);
-            return Some(return_frame);
-        }
-
-        Some(return_frame)
-    }
-}
-
 type GimliReader = gimli::EndianReader<gimli::LittleEndian, std::rc::Rc<[u8]>>;
 type GimliAttribute = gimli::Attribute<GimliReader>;
 
@@ -1259,23 +759,6 @@ impl DebugInfo {
 
                 log::debug!("UNWIND: Call site: {:?}", inlined_caller_source_location);
 
-                // Now that we have the function_name and function_source_location, we can cache the in-scope `Variable`s (`<statics>` and `<locals>`) in `DebugInfo::VariableCache`
-                // Now that we have the function_name and function_source_location, we can cache the in-scope `Variable`s (`[VariableName::StaticScope]` and `[VariableName::LocalScope]`) in `DebugInfo::VariableCache`
-                // We need an empty parent variable for the next operation, but do not need to store it in the cache.
-                let parent_variable = Variable::new(None, None);
-                let mut stackframe_root_variable = Variable::new(
-                    unit_info.unit.header.offset().as_debug_info_offset(),
-                    Some(function_die.function_die.offset()),
-                );
-                stackframe_root_variable.name = VariableName::StackFrame;
-                stackframe_root_variable.source_location = inlined_caller_source_location.clone();
-
-                let function_display_name = if function_die.is_inline() {
-                    format!("{} #[inline]", &function_name)
-                } else {
-                    format!("{} @{:#010x}", &function_name, address)
-                };
-
                 log::trace!("UNWIND: Function name: {}", function_name);
 
                 // Now that we have the function_name and function_source_location, we can create the appropriate variable caches for this stack frame.
@@ -1326,11 +809,11 @@ impl DebugInfo {
                     id: get_sequential_key(),
                     function_name,
                     source_location: inlined_caller_source_location,
-                    registers: stack_frame_registers,
+                    registers: stack_frame_registers.clone(),
                     pc: inlined_call_site.unwrap(),
                     is_inlined: function_die.is_inline(),
-                    static_variables: None,
-                    local_variables: None,
+                    static_variables,
+                    local_variables,
                     register_variables,
                 });
             }
@@ -1344,109 +827,80 @@ impl DebugInfo {
 
             let function_location = self.get_source_location(address);
 
-            // Now that we have the function_name and function_source_location, we can cache the in-scope `Variable`s (`<statics>` and `<locals>`) in `DebugInfo::VariableCache`
-            // We need an empty parent variable for the next operation, but do not need to store it in the cache.
-            let parent_variable = Variable::new(None, None);
-            let mut stackframe_root_variable = Variable::new(
-                unit_info.unit.header.offset().as_debug_info_offset(),
-                Some(last_function.function_die.offset()),
-            );
-            stackframe_root_variable.name = VariableName::StackFrame;
-            stackframe_root_variable.source_location = function_location.clone();
-            let function_display_name = if last_function.is_inline() {
-                format!("{} #[inline]", &function_name)
-            } else {
-                format!("{} @{:#010x}", &function_name, address)
-            };
-            stackframe_root_variable.set_value(function_display_name);
-            stackframe_root_variable = unit_info.extract_location(
-                &unit_info
-                    .unit
-                    .entries_tree(Some(last_function.function_die.offset()))?
-                    .root()?,
-                &parent_variable,
-                stackframe_root_variable,
-                core,
-                &stack_frame_registers,
-                cache,
-            )?;
+            // Now that we have the function_name and function_source_location, we can create the appropriate variable caches for this stack frame.
 
-            stackframe_root_variable = cache.cache_variable(
-                parent_variable.variable_key,
-                stackframe_root_variable,
-                core,
-            )?;
-
-            if let Some(error) = self
-                .cache_register_variables(
-                    cache,
-                    &stack_frame_registers,
-                    &stackframe_root_variable,
-                    core,
-                )
-                .err()
-            {
-                log::warn!(
-                    "Could not resolve register variables.{}. Continuing...",
-                    error
+            let register_variables = self
+                .create_register_scope_cache(&stack_frame_registers, core)
+                .map_or_else(
+                    |error| {
+                        log::error!(
+                            "Could not resolve register variables. {}. Continuing...",
+                            error
+                        );
+                        None
+                    },
+                    Some,
                 );
-            }
 
             // Next, resolve the statics that belong to the compilation unit that this function is in.
-            if let Some(error) = self
-                .cache_static_variables(
-                    cache,
-                    core,
-                    &unit_info,
-                    &stack_frame_registers,
-                    &stackframe_root_variable,
-                )
-                .err()
-            {
-                log::warn!(
-                    "Error while resolving static variables.{}. Continuing...",
-                    error
+            let static_variables = self
+                .create_static_scope_cache(core, &unit_info)
+                .map_or_else(
+                    |error| {
+                        log::error!(
+                            "Could not resolve static variables. {}. Continuing...",
+                            error
+                        );
+                        None
+                    },
+                    Some,
                 );
-            }
 
             // Next, resolve and cache the function variables.
-            self.cache_function_variables(
-                cache,
-                core,
-                last_function,
-                &unit_info,
-                &stack_frame_registers,
-                &stackframe_root_variable,
-            )?;
+            let local_variables = self
+                .create_function_scope_cache(core, last_function, &unit_info)
+                .map_or_else(
+                    |error| {
+                        log::error!(
+                            "Could not resolve function variables. {}. Continuing...",
+                            error
+                        );
+                        None
+                    },
+                    Some,
+                );
 
             frames.push(StackFrame {
                 // MS DAP Specification requires the id to be unique accross all threads, so using  so using unique `Variable::variable_key` of the `stackframe_root_variable` as the id.
-                id: stackframe_root_variable.variable_key as u64,
+                id: get_sequential_key(),
                 function_name,
                 source_location: function_location,
                 registers: stack_frame_registers.clone(),
                 pc: address as u32,
                 is_inlined: last_function.is_inline(),
+                static_variables,
+                local_variables,
+                register_variables,
             });
 
             break;
         }
 
-        // Before returning `unknown_function` [StackFrame], make sure we at least cache the Register values.
-        let register_variables = self
-            .create_register_scope_cache(&stack_frame_registers, core)
-            .map_or_else(
-                |error| {
-                    log::warn!(
-                        "Could not resolve register variables. {}. Continuing...",
-                        error
-                    );
-                    None
-                },
-                Some,
-            );
-
         if frames.is_empty() {
+            // Before returning `unknown_function` [StackFrame], make sure we at least cache the Register values.
+            let register_variables = self
+                .create_register_scope_cache(&stack_frame_registers, core)
+                .map_or_else(
+                    |error| {
+                        log::warn!(
+                            "Could not resolve register variables. {}. Continuing...",
+                            error
+                        );
+                        None
+                    },
+                    Some,
+                );
+
             Ok(vec![StackFrame {
                 id: get_sequential_key(),
                 function_name: unknown_function,
@@ -1486,8 +940,6 @@ impl DebugInfo {
         let mut unwind_context: Box<UnwindContext<DwarfReader>> =
             Box::new(gimli::UnwindContext::new());
         let unwind_bases = gimli::BaseAddresses::default();
-        // If the most recent function in the unwind was an inlined function, we record the caller's [`SourceLocation`] here.
-        let mut inlined_caller_source_location: Option<SourceLocation> = None;
 
         // Unwind [StackFrame]'s for as long as we can unwind a valid PC value.
         'unwind: while let Some(frame_pc) = unwind_registers
@@ -1512,14 +964,30 @@ impl DebugInfo {
                 frame_pc,
             );
 
-            // PART 1-a: Prepare the `StackFrame` that holds the current frame information
-            let return_frame = match self.get_stackframe_info(
-                core,
-                frame_pc,
-                &unwind_registers,
-                inlined_caller_source_location.clone(),
-            ) {
-                Ok(frame) => frame,
+            //
+            // PART 1-a: Prepare the `StackFrame` that holds the current frame information.
+            let return_frame = match self.get_stackframe_info(core, frame_pc, &unwind_registers) {
+                Ok(mut cached_stack_frames) => {
+                    while cached_stack_frames.len() > 1 {
+                        // If we encountered INLINED functions (all `StackFrames`s in this Vec, except for the last one, which is the containing NON-INLINED function), these are simply added to the list of stack_frames we return.
+                        let inlined_frame = cached_stack_frames.pop().unwrap(); // unwrap is safe while .len() > 1
+                        log::debug!(
+                            "UNWIND: Found inlined function - name={}, pc={:#010x}",
+                            inlined_frame.function_name,
+                            inlined_frame.pc
+                        );
+                        stack_frames.push(inlined_frame);
+                    }
+                    if cached_stack_frames.len() == 1 {
+                        // If there is only one stack frame, then it is a NON-INLINED function, and we will attempt to unwind further.
+                        cached_stack_frames.pop().unwrap() // unwrap is safe for .len==1
+                    } else {
+                        // Obviously something has gone wrong and zero stackframes were returned in the vector.
+                        log::error!("UNWIND: No `StackFrame` information: available");
+                        // There is no point in continuing with the unwind, so let's get out of here.
+                        break;
+                    }
+                }
                 Err(e) => {
                     log::error!("UNWIND: Unable to complete `StackFrame` information: {}", e);
                     // There is no point in continuing with the unwind, so let's get out of here.
@@ -1541,45 +1009,12 @@ impl DebugInfo {
             }
 
             // PART 2: Setup the registers for the `next()` iteration (a.k.a. unwind previous frame, a.k.a. "callee", in the call stack).
-            log::trace!("UNWIND Registers for previous function ...");
-            // Part2-a: We check if the StackFrame just processed was an INLINED function, in which case the unwind process below will take a different path than the one for NON-INLINED functions.
-            if let Some(inlined_call_site) = return_frame.inlined_call_site {
-                inlined_caller_source_location =
-                    return_frame.inlined_caller_source_location.clone();
-                log::debug!(
-                "UNWIND - Preparing `StackFrameIterator` to unwind INLINED function {:?} at {:?}",
-                return_frame.function_name,
-                return_frame.source_location
-            );
-                // The only `unwind` we need to do, is to update the PC with the call site address of the inline function. The `StackFrameIterator::next()` iteration will then create a virtual `StackFrame` for the call-site.
-                let register_number = unwind_registers
-                    .register_description
-                    .program_counter()
-                    .address
-                    .0 as u32;
-                log::debug!(
-                    "UNWIND - {:04?}: Caller: {:#010x}\tCallee: {:#010x}\tRule: {}",
-                    unwind_registers.get_name_by_dwarf_register_number(register_number),
-                    inlined_call_site,
-                    unwind_registers
-                        .get_value_by_dwarf_register_number(register_number)
-                        .unwrap_or_default(),
-                    "PC= Inlined function `inlined_call_site`'",
-                );
-                unwind_registers.set_program_counter(Some(inlined_call_site));
-                // We have what we need for this iteration, so we can skip to the next iteration.
-                stack_frames.push(return_frame);
-                continue;
-            } else {
-                inlined_caller_source_location = None;
-            }
-
             log::debug!(
             "UNWIND - Preparing `StackFrameIterator` to unwind NON-INLINED function {:?} at {:?}",
             return_frame.function_name,
             return_frame.source_location
         );
-            // PART 2-b: get the `gimli::FrameDescriptorEntry` for this address and then the unwind info associated with this row.
+            // PART 2-a: get the `gimli::FrameDescriptorEntry` for this address and then the unwind info associated with this row.
             // TODO: The `gimli` docs for this function talks about cases where there might be more than one FDE for a function. Investigate if this affects RUST and how to solve.
             use gimli::UnwindSection;
             let frame_descriptor_entry = match self.frame_section.fde_for_address(
@@ -1608,7 +1043,7 @@ impl DebugInfo {
                 Ok(unwind_info) => {
                     // Because we will be updating the `unwind_registers` with previous frame unwind info, we need to keep a copy of the current frame's registers that can be used to resolve [DWARF](https://dwarfstd.org) expressions.
                     let callee_frame_registers = unwind_registers.clone();
-                    // PART 2-c: Determine the CFA (canonical frame address) to use for this unwind row.
+                    // PART 2-b: Determine the CFA (canonical frame address) to use for this unwind row.
                     let unwind_cfa = match unwind_info.cfa() {
                         gimli::CfaRule::RegisterAndOffset { register, offset } => {
                             let reg_val = unwind_registers
@@ -1633,7 +1068,7 @@ impl DebugInfo {
                         gimli::CfaRule::Expression(_) => unimplemented!(),
                     };
 
-                    // PART 2-d: Unwind registers for the "previous/calling" frame.
+                    // PART 2-c: Unwind registers for the "previous/calling" frame.
                     // TODO: Test for RISCV ... This is only tested for ARM right now.
                     // TODO: Maybe do some cleanup on the `Registerfile` API, to make the following more ergonomic.
                     for register_number in 0..unwind_registers

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -1051,10 +1051,10 @@ impl DebugInfo {
         stack_frame_registers: &Registers,
     ) -> Result<(), DebugError> {
         match parent_variable.variable_node_type {
-            VariableNodeType::Offset(reference_offset) => {
+            VariableNodeType::ReferenceOffset(reference_offset) => {
                 // Only attempt this part if the parent is a pointer and we have not yet resolved the referenced children.
                 if !cache.has_children(parent_variable)? {
-                    if let Some(header_offset) = parent_variable.header_offset {
+                    if let Some(header_offset) = parent_variable.unit_header_offset {
                         let unit_header =
                             self.dwarf.debug_info.header_from_offset(header_offset)?;
                         let unit_info = UnitInfo {
@@ -1084,11 +1084,11 @@ impl DebugInfo {
                                     } else {
                                         referenced_variable.name =
                                             VariableName::Named(format!("*{}", name));
-                                        // Now, retrieve the location by reading the adddress pointed to by the parent variable.
                                     }
                                 }
                                 other => referenced_variable.name = VariableName::Named(format!("ERROR: Unable to generate name, parent variable does not have a name but is special variable {:?}", other)),
                             }
+                        // Now, retrieve the location by reading the adddress pointed to by the parent variable.
                         let mut buff = [0u8; 4];
                         core.read(parent_variable.memory_location as u32, &mut buff)?;
                         referenced_variable.memory_location = u32::from_le_bytes(buff) as u64;
@@ -1097,26 +1097,70 @@ impl DebugInfo {
                             referenced_variable,
                             core,
                         )?;
-                        referenced_variable = unit_info.extract_type(
-                            referenced_node,
-                            parent_variable,
-                            referenced_variable,
+                        if referenced_variable.memory_location == 0 {
+                            // TODO: It is not clear why this happens ... needs more investigation. in the mean time ...
+                            cache.remove_cache_entry(referenced_variable.variable_key)?;
+                            parent_variable.variable_node_type = VariableNodeType::DoNotRecurse;
+                        } else if referenced_variable.type_name.contains("()") {
+                            // Only use this, if it is NOT a unit datatype.
+                            cache.remove_cache_entry(referenced_variable.variable_key)?;
+                        } else {
+                            unit_info.extract_type(
+                                referenced_node,
+                                parent_variable,
+                                referenced_variable,
+                                core,
+                                stack_frame_registers,
+                                cache,
+                            )?;
+                        }
+                    }
+                }
+            }
+            VariableNodeType::TypeOffset(type_offset) => {
+                // Only attempt this if the children are not already resolved.
+                if !cache.has_children(parent_variable)? {
+                    if let Some(header_offset) = parent_variable.unit_header_offset {
+                        let unit_header =
+                            self.dwarf.debug_info.header_from_offset(header_offset)?;
+                        let unit_info = UnitInfo {
+                            debug_info: self,
+                            unit: gimli::Unit::new(&self.dwarf, unit_header)?,
+                        };
+                        // Find the parent node
+                        let mut type_tree = unit_info
+                            .unit
+                            .header
+                            .entries_tree(&unit_info.unit.abbreviations, Some(type_offset))?;
+                        let parent_node = type_tree.root()?;
+
+                        // For process_tree we need to create a temporary parent that will later be eliminated with VariableCache::adopt_grand_children
+                        // TODO: Investigate if UnitInfo::process_tree can be modified to use `&mut parent_variable`, then we would not need this temporary variable.
+                        let mut temporary_variable = parent_variable.clone();
+                        temporary_variable.variable_key = 0;
+                        temporary_variable.parent_key = Some(parent_variable.variable_key);
+                        temporary_variable = cache.cache_variable(
+                            Some(parent_variable.variable_key),
+                            temporary_variable,
+                            core,
+                        )?;
+
+                        temporary_variable = unit_info.process_tree(
+                            parent_node,
+                            temporary_variable,
                             core,
                             stack_frame_registers,
                             cache,
                         )?;
 
-                        // Only use this, if it is NOT a unit datatype.
-                        if referenced_variable.type_name.contains("()") {
-                            cache.remove_cache_entry(referenced_variable.variable_key)?;
-                        }
+                        cache.adopt_grand_children(parent_variable, &temporary_variable)?;
                     }
                 }
             }
             VariableNodeType::DirectLookup => {
                 // Only attempt this if the children are not already resolved.
                 if !cache.has_children(parent_variable)? {
-                    if let Some(header_offset) = parent_variable.header_offset {
+                    if let Some(header_offset) = parent_variable.unit_header_offset {
                         let unit_header =
                             self.dwarf.debug_info.header_from_offset(header_offset)?;
                         let unit_info = UnitInfo {
@@ -1126,7 +1170,7 @@ impl DebugInfo {
                         // Find the parent node
                         let mut type_tree = unit_info.unit.header.entries_tree(
                             &unit_info.unit.abbreviations,
-                            parent_variable.entries_offset,
+                            parent_variable.variable_unit_offset,
                         )?;
                         let parent_node = type_tree.root()?;
 
@@ -1157,7 +1201,6 @@ impl DebugInfo {
                 // Do nothing. These have already been recursed to their maximum.
             }
         }
-
         Ok(())
     }
 
@@ -1232,24 +1275,8 @@ impl DebugInfo {
                 } else {
                     format!("{} @{:#010x}", &function_name, address)
                 };
-                stackframe_root_variable.set_value(function_display_name);
-                stackframe_root_variable = unit_info.extract_location(
-                    &unit_info
-                        .unit
-                        .entries_tree(Some(function_die.function_die.offset()))?
-                        .root()?,
-                    &parent_variable,
-                    stackframe_root_variable,
-                    core,
-                    &stack_frame_registers,
-                    cache,
-                )?;
 
-                stackframe_root_variable = cache.cache_variable(
-                    Some(parent_variable.variable_key),
-                    stackframe_root_variable,
-                    core,
-                )?;
+                log::trace!("UNWIND: Function name: {}", function_name);
 
                 // Now that we have the function_name and function_source_location, we can create the appropriate variable caches for this stack frame.
 
@@ -1514,7 +1541,7 @@ impl DebugInfo {
             }
 
             // PART 2: Setup the registers for the `next()` iteration (a.k.a. unwind previous frame, a.k.a. "callee", in the call stack).
-            log::debug!("UNWIND Registers for previous function ...");
+            log::trace!("UNWIND Registers for previous function ...");
             // Part2-a: We check if the StackFrame just processed was an INLINED function, in which case the unwind process below will take a different path than the one for NON-INLINED functions.
             if let Some(inlined_call_site) = return_frame.inlined_call_site {
                 inlined_caller_source_location =
@@ -1751,7 +1778,7 @@ impl DebugInfo {
                     }
                 }
                 Err(error) => {
-                    log::debug!("UNWIND: Stack unwind complete. No available debug info for program counter {:#x}: {}", frame_pc, error);
+                    log::trace!("UNWIND: Stack unwind complete. No available debug info for program counter {:#x}: {}", frame_pc, error);
                     stack_frames.push(return_frame);
                     break;
                 }
@@ -1873,7 +1900,7 @@ impl DebugInfo {
                     );
                     }
                     Err(error) => {
-                        log::debug!("UNWIND: Stack unwind complete. No available debug info for program counter {:#x}: {}",frame_pc, error);
+                        log::trace!("UNWIND: Stack unwind complete. No available debug info for program counter {:#x}: {}",frame_pc, error);
                         stack_frames.push(return_frame);
                         break;
                     }
@@ -2804,11 +2831,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                         ||  child_variable.name == VariableName::Artifical
                     {
                         cache.remove_cache_entry(child_variable.variable_key)?;
-                    } else if child_variable.type_name == "Some" {
-                        //This is an intermediate node. Once we've resolved the children, we can adopt them to their grandparent
-                        cache.adopt_grand_children(&parent_variable, &child_variable)?;
-                    }
-                    else {
+                    } else {
                         // Recursively process each child.
                         self.process_tree(child_node, child_variable, core, stack_frame_registers, cache, )?;
                     }
@@ -3041,6 +3064,18 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 format!("ERROR: evaluating name: {:?} ", error)
             }
         };
+        if child_variable.type_name.starts_with("&str")
+            || child_variable.type_name.starts_with("Option")
+            || child_variable.type_name.starts_with("Some")
+            || child_variable.type_name.starts_with("Result")
+            || child_variable.type_name.starts_with("Ok")
+            || child_variable.type_name.starts_with("Err")
+            || child_variable.type_name.starts_with("*const")
+            || child_variable.type_name.starts_with("*mut")
+        {
+            // In some cases, it really simplifies the UX if we can auto resolve the children and derive a value that is visible at first glance to the user.
+            child_variable.variable_node_type = VariableNodeType::RecurseToBaseType;
+        }
         child_variable.byte_size = extract_byte_size(self.debug_info, node.entry());
         match node.entry().tag() {
             gimli::DW_TAG_base_type => {
@@ -3067,29 +3102,22 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                             Some(data_type_attribute) => {
                                 match data_type_attribute.value() {
                                     gimli::AttributeValue::UnitRef(unit_ref) => {
-                                        child_variable.variable_node_type =
-                                            VariableNodeType::Offset(unit_ref);
-                                        if child_variable.type_name.starts_with("*const") {
+                                        if child_variable.variable_node_type
+                                            == VariableNodeType::RecurseToBaseType
+                                        {
                                             // Resolve the children of this variable, because they contain essential information required to resolve the value
+                                            child_variable.variable_node_type =
+                                                VariableNodeType::ReferenceOffset(unit_ref);
                                             self.debug_info.cache_deferred_variables(
                                                 cache,
                                                 core,
                                                 &mut child_variable,
                                                 stack_frame_registers,
                                             )?;
-                                        } else if parent_variable.type_name == "Some" {
-                                            // The parent `DW_TAG_structure_type` with name `Some` is an intermediate node that we only need for its children
-                                            // Update the child's name for when we adopt it to the grandparent later on.
-                                            child_variable.name = VariableName::Named(format!(
-                                                "Some({})",
-                                                child_variable.type_name
-                                            ));
+                                        } else {
+                                            child_variable.variable_node_type =
+                                                VariableNodeType::ReferenceOffset(unit_ref);
                                         }
-                                        child_variable = cache.cache_variable(
-                                            Some(parent_variable.variable_key),
-                                            child_variable,
-                                            core,
-                                        )?;
                                     }
                                     other_attribute_value => {
                                         child_variable.set_value(format!(
@@ -3116,20 +3144,24 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 }
             }
             gimli::DW_TAG_structure_type => {
-                // Recursively process a child types.
-                // Unless something is already broken, then don't dig any deeper.
                 if child_variable.memory_location != u64::MAX {
-                    child_variable = self.process_tree(
-                        node,
-                        child_variable,
-                        core,
-                        stack_frame_registers,
-                        cache,
-                    )?;
-                }
-                if !cache.has_children(&child_variable)? {
-                    // Empty structs don't have values. Use the type_name as the display value.
-                    child_variable.set_value(child_variable.type_name.clone());
+                    if child_variable.variable_node_type == VariableNodeType::RecurseToBaseType {
+                        // In some cases, it really simplifies the UX if we can auto resolve the children and dreive a value that is visible at first glance to the user.
+                        child_variable = self.process_tree(
+                            node,
+                            child_variable,
+                            core,
+                            stack_frame_registers,
+                            cache,
+                        )?;
+                    } else {
+                        // Defer the processing of child types.
+                        child_variable.variable_node_type =
+                            VariableNodeType::TypeOffset(node.entry().offset());
+                    }
+                } else {
+                    // If something is already broken, then do nothing ...
+                    child_variable.variable_node_type = VariableNodeType::DoNotRecurse;
                 }
             }
             gimli::DW_TAG_enumeration_type => {

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -21,6 +21,7 @@ use std::{
     path::{Path, PathBuf},
     rc::Rc,
     str::{from_utf8, Utf8Error},
+    sync::atomic::{AtomicI64, Ordering},
     vec,
 };
 
@@ -63,9 +64,14 @@ impl From<gimli::ColumnType> for ColumnType {
     }
 }
 
+static CACHE_KEY: AtomicI64 = AtomicI64::new(1);
+fn get_sequential_key() -> i64 {
+    CACHE_KEY.fetch_add(1, Ordering::SeqCst)
+}
+
 #[derive(Debug)]
 pub struct StackFrame {
-    pub id: u64,
+    pub id: i64,
     pub function_name: String,
     pub source_location: Option<SourceLocation>,
     pub registers: Registers,
@@ -941,7 +947,7 @@ impl DebugInfo {
             static_root_variable.stack_frame_registers = Some(stack_frame_registers.clone());
             static_root_variable.name = VariableName::StaticScope;
             cache.cache_variable(
-                stackframe_root_variable.variable_key,
+                Some(stackframe_root_variable.variable_key),
                 static_root_variable,
                 core,
             )?;
@@ -960,7 +966,7 @@ impl DebugInfo {
         let mut register_root_variable = Variable::new(None, None);
         register_root_variable.name = VariableName::Registers;
         register_root_variable = cache.cache_variable(
-            stackframe_root_variable.variable_key,
+            Some(stackframe_root_variable.variable_key),
             register_root_variable,
             core,
         )?;
@@ -970,7 +976,7 @@ impl DebugInfo {
 
         for (register_number, register_value) in sorted_registers {
             let mut register_variable = Variable::new(None, None);
-            register_variable.parent_key = register_root_variable.variable_key;
+            register_variable.parent_key = Some(register_root_variable.variable_key);
             register_variable.name = VariableName::Named(
                 registers
                     .get_name_by_dwarf_register_number(*register_number)
@@ -979,7 +985,11 @@ impl DebugInfo {
             register_variable.type_name = "Platform Register".to_owned();
             register_variable.byte_size = 4;
             register_variable.set_value(format!("{:#010x}", register_value));
-            cache.cache_variable(register_root_variable.variable_key, register_variable, core)?;
+            cache.cache_variable(
+                Some(register_root_variable.variable_key),
+                register_variable,
+                core,
+            )?;
         }
         Ok(())
     }
@@ -1007,7 +1017,7 @@ impl DebugInfo {
         );
         function_root_variable.name = VariableName::LocalScope;
         function_root_variable = cache.cache_variable(
-            stackframe_root_variable.variable_key,
+            Some(stackframe_root_variable.variable_key),
             function_root_variable,
             core,
         )?;
@@ -1050,7 +1060,7 @@ impl DebugInfo {
                     )?;
                     let referenced_node = type_tree.root()?;
                     let mut referenced_variable = cache.cache_variable(
-                        parent_variable.variable_key,
+                        Some(parent_variable.variable_key),
                         Variable::new(
                             unit_info.unit.header.offset().as_debug_info_offset(),
                             Some(referenced_node.entry().offset()),
@@ -1192,7 +1202,7 @@ impl DebugInfo {
                 )?;
 
                 stackframe_root_variable = cache.cache_variable(
-                    parent_variable.variable_key,
+                    Some(parent_variable.variable_key),
                     stackframe_root_variable,
                     core,
                 )?;
@@ -1241,7 +1251,7 @@ impl DebugInfo {
 
                 frames.push(StackFrame {
                     // MS DAP Specification requires the id to be unique accross all threads, so using  so using unique `Variable::variable_key` of the `stackframe_root_variable` as the id.
-                    id: stackframe_root_variable.variable_key as u64,
+                    id: get_sequential_key(),
                     function_name,
                     source_location: inlined_caller_source_location,
                     registers: stack_frame_registers.clone(),
@@ -1362,7 +1372,7 @@ impl DebugInfo {
             stackframe_root_variable.memory_location = address;
 
             stackframe_root_variable = cache.cache_variable(
-                parent_variable.variable_key,
+                Some(parent_variable.variable_key),
                 stackframe_root_variable,
                 core,
             )?;
@@ -2394,7 +2404,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
         cache: &mut VariableCache,
     ) -> Result<Variable, DebugError> {
         // Identify the parent.
-        child_variable.parent_key = parent_variable.variable_key;
+        child_variable.parent_key = Some(parent_variable.variable_key);
 
         // It often happens that intermediate nodes exist for structure reasons,
         // so we need to pass values like 'member_index' from the parent down to the next level child nodes.
@@ -2576,7 +2586,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                 .entries_tree(&self.unit.abbreviations, Some(unit_ref))?;
                             let mut discriminant_node = type_tree.root()?;
                             let mut discriminant_variable = cache.cache_variable(
-                                parent_variable.variable_key,
+                                Some(parent_variable.variable_key),
                                 Variable::new(
                                     self.unit.header.offset().as_debug_info_offset(),
                                     Some(discriminant_node.entry().offset()),
@@ -2712,14 +2722,14 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
 
                     namespace_variable.type_name = "<namespace>".to_string();
                     namespace_variable.memory_location = 0;
-                    namespace_variable = cache.cache_variable(parent_variable.variable_key, namespace_variable, core)?;
+                    namespace_variable = cache.cache_variable(Some(parent_variable.variable_key), namespace_variable, core)?;
 
                     let mut namespace_children_nodes = child_node.children();
                     while let Some(mut namespace_child_node) = namespace_children_nodes.next()? {
                         match namespace_child_node.entry().tag() {
                             gimli::DW_TAG_variable => {
                                 // We only want the TOP level variables of the namespace (statics).
-                                let static_child_variable = cache.cache_variable(namespace_variable.variable_key, Variable::new(
+                                let static_child_variable = cache.cache_variable(Some(namespace_variable.variable_key), Variable::new(
                                     self.unit.header.offset().as_debug_info_offset(),
                                     Some(namespace_child_node.entry().offset()),), core)?;
                                 self.process_tree_node_attributes(&mut namespace_child_node, &mut namespace_variable, static_child_variable, core, stack_frame_registers, cache)?;
@@ -2741,7 +2751,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                 } else { VariableName::AnonymousNamespace};
                                 namespace_child_variable.type_name = "<namespace>".to_string();
                                 namespace_child_variable.memory_location = 0;
-                                namespace_child_variable = cache.cache_variable(namespace_variable.variable_key, namespace_child_variable, core)?;
+                                namespace_child_variable = cache.cache_variable(Some(namespace_variable.variable_key), namespace_child_variable, core)?;
                                 namespace_child_variable = self.process_tree(namespace_child_node, namespace_child_variable, core, stack_frame_registers, cache, )?;
                                 if !cache.has_children(&namespace_child_variable)? {
                                     cache.remove_cache_entry(namespace_child_variable.variable_key)?;
@@ -2760,7 +2770,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 gimli::DW_TAG_member |      // Members of structured types.
                 gimli::DW_TAG_enumerator    // Possible values for enumerators, used by extract_type() when processing DW_TAG_enumeration_type.
                 => {
-                    let mut child_variable = cache.cache_variable(parent_variable.variable_key, Variable::new(
+                    let mut child_variable = cache.cache_variable(Some(parent_variable.variable_key), Variable::new(
                     self.unit.header.offset().as_debug_info_offset(),
                     Some(child_node.entry().offset()),
                 ), core)?;
@@ -2789,7 +2799,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                     //              Level 4: --> The actual variables, with matching discriminant, which will be added to `parent_variable`
                     // TODO: Handle Level 3 nodes that belong to a DW_AT_discr_list, instead of having a discreet DW_AT_discr_value 
                     let mut child_variable = cache.cache_variable(
-                        parent_variable.variable_key,
+                        Some(parent_variable.variable_key),
                         Variable::new(self.unit.header.offset().as_debug_info_offset(),Some(child_node.entry().offset())),
                         core
                     )?;
@@ -2809,7 +2819,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                     // We only need to do this if we have not already found our variant,
                     if !cache.has_children(&parent_variable)? {
                         let mut child_variable = cache.cache_variable(
-                            parent_variable.variable_key,
+                            Some(parent_variable.variable_key),
                             Variable::new(self.unit.header.offset().as_debug_info_offset(), Some(child_node.entry().offset())),
                             core
                         )?;
@@ -2835,7 +2845,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 gimli::DW_TAG_subrange_type => {
                     // This tag is a child node fore parent types such as (array, vector, etc.).
                     // Recursively process each node, but pass the parent_variable so that new children are caught despite missing these tags.
-                    let mut range_variable = cache.cache_variable(parent_variable.variable_key,Variable::new(
+                    let mut range_variable = cache.cache_variable(Some(parent_variable.variable_key),Variable::new(
                     self.unit.header.offset().as_debug_info_offset(),
                     Some(child_node.entry().offset()),
                 ), core)?;
@@ -3052,7 +3062,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                             ));
                                         }
                                         child_variable = cache.cache_variable(
-                                            parent_variable.variable_key,
+                                            Some(parent_variable.variable_key),
                                             child_variable,
                                             core,
                                         )?;
@@ -3102,7 +3112,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 // Recursively process a child types.
                 child_variable =
                     self.process_tree(node, child_variable, core, stack_frame_registers, cache)?;
-                let enumerator_values = cache.get_children(child_variable.variable_key)?;
+                let enumerator_values = cache.get_children(Some(child_variable.variable_key))?;
                 // NOTE: hard-coding value of variable.byte_size to 1 ... replace with code if necessary.
                 let mut buff = [0u8; 1];
                 core.read(child_variable.memory_location as u32, &mut buff)?;
@@ -3131,7 +3141,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                     gimli::AttributeValue::UnitRef(unit_ref) => {
                                         // First get the DW_TAG_subrange child of this node. It has a DW_AT_type that points to DW_TAG_base_type:__ARRAY_SIZE_TYPE__.
                                         let mut subrange_variable = cache.cache_variable(
-                                            child_variable.variable_key,
+                                            Some(child_variable.variable_key),
                                             Variable::new(
                                                 self.unit.header.offset().as_debug_info_offset(),
                                                 Some(node.entry().offset()),
@@ -3171,7 +3181,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                             let mut array_member_type_node =
                                                 array_member_type_tree.root().unwrap();
                                             let mut array_member_variable = cache.cache_variable(
-                                                child_variable.variable_key,
+                                                Some(child_variable.variable_key),
                                                 Variable::new(
                                                     self.unit
                                                         .header
@@ -3304,7 +3314,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
             }
         }
         cache
-            .cache_variable(parent_variable.variable_key, child_variable, core)
+            .cache_variable(Some(parent_variable.variable_key), child_variable, core)
             .map_err(|error| error.into())
     }
 

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -21,6 +21,7 @@ use std::{
     path::{Path, PathBuf},
     rc::Rc,
     str::{from_utf8, Utf8Error},
+    vec,
 };
 
 use gimli::{
@@ -62,16 +63,19 @@ impl From<gimli::ColumnType> for ColumnType {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct StackFrame {
     pub id: u64,
     pub function_name: String,
     pub source_location: Option<SourceLocation>,
     pub registers: Registers,
     pub pc: u32,
-
     /// Indicate if this stack frame belongs to an inlined function.
     pub is_inlined: bool,
+    /// A cache of 'static' scoped variables for this stackframe
+    pub static_variables: Option<VariableCache>,
+    /// A cache of 'local' scoped variables for this stafckframe
+    pub local_variables: Option<VariableCache>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -223,6 +227,8 @@ pub struct SourceLocation {
     pub file: Option<String>,
     pub directory: Option<PathBuf>,
 }
+
+// TODO: REBASE: Remove this after comparing next() functionality changes.
 
 /// `StackFrameIterator` stores the information required to iterate through (`::next()`) each of the frames (`StackFrame`) involved in a `DebugInfo::try_unwind()` operation.
 /// The most valuable of these are pointers into the core's [`DebugInfo`], as well as the register values for the current frame in the stack (per iteration).
@@ -1241,6 +1247,8 @@ impl DebugInfo {
                     registers: stack_frame_registers.clone(),
                     pc: inlined_call_site.unwrap(),
                     is_inlined: function_die.is_inline(),
+                    static_variables: None,
+                    local_variables: None,
                 });
             }
 
@@ -1380,19 +1388,471 @@ impl DebugInfo {
                 registers: stack_frame_registers.clone(),
                 pc: address as u32,
                 is_inlined: false,
+                static_variables: None,
+                local_variables: None,
             }])
         } else {
             Ok(frames)
         }
     }
 
-    pub fn try_unwind<'debuginfo, 'probe, 'core>(
-        &'debuginfo self,
-        cache: &'debuginfo mut VariableCache,
-        core: &'core mut Core<'probe>,
+    /// Performs the logical unwind of the stack and returns a `Vec<StackFrame>`
+    /// - The first 'StackFrame' represents the frame at the current PC (program counter), and ...
+    /// - Each subsequent `StackFrame` represents the **previous or calling** `StackFrame` in the call stack.
+    /// - The majority of the work happens in the `'unwind: while` loop, where each iteration will create a `StackFrame` where possible, and update the `unwind_registers` to prepare for the next iteration.
+    ///
+    /// The unwind loop will continue until we meet one of the following conditions:
+    /// - We can no longer unwind a valid PC value to be used for the next frame.
+    /// - We encounter a LR register value of 0xFFFFFFFF which is the 'Reset` value for that register.
+    /// - TODO: Catch the situation where the PC value indicates a hard-fault or other non-recoverable exception
+    /// - We can not intelligently calculate a valid LR register value from the other registers, or the gimli::RegisterRule result is a value of 0x0. Note: [DWARF](https://dwarfstd.org) 6.4.4 - CIE defines the return register address used in the `gimli::RegisterRule` tables for unwind operations. Theoretically, if we encounter a function that has `Undefined` `gimli::RegisterRule` for the return register address, it means we have reached the bottom of the stack OR the function is a 'no return' type of function. I have found actual examples (e.g. local functions) where we get `Undefined` for register rule when we cannot apply this logic. Example 1: local functions in main.rs will have LR rule as `Undefined`. Example 2: main()-> ! that is called from a trampoline will have a valid LR rule.
+    /// - Similarly, certain error conditions encountered in `StackFrameIterator` will also break out of the unwind loop.
+    /// Note: In addition to populating the `StackFrame`s, this function will also populate the `DebugInfo::VariableCache` with `Variable`s for available Registers as well as static and function variables.
+    /// TODO: Separate logic for stackframe creation and cache population
+    pub fn unwind(
+        &self,
+        cache: &mut VariableCache,
+        core: &mut Core,
         address: u64,
-    ) -> StackFrameIterator<'_, 'probe, 'core> {
-        StackFrameIterator::new(self, cache, core, address)
+    ) -> Result<Vec<StackFrame>, crate::Error> {
+        let mut stack_frames = Vec::<StackFrame>::new();
+        let mut unwind_registers = Registers::from_core(core);
+        // Register state as updated for every iteration (previous function) of the unwind process.
+        if unwind_registers.get_program_counter().is_none() {
+            unwind_registers.set_program_counter(Some(address as u32));
+        }
+        let mut unwind_context: Box<UnwindContext<DwarfReader>> =
+            Box::new(gimli::UnwindContext::new());
+        let unwind_bases = gimli::BaseAddresses::default();
+        // If the most recent function in the unwind was an inlined function, we record the caller's [`SourceLocation`] here.
+        let mut inlined_caller_source_location: Option<SourceLocation> = None;
+
+        // Unwind [StackFrame]'s for as long as we can unwind a valid PC value.
+        'unwind: while let Some(frame_pc) = unwind_registers
+            .get_program_counter()
+            .map(|frame_pc| frame_pc as u64)
+        {
+            // PART 0: If the LR is set to 0x0 or None, then we can't unwind anything further.
+            // TODO: ARM has special ranges of LR addresses to indicate fault conditions. We should check those also.
+            if unwind_registers
+                .get_return_address()
+                .map_or(true, |lr_value| lr_value == 0x0)
+            {
+                log::warn!(
+                    "UNWIND: We encountered an LR value of `None` or `0x0`, and cannot continue stack unwinding."
+                );
+                break;
+            };
+
+            // PART 1: Construct the `StackFrame` for the current pc.
+            log::debug!(
+                "UNWIND: Will generate `StackFrame` for function at address (PC) {:#010x}",
+                frame_pc,
+            );
+
+            // PART 1-a: Prepare the `StackFrame` that holds the current frame information
+            let return_frame = match self.get_stackframe_info(
+                cache,
+                core,
+                frame_pc,
+                &unwind_registers,
+                inlined_caller_source_location.clone(),
+            ) {
+                Ok(frame) => frame,
+                Err(e) => {
+                    log::error!("UNWIND: Unable to complete `StackFrame` information: {}", e);
+                    // There is no point in continuing with the unwind, so let's get out of here.
+                    break;
+                }
+            };
+
+            // Part 1-b: When we encounter the starting (after reset) return address, we've reached the bottom of the stack, so no more unwinding after this ...
+            // TODO: Validate that this applies to RISCV also.
+            if let Some(check_return_address) = unwind_registers.get_return_address() {
+                if check_return_address == u32::MAX {
+                    unwind_registers.set_return_address(None);
+                    log::debug!(
+                    "UNWIND: Stack unwind complete - Reached the 'Reset' value of the LR register."
+                );
+                    stack_frames.push(return_frame);
+                    break;
+                }
+            }
+
+            // PART 2: Setup the registers for the `next()` iteration (a.k.a. unwind previous frame, a.k.a. "callee", in the call stack).
+            log::debug!("UNWIND Registers for previous function ...");
+            // Part2-a: We check if the StackFrame just processed was an INLINED function, in which case the unwind process below will take a different path than the one for NON-INLINED functions.
+            if let Some(inlined_call_site) = return_frame.inlined_call_site {
+                inlined_caller_source_location =
+                    return_frame.inlined_caller_source_location.clone();
+                log::debug!(
+                "UNWIND - Preparing `StackFrameIterator` to unwind INLINED function {:?} at {:?}",
+                return_frame.function_name,
+                return_frame.source_location
+            );
+                // The only `unwind` we need to do, is to update the PC with the call site address of the inline function. The `StackFrameIterator::next()` iteration will then create a virtual `StackFrame` for the call-site.
+                let register_number = unwind_registers
+                    .register_description
+                    .program_counter()
+                    .address
+                    .0 as u32;
+                log::debug!(
+                    "UNWIND - {:04?}: Caller: {:#010x}\tCallee: {:#010x}\tRule: {}",
+                    unwind_registers.get_name_by_dwarf_register_number(register_number),
+                    inlined_call_site,
+                    unwind_registers
+                        .get_value_by_dwarf_register_number(register_number)
+                        .unwrap_or_default(),
+                    "PC= Inlined function `inlined_call_site`'",
+                );
+                unwind_registers.set_program_counter(Some(inlined_call_site));
+                // We have what we need for this iteration, so we can skip to the next iteration.
+                stack_frames.push(return_frame);
+                continue;
+            } else {
+                inlined_caller_source_location = None;
+            }
+
+            log::debug!(
+            "UNWIND - Preparing `StackFrameIterator` to unwind NON-INLINED function {:?} at {:?}",
+            return_frame.function_name,
+            return_frame.source_location
+        );
+            // PART 2-b: get the `gimli::FrameDescriptorEntry` for this address and then the unwind info associated with this row.
+            // TODO: The `gimli` docs for this function talks about cases where there might be more than one FDE for a function. Investigate if this affects RUST and how to solve.
+            use gimli::UnwindSection;
+            let frame_descriptor_entry = match self.frame_section.fde_for_address(
+                &unwind_bases,
+                frame_pc,
+                gimli::DebugFrame::cie_from_offset,
+            ) {
+                Ok(frame_descriptor_entry) => frame_descriptor_entry,
+                Err(error) => {
+                    log::error!(
+                        "UNWIND: Error reading FrameDescriptorEntry at PC={:#010x} : {}",
+                        frame_pc,
+                        error
+                    );
+                    stack_frames.push(return_frame);
+                    break;
+                }
+            };
+
+            match frame_descriptor_entry.unwind_info_for_address(
+                &self.frame_section,
+                &unwind_bases,
+                &mut unwind_context,
+                frame_pc,
+            ) {
+                Ok(unwind_info) => {
+                    // Because we will be updating the `unwind_registers` with previous frame unwind info, we need to keep a copy of the current frame's registers that can be used to resolve [DWARF](https://dwarfstd.org) expressions.
+                    let callee_frame_registers = unwind_registers.clone();
+                    // PART 2-c: Determine the CFA (canonical frame address) to use for this unwind row.
+                    let unwind_cfa = match unwind_info.cfa() {
+                        gimli::CfaRule::RegisterAndOffset { register, offset } => {
+                            let reg_val = unwind_registers
+                                .get_value_by_dwarf_register_number(register.0 as u32);
+                            match reg_val {
+                                Some(reg_val) => {
+                                    let unwind_cfa = (i64::from(reg_val) + offset) as u32;
+                                    log::debug!(
+                                        "UNWIND - CFA : {:#010x}\tRule: {:?}",
+                                        unwind_cfa,
+                                        unwind_info.cfa()
+                                    );
+                                    Some(unwind_cfa)
+                                }
+                                None => {
+                                    log::error!("UNWIND: `StackFrameIterator` unable to determine the unwind CFA: Missing value of register {}",register.0);
+                                    stack_frames.push(return_frame);
+                                    break;
+                                }
+                            }
+                        }
+                        gimli::CfaRule::Expression(_) => unimplemented!(),
+                    };
+
+                    // PART 2-d: Unwind registers for the "previous/calling" frame.
+                    // TODO: Test for RISCV ... This is only tested for ARM right now.
+                    // TODO: Maybe do some cleanup on the `Registerfile` API, to make the following more ergonomic.
+                    for register_number in 0..unwind_registers
+                        .register_description
+                        .platform_registers
+                        .len() as u32
+                    {
+                        use gimli::read::RegisterRule::*;
+
+                        let register_rule =
+                            unwind_info.register(gimli::Register(register_number as u16));
+
+                        let mut register_rule_string = format!("{:?}", register_rule);
+
+                        let new_value = match register_rule {
+                            Undefined => {
+                                // In many cases, the DWARF has `Undefined` rules for variables like frame pointer, program counter, etc., so we hard-code some rules here to make sure unwinding can continue. If there is a valid rule, it will bypass these hardcoded ones.
+                                match register_number {
+                                    _fp if register_number
+                                        == unwind_registers
+                                            .register_description
+                                            .frame_pointer()
+                                            .address
+                                            .0
+                                            as u32 =>
+                                    {
+                                        register_rule_string =
+                                            "FP=CFA (dwarf Undefined)".to_string();
+                                        callee_frame_registers.get_frame_pointer()
+                                    }
+                                    _sp if register_number
+                                        == unwind_registers
+                                            .register_description
+                                            .stack_pointer()
+                                            .address
+                                            .0
+                                            as u32 =>
+                                    {
+                                        // TODO: ARM Specific - Add rules for RISCV
+                                        // NOTE: [ARMv7-M Architecture Reference Manual](https://developer.arm.com/documentation/ddi0403/ee), Section B.1.4.1: Treat bits [1:0] as `Should be Zero or Preserved`
+                                        register_rule_string =
+                                            "SP=CFA (dwarf Undefined)".to_string();
+                                        unwind_cfa.map(|unwind_cfa| unwind_cfa & !0b11)
+                                    }
+                                    _lr if register_number
+                                        == unwind_registers
+                                            .register_description
+                                            .return_address()
+                                            .address
+                                            .0
+                                            as u32 =>
+                                    {
+                                        // This value is used to determine the Undefined PC value, and will be set correctly later on in this method.
+                                        register_rule_string =
+                                            "LR=current LR (dwarf Undefined)".to_string();
+                                        callee_frame_registers.get_return_address()
+                                    }
+                                    _pc if register_number
+                                        == unwind_registers
+                                            .register_description
+                                            .program_counter()
+                                            .address
+                                            .0
+                                            as u32 =>
+                                    {
+                                        // NOTE: [ARMv7-M Architecture Reference Manual](https://developer.arm.com/documentation/ddi0403/ee), Section A5.1.2: We have to clear the last bit to ensure the PC is half-word aligned. (on ARM architecture, when in Thumb state for certain instruction types will set the LSB to 1)
+                                        // NOTE: PC = Current instruction + 1 address, so to reverse this from LR return address, we have to subtract 4 bytes
+                                        // TODO: Ensure that this operation does not seem to have a negative effect on RISCV.
+                                        let address_size =
+                                            frame_descriptor_entry.cie().address_size() as u32;
+                                        register_rule_string = format!(
+                                            "PC=(unwound LR & !0b1) - {} (dwarf Undefined)",
+                                            address_size
+                                        );
+                                        unwind_registers.get_return_address().and_then(
+                                            |return_address| {
+                                                if return_address == u32::MAX {
+                                                    // No reliable return is available.
+                                                    None
+                                                } else if return_address.is_zero() {
+                                                    Some(0)
+                                                } else {
+                                                    Some((return_address - address_size) & !0b1)
+                                                }
+                                            },
+                                        )
+                                    }
+                                    _ => {
+                                        // This will result in the register value being cleared for the previous frame.
+                                        None
+                                    }
+                                }
+                            }
+                            SameValue => callee_frame_registers
+                                .get_value_by_dwarf_register_number(register_number),
+                            Offset(address_offset) => {
+                                if let Some(unwind_cfa) = unwind_cfa {
+                                    let previous_frame_register_address =
+                                        i64::from(unwind_cfa) + address_offset;
+                                    let mut buff = [0u8; 4];
+                                    if let Err(e) =
+                                        core.read(previous_frame_register_address as u32, &mut buff)
+                                    {
+                                        log::error!(
+                                                        "UNWIND: Failed to read from address {:#010x} ({} bytes): {}",
+                                                        previous_frame_register_address,
+                                                        4,
+                                                        e
+                                                    );
+                                        log::error!(
+                                            "UNWIND: Rule: Offset {} from address {:#010x}",
+                                            address_offset,
+                                            unwind_cfa
+                                        );
+                                        stack_frames.push(return_frame);
+                                        break 'unwind;
+                                    }
+                                    let previous_frame_register_value = u32::from_le_bytes(buff);
+                                    Some(previous_frame_register_value as u32)
+                                } else {
+                                    log::error!("UNWIND: Tried to unwind `RegisterRule` at CFA = None. Please report this as a bug.");
+                                    stack_frames.push(return_frame);
+                                    break 'unwind;
+                                }
+                            }
+                            //TODO: Implement the remainder of these `RegisterRule`s
+                            _ => unimplemented!(),
+                        };
+
+                        unwind_registers.set_by_dwarf_register_number(register_number, new_value);
+                        log::debug!(
+                            "UNWIND - {:04?}: Caller: {:#010x}\tCallee: {:#010x}\tRule: {}",
+                            unwind_registers.get_name_by_dwarf_register_number(register_number),
+                            unwind_registers
+                                .get_value_by_dwarf_register_number(register_number)
+                                .unwrap_or_default(),
+                            callee_frame_registers
+                                .get_value_by_dwarf_register_number(register_number)
+                                .unwrap_or_default(),
+                            register_rule_string,
+                        );
+                    }
+                }
+                Err(error) => {
+                    log::debug!("UNWIND: Stack unwind complete. No available debug info for program counter {:#x}: {}", frame_pc, error);
+                    stack_frames.push(return_frame);
+                    break;
+                }
+            };
+
+            // PART 3: In order to set the correct value of the previous frame we need to peek one frame deeper in the stack.
+            // NOTE: ARM Specific.
+            // TODO: Investigate and document why and under which circumstances this extra step is necessary. It was added during PR#895.
+            // TODO: Test on RISCV and fix as needed
+            if let Some(previous_frame_pc) = unwind_registers.get_program_counter() {
+                let previous_frame_descriptor_entry = match self.frame_section.fde_for_address(
+                    &unwind_bases,
+                    previous_frame_pc as u64,
+                    gimli::DebugFrame::cie_from_offset,
+                ) {
+                    Ok(frame_descriptor_entry) => frame_descriptor_entry,
+                    Err(error) => {
+                        log::error!(
+                        "UNWIND: Error reading previous FrameDescriptorEntry at PC={:#010x} : {}",
+                        previous_frame_pc,
+                        error
+                    );
+                        stack_frames.push(return_frame);
+                        break;
+                    }
+                };
+
+                match previous_frame_descriptor_entry.unwind_info_for_address(
+                    &self.frame_section,
+                    &unwind_bases,
+                    &mut unwind_context,
+                    previous_frame_pc as u64,
+                ) {
+                    Ok(previous_unwind_info) => {
+                        let previous_unwind_cfa = match previous_unwind_info.cfa() {
+                            gimli::CfaRule::RegisterAndOffset { register, offset } => {
+                                let reg_val = unwind_registers
+                                    .get_value_by_dwarf_register_number(register.0 as u32);
+                                match reg_val {
+                                    Some(reg_val) => {
+                                        let unwind_cfa = (i64::from(reg_val) + offset) as u32;
+                                        log::debug!(
+                                            "UNWIND - CFA : {:#010x}\tRule: Previous Function {:?}",
+                                            unwind_cfa,
+                                            previous_unwind_info.cfa()
+                                        );
+                                        Some(unwind_cfa)
+                                    }
+                                    None => {
+                                        log::error!(
+                                                        "UNWIND: `StackFrameIterator` unable to determine the previous frame unwind CFA: Missing value of register {}",
+                                                        register.0
+                                                    );
+                                        stack_frames.push(return_frame);
+                                        break;
+                                    }
+                                }
+                            }
+                            gimli::CfaRule::Expression(_) => unimplemented!(),
+                        };
+                        use gimli::read::RegisterRule::*;
+
+                        let return_register_number = previous_frame_descriptor_entry
+                            .cie()
+                            .return_address_register()
+                            .0 as u32;
+                        let register_rule = previous_unwind_info
+                            .register(gimli::Register(return_register_number as u16));
+
+                        let register_rule_string = format!("{:?}", register_rule);
+
+                        let new_return_value = match register_rule {
+                            Undefined => None,
+                            SameValue => unwind_registers
+                                .get_value_by_dwarf_register_number(return_register_number),
+                            Offset(address_offset) => {
+                                if let Some(unwind_cfa) = previous_unwind_cfa {
+                                    let previous_frame_register_address =
+                                        i64::from(unwind_cfa) + address_offset;
+                                    let mut buff = [0u8; 4];
+                                    if let Err(e) =
+                                        core.read(previous_frame_register_address as u32, &mut buff)
+                                    {
+                                        log::error!(
+                                                        "UNWIND: Failed to read from address {:#010x} ({} bytes): {}",
+                                                        previous_frame_register_address,
+                                                        4,
+                                                        e
+                                                    );
+                                        log::error!(
+                                            "UNWIND: Rule: Offset {} from address {:#010x}",
+                                            address_offset,
+                                            unwind_cfa
+                                        );
+                                        stack_frames.push(return_frame);
+                                        break;
+                                    }
+                                    let previous_frame_register_value = u32::from_le_bytes(buff);
+                                    Some(previous_frame_register_value as u32)
+                                } else {
+                                    log::error!("UNWIND: Tried to unwind `RegisterRule` at CFA = None. Please report this as a bug.");
+                                    stack_frames.push(return_frame);
+                                    break;
+                                }
+                            }
+                            //TODO: Implement the remainder of these `RegisterRule`s
+                            _ => unimplemented!(),
+                        };
+                        unwind_registers
+                            .set_by_dwarf_register_number(return_register_number, new_return_value);
+                        log::debug!(
+                        "UNWIND - {:04?}: Caller: {:#010x}\tRule: Override with previous frame {}",
+                        unwind_registers
+                            .get_name_by_dwarf_register_number(return_register_number),
+                        unwind_registers
+                            .get_value_by_dwarf_register_number(return_register_number)
+                            .unwrap_or_default(),
+                        register_rule_string,
+                    );
+                    }
+                    Err(error) => {
+                        log::debug!("UNWIND: Stack unwind complete. No available debug info for program counter {:#x}: {}",frame_pc, error);
+                        stack_frames.push(return_frame);
+                        break;
+                    }
+                };
+            } else {
+                log::error!("UNWIND: Cannot read previous FrameDescriptorEntry without a valid PC");
+                stack_frames.push(return_frame);
+                break;
+            }
+            stack_frames.push(return_frame);
+        }
+
+        Ok(stack_frames)
     }
 
     /// Find the program counter where a breakpoint should be set,

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -32,41 +32,22 @@ impl Default for VariableCache {
 }
 
 impl VariableCache {
-    pub fn new(_core_index: usize) -> Self {
-        // This is WIP ... please leave commented code.
-        //let variable_cache =
-        VariableCache {
+    pub fn new(core_index: usize) -> Self {
+        let variable_cache = VariableCache {
             variable_cache_key: 0,
             variable_hash_map: HashMap::new(),
-        }
-        //;
+        };
         // The variable_cache will always be pre-populated with a [VariableName::CoreId] variable for the specified core.
-        // TODO: Implement this.
-        // let mut core_id_variable = Variable::new(None, None);
-        // core_id_variable.name = VariableName::CoreId;
-        // core_id_variable.source_location = function_source_location.clone();
-        // let function_display_name = if function_die.is_inline {
-        //     format!("{} #[inline]", &function_name)
-        // } else {
-        //     format!("{} @{:#010x}", &function_name, address)
-        // };
+        let mut core_id_variable = Variable::new(None, None);
+        core_id_variable.name = VariableName::CoreId;
+        core_id_variable.variable_key = core_index as i64;
+        
+        // TODO: set the value to be something human readable form ...
         // core_id_variable.set_value(function_display_name);
-        // core_id_variable = unit_info.extract_location(
-        //     &unit_info
-        //         .unit
-        //         .entries_tree(Some(function_die.function_die.offset()))?
-        //         .root()?,
-        //     &parent_variable,
-        //     core_id_variable,
-        //     core,
-        //     &stack_frame_registers,
-        //     cache,
-        // )?;
-
         //
         // core_id_variable =
         //     cache.cache_variable(parent_variable.variable_key, core_id_variable, core)?;
-        // variable_cache
+        variable_cache
     }
 
     /// Performs an *add* or *update* of a `probe_rs::debug::Variable` to the cache, consuming the input and returning a Clone.

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -372,8 +372,6 @@ pub struct Variable {
     /// TODO: Is there a more efficient method to get on demand access to gimli::Unit through stored references to it?
     pub header_offset: Option<DebugInfoOffset>,
     pub entries_offset: Option<UnitOffset>,
-    /// The register values are needed to resolve the debug information and calculate memory locations and run-time data values. This is only needed for referenced nodes of variables with `DW_TAG_pointer_type`
-    pub stack_frame_registers: Option<Registers>,
     /// The starting location/address in memory where this Variable's value is stored.
     pub memory_location: u64,
     pub byte_size: u64,
@@ -387,7 +385,7 @@ pub struct Variable {
 }
 
 impl Variable {
-    /// In most cases, Variables will be initialized with their ELF references, so that we resolve their data types and values on demand.
+    /// In most cases, Variables will be initialized with their ELF references so that we resolve their data types and values on demand.
     pub(crate) fn new(
         header_offset: Option<DebugInfoOffset>,
         entries_offset: Option<UnitOffset>,

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -27,16 +27,46 @@ pub struct VariableCache {
 }
 impl Default for VariableCache {
     fn default() -> Self {
-        Self::new()
+        Self::new(0)
     }
 }
 
 impl VariableCache {
-    pub fn new() -> Self {
-        Self {
+    pub fn new(_core_index: usize) -> Self {
+        // This is WIP ... please leave commented code.
+        //let variable_cache =
+        VariableCache {
             variable_cache_key: 0,
             variable_hash_map: HashMap::new(),
         }
+        //;
+        // The variable_cache will always be pre-populated with a [VariableName::CoreId] variable for the specified core.
+        // TODO: Implement this.
+        // let mut core_id_variable = Variable::new(None, None);
+        // core_id_variable.name = VariableName::CoreId;
+        // core_id_variable.source_location = function_source_location.clone();
+        // let function_display_name = if function_die.is_inline {
+        //     format!("{} #[inline]", &function_name)
+        // } else {
+        //     format!("{} @{:#010x}", &function_name, address)
+        // };
+        // core_id_variable.set_value(function_display_name);
+        // core_id_variable = unit_info.extract_location(
+        //     &unit_info
+        //         .unit
+        //         .entries_tree(Some(function_die.function_die.offset()))?
+        //         .root()?,
+        //     &parent_variable,
+        //     core_id_variable,
+        //     core,
+        //     &stack_frame_registers,
+        //     cache,
+        // )?;
+
+        //
+        // core_id_variable =
+        //     cache.cache_variable(parent_variable.variable_key, core_id_variable, core)?;
+        // variable_cache
     }
 
     /// Performs an *add* or *update* of a `probe_rs::debug::Variable` to the cache, consuming the input and returning a Clone.

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -623,7 +623,7 @@ impl Variable {
                             child.formatted_variable_value(variable_cache)
                         );
                     }
-                    format!("{}", compound_value)
+                    compound_value
                 } else if self.type_name.as_str() == "Some"
                     || self.type_name.as_str() == "Ok"
                     || self.type_name.as_str() == "Err"
@@ -681,7 +681,7 @@ impl Variable {
                     if let Some(post_fix) = &post_fix {
                         compound_value = format!("{}{}", compound_value, post_fix);
                     };
-                    format!("{}", compound_value)
+                    compound_value
                 }
             } else {
                 // We don't have a value, and we can't generate one from children values, so use the type_name


### PR DESCRIPTION
New PR to supersede #999, which now includes the merged in changes from #1002.

Various `probe_rs::debug` and `probe-rs-debugger` changes/cleanup to the internals
- [x] Removed `StackFrameIterator` and incorporated its logic into `DebugInfo::unwind()`
- [x] `StackFrame` now has `VariableCache` entries for locals, statics and registers
- [x] Modify `DebugSession` and `CoreData` to handle multiple cores.
- [x] Modify `Variable::parent_key` to be `Option<i64>` and use `None` rather than `0` values to control logic.
- [x] Use the updated `StackFrame`, and new `VariableNodeType` to facilitate 'lazy' loading of variables during stack trace operations. VSCode and MS DAP will request one 'level' of variables at a time, and there is no need to resolve and cache variable data unless the user is going to view/use it.