### PR TITLE
target-gen: fix duplicate algo names

### DIFF
--- a/probe-rs/targets/STM32H7_Series.yaml
+++ b/probe-rs/targets/STM32H7_Series.yaml
@@ -16,7 +16,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -58,7 +58,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -100,7 +100,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -142,7 +142,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -184,7 +184,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -226,7 +226,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -268,7 +268,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -310,7 +310,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -352,7 +352,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -394,7 +394,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -436,7 +436,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -478,7 +478,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -520,7 +520,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -562,7 +562,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -604,7 +604,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -646,7 +646,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -688,7 +688,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -730,7 +730,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -772,7 +772,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -814,7 +814,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -856,7 +856,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -898,7 +898,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -940,7 +940,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -982,7 +982,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1024,7 +1024,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1066,7 +1066,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1108,7 +1108,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1150,7 +1150,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1192,7 +1192,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1234,7 +1234,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1276,7 +1276,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1318,7 +1318,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1360,7 +1360,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1402,7 +1402,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1444,7 +1444,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1486,7 +1486,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1528,7 +1528,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1570,7 +1570,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1612,7 +1612,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1654,7 +1654,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1696,7 +1696,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -1738,7 +1738,7 @@ variants:
           name: ~
           range:
             start: 603979776
-            end: 604307456
+            end: 605028352
           is_boot_memory: false
           cores:
             - main
@@ -3144,7 +3144,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -3192,7 +3191,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -3242,7 +3240,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -3290,7 +3287,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -3340,7 +3336,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -3388,7 +3383,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -3438,7 +3432,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -3486,7 +3479,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -3536,7 +3528,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -3584,7 +3575,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -3634,7 +3624,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -3682,7 +3671,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -3732,7 +3720,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -3780,7 +3767,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -3830,7 +3816,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -3878,7 +3863,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -3928,7 +3912,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -3977,7 +3960,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -4025,7 +4007,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -4621,7 +4602,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -4669,7 +4649,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -4719,7 +4698,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -4767,7 +4745,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -4817,7 +4794,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -4865,7 +4841,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -4915,7 +4890,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -4963,7 +4937,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
@@ -5013,7 +4986,6 @@ variants:
             - main
     flash_algorithms:
       - stm32h7x_2048
-      - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco
       - mtfc4gacajcn_stm32h750b-disco
@@ -5061,7 +5033,6 @@ variants:
           cores:
             - main
     flash_algorithms:
-      - stm32h7x_2048
       - stm32h7x_2048
       - stm32h7b3i_eval_fmc-nor
       - mt25tl01g_stm32h747i-disco

--- a/target-gen/README.md
+++ b/target-gen/README.md
@@ -10,7 +10,7 @@ is the following ARM website: https://developer.arm.com/tools-and-software/embed
 
 From a CMSIS-Pack, you can extract the target descriptions for probe-rs:
 
-    cargo run -- pack <CMSIS-PACK> out/
+    cargo run --release -- pack <CMSIS-PACK> out/
 
 This wil generate YAML files containing the target descriptions, which can be used with probe-rs.
 
@@ -23,7 +23,7 @@ can be found at: https://arm-software.github.io/CMSIS_5/Pack/html/algorithmFunc.
 
 Running
 
-    cargo run -- elf <ELF FILE> target.yml
+    cargo run --release -- elf <ELF FILE> target.yml
 
 will create a target description containing the extracted flash algorithm. The values
 for the chip description itself have to be adjusted manually in the generated Yaml file.

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -109,6 +109,15 @@ where
             .map(|fa| fa.name.to_string())
             .collect();
 
+        // Sometimes the algos are referenced twice, for example in the multicore H7s
+        // Deduplicate while keeping order.
+        let flash_algorithm_names: Vec<_> = flash_algorithm_names
+            .iter()
+            .enumerate()
+            .filter(|(i, s)| !flash_algorithm_names[..*i].contains(s))
+            .map(|(_, s)| s.clone())
+            .collect();
+
         let mut memory_map: Vec<MemoryRegion> = Vec::new();
         if let Some(mem) = ram {
             memory_map.push(MemoryRegion::Ram(mem));


### PR DESCRIPTION
#1010 deduplicates the algos themselves, but leaves duplicate algo names in `variants.flash_algorithms`. This PR dedups algo names and updates the troublesome H7 yaml.

This causes this issue when flashing:

```
Error: Error while flashing
Caused by:
    Trying to write flash, but found more than one suitable flash loader algorithim marked as default for NvmRegion { name: None, range: 134217728..136314880, is_boot_memory: true, cores: ["main"] }.
```