### PR TITLE
Derive serde traits on rtt::ChannelMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added an option to disable use of double-buffering when downloading flash (#1030, #883)
+- rtt::ChannelMode implements additional traits: Clone, Copy, serde's Serialize and Deserialize
 - Added a permissions system that allows the user to specify if a full chip erase is allowed (#918)
 - Added debug sequence for the nRF5340 that turns on the network core can unlock both cores by erasing them if that is permitted (#918)
 - Support for core registers `msp`, `psp` and `extra`, extra containing:

--- a/rtt/Cargo.toml
+++ b/rtt/Cargo.toml
@@ -13,4 +13,5 @@ repository = "https://github.com/probe-rs/probe-rs"
 log = "0.4.8"
 probe-rs = { version = "0.12.0", path = "../probe-rs" }
 scroll = "0.10.1"
+serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.11"

--- a/rtt/src/channel.rs
+++ b/rtt/src/channel.rs
@@ -397,7 +397,7 @@ fn read_c_string(
 
 /// Specifies what to do when a channel doesn't have enough buffer space for a complete write on the
 /// target side.
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 #[repr(u32)]
 pub enum ChannelMode {
     /// Skip writing the data completely if it doesn't fit in its entirety.


### PR DESCRIPTION
This is required to allow cargo-embed to use ChannelMode in
configuration files.