### PR TITLE
Fixed missing `derive` feature in Clap examples, migrated from structopt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated STM32H7 series yaml to support newly released chips. (#1011)
 - Debugger: Removed the CLI mode, in favour of `probe-rs-cli` which has richer functionality. (#1041)
 - Renamed `Probe::speed` to `Probe::speed_khz`.
+- `ram_download` example now uses clap syntax.
 
 ### Fixed
 
@@ -60,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Support the new `defmt` 0.3 `DEFMT_LOG` environment variable.
   - Requires `probe-rs/vscode` [PR #27](https://github.com/probe-rs/vscode/pull/27)
   - Debugger: Improved RTT reliability between debug adapter and VSCode (#1035)
+  - Fixed missing `derive` feature for examples using `clap`.
 
 ## [0.12.0]
 

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -84,5 +84,5 @@ rand = "0.8.0"
 reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 serde_json = "1.0.47"
 serde = "1.0.118"
-clap = "3.0"
+clap = { version = "3.0", features = ["derive"] }
 itm-decode = { version = "0.6.1", default-features = false }

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -8,17 +8,17 @@ use rand::prelude::*;
 
 use anyhow::{anyhow, Context, Result};
 
-#[derive(clap::StructOpt)]
+#[derive(clap::Parser)]
 struct Cli {
-    #[structopt(long = "chip")]
+    #[clap(long = "chip")]
     chip: Option<String>,
-    #[structopt(long = "address", parse(try_from_str = parse_hex))]
+    #[clap(long = "address", parse(try_from_str = parse_hex))]
     address: u32,
-    #[structopt(long = "size")]
+    #[clap(long = "size")]
     size: usize,
-    #[structopt(long = "speed")]
+    #[clap(long = "speed")]
     speed: Option<u32>,
-    #[structopt(long = "protocol")]
+    #[clap(long = "protocol")]
     protocol: Option<String>,
 }
 


### PR DESCRIPTION
Clap requires the `derive` feature: https://github.com/clap-rs/clap/blob/v3.1.8/examples/demo.md