### PR TITLE
Support STM32L4P5CETx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for STM32L4P5CETx (#1061)
 - Added an option to disable use of double-buffering when downloading flash (#1030, #883)
 - rtt::ChannelMode implements additional traits: Clone, Copy, serde's Serialize and Deserialize
 - Added a permissions system that allows the user to specify if a full chip erase is allowed (#918)

--- a/probe-rs/targets/STM32L4_Series.yaml
+++ b/probe-rs/targets/STM32L4_Series.yaml
@@ -4531,6 +4531,35 @@ variants:
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
       - mx25lm51245g_stm32l4p5-disco
+  - name: STM32L4P5CETx
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0x0
+            psel: 0x0
+    memory_map:
+      - Ram:
+          range:
+            start: 0x20000000
+            end: 0x20050000
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          range:
+            start: 0x8000000
+            end: 0x8070000
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - mx25lm51245g_stm32l4p5-disco
   - name: STM32L4P5CGTx
     cores:
       - name: main
@@ -4543,7 +4572,7 @@ variants:
       - Ram:
           range:
             start: 0x20000000
-            end: 0x20020000
+            end: 0x20050000
           is_boot_memory: false
           cores:
             - main


### PR DESCRIPTION
This is a naive attempt to add support for the `STM32L4P5CETx`, the brother to the `STM32L4P5CGTx`.

The only relevant difference I've been able to find between the two is that the `CETx` now has 512KB of RAM, rather than 1MB.

I also take the opportunity to fix the RAM mapping of the `CGTx`. Again, let me know if there's a specific reason why it is at `0x20020000`.

I submit this because I'm trying to use `cargo embed` on the `CETx`, but hitting the error below still after having made the changes I'm pushing here. I'm totally able to run a dummy executable on it, but when I go to a bigger executable, it crashes like this. So I first want to get some feedback on those potential changes before investigating other avenues as the source of this problem.

Thanks for your time and your review.

```
       DEBUG probe_rs_cli_util > Running '/home/yellowcar/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo' in directory /home/yellowcar/code/validating-lightning-signer/embedded
    Finished dev [optimized + debuginfo] target(s) in 0.07s
warning: unused import: `cortex_m_semihosting::hprintln`
  --> src/tests.rs:11:5
   |
11 | use cortex_m_semihosting::hprintln;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
help: consider adding a `#[cfg(test)]` to the containing module
  --> src/main.rs:7:1
   |
7  | mod tests;
   | ^^^^^^^^^^

warning: unused import: `hprintln`
 --> src/entry.rs:8:35
  |
8 | use cortex_m_semihosting::{debug, hprintln};
  |                                   ^^^^^^^^

warning: 2 warnings emitted

      Config default
      Target /home/yellowcar/code/validating-lightning-signer/embedded/target/thumbv7em-none-eabihf/debug/embedded
       DEBUG probe_rs::probe::cmsisdap::tools > Searching for CMSIS-DAP probes using libusb
       DEBUG probe_rs::probe::cmsisdap::tools > Found 0 CMSIS-DAP probes using libusb, searching HID
       DEBUG probe_rs::probe::cmsisdap::tools > Found 0 CMSIS-DAP probes total
       DEBUG jaylink                          > libusb 1.0.24.11584
       DEBUG jaylink                          > libusb has capability API: true
       DEBUG jaylink                          > libusb has HID access: true
       DEBUG jaylink                          > libusb has hotplug support: true
       DEBUG jaylink                          > libusb can detach kernel driver: true
       TRACE probe_rs::probe::cmsisdap::tools > Attempting to open device matching 0483:3748:55C3BF6A06C283C288575533430967
       TRACE probe_rs::probe::cmsisdap::tools > Trying device Bus 002 Device 001: ID 1d6b:0003
       TRACE probe_rs::probe::cmsisdap::tools > Error opening: Access
       TRACE probe_rs::probe::cmsisdap::tools > Trying device Bus 001 Device 003: ID 0408:5365
       TRACE probe_rs::probe::cmsisdap::tools > Error opening: Access
       TRACE probe_rs::probe::cmsisdap::tools > Trying device Bus 001 Device 002: ID 0bda:b00c
       TRACE probe_rs::probe::cmsisdap::tools > Error opening: Access
       TRACE probe_rs::probe::cmsisdap::tools > Trying device Bus 001 Device 008: ID 0483:3748
       TRACE probe_rs::probe::cmsisdap::tools > Trying device Bus 001 Device 004: ID 0461:4e22
       TRACE probe_rs::probe::cmsisdap::tools > Error opening: Access
       TRACE probe_rs::probe::cmsisdap::tools > Trying device Bus 001 Device 001: ID 1d6b:0002
       TRACE probe_rs::probe::cmsisdap::tools > Error opening: Access
       DEBUG probe_rs::probe::cmsisdap::tools > Attempting to open 0483:3748 in CMSIS-DAP v1 mode
       DEBUG probe_rs::probe::stlink::usb_interface > Acquired libusb context.
       DEBUG probe_rs::probe::stlink::usb_interface > Aquired handle for probe
       DEBUG probe_rs::probe::stlink::usb_interface > Active config descriptor: ConfigDescriptor { bLength: 9, bDescriptorType: 2, wTotalLength: 39, bNumInterfaces: 1, bConfigurationValue: 1, iConfiguration: 0, bmAttributes: 128, bMaxPower: 50, extra: [] }
       DEBUG probe_rs::probe::stlink::usb_interface > Device descriptor: DeviceDescriptor { bLength: 18, bDescriptorType: 1, bcdUSB: 512, bDeviceClass: 0, bDeviceSubClass: 0, bDeviceProtocol: 0, bMaxPacketSize: 64, idVendor: 1155, idProduct: 14152, bcdDevice: 256, iManufacturer: 1, iProduct: 2, iSerialNumber: 3, bNumConfigurations: 1 }
       DEBUG probe_rs::probe::stlink::usb_interface > Claimed interface 0 of USB device.
       DEBUG probe_rs::probe::stlink::usb_interface > Succesfully attached to STLink.
       DEBUG probe_rs::probe::stlink                > Initializing STLink...
       TRACE probe_rs::probe::stlink                > Getting current mode of device...
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f5] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 2 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                > Current device mode: Jtag
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f1] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 6 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                > STLink version: (2, 37)
        INFO cargo_embed                            > Protocol speed 1800 kHz
       DEBUG probe_rs::config::registry             > Searching registry for chip with name STM32L4P5CETx
       DEBUG probe_rs::config::registry             > Exact match for chip name: STM32L4P5CETx
       DEBUG probe_rs::probe::stlink                > attach(Swd)
       TRACE probe_rs::probe::stlink                > Getting current mode of device...
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f5] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 2 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                > Current device mode: Jtag
       DEBUG probe_rs::probe::stlink                > Switching protocol to SWD
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f7] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 8 bytes, 0 bytes remaining
        INFO probe_rs::probe::stlink                > Target voltage (VAPP): 3.24 V
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 30, a3, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 2 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                > Successfully initialized SWD.
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 43, 1] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 2 bytes, 0 bytes remaining
       DEBUG probe_rs::architecture::arm::ap        > Reading register IDR
       DEBUG probe_rs::probe::stlink                > Opening AP 0
       TRACE probe_rs::probe::stlink                > JTAG_INIT_AP 0
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 4b, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 2 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 45, 0, 0, fc, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 8 bytes, 0 bytes remaining
       DEBUG probe_rs::architecture::arm::ap        > Read register    IDR, value=0x24770011
       DEBUG probe_rs::architecture::arm::ap        > Reading register IDR
       DEBUG probe_rs::probe::stlink                > Opening AP 1
       TRACE probe_rs::probe::stlink                > JTAG_INIT_AP 1
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 4b, 1] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 2 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 45, 1, 0, fc, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 8 bytes, 0 bytes remaining
       DEBUG probe_rs::architecture::arm::ap        > Read register    IDR, value=0x0
       DEBUG probe_rs::architecture::arm::ap        > Reading register IDR
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 45, 0, 0, fc, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 8 bytes, 0 bytes remaining
       DEBUG probe_rs::architecture::arm::ap        > Read register    IDR, value=0x24770011
       DEBUG probe_rs::architecture::arm::ap        > Reading register BASE
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 45, 0, 0, f8, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 8 bytes, 0 bytes remaining
       DEBUG probe_rs::architecture::arm::ap        > Read register    BASE, value=0xe00ff003
       DEBUG probe_rs::architecture::arm::ap        > Reading register BASE2
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 45, 0, 0, f0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 8 bytes, 0 bytes remaining
       DEBUG probe_rs::architecture::arm::ap        > Read register    BASE2, value=0x0
       DEBUG probe_rs::architecture::arm::ap        > Reading register CSW
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 45, 0, 0, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 8 bytes, 0 bytes remaining
       DEBUG probe_rs::architecture::arm::ap        > Read register    CSW, value=0x23000052
       DEBUG probe_rs::architecture::arm::ap        > Writing register CSW, value=CSW { DbgSwEnable: 1, HNONSEC: 1, PROT: 6, CACHE: 3, SPIDEN: 0, _RES0: 0, MTE: 0, Type: 0, Mode: 0, TrinProg: 0, DeviceEn: 0, AddrInc: Single, _RES1: 0, SIZE: U8 }
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 46, 0, 0, 0, 0, 10, 0, 0, e3] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 2 bytes, 0 bytes remaining
       DEBUG probe_rs::architecture::arm::ap        > Reading register CSW
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 45, 0, 0, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 8 bytes, 0 bytes remaining
       DEBUG probe_rs::architecture::arm::ap        > Read register    CSW, value=0x23000050
       DEBUG probe_rs::architecture::arm::ap        > Writing register CSW, value=CSW { DbgSwEnable: 0, HNONSEC: 0, PROT: 2, CACHE: 3, SPIDEN: 0, _RES0: 0, MTE: 0, Type: 0, Mode: 0, TrinProg: 0, DeviceEn: 1, AddrInc: Single, _RES1: 0, SIZE: U32 }
       TRACE probe_rs::probe::stlink::usb_interface > Sending command [f2, 46, 0, 0, 0, 0, 52, 0, 0, 23] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface > Read 2 bytes, 0 bytes remaining
       DEBUG probe_rs::architecture::arm::communication_interface > HNONSEC supported: false
       DEBUG probe_rs::probe::stlink                              > AP ApAddress {
    dp: Default,
    ap: 0x0,
}: MemoryAp(MemoryApInformation { address: ApAddress { dp: Default, ap: 0 }, only_32bit_data_size: false, debug_base_address: 3759140864, supports_hnonsec: false })
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e000edf0, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, f0, ed, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::architecture::arm::sequences               > Core is already in debug mode, no need to enable it again
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e000edf0, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, f0, ed, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e000ed30, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 30, ed, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::architecture::arm::core::armv7m            > Core was halted when connecting, reason: Unknown
       TRACE probe_rs::probe::stlink                              > write_mem_32bit
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 8, 30, ed, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Wrote 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > USB write done!
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e0002000, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 0, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e0002000, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 0, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e0002008, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 8, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e0002000, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 0, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e000200c, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, c, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e0002000, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 0, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e0002010, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 10, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e0002000, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 0, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e0002014, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 14, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e0002000, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 0, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e0002018, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 18, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e0002000, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 0, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       DEBUG probe_rs::probe::stlink                              > Read mem 32 bit, address=e000201c, length=4
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 7, 1c, 20, 0, e0, 4, 0, 0] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 4 bytes, 0 bytes remaining
       TRACE probe_rs::probe::stlink::usb_interface               > Sending command [f2, 3e] to STLink, timeout: 1s
       TRACE probe_rs::probe::stlink::usb_interface               > Read 12 bytes, 0 bytes remaining
       Error failed to flash /home/yellowcar/code/validating-lightning-signer/embedded/target/thumbv7em-none-eabihf/debug/embedded
             
             Caused by:
                 0: Error while flashing
                 1: The execution of 'program_page' failed with code 1. This might indicate a problem with the flash algorithm.
```