### PR TITLE
Add option to disable double-buffer use in downloading flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an option to disable use of double-buffering when downloading flash (#1030, #883)
 - Added a permissions system that allows the user to specify if a full chip erase is allowed (#918)
 - Added debug sequence for the nRF5340 that turns on the network core can unlock both cores by erasing them if that is permitted (#918)
 - Support for core registers `msp`, `psp` and `extra`, extra containing:

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -123,6 +123,10 @@ enum Cli {
         /// Whether to disable fancy progress reporting
         #[structopt(long)]
         disable_progressbars: bool,
+
+        /// Disable double-buffering when downloading flash.  If downloading times out, try this option.
+        #[structopt(long = "disable-double-buffering")]
+        disable_double_buffering: bool,
     },
     /// Erase all nonvolatile memory of attached target
     Erase {
@@ -141,6 +145,10 @@ enum Cli {
         /// Whether to erase the entire chip before downloading
         #[structopt(long)]
         chip_erase: bool,
+
+        /// Disable double-buffering when downloading flash.  If downloading times out, try this option.
+        #[structopt(long = "disable-double-buffering")]
+        disable_double_buffering: bool,
     },
     /// Trace a memory location on the target
     #[structopt(name = "trace")]
@@ -218,18 +226,21 @@ fn main() -> Result<()> {
             path,
             chip_erase,
             disable_progressbars,
+            disable_double_buffering,
         } => download_program_fast(
             common,
             format.into(base_address, skip_bytes),
             &path,
             chip_erase,
             disable_progressbars,
+            disable_double_buffering,
         ),
         Cli::Run {
             common,
             path,
             chip_erase,
-        } => run::run(common, &path, chip_erase),
+            disable_double_buffering,
+        } => run::run(common, &path, chip_erase, disable_double_buffering),
         Cli::Erase { common } => erase(&common),
         Cli::Trace {
             shared,
@@ -298,6 +309,7 @@ fn download_program_fast(
     path: &str,
     do_chip_erase: bool,
     disable_progressbars: bool,
+    disable_double_buffering: bool,
 ) -> Result<()> {
     let mut session = common.simple_attach()?;
 
@@ -322,6 +334,7 @@ fn download_program_fast(
             list_chips: false,
             list_probes: false,
             disable_progressbars,
+            disable_double_buffering,
             reset_halt: false,
             log: None,
             restore_unwritten: false,

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -7,7 +7,12 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-pub fn run(common: ProbeOptions, path: &str, chip_erase: bool) -> Result<()> {
+pub fn run(
+    common: ProbeOptions,
+    path: &str,
+    chip_erase: bool,
+    disable_double_buffering: bool,
+) -> Result<()> {
     let mut session = common.simple_attach()?;
 
     let mut file = match File::open(path) {
@@ -26,6 +31,7 @@ pub fn run(common: ProbeOptions, path: &str, chip_erase: bool) -> Result<()> {
             list_chips: false,
             list_probes: false,
             disable_progressbars: false,
+            disable_double_buffering,
             reset_halt: false,
             log: None,
             restore_unwritten: false,

--- a/probe-rs-cli-util/src/common_options.rs
+++ b/probe-rs-cli-util/src/common_options.rs
@@ -61,6 +61,12 @@ pub struct FlashOptions {
     #[structopt(name = "disable-progressbars", long = "disable-progressbars")]
     pub disable_progressbars: bool,
     #[structopt(
+        long = "disable-double-buffering",
+        help = "Use this flag to disable double-buffering when downloading flash data.  If download fails during\
+        programming with timeout errors, try this option."
+    )]
+    pub disable_double_buffering: bool,
+    #[structopt(
         name = "reset-halt",
         long = "reset-halt",
         help = "Use this flag to reset and halt (instead of just a reset) the attached core after flashing the target."

--- a/probe-rs-cli-util/src/flash.rs
+++ b/probe-rs-cli-util/src/flash.rs
@@ -28,6 +28,7 @@ pub fn run_flash_download(
     download_option.keep_unwritten_bytes = opt.restore_unwritten;
     download_option.dry_run = opt.probe_options.dry_run;
     download_option.do_chip_erase = do_chip_erase;
+    download_option.disable_double_buffering = opt.disable_double_buffering;
 
     if !opt.disable_progressbars {
         // Create progress bars.

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -113,6 +113,8 @@ pub struct DownloadOptions<'progress> {
     pub skip_erase: bool,
     /// After flashing, read back all the flashed data to verify it has been written correctly.
     pub verify: bool,
+    /// Disable double buffering when loading flash.
+    pub disable_double_buffering: bool,
 }
 
 impl<'progress> DownloadOptions<'progress> {

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -322,6 +322,12 @@ impl FlashLoader {
                 }
             }
 
+            let mut do_use_double_buffering = flasher.double_buffering_supported();
+            if do_use_double_buffering && options.disable_double_buffering {
+                log::info!("Disabled double-buffering support for loader via passed option, though target supports it.");
+                do_use_double_buffering = false;
+            }
+
             for region in regions {
                 log::debug!(
                     "    programming region: {:08x}-{:08x} ({} bytes)",
@@ -335,7 +341,7 @@ impl FlashLoader {
                     &region,
                     &self.builder,
                     options.keep_unwritten_bytes,
-                    true,
+                    do_use_double_buffering,
                     options.skip_erase || do_chip_erase,
                     options.progress.unwrap_or(&FlashProgress::new(|_| {})),
                 )?;


### PR DESCRIPTION
This commit adds the "disable_double_buffer" option in
probe-rs::flashing::download::DownloadOptions to disable use
of double buffering when downloading firmware even if the target
reports it is supported.  probe-rs-cli has been updated with
the "--disable-double-buffering" options for "run" and "download".

Some targets, like STM32L071 seem to have issues with double
buffering (see #883).