### PR TITLE
RTT Reliability and new DAP Requests (ReadMemory, WriteMemory, Evaluate & SetVariable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added get_target_voltage to the Probe struct to access the inner DebugProbe method. (#991)
 - Debugger: Added support for showing multiple inlined functions in backtrace. (#1002)
 - Debugger: Add support LocLists (attribute value of DW_AT_location) (#1025)
-- Debugger: Add support for  DAP Requests (ReadMemory, WriteMemory, Evaluate & SetValue) (#1035)
+- Debugger: Add support for  DAP Requests (ReadMemory, WriteMemory, Evaluate & SetVariable) (#1035)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added get_target_voltage to the Probe struct to access the inner DebugProbe method. (#991)
 - Debugger: Added support for showing multiple inlined functions in backtrace. (#1002)
 - Debugger: Add support LocLists (attribute value of DW_AT_location) (#1025)
+- Debugger: Add support for  DAP Requests (ReadMemory, WriteMemory, Evaluate & SetValue) (#1035)
 
 ### Changed
 
@@ -54,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Adapt to `defmt` 0.3 'Rzcobs' encoding to fix [VSCode #26](https://github.com/probe-rs/vscode/issues/26).
   - Support the new `defmt` 0.3 `DEFMT_LOG` environment variable.
   - Requires `probe-rs/vscode` [PR #27](https://github.com/probe-rs/vscode/pull/27) 
+  - Debugger: Improved RTT reliability between debug adapter and VSCode (#1035)
 
 ## [0.12.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added get_target_voltage to the Probe struct to access the inner DebugProbe method. (#991)
 - Debugger: Added support for showing multiple inlined functions in backtrace. (#1002)
 - Debugger: Add support LocLists (attribute value of DW_AT_location) (#1025)
-- Debugger: Add support for  DAP Requests (ReadMemory, WriteMemory, Evaluate & SetVariable) (#1035)
+- Debugger: Add support for DAP Requests (ReadMemory, WriteMemory, Evaluate & SetVariable) (#1035)
 
 ### Changed
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -364,7 +364,7 @@ impl DebugCli {
                         };
 
                         if let Some(mut locals) = local_variable_cache
-                            .get_variable_by_name_and_parent(&VariableName::LocalScope, None)
+                            .get_variable_by_name_and_parent(&VariableName::LocalScopeRoot, None)
                         {
                             // By default, the first level children are always are lazy loaded, so we will force a load here.
                             if locals.variable_node_type.is_deferred()

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -41,6 +41,7 @@ serde = { version = "^1.0", features = ["derive"] }
 schemafy = "^0.6"
 chrono = { version = "0.4", features = ["serde"] }
 goblin = "0.5.1"
+base64 = "0.13"
 
 [dev-dependencies]
 insta = "1.8.0"

--- a/debugger/src/dap_types.rs
+++ b/debugger/src/dap_types.rs
@@ -95,6 +95,7 @@ impl TryFrom<&serde_json::Value> for ReadMemoryArguments {
 }
 
 impl TryFrom<&serde_json::Value> for WriteMemoryArguments {
+    type Error = DebuggerError;
     fn try_from(arguments: &serde_json::Value) -> Result<Self, Self::Error> {
         let memory_reference = get_string_argument(Some(arguments), "memory_reference", 0)?;
         let data = get_string_argument(Some(arguments), "data", 1)?;
@@ -105,8 +106,6 @@ impl TryFrom<&serde_json::Value> for WriteMemoryArguments {
             allow_partial: Some(false),
         })
     }
-
-    type Error = DebuggerError;
 }
 
 // SECTION: For various helper functions

--- a/debugger/src/dap_types.rs
+++ b/debugger/src/dap_types.rs
@@ -34,7 +34,7 @@ pub struct RttWindowOpened {
     pub arguments: Option<RttWindowOpenedArguments>,
     /// The command to execute.
     pub command: String,
-    /// Sequence number (also known as message ID). For protocol messages of type \'request\' this ID
+    /// Sequence number (also known as message ID). For protocol messages of type `request` this ID
     /// can be used to cancel the request.
     pub seq: i64,
     /// Message type.

--- a/debugger/src/dap_types.rs
+++ b/debugger/src/dap_types.rs
@@ -41,7 +41,7 @@ pub struct RttWindowOpened {
     #[serde(rename = "type")]
     pub type_: String,
 }
-///  Arguments for RttWindowOpened request.
+///  Arguments for [`RttWindowOpened`] request.
 #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RttWindowOpenedArguments {

--- a/debugger/src/dap_types.rs
+++ b/debugger/src/dap_types.rs
@@ -25,7 +25,7 @@ pub struct QuitRequest {
     pub type_: String,
 }
 
-/// Custom 'RttWindowOpened' request, so that VSCode can confirm once a specific RTT channel's window has opened.
+/// Custom [`RttWindowOpened`] request, so that VSCode can confirm once a specific RTT channel's window has opened.
 /// `probe-rs-debugger` will delay polling RTT channels until the data window has opened. This ensure no RTT data is lost on the client.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct RttWindowOpened {

--- a/debugger/src/dap_types.rs
+++ b/debugger/src/dap_types.rs
@@ -25,6 +25,31 @@ pub struct QuitRequest {
     pub type_: String,
 }
 
+/// Custom 'RttWindowOpened' request, so that VSCode can confirm once a specific RTT channel's window has opened.
+/// `probe-rs-debugger` will delay polling RTT channels until the data window has opened. This ensure no RTT data is lost on the client.
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct RttWindowOpened {
+    /// Object containing arguments for the command.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<RttWindowOpenedArguments>,
+    /// The command to execute.
+    pub command: String,
+    /// Sequence number (also known as message ID). For protocol messages of type \'request\' this ID
+    /// can be used to cancel the request.
+    pub seq: i64,
+    /// Message type.
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+///  Arguments for RttWindowOpened request.
+#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RttWindowOpenedArguments {
+    /// The RTT channel number.
+    pub channel_number: usize,
+    pub window_is_open: bool,
+}
+
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RttChannelEventBody {
@@ -63,6 +88,21 @@ impl TryFrom<&serde_json::Value> for ReadMemoryArguments {
             count,
             memory_reference,
             offset: None,
+        })
+    }
+
+    type Error = DebuggerError;
+}
+
+impl TryFrom<&serde_json::Value> for WriteMemoryArguments {
+    fn try_from(arguments: &serde_json::Value) -> Result<Self, Self::Error> {
+        let memory_reference = get_string_argument(Some(arguments), "memory_reference", 0)?;
+        let data = get_string_argument(Some(arguments), "data", 1)?;
+        Ok(WriteMemoryArguments {
+            data,
+            memory_reference,
+            offset: None,
+            allow_partial: Some(false),
         })
     }
 

--- a/debugger/src/debugProtocol.json
+++ b/debugger/src/debugProtocol.json
@@ -3573,6 +3573,10 @@
 					"description": "Visibility of variable. Before introducing additional values, try to use the listed values.",
 					"type": "string",
 					"_enum": [ "public", "private", "protected", "internal", "final" ]
+				},
+				"lazy": {
+					"description": "If true, clients can present the variable with a UI that supports a specific gesture to trigger its evaluation.\nThis mechanism can be used for properties that require executing code when retrieving their value and where the code execution can be expensive and/or produce side-effects. A typical example are properties based on a getter function.\nPlease note that in addition to the 'lazy' flag, the variable's 'variablesReference' must refer to a variable that will provide the value through another 'variable' request.",
+					"type": "boolean"
 				}
 			}
 		},

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -211,7 +211,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 Ok(Some(ReadMemoryResponseBody {
                     address: format!("{:#010x}", address),
                     data: Some(response),
-                    unreadable_bytes: None, //Some(num_bytes_unread as i64),
+                    unreadable_bytes: None,
                 })),
             )
         } else {
@@ -303,14 +303,11 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
     /// Evaluates the given expression in the context of the top most stack frame.
     /// The expression has access to any variables and arguments that are in scope.
-    /// TODO: When variables appear in the `watch` context, they will not resolve correctly after a 'step' function. Consider doing the lazy load for 'either/or' of Variables vs. Evaluate
     pub(crate) fn evaluate(&mut self, core_data: &mut CoreData, request: Request) -> Result<()> {
+        // TODO: When variables appear in the `watch` context, they will not resolve correctly after a 'step' function. Consider doing the lazy load for 'either/or' of Variables vs. Evaluate
+
         let arguments: EvaluateArguments = match self.adapter_type() {
             DebugAdapterType::CommandLine => todo!(),
-            // match request.arguments.as_ref().unwrap().try_into() {
-            //     Ok(arguments) => arguments,
-            //     Err(error) => return self.send_response::<()>(request, Err(error)),
-            // },
             DebugAdapterType::DapClient => match get_arguments(&request) {
                 Ok(arguments) => arguments,
                 Err(error) => return self.send_response::<()>(request, Err(error)),

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -170,22 +170,50 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 Err(error) => return self.send_response::<()>(request, Err(error)),
             },
         };
-        let address: u32 = parse(arguments.memory_reference.as_ref()).unwrap();
-        let num_words = arguments.count as usize;
-        let mut buff = vec![0u32; num_words];
-        if num_words > 1 {
-            core_data.target_core.read_32(address, &mut buff).unwrap();
+        let memory_offset = arguments.offset.unwrap_or(0);
+        let mut address: u32 = if let Ok(address) =
+            parse::<i64>(arguments.memory_reference.as_ref())
+        {
+            match (address + memory_offset).try_into() {
+                    Ok(modified_address) => modified_address,
+                    Err(error) => return self.send_response::<()>(
+                    request,
+                    Err(DebuggerError::Other(anyhow!(
+                        "Could not convert memory_reference: {} and offset: {:?} into a 32-bit memory address: {:?}",
+                        arguments.memory_reference, arguments.offset, error
+                    ))),
+                ),
+                }
         } else {
-            buff[0] = core_data.target_core.read_word_32(address).unwrap();
-        }
-        if !buff.is_empty() {
-            let mut response = "".to_string();
-            for (offset, word) in buff.iter().enumerate() {
-                response.push_str(
-                    format!("{:#010x} = {:#010x}\n", address + (offset * 4) as u32, word).as_str(),
-                );
+            return self.send_response::<()>(
+                request,
+                Err(DebuggerError::Other(anyhow!(
+                    "Could not read any data at address {:?}",
+                    arguments.memory_reference
+                ))),
+            );
+        };
+        let mut num_bytes_unread = arguments.count as usize;
+        let mut buff = vec![];
+        while num_bytes_unread > 0 {
+            if let Ok(good_byte) = core_data.target_core.read_word_8(address) {
+                buff.push(good_byte);
+                address += 1;
+                num_bytes_unread -= 1;
+            } else {
+                break;
             }
-            self.send_response::<String>(request, Ok(Some(response)))
+        }
+        if !buff.is_empty() || num_bytes_unread == 0 {
+            let response = base64::encode(&buff);
+            self.send_response(
+                request,
+                Ok(Some(ReadMemoryResponseBody {
+                    address: format!("{:#010x}", address),
+                    data: Some(response),
+                    unreadable_bytes: None, //Some(num_bytes_unread as i64),
+                })),
+            )
         } else {
             self.send_response::<()>(
                 request,
@@ -196,25 +224,321 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             )
         }
     }
-    pub(crate) fn write(&mut self, core_data: &mut CoreData, request: Request) -> Result<()> {
-        let address = match get_int_argument(request.arguments.as_ref(), "address", 0) {
-            Ok(address) => address,
-            Err(error) => return self.send_response::<()>(request, Err(error)),
-        };
-        let data = match get_int_argument(request.arguments.as_ref(), "data", 1) {
-            Ok(data) => data,
-            Err(error) => return self.send_response::<()>(request, Err(error)),
-        };
 
+    pub(crate) fn write_memory(
+        &mut self,
+        core_data: &mut CoreData,
+        request: Request,
+    ) -> Result<()> {
+        let arguments: WriteMemoryArguments = match self.adapter_type() {
+            DebugAdapterType::CommandLine => match request.arguments.as_ref().unwrap().try_into() {
+                Ok(arguments) => arguments,
+                Err(error) => return self.send_response::<()>(request, Err(error)),
+            },
+            DebugAdapterType::DapClient => match get_arguments(&request) {
+                Ok(arguments) => arguments,
+                Err(error) => return self.send_response::<()>(request, Err(error)),
+            },
+        };
+        let memory_offset = arguments.offset.unwrap_or(0);
+        let address: u32 = if let Ok(address) = parse::<i64>(arguments.memory_reference.as_ref()) {
+            match (address + memory_offset).try_into() {
+                    Ok(modified_address) => modified_address,
+                    Err(error) => return self.send_response::<()>(
+                    request,
+                    Err(DebuggerError::Other(anyhow!(
+                        "Could not convert memory_reference: {} and offset: {:?} into a 32-bit memory address: {:?}",
+                        arguments.memory_reference, arguments.offset, error
+                    ))),
+                ),
+                }
+        } else {
+            return self.send_response::<()>(
+                request,
+                Err(DebuggerError::Other(anyhow!(
+                    "Could not read any data at address {:?}",
+                    arguments.memory_reference
+                ))),
+            );
+        };
+        let data_bytes = match base64::decode(&arguments.data) {
+            Ok(decoded_bytes) => decoded_bytes,
+            Err(error) => {
+                return self.send_response::<()>(
+                    request,
+                    Err(DebuggerError::Other(anyhow!(
+                        "Could not decode base64 data:{:?} :  {:?}",
+                        arguments.data,
+                        error
+                    ))),
+                );
+            }
+        };
         match core_data
             .target_core
-            .write_word_32(address, data)
+            .write_8(address, &data_bytes)
             .map_err(DebuggerError::ProbeRs)
         {
-            Ok(_) => Ok(()),
+            Ok(_) => {
+                self.send_response(
+                    request,
+                    Ok(Some(WriteMemoryResponseBody {
+                        bytes_written: Some(data_bytes.len() as i64),
+                        offset: None,
+                    })),
+                )?;
+                // TODO: This doesn't trigger the UI to reload the variables effected. Investigate if we can force it in some other way, or if it is a known issue.
+                self.send_event(
+                    "memory",
+                    Some(MemoryEventBody {
+                        count: data_bytes.len() as i64,
+                        memory_reference: format!("{:#010x}", address),
+                        offset: 0,
+                    }),
+                )
+            }
             Err(error) => self.send_response::<()>(request, Err(error)),
         }
     }
+
+    /// Evaluates the given expression in the context of the top most stack frame.
+    /// The expression has access to any variables and arguments that are in scope.
+    /// TODO: When variables appear in the `watch` context, they will not resolve correctly after a 'step' function. Consider doing the lazy load for 'either/or' of Variables vs. Evaluate
+    pub(crate) fn evaluate(&mut self, core_data: &mut CoreData, request: Request) -> Result<()> {
+        let arguments: EvaluateArguments = match self.adapter_type() {
+            DebugAdapterType::CommandLine => todo!(),
+            // match request.arguments.as_ref().unwrap().try_into() {
+            //     Ok(arguments) => arguments,
+            //     Err(error) => return self.send_response::<()>(request, Err(error)),
+            // },
+            DebugAdapterType::DapClient => match get_arguments(&request) {
+                Ok(arguments) => arguments,
+                Err(error) => return self.send_response::<()>(request, Err(error)),
+            },
+        };
+
+        // Various fields in the response_body will be updated before we return.
+        let mut response_body = EvaluateResponseBody {
+            indexed_variables: None,
+            memory_reference: None,
+            named_variables: None,
+            presentation_hint: None,
+            result: format!("<variable not found {:?}>", arguments.expression),
+            type_: None,
+            variables_reference: 0_i64,
+        };
+
+        // The Variables request always returns a 'evaluate_name' = 'name', this means that the expression will always be the variable name we are looking for.
+        let expression = arguments.expression.clone();
+
+        // Make sure we have a valid StackFrame
+        if let Some(stack_frame) = match arguments.frame_id {
+            Some(frame_id) => core_data
+                .stack_frames
+                .iter_mut()
+                .find(|stack_frame| stack_frame.id == frame_id),
+            None => {
+                // Use the current frame_id
+                core_data.stack_frames.first_mut()
+            }
+        } {
+            // Always search the registers first, because we don't have a [VariableCache] for them.
+            if let Some((_register_number, register_value)) =
+                stack_frame.registers.registers().into_iter().find(
+                    |(register_number, _register_value)| {
+                        let register_number = **register_number;
+                        let register_name = stack_frame
+                            .registers
+                            .get_name_by_dwarf_register_number(register_number)
+                            .unwrap_or_else(|| format!("r{:#}", register_number));
+                        register_name == expression
+                    },
+                )
+            {
+                response_body.type_ = Some(format!("{}", VariableName::RegistersRoot));
+                response_body.result = format!("{:#010x}", register_value);
+            } else {
+                // If the expression wasn't pointing to a register, then check if is a local or static variable in our stack_frame
+                let mut variable: Option<probe_rs::debug::Variable> = None;
+                let mut variable_cache: Option<&mut VariableCache> = None;
+                // Search through available caches and stop as soon as the variable is found
+                #[allow(clippy::manual_flatten)]
+                for stack_frame_variable_cache in [
+                    stack_frame.local_variables.as_mut(),
+                    stack_frame.static_variables.as_mut(),
+                ] {
+                    if let Some(search_cache) = stack_frame_variable_cache {
+                        variable = search_cache
+                            .get_variable_by_name(&VariableName::Named(expression.clone()));
+                        if variable.is_some() {
+                            variable_cache = Some(search_cache);
+                            break;
+                        }
+                    }
+                }
+                // Check if we found a variable.
+                if let (Some(variable), Some(variable_cache)) = (variable, variable_cache) {
+                    let (
+                        variables_reference,
+                        named_child_variables_cnt,
+                        indexed_child_variables_cnt,
+                    ) = self.get_variable_reference(&variable, variable_cache);
+                    response_body.indexed_variables = Some(indexed_child_variables_cnt);
+                    response_body.memory_reference =
+                        Some(format!("{:#010x}", variable.memory_location));
+                    response_body.named_variables = Some(named_child_variables_cnt);
+                    response_body.result = variable.get_value(variable_cache);
+                    response_body.type_ = Some(variable.type_name.clone());
+                    response_body.variables_reference = variables_reference;
+                } else {
+                    // If we made it to here, no register or variable matched the expression.
+                }
+            }
+        }
+
+        self.send_response(request, Ok(Some(response_body)))
+    }
+
+    /// Set the variable with the given name in the variable container to a new value.
+    pub(crate) fn set_variable(
+        &mut self,
+        core_data: &mut CoreData,
+        request: Request,
+    ) -> Result<()> {
+        let arguments: SetVariableArguments = match self.adapter_type() {
+            DebugAdapterType::CommandLine => todo!(),
+            // match request.arguments.as_ref().unwrap().try_into() {
+            //     Ok(arguments) => arguments,
+            //     Err(error) => return self.send_response::<()>(request, Err(error)),
+            // },
+            DebugAdapterType::DapClient => match get_arguments(&request) {
+                Ok(arguments) => arguments,
+                Err(error) => return self.send_response::<()>(request, Err(error)),
+            },
+        };
+
+        // Various fields in the response_body will be updated before we return.
+        let mut response_body = SetVariableResponseBody {
+            indexed_variables: None,
+            named_variables: None,
+            type_: None,
+            value: String::new(),
+            variables_reference: None,
+        };
+
+        // The arguments.variables_reference contains the reference of the variable container. This can be ...
+        // - The `StackFrame.id` for register variables - we will warn the user that updating these are not yet supported.
+        // - The `Variable.parent_key` for a local or static variable - If these are base data types, we will attempt to update their value, otherwise we will warn the user that updating complex / structure variables are not yet supported.
+        let parent_key = arguments.variables_reference;
+        let new_value = arguments.value.clone();
+
+        match core_data
+            .stack_frames
+            .iter_mut()
+            .find(|stack_frame| stack_frame.id == parent_key)
+        {
+            Some(stack_frame) => {
+                // The variable is a register value in this StackFrame
+                if let Some((_register_number, _register_value)) =
+                    stack_frame.registers.registers().into_iter().find(
+                        |(register_number, _register_value)| {
+                            let register_number = **register_number;
+                            let register_name = stack_frame
+                                .registers
+                                .get_name_by_dwarf_register_number(register_number)
+                                .unwrap_or_else(|| format!("r{:#}", register_number));
+                            register_name == arguments.name
+                        },
+                    )
+                {
+                    // TODO: Does it make sense for us to consider implementing an update of platform registers?
+                    return self.send_response::<SetVariableResponseBody>(
+                        request,
+                        Err(DebuggerError::Other(anyhow!(
+                            "Set Register values is not yet supported."
+                        ))),
+                    );
+                }
+            }
+            None => {
+                let variable_name = VariableName::Named(arguments.name.clone());
+
+                // The parent_key refers to a local or static variable in one of the in-scope StackFrames.
+                let mut cache_variable: Option<probe_rs::debug::Variable> = None;
+                let mut variable_cache: Option<&mut VariableCache> = None;
+                for search_frame in core_data.stack_frames.iter_mut() {
+                    if let Some(search_cache) = &mut search_frame.local_variables {
+                        if let Some(search_variable) = search_cache
+                            .get_variable_by_name_and_parent(&variable_name, Some(parent_key))
+                        {
+                            cache_variable = Some(search_variable);
+                            variable_cache = Some(search_cache);
+                            break;
+                        }
+                    }
+                    if let Some(search_cache) = &mut search_frame.static_variables {
+                        if let Some(search_variable) = search_cache
+                            .get_variable_by_name_and_parent(&variable_name, Some(parent_key))
+                        {
+                            cache_variable = Some(search_variable);
+                            variable_cache = Some(search_cache);
+                            break;
+                        }
+                    }
+                }
+
+                if let (Some(cache_variable), Some(variable_cache)) =
+                    (cache_variable, variable_cache)
+                {
+                    // We have found the variable that needs to be updated.
+                    match cache_variable.update_value(
+                        &mut core_data.target_core,
+                        variable_cache,
+                        new_value.clone(),
+                    ) {
+                        Ok(updated_value) => {
+                            let (
+                                variables_reference,
+                                named_child_variables_cnt,
+                                indexed_child_variables_cnt,
+                            ) = self.get_variable_reference(&cache_variable, variable_cache);
+                            response_body.variables_reference = Some(variables_reference);
+                            response_body.named_variables = Some(named_child_variables_cnt);
+                            response_body.indexed_variables = Some(indexed_child_variables_cnt);
+                            response_body.type_ = Some(cache_variable.type_name);
+                            response_body.value = updated_value;
+                        }
+                        Err(error) => {
+                            return self.send_response::<SetVariableResponseBody>(
+                                request,
+                                Err(DebuggerError::Other(anyhow!(
+                                    "Failed to update variable: {}, with new value {:?} : {:?}",
+                                    cache_variable.name,
+                                    new_value,
+                                    error
+                                ))),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        if response_body.value.is_empty() {
+            // If we get here, it is a bug.
+            self.send_response::<SetVariableResponseBody>(
+                                request,
+                                Err(DebuggerError::Other(anyhow!(
+                                    "Failed to update variable: {}, with new value {:?} : Please report this as a bug.",
+                                    arguments.name,
+                                    arguments.value
+                                ))),
+                            )
+        } else {
+            self.send_response(request, Ok(Some(response_body)))
+        }
+    }
+
     pub(crate) fn set_breakpoint(
         &mut self,
         core_data: &mut CoreData,
@@ -872,7 +1196,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     .as_ref()
                     .and_then(|stack_frame| {
                         stack_frame
-                            .get_variable_by_name_and_parent(&VariableName::StaticScope, None)
+                            .get_variable_by_name_and_parent(&VariableName::StaticScopeRoot, None)
                     })
             {
                 dap_scopes.push(Scope {
@@ -910,7 +1234,8 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     .local_variables
                     .as_ref()
                     .and_then(|stack_frame| {
-                        stack_frame.get_variable_by_name_and_parent(&VariableName::LocalScope, None)
+                        stack_frame
+                            .get_variable_by_name_and_parent(&VariableName::LocalScopeRoot, None)
                     })
             {
                 dap_scopes.push(Scope {
@@ -1009,6 +1334,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                         break;
                     }
                 }
+
                 if stack_frame.id == arguments.variables_reference {
                     // This is a special case, where we just want to return the stack frame registers.
 
@@ -1025,13 +1351,18 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                             name: stack_frame
                                 .registers
                                 .get_name_by_dwarf_register_number(register_number)
-                                .unwrap_or_else(|| format!("r{}", register_number)),
-                            evaluate_name: None,
+                                .unwrap_or_else(|| format!("r{:#}", register_number)),
+                            evaluate_name: Some(
+                                stack_frame
+                                    .registers
+                                    .get_name_by_dwarf_register_number(register_number)
+                                    .unwrap_or_else(|| format!("r{:#}", register_number)),
+                            ),
                             memory_reference: None,
                             indexed_variables: None,
                             named_variables: None,
-                            presentation_hint: None,
-                            type_: Some("Platform Register".to_owned()),
+                            presentation_hint: None, // TODO: Implement hint as Hex for registers
+                            type_: Some(format!("{}", VariableName::RegistersRoot)),
                             value: format!("{:#010x}", register_value),
                             variables_reference: 0,
                         })
@@ -1090,7 +1421,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                         ) = self.get_variable_reference(variable, variable_cache);
                         Variable {
                             name: variable.name.to_string(),
-                            evaluate_name: None,
+                            evaluate_name: Some(variable.name.to_string()),
                             memory_reference: Some(format!("{:#010x}", variable.memory_location)),
                             indexed_variables: Some(indexed_child_variables_cnt),
                             named_variables: Some(named_child_variables_cnt),

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -426,7 +426,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             variables_reference: None,
         };
 
-        // The arguments.variables_reference contains the reference of the variable container. This can be ...
+        // The arguments.variables_reference contains the reference of the variable container. This can be:
         // - The `StackFrame.id` for register variables - we will warn the user that updating these are not yet supported.
         // - The `Variable.parent_key` for a local or static variable - If these are base data types, we will attempt to update their value, otherwise we will warn the user that updating complex / structure variables are not yet supported.
         let parent_key = arguments.variables_reference;

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -342,7 +342,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 core_data.stack_frames.first_mut()
             }
         } {
-            // Always search the registers first, because we don't have a [VariableCache] for them.
+            // Always search the registers first, because we don't have a VariableCache for them.
             if let Some((_register_number, register_value)) =
                 stack_frame.registers.registers().into_iter().find(
                     |(register_number, _register_value)| {

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -440,7 +440,7 @@ pub(crate) struct DebuggerRttChannel {
 }
 impl DebuggerRttChannel {
     /// Poll and retrieve data from the target, and send it to the client, depending on the state of `hasClientWindow`.
-    /// Doing this selectively ensures that we don't pull data from target buffers until we have a output window, and also helps us drain buffers after the target has entered a `is_halted` state.
+    /// Doing this selectively ensures that we don't pull data from target buffers until we have an output window, and also helps us drain buffers after the target has entered a `is_halted` state.
     /// Errors will be reported back to the `debug_adapter`, and the return `bool` value indicates whether there was available data that was processed.
     pub(crate) fn send_rtt_data<P: ProtocolAdapter>(
         &mut self,

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -412,7 +412,7 @@ impl DebugSession {
 pub(crate) struct DebuggerRttTarget {
     /// The connection to RTT on the target
     target_rtt: rtt::RttActiveTarget,
-    /// Some status fields and methods to ensure conitnuity in flow of data from target to debugger to client.
+    /// Some status fields and methods to ensure continuity in flow of data from target to debugger to client.
     debugger_rtt_channels: Vec<DebuggerRttChannel>,
 }
 

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -740,7 +740,7 @@ impl Debugger {
                 match debug_adapter.last_known_status {
                     CoreStatus::Unknown => Ok(DebuggerStatus::ContinueSession), // Don't do anything until we know VSCode's startup sequence is complete, and changes this to either Halted or Running.
                     CoreStatus::Halted(_) => {
-                        // Make sure the RTT buffers are drained
+                        // Make sure the RTT buffers are drained.
                         match session_data.attach_core(self.debugger_options.core_index) {
                             Ok(mut core_data) => {
                                 if let Some(rtt_active_target) = &mut core_data.active_rtt_target {

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -23,6 +23,7 @@ use serde::Deserialize;
 use std::cell::RefCell;
 use std::net::Ipv4Addr;
 use std::net::TcpListener;
+use std::ops::Mul;
 use std::rc::Rc;
 use std::{
     env::{current_dir, set_current_dir},
@@ -248,6 +249,8 @@ pub struct DebugSession {
     pub(crate) debug_infos: Vec<DebugInfo>,
     /// [DebugSession] will manage a `Vec<StackFrame>` per [Core]. Each core's collection of StackFrames will be recreated whenever a stacktrace is performed, using the results of [DebugInfo::unwind]
     pub(crate) stack_frames: Vec<Vec<probe_rs::debug::StackFrame>>,
+    /// The control structures for handling RTT in this Core of the DebugSession.
+    pub(crate) active_rtt_target: Option<DebuggerRttTarget>,
 }
 
 impl DebugSession {
@@ -373,6 +376,7 @@ impl DebugSession {
             capstone,
             debug_infos,
             stack_frames,
+            active_rtt_target: None,
         })
     }
 
@@ -395,10 +399,81 @@ impl DebugSession {
                         core_index
                     ))
                 })?,
+                active_rtt_target: &mut self.active_rtt_target,
             }),
             Err(_) => Err(DebuggerError::UnableToOpenProbe(Some(
                 "No core at the specified index.",
             ))),
+        }
+    }
+}
+
+/// Manage the active RTT target for a specific DebugSession, as well as provide methods to reliably move RTT from target, through the debug_adapter, to the client.
+pub(crate) struct DebuggerRttTarget {
+    /// The  connection to RTT on the target
+    target_rtt: rtt::RttActiveTarget,
+    /// Some status fields and methods to ensure conitnuity in flow of data from target to debugger to client.
+    debugger_rtt_channels: Vec<DebuggerRttChannel>,
+}
+
+impl DebuggerRttTarget {
+    pub fn process_rtt_data<P: ProtocolAdapter>(
+        &mut self,
+        debug_adapter: &mut DebugAdapter<P>,
+        target_core: &mut Core,
+    ) -> bool {
+        let mut at_least_one_channel_had_data = false;
+        for debugger_rtt_channel in self.debugger_rtt_channels.iter_mut() {
+            if debugger_rtt_channel.send_rtt_data(target_core, debug_adapter, &mut self.target_rtt)
+            {
+                at_least_one_channel_had_data = true;
+            }
+        }
+        at_least_one_channel_had_data
+    }
+}
+
+pub(crate) struct DebuggerRttChannel {
+    pub(crate) channel_number: usize,
+    // We will not poll target RTT channels until we have confirmation from the client that the output window has been opened.
+    pub(crate) has_client_window: bool,
+}
+impl DebuggerRttChannel {
+    /// Poll and retrieve data from the target, and send it to the client, depending on the state of `hasClientWindow`.
+    /// Doing this selectively ensures that we don't pull data from target buffers until we have a output window, and also helps us drain buffers after the target has entered a `is_halted` state.
+    /// Errors will be reported back to the `debug_adapter`, and the return `bool` value indicates whether there was available data that was processed.
+    pub(crate) fn send_rtt_data<P: ProtocolAdapter>(
+        &mut self,
+        core: &mut Core,
+        debug_adapter: &mut DebugAdapter<P>,
+        rtt_target: &mut rtt::RttActiveTarget,
+    ) -> bool {
+        if self.has_client_window {
+            rtt_target
+                .active_channels
+                .iter_mut()
+                .find(|active_channel| {
+                    if let Some(channel_number) = active_channel.number() {
+                        channel_number == self.channel_number
+                    } else {
+                        false
+                    }
+                })
+                .and_then(|rtt_channel| {
+                    rtt_channel.get_rtt_data(core, rtt_target.defmt_state.as_ref())
+                })
+                .and_then(|(channel_number, channel_data)| {
+                    if debug_adapter
+                        .rtt_output(channel_number.parse::<usize>().unwrap_or(0), channel_data)
+                    {
+                        Some(true)
+                    } else {
+                        None
+                    }
+                })
+                .is_some()
+        } else {
+            false
         }
     }
 }
@@ -411,6 +486,7 @@ pub struct CoreData<'p> {
     pub(crate) target_name: String,
     pub(crate) debug_info: &'p DebugInfo,
     pub(crate) stack_frames: &'p mut Vec<probe_rs::debug::StackFrame>,
+    pub(crate) active_rtt_target: &'p mut Option<DebuggerRttTarget>,
 }
 
 impl<'p> CoreData<'p> {
@@ -419,6 +495,48 @@ impl<'p> CoreData<'p> {
         self.stack_frames
             .iter()
             .find(|stack_frame| stack_frame.id == id)
+    }
+
+    pub fn attach_to_rtt<P: ProtocolAdapter>(
+        &mut self,
+        debug_adapter: &mut DebugAdapter<P>,
+        target_memory_map: &[probe_rs::config::MemoryRegion],
+        program_binary: &std::path::Path,
+        rtt_config: &rtt::RttConfig,
+    ) -> Result<()> {
+        let mut debugger_rtt_channels: Vec<DebuggerRttChannel> = vec![];
+        match rtt::attach_to_rtt(
+            &mut self.target_core,
+            target_memory_map,
+            // We can safely unwrap() program_binary here, because it is validated to exist at startup of the debugger
+            program_binary,
+            rtt_config,
+        ) {
+            Ok(target_rtt) => {
+                for any_channel in target_rtt.active_channels.iter() {
+                    if let Some(up_channel) = &any_channel.up_channel {
+                        debugger_rtt_channels.push(DebuggerRttChannel {
+                            channel_number: up_channel.number(),
+                            // This value will eventually be set to true by a VSCode client request "rtt_window_opened"
+                            has_client_window: false,
+                        });
+                        debug_adapter.rtt_window(
+                            up_channel.number(),
+                            any_channel.channel_name.clone(),
+                            any_channel.data_format,
+                        );
+                    }
+                }
+                *self.active_rtt_target = Some(DebuggerRttTarget {
+                    target_rtt,
+                    debugger_rtt_channels,
+                });
+            }
+            Err(_error) => {
+                log::warn!("Failed to initalize RTT. Will try again on the next request... ");
+            }
+        };
+        Ok(())
     }
 }
 
@@ -458,8 +576,6 @@ pub struct Debugger {
     debugger_options: DebuggerOptions,
     all_commands: Vec<DebugCommand>,
     pub supported_commands: Vec<DebugCommand>,
-    /// The optional connection to RTT on the target
-    target_rtt: Option<rtt::RttActiveTarget>,
 }
 
 impl Debugger {
@@ -491,10 +607,28 @@ impl Debugger {
                     function_name: "pause",
                 },
                 DebugCommand {
-                    dap_cmd: "read_memory",
-                    cli_cmd: "read",
-                    help_text: "Read 32bit value from memory",
+                    dap_cmd: "readMemory",
+                    cli_cmd: "", // TODO:
+                    help_text: "Read binary data from memory",
                     function_name: "read_memory",
+                },
+                DebugCommand {
+                    dap_cmd: "writeMemory",
+                    cli_cmd: "", // TODO:
+                    help_text: "Write binary data to memory",
+                    function_name: "write_memory",
+                },
+                DebugCommand {
+                    dap_cmd: "evaluate",
+                    cli_cmd: "", // TODO:
+                    help_text: "Evaluate the value of a given variable",
+                    function_name: "evaluate",
+                },
+                DebugCommand {
+                    dap_cmd: "setVariable",
+                    cli_cmd: "", // TODO:
+                    help_text: "Set a new value for a variable",
+                    function_name: "set_variable",
                 },
                 DebugCommand {
                     dap_cmd: "",
@@ -583,7 +717,6 @@ impl Debugger {
                 },
             ],
             supported_commands: vec![],
-            target_rtt: None,
         }
     }
 
@@ -607,35 +740,47 @@ impl Debugger {
                 match debug_adapter.last_known_status {
                     CoreStatus::Unknown => Ok(DebuggerStatus::ContinueSession), // Don't do anything until we know VSCode's startup sequence is complete, and changes this to either Halted or Running.
                     CoreStatus::Halted(_) => {
-                        // No need to poll the target if we know it is halted and waiting for us to do something.
+                        // Make sure the RTT buffers are drained
+                        match session_data.attach_core(self.debugger_options.core_index) {
+                            Ok(mut core_data) => {
+                                if let Some(rtt_active_target) = &mut core_data.active_rtt_target {
+                                    rtt_active_target.process_rtt_data(
+                                        debug_adapter,
+                                        &mut core_data.target_core,
+                                    );
+                                }
+                                core_data
+                            }
+                            Err(error) => {
+                                let _ = debug_adapter.send_error_response(&error)?;
+                                return Err(error);
+                            }
+                        };
+
+                        // No need to poll the target status if we know it is halted and waiting for us to do something.
                         thread::sleep(Duration::from_millis(50)); // Small delay to reduce fast looping costs on the client
                         Ok(DebuggerStatus::ContinueSession)
                     }
                     _other => {
-                        let mut core_data =
-                            match session_data.attach_core(self.debugger_options.core_index) {
-                                Ok(core_data) => core_data,
-                                Err(error) => {
-                                    let _ = debug_adapter.send_error_response(&error)?;
-                                    return Err(error);
-                                }
-                            };
-
-                        // Use every opportunity to poll the RTT channels for data
                         let mut received_rtt_data = false;
-                        if let Some(ref mut rtt_active_target) = self.target_rtt {
-                            let channel_data_stream =
-                                rtt_active_target.poll_rtt(&mut core_data.target_core);
-                            if !channel_data_stream.is_empty() {
-                                received_rtt_data = true;
-                                for (rtt_channel, rtt_data) in channel_data_stream {
-                                    debug_adapter.rtt_output(
-                                        rtt_channel.parse::<usize>().unwrap_or(0),
-                                        rtt_data,
+                        let mut core_data = match session_data
+                            .attach_core(self.debugger_options.core_index)
+                        {
+                            Ok(mut core_data) => {
+                                // Use every opportunity to poll the RTT channels for data
+                                if let Some(rtt_active_target) = &mut core_data.active_rtt_target {
+                                    received_rtt_data = rtt_active_target.process_rtt_data(
+                                        debug_adapter,
+                                        &mut core_data.target_core,
                                     );
                                 }
+                                core_data
                             }
-                        }
+                            Err(error) => {
+                                let _ = debug_adapter.send_error_response(&error)?;
+                                return Err(error);
+                            }
+                        };
 
                         // Check and update the core status.
                         let new_status = match core_data.target_core.status() {
@@ -704,6 +849,36 @@ impl Debugger {
                 }
             }
             Some(request) => match request.command.as_ref() {
+                "rtt_window_opened" => {
+                    if let Some(debugger_rtt_target) = &mut session_data.active_rtt_target {
+                        match get_arguments::<RttWindowOpenedArguments>(&request) {
+                            Ok(arguments) => {
+                                debugger_rtt_target
+                                    .debugger_rtt_channels
+                                    .iter_mut()
+                                    .find(|debugger_rtt_channel| {
+                                        debugger_rtt_channel.channel_number
+                                            == arguments.channel_number
+                                    })
+                                    .map_or(false, |rtt_channel| {
+                                        rtt_channel.has_client_window = arguments.window_is_open;
+                                        arguments.window_is_open
+                                    });
+                                debug_adapter.send_response::<()>(request, Ok(None))?;
+                            }
+                            Err(error) => {
+                                debug_adapter.send_response::<()>(
+                                    request,
+                                    Err(DebuggerError::Other(anyhow!(
+                                    "Could not deserialize arguments for RttWindowOpened : {:?}.",
+                                    error
+                                ))),
+                                )?;
+                            }
+                        }
+                    }
+                    Ok(DebuggerStatus::ContinueSession)
+                }
                 "disconnect" => {
                     debug_adapter.send_response::<()>(request, Ok(None))?;
                     Ok(DebuggerStatus::TerminateSession)
@@ -807,7 +982,12 @@ impl Debugger {
                                 "next" => debug_adapter.next(&mut core_data, request),
                                 "pause" => debug_adapter.pause(&mut core_data, request),
                                 "read_memory" => debug_adapter.read_memory(&mut core_data, request),
-                                "write" => debug_adapter.write(&mut core_data, request),
+                                "write_memory" => {
+                                    debug_adapter.write_memory(&mut core_data, request)
+                                }
+                                "set_variable" => {
+                                    debug_adapter.set_variable(&mut core_data, request)
+                                }
                                 "set_breakpoint" => {
                                     debug_adapter.set_breakpoint(&mut core_data, request)
                                 }
@@ -826,7 +1006,7 @@ impl Debugger {
                                 "threads" => debug_adapter.threads(&mut core_data, request),
                                 "restart" => {
                                     // Reset RTT so that the link can be re-established
-                                    self.target_rtt = None;
+                                    *core_data.active_rtt_target = None;
                                     debug_adapter.restart(&mut core_data, Some(request))
                                 }
                                 "set_breakpoints" => {
@@ -837,6 +1017,7 @@ impl Debugger {
                                 "source" => debug_adapter.source(&mut core_data, request),
                                 "variables" => debug_adapter.variables(&mut core_data, request),
                                 "continue" => debug_adapter.r#continue(&mut core_data, request),
+                                "evaluate" => debug_adapter.evaluate(&mut core_data, request),
                                 other => {
                                     debug_adapter.send_response::<()>(
                                     request,
@@ -927,6 +1108,7 @@ impl Debugger {
                 .collect()
         };
 
+        // Reset some fields ....
         // The DapClient startup process has a specific sequence.
         // Handle it here before starting a probe-rs session and looping through user generated requests.
         match debug_adapter.adapter_type() {
@@ -1001,10 +1183,13 @@ impl Debugger {
                 // Reply to Initialize with `Capabilities`.
                 let capabilities = Capabilities {
                     supports_configuration_done_request: Some(true),
-                    supports_read_memory_request: Some(true),
                     supports_restart_request: Some(true),
                     supports_terminate_request: Some(true),
                     supports_delayed_stack_trace_loading: Some(true),
+                    supports_read_memory_request: Some(true),
+                    supports_write_memory_request: Some(true),
+                    supports_set_variable: Some(true),
+                    supports_clipboard_context: Some(true),
                     // supports_value_formatting_options: Some(true),
                     // supports_function_breakpoints: Some(true),
                     // TODO: Use DEMCR register to implement exception breakpoints
@@ -1245,125 +1430,169 @@ impl Debugger {
                                 fill_size_done: 0,
                             }));
 
-                            let flash_progress =
-                                if let Some(id) = progress_id {
-                                    FlashProgress::new(move |event| {
-                                        let mut flash_progress = flash_progress.borrow_mut();
-                                        let mut debug_adapter = rc_debug_adapter_clone.borrow_mut();
-                                        match event {
-                                probe_rs::flashing::ProgressEvent::Initialized { flash_layout } => {
-                                    flash_progress.total_page_size = flash_layout
-                                        .pages()
-                                        .iter()
-                                        .map(|s| s.size() as usize)
-                                        .sum();
+                            let flash_progress = if let Some(id) = progress_id {
+                                FlashProgress::new(move |event| {
+                                    let mut flash_progress = flash_progress.borrow_mut();
+                                    let mut debug_adapter = rc_debug_adapter_clone.borrow_mut();
+                                    match event {
+                                        probe_rs::flashing::ProgressEvent::Initialized {
+                                            flash_layout,
+                                        } => {
+                                            flash_progress.total_page_size = flash_layout
+                                                .pages()
+                                                .iter()
+                                                .map(|s| s.size() as usize)
+                                                .sum();
 
-                                    flash_progress.total_sector_size = flash_layout
-                                        .sectors()
-                                        .iter()
-                                        .map(|s| s.size() as usize)
-                                        .sum();
+                                            flash_progress.total_sector_size = flash_layout
+                                                .sectors()
+                                                .iter()
+                                                .map(|s| s.size() as usize)
+                                                .sum();
 
-                                    flash_progress.total_fill_size = flash_layout
-                                        .fills()
-                                        .iter()
-                                        .map(|s| s.size() as usize)
-                                        .sum();
-                                }
-                                probe_rs::flashing::ProgressEvent::StartedFilling => {
-                                    debug_adapter
-                                        .update_progress(0.0, Some("Reading Old Pages ..."), id)
-                                        .ok();
-                                }
-                                probe_rs::flashing::ProgressEvent::PageFilled { size, .. } => {
-                                    flash_progress.fill_size_done += size as usize;
-                                    let progress = flash_progress.fill_size_done as f64
-                                        / flash_progress.total_fill_size as f64;
-                                    debug_adapter
-                                        .update_progress(
-                                            progress,
-                                            Some(format!("Reading Old Pages ({})", progress)),
-                                            id,
-                                        )
-                                        .ok();
-                                }
-                                probe_rs::flashing::ProgressEvent::FailedFilling => {
-                                    debug_adapter
-                                        .update_progress(1.0, Some("Reading Old Pages Failed!"), id)
-                                        .ok();
-                                }
-                                probe_rs::flashing::ProgressEvent::FinishedFilling => {
-                                    debug_adapter
-                                        .update_progress(
-                                            1.0,
-                                            Some("Reading Old Pages Complete!"),
-                                            id,
-                                        )
-                                        .ok();
-                                }
-                                probe_rs::flashing::ProgressEvent::StartedErasing => {
-                                    debug_adapter
-                                        .update_progress(0.0, Some("Erasing Sectors ..."), id)
-                                        .ok();
-                                }
-                                probe_rs::flashing::ProgressEvent::SectorErased {
-                                    size, ..
-                                } => {
-                                    flash_progress.sector_size_done += size as usize;
-                                    let progress = flash_progress.sector_size_done as f64
-                                        / flash_progress.total_sector_size as f64;
-                                    debug_adapter
-                                        .update_progress(
-                                            progress,
-                                            Some(format!("Erasing Sectors ({})", progress)),
-                                            id,
-                                        )
-                                        .ok();
-                                }
-                                probe_rs::flashing::ProgressEvent::FailedErasing => {
-                                    debug_adapter
-                                        .update_progress(1.0, Some("Erasing Sectors Failed!"), id)
-                                        .ok();
-                                }
-                                probe_rs::flashing::ProgressEvent::FinishedErasing => {
-                                    debug_adapter
-                                        .update_progress(1.0, Some("Erasing Sectors Complete!"), id)
-                                        .ok();
-                                }
-                                probe_rs::flashing::ProgressEvent::StartedProgramming => {
-                                    debug_adapter
-                                        .update_progress(0.0, Some("Programming Pages ..."), id)
-                                        .ok();
-                                }
-                                probe_rs::flashing::ProgressEvent::PageProgrammed {
-                                    size, ..
-                                } => {
-                                    flash_progress.page_size_done += size as usize;
-                                    let progress = flash_progress.page_size_done as f64
-                                        / flash_progress.total_page_size as f64;
-                                    debug_adapter
-                                        .update_progress(
-                                            progress,
-                                            Some(format!("Programming Pages ({})", progress)),
-                                            id,
-                                        )
-                                        .ok();
-                                }
-                                probe_rs::flashing::ProgressEvent::FailedProgramming => {
-                                    debug_adapter
-                                        .update_progress(1.0, Some("Flashing Pages Failed!"), id)
-                                        .ok();
-                                }
-                                probe_rs::flashing::ProgressEvent::FinishedProgramming => {
-                                    debug_adapter
-                                        .update_progress(1.0, Some("Flashing Pages Complete!"), id)
-                                        .ok();
-                                }
-                            }
-                                    })
-                                } else {
-                                    FlashProgress::new(|_event| {})
-                                };
+                                            flash_progress.total_fill_size = flash_layout
+                                                .fills()
+                                                .iter()
+                                                .map(|s| s.size() as usize)
+                                                .sum();
+                                        }
+                                        probe_rs::flashing::ProgressEvent::StartedFilling => {
+                                            debug_adapter
+                                                .update_progress(
+                                                    0.0,
+                                                    Some("Reading Old Pages ..."),
+                                                    id,
+                                                )
+                                                .ok();
+                                        }
+                                        probe_rs::flashing::ProgressEvent::PageFilled {
+                                            size,
+                                            ..
+                                        } => {
+                                            flash_progress.fill_size_done += size as usize;
+                                            let progress = flash_progress.fill_size_done as f64
+                                                / flash_progress.total_fill_size as f64;
+                                            debug_adapter
+                                                .update_progress(
+                                                    progress,
+                                                    Some(format!(
+                                                        "Reading Old Pages ({})",
+                                                        progress
+                                                    )),
+                                                    id,
+                                                )
+                                                .ok();
+                                        }
+                                        probe_rs::flashing::ProgressEvent::FailedFilling => {
+                                            debug_adapter
+                                                .update_progress(
+                                                    1.0,
+                                                    Some("Reading Old Pages Failed!"),
+                                                    id,
+                                                )
+                                                .ok();
+                                        }
+                                        probe_rs::flashing::ProgressEvent::FinishedFilling => {
+                                            debug_adapter
+                                                .update_progress(
+                                                    1.0,
+                                                    Some("Reading Old Pages Complete!"),
+                                                    id,
+                                                )
+                                                .ok();
+                                        }
+                                        probe_rs::flashing::ProgressEvent::StartedErasing => {
+                                            debug_adapter
+                                                .update_progress(
+                                                    0.0,
+                                                    Some("Erasing Sectors ..."),
+                                                    id,
+                                                )
+                                                .ok();
+                                        }
+                                        probe_rs::flashing::ProgressEvent::SectorErased {
+                                            size,
+                                            ..
+                                        } => {
+                                            flash_progress.sector_size_done += size as usize;
+                                            let progress = flash_progress.sector_size_done as f64
+                                                / flash_progress.total_sector_size as f64;
+                                            debug_adapter
+                                                .update_progress(
+                                                    progress,
+                                                    Some(format!("Erasing Sectors ({})", progress)),
+                                                    id,
+                                                )
+                                                .ok();
+                                        }
+                                        probe_rs::flashing::ProgressEvent::FailedErasing => {
+                                            debug_adapter
+                                                .update_progress(
+                                                    1.0,
+                                                    Some("Erasing Sectors Failed!"),
+                                                    id,
+                                                )
+                                                .ok();
+                                        }
+                                        probe_rs::flashing::ProgressEvent::FinishedErasing => {
+                                            debug_adapter
+                                                .update_progress(
+                                                    1.0,
+                                                    Some("Erasing Sectors Complete!"),
+                                                    id,
+                                                )
+                                                .ok();
+                                        }
+                                        probe_rs::flashing::ProgressEvent::StartedProgramming => {
+                                            debug_adapter
+                                                .update_progress(
+                                                    0.0,
+                                                    Some("Programming Pages ..."),
+                                                    id,
+                                                )
+                                                .ok();
+                                        }
+                                        probe_rs::flashing::ProgressEvent::PageProgrammed {
+                                            size,
+                                            ..
+                                        } => {
+                                            flash_progress.page_size_done += size as usize;
+                                            let progress = flash_progress.page_size_done as f64
+                                                / flash_progress.total_page_size as f64;
+                                            debug_adapter
+                                                .update_progress(
+                                                    progress,
+                                                    Some(format!(
+                                                        "Programming Pages ({:02.0}%)",
+                                                        progress.mul(100_f64)
+                                                    )),
+                                                    id,
+                                                )
+                                                .ok();
+                                        }
+                                        probe_rs::flashing::ProgressEvent::FailedProgramming => {
+                                            debug_adapter
+                                                .update_progress(
+                                                    1.0,
+                                                    Some("Flashing Pages Failed!"),
+                                                    id,
+                                                )
+                                                .ok();
+                                        }
+                                        probe_rs::flashing::ProgressEvent::FinishedProgramming => {
+                                            debug_adapter
+                                                .update_progress(
+                                                    1.0,
+                                                    Some("Flashing Pages Complete!"),
+                                                    id,
+                                                )
+                                                .ok();
+                                        }
+                                    }
+                                })
+                            } else {
+                                FlashProgress::new(|_event| {})
+                            };
                             download_options.progress = Some(&flash_progress);
                             download_file_with_options(
                                 &mut session_data.session,
@@ -1461,7 +1690,7 @@ impl Debugger {
                     // Validate and if necessary, initialize the RTT structure.
                     if debug_adapter.adapter_type() == DebugAdapterType::DapClient
                         && self.debugger_options.rtt.enabled
-                        && self.target_rtt.is_none()
+                        && session_data.active_rtt_target.is_none()
                         && !(debug_adapter.last_known_status == CoreStatus::Unknown
                             || debug_adapter.last_known_status.is_halted())
                     // Do not attempt this until we have processed the MSDAP request for "configuration_done" ...
@@ -1477,35 +1706,15 @@ impl Debugger {
                             };
                         log::info!("Attempting to initialize the RTT.");
                         // RTT can only be initialized if the target application has been allowed to run to the point where it does the RTT initialization.
-                        // If the target halts before it processes this code, then this RTT intialization silently fail, and try again later ...
+                        // If the target halts before it processes this code, then this RTT intialization silently fails, and will try again later ...
                         // See `probe-rs-rtt::Rtt` for more information.
-                        self.target_rtt = match rtt::attach_to_rtt(
-                            &mut core_data.target_core,
+                        core_data.attach_to_rtt(
+                            &mut debug_adapter,
                             &target_memory_map,
                             // We can safely unwrap() program_binary here, because it is validated to exist at startup of the debugger
                             self.debugger_options.program_binary.as_ref().unwrap(),
                             &self.debugger_options.rtt,
-                        ) {
-                            Ok(target_rtt) => {
-                                for any_channel in target_rtt.active_channels.iter() {
-                                    if let Some(up_channel) = &any_channel.up_channel {
-                                        debug_adapter.rtt_window(
-                                            up_channel.number(),
-                                            any_channel.channel_name.clone(),
-                                            any_channel.data_format,
-                                        );
-                                    }
-                                }
-
-                                Some(target_rtt)
-                            }
-                            Err(_error) => {
-                                log::warn!(
-                                    "Failed to initalize RTT. Will try again on the next request... "
-                                );
-                                None
-                            }
-                        }
+                        )?;
                     }
                 }
                 Ok(DebuggerStatus::TerminateSession) => {

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -410,7 +410,7 @@ impl DebugSession {
 
 /// Manage the active RTT target for a specific DebugSession, as well as provide methods to reliably move RTT from target, through the debug_adapter, to the client.
 pub(crate) struct DebuggerRttTarget {
-    /// The  connection to RTT on the target
+    /// The connection to RTT on the target
     target_rtt: rtt::RttActiveTarget,
     /// Some status fields and methods to ensure conitnuity in flow of data from target to debugger to client.
     debugger_rtt_channels: Vec<DebuggerRttChannel>,

--- a/probe-rs-cli-util/src/rtt.rs
+++ b/probe-rs-cli-util/src/rtt.rs
@@ -198,6 +198,78 @@ impl RttActiveChannel {
         None
     }
 
+    /// Retrieves available data from the channel and if available, returns Some(channel_number:String, formatted_data:String)
+    pub fn get_rtt_data(
+        &mut self,
+        core: &mut Core,
+        defmt_state: Option<&(defmt_decoder::Table, Option<defmt_decoder::Locations>)>,
+    ) -> Option<(String, String)> {
+        self
+            .poll_rtt(core)
+            .map(|bytes_read| {
+                (
+                    self.number().unwrap_or(0).to_string(), // If the Channel doesn't have a number, then send the output to channel 0
+                    {
+                        let mut formatted_data = String::new();
+                        match self.data_format {
+                            DataFormat::String => {
+                                let incoming = String::from_utf8_lossy(&self.rtt_buffer.0[..bytes_read]).to_string();
+                                for (_i, line) in incoming.split_terminator('\n').enumerate() {
+                                    if self.show_timestamps {
+                                        write!(formatted_data, "{} :", Local::now())
+                                            .map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
+                                    }
+                                    writeln!(formatted_data, "{}", line).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
+                                }
+                            }
+                            DataFormat::BinaryLE => {
+                                for element in &self.rtt_buffer.0[..bytes_read] {
+                                    // Width of 4 allows 0xFF to be printed.
+                                    write!(formatted_data, "{:#04x}", element).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
+                                }
+                            }
+                            DataFormat::Defmt => {
+                                match defmt_state {
+                                    Some((table, locs)) => {
+
+                                        let mut stream_decoder = table.new_stream_decoder();
+                                        stream_decoder.received(&self.rtt_buffer.0[..bytes_read]);
+                                        while let Ok(frame) = stream_decoder.decode()
+                                        {
+                                            // NOTE(`[]` indexing) all indices in `table` have already been
+                                            // verified to exist in the `locs` map.
+                                            let loc = locs.as_ref().map(|locs| &locs[&frame.index()]);
+                                            writeln!(formatted_data, "{}", frame.display(false)).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
+                                            if let Some(loc) = loc {
+                                                let relpath = if let Ok(relpath) =
+                                                    loc.file.strip_prefix(&std::env::current_dir().unwrap())
+                                                {
+                                                    relpath
+                                                } else {
+                                                    // not relative; use full path
+                                                    &loc.file
+                                                };
+                                                writeln!(formatted_data,
+                                                    "└─ {}:{}",
+                                                    relpath.display(),
+                                                    loc.line
+                                                ).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
+                                            }
+                                        }
+                                    }
+                                    None => {
+                                        write!(formatted_data, "Running rtt in defmt mode but table or locations could not be loaded.")
+                                            .map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
+                                    }
+                                }
+                            }
+                        };
+                        formatted_data
+                    }
+                )
+            })
+    }
+
     pub fn _push_rtt(&mut self, core: &mut Core) {
         if let Some(down_channel) = self.down_channel.as_mut() {
             self._input_data += "\n";
@@ -213,7 +285,7 @@ impl RttActiveChannel {
 #[derive(Debug)]
 pub struct RttActiveTarget {
     pub active_channels: Vec<RttActiveChannel>,
-    defmt_state: Option<(defmt_decoder::Table, Option<defmt_decoder::Locations>)>,
+    pub defmt_state: Option<(defmt_decoder::Table, Option<defmt_decoder::Locations>)>,
 }
 
 impl RttActiveTarget {
@@ -313,77 +385,12 @@ impl RttActiveTarget {
         None
     }
 
-    /// Polls the RTT target for new data on all channels.
+    /// Polls the RTT target for on all channels and returns available data.
     pub fn poll_rtt(&mut self, core: &mut Core) -> HashMap<String, String> {
         let defmt_state = self.defmt_state.as_ref();
         self.active_channels
             .iter_mut()
-            .filter_map(|active_channel| {
-                 active_channel
-                    .poll_rtt(core)
-                    .map(|bytes_read| {
-                        (
-                            active_channel.number().unwrap_or(0).to_string(), // If the Channel doesn't have a number, then send the output to channel 0
-                            {
-                                let mut formatted_data = String::new();
-                                match active_channel.data_format {
-                                    DataFormat::String => {
-                                        let incoming = String::from_utf8_lossy(&active_channel.rtt_buffer.0[..bytes_read]).to_string();
-                                        for (_i, line) in incoming.split_terminator('\n').enumerate() {
-                                            if active_channel.show_timestamps {
-                                                write!(formatted_data, "{} :", Local::now())
-                                                    .map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
-                                            }
-                                            writeln!(formatted_data, "{}", line).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
-                                        }
-                                    }
-                                    DataFormat::BinaryLE => {
-                                        for element in &active_channel.rtt_buffer.0[..bytes_read] {
-                                            // Width of 4 allows 0xFF to be printed.
-                                            write!(formatted_data, "{:#04x}", element).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
-                                        }
-                                    }
-                                    DataFormat::Defmt => {
-                                        match defmt_state {
-                                            Some((table, locs)) => {
-
-                                                let mut stream_decoder = table.new_stream_decoder();
-                                                stream_decoder.received(&active_channel.rtt_buffer.0[..bytes_read]);
-                                                while let Ok(frame) = stream_decoder.decode()
-                                                {
-                                                    // NOTE(`[]` indexing) all indices in `table` have already been
-                                                    // verified to exist in the `locs` map.
-                                                    let loc = locs.as_ref().map(|locs| &locs[&frame.index()]);
-                                                    writeln!(formatted_data, "{}", frame.display(false)).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
-                                                    if let Some(loc) = loc {
-                                                        let relpath = if let Ok(relpath) =
-                                                            loc.file.strip_prefix(&std::env::current_dir().unwrap())
-                                                        {
-                                                            relpath
-                                                        } else {
-                                                            // not relative; use full path
-                                                            &loc.file
-                                                        };
-                                                        writeln!(formatted_data,
-                                                            "└─ {}:{}",
-                                                            relpath.display(),
-                                                            loc.line
-                                                        ).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
-                                                    }
-                                                }
-                                            }
-                                            None => {
-                                                write!(formatted_data, "Running rtt in defmt mode but table or locations could not be loaded.")
-                                                    .map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
-                                            }
-                                        }
-                                    }
-                                };
-                                formatted_data
-                            }
-                        )
-                    })
-            })
+            .filter_map(|active_channel| active_channel.get_rtt_data(core, defmt_state))
             .collect::<HashMap<_, _>>()
     }
 

--- a/probe-rs-cli-util/src/rtt.rs
+++ b/probe-rs-cli-util/src/rtt.rs
@@ -198,7 +198,7 @@ impl RttActiveChannel {
         None
     }
 
-    /// Retrieves available data from the channel and if available, returns Some(channel_number:String, formatted_data:String)
+    /// Retrieves available data from the channel and if available, returns `Some(channel_number:String, formatted_data:String)`.
     pub fn get_rtt_data(
         &mut self,
         core: &mut Core,

--- a/probe-rs-cli-util/src/rtt.rs
+++ b/probe-rs-cli-util/src/rtt.rs
@@ -385,7 +385,7 @@ impl RttActiveTarget {
         None
     }
 
-    /// Polls the RTT target for on all channels and returns available data.
+    /// Polls the RTT target on all channels and returns available data.
     pub fn poll_rtt(&mut self, core: &mut Core) -> HashMap<String, String> {
         let defmt_state = self.defmt_state.as_ref();
         self.active_channels

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -481,7 +481,7 @@ impl DebugInfo {
                 Some(unit_node.entry().offset()),
             );
             static_root_variable.variable_node_type = VariableNodeType::DirectLookup;
-            static_root_variable.name = VariableName::StaticScope;
+            static_root_variable.name = VariableName::StaticScopeRoot;
             static_variable_cache.cache_variable(None, static_root_variable, core)?;
         }
         Ok(static_variable_cache)
@@ -508,7 +508,7 @@ impl DebugInfo {
             Some(function_node.entry().offset()),
         );
         function_root_variable.variable_node_type = VariableNodeType::DirectLookup;
-        function_root_variable.name = VariableName::LocalScope;
+        function_root_variable.name = VariableName::LocalScopeRoot;
         function_variable_cache.cache_variable(None, function_root_variable, core)?;
         Ok(function_variable_cache)
     }

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -477,7 +477,7 @@ impl Variable {
         } else {
             String::new()
         };
-        let updated_value = if self.is_valid()
+        let updated_value = if !self.is_valid()
                 // Need a valid type
                 || self.type_name.is_empty()
                 // Need a valid memory location

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -894,7 +894,7 @@ trait Value {
     where
         Self: Sized;
 
-    /// This update_value will update the target memory with a new value for the [Variable], ...
+    /// This `update_value` will update the target memory with a new value for the [`Variable`], ...
     /// - Only `base` data type can have their value updated in target memory.
     /// - The input format of the [Variable.value] is a [String], and the impl of this trait must convert the memory value appropriately before storing.
     fn update_value(

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -3,6 +3,7 @@ use crate::Error;
 use anyhow::anyhow;
 use gimli::{DebugInfoOffset, UnitOffset};
 use num_traits::Zero;
+use std::str::FromStr;
 
 /// VariableCache stores available `Variable`s, and provides methods to create and navigate the parent-child relationships of the Variables.
 #[derive(Debug)]
@@ -142,6 +143,30 @@ impl VariableCache {
             child_count => {
                 log::error!("Found {} variables with parent_key={:?} and name={}. Please report this as a bug.", child_count, parent_key, variable_name);
                 child_variables.last().cloned()
+            }
+        }
+    }
+
+    /// Retrieve a clone of a specific `Variable`, using the `name`.
+    /// If there is more than one, it will be logged (log::warn!), and only the first will be returned.
+    /// It is possible for a hierarchy of variables in a cache to have duplicate names under different parents.
+    pub fn get_variable_by_name(&self, variable_name: &VariableName) -> Option<Variable> {
+        let child_variables = self
+            .variable_hash_map
+            .values()
+            .filter(|child_variable| &child_variable.name == variable_name)
+            .cloned()
+            .collect::<Vec<Variable>>();
+        match child_variables.len() {
+            0 => None,
+            1 => child_variables.first().cloned(),
+            child_count => {
+                log::warn!(
+                    "Found {} variables with name={}. Please report this as a bug.",
+                    child_count,
+                    variable_name
+                );
+                child_variables.first().cloned()
             }
         }
     }
@@ -288,11 +313,11 @@ impl VariableValue {
 #[derive(Debug, PartialEq, Clone)]
 pub enum VariableName {
     /// Top-level variable for static variables, child of a stack frame variable, and holds all the static scoped variables which are directly visible to the compile unit of the frame.
-    StaticScope,
+    StaticScopeRoot,
     /// Top-level variable for registers, child of a stack frame variable.
-    Registers,
+    RegistersRoot,
     /// Top-level variable for local scoped variables, child of a stack frame variable.
-    LocalScope,
+    LocalScopeRoot,
     /// Artificial variable, without a name (e.g. enum discriminant)
     Artifical,
     /// Anonymous namespace
@@ -314,9 +339,9 @@ impl Default for VariableName {
 impl std::fmt::Display for VariableName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            VariableName::StaticScope => write!(f, "<static_scope>"),
-            VariableName::Registers => write!(f, "<registers>"),
-            VariableName::LocalScope => write!(f, "<local_scope>"),
+            VariableName::StaticScopeRoot => write!(f, "Static Variable"),
+            VariableName::RegistersRoot => write!(f, "Platform Register"),
+            VariableName::LocalScopeRoot => write!(f, "Function Variable"),
             VariableName::Artifical => write!(f, "<artifical>"),
             VariableName::AnonymousNamespace => write!(f, "<anonymous_namespace>"),
             VariableName::Namespace(name) => name.fmt(f),
@@ -436,6 +461,104 @@ impl Variable {
         } else {
             // Concatenate the error messages ...
             self.value = VariableValue::Error(format!("{} : {}", self.value, new_value));
+        }
+    }
+
+    /// Call the underlaying [Value::update_value] trait to convert the [String] value into the appropriate memory format and update the target memory with the new value.
+    pub fn update_value(
+        &self,
+        core: &mut Core,
+        variable_cache: &mut VariableCache,
+        new_value: String,
+    ) -> Result<String, DebugError> {
+        // For now, we will restrict this functionality to base data types only. There is no provision in the MS DAP API to catch this client side, so we can only respond with a 'gentle' error message if the user attemtps this.
+        let is_base_type = match variable_cache.has_children(self) {
+            Ok(has_children) => {
+                if has_children {
+                    false
+                } else {
+                    // Deferred variable types are also not base data types.
+                    !self.variable_node_type.is_deferred()
+                }
+            }
+            Err(error) => {
+                return Err(anyhow!(
+                    "Could not verify that this is a base data type `Variable`:{}. {:?}",
+                    self.name,
+                    error
+                )
+                .into());
+            }
+        };
+
+        if is_base_type {
+            let variable_name = if let VariableName::Named(variable_name) = &self.name {
+                variable_name.clone()
+            } else {
+                String::new()
+            };
+            let updated_value = if self.is_valid()
+                // Need a valid type
+                || self.type_name.is_empty()
+                // Need a valid memory location
+                || self.memory_location.is_zero()
+            {
+                // Insufficient data available.
+                return Err(anyhow!(
+                "Cannot update variable: {:?}, with supplied information (value={:?}, type={}, memory location={:#010x}).",
+                self.name, self.value, self.type_name, self.memory_location).into());
+            } else if variable_name.starts_with('*') {
+                // Writing the values of pointers is a bit more complex, and not currently supported.
+                return  Err(anyhow!("Please only update variables with a base data type. Updating pointer variable types is not yet supported.").into());
+            } else {
+                // We have everything we need to update the variable value.
+                match match self.type_name.as_str() {
+                    "bool" => bool::update_value(self, core, new_value.as_str()),
+                    "char" => char::update_value(self, core, new_value.as_str()),
+                    "i8" => i8::update_value(self, core, new_value.as_str()),
+                    "i16" => i16::update_value(self, core, new_value.as_str()),
+                    "i32" => i32::update_value(self, core, new_value.as_str()),
+                    "i64" => i64::update_value(self, core, new_value.as_str()),
+                    "i128" => i128::update_value(self, core, new_value.as_str()),
+                    "isize" => isize::update_value(self, core, new_value.as_str()),
+                    "u8" => u8::update_value(self, core, new_value.as_str()),
+                    "u16" => u16::update_value(self, core, new_value.as_str()),
+                    "u32" => u32::update_value(self, core, new_value.as_str()),
+                    "u64" => u64::update_value(self, core, new_value.as_str()),
+                    "u128" => u128::update_value(self, core, new_value.as_str()),
+                    "usize" => usize::update_value(self, core, new_value.as_str()),
+                    "f32" => f32::update_value(self, core, new_value.as_str()),
+                    "f64" => f64::update_value(self, core, new_value.as_str()),
+                    other => Err(DebugError::Other(anyhow::anyhow!(
+                        "Unsupported datatype: {}",
+                        other.to_string()
+                    ))),
+                } {
+                    Ok(()) => {
+                        // Now update the cache with the new value for this variable.
+                        let mut cache_variable = self.clone();
+                        cache_variable.value = VariableValue::Valid(new_value.clone());
+                        variable_cache.cache_variable(
+                            cache_variable.parent_key,
+                            cache_variable,
+                            core,
+                        )?;
+                        new_value
+                    }
+                    Err(error) => {
+                        return Err(DebugError::Other(anyhow::anyhow!(
+                            "Invalid data value={:?}: {}",
+                            new_value,
+                            error
+                        )));
+                    }
+                }
+            };
+            Ok(updated_value)
+        } else {
+            Err(
+                anyhow!("Please only update variables with a base data type. Updating complex/structured variable types is not yet supported.").into(),
+            )
         }
     }
 
@@ -760,9 +883,9 @@ impl Variable {
     }
 }
 
-/// Traits and Impl's to read from memory and decode the Variable value based on Variable::typ and Variable::location.
-/// The MS DAP protocol passes the value as a string, so these are here only to provide the memory read logic before returning it as a string.
+/// Traits and Impl's to read from, and write to, memory value based on Variable::typ and Variable::location.
 trait Value {
+    /// The MS DAP protocol passes the value as a string, so this trait is here to provide the memory read logic before returning it as a string.
     fn get_value(
         variable: &Variable,
         core: &mut Core<'_>,
@@ -770,6 +893,15 @@ trait Value {
     ) -> Result<Self, DebugError>
     where
         Self: Sized;
+
+    /// This update_value will update the target memory with a new value for the [Variable], ...
+    /// - Only `base` data type can have their value updated in target memory.
+    /// - The input format of the [Variable.value] is a [String], and the impl of this trait must convert the memory value appropriately before storing.
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError>;
 }
 
 impl Value for bool {
@@ -781,6 +913,24 @@ impl Value for bool {
         let mem_data = core.read_word_8(variable.memory_location as u32)?;
         let ret_value: bool = mem_data != 0;
         Ok(ret_value)
+    }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        core.write_word_8(
+            variable.memory_location as u32,
+            <bool as FromStr>::from_str(new_value).map_err(|error| {
+                DebugError::Other(anyhow::anyhow!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value,
+                    error
+                ))
+            })? as u8,
+        )
+        .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
     }
 }
 impl Value for char {
@@ -796,8 +946,25 @@ impl Value for char {
             Ok('?')
         }
     }
-}
 
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        core.write_word_32(
+            variable.memory_location as u32,
+            <char as FromStr>::from_str(new_value).map_err(|error| {
+                DebugError::Other(anyhow::anyhow!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value,
+                    error
+                ))
+            })? as u32,
+        )
+        .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
+    }
+}
 impl Value for String {
     fn get_value(
         variable: &Variable,
@@ -863,6 +1030,14 @@ impl Value for String {
         };
         Ok(str_value)
     }
+
+    fn update_value(
+        _variable: &Variable,
+        _core: &mut Core<'_>,
+        _new_value: &str,
+    ) -> Result<(), DebugError> {
+        unimplemented!()
+    }
 }
 impl Value for i8 {
     fn get_value(
@@ -874,6 +1049,24 @@ impl Value for i8 {
         core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = i8::from_le_bytes(buff);
         Ok(ret_value)
+    }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        core.write_word_8(
+            variable.memory_location as u32,
+            <i8 as FromStr>::from_str(new_value).map_err(|error| {
+                DebugError::Other(anyhow::anyhow!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value,
+                    error
+                ))
+            })? as u8,
+        )
+        .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
     }
 }
 impl Value for i16 {
@@ -887,6 +1080,22 @@ impl Value for i16 {
         let ret_value = i16::from_le_bytes(buff);
         Ok(ret_value)
     }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        let buff = i16::to_le_bytes(<i16 as FromStr>::from_str(new_value).map_err(|error| {
+            DebugError::Other(anyhow::anyhow!(
+                "Invalid data conversion from value: {:?}. {:?}",
+                new_value,
+                error
+            ))
+        })?);
+        core.write_8(variable.memory_location as u32, &buff)
+            .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
+    }
 }
 impl Value for i32 {
     fn get_value(
@@ -898,6 +1107,22 @@ impl Value for i32 {
         core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = i32::from_le_bytes(buff);
         Ok(ret_value)
+    }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        let buff = i32::to_le_bytes(<i32 as FromStr>::from_str(new_value).map_err(|error| {
+            DebugError::Other(anyhow::anyhow!(
+                "Invalid data conversion from value: {:?}. {:?}",
+                new_value,
+                error
+            ))
+        })?);
+        core.write_8(variable.memory_location as u32, &buff)
+            .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
     }
 }
 impl Value for i64 {
@@ -911,6 +1136,22 @@ impl Value for i64 {
         let ret_value = i64::from_le_bytes(buff);
         Ok(ret_value)
     }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        let buff = i64::to_le_bytes(<i64 as FromStr>::from_str(new_value).map_err(|error| {
+            DebugError::Other(anyhow::anyhow!(
+                "Invalid data conversion from value: {:?}. {:?}",
+                new_value,
+                error
+            ))
+        })?);
+        core.write_8(variable.memory_location as u32, &buff)
+            .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
+    }
 }
 impl Value for i128 {
     fn get_value(
@@ -922,6 +1163,22 @@ impl Value for i128 {
         core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = i128::from_le_bytes(buff);
         Ok(ret_value)
+    }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        let buff = i128::to_le_bytes(<i128 as FromStr>::from_str(new_value).map_err(|error| {
+            DebugError::Other(anyhow::anyhow!(
+                "Invalid data conversion from value: {:?}. {:?}",
+                new_value,
+                error
+            ))
+        })?);
+        core.write_8(variable.memory_location as u32, &buff)
+            .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
     }
 }
 impl Value for isize {
@@ -936,8 +1193,24 @@ impl Value for isize {
         let ret_value = i32::from_le_bytes(buff);
         Ok(ret_value as isize)
     }
-}
 
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        let buff =
+            isize::to_le_bytes(<isize as FromStr>::from_str(new_value).map_err(|error| {
+                DebugError::Other(anyhow::anyhow!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value,
+                    error
+                ))
+            })?);
+        core.write_8(variable.memory_location as u32, &buff)
+            .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
+    }
+}
 impl Value for u8 {
     fn get_value(
         variable: &Variable,
@@ -948,6 +1221,24 @@ impl Value for u8 {
         core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = u8::from_le_bytes(buff);
         Ok(ret_value)
+    }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        core.write_word_8(
+            variable.memory_location as u32,
+            <u8 as FromStr>::from_str(new_value).map_err(|error| {
+                DebugError::Other(anyhow::anyhow!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value,
+                    error
+                ))
+            })? as u8,
+        )
+        .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
     }
 }
 impl Value for u16 {
@@ -961,6 +1252,22 @@ impl Value for u16 {
         let ret_value = u16::from_le_bytes(buff);
         Ok(ret_value)
     }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        let buff = u16::to_le_bytes(<u16 as FromStr>::from_str(new_value).map_err(|error| {
+            DebugError::Other(anyhow::anyhow!(
+                "Invalid data conversion from value: {:?}. {:?}",
+                new_value,
+                error
+            ))
+        })?);
+        core.write_8(variable.memory_location as u32, &buff)
+            .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
+    }
 }
 impl Value for u32 {
     fn get_value(
@@ -972,6 +1279,22 @@ impl Value for u32 {
         core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = u32::from_le_bytes(buff);
         Ok(ret_value)
+    }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        let buff = u32::to_le_bytes(<u32 as FromStr>::from_str(new_value).map_err(|error| {
+            DebugError::Other(anyhow::anyhow!(
+                "Invalid data conversion from value: {:?}. {:?}",
+                new_value,
+                error
+            ))
+        })?);
+        core.write_8(variable.memory_location as u32, &buff)
+            .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
     }
 }
 impl Value for u64 {
@@ -985,6 +1308,22 @@ impl Value for u64 {
         let ret_value = u64::from_le_bytes(buff);
         Ok(ret_value)
     }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        let buff = u64::to_le_bytes(<u64 as FromStr>::from_str(new_value).map_err(|error| {
+            DebugError::Other(anyhow::anyhow!(
+                "Invalid data conversion from value: {:?}. {:?}",
+                new_value,
+                error
+            ))
+        })?);
+        core.write_8(variable.memory_location as u32, &buff)
+            .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
+    }
 }
 impl Value for u128 {
     fn get_value(
@@ -996,6 +1335,22 @@ impl Value for u128 {
         core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = u128::from_le_bytes(buff);
         Ok(ret_value)
+    }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        let buff = u128::to_le_bytes(<u128 as FromStr>::from_str(new_value).map_err(|error| {
+            DebugError::Other(anyhow::anyhow!(
+                "Invalid data conversion from value: {:?}. {:?}",
+                new_value,
+                error
+            ))
+        })?);
+        core.write_8(variable.memory_location as u32, &buff)
+            .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
     }
 }
 impl Value for usize {
@@ -1010,6 +1365,23 @@ impl Value for usize {
         let ret_value = u32::from_le_bytes(buff);
         Ok(ret_value as usize)
     }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        let buff =
+            usize::to_le_bytes(<usize as FromStr>::from_str(new_value).map_err(|error| {
+                DebugError::Other(anyhow::anyhow!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value,
+                    error
+                ))
+            })?);
+        core.write_8(variable.memory_location as u32, &buff)
+            .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
+    }
 }
 impl Value for f32 {
     fn get_value(
@@ -1022,6 +1394,22 @@ impl Value for f32 {
         let ret_value = f32::from_le_bytes(buff);
         Ok(ret_value)
     }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        let buff = f32::to_le_bytes(<f32 as FromStr>::from_str(new_value).map_err(|error| {
+            DebugError::Other(anyhow::anyhow!(
+                "Invalid data conversion from value: {:?}. {:?}",
+                new_value,
+                error
+            ))
+        })?);
+        core.write_8(variable.memory_location as u32, &buff)
+            .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
+    }
 }
 impl Value for f64 {
     fn get_value(
@@ -1033,5 +1421,21 @@ impl Value for f64 {
         core.read(variable.memory_location as u32, &mut buff)?;
         let ret_value = f64::from_le_bytes(buff);
         Ok(ret_value)
+    }
+
+    fn update_value(
+        variable: &Variable,
+        core: &mut Core<'_>,
+        new_value: &str,
+    ) -> Result<(), DebugError> {
+        let buff = f64::to_le_bytes(<f64 as FromStr>::from_str(new_value).map_err(|error| {
+            DebugError::Other(anyhow::anyhow!(
+                "Invalid data conversion from value: {:?}. {:?}",
+                new_value,
+                error
+            ))
+        })?);
+        core.write_8(variable.memory_location as u32, &buff)
+            .map_err(|error| DebugError::Other(anyhow::anyhow!("{:?}", error)))
     }
 }

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -895,7 +895,7 @@ trait Value {
         Self: Sized;
 
     /// This `update_value` will update the target memory with a new value for the [`Variable`], ...
-    /// - Only `base` data type can have their value updated in target memory.
+    /// - Only `base` data types can have their value updated in target memory.
     /// - The input format of the [Variable.value] is a [String], and the impl of this trait must convert the memory value appropriately before storing.
     fn update_value(
         variable: &Variable,

--- a/probe-rs/targets/STM32H7_Series.yaml
+++ b/probe-rs/targets/STM32H7_Series.yaml
@@ -3113,7 +3113,7 @@ variants:
   - name: STM32H745BGTx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3161,7 +3161,7 @@ variants:
   - name: STM32H745BITx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3209,7 +3209,7 @@ variants:
   - name: STM32H745IGKx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3257,7 +3257,7 @@ variants:
   - name: STM32H745IGTx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3305,7 +3305,7 @@ variants:
   - name: STM32H745IIKx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3353,7 +3353,7 @@ variants:
   - name: STM32H745IITx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3401,7 +3401,7 @@ variants:
   - name: STM32H745XGHx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3449,7 +3449,7 @@ variants:
   - name: STM32H745XIHx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3497,7 +3497,7 @@ variants:
   - name: STM32H745ZGTx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3545,7 +3545,7 @@ variants:
   - name: STM32H745ZITx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3593,7 +3593,7 @@ variants:
   - name: STM32H747AGIx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3641,7 +3641,7 @@ variants:
   - name: STM32H747AIIx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3689,7 +3689,7 @@ variants:
   - name: STM32H747BGTx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3737,7 +3737,7 @@ variants:
   - name: STM32H747BITx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3785,7 +3785,7 @@ variants:
   - name: STM32H747IGTx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3833,7 +3833,7 @@ variants:
   - name: STM32H747IITx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3881,7 +3881,7 @@ variants:
   - name: STM32H747XGHx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3929,7 +3929,7 @@ variants:
   - name: STM32H747XIHx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -3977,7 +3977,7 @@ variants:
   - name: STM32H747ZIYx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -4571,7 +4571,7 @@ variants:
   - name: STM32H755BITx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -4619,7 +4619,7 @@ variants:
   - name: STM32H755IIKx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -4667,7 +4667,7 @@ variants:
   - name: STM32H755IITx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -4715,7 +4715,7 @@ variants:
   - name: STM32H755XIHx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -4763,7 +4763,7 @@ variants:
   - name: STM32H755ZITx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -4811,7 +4811,7 @@ variants:
   - name: STM32H757AIIx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -4859,7 +4859,7 @@ variants:
   - name: STM32H757BITx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -4907,7 +4907,7 @@ variants:
   - name: STM32H757IITx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -4955,7 +4955,7 @@ variants:
   - name: STM32H757XIHx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:
@@ -5003,7 +5003,7 @@ variants:
   - name: STM32H757ZIYx
     part: ~
     cores:
-      - name: cm7
+      - name: main
         type: armv7em
         core_access_options:
           Arm:


### PR DESCRIPTION
There are three linked PR's that depend on each other:
- [probe-rs/probe-rs](https://github.com/probe-rs/probe-rs/pull/1035)
  -  When RTT is enabled, it waits for a custom request from VSCode to confirm that the output window is opened, before it starts polling the target for RTT data. This is to ensure that target RTT data is not sent into the 'void' before the VSCode output window has completed opening.
  - Implements the debug adapter capabilities to support new requests from VSCode, i.e. `ReadMemory`, `WriteMemory`, `Evaluate` and `SetVariable`
- [probe-rs/vscode](https://github.com/probe-rs/vscode/pull/29)
  -  The VSCode debug extension changes to implement the RTT interactions described above.
  - A WIP release is available for testing at [probe-rs-debugger-0.3.5.vsix](https://github.com/probe-rs/vscode/releases/download/v0.3.5/probe-rs-debugger-0.3.5.vsix)
  - Update the MS DAP specification and other dependencies.
- [probe-rs/webpage](https://github.com/probe-rs/webpage/pull/43)
  - Document (with visual tour) the new features described above, in the `docs/tools/vscode/` section of the guide.
