### PR TITLE
ARM: Permit register read errors while resetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- ARM reset sequence now retries failed reads of DHCSR, fixes >500kHz SWD for ATSAMD21.
 - Chip names are now matched treating an 'x' as a wildcard. (#964)
 - GDB server is now available as a subcommand in the probe-rs-cli, not as a separate binary in the `gdb-server` package anymore . (#972)
 - Updated STM32H7 series yaml to support newly released chips. (#1011)


### PR DESCRIPTION
With a hs-probe (current firmware e955d5246b) connected to an ATSAMD21 target, flashing fails when the SWD speed is set above about 500kHz.  @adamgreig and I traced this over chat, back to this read failing while the target chip is still in reset.