### PR TITLE
Increase SWD wait timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Requires `probe-rs/vscode` [PR #27](https://github.com/probe-rs/vscode/pull/27)
   - Debugger: Improved RTT reliability between debug adapter and VSCode (#1035)
   - Fixed missing `derive` feature for examples using `clap`.
+  - Increase SWD wait timeout (#994)
 
 ## [0.12.0]
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -440,7 +440,7 @@ impl DebugProbe for CmsisDap {
 
         self.transfer_configure(ConfigureRequest {
             idle_cycles: 0,
-            wait_retry: 80,
+            wait_retry: 0xffff,
             match_retry: 0,
         })?;
 


### PR DESCRIPTION
We currently send to the probe that it should retry when it receives a WAIT response for 80 times. But this doesn't seem to be enough, so I've increased it to the maximum of 0xFFFF.

This should fix #994 and possibly #1058. Both issues should be checked by the original issue reporter.