### PR TITLE
probe-rs-debugger: Add support for stepping at statement level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debugger: Add support LocLists (attribute value of DW_AT_location) (#1025)
 - Debugger: Add support for DAP Requests (ReadMemory, WriteMemory, Evaluate & SetVariable) (#1035)
 - Debugger: Add support for DAP Requests (Disassemble & SetInstructionBreakpoints) (#1049)
-- Debugger: Add support for stepping at 'statement' level, plus 'step in' and 'step out' (# )
+- Debugger: Add support for stepping at 'statement' level, plus 'step in', 'step out' (#1056)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debugger: Add support LocLists (attribute value of DW_AT_location) (#1025)
 - Debugger: Add support for DAP Requests (ReadMemory, WriteMemory, Evaluate & SetVariable) (#1035)
 - Debugger: Add support for DAP Requests (Disassemble & SetInstructionBreakpoints) (#1049)
+- Debugger: Add support for stepping at 'statement' level, plus 'step in' and 'step out' (# )
 
 ### Changed
 

--- a/debugger/src/debug_adapter.rs
+++ b/debugger/src/debug_adapter.rs
@@ -981,13 +981,16 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     // When we have less than 20 frames - use the RHS of of the split at `start_frame`
                     core_data.stack_frames.split_at(start_frame as usize).1
                 } else if total_frames > 20 && start_frame + levels <= total_frames {
-                    // When we have more than 20 frames - we can safely split twice
+                    // When we have more than 20 frames - we can safely split twice.
                     core_data
                         .stack_frames
                         .split_at(start_frame as usize)
                         .1
                         .split_at(levels as usize)
                         .0
+                } else if total_frames > 20 && start_frame + levels > total_frames {
+                    // The MS DAP spec may also ask for more frames than what we reported.
+                    core_data.stack_frames.split_at(start_frame as usize).1
                 } else {
                     return self.send_response::<()>(
                         request,

--- a/debugger/src/debugger.rs
+++ b/debugger/src/debugger.rs
@@ -903,6 +903,12 @@ impl Debugger {
                     "next" => debug_adapter
                         .next(&mut core_data, request)
                         .and(Ok(DebuggerStatus::ContinueSession)),
+                    "stepIn" => debug_adapter
+                        .step_in(&mut core_data, request)
+                        .and(Ok(DebuggerStatus::ContinueSession)),
+                    "stepOut" => debug_adapter
+                        .step_out(&mut core_data, request)
+                        .and(Ok(DebuggerStatus::ContinueSession)),
                     "pause" => debug_adapter
                         .pause(&mut core_data, request)
                         .and(Ok(DebuggerStatus::ContinueSession)),
@@ -1065,6 +1071,7 @@ impl Debugger {
             supports_clipboard_context: Some(true),
             supports_disassemble_request: Some(true),
             supports_instruction_breakpoints: Some(true),
+            supports_stepping_granularity: Some(true),
             // supports_value_formatting_options: Some(true),
             // supports_function_breakpoints: Some(true),
             // TODO: Use DEMCR register to implement exception breakpoints

--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -35,8 +35,6 @@ pub enum DebuggerError {
     MissingSession,
     #[error(transparent)]
     Other(#[from] anyhow::Error),
-    // #[error("Error in interaction with probe")]
-    // ProbeError(#[from] probe_rs::Error),
     #[error(transparent)]
     ProbeRs(#[from] Error),
     #[error("Serialiazation error")]

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -559,9 +559,7 @@ impl DebugInfo {
     /// This function uses [`gimli::read::CompleteLineProgram`] functionality to calculate valid addresses where we can request a halt.
     /// Validity of halt locations are defined as target instructions that live between the end of the prologue, and the start of the end sequence of a [`gimli::read::LineRow`].
     ///
-    /// To populate a [`ValidHaltLocations`] struct for a given location.
-    /// - If `source_location` is supplied in the arguments, it will use path/file/line/row as the location selector.
-    /// - Otherwise, `program_counter` must be supplied as the location selector.
+    /// To populate a [`ValidHaltLocations`] struct for a given program_counter.
     fn get_valid_halt_locations(
         &self,
         program_counter: u64,


### PR DESCRIPTION
`probe-rs-debugger` now supports stepping at statement level. This includes the ability to 'Step Over', 'Step In', 'Step Out' and 'Run to Cursor'. 

### Some implementation notes: 
- In statement stepping mode, we only step to **'valid' addresses**, i.e. target instructions which are NOT inside a function prologue or epilogue.
- If there is insufficient debug information available to determine a 'valid' target instruction, then the user will be notified and can choose an alternate action.
- Once a target instruction is identified, the debugger will:
  - Temporarily borrow a hardware breakpoint to run to that address.
  - If no hardware breakpoints are available, the debugger will step at instruction level, in a loop,  until it reaches the target instruction.
    - I am not convinced we should allow this last option. If the target instructions are redirected by a hardware interrupt, the debugger may never reach the end of the loop.
- If the user has a VSCode 'Disassembly View' open, then VSCode will automatically use instruction level stepping in all requests, and the 'step over', 'step in', etc. will only step a single instruction and ignore statement level behaviour.

### Additional changes to setting of breakpoints
- The debugger will now use the **'valid' addresses** approach to identifying breakpoint locations requested for a specific source location.
- The debugger will use the requested file/line/column to identify the closest 'valid' statement to step to. 
  - If this location is different from the requested file/line/column, it will notify the DAP client/VSCode of the actual verified position of the breakpoint.
  - If no 'valid' location can be identified, it will notify the user that the breakpoint could not be set as requested.
- In addition to source level breakpoints, the VSCode 'Disassembly View` will allow the setting of breakpoints at ANY target address, and will also allow stepping through instructions which may be outside the definition of 'valid' addresses.