### PR TITLE
Update STM32L4_Series.yaml from Keil.STM32L4xx_DFP.2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `Probe::speed` to `Probe::speed_khz`.
 - Debugger: Changes to DAP Client `launch.json` to prepare for WIP multi-core support. (#1072)
 - `ram_download` example now uses clap syntax.
+- Update STM32L4 series yaml from Keil.STM32L4xx_DFP.2.5.0. (#1086)
 
 ### Fixed
 

--- a/probe-rs/targets/STM32L4_Series.yaml
+++ b/probe-rs/targets/STM32L4_Series.yaml
@@ -1,57 +1,30 @@
+---
 name: STM32L4 Series
+manufacturer: ~
 variants:
-  - name: Flash
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x200a0000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8200000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4rx_2048
-      - stm32l4rx_2048_dual
-      - stm32l4rx_sb_opt
-      - stm32l4rx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
   - name: STM32L412C8Tx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8010000
+            start: 134217728
+            end: 134283264
           is_boot_memory: true
           cores:
             - main
@@ -61,27 +34,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L412C8Ux
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8010000
+            start: 134217728
+            end: 134283264
           is_boot_memory: true
           cores:
             - main
@@ -91,27 +70,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L412CBTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -121,27 +106,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L412CBTxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_128
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L412CBUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -151,57 +178,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L412K8Ix
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L412CBUxP
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8010000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
     flash_algorithms:
-      - stm32l4xx_64
+      - stm32l4xx_128
       - stm32l4xx_sb_opt
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L412K8Tx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8010000
+            start: 134217728
+            end: 134283264
           is_boot_memory: true
           cores:
             - main
@@ -211,27 +250,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L412K8Ux
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8010000
+            start: 134217728
+            end: 134283264
           is_boot_memory: true
           cores:
             - main
@@ -241,57 +286,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L412KBIx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20008000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_128
-      - stm32l4xx_sb_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L412KBTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -301,27 +322,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L412KBUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -331,27 +358,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L412T8Yx
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L412R8Ix
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8010000
+            start: 134217728
+            end: 134283264
           is_boot_memory: true
           cores:
             - main
@@ -361,27 +394,249 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L412R8Tx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_64
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L412RBIx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_128
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L412RBIxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_128
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L412RBTx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_128
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L412RBTxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_128
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L412T8Yx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134283264
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_64
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L412TBYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -391,27 +646,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L412TBYxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_128
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L422CBTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -421,27 +718,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L422CBUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -451,57 +754,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L422KBIx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20008000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_128
-      - stm32l4xx_sb_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L422KBTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -511,27 +790,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L422KBUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -541,27 +826,105 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L422RBIx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_128
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L422RBTx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536903680
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134348800
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_128
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L422TBYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20008000
+            start: 536870912
+            end: 536903680
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -571,27 +934,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431CBTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -601,27 +970,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431CBUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -631,27 +1006,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431CBYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -661,27 +1042,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431CCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -691,27 +1078,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431CCUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -721,27 +1114,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431CCYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -751,27 +1150,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431KBUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -781,27 +1186,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431KCUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -811,27 +1222,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431RBIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -841,27 +1258,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431RBTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -871,27 +1294,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431RBYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -901,27 +1330,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431RCIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -931,27 +1366,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431RCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -961,27 +1402,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431RCYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -991,27 +1438,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431VCIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1021,27 +1474,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L431VCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1051,27 +1510,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L432KBUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -1081,27 +1546,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L432KCUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1111,27 +1582,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L433CBTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -1141,27 +1618,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L433CBUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -1171,27 +1654,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L433CBYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -1201,27 +1690,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L433CCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1231,27 +1726,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L433CCUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1261,27 +1762,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L433CCYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1291,27 +1798,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L433RBIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -1321,27 +1834,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L433RBTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -1351,27 +1870,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L433RBYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8020000
+            start: 134217728
+            end: 134348800
           is_boot_memory: true
           cores:
             - main
@@ -1381,27 +1906,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L433RCIx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536920064
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134479872
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_256
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L433RCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1411,27 +1978,105 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L433RCTxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536920064
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134479872
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_256
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L433RCYx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536920064
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134479872
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_256
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L433VCIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1441,27 +2086,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L433VCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1471,27 +2122,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L442KCTx
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L442KCUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1501,27 +2158,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L443CCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1531,27 +2194,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L443CCUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1561,27 +2230,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L443CCYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1591,27 +2266,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L443RCIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1621,27 +2302,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L443RCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1651,27 +2338,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L443RCYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1681,27 +2374,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L443VCIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1711,27 +2410,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L443VCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x2000c000
+            start: 536870912
+            end: 536920064
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1741,27 +2446,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L451CCUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1771,27 +2482,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L451CEUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -1801,27 +2518,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L451RCIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1831,27 +2554,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L451RCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1861,27 +2590,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L451RCYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -1891,27 +2626,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L451REIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -1921,27 +2662,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L451RETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -1951,27 +2698,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L451REYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -1981,27 +2734,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L451VCIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -2011,27 +2770,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L451VCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -2041,27 +2806,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L451VEIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2071,27 +2842,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L451VETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2101,27 +2878,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L452CCUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -2131,27 +2914,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L452CEUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2161,27 +2950,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L452RCIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -2191,27 +2986,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L452RCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -2221,27 +3022,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L452RCYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -2251,27 +3058,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L452REIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2281,27 +3094,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L452RETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2311,27 +3130,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L452RETxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_512
+      - stm32l4xx_sb_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L452REYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2341,27 +3202,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L452VCIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -2371,27 +3238,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L452VCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -2401,27 +3274,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L452VEIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2431,27 +3310,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L452VETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2461,27 +3346,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L462CEUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2491,27 +3382,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L462REIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2521,27 +3418,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L462RETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2551,27 +3454,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L462REYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2581,27 +3490,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L462VEIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2611,27 +3526,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L462VETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2641,87 +3562,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L471JEYx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20018000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8080000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_512
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L471JGYx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20018000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8100000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_1024
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L471QEIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2731,27 +3598,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L471QGIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -2761,87 +3634,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L471RCTx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20018000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8040000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_256
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L471RCYx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20018000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8040000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_256
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L471RETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2851,27 +3670,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L471RGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -2881,87 +3706,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L471RGYx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20018000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8100000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_1024
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L471VCTx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20018000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8040000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_256
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L471VETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -2971,27 +3742,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L471VGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3001,27 +3778,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L471ZEJx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536969216
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_512
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L471ZETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -3031,27 +3850,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L471ZGJx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536969216
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L471ZGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3061,147 +3922,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L475JEYx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20018000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8080000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_512
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L475JGYx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20018000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8100000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_1024
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L475QEIx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20018000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8080000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_512
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L475QGIx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20018000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8100000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_1024
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L475RCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -3211,27 +3958,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L475RETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -3241,27 +3994,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L475RGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3271,27 +4030,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L475VCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -3301,27 +4066,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L475VETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -3331,27 +4102,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L475VGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3361,87 +4138,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L475ZETx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20018000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8080000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_512
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L475ZGTx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20018000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8100000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_1024
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476JEYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -3451,27 +4174,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476JGYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3481,27 +4210,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L476JGYxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536969216
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476MEYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -3511,27 +4282,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476MGYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3541,27 +4318,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476QEIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -3571,27 +4354,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476QGIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3601,27 +4390,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476RCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -3631,27 +4426,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476RETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -3661,27 +4462,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476RGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3691,27 +4498,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476VCTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8040000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
@@ -3721,27 +4534,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476VETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -3751,27 +4570,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476VGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3781,27 +4606,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476ZETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -3811,27 +4642,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L476ZGJx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536969216
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L476ZGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3841,57 +4714,141 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L476ZGTxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536969216
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134479872
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L485JCYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 134479872
           is_boot_memory: true
           cores:
             - main
     flash_algorithms:
-      - stm32l4xx_1024
+      - stm32l4xx_256
       - stm32l4xx_db_opt
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L485JEYx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 536969216
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_512
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L486JGYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3901,27 +4858,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L486QGIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3931,27 +4894,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L486RGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3961,27 +4930,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L486VGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -3991,27 +4966,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L486ZGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20018000
+            start: 536870912
+            end: 536969216
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4021,27 +5002,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L496AEIx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_512
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L496AGIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4051,27 +5074,105 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L496AGIxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L496QEIx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_512
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L496QGIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4081,27 +5182,105 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L496QGIxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L496RETx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_512
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L496RGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4111,27 +5290,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L496RGTxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L496VETx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8080000
+            start: 134217728
+            end: 134742016
           is_boot_memory: true
           cores:
             - main
@@ -4141,57 +5362,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L496VEYx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x20040000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8080000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4xx_512
-      - stm32l4xx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L496VGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4201,27 +5398,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L496VGTxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L496VGYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4231,27 +5470,141 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L496VGYxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L496WGYxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L496ZETx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_512
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L496ZGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4261,27 +5614,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L496ZGYx
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L496ZGTxP
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4291,27 +5650,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4A6AGIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4321,27 +5686,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4A6AGIxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4A6QGIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4351,27 +5758,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4A6QGIxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4A6RGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4381,27 +5830,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4A6RGTxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4A6VGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4411,27 +5902,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4A6VGTxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4A6VGYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4441,27 +5974,69 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4A6VGYxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537133056
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4xx_1024
+      - stm32l4xx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4A6ZGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4471,27 +6046,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L4A6ZGYx
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4A6ZGTxP
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20040000
+            start: 536870912
+            end: 537133056
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4501,27 +6082,68 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L4P5AGTx
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5AEIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_512
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5AGIx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4530,27 +6152,138 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5AGIxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5CETx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_512
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5CEUx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_512
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4P5CGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4559,27 +6292,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L4P5QGTx
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5CGTxP
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4588,27 +6327,243 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5CGUx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5CGUxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5QEIx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_512
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5QGIx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5QGIxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5RETx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_512
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4P5RGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4617,27 +6572,138 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5RGTxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5VETx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_512
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5VEYx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_512
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4P5VGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4646,27 +6712,173 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5VGTxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5VGYx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5VGYxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5ZETx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 134742016
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_512
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4P5ZGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4675,27 +6887,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L4Q5AGTx
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4P5ZGTxP
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4704,27 +6922,68 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4Q5AGIx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4Q5CGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4733,27 +6992,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L4Q5QGTx
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4Q5CGUx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4762,27 +7027,68 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4Q5QGIx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4Q5RGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4791,27 +7097,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4Q5VGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4820,27 +7132,68 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4Q5VGYx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537001984
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 135266304
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4p5xx_1m
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4Q5ZGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x20020000
+            start: 536870912
+            end: 537001984
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4849,27 +7202,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R5AGIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4880,27 +7239,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R5AIIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -4911,27 +7276,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R5QGIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -4942,27 +7313,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R5QIIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -4973,27 +7350,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R5VGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -5004,27 +7387,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R5VITx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5035,27 +7424,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R5ZGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -5066,27 +7461,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R5ZGYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -5097,27 +7498,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R5ZITx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5128,27 +7535,70 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4R5ZITxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537526272
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 136314880
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4rx_2048_dual
+      - stm32l4rx_sb_opt
+      - stm32l4rx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R5ZIYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5159,27 +7609,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R7AIIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5190,27 +7646,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R7VITx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5221,27 +7683,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R7ZITx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5252,27 +7720,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R9AGIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -5283,27 +7757,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R9AIIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5314,27 +7794,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R9VGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -5345,27 +7831,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R9VITx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5376,27 +7868,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R9ZGJx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -5407,27 +7905,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R9ZGTx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -5438,27 +7942,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R9ZGYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8100000
+            start: 134217728
+            end: 135266304
           is_boot_memory: true
           cores:
             - main
@@ -5469,27 +7979,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R9ZIJx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5500,27 +8016,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R9ZITx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5531,27 +8053,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4R9ZIYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5562,27 +8090,70 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4R9ZIYxP
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537526272
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 136314880
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4rx_2048_dual
+      - stm32l4rx_sb_opt
+      - stm32l4rx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4S5AIIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5593,27 +8164,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4S5QIIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5624,27 +8201,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4S5VITx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5655,27 +8238,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4S5ZITx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5686,27 +8275,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4S5ZIYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5717,27 +8312,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4S7AIIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5749,27 +8350,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4S7VITx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5781,27 +8388,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4S7ZITx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5813,27 +8426,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4S9AIIx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5845,27 +8464,109 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4S9VITx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537526272
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 136314880
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4rx_2048
+      - stm32l4rx_2048_dual
+      - stm32l4rx_sb_opt
+      - stm32l4rx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
+  - name: STM32L4S9ZIJx
+    part: ~
+    cores:
+      - name: main
+        type: armv7em
+        core_access_options:
+          Arm:
+            ap: 0
+            psel: 0
+    memory_map:
+      - Ram:
+          name: ~
+          range:
+            start: 536870912
+            end: 537526272
+          is_boot_memory: false
+          cores:
+            - main
+      - Nvm:
+          name: ~
+          range:
+            start: 134217728
+            end: 136314880
+          is_boot_memory: true
+          cores:
+            - main
+    flash_algorithms:
+      - stm32l4rx_2048
+      - stm32l4rx_2048_dual
+      - stm32l4rx_sb_opt
+      - stm32l4rx_db_opt
+      - stm32l4r9i_eval
+      - stm32l4r9i_disco_ospi1
+      - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
+      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4S9ZITx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5877,27 +8578,33 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
   - name: STM32L4S9ZIYx
+    part: ~
     cores:
       - name: main
         type: armv7em
         core_access_options:
           Arm:
-            ap: 0x0
-            psel: 0x0
+            ap: 0
+            psel: 0
     memory_map:
       - Ram:
+          name: ~
           range:
-            start: 0x20000000
-            end: 0x200a0000
+            start: 536870912
+            end: 537526272
           is_boot_memory: false
           cores:
             - main
       - Nvm:
+          name: ~
           range:
-            start: 0x8000000
-            end: 0x8200000
+            start: 134217728
+            end: 136314880
           is_boot_memory: true
           cores:
             - main
@@ -5909,405 +8616,468 @@ variants:
       - stm32l4r9i_eval
       - stm32l4r9i_disco_ospi1
       - stm32l4r9i_disco_ospi2
+      - stm32l4r9i-dk_psram
       - mx25lm51245g_stm32l4p5-disco
-  - name: STM32L4S9ZJIx
-    cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          Arm:
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - Ram:
-          range:
-            start: 0x20000000
-            end: 0x200a0000
-          is_boot_memory: false
-          cores:
-            - main
-      - Nvm:
-          range:
-            start: 0x8000000
-            end: 0x8200000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32l4rx_2048
-      - stm32l4rx_2048_dual
-      - stm32l4rx_sb_opt
-      - stm32l4rx_db_opt
-      - stm32l4r9i_eval
-      - stm32l4r9i_disco_ospi1
-      - stm32l4r9i_disco_ospi2
-      - mx25lm51245g_stm32l4p5-disco
+      - aps6408l-3ob_stm32l4p5g-dk
+      - n25q128a_stm32l476-disco
 flash_algorithms:
-  - name: stm32l4r9i_eval
-    description: MX25LM51245G_STM32L4R9I_EVAL
-    cores:
-      - main
-    default: false
-    instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEdP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEdP8AACALUTRpRGlkYgOSK/oOgMUKDoDFCx8SABv/T3rwkHKL+g6AxQSL8MwF34BOuJACi/QPgEKwi/cEdIvyD4AisR8IBPGL8A+AErcEcQtQdIB0lJRAhgCEYC8ET/CLEBIBC9BfCd/AAg+ucAAAAQAKAwAAAAALWXsCZISEQF8Dr/ELEBIBewAL0BIAOQACAEkE72E0AFkAQgBpAQIAeQACAIkE/0gGAKkE/0QFALkAAgDJAOkE/wgGARkAAgE5AIIBSQACAVkBaQQh4DqRFISEQC8E7+CLEBINTnAiADkEHy7SAFkAAgFJBCHgOpCUhIRALwPv4IsQEgxOcAIAGQAakESEhEA/AO+QixASC65wAguOcAADAAAAAAtZewJkhIRAXw6P4QsQEgF7AAvQIgA5AAIASQTvYTQAWQBCAGkBAgB5AAIAiQT/SAYAqQT/RAUAuQACAMkA6QT/CAYBGQACATkAggFJAAIBWQFpBCHgOpEUhIRALw/P0IsQEg1OcCIAOQQfLtIAWQACAUkEIeA6kJSEhEAvDs/QixASDE5wAgAZABqQRISEQD8Lz4CLEBILrnACC45wAAMAAAAAC1lbAAIAGQApBL9kYQA5AEIASQECAFkAAgBpAIkAyQD5ASkBOQFJBCHgGpBEhIRALwwP0QsQEgFbAAvQAg++cwAAAAELWUsARGACAAkAGQTfYjQAKQBCADkBAgBJAAIAWQBpRP9IBgB5BP9EBQCJAAIAmQC5AOkBGQEpATkApISEQF8Fn+T/D/MmlGBkhIRALwkP1P8P8xA0hIRAXwWvsAIBSwEL0AADAAAAAAtZWwACABkAKQRvKfAAOQBCAEkBAgBZAAIAaQCJAMkA+QEpATkBSQCUhIRAXwLv5P8P8yAakGSEhEAvBl/W/wDwEDSEhEBfAv+wAgFbAAvTAAAAAQtZSwBEa09YBPAtMBIBSwEL0AIACQAZBC8t4QApAEIAOQECAEkAAgBZAgAwaQT/SAYAeQT/RAUAiQACAJkAuQDpARkBKQE5AJSEhEBfD0/QixASDb50/w/zJpRgRISEQC8Cj9CLEBINHnACDP5wAAMAAAAAFGT/CAYAhggBJIYIARiGCAEMhggAIIYQAgcEcAtZWwACABkAKQQvbUMAOQBCAEkBAgBZAAIAaQB5BP9IBgCJBP9EBQCZAAIAqQDJBP8IBgD5ABIBCQACARkAYgEpAAIBOQFJBCHgGpH0hIRALw6PwQsQEgFbAAvU/w/zJpRhpISEQC8PP/CLEBIPPnnfgAAADwYAAIsQEg7Oed+AAAAPAMAAixCCDl50Dy+lADkE/w/zIBqQxISEQC8ML8CLEBINjnT/D/MmlGB0hIRALwzv8IsQEgzued+AAAAPABAAixAiDH5wAgxecwAAAAELUgSCBJSUQIYAhGAvBc/QixASAQvQXwB/sEIBpJSURIYAAhGEhIRIFgwWBP8IBgkPqg8LD6gPBAHhNJSUQIYQIhEUhIREFhACGBYcFhAWIEIUFiACGBYsFiAWMC8Lb+CLEBINbnCEhIRAXw+/wBIQVISEQF8J77CLEBIMrnACDI5wAAABAAoDAAAAAAtZWwACABkAKQ/yADkAQgBJAQIAWQACAGkAiQDJAPkBKQE5AUkEIeAakFSEhEAvBL/BCxASAVsAC9ACD75wAAMAAAAHC1lLAERg1GFkYAIACQAZBO9hNAApAEIAOQECAEkAAgBZAGlU/0gGAHkE/0QFAIkAAgCZALkE/wgGAOkA+WACAQkAggEZAAIBKQE5ABIQtISERBYooeaUYC8BT8ELEBIBSwcL1P8P8yIUYESEhEAvAf/wixASDz5wAg8ecwAAAAALWVsP/37P4IKCPRACABkAKQQ/LPAAOQBCAEkBAgBZAAIAaQCJAMkA+QEpATkBSQQh4BqQhISEQC8OT7ELEBIBWwAL3/98z+AigB0QAg9+cBIPXnACDz5zAAAAAAtZWw//e+/gIoI9EAIAGQApBL8k8AA5AEIASQECAFkAAgBpAIkAyQD5ASkBOQFJBCHgGpCEhIRALwtvsQsQEgFbAAvf/3nv4IKAHRACD35wEg9ecAIPPnMAAAAC3p8EWVsIJGDUaQRuiywPWAdkZFANlGRixGBesIBwAgAZACkEHy7SADkAQgBJAQIAWQACAGkE/0gGAIkE/0QFAJkAAgCpAMkE/wgGAPkAAgEZASkBOQFJAEIR1ISERBYgC/B5QQlhpISEQF8DH8GLEBIBWwvejwhU/w/zIBqRRISEQC8GP7CLEBIPLnT/D/MlFGD0hIRALw8/8IsQEg6OdP8P8xCkhIRAXwIPkIsQEg3+c0RLJEBPWAcLhCAdk4GwHgT/SAcAZGvELK0wAg0OcwAAAAA0YBIHBHAL/+5wAAAUYMSwhomEID0wtLCGiYQgHZACBwRwhLeDsIaJhCAdIGSgHgBUocMkhsgAgC64AA8OcAAAgAAkCABAJAAAgCQPC1BEYLRgTwAwXesgTwAwAkGgPwAwAIuQAgA+AD8AMAwPEEAANEACdV4CFo/bEBLQTQAi0N0AMtGNES4MHzByACRMHzB0ACRALrEWJoHsWyDODB8wdAAkQC6xFiqB7FsgTgAusRYugexbIAvzHgmBsA8AMAGLPYGwQoINiYGwEoBNACKA3QAygY0RLgyLICRMHzByACRMHzB0ACRHAexrIM4MiyAkTB8wcgAkSwHsayBODIsgJE8B7GsgC/CeDIsgJEwfMHIAJEwfMHQAJEAusRYiQdPx2fQqfTEEbwvTC1kPhEUAEkrEAFbGxgBGhjYIRoECwE0QRoomAEaOFgA+AEaKFgBGjiYDC9cEdwtU/wEEUAJAC/B+Al8HBA//fO/AXrBEVkHGQctPWAb/TbACBwvRC1BEYk8HBA//e//AixASAQvQAg/OceSEhEAH8BKATQHEhIRAB/AygR0QC/GkgAaED0AGAYSQhgCEYAaCD0AGAIYAC/CEYAaED0AHAIYBBISEQAfwIoBNAOSEhEAH8DKBHRAL8MSABoQPSAUApJCGAIRgBoIPSAUAhgAL8IRgBoQPSAYAhgACACSUlECHdwRwAAEAAAAAAgAkASSQlqAfSAAZGxAPABASmxDklJaUHwBAEMSlFhAPACAWmxCklJaUH0AEEISlFhBuAGSUlpSPIEAhFDBEpRYQNJSWlB9IAxAUpRYXBHACACQPC1A0YAIEdONmgG9IB2lrlP8ABkRE42iE/2/3e+QgHRphED4EBONog2BbYKT/AAZwfrZgUR4DxONohP9v93vkIC0U/0ABYD4DdONog2BbYKT/AAZwfrZgQ9RjRONmoG9IAGfrseeAbwAwYBLhLRL052asbzEABP8ABmBusAFg5gKk62asbzEABP8ABmBusAFhZgP+AeeAbwAwYCLjrRI052bMbzEABP8ABmBusAFg5gHk62bMbzEABP8ABmBusAFhZgJ+D/5x54BvADBgEuDtEWTnZqxvMQAATrwAYOYBNOtmrG8xAABOvABhZgEuAeeAbwAwYCLg3RDE52bMbzEAAF68AGDmAJTrZsxvMQAAXrwAYWYAVPHmi/agfwAEc+Qx5g8L0AAAFA4HX/HwAgAkAHSABqwLKqKAbQBUgAasCyzCgB0LsgcEcBSABqwLL65wAgAkACSQhqIPD/AHBHAAAAIAJASLkXS9tq27ILYBVL22rD8wdDE2Ai4AEoCdERSxtr27ILYA9LG2vD8wdDE2AW4AIoCdELS9ts27ILYAlL22zD8wdDE2AK4AQoCNEFSxtt27ILYANLG23D8wdDE2BwRwAAACACQC3p8E0FRg5GF0ZP8AALACRM8lAwAPDu+oNGu/EAD3jRVUgAaAD0gHCYuU/wAGhTSACIT/b/cYhCAtFP9AAQA+BOSACIAAWACk/wAGEB62AKEeBKSACIT/b/cYhCAtFP9AAQA+BFSACIAAWACk/wAGEB62AIikZCSABqAPSAAHi7BfADAAEoE9Gm8QBgBAk8SEBqb/MQACBDOUlIYqfxAGAECQhGgGpv8xAAIEOIYkjgBfADAAIoRNGm8QBgBAkwSEBsb/MQACBDLUlIZKfxAGAECQhGgGxv8xAAIEOIZDDg/+cF8AMAASgU0abrCADECCNIQGpv8xAAIEMhSUhip+sIAMQICEaAam/zEAAgQ4hiF+At4AXwAwACKBLRpusKAMQIF0hAbG/zEAAgQxRJSGSn6woAxAgIRoBsb/MQACBDiGQPSIFqKEZh8x4ADEmIYghGQGlA9AAwSGFM8lAwAPBJ+oNGBkhAaSD0ADAESUhhWEa96PCNAAAAAAFA4HX/HwAgAkBwtQRGACVM8lAwAPAx+gVGtbkMSABqIPD/ACBDCUkIYghGQGlA9AAwSGFM8lAwAPAf+gVGA0hAaSD0ADABSUhhKEZwvQAgAkAt6fBBBEYNRgAmACewRkzyUDAA8An6gEa48QAPftEE8AEAILEF9OBgBkNH9OBnBPACACCxBfSAUAZDR/SAVwTwBAAgsQX0AFAGQ0f0AFcE9IBQILEF9IBABkNH9IBHBPAIACCxBfSAMAZDR/SANwTwEAAgsQX0ADAGQ0f0ADcE8CAAILEF9IAgBkNH9IAnBPBAACCxBfQAIAZDR/QAJwTwgAAgsQX0gBAGQ0f0gBcE9IBwILEF9AAQBkNH9AAXBPQAcCCxBfQAAAZDR/QABwT0gGAgsQXwgHAGQ0fwgHcE9ABgILEF8ABwBkNH8AB3BPQAUCCxBfCAYAZDR/CAZwT0gEAgsQXwAGAGQ0fwAGcNSABquEMwQwtJCGIA4A/gCEZAaUD0ADBIYUzyUDAA8Hz5gEYESEBpIPQAMAJJSGFARr3o8IEAIAJALenwQQRGDUYWRgAnTPJQMADwZvkHRu+7TLkhSMBqAPD/IEXqBkEIQx1JyGIi4AEsCdEbSABrAPD/IEXqBkEIQxdJCGMW4AIsCdEVSMBsAPD/IEXqBkEIQxFJyGQK4AQsCNEPSABtAPD/IEXqBkEIQwtJCGUKSEBpQPQAMAhJSGFM8lAwAPAs+QdGBUhAaSD0ADAA4AHgAklIYThGvejwgQAgAkAaShJqAvSAAjK5GEpSaSL0AGIWS1phD+AB8AECMrETSlJpIvQAYhFLWmEF4A9KUmlC9ABiDUtaYQxKUmki9P9iT/T/Y5P6o/Oz+oPzAPoD8xpDBktaYRpGUmlC8AICWmEaRlJpQvSAMlphcEcAIAJAELUESUlpQfABAQJMYWECYENgEL0AIAJAcLWAJAJGC0YHTW1pRfSAJQVOdWFytgC/IMsgwmUe7bIsHvnRYrZwvQAgAkBfSABpAPACAAIoB9FdSEhEQGhA8AEAW0lJREhgWEgAaQDwCAAIKAfRVkhIREBoQPACAFRJSURIYFFIAGkA8BAAECgH0U9ISERAaEDwBABNSUlESGBKSABpAPAgACAoB9FISEhEQGhA8AgARklJREhgQ0gAaQDwQABAKAfRQUhIREBoQPAQAD9JSURIYDxIAGkA8IAAgCgH0TpISERAaEDwIAA4SUlESGA1SABpAPSAcLD1gH8H0TNISERAaEDwQAAwSUlESGAuSABpAPQAcLD1AH8H0StISERAaEDwgAApSUlESGAmSABpAPSAQLD1gE8H0SRISERAaED0gHAhSUlESGAfSABpAPQAQLD1AE8H0RxISERAaED0AHAaSUlESGAXSIBpAPAAQLDxAE8H0RVISERAaED0gGASSUlESGAQSABpAPQAMLD1AD8N0Q1ISERAaED0AGALSUlESGAAv0/0ADAHSQhhAL8AvwVIgGlA8ABAA0mIYUzy+jAIYQC/cEcAIAJAEAAAAHC1BEYB8B75BRkH4GAcKLEB8Bj5qEIB0wMgcL0ySABpAPSAMLD1gD/w0C9IAGkA8AIAAihH0CxIAGkA8AgACChB0ClIAGkA8BAAECg70CZIAGkA8CAAICg10CNIAGkA8EAAQCgv0CBIAGkA8IAAgCgp0B1IAGkA9IBwsPWAfyLQGUgAaQD0AHCw9QB/G9AWSABpAPSAQLD1gE8U0BJIAGkA9ABAsPUATw3QD0iAaQDwAECw8QBPBtALSABpAPQAMLD1AD8D0f/31/4BIKXnBkgAaQDwAQAgsQC/ASACSQhhAL8AIJnnAAAAIAJAA0hAaCDwAQABSUhgcEcAAAAgBOADSEBoIPAEAAFJSGBwRwAAACAE4ANIQGgg8AIAAUlIYHBHAAAAIATgA0hAaEDwAQABSUhgcEcAAAAgBOADSEBoQPAEAAFJSGBwRwAAACAE4ANIQGhA8AIAAUlIYHBHAAAAIATgAUYAIApoEmgi8A4CC2gaYApoEmgi8AECC2gaYJH4RDABIppAC2xaYAEigfgmIAC/ACKB+CQgAL9wR3C1BEYAJZT4JgACKAPQBCDgYwElHuAgaABoIPAOACFoCGAgaABoIPABACFoCGCU+EQQASCIQCFsSGABIIT4JgAAvwAghPgkAAC/oGsQsSBGoWuIRyhGcL0AADC1BEYMuQEgML0gaABoIPABACFoCGAaSSBoiEIL0hlJIGhAGhQhsPvx8IAAYGQVSAg4IGQK4BJJIGhAGhQhsPvx8IAAYGQOSAg4IGQAICFoCGCU+EQQASCIQCFsSGAgRv/3xvkFRg2xACAoYAAg4GOE+CYAAL+E+CQAAL8Av8PnCAQCQAgAAkABRshrcEcBRpH4JgBwR3C1BEYgbAVoIGgGaJT4RBAEIIhAKEDQsQbwBAC4sSBoAGgA8CAAKLkgaABoIPAEACFoCGCU+EQQBCCIQCFsSGAgawAoTtAgRiFriEdK4JT4RBACIIhAKEAIswbwAgDwsSBoAGgA8CAAQLkgaABoIPAKACFoCGABIIT4JgCU+EQQAiCIQCFsSGAAvwAghPgkAAC/4GowsyBG4WqIRyLglPhEEAggiEAoQOCxBvAIAMixIGgAaCDwDgAhaAhglPhEEAEgiEAhbEhgASDgY4T4JgAAvwAghPgkAAC/YGsQsSBGYWuIR3C9cLUERgAlACYMuQEgcL2gaLD1gE8A0AC/JkkgaIhCC9IlSSBoQBoUIbD78fCAAGBkIUgIOCBkCuAeSSBoQBoUIbD78fCAAGBkGkgIOCBkIEb/9xD5BkYOuQEg1+emZGBoMGACIIT4JgAgaAVoR/bwcIVD1OkCAQhDIWkIQ2FpCEOhaQhD4WkIQyFqCEMFQyBoBWAAIOBiIGNgY6Bj4GOE+CUAASCE+CYAACCE+CQAAL+s5wAACAQCQAgAAkAt6fBBBEYORhVGT/AACJT4JgACKAnQBCDgYwC/ACCE+CQAAL8BIL3o8IEgaABoAPAgACCxT/SAcOBjASDz5y65lPhEEAIgAPoB9wTglPhEEAQgAPoB9wDw3f6ARi3gIGwAaJT4RCAIIZFACECAsZT4RBABIIhAIWxIYAEg4GOE+CYAAL8AIIT4JAAAvwEgyudoHJCxLbEA8L3+oOsIAKhCC9kgIOBjASCE+CYAAL8AIIT4JAAAvwEgtecgbABoOEAAKMzQTrmU+EQQAiCIQCFsSGABIIT4JgAF4JT4RBAEIIhAIWxIYAC/ACCE+CQAAL8Av5jnELUDRgAkAL+T+CQAASgB0QIgEL0BIIP4JAAAv5P4JgABKBLRMbEBKQbQAikG0AMpCNEF4NpiB+AaYwXgWmMD4JpjAeABJAC/AOABJAC/ACCD+CQAAL8gRtvnLenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JgABKBfRAiCE+CYAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//eb+CBoAGhA8AEAIWgIYAbgAL8AIIT4JAAAv0/wAghARtTnLenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JgABKCzRAiCE+CYAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//di+CBrMLEgaABoQPAOACFoCGAL4CBoAGgg8AQAIWgIYCBoAGhA8AoAIWgIYCBoAGhA8AEAIWgIYAbgAL8AIIT4JAAAv0/wAghARr/nAkYAIwC/kvgkAAEoAdECIHBHASCC+CQAAL+S+CYAASgb0QUpFtLf6AHwAwYJDA8AACDQYhDgACAQYw3gACBQYwrgACCQYwfgACDQYhBjUGOQYwHgASMAvwDgASMAvwAggvgkAAC/GEbS5wAAELVP8P8wDEmIYwAgiGNAHghkACAIZEAeiGIAIIhiQB7IYgAgyGJAHghjACAIYwDw+f0AIBC9AAAAEAJAcLUERgAlAPCD/QVGAL8A8H/9QBugQvrTcL0AAC3p8EEERg5GAScAJQC/Q0hIRAB4ASgC0QIgvejwgQEgPklJRAhwAL9M8lAw//dA/AdGAC9p0TlJSURIYDhIAGgA9ABwyLE2SABoIPQAcDRJCGAIRgBoAPSAYEixCEYAaCD0gGAIYAMgLElJRAh3GOABICpJSUQIdxPgKUgAaAD0gGBQsSZIAGgg9IBgJEkIYAIgIklJRAh3A+AAIB9JSUQIdyBoASgP0WBo/vf7/0zyUDD/9/37B0YZSEBpSPIEAYhDF0lIYR7gT/D/MDBgpWgT4ChGYWj/9836TPJQMP/35/sHRg5IQGlA8vpxiEMMSUhhD7E1YAXgbRzU6QIBCESoQubYAL/+94v/AL8AIANJSUQIcAC/OEZ/5wAAEAAAAAAgAkBwtQRGACUAvzFISEQAeAEoAdECIHC9ASAtSUlECHAAvwAgSGArSABoAPQAcMixKUgAaCD0AHAnSQhgCEYAaAD0gGBIsQhGAGgg9IBgCGADIB9JSUQIdxjgASAdSUlECHcT4BxIAGgA9IBgULEZSABoIPSAYBdJCGACIBVJSUQIdwPgACASSUlECHcAvxFIQGlA8EBwD0lIYQC/DUlJRGBoCGEgaAEoBdECIAhyYGj+92f/C+ABIAZJSUQIcuBoiGGgaEhh1OkBEP/3QvooRqHnEAAAAAAgAkAQtQRGBiAgYGBoQLFgaAEoBdBgaAIoAtBgaAQoCdEgaEDwAQAgYATxDAIRH2Bo//cV+P73+f8gYf/3CPigYeBpASgC0OBpAigJ0SBoQPAIACBgBPEkAhEfCB/+903/EL1wtQRGASUAvx5ISEQAeAEoAdECIHC9ASAaSUlECHAAvwAgSGAgeADwAQAgsSAdB8j/96D5BUYgeADwAgAYsSBp//fQ+AVGIHgA8AQAILHU6QUB//fr+AVGIHgA8AgASLHU6QgBiEIF0NTpCBLgaf739/8FRgC/ACACSUlECHAAvyhGx+cQAAAAcEcAAAFISERAaHBHEAAAABC1fkhAaW/zCgB8SUhhCEZAaSD0AEBIYXlISEQAegQoBNEIRkBpIPSAIEhhc0gAaQDwAgACKEfQcEgAaQDwCAAIKEHQbUgAaQDwEAAQKDvQakgAaQDwIAAgKDXQZ0gAaQDwQABAKC/QZEgAaQDwgACAKCnQYUgAaQD0gHCw9YB/ItBeSABpAPQAcLD1AH8b0FpIAGkA9IBAsPWATxTQV0gAaQD0AECw9QBPDdBTSIBpAPAAQLDxAE8G0FBIAGkA9AAwsPUAPyzR//e0+f73Lv5LSEhEAHoBKAXRSUlJREhpAPDI+BngRkhIRAB6AigF0UNJSUQIaQDwvfgO4EBISEQAegMoBNA+SEhEAHoEKATRO0lJRMhoAPCt+AAgOElJRAhyNkgAaQDwAQAAKFPQAL8BIDJJCGEAvzFISEQAegEoKdEvSEhEgGlAHi1JSUSIYQhGgGmAsUhp//dK/yhISERAaUAcJklJREhhCEZEaQFpIEb/9wX5LuBP8P8wIElJREhhACAIcv730f0dSUlESGn/9y7/H+D+98n9GUhIRAB6AigF0RZJSUQIaf/3If8O4BNISEQAegMoBNARSEhEAHoEKATRDklJRMho//cR/wAgC0lJRAhyCkhIRAB6aLkAvwZIQGkg8EBwBElIYQC/AL8AIANJSUQIcAC/EL0AIAJAEAAAAANIQGlA8ABAAUlIYQAgcEcAIAJAELUFSEBpQPAAYANJSGFM8lAw//fH+RC9ACACQANIQGlA8IBAAUlIYQAgcEcAIAJAB0hAaQDwgEAosQZIBEnIYAVIyGAB4AEgcEcAIPznAAAAIAJAOyoZCH9uXUxwRwAALenwRwRGD0YVRh5GT/ABCE/wAAoAvy1ISEQAeAEoAtECIL3o8IcBIChJSUQIcAC/TPJQMP/3hvmARrjxAA880QAgIklJREhgIUgAaAD0gGBQsR9IAGgg9IBgHUkIYAIgGklJRAh3A+AAIBhJSUQIdzy5KkYzRjhG//d++E/wAQoL4AEsAdACLAfRKUY4Rv/3f/gCLAHRT/SAKkzyUDD/91H5gEa68QAPBdAJSEBpIOoKAAdJSGH+9/38AL8AIANJSUQIcAC/QEar5wAAEAAAAAAgAkAt6fBBBEYPRhVGHkZP8AAIAL8lSEhEAHgBKALRAiC96PCBASAgSUlECHAAvwAgSGAeSABoAPSAYFCxHEgAaCD0gGAaSQhgAiAXSUlECHcD4AAgFUlJRAh3AiwE0QQgEklJRAhyA+ADIA9JSUQIcg5ISETHYAC/DUhAaUDwQHALSUhhAL8suSpGM0Y4Rv/3CvgH4AEsAdACLAPRKUY4Rv/3DfhARrvnAAAQAAAAACACQAdIQGkA8ABAKLEGSARJiGAFSIhgAeABIHBHACD85wAAACACQCMBZ0Wrie/N8LULRgAhACIAJIbgASWNQAXqAwIAKn/QBWhPAAMmvkA1QwVgzggA8SAFVfgmUE4H9w4PJr5AtUPPCADxIAZG+CdQhWhPAAMmvkC1Q4VgRWgBJo5AtUNFYMVoTwADJr5AtUPFYDBNjghV+CZAjQcuDw8ltUAsQLDxkE8B0QAlI+AqTahCAdEBJR7gKU2oQgHRAiUZ4CdNqEIB0QMlFOAmTahCAdEEJQ/gJE2oQgHRBSUK4CNNqEIB0QYlBeAhTahCAdEHJQDgCCWOBzYPtUClQiLRjQcuDw8lBfoG9BJNjghV+CZgpkOPCEX4J2AWTS1olUMVTjVgNR0taJVDNh01YDUdLWiVQzYdNWA1HS1olUM2HQDgAOA1YEkcI/oB9QAtf/R0r/C9AAAIAAFAAAQASAAIAEgADABIABAASAAUAEgAGABIABwASAAEAUBwRwAAELUERgRIAGggQCCxAkgEYCBG//fz/xC9FAQBQHi1AkYAIwAkACDa4AEmnkANaAXqBgQALHLQTWgCLQLQTWgSLRPR3ggC8SAFVfgmAF0H7g4PJbVAqENeB/YODWm1QChD3ggC8SAFRfgmABBoXgADJbVAqEMNeQXwAwVeALVAKEMQYE1oAS0I0E1oAi0F0E1oES0C0E1oEi0T0ZBoXgADJbVAqENeAM1otUAoQ5BgUGgBJZ1AqEMNecXzABWdQChDUGDQaF4AAyW1QKhDXgCNaLVAKEPQYE1oBfCAVbXxgF980QC/QU0tbkXwAQU/TjVmNUYtbgXwAQUAlQC/AL9P6rY1nghV+CYAnQcuDw8ltUCoQ7LxkE8C0QAlJOBe4DRNqkIB0QElHuAyTapCAdECJRngMU2qQgHRAyUU4C9NqkIB0QQlD+AuTapCAdEFJQrgLE2qQgHRBiUF4CtNqkIB0QclAOAIJZ4HNg+1QChDJ02eCEX4JgAmTShooENNaAX0gDW19YA/ANEgQyFNKGAtHShooENNaAX0ADW19QA/ANEgQxtNLR0oYC0dKGigQ01oBfSAFbX1gB8A0SBDFE0INShgLR0oaKBDTWgF9AAVtfUAHwDRIEMOTQw1KGBbHA1o3UAALX/0IK94vQAAABACQAAEAEgACABIAAwASAAQAEgAFABIABgASAAcAEgIAAFAAAQBQAi1AkZP9IAwAJAAmAhDAJAAmNBh0WEAmNBh0GkAkNBpAPSAMAixACAIvQEg/OcCRhNpC0ALsQEgAOAAIHBHQmlKQEJhcEcKsYFhAOCBYnBHAkgAaMDzCwBwRwAAACAE4ABIcEcCAAgBAUgAaAAMcEcAIATgBEhIRAFoCEZKHAJLS0QaYHBHAAAIAAAAA0hIRABoQBwBSUlECGBwRwgAAAAQtQVIAGhA9IBwA0kIYADwTvgAIBC9AAAAIAJAcLUERghISEQAaE/0enGw+/H1KEYD8DH4ACIhRlAeAPDn+AAgcL0AAAQAAAABRgAgcEcAAEF4FUoRYAF4+bESHUFoEWABewkHwnpB6gJhgnpB6sJBQntB6oJBgntB6kJBwntB6gJBQnpB6gIhAnpB6kIBAngRQwVKCDIRYAXgACECShIdEWASHRFgcEeY7QDgcEdwRwC/APAfAgEhkUADSkMJQvgjEAC/cEcAAIDiAOAAvwDwHwIBIZFAA0pDCUL4IxAAv3BHAACA4QDgAL8A8B8CASGRQEIJkgAC8eAiwvgAEQC/cEcAABC1AUYIRgdKQwlS+CMgAPAfBAEjo0AaQAqxASIA4AAiEEYQvQDjAOAQtQFGCEYHSkMJUvgjIADwHwQBI6NAGkAKsQEiAOAAIhBGEL0A4gDgLenwRQRGIEYAKAjaH08A8A8MrPEEDBf4DHA/CQLgHE8/XD8JPUYORgbwBwDA8QcIuPEEDwLZT/AECAHgwPEHCMRGAPEECLjxBw8C0k/wAAgB4KDxAwhHRiX6B/hP8AEKCvoM+qrxAQoI6goIwvgAgE/wAQgI+gf4qPEBCAjqBQjD+ACAAL+96PCFAAAY7QDgAOQA4BC1AvC3/xC9AL8A8B8CASGRQANKQwlC+CMQAL9wRwAAAOIA4C3p8E2ARg1GFkYAJwLwoP8HRjlGKkYzRgHwBwDA8QcLu/EEDwLZT/AECwHgwPEHC9pGAPEEC7vxBw8C0k/wAAsB4KDxAwvcRk/wAQsL+gr7q/EBCwvqAgsL+gz7T/ABDg76DP6u8QEODuoDDkvqDgQhRkBGAvB0/73o8I0AvwDwBwIGSxloT/b/AxlABEsLQ0PqAiEBSxlgAL9wRwztAOAAAPoFAL8AvwC/AL8Av7/zT48AvwC/AL8JSABoAPTgYAhJCEMAHQZJCGAAvwC/AL+/80+PAL8AvwC/AL8Av/3nDO0A4AAA+gUt6fBNjLCCRgxGT/AAC//3Z/4LkAAnuEYAJQAm/kna+AAAiEIC0QC/ASYB4AElACYAJxDgB+uHAgGrA+uCAXoc0LIC8C3/ILFP8AELCCDK+EgAeBzHsgIv7Nu78QAPfdHtSABoAPABADix60gAaCDwAQDpSQhgSPABCOhIAGgA8AEAOLHlSABoIPABAONJCGBI8AIIBeuFAAGpUfggAAAobdDfSAXrhQEBqlL4IRBJHlD4IQAg8AEC2UgF64UBAatT+CEQSR5A+CEgBeuFAQGqAuuBAUloSR5Q+CEAIPAQAs9IBeuFAQPrgQFJaEkeQPghIAXrhQEBqgLrgQGJaEkeUPghACD0gHLFSAXrhQED64EBiWhJHkD4ISAF64UBAaoC64EBCXsB8A8BSR5Q+CEAIPSAMrpIBeuFAQPrgQEJewHwDwFJHkD4ISAF64UBAaoC64EBCXwB8A8BAOB24UkeUPghACDwgHKtSAXrhQED64EBCXwB8A8BSR5A+CEgBuuGAQGqUvghECBoiEIf0AbrhgEC64EBYGhJaIhCF9AG64YBAuuBAaBoiWiIQg/QBuuGAQLrgQHgaMloiEIH0AbrhgEC64EBIGkJaYhCa9GUSAbrhgEBqlL4IRBJHlD4IQAg8AECjkgG64YBAatT+CEQSR5A+CEgBuuGAQGqAuuBAUloSR5Q+CEAIPAQAoRIBuuGAQPrgQFJaEkeQPghIAbrhgEBqgLrgQGJaEkeUPghACD0gHJ6SAbrhgED64EBiWhJHkD4ISAG64YBAaoC64EBCXsB8A8BSR5Q+CEAIPSAMm9IBuuGAQPrgQEJewHwDwFJHkD4ISAG64YBAaoC64EBCXwB8A8BSR5Q+CEAIPCAcmNIBuuGAQPrgQEJfAHwDwFJHkD4ISBeSCFoSR5Q+CEAIPADAAIhkfqh8bH6gfEF+gHxQfABAQhDVUkiaFIeQfgiAAhGYWhJHlD4IQAg8DAAICGR+qHxsfqB8QX6AfFB8BABCENKSWJoUh5B+CIACEahaEkeUPghACD0QHFP9ABwkPqg8LD6gPAF+gDwQPSAcAFDP0iiaFIeQPgiEOBoAPSAMNixOkghewHwDwFJHlD4IQAg9OAgT/SAIZH6ofGx+oHxBfoB8UH0gDEIQzBJInsC8A8CUh5B+CIAGuAsSCF7AfAPAUkeUPghACDw4GFP8IBgkPqg8LD6gPAF+gDwQPCAcAFDIkgiewLwDwJSHkD4IhAgaQD0gDDYsR1IIXwB8A8BSR5Q+CEAIPTgIE/0gCGR+qHxsfqB8QX6AfFB9EAxCEMTSSJ8AvAPAlIeQfgiACLgD0ghfAHwDwFJHlD4IQAg8OBgT/CAYZH6ofGx+oHxBfoB8UHwQHEIQwVJInwC8A8CUh4G4AAAABAAoAAUAKAEHAZQQfgiAAjwAQAosQlIAGhA8AEAB0kIYAjwAgAosQVIAGhA8AEAA0kIYFhGDLC96PCNABAAoAAUAKD4tQRGACX/9z38Bka0+EQAAPAIACC5tPhEAADwBACQsyBoAGgA8AQAYLEgaABoIPAEACFoCGAgbP73tPsFRg2xBCCgZCBoAGhA8AIAIWgIYOBsM0YBIgIhAJAgRgPwMvoFRqW5AiAhaEhi4GwzRgAiICEAkCBGA/Al+gVGPbkCIKT4RAAD4P/nASUQIKBkKEb4vXBHcLUERgAltPhEAADwCAAgubT4RAAA8AQAYLMgaABoIPT4ECFoCGBP9IBwpPhEACBoAGgA8AQAaLEgaABoIPAEACFoCGAOSHhEIWyIYyBs/vd8+xLgAiAhaEhiIGgAaED0ADAhaAhgIGgAaEDwAgAhaAhgAuABJRAgoGQoRnC9AACfLAAALen4TwRGDUYWRgAn//eu+4JGIGjQ+EiAIGjQ+BCxtPhEAAQoStHoaLD1gA9G0VNGACIgISBGAJYD8Lj5B0YALz/RKGghaMH4iABoaCFowfiAAChpIWjB+JAA1ekCAQhDQPAAUCFoCWgh8ENRCEMhaAhg4Giw8YBvA9EgaMD4SIAM4CBo0PgAAQD04GAYsSBowPhIgALgIGjA+BCxU0YBIgghIEYAlgPwgfkHRk+5CCAhaEhiAiCk+EQAAuABJxAgoGQ4Rr3o+I8t6fhFBEYNRgAm//dL+4BGIGiHbCBo0PgQobT4RAAEKEHR4GxDRgAiICEAkCBGA/BZ+QZGTrsoaCFowfiIAGhoIWjB+IAAKGkhaMH4kADV6QIBCENA8ABQIWgJaCHwQ1EIQyFoCGAJICFoSGJIIKT4RAAgaABoQPQQICFoCGDgaLDxgG8C0SBoh2QP4CBo0PgAAQD04GAQsSBoh2QG4CBowPgQoQLgASYQIKBkMEa96PiFcEct6fhDBEYNRhZGACf/9/D6gEagaAC5AL/oaACxAL/oaQCxAL/oagCxAL+oawCxAL+0+EQAAigD0eBosPGAbw3RtPhEABQoAtEoaAIoBtC0+EQAJChC0ShoASg/0UNGACIgISBGAJYD8OP4B0YvuwAgoGQpRiBGAvAN/AdG77moa1i5Q0YBIgIhIEYAlgPw0PgHRgIgIWhIYiPgKGgYuQQgpPhEAB3gKGgBKAvRtPhEACQoA9EEIKT4RAAS4BQgpPhEAA7gtPhEABQoA9EEIKT4RAAG4CQgpPhEAALgAScQIKBkOEa96PiD+LUERg1GACb/9376B0agaAC5AL/oaACxAL/oaQCxAL/oagCxAL+oawCxAL+0+EQAAigm0ShoILuoaxC74Giw8YBvHtDgbDtGACIgIQCQIEYD8Hr4Bka+uQAgoGQDICFoSGIpRiBGAvCh+wZGZrkIIKT4RAAgaABoQPRAMCFoCGAC4AEmECCgZDBG+L1wtQRGACUMuQElC+AgaABoIPABACFoCGAgRgDwS/oAIKT4RAAoRnC9cEdwRwFGiGxwRwFGCGgAaAD0+FBP9PhSkvqi8rL6gvLQQEAccEcBRrH4RABwRy3p+EMERg1GFkYAJ//3C/qARrT4RAABKCTRQ0YAIiAhIEYAlgPwH/gHRve5T/R/AZH6ofGx+oHxKGiIQE/0f0KS+qLysvqC8mlokUAIQ6loCEPpaAhDIWjB+AACAiCk+EQAAuABJxAgoGQ4Rr3o+IMt6fhDBEYNRhZGACf/99P5gEa0+EQAAigv0eBosPGAbyvRQ0YAIiAhIEYAlgLw4/8HRg+7IGgAaCDwQFAhaAhgIGiAaCDwgHApaAhDIWiIYChpQPBAYKloCENA9EBgIWjB+AAB6GhAHiFoCGRoaCFoiGQEIKT4RAAC4AEnECCgZDhGvej4gy3p8EEERiBoAPFQCCBoBWogaAdotPhEYAXwBAAoswf0gCAQsxguCdFha0gcYGMIeIj4AADga0Ae4GMK4CguCNGY+AAQYmtQHGBjEXDga0Ae4GPgayi5IGgAaCD0gCAhaAhgIEb/9zv/ouAF8AIAAChM0Af0ADAAKEjQKC4h0QX0fFBYseBrSLGY+AAQYmtQHGBjEXDga0Ae4GOJ4OBrACji0QIgIWhIYiBoAGgg9OAgIWgIYAIgpPhEACBGAPC0+nbgAiAhaEhiIGgAaCD04CAhaAhgAiCk+EQAGC4D0SBGAPDQ+2TgCC4D0SBG//cn/l7gtvWAf1vRoGwYuSBG//ce/VXgIEb/9+n+UeAF8AgAuLEH9AAgoLEIICFoSGIgaABoAPSAAECxIGgAaCD0ECAhaAhgAiCk+EQAIEYA8Jj6NuAF8AEAOLMH9IAwILMBICFoSGIgaABoIPT4ECFoCGACIKBkIGgAaADwBABosSBoAGgg8AQAIWgIYA5IeEQhbIhjIGz+94H4EuACIKT4RAAgRv/3o/4L4AXwEABAsQf0gBAosRAgIWhIYiBGAPBh+r3o8IGpJgAA+LUERgAl//e3+AZGDLkBJY/gACCgZLT4RABAuSBGAPDI+E/w/zEgRgDwQvoFRgAtf9HU6QMQQB5P9PgSkvqi8rL6gvKQQAhDYWlJHk/04GKS+qLysvqC8pFACEOhaQhD4WkIQyFoiWgzShFACEMhaIhgIGjAaCD04CAhaghDIWjIYE/0+BGR+qHxsfqB8SBriEAhaAhhIGgAaCD0+FFgaEAeT/T4UpL6ovKy+oLykEABQyBoAWDgbDNGACIgIQCQIEYC8Hn+BUZ9uyBowGgg8P8BYGpAHv8ikvqi8rL6gvKQQAFDIGjBYCBoAGgg8EAAoWgIQyFoCGDU6QoBCEMhaNH4CBEh8KBBCEMhaMH4CAEgaABoQPABACFoCGDgaLDxgG8D0QEgpPhEAALgAiCk+EQAKEb4vQAA/Pjg+Pi1BEYNRgAm//cY+AdGtPhEAAQoJ9HgbDtGACIgIQCQIEYC8Cv+BkYGu4ggpPhEAChoCCgM0WhoIWjB+DABECAhaEhiIGgAaED0gBAhaAhgIGgAaAZJCEApaEHwQFEIQyFoCGAC4AEmECCgZDBG+L33///PcEdwRy3p/E0ERg5GF0YAJf732v8BkCBoAPFQCiBo0PhIgCBo0PgQsR65ASUIIKBkUuC0+EQABChL0SBoAGxAHOBj4GugY2ZjIGgAaCDwQFBA8IBQIWgIYOBosPGAbwPRIGjA+EiADOAgaND4AAEA9OBgGLEgaMD4SIAC4CBowPgQsQC/AJcBIgYhIEYBmwLwu/0FRgWxC+Ca+AAQYmtQHGBjEXDga0Ae4GPgawAo6dEAv425AJcBIgIhIEYBmwLwo/0FRkW5AiAhaEhipPhEAALgASUQIKBkKEa96PyNAAAt6fNHBEYAJiBoAGxFHCBo0PhIgCBo0PgQoQGYGLkBJgggoGSO4LT4RAAEKHLRIGxAaQi55WMk4CBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggoGQBJhTgaAjgYxHgIGxAabD1AH8M0QXwAwAYuSB5APADABixCCCgZAEmAeCoCOBjAC5e0eBroGMBmGBjIGgAaCDwQFBA8IBQIWgIYAMgIWhIYiggpPhEAChIeEQhbMhiJ0h4RCFsCGMmSHhEIWxIYwAgIWyIYwAhIGyBYCBsAGgAaCDwEAAhbIloCEMhbAloCGABr6NrOmjU+ADADPFQASBs/vfO+CBoAGhA9IAwIWgIYOBosPGAbwTRIGjA+EiADeAT4CBo0PgAAQD04GAYsSBowPhIgALgIGjA+BChIGgAaEDwBAAhaAhgAuABJhAgoGQwRr3o/IcAAHMjAAC7IwAAkSMAAHC1AkYAIBVoq2wVaNX4EEEZuQEgCCWVZDXgsvhEUAQtLtEVaC1sbRzVY9VrlWNRYxVoLWgl8EBVRfCAVRZoNWADJRZodWIoJaL4RFAVaC1oRfTgJRZoNWDVaLXxgG8C0RVoq2QP4BVo1fgAUQX04GUVsRVoq2QG4BVoxfgQQQLgASAQJZVkcL1wR3BHMLUCRgAgsvhEMAPwCAOLuVFgE2gbaCP0+FRTaFseT/T4VZX6pfW1+oX1q0AcQxNoHGAC4AEgECOTZDC9AkbRZAAgcEdwR3BHLen4RQRGDkYXRgAl/vdW/oBGIGgA8VAKHrkBJQggoGQ74LT4RAAEKDTRIGgAbEAc4GPga6BjZmMgaABoIPBAUCFoCGAAv0NGASIEISBGAJcC8FT8BUYFsQvgYWtIHGBjCHiK+AAA4GtAHuBj4GsAKOnRAL+NuUNGASICISBGAJcC8Dz8BUZFuQIgIWhIYqT4RAAC4AElECCgZChGvej4hS3p80EERgAmIGgAbEUcAZgYuQEmCCCgZHfgtPhEAAQocNEgbEBpCLnlYyTgIGxAabD1gH8N0QXwAQAYuSB5APABABixCCCgZAEmFOBoCOBjEeAgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIIKBkASYB4KgI4GMALkfR4GugYwGYYGMgaABoIPBAUCFoCGADICFoSGIYIKT4RAAdSHhEIWzIYhxIeEQhbAhjG0h4RCFsSGMAICFsiGMQISBsgWAgbABoAGgg8BAAIWyJaAhDIWwJaAhgAa+ja9T4AMAM8VACOWggbP33cP8gaABoQPSAMCFoCGAgaABoQPAEACFoCGAD4P/nASYQIKBkMEa96PyBtyAAAP8gAADVIAAAELUCRgAgGbkBIAgjk2Qg4LL4RDAEKxnRE2gbbFsc02PTa5NjUWMTaBtoI/BAUxRoI2ADIxRoY2IYI6L4RDATaBtoQ/TgIxRoI2AC4AEgECOTZBC9cEdwRwFGCGgQKAbQIChS0EAofNCAKHvR7OCgSABoIPAIAJ5KEGAQHwBoIPAIABIfEGCaSAgwAGgg8AgAl0oIMhBgEB8AaCDwCAASHxBgSGgA9IAwsPWAPwfRkEgAHwBoQPAIAI1KEh8QYEhoAPQAMLD1AD8F0YlIAGhA8AgAh0oQYAh5APABADixhEgAHQBoQPAIAIFKEh0QYAh5APACAAIoB9F9SAgwAGhA8AgAe0oIMhBg7uB5SABoIPAQAHdKEGAQHwBoIPAQABIfEGBzSAgwAGgg8BAAcEoIMhBgEB8AaCDwEAASHxBgSGgA9IAwsPWAPwfRaUgAHwBoQPAQAGZKEh8QYEhoAPQAMAHgI+C+4LD1AD8F0WBIAGhA8BAAXkoQYAh5APABADixW0gAHQBoQPAQAFlKEh0QYAh5APACAAIoB9FVSAgwAGhA8BAAUkoIMhBgneBQSABoIPAgAE5KEGAQHwBoIPAgABIfEGBKSAgwAGgg8CAASEoIMhBgEB8AaCDwIAASHxBgSGgA9IAwsPWAPwfRQEgAHwBoQPAgAD5KEh8QYEhoAPQAMLD1AD8F0TlIAGhA8CAAN0oQYAh5APABADixNEgAHQBoQPAgADJKEh0QYAh5APACAAIoB9EuSAgwAGhA8CAAK0oIMhBgT+ApSABoIPBAACdKEGAQHwBoIPBAABIfEGAjSAgwAGgg8EAAIUoIMhBgEB8AaCDwQAASHxBgSGgA9IAwsPWAPwfRGUgAHwBoQPBAABdKEh8QYEhoAPQAMLD1AD8F0RJIAGhA8EAAEEoQYAh5APABADixDUgAHQBoQPBAAAtKEh0QYAh5APACAAIoB9EHSAgwAGhA8EAABEoIMhBgAeABIHBHAL8AIPvnAAAkBAFAAkYAIbL1AH8q0R5IAGgA9MBgsPUAfzLQGkgAaCD0wGBA9ABwF0sYYBdISEQAaBdLsPvz8DIjAPsD8QDgSR4xsRBIQGkA9IBgsPWAb/bQDUhAaQD0gGCw9YBvENEDIHBHCEgAaAD0wGCw9YBvB9AFSABoIPTAYED0gGACSxhgACDt5wAAAHAAQAQAAABAQg8AA0jAaCD0gHABSchgcEcAAABwAEACRgkqQ9Lf6ALwBQ0VGyEnLTM6ACBIQGoh9CBDmEMeS1hiNuAcSMBqIfAQA5hDGkvYYi7gGEhAa4hDF0tYYyjgFUjAa4hDFEvYYyLgEkhAbIhDEUtYZBzgD0jAbIhDDkvYZBbgDEhAbYhDC0tYZRDgCUjAbYuymEMHS9hlCeAGSEBuwfMLA5hDA0tYZgHgASBwRwC/ACD75wBwAEACRgkqQdLf6ALwBQ0TGR8lKzE4AB9IAGoh9IBDmEMdSxhiNOAbSIBqiEMaS5hiLuAYSABriEMXSxhjKOAVSIBriEMUS5hjIuASSABsiEMRSxhkHOAPSIBsiEMOS5hkFuAMSABtiEMLSxhlEOAJSIBti7KYQwdLmGUJ4AZIAG7B8wsDmEMDSxhmAeABIHBHAL8AIPvnAHAAQANIgGgg9ABAAUmIYHBHAAAAcABAAL8SSABoIPSAQBBKEGAQSEhEAGgPSrD78vAyIgD7AvEA4EkeMbEJSEBpAPQAcLD1AH/20AVIQGkA9ABwsPUAfwHRAyBwRwAg/OcAAABwAEAEAAAAQEIPAANIQGgg8BAAAUlIYHBHAAAAcABAA0hAaCDwIAABSUhgcEcAAABwAEADSEBoIPBAAAFJSGBwRwAAAHAAQANIQGgg8IAAAUlIYHBHAAAAcABAA0iAaCD0gGABSYhgcEcAAABwAEADSIBoIPSAcAFJiGBwRwAAAHAAQANIQGgg9ABwAUlIYHBHAAAAcABAA0hAaCD0gGABSUhgcEcAAABwAEAGScloIfQAcQFDBErRYBFGyWhB9IBx0WBwRwAAAHAAQAJGCSpw0t/oAvAFFCAqND5IUl8AN0hAaiH0IEMYQzVLWGIYRgBqIfSAQ5hDMUsYYlzgMEjAaiHwEAMYQy1L2GIYRoBqiEOYYlDgKkhAawhDKEtYYxhGAGuIQxhjRuAlSMBrCEMjS9hjGEaAa4hDmGM84CBIQGwIQx5LWGQYRgBsiEMYZDLgG0jAbAhDGUvYZBhGgGyIQ5hkKOAWSEBtCEMUS1hlGEYAbYhDGGUe4BFIwG2LshhDD0vYZRhGgG2LsphDDEuYZRHgCkhAbsHzCwMYQwhLWGYYRgBuwfMLA5hDBEsYZgLg/+cBIHBHAL8AIPvnAAAAcABAAkYJKnHS3+gC8AUUISs1P0lTYAA3SABqIfSAQxhDNUsYYhhGQGoh9CBDmEMxS1hiXeAwSIBqCEMuS5hiGEbAaiHwEAOYQytL2GJQ4ClIAGsIQyhLGGMYRkBriENYY0bgJEiAawhDI0uYYxhGwGuIQ9hjPOAfSABsCEMeSxhkGEZAbIhDWGQy4BpIgGwIQxlLmGQYRsBsiEPYZCjgFUgAbQhDFEsYZRhGQG2IQ1hlHuAQSIBti7IYQw5LmGUYRsBti7KYQwtL2GUR4ApIAG7B8wsDGEMHSxhmGEZAbsHzCwOYQwRLWGYC4P/nASBwRwC/ACD75wBwAEADSIBoQPQAQAFJiGBwRwAAAHAAQANIAGhA9IBAAUkIYHBHAAAAcABAA0hAaEDwEAABSUhgcEcAAABwAEADSEBoQPAgAAFJSGBwRwAAAHAAQANIQGhA8EAAAUlIYHBHAAAAcABAA0hAaEDwgAABSUhgcEcAAABwAEADSIBoQPSAYAFJiGBwRwAAAHAAQANIgGhA9IBwAUmIYHBHAAAAcABAA0hAaED0AHABSUhgcEcAAABwAEADSEBoQPSAYAFJSGBwRwAAAHAAQAhIAGgg8AcAAB0GSQhgBkgAaEDwBAAESQhgAL8AvzC/cEcAAABwAEAQ7QDgDEkJaCHwBwEKShFgCkkJaEHwBAEIShFgASgB0TC/AuBAvyC/IL8ESQloIfAEAQJKEWBwRwBwAEAQ7QDgDUkJaCHwBwFJHAtKEWALSQloQfAEAQlKEWABKAHRML8C4EC/IL8gvwRJCWgh8AQBAkoRYHBHAAAAcABAEO0A4A1JCWgh8AcBiRwLShFgC0kJaEHwBAEJShFgASgB0TC/AuBAvyC/IL8ESQloIfAEAQJKEWBwRwAAAHAAQBDtAOACSABoAPTAYHBHAAAAcABAELUeSABoAPSAMCixAPBg+U/0gDAZSQhgGEggMABoAPAIACixAPAs+AggFEkgMQhgEkggMABoAPAQACixAPAh+BAgDkkgMQhgDEggMABoAPAgACixAPAW+CAgCEkgMQhgBkggMABoAPBAACixAPAL+EAgAkkgMQhgEL0AABQEAUBwR3BHcEdwRwFGK0hAaCDwDgAKaBBDKEpQYChIAGgg9IAwJkoQYBAfAGgg9IAwEh8QYCJICDAAaCD0gDAfSggyEGAQHwBoIPSAMBIfEGBIaAD0gDCw9YA/B9EYSAAfAGhA9IAwFUoSHxBgSGgA9AAwsPUAPwXREUgAaED0gDAPShBgCHkA8AEAOLEMSAAdAGhA9IAwCUoSHRBgCHkA8AIAAigH0QVICDAAaED0gDADSggyEGAAIHBHAHAAQAQEAUAFSIBrQPCAUANJiGMIRoBrIPCAUIhjcEcAEAJAA0gAaCD0gHABSQhgcEcAAABwAEADSEBoIPABAAFJSGBwRwAAAHAAQANIAGgg8BAAAUkIYHBHAAAQ7QDgA0gAaCDwAgABSQhgcEcAABDtAOADSYloAPAfApFDAUqRYHBHAHAAQANIAGhA9IBwAUkIYHBHAAAAcABAA0hAaEDwAQABSUhgcEcAAABwAEADSABoQPAQAAFJCGBwRwAAEO0A4ANIAGhA8AIAAUkIYHBHAAAQ7QDgCEnJaADwHwKRQ0HqUBEFStFgEUaJaADwHwIRQwFKkWBwRwAAAHAAQHC1BUYMRk25D0hAaQD0AHCw9QB/CdH/93P8BuAKSEBpwPNAIAi5//f5/QhIAGgg8AQABkkIYAEsAdEwvwLgQL8gvyC/cL0AAABwAEAQ7QDgCEgAaCDwBwDAHAZJCGAGSABoQPAEAARJCGAAvwC/ML9wRwAAAHAAQBDtAOBwtQVGDEa19YBPA9EgRv/3Vf4C4CBG//cz/nC9cEdwRy3p8EEERg1GACYAJ7BGkEgAaADwDwCoQg/SjUgAaCDwDwAoQ4pJCGAIRgBoAPAPAKhCAtABIL3o8IEgeADwAQAAKG7QYGgDKCPRgkgAaADwAHAIuQEg7ucB8Hj9B0Z+SIdCBtkgeADwAgACKAHRoGggsXhIgGgA8PAAoLt1SIBoIPDwAEDwgABySYhgT/CACCngYGgCKAbRbkgAaAD0ADCIuQEgx+dgaDC5akgAaADwAgBAuQEgvudmSABoAPSAYAi5ASC35wDwRfoHRmJIh0IJ2WBIgGgg8PAAQPCAAF1JiGBP8IAIW0iAaCDwAwBhaAhDWEmIYP33xf4GRmBoAygQ0Qjg/fe+/oAbQfKIMYhCAdkDII/nT0iAaADwDAAMKPDRNuBgaAIoENEI4P33qv6AG0HyiDGIQgHZAyB750VIgGgA8AwACCjw0SLgYGiAuQjg/feX/oAbQfKIMYhCAdkDIGjnO0iAaADwDAAAKPDRD+AI4P33hv6AG0HyiDGIQgHZAyBX5zNIgGgA8AwABCjw0SB4APACAAIoCNEtSIBoIPDwAKFoCEMqSYhgCOC48YAPBdEnSIBoIPDwACVJiGAjSABoAPAPAKhCDtkgSABoIPAPAChDHkkIYAhGAGgA8A8AqEIB0AEgJecgeADwBAAEKAfRF0iAaCD04GDhaAhDFEmIYCB4APAIAAgoCNERSIBoIPRgUCFpQOrBAA1JiGAA8Jj5C0mJaAHw8AHwIpL6ovKy+oLy0UAISnpEUVzIQAdJSUQIYA8g/fdW/gAg8uYAIAJAABACQAC0xAR6HQAABAAAAB9IAGhA8AEAHUkIYADgAL8bSABoAPACAAAo+NAYSABoIPDwAEDwYAAVSQhgACCIYAhGAGgTSQhAEUkIYAAgyGAIRsBoQPSAUMhgACAIYQhGAGlA9IBQCGEAIEhhCEZAaUD0gFBIYQhGAGgg9IAgCGAAIIhhBEgFSUlECGBwRwAAABACQP/0/uoACT0ABAAAAANIAGhA9AAgAUkIYHBHAAAAEAJADyICYA1KkmgC8AMCQmALSpJoAvDwAoJgCEqSaAL04GLCYAZKkmgC9GBS0ggCYQRKEmgC8A8CCmBwRwAAABACQAAgAkABSEhEAGhwRwQAAAA/IQFgZEkJaAH0gCGx9YAvA9FP9KAhQWAM4F9JCWgB9IAxsfWAPwPRT/SAMUFgAeAAIUFgWEkJaAHwAQERsQEhgWEB4AAhgWFTSQloAfR/QU/0f0KS+qLysvqC8tFAwWFNSQloAfDwAQFiS0kJaAH0gHGx9YB/A9FP9IBxwWAB4AAhwWBESUloAfD+QU/w/kKS+qLysvqC8tFAAWE+SZAxCWgB8AQBBCkC0QUhgWAK4DlJkDEJaAHwAQERsQEhgWAB4AAhgWA0SZQxCWgB8AEBEbEBIUFhAeAAIUFhLkmYMQloAfABARGxASFBYgHgACFBYilJCWgB8IBxsfGAfwLRAiGBYgHgASGBYiNJyWgB8AMCwmIgScloAfDwAfAikvqi8rL6gvLRQEkcAWMaScloAfT+QU/0/kKS+qLysvqC8tFAQWMUScloAfTAAU/0wAKS+qLysvqC8tFASRxKAMJjDUnJaAHwwGFP8MBikvqi8rL6gvLRQEkcSgACZAZJyWgB8HhBT/B4QpL6ovKy+oLy0UCBY3BHAAAAEAJAALX/9yn/CEmJaAH04GFP9OBikvqi8rL6gvLRQANKekRRXMhAAL0AAAAQAkCaGgAAALX/9xH/CEmJaAH0YFFP9GBSkvqi8rL6gvLRQANKekRRXMhAAL0AAAAQAkBqGgAA8LUAIQAjACQCJQIiACBWTrZoBvAMBl6xU062aAbwDAYMLi7RUE72aAbwAwYBLijRTU42aAbwCAZuuUtOlDY2aAb0cGZP9HBnl/qn97f6h/cm+gfxCuBETjZoBvDwBvAnl/qn97f6h/cm+gfxP05+RFb4IRA8TrZoBvAMBoa5CEYO4DlOtmgG8AwGBC4B0ThIBuA1TrZoBvAMBgguANE1SDFOtmgG8AwGDC5b0S5O9mgG8AMELE72aAbw8AbwJ5f6p/e3+of3/kByHAEsKdACLALQAywk0RHgJU62+/L2Ik//aAf0/kdP9P5MnPqs/Lz6jPwn+gz3BvsH8yPgHU62+/L2GU//aAf0/kdP9P5MnPqs/Lz6jPwn+gz3BvsH8xHgAL+x+/L2EE//aAf0/kdP9P5MnPqs/Lz6jPwn+gz3BvsH8wC/AL8ITvZoBvDAZk/wwGeX+qf3t/qH9/5Adhx1ALP79fDwvQAAABACQAIaAAAAJPQAABJ6AHC1hrAGRg1GFEYAvxJIwGxA8AEAEEnIZAhGwGwA8AEAAJAAvwC/iBUBkAIgApAEkAAgA5AFkAGpT/CQQP33hvoFSIBoIPD+QEXqBAEIQwJJiGAGsHC9AAAAEAJAELUHSMBpAPSAcLD1gH8F0f/3YfxP9IBwAUkIYhC9AAAAEAJA+LUERgAlIHgA8BAAECh20f5IgGgA8AwAAChy0ftIAGgA8AIAGLGgaQi5ASD4vfdIIWoAaADwCAAgsfRIAGgA8PAABeDxSJQwAGgA9HBgAAmBQh/ZIGoB8Gf6CLEBIOXnAL/qSABoQPAIAOhJCGAIRgBoIPDwACFqCEPkSQhgAL8IRkBoIPR/QOFpQOoBIN9JSGAe4AC/3UgAaEDwCADbSQhgCEYAaCDw8AAhaghD10kIYAC/CEZAaCD0f0DhaUDqASDSSUhgIGoB8C76CLEBIKzn//eZ/s1JiWgB8PAB8CKS+qLysvqC8tFAyUp6RFFcyEDISUlECGAPIP33V/tL4P/noGmAs8FIAGhA8AEAv0kIYP33EfsFRgbg/fcN+0AbAigB2QMggee4SABoAPACAAAo8tAAv7VIAGhA8AgAs0kIYAhGAGgg8PAAIWoIQ69JCGAAvwhGQGgg9H9A4WlA6gEgqklIYBfg/+eoSABoIPABAKZJCGD999/6BUYG4P332/pAGwIoAdkDIE/nn0gAaADwAgAAKPLRIHgA8AEAAChs0JpIgGgA8AwACCgL0JdIgGgA8AwADCgO0ZRIwGgA8AMAAygI0ZFIAGgA9AAwiLNgaHi7ASAp5wC/YGiw9YA/BtGKSABoQPSAMIhJCGAa4GBosPWgLwvRhEgAaED0gCCCSQhgCEYAaED0gDAIYArgfkgAaCD0gDB8SQhgCEYAaCD0gCAIYAC/YGigsf33hPoFRgngIuD993/6QBtB8ogxiEIB2QMg8eZwSABoAPQAMAAo8NAS4P33b/oFRgjg/fdr+kAbQfKIMYhCAdkDIN3mZkgAaAD0ADAAKPDRIHgA8AIAAihq0WFIgGgA8AwABCgL0F5IgGgA8AwADCge0VtIwGgA8AMAAigY0VhIAGgA9IBgGLHgaAi5ASC35lNIQGgg8P5AT/D+QpL6ovKy+oLyIWmRQAhDTUlIYD/g4Ggws0pIAGhA9IBwSEkIYP33JPoFRgbg/fcg+kAbAigB2QMglOZCSABoAPSAYAAo8tA/SEBoIPD+QE/w/kKS+qLysvqC8iFpkUAIQzhJSGAW4DdIAGgg9IBwNUkIYP33/fkFRgbg/ff5+UAbAigB2QMgbeYuSABoAPSAYAAo8tEgeADwCAAIKDbRYGnQsShIlDAAaEDwAQAlScH4lAD99935BUYG4P332flAGwIoAdkDIE3mHkiUMABoAPACAAAo8dAZ4BpIlDAAaCDwAQAYScH4lAD998L5BUYG4P33vvlAGwIoAdkDIDLmEUiUMABoAPACAAAo8dEgeADwBAAEKG/RACYKSIBtAPCAUHC5AL8HSIBtQPCAUAVJiGUIRoBtAPCAUACQAL8AvwEmA0gH4AAQAkB8FwAABAAAAABwAEAAaAD0gHCwuahIAGhA9IBwpkkIYP33gvkFRgbg/fd++UAbAigB2QMg8uWgSABoAPSAcAAo8tAAv6BoASgI0ZxIAGhA8AEAmkmQOcH4kAAh4KBoBSgP0ZZIAGhA8AQAlEmQOcH4kAAIRtD4kABA8AEAwfiQAA7gjkgAaCDwAQCMSZA5wfiQAAhG0PiQACDwBADB+JAAAL+gaKCx/fc/+QVGCeAt4P33OvlAG0HyiDGIQgHZAyCs5X5IAGgA8AIAACjw0BLg/fcq+QVGCOD99yb5QBtB8ogxiEIB2QMgmOV0SABoAPACAAAo8NEBLgfRcEiQOIBtIPCAUG1JkDmIZQC/IHgA8CAAICg40WBq2LFoSAgwAGhA8AEAZUmQOcH4mAD99/z4BUYG4P33+PhAGwIoAdkDIGzlXkgIMABoAPACAAAo8dAa4FpICDAAaCDwAQBXSZA5wfiYAP334PgFRgbg/ffc+EAbAigB2QMgUOVQSAgwAGgA8AIAACjx0aBq6LNLSJA4gGgA8AwADCh50KBqAihT0UZIkDgAaCDwgHBESZA5CGD997r4BUYG4P33tvhAGwIoAdkDICrlPUiQOABoAPAAcAAo8dEga0AeAQFga0HqACDhaghDoY8BIsLrUQFA6kFRQCAAXcLrUABB6kBhOCAAXUHqwGAtSQDgU+CQOchgCEYAaEDwgHAIYAhGwGhA8IBwyGD994H4BUYG4P33ffhAGwIoAdkDIPHkIEiQOABoAPAAcAAo8dA04BxIkDgAaCDwgHAaSZA5CGAIRgBoAPAAYEi5CEYAaADwAFAguQhGwGgg8AMAyGARSJA4wGgQSQhADkmQOchg/fdP+AVGB+AO4P33SvhAGwIoAdkDIL7kB0iQOABoAPAAcAAo8dEB4AEgtOQAILLkAAAAcABAkBACQP//7v5P8OAgAGlA8AIAT/DgIQhhcEcAAANIQGgg9IBwAUlIYHBHAAAAAAFAACABSQhicEcAACBCA0gAayDwAQABSQhjcEcAAAAAAUADSEBoQPSAcAFJSGBwRwAAAAABQAEgAUkIYnBHAAAgQhC1ACQMSABrQPABAApJCGP89/T/BEYG4Pz38P8AGwooAdkDIBC9BEgAawDwCAAAKPLQACD25wAAAAABQMogBElIYlMgSGIBIAJJCGBwRwAAAAABQAADIEIDSQlrIfACAQFDAUoRY3BHAAABQANJSWsh8D8BAUMBSlFjcEcAAAFAA0kJayHwBAEBQwFKEWNwRwAAAUAEKAjRT/DgIQlpQfAEAU/w4CIRYQfgT/DgIQlpIfAEAU/w4CIRYXBHcEdwtQRGJUZoHrDxgH8B0wEgD+BoHk/w4CFIYQ8hT/D/MADwWfgAIE/w4CGIYQcgCGEAIHC9ELX/9+L/EL1P8OAgAGkg8AIAT/DgIQhhcEcAv/7ncLUERg1GFkZQIQhISET697z9UCEGSEhE+ve3/fz3fP8A8MH++vfA/wAgcL3QAAAAMAAAABC1BEZQIQpISET696T9UCEISEhE+vef/fz3ZP8A8Kn++veo/wy5+vfR/QEgEL0AAIAAAAAwAAAAAL/+53BHAAACSABowPMCIHBHAAAM7QDgELUAKAfaCgcUDgVKAPAPAxsf1FQD4AoHEw4CShNUEL0Y7QDgAOQA4PC1BEYAIAAiACUAIxSxAiwA3Am5ASBg4AAmDmHOYI5gTmAOYAEsAdEAJQLgAiwA0SpNACNP4CpOVvgjIALwAQY+sQLwAgYF8AIHvkIB0V4cDmAC8BAGPrEC8CAGBfAgB75CAdFeHE5gAvSAdj6xAvQAdgX0AHe+QgHRXhyOYAL0gDaOsQL0gCYF9IAnvkIL0QL0ADYmuV4cRvSANs5gA+BeHEbwgHbOYALwgHaOsQLwgGYF8IBnvkIL0QLwAHYmuV4cRvSANg5hA+BeHEbwgHYOYV4c87ICK63b8L0iAgQEBBwGUC3p8EECRgAgF2g/aCfwQFfS+ADAzPgAcJdoX7kXaD9oJ/CAB9H4BMBH6gwH0vgAwMz4AHAPaAIvDNAXaAf1gHMXaAf1hHQXaAf1iHUXaAf1kHYL4BdoB/XAcxdoB/XEdBdoB/XIdRdoB/XQdtHpEnxH6gwHH2DPao+xj2o3YNH4NMDPakfqDAfR+DDAR+oMB9P4AMAs9HwcR+oMBx9gJ2gn8B8H0fhEwEfqDAcnYI9rP7EPaC+5z2t/HtL4AMDM+EBwz2gAL2/Qz2nns49rN7PR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMBH6gwH0fggwEfqDAfR+DjAR+oMB9H4QMBH6gwH0/gAwN/4PIEM6ggMR+oMBx9gH+DR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMBH6gwH0fggwADgEuBH6gwH0/gAwEP2P3gs6ggMR+oMBx9gj2gvYI9p0vgAwMz4SHBr4I9r37HR+BTAz2hH6gwH0fgQwEfqDAfR+DjAR+oMB9H4QMBH6gwH0/gAwN/4tIAM6ggMR+oMBx9gEOAS4NH4FMDPaEfqDAfR+BDAR+oMB9P4AMAs8D8MR+oMBx9gj2gvYDrgz2mns49r57HR+CTAz2lH6gwH0fggwEfqDAfR+DjAR+oMB9H4QMBH6gwH0/gAwN/4TIAI8T8IDOoIDEfqDAcfYA/g0fgkwM9pR+oMB9H4IMBH6gwH0/gAwCz0fFxH6gwHH2CPadL4AMDM+EhwA+D/5wEgCCeXZL3o8IEAAMDA//DA///wcLUFRqxqACDgY7T4RACw9YB/D9ECICFoSGIgaABoQPQAMCFoCGAgaABoQPACACFoCGAF4AIgpPhEACBG/fc6+3C9AUaIagAiwmMCaBJoIvAEAgNoGmAKaBJoIvABAgtoGmACaBJoQvQAMgNoGmBwR3C1BUasagAg4GMEIKBkIGgAaCDwBAAhaAhgIEb990T5cL1wtQVGrGrga0AI4GO0+EQAKCgD0SBG/fer/gLgIEb999X/cL0AADC1mbAFRgxGACAFkAaQQPL6UAeQBCAIkBAgCZAAIAqQC5BP9IBgDJBP9EBQDZAAIA6QEJBP8IBgE5ABIBSQACAVkAYgFpAAIBeQGJAAkAEgAZAAIAKQECAEkIAEA5BP8P8yBakJSEhE/ff6+RCxASAZsDC9IkZpRgRISET99zL5CLEBIPTnACDy5wAAMAAAAAC1hbDAIU/wkED89+36ByEfSPz36foYIR5I/Pfl+k/0AGEdSPz34PoEIRxI/Pfc+gAgAZAEIACQACACkAOQaUZP8JBA/PeG+wEgAZAAIAKQCCAAkGlGT/CQQPz3e/sAIgghT/CQQPz3lPwNSABrQPSAcAtJCGMIRgBrIPSAcAhjCEYAbSD0gHAIZQWwAL0AAAAEAEgACABIABgASAAcAEgAEAJAALWHsAC/W0jAbED0gBBZSchkCEbAbAD0gBABkAC/AL8AvwhGAG1A9IBwCGUIRgBtAPSAcAGQAL8AvwhGAGtA9IBwCGMIRgBrIPSAcAhjAL8IRoBtQPCAUIhlCEaAbQDwgFABkAC/AL9DSEBoQPQAcEFJSGAAvz9IwGxA8AEAPUnIZAhGwGwA8AEAAZAAvwC/AL8IRsBsQPACAMhkCEbAbADwAgABkAC/AL8AvwhGwGxA8AQAyGQIRsBsAPAEAAGQAL8AvwC/CEbAbEDwQADIZAhGwGwA8EAAAZAAvwC/AL8IRsBsQPCAAMhkCEbAbADwgAABkAC/AL8EIAKQAiADkAEgBJADIAWQCiAGkAKpT/CQQPz3zfoEIAKQAiAEkAKpFkj898X6yCACkAAgBJACqU/wkED897z6AyACkAKpD0j897b6GCACkAKpDUj897D6T/QAYAKQAyAGkAKpCUj896f6BCACkAKpB0j896H6B7AAvQAAABACQABwAEAABABIAAgASAAYAEgAHABIMLWbsAVGDEYAIAeQCJAMkE/0QFAPkAAgEJASkBeQGZAakASQECAGkIAEBZABLHPRBiAJkAEgCpAAIAuQDpAVkBiQQh4HqZhISET996n4ELEBIBuwML0CIAKQA5AFIAmQT/CAcBWQASAWkIIeB6mOSEhE/feV+AixASDq50/w/zICqYlISET8983/CLEBIODnciAJkE/0QHANkE/0gHAOkAYgAZDCHwepf0hIRP33ePgIsQEgzedP8P8yAal6SEhE/fcI/QixASDD5wYgCZAAIA6QFZBCHgepc0hIRP33YPgIsQEgtecFIAmQT/CAcBWQT/D/MgepbEhIRP33UfgIsQEgpudP8P8yAqlnSEhE/PeJ/xCxASCc503gciAJkAAgDZBP9IBwDpABIAGQgh4HqV1ISET99zT4CLEBIInnT/D/MgGpWEhIRP33xPwIsQEgf+dWSPv3lP1P8P8xUkhIRP/37v0IsQEgc+dH8o4QCZAEIAqQECALkIABDpAABBWQBiAYkMIfB6lHSEhE/fcI+AixASBd50/w/zIBqUJISET99xT7CLEBIFPnnfgEAAEod9ABIE3nPEhIRADws/gIsQEgRudH8o0gCZAEIAqQECALkAAgDZBP9IBgDpAABBWQASAWkAYgGJAAIAGQQh4HqS1ISET899T/CLEBICnnT/D/MgGpKEhIRP33ZPwIsQEgH+cmSPv3NP0FIAmQASAKkAAgC5AOkE/wgHAVkAEgFpAAIBiQApABIAOQgh4HqRpISET8963/CLEBIALnT/D/MgKpFUhIRPz35f4IsQEg+OZxIAmQACANkE/0gHAOkE/w/zIHqQxISET895L/CLEBIOfmT/D/MgGpB0hIRP33nvoQsQEg3eYE4J34BAAIsQEg1+YAINXmAAAwAAAAgFhPABC1lLAERgAgAJABkEbymWACkAQgA5AQIASQACAFkAeQC5AOkBGQEpATkEIeaUYQSEhE/Pdd/xCxASAUsBC9SfZmEAKQT/D/MmlGCUhIRPz3T/8IsQEg8OdP8P8xBEhIRP/3Fv0IsQEg5+cAIOXnAAAwAAAAELWasARGACAGkAeQQPL5YAiQBCAJkBAgCpAAIAuQDZARkBSQF5AYkBmQQh4GqR5ISET89yP/ELEBIBqwEL0CIAGQApAAIAOQECAFkIAEBJBA8vpQCJAAIAyQT/SAYA2QT/RAUA6QACAPkE/wgGAUkAEgFZAAIBaQBiAXkMIfBqkJSEhE/Pf6/gixASDV50/w/zIBqQRISET89zL+CLEBIMvnACDJ5wAAMAAAAC3p8EcERg5GF0aaRgid/PfX+YBGE+BoHIixLbH899D5oOsIAKhCCtlP9ABwpPhEAKBsQPABAKBkASC96PCHIGgAajBACLEBIADgACC4QuLRACDy53BHcLUERg1GFkYqRiFGMEb69w77CLEBIHC9ACD85wFGASBwRxC1AkhIRP33B/gQvYAAAADwtQAiACMAJAIlAiEAIEJO9mgG8AMGAS4h0T9ONmgG8AgGbrk8TpQ2NmgG9HBmT/RwZ5f6p/e3+of3JvoH8grgNU42aAbw8AbwJ5f6p/e3+of3JvoH8jFOfkRW+CIgLk72aAbwAwQsTvZoBvDwBvAnl/qn97f6h/f+QHEcASwp0AIsAtADLCTREeAlTrb78fYhT/9oB/T+R0/0/kyc+qz8vPqM/Cf6DPcG+wfzI+AdTrb78fYYT/9oB/T+R0/0/kyc+qz8vPqM/Cf6DPcG+wfzEeAAv7L78fYPT/9oB/T+R0/0/kyc+qz8vPqM/Cf6DPcG+wfzAL8AvwdO9mgG8MBmT/DAZ5f6p/e3+of3/kB2HHUAs/v18PC9ABACQCAEAAAAJPQAABJ6APi1BEYAJgAlIUiAbQDwgFAYsf73SfgGRhbgAL8cSIBtQPCAUBpJiGUIRoBtAPCAUACQAL8Av/73N/gGRhRIgG0g8IBQEkmIZbb1AH8H0YAsDNmgLAHZAiUI4AElBuCALAHTAiUC4HAsANEBJQlIAGgg8A8AKEMHSQhgCEYAaADwDwCoQgHQASD4vQAg/OcAAAAQAkAAIAJAcEdwtQRGDUagsiQaCeAk8HBGMEb69wD4CLEAIHC9BPWANKVC89IBIPjnELX897D4EL0AtZewFCESqPn37P5EIQGo+ffo/hAgAZABIAeQACAIkAIgC5ABIQyRYCAJkA2RPCEOkQIhEZEQkQchD5EBqP735vwPIBKQAyATkIAgFJAAIBWQFpADIRKo/vcz+QIgEpAAIBSQBSESqP73K/kXsAC9AADwtQAjACAAIgIkACUCITZONmgG8AgGLrkzTpQ2NmjG8wMgA+AwTjZoxvMDEC9OfkRW+CAALE62aAbwDAY2sQQuCNAILgvQDC450Q3gKE5ORDBgOOAnTiZPT0Q+YDPgJk4jT09EPmAu4B9O9mgG8AMFHU72aMbzAxZxHAItAtADLQjRA+AbTrb78fIG4BpOtvvx8gLgsPvx8gC/AL8STvZoxvMGJnJDEE72aMbzQWZ2HHQAsvv09g5PT0Q+YAPgDE5ORDBgAL8AvwdOtmjG8wMWCk9/RLtdBk5ORDZo3kAET09EPmDwvQAAABACQOYBAAAEAAAAACT0AAASegAyAQAAEEgAaED0cAAOSQhgDkgAaEDwAQAMSQhgACCIYAhGAGgKSQhACEkIYMgUyGAIRgBoIPSAIAhgACCIYcgDAUmAOQhgcEeI7QDgABACQP//9uoQtQRG+fc0/gAgEL0Av/7ncLUERg5GFUb59z7+B+AU+AEbFfgBK5FCAdAgRnC9MB6m8QEG89EgRvjnLenYTQZGi0YXRppGT/AACAAgAJC/APn3Iv7K8wNCuRoK8A8CkBkAmvr3gfkERg/gFvgBGxv4CACBQgfQACIG6wgAEBhE6wIBvejYjQjxAQhHRe3YIUYAIPbncLUERg1GFkYqRiFGMEb699H4CLEAIHC9ASD85wAAAAAAAAAAAAAAAAAAAAABAgMEBgcICaCGAQBADQMAgBoGAAA1DABAQg8AgIQeAAAJPQAAEnoAACT0AAA2bgEASOgBAGzcAk1YMjVMTTUxMjQ1R19TVE0zMkw0UjlJLUVWQUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAkAAAAAQAAAEA/wAAAAAEAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 0x5575
-    pc_uninit: 0x64dd
-    pc_program_page: 0x60f7
-    pc_erase_sector: 0x977
-    pc_erase_all: 0x951
-    data_section_offset: 0x669c
-    flash_properties:
-      address_range:
-        start: 0x90000000
-        end: 0x94000000
-      page_size: 0x100
-      erased_byte_value: 0xff
-      program_page_timeout: 0x2710
-      erase_sector_timeout: 0x2710
-      sectors:
-        - size: 0x10000
-          address: 0x0
-  - name: stm32l4r9i_disco_ospi2
-    description: MX25L51245G_STM32L4R9I_DISCO_OSPI2
-    cores:
-      - main
-    default: false
-    instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAARkgAaEDwAQBESQhgACCIYAhGAGhCSQhAQEkIYMgUyGAIRgBoIPSAIAhgACCIYcgDPEkIYHBH8LUAIwAgACICJAAlAiE1TjZoBvAIBi65M06UNjZoxvMDIAPgME42aMbzAxAxTn5EVvggACxOtmgG8AwGNrEELgjQCC4L0AwuOdEN4CpOTkQwYDjgKU4nT09EPmAz4CdOJU9PRD5gLuAfTvZoBvADBR1O9mjG8wMWcRwCLQLQAy0I0QPgHU62+/HyBuAcTrb78fIC4LD78fIAvwC/Ek72aMbzBiZyQw9O9mjG80Fmdhx0ALL79PYPT09EPmAD4A1OTkQwYAC/AL8HTrZoxvMDFgxPf0S7XQdOTkQ2aN5ABU9PRD5g8L0AEAJA///26gjtAOBwUwAABAAAAAAk9AAAEnoAtFIAAHtIgGtA8IBQeUmIYwhGgGsg8IBQiGNwR3ZIAGhA9IBwdEkIYHBHc0gAaCD0gHBxSQhgcEcBRm9IQGgg8A4ACmgQQ2xKUGBsSABoIPSAMGpKEGAQHwBoIPSAMBIfEGBmSAgwAGgg9IAwY0oIMhBgEB8AaCD0gDASHxBgSGgA9IAwsPWAPwfRXEgAHwBoQPSAMFlKEh8QYEhoAPQAMLD1AD8F0VVIAGhA9IAwU0oQYAh5APABADixUEgAHQBoQPSAME1KEh0QYAh5APACAAIoB9FJSAgwAGhA9IAwR0oIMhBgACBwR0NIQGhA8AEAQUlIYHBHQEhAaCDwAQA+SUhgcEc8ScloAPAfApFDQepQETlK0WARRoloAPAfAhFDNUqRYHBHNEmJaADwHwKRQzFKkWBwR3C1BUYMRk25LkhAaQD0AHCw9QB/CdED8BX5BuApSEBpwPNAIAi5A/AG+SdIAGgg8AQAJUkIYAEsAdEwvwLgQL8gvyC/cL1wtQVGDEa19YBPA9EgRgPwNfkC4CBGA/AX+XC9F0gAaCDwBwDAHBVJCGAWSABoQPAEABRJCGAAvwC/ML9wRxFIAGhA8AIAD0kIYHBHDUgAaCDwAgALSQhgcEcKSABoQPAQAAhJCGBwRwZIAGgg8BAABEkIYHBHcEcAEAJAAHAAQAQEAUAQ7QDgcEdwtQRGhUhIRABoT/R6cbD78fUoRgDwofkAIiFGUB4A8DL5ACBwvRC1fUgAaED0gHB7SQhgAyAA8BT5DyAE8PL///fd/wAgEL1wRxC1T/D/MHRJiGMAIIhjQB4IZAAgCGRAHohiACCIYkAeyGIAIMhiQB4IYwAgCGP/9+b/ACAQvWlISEQAaEAcZ0lJRAhgcEdlSEhEAWgIRkocYktLRBpgcEdwtQRG//fz/wZGJUZoHACxbRwAv//36/+AG6hC+tNwvU/w4CAAaSDwAgBP8OAhCGFwR0/w4CAAaUDwAgBP8OAhCGFwR1BIcEdQSABoAAxwR05IAGjA8wsAcEdNSABocEdLSAAdAGhwR0lICDAAaHBHRkhAaEDwAQBESUhgcEdDSEBoIPABAEFJSGBwRz9IQGhA8AIAPUlIYHBHPEhAaCDwAgA6SUhgcEc4SEBoQPAEADZJSGBwRzVIQGgg8AQAM0lIYHBHyiAzSUhiUyBIYgEgMUkIYHBHASAwSQhicEcAIC5JCGJwRytJCWsh8AQBAUMoShFjcEcnSQlrIfACAQFDJEoRY3BHI0lJayHwPwEBQyBKUWNwRxC1ACQeSABrQPABABxJCGP/92L/BEYG4P/3Xv8AGwooAdkDIBC9FUgAawDwCAAAKPLQACD25xFIAGsg8AEAD0kIY3BHDkhAaED0gHAMSUhgcEcKSEBoIPSAcAhJSGBwRwAABAAAAAAgAkAAEAJACAAAAAUACAEAIATgkHX/HwAAAUAAAyBCAAAgQhC1ACgH2goHFA65SgDwDwMbH9RUA+AKBxMOtkoTVBC9AL8A8AcCsksMOxloT/b/AxlAsUsLQ0PqAiGtSww7GWAAv3BHLenwTYBGDUYWRgAnAPBI+QdGOUYqRjNGAfAHAMDxBwu78QQPAtlP8AQLAeDA8QcL2kYA8QQLu/EHDwLST/AACwHgoPEDC9xGT/ABCwv6Cvur8QELC+oCCwv6DPtP8AEODvoM/q7xAQ4O6gMOS+oOBCFGQEb/96L/vejwjXBHAL8A8B8CASGRQItKQwlC+CMQAL9wRwC/AL8AvwC/AL+/80+PAL8AvwC/gEgMOABoAPTgYIBJCEMAHXxJDDkIYAC/AL8Av7/zT48AvwC/AL8AvwC//edwtQRGJUZoHrDxgH8B0wEgD+BoHk/w4CFIYQ8hT/D/MP/3Yv8AIE/w4CGIYQcgCGEAIHC9ELUA8Mn4EL0t6fBFBEYgRgAoCNpjTwDwDwys8QQMF/gMcD8JAuBgTz9cPwk9Rg5GBvAHAMDxBwi48QQPAtlP8AQIAeDA8QcIxEYA8QQIuPEHDwLST/AACAHgoPEDCEdGJfoH+E/wAQoK+gz6qvEBCgjqCgjC+ACAT/ABCAj6B/io8QEICOoFCMP4AIAAv73o8IUAvwDwHwIBIZFAREqAMkMJQvgjEAC/cEcQtQFGCEY/SoAyQwlS+CMgAPAfBAEjo0AaQAqxASIA4AAiEEYQvQC/APAfAgEhkUA2SkMJQvgjEAC/cEcQtQFGCEYxSoAyQwlS+CMgAPAfBAEjo0AaQAqxASIA4AAiEEYQvQQoCNFP8OAhCWlB8AQBT/DgIhFhB+BP8OAhCWkh8AQBT/DgIhFhcEdwRxC1//f8/xC9QXgYSoAyEWABePmxEh1BaBFgAXsJB8J6QeoCYYJ6QerCQUJ7QeqCQYJ7QepCQcJ7QeoCQUJ6QeoCIQJ6QepCAQJ4EUMISogyEWAF4AAhBUqEMhFgEh0RYHBHAkgMOABowPMCIHBHGO0A4ADkAOAAAPoFgOEA4IDiAOAt6fBHBEYORhdGmEYInf/3nP2CRhPgaByIsS2x//eV/aDrCACoQgrZT/QAcKT4RACgbEDwAQCgZAEgvejwhyBoAGowQAixASAA4AAguELi0QAg8ucCRtFkACBwR3BH+LUERgAl//dx/QZGDLkBJY/gACCgZLT4RABAuSBGBPD6+k/w/zEgRv/35f8FRgAtf9HU6QMQQB5P9PgSkvqi8rL6gvKQQAhDYWlJHk/04GKS+qLysvqC8pFACEOhaQhD4WkIQyFoiWj+ShFACEMhaIhgIGjAaCD04CAhaghDIWjIYE/0+BGR+qHxsfqB8SBriEAhaAhhIGgAaCD0+FFgaEAeT/T4UpL6ovKy+oLykEABQyBoAWDgbDNGACIgIQCQIEb/927/BUZ9uyBowGgg8P8BYGpAHv8ikvqi8rL6gvKQQAFDIGjBYCBoAGgg8EAAoWgIQyFoCGDU6QoBCEMhaNH4CBEh8KBBCEMhaMH4CAEgaABoQPABACFoCGDgaLDxgG8D0QEgpPhEAALgAiCk+EQAKEb4vXBHcLUERgAlDLkBJQvgIGgAaCDwAQAhaAhgIEYE8JD7ACCk+EQAKEZwvXBHcEdwtQVGrGoAIOBjtPhEALD1gH8P0QIgIWhIYiBoAGhA9AAwIWgIYCBoAGhA8AIAIWgIYAXgAiCk+EQAIEb/99//cL1wR3BHcEdwR3BHcEct6fBBBEYgaADxUAggaAVqIGgHaLT4RGAF8AQAKLMH9IAgELMYLgnRYWtIHGBjCHiI+AAA4GtAHuBjCuAoLgjRmPgAEGJrUBxgYxFw4GtAHuBj4GsouSBoAGgg9IAgIWgIYCBG//fL/6LgBfACAAAoTNAH9AAwAChI0CguIdEF9HxQWLHga0ixmPgAEGJrUBxgYxFw4GtAHuBjieDgawAo4tECICFoSGIgaABoIPTgICFoCGACIKT4RAAgRv/3nv924AIgIWhIYiBoAGgg9OAgIWgIYAIgpPhEABguA9EgRv/3i/9k4AguA9EgRv/3hP9e4Lb1gH9b0aBsGLkgRv/3ev9V4CBG//dT/1HgBfAIALixB/QAIKCxCCAhaEhiIGgAaAD0gABAsSBoAGgg9BAgIWgIYAIgpPhEACBG//da/zbgBfABADizB/SAMCCzASAhaEhiIGgAaCD0+BAhaAhgAiCgZCBoAGgA8AQAaLEgaABoIPAEACFoCGBOSHhEIWyIYyBsA/Cu/xLgAiCk+EQAIEb/9w3/C+AF8BAAQLEH9IAQKLEQICFoSGIgRv/3//696PCBLenwQQNGACAfaD9oJ/BAV9P4AMDM+ABwn2hfuR9oP2gn8IAH0fgEwEfqDAfT+ADAzPgAcA9oAi8M0B9oB/WAch9oB/WEdB9oB/WIdR9oB/WQdgvgH2gH9cByH2gH9cR0H2gH9ch1H2gH9dB20ekSfEfqDAcXYM9qj7GPajdg0fg0wM9qR+oMB9H4MMBH6gwH0vgAwCz0fBxH6gwHF2AnaCfwHwfR+ETAR+oMBydgj2s/sQ9oL7nPa38e0/gAwMz4QHDPaAAvfNDPae+zj2tfs9H4FMDPaEfqDAfR+BDAR+oMB9H4HMBH6gwH0fgkwEfqDAfR+CDAR+oMBwPg/Pjg+DP+///R+DjAR+oMB9H4QMBH6gwH0vgAwN/4YIoM6ggMR+oMBxdgKuDR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMAA4CHgR+oMB9H4IMBH6gwH0vgAwEP2P3gs6ggMR+oMBxdg32q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2CPadP4AMDM+Ehwd+CPa+ex0fgUwM9oR+oMB9H4EMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+MSJDOoIDADgIeBH6gwHF2Aa4NH4FMDPaEfqDAfR+BDAR+oMB9L4AMAs8D8MR+oMBxdg32q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2A64M9pp7OPa+ex0fgkwM9pR+oMB9H4IMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+ESJCPE/CAzqCAxH6gwHF2AP4NH4JMDPaUfqDAfR+CDAR+oMB9L4AMAs9HxcR+oMBxdgj2nT+ADAzPhIcAPg/+cBIAgnn2S96PCBLen4QwRGDUYWRgAn//d6+oBGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsYsShoALkAvwC/tPhEAAIoA9HgaLDxgG8N0bT4RAAUKALRKGgCKAbQtPhEACQoQtEoaAEoP9FDRgAiICEgRgCW//el/AdGL7sAIKBkKUYgRv/3f/4HRu+5qGtYuUNGASICISBGAJb/95L8B0YCICFoSGIj4ChoGLkEIKT4RAAd4ChoASgL0bT4RAAkKAPRBCCk+EQAEuAUIKT4RAAO4LT4RAAUKAPRBCCk+EQABuAkIKT4RAAC4AEnECCgZDhGvej4g/i1BEYNRgAm//cF+gdGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsAsQC/tPhEAAIoJtEoaCC7qGsQu+BosPGAbx7Q4Gw7RgAiICEAkCBG//c8/AZGvrkAIKBkAyAhaEhiKUYgRv/3E/4GRma5CCCk+EQAIGgAaED0QDAhaAhgAuABJhAgoGQwRvi9Len4QwRGDUYWRgAn//e9+YBGtPhEAAEoA9C0+EQAAigk0UNGACIgISBGAJb/9wj8B0b3uU/0fwGR+qHxsfqB8ShoiEBP9H9Ckvqi8rL6gvJpaJFACEOpaAhD6WgIQyFowfgAAgIgpPhEAALgAScQIKBkOEa96PiDLen4QwRGDUYWRgAn//eB+YBGtPhEAAIoOdHgaLDxgG810UNGACIgISBGAJb/98z7B0ZfuyBoAGgg8EBQIWgIYCBogGgg8IBwKWgIQyFoiGAoaUDwQGCpaAhDQPRAYCFowfgAAShpQPBAYKloCENA9EBgIWjB+IAB6GhAHiFoCGRoaCFoiGQEIKT4RAAC4AEnECCgZDhGvej4gy3p+EUERg5GF0YAJf/3NPmARiBoAPFQCh65ASUIIKBkO+C0+EQABCg00SBoAGxAHOBj4GugY2ZjIGgAaCDwQFAhaAhgAL9DRgEiBCEgRgCX//dt+wVGBbEL4GFrSBxgYwh4ivgAAOBrQB7gY+BrACjp0QC/jblDRgEiAiEgRgCX//dV+wVGRbkCICFoSGKk+EQAAuABJRAgoGQoRr3o+IUt6fxNBEYORhdGACX/9+T4AZAgaADxUAogaND4SIAgaND4ELEeuQElCCCgZFLgtPhEAAQoS9EgaABsQBzgY+BroGNmYyBoAGgg8EBQQPCAUCFoCGDgaLDxgG8D0SBowPhIgAzgIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4ELEAvwCXASIGISBGAZv/9wD7BUYFsQvgmvgAEGJrUBxgYxFw4GtAHuBj4GsAKOnRAL+NuQCXASICISBGAZv/9+j6BUZFuQIgIWhIYqT4RAAC4AElECCgZChGvej8jRC1AkYAIBm5ASAII5NkIOCy+EQwBCsZ0RNoG2xbHNNj02uTY1FjE2gbaCPwQFMUaCNgAyMUaGNiGCOi+EQwE2gbaEP04CMUaCNgAuABIBAjk2QQvXC1AkYAIBVoq2wVaNX4EEEZuQEgCCWVZDXgsvhEUAQtLtEVaC1sbRzVY9VrlWNRYxVoLWgl8EBVRfCAVRZoNWADJRZodWIoJaL4RFAVaC1oRfTgJRZoNWDVaLXxgG8C0RVoq2QP4BVo1fgAUQX04GUVsRVoq2QG4BVoxfgQQQLgASAQJZVkcL1wtQRGACW0+EQAAPAIACC5tPhEAADwBABgsyBoAGgg9PgQIWgIYE/0gHCk+EQAIGgAaADwBABosSBoAGgg8AQAIWgIYPZIeEQhbIhjIGwD8L37EuACICFoSGIgaABoQPQAMCFoCGAgaABoQPACACFoCGAC4AElECCgZChGcL1wtQVGrGoAIOBjBCCgZCBoAGgg8AQAIWgIYCBG//ex/3C9cEdwR3C1BUasauBrQAjgY7T4RAAoKAPRIEb/9/L/AuAgRv/37f9wvQFGiGoAIsJjAmgSaCLwBAIDaBpgCmgSaCLwAQILaBpgAmgSaEL0ADIDaBpgcEct6fNBBEYAJiBoAGxFHAGYGLkBJgggoGR34LT4RAAEKHDRIGxAaQi55WMk4CBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggoGQBJhTgaAjgYxHgIGxAabD1AH8M0QXwAwAYuSB5APADABixCCCgZAEmAeCoCOBjAC5H0eBroGMBmGBjIGgAaCDwQFAhaAhgAyAhaEhiGCCk+EQApEh4RCFsyGKjSHhEIWwIY6JIeEQhbEhjACAhbIhjECEgbIFgIGwAaABoIPAQACFsiWgIQyFsCWgIYAGvo2vU+ADADPFQAjloIGwD8GH6IGgAaED0gDAhaAhgIGgAaEDwBAAhaAhgA+D/5wEmECCgZDBGvej8gS3p80cERgAmIGgAbEUcIGjQ+EiAIGjQ+BChAZgYuQEmCCCgZI7gtPhEAAQoctEgbEBpCLnlYyTgIGxAabD1gH8N0QXwAQAYuSB5APABABixCCCgZAEmFOBoCOBjEeAgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIIKBkASYB4KgI4GMALl7R4GugYwGYYGMgaABoIPBAUEDwgFAhaAhgAyAhaEhiKCCk+EQAX0h4RCFsyGJeSHhEIWwIY11IeEQhbEhjACAhbIhjACEgbIFgIGwAaABoIPAQACFsiWgIQyFsCWgIYAGvo2s6aNT4AMAM8VABIGwD8NH5IGgAaED0gDAhaAhg4Giw8YBvBNEgaMD4SIAN4BPgIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4EKEgaABoQPAEACFoCGAC4AEmECCgZDBGvej8hy3p+E8ERg1GFkYAJ/73Yf6CRiBo0PhIgCBo0PgQsbT4RAAEKErR6Giw9YAPRtFTRgAiICEgRgCW//em+AdGAC8/0ShoIWjB+IgAaGghaMH4gAAoaSFowfiQANXpAgEIQ0DwAFAhaAloIfBDUQhDIWgIYOBosPGAbwPRIGjA+EiADOAgaND4AAEA9OBgGLEgaMD4SIAC4CBowPgQsVNGASIIISBGAJb/92/4B0ZPuQggIWhIYgIgpPhEAALgAScQIKBkOEa96PiPwMD/8MD///BR9v//M////wf////Z/v//E/7//+f9//+5/f//Len4RQRGDUYAJv737P2ARiBoh2wgaND4EKG0+EQABChB0eBsQ0YAIiAhAJAgRv/3NfgGRk67KGghaMH4iABoaCFowfiAAChpIWjB+JAA1ekCAQhDQPAAUCFoCWgh8ENRCEMhaAhgCSAhaEhiSCCk+EQAIGgAaED0ECAhaAhg4Giw8YBvAtEgaIdkD+AgaND4AAEA9OBgELEgaIdkBuAgaMD4EKEC4AEmECCgZDBGvej4hfi1BEYNRgAm/veU/QdGtPhEAAQoJ9HgbDtGACIgIQCQIEb+9+L/BkYGu4ggpPhEAChoCCgM0WhoIWjB+DABECAhaEhiIGgAaED0gBAhaAhgIGgAaP5JCEApaEHwQFEIQyFoCGAC4AEmECCgZDBG+L34tQRGACX+9139Bka0+EQAAPAIACC5tPhEAADwBACQsyBoAGgA8AQAYLEgaABoIPAEACFoCGAgbAPw5PgFRg2xBCCgZCBoAGhA8AIAIWgIYOBsM0YBIgIhAJAgRv73jf8FRqW5AiAhaEhi4GwzRgAiICEAkCBG/veA/wVGPbkCIKT4RAAD4P/nASUQIKBkKEb4vTC1AkYAILL4RDAD8AgDi7lRYBNoG2gj9PhUU2hbHk/0+FWV+qX1tfqF9atAHEMTaBxgAuABIBAjk2QwvQFGCGgAaAD0+FBP9PhSkvqi8rL6gvLQQEAccEcBRohscEcBRrH4RABwR/C1BEYAIAAiACUAIxSxAiwA3Am5ASBg4AAmDmHOYI5gTmAOYAEsAdEAJQLgAiwA0a5NACNP4K1OVvgjIALwAQY+sQLwAgYF8AIHvkIB0V4cDmAC8BAGPrEC8CAGBfAgB75CAdFeHE5gAvSAdj6xAvQAdgX0AHe+QgHRXhyOYAL0gDaOsQL0gCYF9IAnvkIL0QL0ADYmuV4cRvSANs5gA+BeHEbwgHbOYALwgHaOsQLwgGYF8IBnvkIL0QLwAHYmuV4cRvSANg5hA+BeHEbwgHYOYV4c87ICK63b8L0t6fBNjLCCRgxGT/AAC/73b/wLkAAnuEYAJQAmfkna+AAAiEIC0QC/ASYB4AElACYAJxDgB+uHAgGrA+uCAXoc0LL/92//ILFP8AELCCDK+EgAeBzHsgIv7Nu78QAPftFtSABoAPABADixakgAaCDwAQBoSQhgSPABCGdIAGgA8AEAOLFlSABoIPABAGNJCGBI8AIIBeuFAAGpUfggAAAobdBbSAXrhQEBqlL4IRBJHlD4IQAg8AECVkgF64UBAatT+CEQSR5A+CEgBeuFAQGqAuuBAUloSR5Q+CEAIPAQAkxIBeuFAQPrgQFJaEkeQPghIAXrhQEBqgLrgQGJaEkeUPghACD0gHJCSAXrhQED64EBiWhJHkD4ISAF64UBAaoC64EBCXsB8A8BSR5Q+CEAIPSAMjdIBeuFAQPrgQEJewHwDwFJHkD4ISAF64UBAaoC64EBCXwB8A8BSR4A4HjhUPghACDwgHIqSAXrhQED64EBCXwB8A8BSR5A+CEgBuuGAQGqUvghECBoiEIf0AbrhgEC64EBYGhJaIhCF9AG64YBAuuBAaBoiWiIQg/QBuuGAQLrgQHgaMloiEIH0AbrhgEC64EBIGkJaYhCdtEQSAbrhgEBqlL4IRBJHlD4IQAg8AECC0gG64YBAatT+CEQSR5A+CEgBuuGAQGqAuuBAUloSR5Q+CEACeD3///PIgIEBAQcBlAAEACgABQAoCDwEAKNSAbrhgED64EBSWhJHkD4ISAG64YBAaoC64EBiWhJHlD4IQAg9IByg0gG64YBA+uBAYloSR5A+CEgBuuGAQGqAuuBAQl7AfAPAUkeUPghACD0gDJ4SAbrhgED64EBCXsB8A8BSR5A+CEgBuuGAQGqAuuBAQl8AfAPAUkeUPghACDwgHJsSAbrhgED64EBCXwB8A8BSR5A+CEgZ0ghaEkeUPghACDwAwACIZH6ofGx+oHxBfoB8UHwAQEIQ15JImhSHkH4IgAIRmFoSR5Q+CEAIPAwACAhkfqh8bH6gfEF+gHxQfAQAQhDU0liaFIeQfgiAAhGoWhJHlD4IQAg9EBxT/QAcJD6oPCw+oDwBfoA8ED0gHABQ0hIomhSHkD4IhDgaAD0gDDYsUNIIXsB8A8BSR5Q+CEAIPTgIE/0gCGR+qHxsfqB8QX6AfFB9IAxCEM5SSJ7AvAPAlIeQfgiABrgNUghewHwDwFJHlD4IQAg8OBhT/CAYJD6oPCw+oDwBfoA8EDwgHABQytIInsC8A8CUh5A+CIQIGkA9IAw2LEmSCF8AfAPAUkeUPghACD04CBP9IAhkfqh8bH6gfEF+gHxQfRAMQhDHEkifALwDwJSHkH4IgAa4BhIIXwB8A8BSR5Q+CEAIPDgYE/wgGGR+qHxsfqB8QX6AfFB8EBxCEMOSSJ8AvAPAlIeQfgiAAjwAQAosQpIAGhA8AEACEkIYAjwAgAosQZIAGhA8AEABEkIYFhGDLC96PCNBBwGUAAQAKAAFACgELWasARGACAGkAeQQPL5YAiQBCAJkBAgCpAAIA2QEZAUkBeQGJAZkAggC5BP8P8yBqn+SEhE/vem/xCxASAasBC9AiABkAKQACADkBAgBZCABASQQPL6UAiQACAMkE/0gGANkE/0QFAOkE/wgGAUkAIgFZCAAg+QAAQWkIAAGJAEIBeQAL8BIP73CPpP8P8yBqnmSEhE/vd2/wixASDO50/w/zJpRuFISET/9wL5CLEBIMTnnfgAAAKZCEABmYhC4dEAILvnMLWbsARGDUYAIAeQCJBA8vpQCZAEIAqQECALkAAgDZBP9IBgDpBP9EBQD5AAIBKQT/CAYBWQAiAWkAYgGJAAIBqQCCAMkAACEJAABBeQgAAZkAAgApABIAOQACAEkBAgBpCABAWQAL8BIP73tPlP8P8yB6m8SEhE/vci/xCxASAbsDC9T/D/MgGptkhIRP/3rfgIsQEg8+ed+AQAA5kIQAKZiELg0QAg6ucwtZuwBUYMRgAgB5AIkAyQT/RAUA+QACAQkBKQF5AZkBqQBJAQIAaQgAQFkAEsddEGIAmQASAKkAAgC5AOkBWQGJBCHgepnUhIRP735P4QsQEgG7AwvQIgApADkAUgCZBP8IBwFZABIBaQgh4HqZNISET+99D+CLEBIOrnT/D/MgKpjkhIRP/33/oIsQEg4OdyIAmQT/RAcA2QT/SAcA6QByCN+AQAT/D/Mgepg0hIRP73sf4IsQEgy+dP8P8yAal+SEhE/vft/wixASDB5wYgCZAAIA6QFZBCHgepd0hIRP73mf4IsQEgs+cFIAmQT/CAcBWQT/D/MgepcEhIRP73iv4IsQEgpOdP8P8yAqlrSEhE//eZ+hCxASCa51zgciAJkAAgDZBP9IBwDpACII34BADCHgepYUhIRP73bP4IsQEghudP8P8yAalcSEhE/veo/wixASB85ygg/vfn+E/w/zFWSEhE//f2/gixASBw50fyjhAJkAQgCpAQIAuQgAEOkAAEFZAGIBiQAiAWkAAgjfgEAAggDJAAAhCQAAQXkIAAGZBP8P8yB6lESEhE/vcy/gixASBM50/w/zIBqT9ISET+977/CLEBIELnnfgEAAIoddABIDznOEhIRP/3WP4IsQEgNedH8o0gCZAEIAqQECALkAAgDZBP9IBgDpAABBWQAiAWkAAgGJCN+AQAjfgFAAggDJAAAhCQAAQXkE/w/zIHqSVISET+9/X9CLEBIA/nT/D/MgGpIEhIRP73Mf8IsQEgBecoIP73cPgFIAmQASAKkAAgC5AOkE/wgHAVkAEgFpAAIBiQDJAQkBeQApABIAOQgh4HqRBISET+98v9CLEBIOXmT/D/MgKpC0hIRP/32vkIsQEg2+ZxIAmQACANkE/0gHAOkE/w/zIHqQNISET+97D9ILEBIMrmEAAAAA7gT/D/MgGp/khIRP73Of8IsQEgvead+AQACLEBILjmACC25hC1mrAERgAgBpAHkGYgCJABIAmQACAKkAuQDZARkBSQF5AYkBmQQh4Gqe1ISET+94D9ELEBIBqwEL2ZIAiQT/D/Mgap5khIRP73c/0IsQEg8ecFIAiQT/CAcBSQASAVkAAgFpABkAEgApAAIAOQECAFkIAEBJBP8P8yBqnYSEhE/vdX/QixASDV50/w/zIBqdNISET/92b5CLEBIMvnACDJ5wC1h7AAv85IwGxA9IAQzEnIZAhGwGwA9IAQAZAAvwC/AL8IRgBtQPSAcAhlCEYAbQD0gHABkAC/AL8IRgBrQPSAcAhjCEYAayD0gHAIYwC/CEaAbUDwgFCIZQhGgG0A8IBQAZAAvwC/t0hAaED0AHC1SUhgAL+ySMBsQPBAALBJyGQIRsBsAPBAAAGQAL8AvwC/CEbAbEDwgADIZAhGwGwA8IAAAZAAvwC/AL8IRsBsQPSAcMhkCEbAbAD0gHABkAC/AL+IFAKQAiADkAEgBJADIAWQBSAGkAKpm0gB8J//T/QAQAKQAqmYSAHwmP9P9GRgApAAIASQAqmUSAHwj/9P9OBgApACqZJIAfCI/0/0wGACkAKpjEgB8IH/B7AAvQC1hbCMSIVJSUQIYAhG/vdX+hCxASAFsAC9//dh/wQgf0lJREhgACF9SEhEgWBP8IBgkPqg8LD6gPF4SEhEAWECIUFhACGBYcFhAWICIUFiACGBYk/wgHHBYAkBwWIAIQFj/veR+QixASDU5wIgAJABkHFIBJBxSAOQAiACkMIeaUZmSEhE//d9+gixASDC52NISET/99P+CLEEILvnASFfSEhE//dZ/QixASCz5wAgsecAtYWwT/QWQVtIAvAG+E/04GFbSALwAfhP9GRhV0gB8Pz/ACABkE/0gFAAkAAgApADkGlGUEgB8An/ASABkAAgApBP9ABAAJBpRktIAfD+/gAiT/QAQUhIAvB4+ERIAGtA9IBwQkkIYwhGAGsg9IBwCGMIRgBtIPSAcAhlBbAAvRC1Q0g5SUlECGAIRv/3r/kCKAbQNUhIRP/3MfkIsQEgEL0AITFISET/9/78CLEBIPbnLkhIRP73qvkIsQEg7+f/957/ACDr53C1lLAERg1GFkYAIACQAZAEIAOQECAEkAaVgAEHkE/0QFAIkAAgC5BP8IBgDpAPlgYgEZAAIBOQTvYRYAKQCCAFkAACCZAABBCQgAASkE/w/zJpRhNISET+9837ELEBIBSwcL1P8P8yIUYOSEhE/vdY/QixASDz5wAg8ect6fBFlbCCRg1GkEbossD1gHZGRQDZRkYsRgXrCAcAIAGQApAU4AAAEAAAAAAQAkAAcABAABgASAAgAEgAHABIABQAoAIAAAECAAEAABAAoEHy7SADkAQgBJAQIAWQgAEIkE/0QFAJkAAgDJBP8IBgD5AAIBKQFJAIIAaQAAIKkAAEEZCAABOQAL8HlBCW+UhIRP/3r/sYsQEgFbC96PCFT/D/MgGp80hIRP73ZvsIsQEg8udP8P8yUUbuSEhE/vei/AixASDo50/w/zHpSEhE//fz+wixASDf5zREskQE9YBwuEIB2TgbAeBP9IBwBka8QsrTACDQ5xC1lLAERgAgAJABkE32I0ACkAQgA5AQIASQBpSAAQeQT/RAUAiQACALkA6QEZASkBOQCCAFkAACCZDQSEhE//dd+xCxASAUsBC9T/D/MmlGykhIRP73FfsIsQEg8+dP9PphxkhIRP/3rPsIsQEg6ucAIOjnELWUsARGtPWATwLTASAUsBC9ACAAkAGQQvLeEAKQBCADkBAgBJAgAwaQT/SAYAeQT/RAUAiQACALkA6QEZASkBOQCCAFkAACCZCvSEhE//cb+wixASDa50/w/zJpRqpISET+99T6CLEBINDnACDO5wC1lbAAIAGQApBG8p8AA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkJtISET/9/P6ELEBIBWwAL1P8P8yAamVSEhE/ver+gixASDz55NJkUhIRP/3Q/sIsQEg6+cAIOnnALWVsAAgAZACkEL21DADkAQgBJAQIAWQACAHkE/0gGAIkE/0QFAJkAAgDJBP8IBgD5ACIBCQBiASkAAgFJAIIAaQAAIKkAAEEZCAABOQT/D/MgGpeEhIRP73cPoQsQEgFbAAvU/w/zJpRnJISET+9/v7CLEBIPPnnfgAAADwYAAIsQEg7Oed+AAAAPAMAAixCCDl50Dy+lADkE/w/zIBqWVISET+90r6CLEBINjnT/D/MmlGYEhIRP731vsIsQEgzued+AAAAPABAAixAiDH5wAgxecBRk/wgGAIYIASSGCAEYhggBDIYIACCGEAIHBHALWXsFBISET/9136ELEBIBewAL0BIAOQACAEkAQgBpAQIAeQgAEKkE/0QFALkAAgDpBP8IBgEZAGIBSQACAWkE72EWAFkAggCJAAAgyQAAQTkIAAFZBP8P8yA6k6SEhE/vf0+QixASDS5wIgA5BB8u0gBZAAIBSQQh4DqTJISET+9+T5CLEBIMLnACABkAGpLUhIRP73wv4IsQEguOcAILbnALWVsP/3M/8CKCXRACABkAKQS/JPAAOQBCAEkBAgBZAAIAiQDJAPkBKQE5AUkAggBpBP8P8yAakaSEhE/ve1+RCxASAVsAC9//cR/wgoAdEAIPfnASD15wAg8+cAtZWw//cF/wgoKdEAIAGQApBD8s8AA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkE/w/zIBqQNISET+94f5MLEBIBWwAL0QAAAA4JMEAP/33/4CKAHRACDz5wEg8ecAIO/nALWVsAAgAZACkEv2RhADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQT/D/MgGpFUhIRP73WfkQsQEgFbAAvQAg++cAtZWwACABkAKQ/yADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQT/D/MgGpBUhIRP73OPkQsQEgFbAAvQAg++cAABAAAAD7SABoAPTAYLD1gG8C0U/0gGBwR/ZIgDAAaAD0gHCw9YB/AtFP9ABw8+cAIPHnAkYAIYq77kgAaAD0wGCw9YBvK9HrSIAwAGgg9IBw6EvD+IAAGEYAaCD0wGBA9ABwGGDkSEhEAGjkS7D78/AyIwD7A/EA4EkeMbHdSEBpAPSAYLD1gG/20NpIQGkA9IBgsPWAb1HRAyBwRwjg1UiAMABoIPSAcNJLw/iAAEXgsvUAfzrRz0gAaAD0wGCw9YBvKtHLSIAwAGhA9IBwyUvD+IAAGEYAaCD0wGBA9ABwGGDFSEhEAGjES7D78/AyIwD7A/EA4EkeMbG+SEBpAPSAYLD1gG/20LpIQGkA9IBgsPWAbxLRAyC/57ZIgDAAaED0gHCzS8P4gAAH4LFIAGgg9MBgQPSAYK5LGGAAIKznrEnJaCH0AHEBQ6pK0WARRsloQfSAcdFgcEemSMBoIPSAcKRJyGBwR6JIQGhA9IBgoElIYHBHn0hAaCD0gGCdSUhgcEebSEBoQPQAcJlJSGBwR5hIQGgg9ABwlklIYHBHlEiAaED0AECSSYhgcEeRSIBoIPQAQI9JiGBwRwJGCSpx0t/oAvAFFCErNT9JU2AAiEgAaiH0gEMYQ4ZLGGIYRkBqIfQgQ5hDgktYYl3ggUiAaghDf0uYYhhGwGoh8BADmEN8S9hiUOB6SABrCEN5SxhjGEZAa4hDWGNG4HVIgGsIQ3RLmGMYRsBriEPYYzzgcEgAbAhDb0sYZBhGQGyIQ1hkMuBrSIBsCENqS5hkGEbAbIhD2GQo4GZIAG0IQ2VLGGUYRkBtiENYZR7gYUiAbYuyGENfS5hlGEbAbYuymENcS9hlEeBbSABuwfMLAxhDWEsYZhhGQG7B8wsDmENVS1hmAuD/5wEgcEcAvwAg++cCRgkqQdLf6ALwBQ0TGR8lKzE4AEtIAGoh9IBDmENJSxhiNOBHSIBqiENGS5hiLuBESABriENDSxhjKOBBSIBriENAS5hjIuA+SABsiEM9SxhkHOA7SIBsiEM6S5hkFuA4SABtiEM3SxhlEOA1SIBti7KYQzNLmGUJ4DJIAG7B8wsDmEMvSxhmAeABIHBHAL8AIPvnAkYJKnfS3+gC8AUUICo0PkhZZgAmSEBqIfQgQxhDJEtYYhhGAGoh9IBDmEMgSxhiY+AfSMBqIfAQAxhDHEvYYhhGgGqIQ5hiV+AZSEBrCEMXS1hjGEYAa4hDGGNN4BRIwGsIQxJL2GMYRoBriEOYY0PgD0hAbAhDDUtYZBhGAGyIQxhkOeAKSMBsCEMIS9hkGEaAbIhDmGQv4AVIQG0IQwNLWGUYRgBtiEMYZSXgAAAAcABABAAAAEBCDwD+SMBti7IYQ/xL2GUYRoBti7KYQ/lLmGUR4PhIQG7B8wsDGEP1S1hmGEYAbsHzCwOYQ/JLGGYC4P/nASBwRwC/ACD75wJGCSpD0t/oAvAFDRUbISctMzoA6EhAaiH0IEOYQ+ZLWGI24ORIwGoh8BADmEPiS9hiLuDgSEBriEPfS1hjKODdSMBriEPcS9hjIuDaSEBsiEPZS1hkHODXSMBsiEPWS9hkFuDUSEBtiEPTS1hlEODRSMBti7KYQ89L2GUJ4M5IQG7B8wsDmEPLS1hmAeABIHBHAL8AIPvnx0iAaED0gGDFSYhgcEfESIBoIPSAYMJJiGBwR8BIgGhA9IBwvkmIYHBHvUiAaCD0gHC7SYhgcEe5SABoQPAQALdJCGBwR7ZIAGgg8BAAtEkIYHBHskhAaEDwEACwSUhgcEevSEBoIPAQAK1JSGBwR6tIQGhA8CAAqUlIYHBHqEhAaCDwIACmSUhgcEekSEBoQPBAAKJJSGBwR6FIQGgg8EAAn0lIYHBHnUhAaEDwgACbSUhgcEeaSEBoIPCAAJhJSGBwRwFGCGgQKAbQIChS0EAofNCAKHvR7OCSSABoIPAIAJBKEGAQHwBoIPAIABIfEGCMSAgwAGgg8AgAiUoIMhBgEB8AaCDwCAASHxBgSGgA9IAwsPWAPwfRgkgAHwBoQPAIAH9KEh8QYEhoAPQAMLD1AD8F0XtIAGhA8AgAeUoQYAh5APABADixdkgAHQBoQPAIAHNKEh0QYAh5APACAAIoB9FvSAgwAGhA8AgAbUoIMhBg8eBrSABoIPAQAGlKEGAQHwBoIPAQABIfEGBlSAgwAGgg8BAAYkoIMhBgEB8AaCDwEAASHxBgSGgA9IAwsPWAPwfRW0gAHwBoQPAQAFhKEh8QYEhoAPQAMAHgI+DB4LD1AD8F0VJIAGhA8BAAUEoQYAh5APABADixTUgAHQBoQPAQAEtKEh0QYAh5APACAAIoB9FHSAgwAGhA8BAAREoIMhBgoOBCSABoIPAgAEBKEGAQHwBoIPAgABIfEGA8SAgwAGgg8CAAOkoIMhBgEB8AaCDwIAASHxBgSGgA9IAwsPWAPwfRMkgAHwBoQPAgADBKEh8QYEhoAPQAMLD1AD8F0StIAGhA8CAAKUoQYAh5APABADixJkgAHQBoQPAgACRKEh0QYAh5APACAAIoB9EgSAgwAGhA8CAAHUoIMhBgUuAbSABoIPBAABlKEGAQHwBoIPBAABIfEGAVSAgwAGgg8EAAE0oIMhBgEB8AaCDwQAASHxBgSGgA9IAwsPWAPwfRC0gAHwBoQPBAAAlKEh8QYEhoAPQAMLD1AD8F0QRIAGhA8EAAAkoQYAh5A+AAcABAJAQBQADwAQAosXRIAGhA8EAAckoQYAh5APACAAIoB9FuSAAdAGhA8EAAbEoSHRBgAeABIHBHAL8AIPvnaEgAaED0gEBmSQhgcEcAv2RIAGgg9IBAYkoQYGJISEQAaGJKsPvy8DIiAPsC8QDgSR4xsVtIQGkA9ABwsPUAf/bQWEhAaQD0AHCw9QB/AdEDIHBHACD851JJCWgh8AcBUEoRYFJJCWhB8AQBUEoRYAEoAdEwvwLgQL8gvyC/TEkJaCHwBAFKShFgcEdFSQloIfAHAUkcQ0oRYEVJCWhB8AQBQ0oRYAEoAdEwvwLgQL8gvyC/PkkJaCHwBAE8ShFgcEc4SQloIfAHAYkcNUoRYDdJCWhB8AQBNUoRYAEoAdEwvwLgQL8gvyC/MUkJaCHwBAEvShFgcEcqSABoIPAHAAAdKEkIYCpIAGhA8AQAKEkIYAC/AL8wv3BHcEdwR3BHcEcQtR5IFDgAaAD0gDAwsfz3qf5P9IAwGUkUOQhgGEgMMABoAPAIACix//fp/wggE0kMMQhgEkgMMABoAPAQACix//fc/xAgDUkMMQhgDEgMMABoAPAgACix//fP/yAgB0kMMQhgBkgMMABoAPBAACix//fC/0AgAUkMMQhgEL0oBAFAAHAAQAQAAABAQg8AEO0A4PpIAGhA8AEA+EkIYADgAL/2SABoAPACAAAo+NDzSABoIPDwAEDwYADwSQhgACCIYAhGAGjuSQhA7EkIYAAgyGAIRsBoQPSAUMhgACAIYQhGAGlA9IBQCGEAIEhhCEZAaUD0gFBIYQhGAGgg9IAgCGAAIIhh30jgSUlECGBwR/C1ACEAIwAkAiUCIgAg1062aAbwDAZesdVOtmgG8AwGDC4f0dJO9mgG8AMGAS4Z0c9ONmgG8AgGLrnMTpQ2NmjG8wMhA+DJTjZoxvMDEctOfkRW+CEQxU62aAbwDAaGuQhGDuDCTrZoBvAMBgQuAdHESAbgvk62aAbwDAYILgDRwUi6TrZoBvAMBgwuNtG3TvZoBvADBLVO9mjG8wMWchwBLBnQAiwC0AMsFNEJ4LROtvvy9q5P/2jH8wYnBvsH8xPgsE62+/L2qU//aMfzBicG+wfzCeAAv7H78vakT/9ox/MGJwb7B/MAvwC/oE72aMbzQWZ2HHUAs/v18PC9+LUERgAmACWZSIBtAPCAUBix//dB+gZGFuAAv5RIgG1A8IBQkkmIZQhGgG0A8IBQAJAAvwC///cv+gZGjEiAbSDwgFCKSYhltvUAfwfRgCwM2aAsAdkCJQjgASUG4IAsAdMCJQLgcCwA0QElh0gAaCDwDwAoQ4VJCGAIRgBoAPAPAKhCAdABIPi9ACD85/i1BEYAJSB4APAQABAocNF0SIBoAPAMAAAoa9FxSABoAPACABixoGkIuQEg+L1sSCFqAGgA8AgAILFpSABoAPDwAAXgZ0iUMABoAPRwYAAJgUIf2SBq//eM/wixASDl5wC/X0gAaEDwCABdSQhgCEYAaCDw8AAhaghDWUkIYAC/CEZAaCD0f0DhaUDqASBUSUhgHuAAv1JIAGhA8AgAUEkIYAhGAGgg8PAAIWoIQ0xJCGAAvwhGQGgg9H9A4WlA6gEgR0lIYCBq//dT/wixASCs5//3z/5CSYlowfMDEUhKekRRXMhAQUlJRAhgDyAB8Af9SuCgaYCzOkgAaEDwAQA4SQhg/Pcy/QVGBuD89y79QBsCKAHZAyCI5zFIAGgA8AIAACjy0AC/LkgAaEDwCAAsSQhgCEYAaCDw8AAhaghDKEkIYAC/CEZAaCD0f0DhaUDqASAjSUhgF+D/5yFIAGgg8AEAH0kIYPz3AP0FRgbg/Pf8/EAbAigB2QMgVucYSABoAPACAAAo8tEgeADwAQAAKH7QE0iAaADwDAAIKAvQEEiAaADwDAAMKA7RDUjAaADwAwADKAjRCkgAaAD0ADCIs2BoeLsBIDDnAL9gaLD1gD8Y0QNIAGhA9IAwAUkIYC3gABACQP/0/uoACT0ABAAAAK4cAAAAJPQAABJ6AAAgAkB6GgAAYGiw9aAvDNH9SABoQPSAIPtJCGAIRgBoQPSAMAhgC+A04PdIAGgg9IAw9UkIYAhGAGgg9IAgCGAAv2BomLH895L8BUYI4Pz3jvxAG0HyiDGIQgHZAyDm5ulIAGgA9AAwACjw0BLg/Pd+/AVGCOD893r8QBtB8ogxiEIB2QMg0ubfSABoAPQAMAAo8NEgeADwAgACKF7R2kiAaADwDAAEKAvQ10iAaADwDAAMKBjR1EjAaADwAwACKBLR0UgAaAD0gGAYseBoCLkBIKzmzEhAaCDw/kAhfEDqAWDJSUhgOeDgaACzxkgAaED0gHDESQhg/Pc5/AVGBuD89zX8QBsCKAHZAyCP5r5IAGgA9IBgACjy0LtIQGgg8P5AIXxA6gFgt0lIYBbgtkgAaCD0gHC0SQhg/PcY/AVGBuD89xT8QBsCKAHZAyBu5q1IAGgA9IBgACjy0SB4APAIAAgoNtFgadCxp0iUMABoQPABAKRJwfiUAPz3+PsFRgbg/Pf0+0AbAigB2QMgTuadSJQwAGgA8AIAACjx0BngmUiUMABoIPABAJdJwfiUAPz33fsFRgbg/PfZ+0AbAigB2QMgM+aQSJQwAGgA8AIAACjx0SB4APAEAAQob9EAJolIgG0A8IBQcLkAv4ZIgG1A8IBQhEmIZQhGgG0A8IBQAJAAvwC/ASaASABoAPSAcLC5fkgAaED0gHB8SQhg/Pem+wVGBuD896L7QBsCKAHZAyD85XVIAGgA9IBwACjy0AC/oGgBKAjRb0iQMABoQPABAG1JwfiQACHgoGgFKA/RaUiQMABoQPAEAGdJwfiQAAhG0PiQAEDwAQDB+JAADuBhSJAwAGgg8AEAX0nB+JAACEbQ+JAAIPAEAMH4kAAAv6BoqLH892P7BUYJ4Pz3X/tAG0HyiDGIQgLZAyC35STgUUiQMABoAPACAAAo7tAT4Pz3TfsFRgjg/PdJ+0AbQfKIMYhCAdkDIKHlR0iQMABoAPACAAAo79EBLgXRQkiAbSDwgFBASYhlAL8geADwIAAgKDbRYGrQsTtImDAAaEDwAQA5ScH4mAD89yH7BUYG4Pz3HftAGwIoAdkDIHflMkiYMABoAPACAAAo8dAZ4C5ImDAAaCDwAQArScH4mAD89wb7BUYG4Pz3AvtAGwIoAdkDIFzlJEiYMABoAPACAAAo8dGgavCzIEiAaADwDAAMKHXQoGoCKFPRG0gAaCDwgHAZSQhg/Pfj+gVGBuD899/6QBsCKAHZAyA55RNIAGgA8ABwACjy0SBrQB4BAWBrQeoAIOFqCEOhjwEiwutRAUDqQVFAIABdwutQAEHqQGE4IABdQerAYARJyGAIRgBoQPCAcAXgTOAAAAAQAkAAcABACGAIRsBoQPCAcMhg/Pen+gVGBuD896P6QBsCKAHZAyD95PdIAGgA8ABwACjy0C/g80gAaCDwgHDxSQhgCEYAaADwAGBIuQhGAGgA8ABQILkIRsBoIPADAMhg6UjAaOlJCEDnSchg/Pd6+gVGB+AN4Pz3dfpAGwIoAdkDIM/k4EgAaADwAHAAKPLRAeABIMbkACDE5PC1ACIAIwAkAiUCIQAg1072aAbwAwYBLhLR1E42aAbwCAYuudFOlDY2aMbzAyID4M5ONmjG8wMSzk5+RFb4IiDKTvZoBvADBMhO9mjG8wMWcRwBLBnQAiwC0AMsFNEJ4MVOtvvx9sFP/2jH8wYnBvsH8xPgwU62+/H2vE//aMfzBicG+wfzCeAAv7L78fa3T/9ox/MGJwb7B/MAvwC/s072aMbzQWZ2HHUAs/v18PC9LenwQQRGDUYAJgAnsEawSABoAPAPAKhCD9KtSABoIPAPAChDqkkIYAhGAGgA8A8AqEIC0AEgvejwgSB4APABAAAobtBgaAMoI9GcSABoAPAAcAi5ASDu5//3ev8HRp1Ih0IG2SB4APACAAIoAdGgaCCxkkiAaADw8ACgu49IgGgg8PAAQPCAAIxJiGBP8IAIKeBgaAIoBtGISABoAPQAMIi5ASDH52BoMLmESABoAPACAEC5ASC+54BIAGgA9IBgCLkBILfn//cs+wdGgUiHQgnZekiAaCDw8ABA8IAAd0mIYE/wgAh1SIBoIPADAGFoCENySYhg/PeQ+QZGYGgDKBDRCOD894n5gBtB8ogxiEIB2QMgj+dpSIBoAPAMAAwo8NE24GBoAigQ0Qjg/Pd1+YAbQfKIMYhCAdkDIHvnX0iAaADwDAAIKPDRIuBgaIC5COD892L5gBtB8ogxiEIB2QMgaOdVSIBoAPAMAAAo8NEP4Ajg/PdR+YAbQfKIMYhCAdkDIFfnTUiAaADwDAAEKPDRIHgA8AIAAigI0UdIgGgg8PAAoWgIQ0RJiGAI4LjxgA8F0UFIgGgg8PAAP0mIYENIAGgA8A8AqEIO2UBIAGgg8A8AKEM+SQhgCEYAaADwDwCoQgHQASAl5yB4APAEAAQoB9ExSIBoIPTgYOFoCEMuSYhgIHgA8AgACCgI0StIgGgg9GBQIWlA6sEAJ0mIYP/3f/olSYlowfMDESpKekRRXMhAKUlJRAhgDyAB8Lf4ACD45nC1hrAGRg1GFEYAvxpIwGxA8AEAGEnIZAhGwGwA8AEAAJAAvwC/iBUBkAIgApAEkAAgA5AFkAGpT/CQQADwEPkNSIBoIPD+QEXqBAEIQwpJiGAGsHC9EEhIRABocEcAtf/3+f8ESYlowfMCIQtKekRRXMhAAL0AAAAQAkD//+7+lhQAAAAk9AAAEnoAACACQAC0xATaEQAABAAAAGYRAAAAtf/32P9rSYlowfPCIWpKekRRXMhAAL0/IQFgZUkJaAH0gCGx9YAvA9FP9KAhQWAM4GBJCWgB9IAxsfWAPwPRT/SAMUFgAeAAIUFgWUkJaAHwAQERsQEhgWEB4AAhgWFUSUlowfMHIcFhUkkJaAHw8AEBYk9JCWgB9IBxsfWAfwPRT/SAccFgAeAAIcFgSUlJaMHzBmEBYUZJkDEJaAHwBAEEKQLRBSGBYArgQUmQMQloAfABARGxASGBYAHgACGBYDxJlDEJaAHwAQERsQEhQWEB4AAhQWE2SZgxCWgB8AEBEbEBIUFiAeAAIUFiMUkJaAHwgHGx8YB/AtECIYFiAeABIYFiK0nJaAHwAwLCYihJyWjB8wMRSRwBYyVJyWjB8wYiQmMjSclowfNBUUkcSgDCYx9JyWjB80FhSRxKAAJkHEnJaMoOgmNwRw8iAmAYSpJoAvADAkJgFkqSaALw8AKCYBNKkmgC9OBiwmARSpJoAvRgUtIIAmEQShJoAvAPAgpgcEcLSABoQPQAIAlJCGBwR3BHELUGSMBpAPSAcLD1gH8F0f/39f9P9IBwAUkIYhC9ABACQCQRAAAAIAJAeLUCRgAjACQAINrgASaeQA1oBeoGBAAsctBNaAItAtBNaBItE9HeCALxIAVV+CYAXQfuDg8ltUCoQ14H9g4NabVAKEPeCALxIAVF+CYAEGheAAMltUCoQw15BfADBV4AtUAoQxBgTWgBLQjQTWgCLQXQTWgRLQLQTWgSLRPRkGheAAMltUCoQ14AzWi1QChDkGBQaAElnUCoQw15xfMAFZ1AKENQYNBoXgADJbVAqENeAI1otUAoQ9BgTWgF8IBVtfGAX3zRAL+lTS1uRfABBaNONWY1Ri1uBfABBQCVAL8Av0/qtjWeCFX4JgCdBy4PDyW1QKhDsvGQTwLRACUk4F7gmE2qQgHRASUe4JZNqkIB0QIlGeCVTapCAdEDJRTgk02qQgHRBCUP4JJNqkIB0QUlCuCQTapCAdEGJQXgj02qQgHRByUA4Aglngc2D7VAKEOLTZ4IRfgmAIpNKGigQ01oBfSANbX1gD8A0SBDhU0oYC0dKGigQ01oBfQANbX1AD8A0SBDf00tHShgLR0oaKBDTWgF9IAVtfWAHwDRIEN4TQg1KGAtHShooENNaAX0ABW19QAfANEgQ3JNDDUoYFscDWjdQAAtf/Qgr3i98LULRgAhACIAJITgASWNQAXqAwIAKn3QBWhPAAMmvkA1QwVgzggA8SAFVfgmUE4H9w4PJr5AtUPPCADxIAZG+CdQhWhPAAMmvkC1Q4VgRWgBJo5AtUNFYMVoTwADJr5AtUPFYFNNjghV+CZAjQcuDw8ltUAsQLDxkE8B0QAlI+BFTahCAdEBJR7gQ02oQgHRAiUZ4EJNqEIB0QMlFOBATahCAdEEJQ/gP02oQgHRBSUK4D1NqEIB0QYlBeA8TahCAdEHJQDgCCWOBzYPtUClQiDRjQcuDw8lBfoG9DVNjghV+CZgpkOPCEX4J2AyTS1olUMwTjVgNR0taJVDNh01YDUdLWiVQzYdNWA1HS1olUM2HTVgSRwj+gH1AC1/9Hav8L0CRhNpC0ALsQEgAOAAIHBHCrGBYQDggWJwR0JpSkBCYXBHCLUCRk/0gDAAkACYCEMAkACY0GHRYQCY0GHQaQCQ0GkA9IAwCLEAIAi9ASD853BHELUERg9IFDAAaCBAKLEMSBQwBGAgRv/38v8QvQAAABACQAAEAEgACABIAAwASAAQAEgAFABIABgASAAcAEgIAAFAAAQBQAF5Sh7+SwPrggJCZfxKQDKCZUoeASOTQMNlcEcQtQAi+EwDaKNCAdL3SQHg9kkcMQN4CDsUJLP79PJDbJsIAeuDA4Nk7kuAO8NkASOTQANlEL1wtQRGACUMuQEgcL3pSSBoiEIL0ulJIGhAGhQhsPvx8IAAYGTlSAg4IGQK4OFJIGhAGhQhsPvx8IAAYGTdSAg4IGQCIIT4JQAgaAVoR/bwcIVD1OkCAQhDIWkIQ2FpCEOhaQhD4WkIQyFqCEMFQyBoBWAgRv/3qf+gaLD1gE8B0QAgYGAgeaFsCGDU6RMQSGBgaGCxYGgEKAnYIEb/94f/ACBhbQhg1OkWEEhgA+AAIGBloGXgZQAg4GIgY2BjoGPgYwEghPglAAAghPgkAAC/m+cQtQRGDLkBIBC9IGgAaCDwAQAhaAhgskkgaIhCC9KySSBoQBoUIbD78fCAAGBkrkgIOCBkCuCqSSBoQBoUIbD78fCAAGBkpkgIOCBkACAhaAhglPhEEAEgiEAhbEhgIEb/90r/ACChbAhg1OkTEEhgYG0osQAgYW0IYNTpFhBIYAAgYGWgZeBl4GOE+CUAAL+E+CQAAL8Av7bnMLXQ6RNUbGBEbRSx0OkWVGxgkPhEUAEkrEAFbGxgBGhjYIRoECwE0QRoomAEaOFgA+AEaKFgBGjiYDC9LenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKBfRAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//e5/yBoAGhA8AEAIWgIYAbgAL8AIIT4JAAAv0/wAghARtTnLenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKD/RAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//eA/yBrMLEgaABoQPAOACFoCGAL4CBoAGgg8AQAIWgIYCBoAGhA8AoAIWgIYKBsAGgA9IAwKLGgbABoQPSAcKFsCGBgbSixYG0AaED0gHBhbQhgIGgAaEDwAQAhaAhgBuAAvwAghPgkAAC/T/ACCEBGrOcBRgAiCbkBIHBHCGgAaCDwDgALaBhgiGwAaCD0gHCLbBhgCGgAaCDwAQALaBhgkfhEMAEgmEALbFhg0ekTMFhgSG1AsUhtAGgg9IBwS20YYNHpFjBYYAEggfglAAC/ACCB+CQAAL8QRs7ncLUERgAllPglAAIoA9AEIOBjASU84CBoAGgg8A4AIWgIYCBoAGgg8AEAIWgIYKBsAGgg9IBwoWwIYJT4RBABIIhAIWxIYNTpExBIYGBtQLFgbQBoIPSAcGFtCGDU6RYQSGABIAjgAAAACQJACAQCQAAIAkAIAAJAhPglAAC/ACCE+CQAAL+gaxCxIEaha4hHKEZwvS3p8EEERg5GFUZP8AAIlPglAAIoCdAEIOBjAL8AIIT4JAAAvwEgvejwgSBoAGgA8CAAILFP9IBw4GMBIPPnLrmU+EQQAiAA+gH3BOCU+EQQBCAA+gH3+/e0+4BGLeAgbABolPhEIAghkUAIQICxlPhEEAEgiEAhbEhgASDgY4T4JQAAvwAghPgkAAC/ASDK52gckLEtsfv3lPug6wgAqEIL2SAg4GMBIIT4JQAAvwAghPgkAAC/ASC15yBsAGg4QAAozNBgbYixoG0AaOFtCEBgsWBtAGhA9IBwYW0IYNTpFhBIYOBrQPSAYOBj4GwAaCFtCEAwsdTpExBIYOBrQPQAcOBjTrmU+EQQAiCIQCFsSGABIIT4JQAF4JT4RBAEIIhAIWxIYAC/ACCE+CQAAL8Av3jncLUERiBsBWggaAZolPhEEAQgiEAoQNCxBvAEALixIGgAaADwIAAouSBoAGgg8AQAIWgIYJT4RBAEIIhAIWxIYCBrAChO0CBGIWuIR0rglPhEEAIgiEAoQAizBvACAPCxIGgAaADwIABAuSBoAGgg8AoAIWgIYAEghPglAJT4RBACIIhAIWxIYAC/ACCE+CQAAL/gajCzIEbhaohHIuCU+EQQCCCIQChA4LEG8AgAyLEgaABoIPAOACFoCGCU+EQQASCIQCFsSGABIOBjhPglAAC/ACCE+CQAAL9gaxCxIEZha4hHcL0QtQNGACQAv5P4JAABKAHRAiAQvQEgg/gkAAC/k/glAAEoEtExsQEpBtACKQbQAykI0QXg2mIH4BpjBeBaYwPgmmMB4AEkAL8A4AEkAL8AIIP4JAAAvyBG2+cCRgAjAL+S+CQAASgB0QIgcEcBIIL4JAAAv5L4JQABKBvRBSkW0t/oAfADBgkMDwAAINBiEOAAIBBjDeAAIFBjCuAAIJBjB+AAINBiEGNQY5BjAeABIwC/AOABIwC/ACCC+CQAAL8YRtLnAUaR+CUAcEcBRshrcEcQtYywBEYAv75IAG1A9ABwvEkIZQhGAG0A9ABwAZAAvwC/AL8IRsBsQPSAEMhkCEbAbAD0gBABkAC/AL8IRgBrQPQAcAhjCEYAayD0AHAIYwC/CEaAbUDwgFCIZQhGgG0A8IBQAZAAvwC/p0hAaED0AHClSUhgAL+iSMBsQPBAAKBJyGQIRsBsAPBAAAGQAL8AvwC/CEbAbED0gHDIZAhGwGwA9IBwAZAAvwC/AL8IRsBsQPSAcMhkCEbAbAD0gHABkAC/AL8AvwhGwGxA9IBwyGQIRsBsAPSAcAGQAL8AvwC/CEbAbED0gHDIZAhGwGwA9IBwAZAAvwC/AL8IRsBsQPCAAMhkCEbAbADwgAABkAC/AL8AvwhGwGxA8IAAyGQIRsBsAPCAAAGQAL8AvwC/CEbAbEDwgADIZAhGwGwA8IAAAZAAvwC/AL8IRsBsQPBAAMhkCEbAbADwQAABkAC/AL8AvwhGwGxA8EAAyGQIRsBsAPBAAAGQAL8AvwC/CEbAbEDwQADIZAhGwGwA8EAAAZAAvwC/iBQHkAIgCJABIAmQAiAKkAUgC5AHqVdI//fX+UAgB5AAIAmQB6lUSP/3z/lP9ABgB5AHqVFI//fI+U/0gGAHkAepTUj/98H5T/QAcAeQB6lKSP/3uvlP9IBwB5AHqUdI//ez+U/0AHAHkAepREj/96z5T/SAYAeQB6lASP/3pflP9ABwB5AHqTtI//ee+U/0gGAHkAepN0j/95f5T/QAQAeQB6k0SP/3kPkCIAKQA5A0SAaQNEgFkAIgBJDCHgKpIEb898X8DLAQvRC1BEZMIPv3cPpP9IBRJ0j/9136QCEmSP/3WfpP9ABhI0j/91T6T/SAYSFI//dP+k/0AHEeSP/3SvpP9IBxHUj/90X6T/QAcRpI//dA+k/0gGEYSP/3O/pP9ABxE0j/9zb6T/SAYRFI//cx+k/0AEEOSP/3LPoLSABrQPQAcAlJCGMIRgBrIPQAcAhjCEYAbSD0AHAIZQhGwGwg9IAQyGQQvQAAABACQABwAEAAGABIACAASAAcAEgCAAABAgABAAC1l7AUIRKoAPCm+EQhAagA8KL4ECABkAEgB5AAIAiQAiALkAEhDJFgIAmQDZE3IQ6RAiERkRCRByEPkQGo/vcE+wixF7AAvQ8gEpADIBOQgCAUkAAgFZAWkAMhEqj+953+ALHu5wIgEpAAIBSQBSESqP73k/4AseTnAL/i53y1BEYNRhZGUCExSEhEAPBk+FAhMEhIRADwX/gAIACQAZD791T4//es/wIgKklJRAhgQfLtIIhgT/CAYIhjASDIYwhgTvYTQIhgCCBIZACQICABkP33NvkIsQEgfL0AIPzncLUERgAlJPBwRShG/feg+gAgcL0BRgAgcEcQtf33CvsAIBC9cLUERg1GFkYqRiFGMEb99xH6ACBwvXC1BEYORhVG/feg+wfgFPgBGxX4ASuRQgHQIEZwvTAepvEBBvPRIEb45wNGASBwRwFGACBwRxAAAABgAAAAT/AAAgC1E0aURpZGIDkiv6DoDFCg6AxQsfEgAb/0968JByi/oOgMUEi/DMBd+ATriQAov0D4BCsIv3BHSL8g+AIrEfCATxi/APgBK3BHAAAAAAAAAAAAAAECAwQGBwgJAAAAAAECAwSghgEAQA0DAIAaBgAANQwAQEIPAICEHgAACT0AABJ6AAAk9AAANm4BAEjoAQBs3AIAAAAAAAk9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-    pc_init: 0x5357
-    pc_uninit: 0x53cd
-    pc_program_page: 0x53dd
-    pc_erase_sector: 0x53b9
-    pc_erase_all: 0x53d3
-    data_section_offset: 0x54c8
-    flash_properties:
-      address_range:
-        start: 0x70000000
-        end: 0x74000000
-      page_size: 0x100
-      erased_byte_value: 0xff
-      program_page_timeout: 0xbb8
-      erase_sector_timeout: 0xbb8
-      sectors:
-        - size: 0x10000
-          address: 0x0
-  - name: stm32l4xx_256
-    description: STM32L4xx 256 KB Flash
-    cores:
-      - main
-    default: true
-    instructions: T/T/YUD2+nMB6hAhQvIUAMTyAgACaJpDEUQCMQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvACAgJgOCDA8gEACEAYvwEgcEdC8hQAxPICAAFoQfAEAQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvAEAgJgOCDA8gEACEAYvwEgcEdC8ggAQPIjEcTyAgDE8mdRAWBI9qsRzPbvUQFgwGjAD3BH8LUDry3pAAtA8jgMQvIQAyHwBw7A8gEMxPICA77xAA8v0BZG8UZms6nxCAkG8QgINWh2aFxoRPABBFxgBWBGYBxo5ANBvxxoX+rENBxoX+rENALVHGjkA/LUHGgU6gwPadEcaAgwRkbkBx6/HGgk8AEEHGBcaLnxAA8k8AEEXGDR0RHwBwFl0ALrDgVqGBL4AR2VQmHw/wEj0BL4AW2VQkbqASQg0BL4AW2VQkbqBC4e0BL4AW2VQkbqDigc0BL4AW2VQkbqCCYa0BL4AR2VQkHqBiEX0BL4ASxC6gEhckYS4E/w/zIP4E/w/zIhRgvgT/D/MnFGB+BP8P8yQUYD4ApGMUYA4CJGXmhG8AEGXmABYEJgGGjAA0G/GGhf6sAwGGhf6sAwAtUYaMAD8tQYaBDqDA8D0AEgvegAC/C9GGjABx6/GGgg8AEAGGBYaCDwAQBYYAAgvegAC/C9QvIUAMTyAgABaEHwAEEBYAAgcEeAtW9G//cz/wAg//fV/v/3BP8AIAAhACL/9zr///fm//7n1NQEAAAA
-    pc_init: 0xb7
-    pc_uninit: 0x235
-    pc_program_page: 0xd9
-    pc_erase_sector: 0x1
-    pc_erase_all: 0x63
-    data_section_offset: 0x26c
-    flash_properties:
-      address_range:
-        start: 0x8000000
-        end: 0x8040000
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0x190
-      erase_sector_timeout: 0x190
-      sectors:
-        - size: 0x800
-          address: 0x0
-  - name: stm32l4xx_512
-    description: STM32L4xx 512 KB Flash
-    cores:
-      - main
-    default: true
-    instructions: T/T/YUD2+nMB6hAhQvIUAMTyAgACaJpDEUQCMQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvACAgJgOCDA8gEACEAYvwEgcEdC8hQAxPICAAFoQfAEAQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvAEAgJgOCDA8gEACEAYvwEgcEdC8ggAQPIjEcTyAgDE8mdRAWBI9qsRzPbvUQFgwGjAD3BH8LUDry3pAAtA8jgMQvIQAyHwBw7A8gEMxPICA77xAA8v0BZG8UZms6nxCAkG8QgINWh2aFxoRPABBFxgBWBGYBxo5ANBvxxoX+rENBxoX+rENALVHGjkA/LUHGgU6gwPadEcaAgwRkbkBx6/HGgk8AEEHGBcaLnxAA8k8AEEXGDR0RHwBwFl0ALrDgVqGBL4AR2VQmHw/wEj0BL4AW2VQkbqASQg0BL4AW2VQkbqBC4e0BL4AW2VQkbqDigc0BL4AW2VQkbqCCYa0BL4AR2VQkHqBiEX0BL4ASxC6gEhckYS4E/w/zIP4E/w/zIhRgvgT/D/MnFGB+BP8P8yQUYD4ApGMUYA4CJGXmhG8AEGXmABYEJgGGjAA0G/GGhf6sAwGGhf6sAwAtUYaMAD8tQYaBDqDA8D0AEgvegAC/C9GGjABx6/GGgg8AEAGGBYaCDwAQBYYAAgvegAC/C9QvIUAMTyAgABaEHwAEEBYAAgcEeAtW9G//cz/wAg//fV/v/3BP8AIAAhACL/9zr///fm//7n1NQEAAAA
-    pc_init: 0xb7
-    pc_uninit: 0x235
-    pc_program_page: 0xd9
-    pc_erase_sector: 0x1
-    pc_erase_all: 0x63
-    data_section_offset: 0x26c
-    flash_properties:
-      address_range:
-        start: 0x8000000
-        end: 0x8080000
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0x190
-      erase_sector_timeout: 0x190
-      sectors:
-        - size: 0x800
-          address: 0x0
-  - name: stm32l4xx_1024
-    description: STM32L4xx 1MB Flash
-    cores:
-      - main
-    default: true
-    instructions: T/T/YUD2+nMB6hAhQvIUAMTyAgACaJpDEUQCMQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvACAgJgOCDA8gEACEAYvwEgcEdC8hQAxPICAAFoQfAEAQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvAEAgJgOCDA8gEACEAYvwEgcEdC8ggAQPIjEcTyAgDE8mdRAWBI9qsRzPbvUQFgwGjAD3BH8LUDry3pAAtA8jgMQvIQAyHwBw7A8gEMxPICA77xAA8v0BZG8UZms6nxCAkG8QgINWh2aFxoRPABBFxgBWBGYBxo5ANBvxxoX+rENBxoX+rENALVHGjkA/LUHGgU6gwPadEcaAgwRkbkBx6/HGgk8AEEHGBcaLnxAA8k8AEEXGDR0RHwBwFl0ALrDgVqGBL4AR2VQmHw/wEj0BL4AW2VQkbqASQg0BL4AW2VQkbqBC4e0BL4AW2VQkbqDigc0BL4AW2VQkbqCCYa0BL4AR2VQkHqBiEX0BL4ASxC6gEhckYS4E/w/zIP4E/w/zIhRgvgT/D/MnFGB+BP8P8yQUYD4ApGMUYA4CJGXmhG8AEGXmABYEJgGGjAA0G/GGhf6sAwGGhf6sAwAtUYaMAD8tQYaBDqDA8D0AEgvegAC/C9GGjABx6/GGgg8AEAGGBYaCDwAQBYYAAgvegAC/C9QvIUAMTyAgABaEHwAEEBYAAgcEeAtW9G//cz/wAg//fV/v/3BP8AIAAhACL/9zr///fm//7n1NQEAAAA
-    pc_init: 0xb7
-    pc_uninit: 0x235
-    pc_program_page: 0xd9
-    pc_erase_sector: 0x1
-    pc_erase_all: 0x63
-    data_section_offset: 0x26c
-    flash_properties:
-      address_range:
-        start: 0x8000000
-        end: 0x8100000
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0x190
-      erase_sector_timeout: 0x190
-      sectors:
-        - size: 0x800
-          address: 0x0
-  - name: stm32l4xx_128
-    description: STM32L4xx 128 KB Flash
-    cores:
-      - main
-    default: true
-    instructions: T/T/YUD2+nMB6hAhQvIUAMTyAgACaJpDEUQCMQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvACAgJgOCDA8gEACEAYvwEgcEdC8hQAxPICAAFoQfAEAQFgAWhB9IAxAWBQ+AQcyQMM1VD4BBzJA0S/UPgEHF/qwTED1VD4BBzJA+7UUPgEHAJoIvAEAgJgOCDA8gEACEAYvwEgcEdC8ggAQPIjEcTyAgDE8mdRAWBI9qsRzPbvUQFgwGjAD3BH8LUDry3pAAcB8AcIQPI4DELyEAOh6wgOwPIBDMTyAgO+8QgPL9MWRvJGZrOq8QgKBvEICTRodmhdaEXwAQVdYARgRmAcaOQDRL8caF/qxDQF1Rxo5AMC1Rxo5APy1BxoFOoMD2nRHGgIME5G5AcevxxoJPABBBxgXGi68QgPJPABBFxg0dK48QAPZdAC6w4GCkQS+AEdlkJh8P8BI9AS+AFdlkJF6gElINAS+AFNlkJE6gUoHtAS+AFNlkJE6gguHNAS+AFNlkJE6g4uGtAS+AEdlkJB6g4hF9AS+AEsQuoBIUJGEuBP8P8yD+BP8P8yKUYL4E/w/zJBRgfgT/D/MnFGA+AKRnFGAOAqRl5oRvABBl5gAWBCYBhowANEvxhoX+rAMAXVGGjAAwLVGGjAA/LUGGgQ6gwPA9ABIL3oAAfwvRhowAcevxhoIPABABhgWGgg8AEAWGAAIL3oAAfwvULyFADE8gIAAWhB8ABBAWAAIHBHgLVvRv/3Mf8AIP/30/7/9wL/ACAAIQAi//c4///35v/+59TUBAAAAA==
-    pc_init: 0xb7
-    pc_uninit: 0x239
-    pc_program_page: 0xd9
-    pc_erase_sector: 0x1
-    pc_erase_all: 0x63
-    data_section_offset: 0x270
-    flash_properties:
-      address_range:
-        start: 0x8000000
-        end: 0x8020000
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0x190
-      erase_sector_timeout: 0x190
-      sectors:
-        - size: 0x800
-          address: 0x0
-  - name: stm32l4r9i_disco_ospi1
-    description: MX25L51245G_STM32L4R9I_DISCO_OSPI1
-    cores:
-      - main
-    default: false
-    instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAARkgAaEDwAQBESQhgACCIYAhGAGhCSQhAQEkIYMgUyGAIRgBoIPSAIAhgACCIYcgDPEkIYHBH8LUAIwAgACICJAAlAiE1TjZoBvAIBi65M06UNjZoxvMDIAPgME42aMbzAxAxTn5EVvggACxOtmgG8AwGNrEELgjQCC4L0AwuOdEN4CpOTkQwYDjgKU4nT09EPmAz4CdOJU9PRD5gLuAfTvZoBvADBR1O9mjG8wMWcRwCLQLQAy0I0QPgHU62+/HyBuAcTrb78fIC4LD78fIAvwC/Ek72aMbzBiZyQw9O9mjG80Fmdhx0ALL79PYPT09EPmAD4A1OTkQwYAC/AL8HTrZoxvMDFgxPf0S7XQdOTkQ2aN5ABU9PRD5g8L0AEAJA///26gjtAOBsUwAABAAAAAAk9AAAEnoAsFIAAHtIgGtA8IBQeUmIYwhGgGsg8IBQiGNwR3ZIAGhA9IBwdEkIYHBHc0gAaCD0gHBxSQhgcEcBRm9IQGgg8A4ACmgQQ2xKUGBsSABoIPSAMGpKEGAQHwBoIPSAMBIfEGBmSAgwAGgg9IAwY0oIMhBgEB8AaCD0gDASHxBgSGgA9IAwsPWAPwfRXEgAHwBoQPSAMFlKEh8QYEhoAPQAMLD1AD8F0VVIAGhA9IAwU0oQYAh5APABADixUEgAHQBoQPSAME1KEh0QYAh5APACAAIoB9FJSAgwAGhA9IAwR0oIMhBgACBwR0NIQGhA8AEAQUlIYHBHQEhAaCDwAQA+SUhgcEc8ScloAPAfApFDQepQETlK0WARRoloAPAfAhFDNUqRYHBHNEmJaADwHwKRQzFKkWBwR3C1BUYMRk25LkhAaQD0AHCw9QB/CdED8BP5BuApSEBpwPNAIAi5A/AE+SdIAGgg8AQAJUkIYAEsAdEwvwLgQL8gvyC/cL1wtQVGDEa19YBPA9EgRgPwM/kC4CBGA/AV+XC9F0gAaCDwBwDAHBVJCGAWSABoQPAEABRJCGAAvwC/ML9wRxFIAGhA8AIAD0kIYHBHDUgAaCDwAgALSQhgcEcKSABoQPAQAAhJCGBwRwZIAGgg8BAABEkIYHBHcEcAEAJAAHAAQAQEAUAQ7QDgcEdwtQRGhUhIRABoT/R6cbD78fUoRgDwofkAIiFGUB4A8DL5ACBwvRC1fUgAaED0gHB7SQhgAyAA8BT5DyAE8PD///fd/wAgEL1wRxC1T/D/MHRJiGMAIIhjQB4IZAAgCGRAHohiACCIYkAeyGIAIMhiQB4IYwAgCGP/9+b/ACAQvWlISEQAaEAcZ0lJRAhgcEdlSEhEAWgIRkocYktLRBpgcEdwtQRG//fz/wZGJUZoHACxbRwAv//36/+AG6hC+tNwvU/w4CAAaSDwAgBP8OAhCGFwR0/w4CAAaUDwAgBP8OAhCGFwR1BIcEdQSABoAAxwR05IAGjA8wsAcEdNSABocEdLSAAdAGhwR0lICDAAaHBHRkhAaEDwAQBESUhgcEdDSEBoIPABAEFJSGBwRz9IQGhA8AIAPUlIYHBHPEhAaCDwAgA6SUhgcEc4SEBoQPAEADZJSGBwRzVIQGgg8AQAM0lIYHBHyiAzSUhiUyBIYgEgMUkIYHBHASAwSQhicEcAIC5JCGJwRytJCWsh8AQBAUMoShFjcEcnSQlrIfACAQFDJEoRY3BHI0lJayHwPwEBQyBKUWNwRxC1ACQeSABrQPABABxJCGP/92L/BEYG4P/3Xv8AGwooAdkDIBC9FUgAawDwCAAAKPLQACD25xFIAGsg8AEAD0kIY3BHDkhAaED0gHAMSUhgcEcKSEBoIPSAcAhJSGBwRwAABAAAAAAgAkAAEAJACAAAAAUACAEAIATgkHX/HwAAAUAAAyBCAAAgQhC1ACgH2goHFA65SgDwDwMbH9RUA+AKBxMOtkoTVBC9AL8A8AcCsksMOxloT/b/AxlAsUsLQ0PqAiGtSww7GWAAv3BHLenwTYBGDUYWRgAnAPBI+QdGOUYqRjNGAfAHAMDxBwu78QQPAtlP8AQLAeDA8QcL2kYA8QQLu/EHDwLST/AACwHgoPEDC9xGT/ABCwv6Cvur8QELC+oCCwv6DPtP8AEODvoM/q7xAQ4O6gMOS+oOBCFGQEb/96L/vejwjXBHAL8A8B8CASGRQItKQwlC+CMQAL9wRwC/AL8AvwC/AL+/80+PAL8AvwC/gEgMOABoAPTgYIBJCEMAHXxJDDkIYAC/AL8Av7/zT48AvwC/AL8AvwC//edwtQRGJUZoHrDxgH8B0wEgD+BoHk/w4CFIYQ8hT/D/MP/3Yv8AIE/w4CGIYQcgCGEAIHC9ELUA8Mn4EL0t6fBFBEYgRgAoCNpjTwDwDwys8QQMF/gMcD8JAuBgTz9cPwk9Rg5GBvAHAMDxBwi48QQPAtlP8AQIAeDA8QcIxEYA8QQIuPEHDwLST/AACAHgoPEDCEdGJfoH+E/wAQoK+gz6qvEBCgjqCgjC+ACAT/ABCAj6B/io8QEICOoFCMP4AIAAv73o8IUAvwDwHwIBIZFAREqAMkMJQvgjEAC/cEcQtQFGCEY/SoAyQwlS+CMgAPAfBAEjo0AaQAqxASIA4AAiEEYQvQC/APAfAgEhkUA2SkMJQvgjEAC/cEcQtQFGCEYxSoAyQwlS+CMgAPAfBAEjo0AaQAqxASIA4AAiEEYQvQQoCNFP8OAhCWlB8AQBT/DgIhFhB+BP8OAhCWkh8AQBT/DgIhFhcEdwRxC1//f8/xC9QXgYSoAyEWABePmxEh1BaBFgAXsJB8J6QeoCYYJ6QerCQUJ7QeqCQYJ7QepCQcJ7QeoCQUJ6QeoCIQJ6QepCAQJ4EUMISogyEWAF4AAhBUqEMhFgEh0RYHBHAkgMOABowPMCIHBHGO0A4ADkAOAAAPoFgOEA4IDiAOAt6fBHBEYORhdGmEYInf/3nP2CRhPgaByIsS2x//eV/aDrCACoQgrZT/QAcKT4RACgbEDwAQCgZAEgvejwhyBoAGowQAixASAA4AAguELi0QAg8ucCRtFkACBwR3BH+LUERgAl//dx/QZGDLkBJY/gACCgZLT4RABAuSBGBPD4+k/w/zEgRv/35f8FRgAtf9HU6QMQQB5P9PgSkvqi8rL6gvKQQAhDYWlJHk/04GKS+qLysvqC8pFACEOhaQhD4WkIQyFoiWj+ShFACEMhaIhgIGjAaCD04CAhaghDIWjIYE/0+BGR+qHxsfqB8SBriEAhaAhhIGgAaCD0+FFgaEAeT/T4UpL6ovKy+oLykEABQyBoAWDgbDNGACIgIQCQIEb/927/BUZ9uyBowGgg8P8BYGpAHv8ikvqi8rL6gvKQQAFDIGjBYCBoAGgg8EAAoWgIQyFoCGDU6QoBCEMhaNH4CBEh8KBBCEMhaMH4CAEgaABoQPABACFoCGDgaLDxgG8D0QEgpPhEAALgAiCk+EQAKEb4vXBHcLUERgAlDLkBJQvgIGgAaCDwAQAhaAhgIEYE8I77ACCk+EQAKEZwvXBHcEdwtQVGrGoAIOBjtPhEALD1gH8P0QIgIWhIYiBoAGhA9AAwIWgIYCBoAGhA8AIAIWgIYAXgAiCk+EQAIEb/99//cL1wR3BHcEdwR3BHcEct6fBBBEYgaADxUAggaAVqIGgHaLT4RGAF8AQAKLMH9IAgELMYLgnRYWtIHGBjCHiI+AAA4GtAHuBjCuAoLgjRmPgAEGJrUBxgYxFw4GtAHuBj4GsouSBoAGgg9IAgIWgIYCBG//fL/6LgBfACAAAoTNAH9AAwAChI0CguIdEF9HxQWLHga0ixmPgAEGJrUBxgYxFw4GtAHuBjieDgawAo4tECICFoSGIgaABoIPTgICFoCGACIKT4RAAgRv/3nv924AIgIWhIYiBoAGgg9OAgIWgIYAIgpPhEABguA9EgRv/3i/9k4AguA9EgRv/3hP9e4Lb1gH9b0aBsGLkgRv/3ev9V4CBG//dT/1HgBfAIALixB/QAIKCxCCAhaEhiIGgAaAD0gABAsSBoAGgg9BAgIWgIYAIgpPhEACBG//da/zbgBfABADizB/SAMCCzASAhaEhiIGgAaCD0+BAhaAhgAiCgZCBoAGgA8AQAaLEgaABoIPAEACFoCGBOSHhEIWyIYyBsA/Cs/xLgAiCk+EQAIEb/9w3/C+AF8BAAQLEH9IAQKLEQICFoSGIgRv/3//696PCBLenwQQNGACAfaD9oJ/BAV9P4AMDM+ABwn2hfuR9oP2gn8IAH0fgEwEfqDAfT+ADAzPgAcA9oAi8M0B9oB/WAch9oB/WEdB9oB/WIdR9oB/WQdgvgH2gH9cByH2gH9cR0H2gH9ch1H2gH9dB20ekSfEfqDAcXYM9qj7GPajdg0fg0wM9qR+oMB9H4MMBH6gwH0vgAwCz0fBxH6gwHF2AnaCfwHwfR+ETAR+oMBydgj2s/sQ9oL7nPa38e0/gAwMz4QHDPaAAvfNDPae+zj2tfs9H4FMDPaEfqDAfR+BDAR+oMB9H4HMBH6gwH0fgkwEfqDAfR+CDAR+oMBwPg/Pjg+DP+///R+DjAR+oMB9H4QMBH6gwH0vgAwN/4YIoM6ggMR+oMBxdgKuDR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMAA4CHgR+oMB9H4IMBH6gwH0vgAwEP2P3gs6ggMR+oMBxdg32q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2CPadP4AMDM+Ehwd+CPa+ex0fgUwM9oR+oMB9H4EMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+MSJDOoIDADgIeBH6gwHF2Aa4NH4FMDPaEfqDAfR+BDAR+oMB9L4AMAs8D8MR+oMBxdg32q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2A64M9pp7OPa+ex0fgkwM9pR+oMB9H4IMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+ESJCPE/CAzqCAxH6gwHF2AP4NH4JMDPaUfqDAfR+CDAR+oMB9L4AMAs9HxcR+oMBxdgj2nT+ADAzPhIcAPg/+cBIAgnn2S96PCBLen4QwRGDUYWRgAn//d6+oBGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsYsShoALkAvwC/tPhEAAIoA9HgaLDxgG8N0bT4RAAUKALRKGgCKAbQtPhEACQoQtEoaAEoP9FDRgAiICEgRgCW//el/AdGL7sAIKBkKUYgRv/3f/4HRu+5qGtYuUNGASICISBGAJb/95L8B0YCICFoSGIj4ChoGLkEIKT4RAAd4ChoASgL0bT4RAAkKAPRBCCk+EQAEuAUIKT4RAAO4LT4RAAUKAPRBCCk+EQABuAkIKT4RAAC4AEnECCgZDhGvej4g/i1BEYNRgAm//cF+gdGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsAsQC/tPhEAAIoJtEoaCC7qGsQu+BosPGAbx7Q4Gw7RgAiICEAkCBG//c8/AZGvrkAIKBkAyAhaEhiKUYgRv/3E/4GRma5CCCk+EQAIGgAaED0QDAhaAhgAuABJhAgoGQwRvi9Len4QwRGDUYWRgAn//e9+YBGtPhEAAEoA9C0+EQAAigk0UNGACIgISBGAJb/9wj8B0b3uU/0fwGR+qHxsfqB8ShoiEBP9H9Ckvqi8rL6gvJpaJFACEOpaAhD6WgIQyFowfgAAgIgpPhEAALgAScQIKBkOEa96PiDLen4QwRGDUYWRgAn//eB+YBGtPhEAAIoOdHgaLDxgG810UNGACIgISBGAJb/98z7B0ZfuyBoAGgg8EBQIWgIYCBogGgg8IBwKWgIQyFoiGAoaUDwQGCpaAhDQPRAYCFowfgAAShpQPBAYKloCENA9EBgIWjB+IAB6GhAHiFoCGRoaCFoiGQEIKT4RAAC4AEnECCgZDhGvej4gy3p+EUERg5GF0YAJf/3NPmARiBoAPFQCh65ASUIIKBkO+C0+EQABCg00SBoAGxAHOBj4GugY2ZjIGgAaCDwQFAhaAhgAL9DRgEiBCEgRgCX//dt+wVGBbEL4GFrSBxgYwh4ivgAAOBrQB7gY+BrACjp0QC/jblDRgEiAiEgRgCX//dV+wVGRbkCICFoSGKk+EQAAuABJRAgoGQoRr3o+IUt6fxNBEYORhdGACX/9+T4AZAgaADxUAogaND4SIAgaND4ELEeuQElCCCgZFLgtPhEAAQoS9EgaABsQBzgY+BroGNmYyBoAGgg8EBQQPCAUCFoCGDgaLDxgG8D0SBowPhIgAzgIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4ELEAvwCXASIGISBGAZv/9wD7BUYFsQvgmvgAEGJrUBxgYxFw4GtAHuBj4GsAKOnRAL+NuQCXASICISBGAZv/9+j6BUZFuQIgIWhIYqT4RAAC4AElECCgZChGvej8jRC1AkYAIBm5ASAII5NkIOCy+EQwBCsZ0RNoG2xbHNNj02uTY1FjE2gbaCPwQFMUaCNgAyMUaGNiGCOi+EQwE2gbaEP04CMUaCNgAuABIBAjk2QQvXC1AkYAIBVoq2wVaNX4EEEZuQEgCCWVZDXgsvhEUAQtLtEVaC1sbRzVY9VrlWNRYxVoLWgl8EBVRfCAVRZoNWADJRZodWIoJaL4RFAVaC1oRfTgJRZoNWDVaLXxgG8C0RVoq2QP4BVo1fgAUQX04GUVsRVoq2QG4BVoxfgQQQLgASAQJZVkcL1wtQRGACW0+EQAAPAIACC5tPhEAADwBABgsyBoAGgg9PgQIWgIYE/0gHCk+EQAIGgAaADwBABosSBoAGgg8AQAIWgIYPZIeEQhbIhjIGwD8Lv7EuACICFoSGIgaABoQPQAMCFoCGAgaABoQPACACFoCGAC4AElECCgZChGcL1wtQVGrGoAIOBjBCCgZCBoAGgg8AQAIWgIYCBG//ex/3C9cEdwR3C1BUasauBrQAjgY7T4RAAoKAPRIEb/9/L/AuAgRv/37f9wvQFGiGoAIsJjAmgSaCLwBAIDaBpgCmgSaCLwAQILaBpgAmgSaEL0ADIDaBpgcEct6fNBBEYAJiBoAGxFHAGYGLkBJgggoGR34LT4RAAEKHDRIGxAaQi55WMk4CBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggoGQBJhTgaAjgYxHgIGxAabD1AH8M0QXwAwAYuSB5APADABixCCCgZAEmAeCoCOBjAC5H0eBroGMBmGBjIGgAaCDwQFAhaAhgAyAhaEhiGCCk+EQApEh4RCFsyGKjSHhEIWwIY6JIeEQhbEhjACAhbIhjECEgbIFgIGwAaABoIPAQACFsiWgIQyFsCWgIYAGvo2vU+ADADPFQAjloIGwD8F/6IGgAaED0gDAhaAhgIGgAaEDwBAAhaAhgA+D/5wEmECCgZDBGvej8gS3p80cERgAmIGgAbEUcIGjQ+EiAIGjQ+BChAZgYuQEmCCCgZI7gtPhEAAQoctEgbEBpCLnlYyTgIGxAabD1gH8N0QXwAQAYuSB5APABABixCCCgZAEmFOBoCOBjEeAgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIIKBkASYB4KgI4GMALl7R4GugYwGYYGMgaABoIPBAUEDwgFAhaAhgAyAhaEhiKCCk+EQAX0h4RCFsyGJeSHhEIWwIY11IeEQhbEhjACAhbIhjACEgbIFgIGwAaABoIPAQACFsiWgIQyFsCWgIYAGvo2s6aNT4AMAM8VABIGwD8M/5IGgAaED0gDAhaAhg4Giw8YBvBNEgaMD4SIAN4BPgIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4EKEgaABoQPAEACFoCGAC4AEmECCgZDBGvej8hy3p+E8ERg1GFkYAJ/73Yf6CRiBo0PhIgCBo0PgQsbT4RAAEKErR6Giw9YAPRtFTRgAiICEgRgCW//em+AdGAC8/0ShoIWjB+IgAaGghaMH4gAAoaSFowfiQANXpAgEIQ0DwAFAhaAloIfBDUQhDIWgIYOBosPGAbwPRIGjA+EiADOAgaND4AAEA9OBgGLEgaMD4SIAC4CBowPgQsVNGASIIISBGAJb/92/4B0ZPuQggIWhIYgIgpPhEAALgAScQIKBkOEa96PiPwMD/8MD///BR9v//M////wf////Z/v//E/7//+f9//+5/f//Len4RQRGDUYAJv737P2ARiBoh2wgaND4EKG0+EQABChB0eBsQ0YAIiAhAJAgRv/3NfgGRk67KGghaMH4iABoaCFowfiAAChpIWjB+JAA1ekCAQhDQPAAUCFoCWgh8ENRCEMhaAhgCSAhaEhiSCCk+EQAIGgAaED0ECAhaAhg4Giw8YBvAtEgaIdkD+AgaND4AAEA9OBgELEgaIdkBuAgaMD4EKEC4AEmECCgZDBGvej4hfi1BEYNRgAm/veU/QdGtPhEAAQoJ9HgbDtGACIgIQCQIEb+9+L/BkYGu4ggpPhEAChoCCgM0WhoIWjB+DABECAhaEhiIGgAaED0gBAhaAhgIGgAaP5JCEApaEHwQFEIQyFoCGAC4AEmECCgZDBG+L34tQRGACX+9139Bka0+EQAAPAIACC5tPhEAADwBACQsyBoAGgA8AQAYLEgaABoIPAEACFoCGAgbAPw4vgFRg2xBCCgZCBoAGhA8AIAIWgIYOBsM0YBIgIhAJAgRv73jf8FRqW5AiAhaEhi4GwzRgAiICEAkCBG/veA/wVGPbkCIKT4RAAD4P/nASUQIKBkKEb4vTC1AkYAILL4RDAD8AgDi7lRYBNoG2gj9PhUU2hbHk/0+FWV+qX1tfqF9atAHEMTaBxgAuABIBAjk2QwvQFGCGgAaAD0+FBP9PhSkvqi8rL6gvLQQEAccEcBRohscEcBRrH4RABwR/C1BEYAIAAiACUAIxSxAiwA3Am5ASBg4AAmDmHOYI5gTmAOYAEsAdEAJQLgAiwA0a5NACNP4K1OVvgjIALwAQY+sQLwAgYF8AIHvkIB0V4cDmAC8BAGPrEC8CAGBfAgB75CAdFeHE5gAvSAdj6xAvQAdgX0AHe+QgHRXhyOYAL0gDaOsQL0gCYF9IAnvkIL0QL0ADYmuV4cRvSANs5gA+BeHEbwgHbOYALwgHaOsQLwgGYF8IBnvkIL0QLwAHYmuV4cRvSANg5hA+BeHEbwgHYOYV4c87ICK63b8L0t6fBNjLCCRgxGT/AAC/73b/wLkAAnuEYAJQAmfkna+AAAiEIC0QC/ASYB4AElACYAJxDgB+uHAgGrA+uCAXoc0LL/92//ILFP8AELCCDK+EgAeBzHsgIv7Nu78QAPftFtSABoAPABADixakgAaCDwAQBoSQhgSPABCGdIAGgA8AEAOLFlSABoIPABAGNJCGBI8AIIBeuFAAGpUfggAAAobdBbSAXrhQEBqlL4IRBJHlD4IQAg8AECVkgF64UBAatT+CEQSR5A+CEgBeuFAQGqAuuBAUloSR5Q+CEAIPAQAkxIBeuFAQPrgQFJaEkeQPghIAXrhQEBqgLrgQGJaEkeUPghACD0gHJCSAXrhQED64EBiWhJHkD4ISAF64UBAaoC64EBCXsB8A8BSR5Q+CEAIPSAMjdIBeuFAQPrgQEJewHwDwFJHkD4ISAF64UBAaoC64EBCXwB8A8BSR4A4HjhUPghACDwgHIqSAXrhQED64EBCXwB8A8BSR5A+CEgBuuGAQGqUvghECBoiEIf0AbrhgEC64EBYGhJaIhCF9AG64YBAuuBAaBoiWiIQg/QBuuGAQLrgQHgaMloiEIH0AbrhgEC64EBIGkJaYhCdtEQSAbrhgEBqlL4IRBJHlD4IQAg8AECC0gG64YBAatT+CEQSR5A+CEgBuuGAQGqAuuBAUloSR5Q+CEACeD3///PIgIEBAQcBlAAEACgABQAoCDwEAKNSAbrhgED64EBSWhJHkD4ISAG64YBAaoC64EBiWhJHlD4IQAg9IByg0gG64YBA+uBAYloSR5A+CEgBuuGAQGqAuuBAQl7AfAPAUkeUPghACD0gDJ4SAbrhgED64EBCXsB8A8BSR5A+CEgBuuGAQGqAuuBAQl8AfAPAUkeUPghACDwgHJsSAbrhgED64EBCXwB8A8BSR5A+CEgZ0ghaEkeUPghACDwAwACIZH6ofGx+oHxBfoB8UHwAQEIQ15JImhSHkH4IgAIRmFoSR5Q+CEAIPAwACAhkfqh8bH6gfEF+gHxQfAQAQhDU0liaFIeQfgiAAhGoWhJHlD4IQAg9EBxT/QAcJD6oPCw+oDwBfoA8ED0gHABQ0hIomhSHkD4IhDgaAD0gDDYsUNIIXsB8A8BSR5Q+CEAIPTgIE/0gCGR+qHxsfqB8QX6AfFB9IAxCEM5SSJ7AvAPAlIeQfgiABrgNUghewHwDwFJHlD4IQAg8OBhT/CAYJD6oPCw+oDwBfoA8EDwgHABQytIInsC8A8CUh5A+CIQIGkA9IAw2LEmSCF8AfAPAUkeUPghACD04CBP9IAhkfqh8bH6gfEF+gHxQfRAMQhDHEkifALwDwJSHkH4IgAa4BhIIXwB8A8BSR5Q+CEAIPDgYE/wgGGR+qHxsfqB8QX6AfFB8EBxCEMOSSJ8AvAPAlIeQfgiAAjwAQAosQpIAGhA8AEACEkIYAjwAgAosQZIAGhA8AEABEkIYFhGDLC96PCNBBwGUAAQAKAAFACgELWasARGACAGkAeQQPL5YAiQBCAJkBAgCpAAIA2QEZAUkBeQGJAZkAggC5BP8P8yBqn+SEhE/vem/xCxASAasBC9AiABkAKQACADkBAgBZCABASQQPL6UAiQACAMkE/0gGANkE/0QFAOkE/wgGAUkAIgFZCAAg+QAAQWkIAAGJAEIBeQAL8BIP73CPpP8P8yBqnmSEhE/vd2/wixASDO50/w/zJpRuFISET/9wL5CLEBIMTnnfgAAAKZCEABmYhC4dEAILvnMLWbsARGDUYAIAeQCJBA8vpQCZAEIAqQECALkAAgDZBP9IBgDpBP9EBQD5AAIBKQT/CAYBWQAiAWkAYgGJAAIBqQCCAMkAACEJAABBeQgAAZkAAgApABIAOQACAEkBAgBpCABAWQAL8BIP73tPlP8P8yB6m8SEhE/vci/xCxASAbsDC9T/D/MgGptkhIRP/3rfgIsQEg8+ed+AQAA5kIQAKZiELg0QAg6ucwtZuwBUYMRgAgB5AIkAyQT/RAUA+QACAQkBKQF5AZkBqQBJAQIAaQgAQFkAEsddEGIAmQASAKkAAgC5AOkBWQGJBCHgepnUhIRP735P4QsQEgG7AwvQIgApADkAUgCZBP8IBwFZABIBaQgh4HqZNISET+99D+CLEBIOrnT/D/MgKpjkhIRP/33/oIsQEg4OdyIAmQT/RAcA2QT/SAcA6QByCN+AQAT/D/Mgepg0hIRP73sf4IsQEgy+dP8P8yAal+SEhE/vft/wixASDB5wYgCZAAIA6QFZBCHgepd0hIRP73mf4IsQEgs+cFIAmQT/CAcBWQT/D/MgepcEhIRP73iv4IsQEgpOdP8P8yAqlrSEhE//eZ+hCxASCa51zgciAJkAAgDZBP9IBwDpACII34BADCHgepYUhIRP73bP4IsQEghudP8P8yAalcSEhE/veo/wixASB85ygg/vfn+E/w/zFWSEhE//f2/gixASBw50fyjhAJkAQgCpAQIAuQgAEOkAAEFZAGIBiQAiAWkAAgjfgEAAggDJAAAhCQAAQXkIAAGZBP8P8yB6lESEhE/vcy/gixASBM50/w/zIBqT9ISET+977/CLEBIELnnfgEAAIoddABIDznOEhIRP/3WP4IsQEgNedH8o0gCZAEIAqQECALkAAgDZBP9IBgDpAABBWQAiAWkAAgGJCN+AQAjfgFAAggDJAAAhCQAAQXkE/w/zIHqSVISET+9/X9CLEBIA/nT/D/MgGpIEhIRP73Mf8IsQEgBecoIP73cPgFIAmQASAKkAAgC5AOkE/wgHAVkAEgFpAAIBiQDJAQkBeQApABIAOQgh4HqRBISET+98v9CLEBIOXmT/D/MgKpC0hIRP/32vkIsQEg2+ZxIAmQACANkE/0gHAOkE/w/zIHqQNISET+97D9ILEBIMrmEAAAAA7gT/D/MgGp/khIRP73Of8IsQEgvead+AQACLEBILjmACC25hC1mrAERgAgBpAHkGYgCJABIAmQACAKkAuQDZARkBSQF5AYkBmQQh4Gqe1ISET+94D9ELEBIBqwEL2ZIAiQT/D/Mgap5khIRP73c/0IsQEg8ecFIAiQT/CAcBSQASAVkAAgFpABkAEgApAAIAOQECAFkIAEBJBP8P8yBqnYSEhE/vdX/QixASDV50/w/zIBqdNISET/92b5CLEBIMvnACDJ5wC1h7AAv85IwGxA9IAQzEnIZAhGwGwA9IAQAZAAvwC/AL8IRgBtQPSAcAhlCEYAbQD0gHABkAC/AL8IRgBrQPSAcAhjCEYAayD0gHAIYwC/CEaAbUDwgFCIZQhGgG0A8IBQAZAAvwC/t0hAaED0AHC1SUhgAL+ySMBsQPBAALBJyGQIRsBsAPBAAAGQAL8AvwC/CEbAbEDwgADIZAhGwGwA8IAAAZAAvwC/AL8IRsBsQPSAcMhkCEbAbAD0gHABkAC/AL+IFAKQAiADkAEgBJADIAWQBSAGkAKpm0gB8J3/T/QAQAKQAqmYSAHwlv9P9GRgApAAIASQAqmUSAHwjf9P9OBgApACqZJIAfCG/0/0wGACkAKpjEgB8H//B7AAvQC1hbCMSIVJSUQIYAhG/vdX+hCxASAFsAC9//dh/wQgf0lJREhgACF9SEhEgWBP8IBgkPqg8LD6gPF4SEhEAWECIUFhACGBYcFhAWICIUFiACGBYk/wgHHBYAkBwWIAIQFj/veR+QixASDU5wIgAJABkHFIBJBxSAOQAiACkMIeaUZmSEhE//d9+gixASDC52NISET/99P+CLEEILvnASFfSEhE//dZ/QixASCz5wAgsecAtYWwT/QWQVtIAvAE+E/04GFbSAHw//9P9GRhV0gB8Pr/ACABkE/0gFAAkAAgApADkGlGUEgB8Af/ASABkAAgApBP9ABAAJBpRktIAfD8/gAiT/QAQUhIAvB2+ERIAGtA9IBwQkkIYwhGAGsg9IBwCGMIRgBtIPSAcAhlBbAAvRC1QEg5SUlECGAIRv/3r/kCKAbQNUhIRP/3MfkIsQEgEL0AITFISET/9/78CLEBIPbnLkhIRP73qvkIsQEg7+f/957/ACDr53C1lLAERg1GFkYAIACQAZAEIAOQECAEkAaVgAEHkE/0QFAIkAAgC5BP8IBgDpAPlgYgEZAAIBOQTvYRYAKQCCAFkAACCZAABBCQgAASkE/w/zJpRhNISET+9837ELEBIBSwcL1P8P8yIUYOSEhE/vdY/QixASDz5wAg8ect6fBFlbCCRg1GkEbossD1gHZGRQDZRkYsRgXrCAcAIAGQApAS4AAAEAAAAAAQAkAAcABAABgASAAgAEgAHABIABAAoAIAAAECAAEAQfLtIAOQBCAEkBAgBZCAAQiQT/RAUAmQACAMkE/wgGAPkAAgEpAUkAggBpAAAgqQAAQRkIAAE5AAvweUEJb5SEhE//ex+xixASAVsL3o8IVP8P8yAanzSEhE/vdo+wixASDy50/w/zJRRu5ISET+96T8CLEBIOjnT/D/MelISET/9/X7CLEBIN/nNESyRAT1gHC4QgHZOBsB4E/0gHAGRrxCytMAINDnELWUsARGACAAkAGQTfYjQAKQBCADkBAgBJAGlIABB5BP9EBQCJAAIAuQDpARkBKQE5AIIAWQAAIJkNBISET/91/7ELEBIBSwEL1P8P8yaUbKSEhE/vcX+wixASDz50/0+mHGSEhE//eu+wixASDq5wAg6OcQtZSwBEa09YBPAtMBIBSwEL0AIACQAZBC8t4QApAEIAOQECAEkCADBpBP9IBgB5BP9EBQCJAAIAuQDpARkBKQE5AIIAWQAAIJkK9ISET/9x37CLEBINrnT/D/MmlGqkhIRP731voIsQEg0OcAIM7nALWVsAAgAZACkEbynwADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQm0hIRP/39foQsQEgFbAAvU/w/zIBqZVISET+9636CLEBIPPnk0mRSEhE//dF+wixASDr5wAg6ecAtZWwACABkAKQQvbUMAOQBCAEkBAgBZAAIAeQT/SAYAiQT/RAUAmQACAMkE/wgGAPkAIgEJAGIBKQACAUkAggBpAAAgqQAAQRkIAAE5BP8P8yAal4SEhE/vdy+hCxASAVsAC9T/D/MmlGckhIRP73/fsIsQEg8+ed+AAAAPBgAAixASDs5534AAAA8AwACLEIIOXnQPL6UAOQT/D/MgGpZUhIRP73TPoIsQEg2OdP8P8yaUZgSEhE/vfY+wixASDO5534AAAA8AEACLECIMfnACDF5wFGT/CAYAhggBJIYIARiGCAEMhggAIIYQAgcEcAtZewUEhIRP/3X/oQsQEgF7AAvQEgA5AAIASQBCAGkBAgB5CAAQqQT/RAUAuQACAOkE/wgGARkAYgFJAAIBaQTvYRYAWQCCAIkAACDJAABBOQgAAVkE/w/zIDqTpISET+9/b5CLEBINLnAiADkEHy7SAFkAAgFJBCHgOpMkhIRP735vkIsQEgwucAIAGQAaktSEhE/vfE/gixASC45wAgtucAtZWw//cz/wIoJdEAIAGQApBL8k8AA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkE/w/zIBqRpISET+97f5ELEBIBWwAL3/9xH/CCgB0QAg9+cBIPXnACDz5wC1lbD/9wX/CCgp0QAgAZACkEPyzwADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQT/D/MgGpA0hIRP73ifkwsQEgFbAAvRAAAADgkwQA//ff/gIoAdEAIPPnASDx5wAg7+cAtZWwACABkAKQS/ZGEAOQBCAEkBAgBZAAIAiQDJAPkBKQE5AUkAggBpBP8P8yAakVSEhE/vdb+RCxASAVsAC9ACD75wC1lbAAIAGQApD/IAOQBCAEkBAgBZAAIAiQDJAPkBKQE5AUkAggBpBP8P8yAakFSEhE/vc6+RCxASAVsAC9ACD75wAAEAAAAPtIAGgA9MBgsPWAbwLRT/SAYHBH9kiAMABoAPSAcLD1gH8C0U/0AHDz5wAg8ecCRgAhirvuSABoAPTAYLD1gG8r0etIgDAAaCD0gHDoS8P4gAAYRgBoIPTAYED0AHAYYORISEQAaORLsPvz8DIjAPsD8QDgSR4xsd1IQGkA9IBgsPWAb/bQ2khAaQD0gGCw9YBvUdEDIHBHCODVSIAwAGgg9IBw0kvD+IAAReCy9QB/OtHPSABoAPTAYLD1gG8q0ctIgDAAaED0gHDJS8P4gAAYRgBoIPTAYED0AHAYYMVISEQAaMRLsPvz8DIjAPsD8QDgSR4xsb5IQGkA9IBgsPWAb/bQukhAaQD0gGCw9YBvEtEDIL/ntkiAMABoQPSAcLNLw/iAAAfgsUgAaCD0wGBA9IBgrksYYAAgrOesScloIfQAcQFDqkrRYBFGyWhB9IBx0WBwR6ZIwGgg9IBwpEnIYHBHokhAaED0gGCgSUhgcEefSEBoIPSAYJ1JSGBwR5tIQGhA9ABwmUlIYHBHmEhAaCD0AHCWSUhgcEeUSIBoQPQAQJJJiGBwR5FIgGgg9ABAj0mIYHBHAkYJKnHS3+gC8AUUISs1P0lTYACISABqIfSAQxhDhksYYhhGQGoh9CBDmEOCS1hiXeCBSIBqCEN/S5hiGEbAaiHwEAOYQ3xL2GJQ4HpIAGsIQ3lLGGMYRkBriENYY0bgdUiAawhDdEuYYxhGwGuIQ9hjPOBwSABsCENvSxhkGEZAbIhDWGQy4GtIgGwIQ2pLmGQYRsBsiEPYZCjgZkgAbQhDZUsYZRhGQG2IQ1hlHuBhSIBti7IYQ19LmGUYRsBti7KYQ1xL2GUR4FtIAG7B8wsDGENYSxhmGEZAbsHzCwOYQ1VLWGYC4P/nASBwRwC/ACD75wJGCSpB0t/oAvAFDRMZHyUrMTgAS0gAaiH0gEOYQ0lLGGI04EdIgGqIQ0ZLmGIu4ERIAGuIQ0NLGGMo4EFIgGuIQ0BLmGMi4D5IAGyIQz1LGGQc4DtIgGyIQzpLmGQW4DhIAG2IQzdLGGUQ4DVIgG2LsphDM0uYZQngMkgAbsHzCwOYQy9LGGYB4AEgcEcAvwAg++cCRgkqd9Lf6ALwBRQgKjQ+SFlmACZIQGoh9CBDGEMkS1hiGEYAaiH0gEOYQyBLGGJj4B9IwGoh8BADGEMcS9hiGEaAaohDmGJX4BlIQGsIQxdLWGMYRgBriEMYY03gFEjAawhDEkvYYxhGgGuIQ5hjQ+APSEBsCEMNS1hkGEYAbIhDGGQ54ApIwGwIQwhL2GQYRoBsiEOYZC/gBUhAbQhDA0tYZRhGAG2IQxhlJeAAAABwAEAEAAAAQEIPAP5IwG2LshhD/EvYZRhGgG2LsphD+UuYZRHg+EhAbsHzCwMYQ/VLWGYYRgBuwfMLA5hD8ksYZgLg/+cBIHBHAL8AIPvnAkYJKkPS3+gC8AUNFRshJy0zOgDoSEBqIfQgQ5hD5ktYYjbg5EjAaiHwEAOYQ+JL2GIu4OBIQGuIQ99LWGMo4N1IwGuIQ9xL2GMi4NpIQGyIQ9lLWGQc4NdIwGyIQ9ZL2GQW4NRIQG2IQ9NLWGUQ4NFIwG2LsphDz0vYZQngzkhAbsHzCwOYQ8tLWGYB4AEgcEcAvwAg++fHSIBoQPSAYMVJiGBwR8RIgGgg9IBgwkmIYHBHwEiAaED0gHC+SYhgcEe9SIBoIPSAcLtJiGBwR7lIAGhA8BAAt0kIYHBHtkgAaCDwEAC0SQhgcEeySEBoQPAQALBJSGBwR69IQGgg8BAArUlIYHBHq0hAaEDwIACpSUhgcEeoSEBoIPAgAKZJSGBwR6RIQGhA8EAAoklIYHBHoUhAaCDwQACfSUhgcEedSEBoQPCAAJtJSGBwR5pIQGgg8IAAmElIYHBHAUYIaBAoBtAgKFLQQCh80IAoe9Hs4JJIAGgg8AgAkEoQYBAfAGgg8AgAEh8QYIxICDAAaCDwCACJSggyEGAQHwBoIPAIABIfEGBIaAD0gDCw9YA/B9GCSAAfAGhA8AgAf0oSHxBgSGgA9AAwsPUAPwXRe0gAaEDwCAB5ShBgCHkA8AEAOLF2SAAdAGhA8AgAc0oSHRBgCHkA8AIAAigH0W9ICDAAaEDwCABtSggyEGDx4GtIAGgg8BAAaUoQYBAfAGgg8BAAEh8QYGVICDAAaCDwEABiSggyEGAQHwBoIPAQABIfEGBIaAD0gDCw9YA/B9FbSAAfAGhA8BAAWEoSHxBgSGgA9AAwAeAj4MHgsPUAPwXRUkgAaEDwEABQShBgCHkA8AEAOLFNSAAdAGhA8BAAS0oSHRBgCHkA8AIAAigH0UdICDAAaEDwEABESggyEGCg4EJIAGgg8CAAQEoQYBAfAGgg8CAAEh8QYDxICDAAaCDwIAA6SggyEGAQHwBoIPAgABIfEGBIaAD0gDCw9YA/B9EySAAfAGhA8CAAMEoSHxBgSGgA9AAwsPUAPwXRK0gAaEDwIAApShBgCHkA8AEAOLEmSAAdAGhA8CAAJEoSHRBgCHkA8AIAAigH0SBICDAAaEDwIAAdSggyEGBS4BtIAGgg8EAAGUoQYBAfAGgg8EAAEh8QYBVICDAAaCDwQAATSggyEGAQHwBoIPBAABIfEGBIaAD0gDCw9YA/B9ELSAAfAGhA8EAACUoSHxBgSGgA9AAwsPUAPwXRBEgAaEDwQAACShBgCHkD4ABwAEAkBAFAAPABACixdEgAaEDwQAByShBgCHkA8AIAAigH0W5IAB0AaEDwQABsShIdEGAB4AEgcEcAvwAg++doSABoQPSAQGZJCGBwRwC/ZEgAaCD0gEBiShBgYkhIRABoYkqw+/LwMiIA+wLxAOBJHjGxW0hAaQD0AHCw9QB/9tBYSEBpAPQAcLD1AH8B0QMgcEcAIPznUkkJaCHwBwFQShFgUkkJaEHwBAFQShFgASgB0TC/AuBAvyC/IL9MSQloIfAEAUpKEWBwR0VJCWgh8AcBSRxDShFgRUkJaEHwBAFDShFgASgB0TC/AuBAvyC/IL8+SQloIfAEATxKEWBwRzhJCWgh8AcBiRw1ShFgN0kJaEHwBAE1ShFgASgB0TC/AuBAvyC/IL8xSQloIfAEAS9KEWBwRypIAGgg8AcAAB0oSQhgKkgAaEDwBAAoSQhgAL8AvzC/cEdwR3BHcEdwRxC1HkgUOABoAPSAMDCx/Per/k/0gDAZSRQ5CGAYSAwwAGgA8AgAKLH/9+n/CCATSQwxCGASSAwwAGgA8BAAKLH/99z/ECANSQwxCGAMSAwwAGgA8CAAKLH/98//ICAHSQwxCGAGSAwwAGgA8EAAKLH/98L/QCABSQwxCGAQvSgEAUAAcABABAAAAEBCDwAQ7QDg+kgAaEDwAQD4SQhgAOAAv/ZIAGgA8AIAACj40PNIAGgg8PAAQPBgAPBJCGAAIIhgCEYAaO5JCEDsSQhgACDIYAhGwGhA9IBQyGAAIAhhCEYAaUD0gFAIYQAgSGEIRkBpQPSAUEhhCEYAaCD0gCAIYAAgiGHfSOBJSUQIYHBH8LUAIQAjACQCJQIiACDXTrZoBvAMBl6x1U62aAbwDAYMLh/R0k72aAbwAwYBLhnRz042aAbwCAYuucxOlDY2aMbzAyED4MlONmjG8wMRy05+RFb4IRDFTrZoBvAMBoa5CEYO4MJOtmgG8AwGBC4B0cRIBuC+TrZoBvAMBgguANHBSLpOtmgG8AwGDC420bdO9mgG8AMEtU72aMbzAxZyHAEsGdACLALQAywU0QngtE62+/L2rk//aMfzBicG+wfzE+CwTrb78vapT/9ox/MGJwb7B/MJ4AC/sfvy9qRP/2jH8wYnBvsH8wC/AL+gTvZoxvNBZnYcdQCz+/Xw8L34tQRGACYAJZlIgG0A8IBQGLH/90H6BkYW4AC/lEiAbUDwgFCSSYhlCEaAbQDwgFAAkAC/AL//9y/6BkaMSIBtIPCAUIpJiGW29QB/B9GALAzZoCwB2QIlCOABJQbggCwB0wIlAuBwLADRASWHSABoIPAPAChDhUkIYAhGAGgA8A8AqEIB0AEg+L0AIPzn+LUERgAlIHgA8BAAEChw0XRIgGgA8AwAAChr0XFIAGgA8AIAGLGgaQi5ASD4vWxIIWoAaADwCAAgsWlIAGgA8PAABeBnSJQwAGgA9HBgAAmBQh/ZIGr/94z/CLEBIOXnAL9fSABoQPAIAF1JCGAIRgBoIPDwACFqCENZSQhgAL8IRkBoIPR/QOFpQOoBIFRJSGAe4AC/UkgAaEDwCABQSQhgCEYAaCDw8AAhaghDTEkIYAC/CEZAaCD0f0DhaUDqASBHSUhgIGr/91P/CLEBIKzn//fP/kJJiWjB8wMRSEp6RFFcyEBBSUlECGAPIAHwB/1K4KBpgLM6SABoQPABADhJCGD89zT9BUYG4Pz3MP1AGwIoAdkDIIjnMUgAaADwAgAAKPLQAL8uSABoQPAIACxJCGAIRgBoIPDwACFqCEMoSQhgAL8IRkBoIPR/QOFpQOoBICNJSGAX4P/nIUgAaCDwAQAfSQhg/PcC/QVGBuD89/78QBsCKAHZAyBW5xhIAGgA8AIAACjy0SB4APABAAAoftATSIBoAPAMAAgoC9AQSIBoAPAMAAwoDtENSMBoAPADAAMoCNEKSABoAPQAMIizYGh4uwEgMOcAv2BosPWAPxjRA0gAaED0gDABSQhgLeAAEAJA//T+6gAJPQAEAAAArhwAAAAk9AAAEnoAACACQHoaAABgaLD1oC8M0f1IAGhA9IAg+0kIYAhGAGhA9IAwCGAL4DTg90gAaCD0gDD1SQhgCEYAaCD0gCAIYAC/YGiYsfz3lPwFRgjg/PeQ/EAbQfKIMYhCAdkDIObm6UgAaAD0ADAAKPDQEuD894D8BUYI4Pz3fPxAG0HyiDGIQgHZAyDS5t9IAGgA9AAwACjw0SB4APACAAIoXtHaSIBoAPAMAAQoC9DXSIBoAPAMAAwoGNHUSMBoAPADAAIoEtHRSABoAPSAYBix4GgIuQEgrObMSEBoIPD+QCF8QOoBYMlJSGA54OBoALPGSABoQPSAcMRJCGD89zv8BUYG4Pz3N/xAGwIoAdkDII/mvkgAaAD0gGAAKPLQu0hAaCDw/kAhfEDqAWC3SUhgFuC2SABoIPSAcLRJCGD89xr8BUYG4Pz3FvxAGwIoAdkDIG7mrUgAaAD0gGAAKPLRIHgA8AgACCg20WBp0LGnSJQwAGhA8AEApEnB+JQA/Pf6+wVGBuD89/b7QBsCKAHZAyBO5p1IlDAAaADwAgAAKPHQGeCZSJQwAGgg8AEAl0nB+JQA/Pff+wVGBuD899v7QBsCKAHZAyAz5pBIlDAAaADwAgAAKPHRIHgA8AQABChv0QAmiUiAbQDwgFBwuQC/hkiAbUDwgFCESYhlCEaAbQDwgFAAkAC/AL8BJoBIAGgA9IBwsLl+SABoQPSAcHxJCGD896j7BUYG4Pz3pPtAGwIoAdkDIPzldUgAaAD0gHAAKPLQAL+gaAEoCNFvSJAwAGhA8AEAbUnB+JAAIeCgaAUoD9FpSJAwAGhA8AQAZ0nB+JAACEbQ+JAAQPABAMH4kAAO4GFIkDAAaCDwAQBfScH4kAAIRtD4kAAg8AQAwfiQAAC/oGiosfz3ZfsFRgng/Pdh+0AbQfKIMYhCAtkDILflJOBRSJAwAGgA8AIAACju0BPg/PdP+wVGCOD890v7QBtB8ogxiEIB2QMgoeVHSJAwAGgA8AIAACjv0QEuBdFCSIBtIPCAUEBJiGUAvyB4APAgACAoNtFgatCxO0iYMABoQPABADlJwfiYAPz3I/sFRgbg/Pcf+0AbAigB2QMgd+UySJgwAGgA8AIAACjx0BngLkiYMABoIPABACtJwfiYAPz3CPsFRgbg/PcE+0AbAigB2QMgXOUkSJgwAGgA8AIAACjx0aBq8LMgSIBoAPAMAAwoddCgagIoU9EbSABoIPCAcBlJCGD89+X6BUYG4Pz34fpAGwIoAdkDIDnlE0gAaADwAHAAKPLRIGtAHgEBYGtB6gAg4WoIQ6GPASLC61EBQOpBUUAgAF3C61AAQepAYTggAF1B6sBgBEnIYAhGAGhA8IBwBeBM4AAAABACQABwAEAIYAhGwGhA8IBwyGD896n6BUYG4Pz3pfpAGwIoAdkDIP3k90gAaADwAHAAKPLQL+DzSABoIPCAcPFJCGAIRgBoAPAAYEi5CEYAaADwAFAguQhGwGgg8AMAyGDpSMBo6UkIQOdJyGD893z6BUYH4A3g/Pd3+kAbAigB2QMgz+TgSABoAPAAcAAo8tEB4AEgxuQAIMTk8LUAIgAjACQCJQIhACDXTvZoBvADBgEuEtHUTjZoBvAIBi650U6UNjZoxvMDIgPgzk42aMbzAxLOTn5EVvgiIMpO9mgG8AMEyE72aMbzAxZxHAEsGdACLALQAywU0QngxU62+/H2wU//aMfzBicG+wfzE+DBTrb78fa8T/9ox/MGJwb7B/MJ4AC/svvx9rdP/2jH8wYnBvsH8wC/AL+zTvZoxvNBZnYcdQCz+/Xw8L0t6fBBBEYNRgAmACewRrBIAGgA8A8AqEIP0q1IAGgg8A8AKEOqSQhgCEYAaADwDwCoQgLQASC96PCBIHgA8AEAAChu0GBoAygj0ZxIAGgA8ABwCLkBIO7n//d6/wdGnUiHQgbZIHgA8AIAAigB0aBoILGSSIBoAPDwAKC7j0iAaCDw8ABA8IAAjEmIYE/wgAgp4GBoAigG0YhIAGgA9AAwiLkBIMfnYGgwuYRIAGgA8AIAQLkBIL7ngEgAaAD0gGAIuQEgt+f/9yz7B0aBSIdCCdl6SIBoIPDwAEDwgAB3SYhgT/CACHVIgGgg8AMAYWgIQ3JJiGD895L5BkZgaAMoENEI4Pz3i/mAG0HyiDGIQgHZAyCP52lIgGgA8AwADCjw0TbgYGgCKBDRCOD893f5gBtB8ogxiEIB2QMge+dfSIBoAPAMAAgo8NEi4GBogLkI4Pz3ZPmAG0HyiDGIQgHZAyBo51VIgGgA8AwAACjw0Q/gCOD891P5gBtB8ogxiEIB2QMgV+dNSIBoAPAMAAQo8NEgeADwAgACKAjRR0iAaCDw8AChaAhDREmIYAjguPGADwXRQUiAaCDw8AA/SYhgQ0gAaADwDwCoQg7ZQEgAaCDwDwAoQz5JCGAIRgBoAPAPAKhCAdABICXnIHgA8AQABCgH0TFIgGgg9OBg4WgIQy5JiGAgeADwCAAIKAjRK0iAaCD0YFAhaUDqwQAnSYhg//d/+iVJiWjB8wMRKkp6RFFcyEApSUlECGAPIAHwt/gAIPjmcLWGsAZGDUYURgC/GkjAbEDwAQAYSchkCEbAbADwAQAAkAC/AL+IFQGQAiACkASQACADkAWQAalP8JBAAPAQ+Q1IgGgg8P5AReoEAQhDCkmIYAawcL0QSEhEAGhwRwC1//f5/wRJiWjB8wIhC0p6RFFcyEAAvQAAABACQP//7v6WFAAAACT0AAASegAAIAJAALTEBNoRAAAEAAAAZhEAAAC1//fY/2tJiWjB88Ihakp6RFFcyEAAvT8hAWBlSQloAfSAIbH1gC8D0U/0oCFBYAzgYEkJaAH0gDGx9YA/A9FP9IAxQWAB4AAhQWBZSQloAfABARGxASGBYQHgACGBYVRJSWjB8wchwWFSSQloAfDwAQFiT0kJaAH0gHGx9YB/A9FP9IBxwWAB4AAhwWBJSUlowfMGYQFhRkmQMQloAfAEAQQpAtEFIYFgCuBBSZAxCWgB8AEBEbEBIYFgAeAAIYFgPEmUMQloAfABARGxASFBYQHgACFBYTZJmDEJaAHwAQERsQEhQWIB4AAhQWIxSQloAfCAcbHxgH8C0QIhgWIB4AEhgWIrScloAfADAsJiKEnJaMHzAxFJHAFjJUnJaMHzBiJCYyNJyWjB80FRSRxKAMJjH0nJaMHzQWFJHEoAAmQcScloyg6CY3BHDyICYBhKkmgC8AMCQmAWSpJoAvDwAoJgE0qSaAL04GLCYBFKkmgC9GBS0ggCYRBKEmgC8A8CCmBwRwtIAGhA9AAgCUkIYHBHcEcQtQZIwGkA9IBwsPWAfwXR//f1/0/0gHABSQhiEL0AEAJAJBEAAAAgAkB4tQJGACMAJAAg2uABJp5ADWgF6gYEACxy0E1oAi0C0E1oEi0T0d4IAvEgBVX4JgBdB+4ODyW1QKhDXgf2Dg1ptUAoQ94IAvEgBUX4JgAQaF4AAyW1QKhDDXkF8AMFXgC1QChDEGBNaAEtCNBNaAItBdBNaBEtAtBNaBItE9GQaF4AAyW1QKhDXgDNaLVAKEOQYFBoASWdQKhDDXnF8wAVnUAoQ1Bg0GheAAMltUCoQ14AjWi1QChD0GBNaAXwgFW18YBffNEAv6VNLW5F8AEFo041ZjVGLW4F8AEFAJUAvwC/T+q2NZ4IVfgmAJ0HLg8PJbVAqEOy8ZBPAtEAJSTgXuCYTapCAdEBJR7glk2qQgHRAiUZ4JVNqkIB0QMlFOCTTapCAdEEJQ/gkk2qQgHRBSUK4JBNqkIB0QYlBeCPTapCAdEHJQDgCCWeBzYPtUAoQ4tNnghF+CYAik0oaKBDTWgF9IA1tfWAPwDRIEOFTShgLR0oaKBDTWgF9AA1tfUAPwDRIEN/TS0dKGAtHShooENNaAX0gBW19YAfANEgQ3hNCDUoYC0dKGigQ01oBfQAFbX1AB8A0SBDck0MNShgWxwNaN1AAC1/9CCveL3wtQtGACEAIgAkhOABJY1ABeoDAgAqfdAFaE8AAya+QDVDBWDOCADxIAVV+CZQTgf3Dg8mvkC1Q88IAPEgBkb4J1CFaE8AAya+QLVDhWBFaAEmjkC1Q0VgxWhPAAMmvkC1Q8VgU02OCFX4JkCNBy4PDyW1QCxAsPGQTwHRACUj4EVNqEIB0QElHuBDTahCAdECJRngQk2oQgHRAyUU4EBNqEIB0QQlD+A/TahCAdEFJQrgPU2oQgHRBiUF4DxNqEIB0QclAOAIJY4HNg+1QKVCINGNBy4PDyUF+gb0NU2OCFX4JmCmQ48IRfgnYDJNLWiVQzBONWA1HS1olUM2HTVgNR0taJVDNh01YDUdLWiVQzYdNWBJHCP6AfUALX/0dq/wvQJGE2kLQAuxASAA4AAgcEcKsYFhAOCBYnBHQmlKQEJhcEcItQJGT/SAMACQAJgIQwCQAJjQYdFhAJjQYdBpAJDQaQD0gDAIsQAgCL0BIPzncEcQtQRGD0gUMABoIEAosQxIFDAEYCBG//fy/xC9AAAAEAJAAAQASAAIAEgADABIABAASAAUAEgAGABIABwASAgAAUAABAFAAXlKHv5LA+uCAkJl/EpAMoJlSh4BI5NAw2VwRxC1ACL4TANoo0IB0vdJAeD2SRwxA3gIOxQks/v08kNsmwgB64MDg2TuS4A7w2QBI5NAA2UQvXC1BEYAJQy5ASBwvelJIGiIQgvS6UkgaEAaFCGw+/HwgABgZOVICDggZArg4UkgaEAaFCGw+/HwgABgZN1ICDggZAIghPglACBoBWhH9vBwhUPU6QIBCEMhaQhDYWkIQ6FpCEPhaQhDIWoIQwVDIGgFYCBG//ep/6BosPWATwHRACBgYCB5oWwIYNTpExBIYGBoYLFgaAQoCdggRv/3h/8AIGFtCGDU6RYQSGAD4AAgYGWgZeBlACDgYiBjYGOgY+BjASCE+CUAACCE+CQAAL+b5xC1BEYMuQEgEL0gaABoIPABACFoCGCySSBoiEIL0rJJIGhAGhQhsPvx8IAAYGSuSAg4IGQK4KpJIGhAGhQhsPvx8IAAYGSmSAg4IGQAICFoCGCU+EQQASCIQCFsSGAgRv/3Sv8AIKFsCGDU6RMQSGBgbSixACBhbQhg1OkWEEhgACBgZaBl4GXgY4T4JQAAv4T4JAAAvwC/tucwtdDpE1RsYERtFLHQ6RZUbGCQ+ERQASSsQAVsbGAEaGNghGgQLATRBGiiYARo4WAD4ARooWAEaOJgML0t6fBBBEYNRhZGH0ZP8AAIAL+U+CQAASgC0QIgvejwgQEghPgkAAC/lPglAAEoF9ECIIT4JQAAIOBjIGgAaCDwAQAhaAhgO0YyRilGIEb/97n/IGgAaEDwAQAhaAhgBuAAvwAghPgkAAC/T/ACCEBG1Oct6fBBBEYNRhZGH0ZP8AAIAL+U+CQAASgC0QIgvejwgQEghPgkAAC/lPglAAEoP9ECIIT4JQAAIOBjIGgAaCDwAQAhaAhgO0YyRilGIEb/94D/IGswsSBoAGhA8A4AIWgIYAvgIGgAaCDwBAAhaAhgIGgAaEDwCgAhaAhgoGwAaAD0gDAosaBsAGhA9IBwoWwIYGBtKLFgbQBoQPSAcGFtCGAgaABoQPABACFoCGAG4AC/ACCE+CQAAL9P8AIIQEas5wFGACIJuQEgcEcIaABoIPAOAAtoGGCIbABoIPSAcItsGGAIaABoIPABAAtoGGCR+EQwASCYQAtsWGDR6RMwWGBIbUCxSG0AaCD0gHBLbRhg0ekWMFhgASCB+CUAAL8AIIH4JAAAvxBGzudwtQRGACWU+CUAAigD0AQg4GMBJTzgIGgAaCDwDgAhaAhgIGgAaCDwAQAhaAhgoGwAaCD0gHChbAhglPhEEAEgiEAhbEhg1OkTEEhgYG1AsWBtAGgg9IBwYW0IYNTpFhBIYAEgCOAAAAAJAkAIBAJAAAgCQAgAAkCE+CUAAL8AIIT4JAAAv6BrELEgRqFriEcoRnC9LenwQQRGDkYVRk/wAAiU+CUAAigJ0AQg4GMAvwAghPgkAAC/ASC96PCBIGgAaADwIAAgsU/0gHDgYwEg8+cuuZT4RBACIAD6AfcE4JT4RBAEIAD6Aff797b7gEYt4CBsAGiU+EQgCCGRQAhAgLGU+EQQASCIQCFsSGABIOBjhPglAAC/ACCE+CQAAL8BIMrnaByQsS2x+/eW+6DrCACoQgvZICDgYwEghPglAAC/ACCE+CQAAL8BILXnIGwAaDhAACjM0GBtiLGgbQBo4W0IQGCxYG0AaED0gHBhbQhg1OkWEEhg4GtA9IBg4GPgbABoIW0IQDCx1OkTEEhg4GtA9ABw4GNOuZT4RBACIIhAIWxIYAEghPglAAXglPhEEAQgiEAhbEhgAL8AIIT4JAAAvwC/eOdwtQRGIGwFaCBoBmiU+EQQBCCIQChA0LEG8AQAuLEgaABoAPAgACi5IGgAaCDwBAAhaAhglPhEEAQgiEAhbEhgIGsAKE7QIEYha4hHSuCU+EQQAiCIQChACLMG8AIA8LEgaABoAPAgAEC5IGgAaCDwCgAhaAhgASCE+CUAlPhEEAIgiEAhbEhgAL8AIIT4JAAAv+BqMLMgRuFqiEci4JT4RBAIIIhAKEDgsQbwCADIsSBoAGgg8A4AIWgIYJT4RBABIIhAIWxIYAEg4GOE+CUAAL8AIIT4JAAAv2BrELEgRmFriEdwvRC1A0YAJAC/k/gkAAEoAdECIBC9ASCD+CQAAL+T+CUAASgS0TGxASkG0AIpBtADKQjRBeDaYgfgGmMF4FpjA+CaYwHgASQAvwDgASQAvwAgg/gkAAC/IEbb5wJGACMAv5L4JAABKAHRAiBwRwEggvgkAAC/kvglAAEoG9EFKRbS3+gB8AMGCQwPAAAg0GIQ4AAgEGMN4AAgUGMK4AAgkGMH4AAg0GIQY1BjkGMB4AEjAL8A4AEjAL8AIIL4JAAAvxhG0ucBRpH4JQBwRwFGyGtwRxC1jLAERgC/vkgAbUD0AHC8SQhlCEYAbQD0AHABkAC/AL8AvwhGwGxA9IAQyGQIRsBsAPSAEAGQAL8AvwhGAGtA9ABwCGMIRgBrIPQAcAhjAL8IRoBtQPCAUIhlCEaAbQDwgFABkAC/AL+nSEBoQPQAcKVJSGAAv6JIwGxA8EAAoEnIZAhGwGwA8EAAAZAAvwC/AL8IRsBsQPSAcMhkCEbAbAD0gHABkAC/AL8AvwhGwGxA9IBwyGQIRsBsAPSAcAGQAL8AvwC/CEbAbED0gHDIZAhGwGwA9IBwAZAAvwC/AL8IRsBsQPSAcMhkCEbAbAD0gHABkAC/AL8AvwhGwGxA8IAAyGQIRsBsAPCAAAGQAL8AvwC/CEbAbEDwgADIZAhGwGwA8IAAAZAAvwC/AL8IRsBsQPCAAMhkCEbAbADwgAABkAC/AL8AvwhGwGxA8EAAyGQIRsBsAPBAAAGQAL8AvwC/CEbAbEDwQADIZAhGwGwA8EAAAZAAvwC/AL8IRsBsQPBAAMhkCEbAbADwQAABkAC/AL+IFAeQAiAIkAEgCZACIAqQBSALkAepV0j/99f5QCAHkAAgCZAHqVRI//fP+U/0AGAHkAepUUj/98j5T/SAYAeQB6lNSP/3wflP9ABwB5AHqUpI//e6+U/0gHAHkAepR0j/97P5T/QAcAeQB6lESP/3rPlP9IBgB5AHqUBI//el+U/0AHAHkAepO0j/9575T/SAYAeQB6k3SP/3l/lP9ABAB5AHqTRI//eQ+QIgApADkDRIBpA0SAWQAiAEkMIeAqkgRvz3x/wMsBC9ELUERkwg+/dy+k/0gFEnSP/3XfpAISZI//dZ+k/0AGEjSP/3VPpP9IBhIUj/90/6T/QAcR5I//dK+k/0gHEdSP/3RfpP9ABxGkj/90D6T/SAYRhI//c7+k/0AHETSP/3NvpP9IBhEUj/9zH6T/QAQQ5I//cs+gtIAGtA9ABwCUkIYwhGAGsg9ABwCGMIRgBtIPQAcAhlCEbAbCD0gBDIZBC9AAAAEAJAAHAAQAAYAEgAIABIABwASAIAAAECAAEAALWXsBQhEqgA8Kb4RCEBqADwovgQIAGQASAHkAAgCJACIAuQASEMkWAgCZANkTchDpECIRGREJEHIQ+RAaj+9wT7CLEXsAC9DyASkAMgE5CAIBSQACAVkBaQAyESqP73nf4Ase7nAiASkAAgFJAFIRKo/veT/gCx5OcAv+LnfLUERg1GFkZQITFISEQA8GT4UCEwSEhEAPBf+AAgAJABkPv3Vvj/96z/AiAqSUlECGBB8u0giGBP8IBgiGMBIMhjCGBO9hNAiGAIIEhkAJAgIAGQ/fc4+QixASB8vQAg/OdwtQRGACUk8HBFKEb996D6ACBwvQFGACBwRxC1/fcK+wAgEL1wtQRGDUYWRipGIUYwRv33E/oAIHC9cLUERg5GFUb996D7B+AU+AEbFfgBK5FCAdAgRnC9MB6m8QEG89EgRvjnA0YBIHBHAUYAIHBHEAAAAGAAAABP8AACALUTRpRGlkYgOSK/oOgMUKDoDFCx8SABv/T3rwkHKL+g6AxQSL8MwF34BOuJACi/QPgEKwi/cEdIvyD4AisR8IBPGL8A+AErcEcAAAAAAAAAAAAAAQIDBAYHCAkAAAAAAQIDBKCGAQBADQMAgBoGAAA1DABAQg8AgIQeAAAJPQAAEnoAACT0AAA2bgEASOgBAGzcAgAAAAAACT0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 0x5353
-    pc_uninit: 0x53c9
-    pc_program_page: 0x53d9
-    pc_erase_sector: 0x53b5
-    pc_erase_all: 0x53cf
-    data_section_offset: 0x54c4
-    flash_properties:
-      address_range:
-        start: 0x90000000
-        end: 0x94000000
-      page_size: 0x100
-      erased_byte_value: 0xff
-      program_page_timeout: 0xbb8
-      erase_sector_timeout: 0xbb8
-      sectors:
-        - size: 0x10000
-          address: 0x0
-  - name: mx25lm51245g_stm32l4p5-disco
-    description: MX25LM51245G_STM32L4P5-Disco
-    cores:
-      - main
-    default: false
-    instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwR3C1BEYNRhZGAPCt+AixACBwvQEg/OcBRgAgcEcQtQfwu/gQvXC1BUYAJAX1gDEoRgDwxfgERgEsAdEAIHC9IEb853C1BEYNRhZGMkYpRiBGAPCm+AixACBwvQEg/Oct6fBBBEYORhVGACcA8Hz4B0YXuQEgvejwgQfgFPgBGxX4ASuRQgHQIEb05zAepvEBBvPRIEbu5wFGACAAvwDgQByw9YBf+9twRwEgcEcAv/7nAUYAIHBHALWZsBQhFKgH8CT6SCECqAfwIPoAv0pIgG1A8IBQSEmIZQhGgG0A8IBQAZAAvwC/ACAD8Mr4QkiAbSDwgFBASYhlECACkAEgCZAAIAqQAiANkAEhDpFgIAuQD5E3IRCRAiETkRKRByERkQKoA/AK/wix//fA/w8gFJADIBWQgCAWkAAgF5AYkAMhFKgE8NH6CLH/97D/AiAUkAAgFpAFIRSoBPDG+gix//el/xmwAL0QtQAkBvDo+gDwbvj/96D/BvAV/gixACAQvQfwufgERgyxIEb45wEg9ucQtQRGBvAG/gbw/v8BIBC9cLUERg1GFkYk8HBEBvD6/SpGIUYwRgbwAf8BIHC9cLUERg1GJPBwRCXwcEWgsiQaDeAmRjBGBvBZ/wixACBwvQC/B/AU+AAo+9EE9YA0pULv0gEg8+cAEAJAcEdwtQRGACWcSEhEAGjwsZpISEQAaE/0enGx+/DwmElJRAlosfvw9jBGAPDs+WC5ECwI0gAiIUZQHgDwV/mRSEhEBGAE4AElAuABJQDgASUoRnC9ELUAJAMgAPA1+Q8g//cp/wixASQB4P/3yf8gRhC9cEcQtU/w/zCDSYhjACCIY0AeCGQAIAhkQB6IYgAgiGJAHshiACDIYkAeCGMAIAhj//fm/wAgEL14SEhEAGhySUlECWgIRHRJSUQIYHBHckhIRABocEduSEhEAGhwR3C1BEYAJWlISEQAaKBCCdBoSEhEAGj/9+b+BUYVuWNISEQEYChGcL1gSEhEAGhwR3C1BEb/99P+BkYlRmgcGLFaSEhEAGgFRAC///fI/oAbqEL603C9T/DgIABpIPACAE/w4CEIYXBHT/DgIABpQPACAE/w4CEIYXBHUUhwR1FIAGgADHBHT0gAaMDzCwBwR01IAGhwR0xIAB0AaHBHSkgIMABocEdHSEBoQPABAEVJSGBwR0NIQGgg8AEAQUlIYHBHQEhAaEDwAgA+SUhgcEc8SEBoIPACADpJSGBwRzlIQGhA8AQAN0lIYHBHNUhAaCDwBAAzSUhgcEfKIDNJSGJTIEhiASAySQhgcEcBIDFJCGJwRwAgL0kIYnBHK0kJayHwBAEBQylKEWNwRydJCWsh8AIBAUMlShFjcEcjSUlrIfA/AQFDIUpRY3BHELUfSABrQPABAB1JCGP/90D+BEYG4P/3PP4AGwooAdkDIBC9FkgAawDwCAAAKPLQACD25xJIAGsg8AEAEEkIY3BHD0hAaED0gHANSUhgcEcLSEBoIPSAcAlJSGBwRwAAFAAAABgAAAAQAAAAABACQAwAAAADAAsBACAE4JB1/x8AAAFAAAMgQgAAIEIQtQAoBNsKBxMO5EoTVAbgCgcUDuJKAPAPAxsf1FQQvQC/APAHAt5LDDsZaE/2/wMZQNxLC0ND6gIh2UsMOxlgAL9wRy3p8E2ARg1GFkYAJwDwnvkHRjlGKkYzRgHwBwDA8QcLu/EEDwLZT/AECwHgwPEHC9pGAPEEC7vxBw8C0k/wAAsB4KDxAwvcRk/wAQsL+gr7q/EBCwvqAgsL+gz7T/ABDg76DP6u8QEODuoDDkvqDgQhRkBG//ei/73o8I0BRghGACgJ2wDwHwMBIppAQwmbAAPx4CPD+AAhAL9wRxC1AUYIRgAoF9sA8B8DASKaQK1LRAlD+CQgAL8AvwC/v/NPjwC/AL8AvwC/AL8Av7/zb48AvwC/AL8AvxC9AL8AvwC/AL8Av7/zT48AvwC/AL+bSAw4AGgA9OBgmUkIQwAdl0kMOQhgAL8AvwC/v/NPjwC/AL8AvwC/AL/953C1BEYlRmgesPGAfwHTASAP4GgeT/DgIUhhDyFP8P8w//c//wAgT/DgIYhhByAIYQAgcL0QtQDw/PgQvS3p8EUERiBGACgD231PP1w/CQfgfE8A8A8MrPEEDBf4DHA/CT1GDkYG8AcAwPEHCLjxBA8C2U/wBAgB4MDxBwjERgDxBAi48QcPAtJP8AAIAeCg8QMIR0Yl+gf4T/ABCgr6DPqq8QEKCOoKCML4AIBP8AEICPoH+KjxAQgI6gUIw/gAgAC/vejwhRC1AUYIRgAoCNsA8B8DASKaQFxLgDNECUP4JCAAvxC9ELUBRghGACgO21ZKgDJDCVL4IyAA8B8EASOjQBpACrEBIgLgACIA4AAiEEYQvRC1AUYIRgAoB9sA8B8DASKaQElLRAlD+CQgAL8QvRC1AUYIRgAoDttESoAyQwlS+CMgAPAfBAEjo0AaQAqxASIC4AAiAOAAIhBGEL0EKAjRT/DgIQlpQfAEAU/w4CIRYQfgT/DgIQlpIfAEAU/w4CIRYXBHcEcQtf/3/P8QvUDwAQEqSnwyEWAAvwC/AL+/80+PAL8AvwC/AL8AvwC/v/NvjwC/AL8Av3BHAL8AvwC/v/NfjwC/AL8AvwAgHEl8MQhgcEdBeBlKgDIRYAF4+bESHUFoEWABewkHwnpB6gJhgnpB6sJBQntB6oJBgntB6kJBwntB6gJBQnpB6gIhAnpB6kIBAngRQwlKiDIRYAXgACEGSoQyEWASHRFgcEcDSAw4AGjA8wIgcEcA5ADgGO0A4AAA+gWA4QDggOIA4AF5Sh74SwPrggJCZfZKQDKCZUoeAvADAwEimkDCZXBH8ksCaJpCBtJCbJII8EsD64ICgmQG4EJskgjtSxwzA+uCAoJkAngIOhQjsvvz8eZKgDrCZAHwHAMBIppAAmVwR3C1BEYMuQEgcL3gSSBoiEIL0uBJIGhAGhQhsPvx8IAAYGTcSAg4IGQK4NhJIGhAGhQhsPvx8IAAYGTUSAg4IGQCIIT4JQAgaAVoR/bwcIVD1OkCAQhDIWkIQ2FpCEOhaQhD4WkIQyFqCEMFQyBoBWAgRv/3pf+gaLD1gE8B0QAgYGAgeaFsCGDU6RMQSGBgaGCxYGgEKAnYIEb/94H/ACBhbQhg1OkWEEhgA+AAIGBloGXgZQAg4GMBIIT4JQAAIIT4JAAAv5/nELUERgy5ASAQvSBoAGgg8AEAIWgIYKtJIGiIQgvSq0kgaEAaFCGw+/HwgABgZKdICDggZArgo0kgaEAaFCGw+/HwgABgZJ9ICDggZAAgIWgIYJT4RAAA8BwBASCIQCFsSGAgRv/3SP8AIKFsCGDU6RMQSGBgaFixYGgEKAjYIEb/9yr/ACBhbQhg1OkWEEhgACBgZaBl4GXgYiBjYGOgY+BjhPglAAC/hPgkAAC/AL+q5zC10OkTVGxgRG0UsdDpFlRsYJD4REAE8BwFASSsQAVsbGAEaGNghGgQLATRBGiiYARo4WAD4ARooWAEaOJgML0t6fBBBEYNRhZGH0ZP8AAIAL+U+CQAASgC0QIgvejwgQEghPgkAAC/lPglAAEoF9ECIIT4JQAAIOBjIGgAaCDwAQAhaAhgO0YyRilGIEb/97f/IGgAaEDwAQAhaAhgBuAAvwAghPgkAAC/T/ACCEBG1Oct6fBBBEYNRhZGH0ZP8AAIAL+U+CQAASgC0QIgvejwgQEghPgkAAC/lPglAAEoP9ECIIT4JQAAIOBjIGgAaCDwAQAhaAhgO0YyRilGIEb/937/IGswsSBoAGhA8A4AIWgIYAvgIGgAaCDwBAAhaAhgIGgAaEDwCgAhaAhgoGwAaAD0gDAosaBsAGhA9IBwoWwIYGBtKLFgbQBoQPSAcGFtCGAgaABoQPABACFoCGAG4AC/ACCE+CQAAL9P8AIIQEas5wFGACKR+CUAAigI0AQgyGMAvwAggfgkAAC/ASBwRwhoAGgg8A4AC2gYYIhsAGgg9IBwi2wYYAhoAGgg8AEAC2gYYJH4RAAA8BwDASCYQAtsWGDR6RMwWGBIbUCxSG0AaCD0gHBLbRhg0ekWMFhgASCB+CUAAL8AIIH4JAAAvxBGzOdwtQRGACWU+CUAAigM0AQg4GMBJT3gAAAACQJACAQCQAAIAkAIAAJAIGgAaCDwDgAhaAhgIGgAaCDwAQAhaAhgoGwAaCD0gHChbAhglPhEAADwHAEBIIhAIWxIYNTpExBIYGBtQLFgbQBoIPSAcGFtCGDU6RYQSGABIIT4JQAAvwAghPgkAAC/oGsQsSBGoWuIRyhGcL0t6fBBBEYORhVGlPglAAIoCdAEIOBjAL8AIIT4JAAAvwEgvejwgSBoAGgA8CAAILFP9IBw4GMBIPPnPrmU+EQAAPAcAQIgAPoB+AbglPhEAADwHAEEIAD6Afj/98n5B0Yw4CBsAGiU+EQQAfAcAgghkUAIQJCxlPhEAADwHAEBIIhAIWxIYAEg4GOE+CUAAL8AIIT4JAAAvwEgwudoHIix//em+cAbqEIA2F25ICDgYwEghPglAAC/ACCE+CQAAL8BIK7nIGwAaADqCAAAKMjQYG2IsaBtAGjhbQhAYLFgbQBoQPSAcGFtCGDU6RYQSGDga0D0gGDgY+BsAGghbQhAMLHU6RMQSGDga0D0AHDgY165lPhEAADwHAECIIhAIWxIYAEghPglAAfglPhEAADwHAEEIIhAIWxIYAC/ACCE+CQAAL8Av2zncLUERiBsBWggaAZolPhEAADwHAEEIIhAKEDgsQbwBADIsSBoAGgA8CAAKLkgaABoIPAEACFoCGCU+EQAAPAcAQQgiEAhbEhgIGsAKFbQIEYha4hHUuCU+EQAAPAcAQIgiEAoQBizBvACAACzIGgAaADwIABAuSBoAGgg8AoAIWgIYAEghPglAJT4RAAA8BwBAiCIQCFsSGAAvwAghPgkAAC/4GpQsyBG4WqIRybglPhEAADwHAEIIIhAKEDwsQbwCADYsSBoAGgg8A4AIWgIYJT4RAAA8BwBASCIQCFsSGABIOBjhPglAAC/ACCE+CQAAL9gaxCxIEZha4hHcL0QtQNGACQAv5P4JAABKAHRAiAQvQEgg/gkAAC/k/glAAEoEtExsQEpBtACKQbQAykI0QXg2mIH4BpjBeBaYwPgmmMB4AEkAL8A4AEkAL8AIIP4JAAAvyBG2+cCRgAjAL+S+CQAASgB0QIgcEcBIIL4JAAAv5L4JQABKBvRBSkW0t/oAfADBgkMDwAAINBiEOAAIBBjDeAAIFBjCuAAIJBjB+AAINBiEGNQY5BjAeABIwC/AOABIwC/ACCC+CQAAL8YRtLnAUaR+CUAcEcBRshrcEcCRpL4JQABKCTRAL+S+CQAASgB0QIgcEcBIIL4JAAAvwh4AwaIiUAeQ+rAQEtoGEMLekDqA0BLekDqQyCTbBto27IYQ5NsGGAAvwAggvgkAAC/4OcBIN7nAkaS+CUAASgb0VBtyLEAv5L4JAABKAHRAiBwRwEggvgkAAC/CIlAHgtoQ+rAQEtoGENTbRhgAL8AIIL4JAAAv+vnASDp5wFGkfglAEixSG04sUhtAGhA9IAwSm0QYAAgcEcBIPznAUaR+CUASLFIbTixSG0AaCD0gDBKbRBgACBwRwEg/OcQtQRG4GwAaCFtCECIsaBsAGgg9IBwoWwIYNTpExBIYOBrQPQAcOBjYGsQsSBGYWuIR2BtsLGgbQBo4W0IQIixYG0AaCD0gHBhbQhg1OkWEEhg4GtA9IBg4GNgaxCxIEZha4hHEL0AAHi1AkYAI9rgASaeQA1oBeoGBAAsctBNaAItAtBNaBItE9HeCALxIAVV+CYAXQfuDg8ltUCoQ14H9g4NabVAKEPeCALxIAVF+CYAEGheAAMltUCoQw15BfADBV4AtUAoQxBgTWgBLQjQTWgCLQXQTWgRLQLQTWgSLRPRkGheAAMltUCoQ14AzWi1QChDkGBQaAElnUCoQw15xfMAFZ1AKENQYNBoXgADJbVAqENeAI1otUAoQ9BgTWgF8IBVtfGAX3zRAL+nTS1uRfABBaVONWY1Ri1uBfABBQCVAL8Av0/qtjWeCFX4JgCdBy4PDyW1QKhDsvGQTwLRACUk4F7gmk2qQgHRASUe4JhNqkIB0QIlGeCXTapCAdEDJRTglU2qQgHRBCUP4JRNqkIB0QUlCuCSTapCAdEGJQXgkU2qQgHRByUA4Aglngc2D7VAKEONTZ4IRfgmAIxNKGigQ01oBfSANbX1gD8A0SBDh00oYC0dKGigQ01oBfQANbX1AD8A0SBDgU0tHShgLR0oaKBDTWgF9IAVtfWAHwDRIEN6TQg1KGAtHShooENNaAX0ABW19QAfANEgQ3RNDDUoYFscDWjdQAAtf/Qgr3i98LULRgAhh+ABJY1ABeoDAgAqftBpTY4IVfgmQI0HLg8PJbVALECw8ZBPAdEAJSPgW02oQgHRASUe4FlNqEIB0QIlGeBYTahCAdEDJRTgVk2oQgHRBCUP4FVNqEIB0QUlCuBTTahCAdEGJQXgUk2oQgHRByUA4Agljgc2D7VApUIh0U5NLWiVQ01ONWA1HS1olUM2HTVgNR0taJVDNh01YDUdLWiVQzYdNWCNBy4PDyUF+gb0QU2OCFX4JlClQz5OjwhG+CdQBWhPAAMmvkA1QwVgzggA8SAFVfgmUE4H9w4PJr5AtUPPCADxIAZG+CdQhWhPAAMmvkC1Q4VgRmgBJY1ArkNGYMVoTwADJr5AtUMA4ADgxWBJHCP6AfUALX/0c6/wvQJGE2kLQAuxASAA4AAgcEcKsYFhAOCBYnBHQmkKQAqxgWIA4IFhcEcItQJGT/SAMACQAJgIQwCQAJjQYdFhAJjQYdBpAJDQaQD0gDAIsQAgCL0BIPzncEcQtQRGD0gUMABoIEAosQxIFDAEYCBG//fy/xC9AAAAEAJAAAQASAAIAEgADABIABAASAAUAEgAGABIABwASAgAAUAABAFAELWGsARGAiACkAMgBJAAIAOQAL/ISMBsQPSAEMZJyGQIRsBsAPSAEACQAL8AvwC/CEaAbUDwgFCIZQhGgG0A8IBQAJAAvwC/vEhAaED0AHC6SUhgAL+4SMBsQPAQALZJyGQIRsBsAPAQAACQAL8AvwC/CEbAbEDwEADIZAhGwGwA8BAAAJAAvwC/AL8IRsBsQPAQAMhkCEbAbADwEAAAkAC/AL8AvwhGwGxA8BAAyGQIRsBsAPAQAACQAL8AvwC/CEbAbEDwEADIZAhGwGwA8BAAAJAAvwC/AL8IRsBsQPABAMhkCEbAbADwAQAAkAC/AL8AvwhGwGxA8AEAyGQIRsBsAPABAACQAL8AvwC/CEbAbEDwCADIZAhGwGwA8AgAAJAAvwC/AL8IRsBsQPAIAMhkCEbAbADwCAAAkAC/AL8AvwhGwGxA8AQAyGQIRsBsAPAEAACQAL8AvwC/CEbAbEDwCADIZAhGwGwA8AgAAJAAvwC/AL8IRsBsQPBAAMhkCEbAbADwQAAAkAC/AL8KIAWQASADkMACAZABqWhI//dp/QAgA5BP9IBgAZABqWRI//dg/QAgA5BP9ABwAZABqV9I//dX/U/0gFABkAGpXEj/91D9T/QAUAGQAalYSP/3Sf2AIAGQAalP8JBA//dC/UAgAZABqU/wkED/9zv9CCABkAGpT0j/9zX9gCABkAGpTUj/9y/9ECABkAGpSkj/9yn9ICABkAGpR0j/9yP9AyAFkEAgAZABqURI//cb/QC/PUgAbUD0gHA7SQhlCEYAbQD0gHAAkAC/AL8IRgBrQPSAcAhjCEYAayD0gHAIYwAiDyFHIP735v5HIP73If8GsBC9OLUERkcg/vcq/0/0AGErSP/31P1P9IBhKUj/98/9T/QAcSZI//fK/U/0gFEkSP/3xf1P9ABRIUj/98D9gCFP8JBA//e7/UAhT/CQQP/3tv0QIRxI//ey/SAhGkj/9679CCEXSP/3qv2AIRZI//em/UAhFUj/96L9D0gAa0D0gHANSQhjCEYAayD0gHAIYwC/CEYAbUD0gHAIZQhGAG0A9IBwAJAAvwC/CEbAbCD0gBDIZDi9AAAAEAJAAHAAQAAQAEgACABIAAwASAAYAEgt6fBBBEYORhdGmEYGnRLgaByAsf73T/yg6wgAqEIA2E25T/QAcKBk4GxA8AEA4GQBIL3o8IEgaABqMEAIsQEgAOAAILhC49EAIPLnAkYRZQAgcEdwR/i1BEYAJf73K/wGRgy5ASV44AAg4GSgbEC5IEb/9x3+QfKIMSBG//fm/wVGAC1p0SCKQB7haEHqAEFgaUAeQeoAIOFpCEMhaIlo/koRQAhDIWiIYCBowGgg9OAgIWoIQyFoyGAgjgAEIWgIYSFoYGtIYSBoAGgg9PhRYGhAHkHqACAhaAhgIG0zRgAiICEAkCBG//eK/wVGjbsgaMBoIPD/AGFqSR4IQyFoyGAgaABoIPBAAKFoCEMhaAhg1OkKAQhDIWjR+AgRIfCgQQhDIWjB+AgBIGgAaEDwAQAhaAhgoGkCKAXRIGiAaEDwAgAhaIhg4Giw8YBvAtEBIKBkAeACIKBkKEb4vXBHcLUERgAlDLkBJRDgIGgAaCDwAQAhaAhgIGiAaCDwAgAhaIhgIEb/99T+ACCgZChGcL1wR3BHcEdwtQVGrGoAICBkoGyw9YB/GtEgaABqwPNAEHixAiAhaEhiIGgAaED0ADAhaAhgIGgAaEDwAgAhaAhgCuACIKBkIEb/99z/BOACIKBkIEb/99X/cL1wR3BHcEdwR3BHLenwQQRGIGgA8VAIIGgFaiBoB2imbAXwBAA4swf0gCAgsxguCtGgawB4iPgAAKBrQBygYyBsQB4gZAvgKC4J0Zj4AAChawhwoGtAHKBjIGxAHiBkIGwouSBoAGgg9IAgIWgIYCBG//fK/6XgBfACAAAoS9AH9AAwAChH0CguIdEgbGixBfR8UFCxmPgAAKFrCHCga0AcoGMgbEAeIGSL4CBsACjh0QIgIWhIYiBoAGgg9OAgIWgIYAIgoGQgRv/3nf954AIgIWhIYiBoAGgg9OAgIWgIYAIgoGQYLgPRIEb/94v/aOAILgPRIEb/94T/YuC29YB/X9HgbBi5IEb/90//WeAgRv/3Sv9V4AXwCACwsQf0ACCYsQggIWhIYiBoAGgA9IAAOLEgaABoIPQQICFoCGACIKBkIEb/91z/O+AF8AEAYLMH9IAwSLMBICFoSGIgaABoIPT4ECFoCGACIOBkIGgAaADwBACYsSBoAGgg8AQAIWgIYExIeERhbIhjYGz/91r4uLECIKBkIEb/9wb/EeACIKBkIEb/9wD/C+AF8BAAQLEH9IAQKLEQICFoSGIgRv/38v696PCBLenwQQNGACAfaD9oJ/BAV9P4AMDM+ABwn2hfuR9oP2gn8IAH0fgEwEfqDAfT+ADAzPgAcA9oAi8M0R9oB/XAch9oB/XEdB9oB/XIdR9oB/XQdgvgH2gH9YByH2gH9YR0H2gH9Yh1H2gH9ZB20ekSfEfqDAcXYM9qj7GPajdg0fg0wM9qR+oMB9H4MMBH6gwH0vgAwCz0fBxH6gwHF2AnaCfwHwfR+ETAR+oMBydgj2s/sQ9oL7nPa38e0/gAwMz4QHDPaAAvfdDPafezj2tns9H4FMDPaEfqDAfR+BDAR+oMB9H4HMAE4AAA/Pjg+CX+//9H6gwH0fgkwEfqDAfR+CDAR+oMB9H4OMBH6gwH0fhAwEfqDAfS+ADA3/gYigzqCAxH6gwHF2Aq4NH4FMDPaEfqDAfR+BDAR+oMB9H4HMBH6gwH0fgkwADgIeBH6gwH0fggwEfqDAfS+ADAQ/Y/eCzqCAxH6gwHF2DfarfxgF8G0U9pCC8D0RdoR/AAZxdgj2gvYI9p0/gAwMz4SHB34I9r57HR+BTAz2hH6gwH0fgQwEfqDAfR+DjAR+oMB9H4QMBH6gwH0vgAwN/4fIkM6ggMAOAh4EfqDAcXYBrg0fgUwM9oR+oMB9H4EMBH6gwH0vgAwCzwPwxH6gwHF2DfarfxgF8G0U9pCC8D0RdoR/AAZxdgj2gvYDrgz2mns49r57HR+CTAz2lH6gwH0fggwEfqDAfR+DjAR+oMB9H4QMBH6gwH0vgAwN/4/IgI8T8IDOoIDEfqDAcXYA/g0fgkwM9pR+oMB9H4IMBH6gwH0vgAwCz0fFxH6gwHF2CPadP4AMDM+EhwA+D/5wEgCCffZL3o8IEt6fhFBEYNRpBG/vc5+YJGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsYsShoALkAvwC/p2wCLwPR4Giw8YBvCdEULwLRKGgCKATQJC890ShoASg60VNGACIgISBGzfgAgP/3svwGRh67ACDgZClGIEb/94P+BkbeuahrYLlTRgEiAiEgRs34AID/9578BkYCICFoSGIc4ChoELkEIKBkF+AoaAEoCNGgbCQoAtEEIKBkDuAUIKBkC+CgbBQoAtEEIKBkBeAkIKBkAuABJhAg4GQwRr3o+IX4tQRGDUb+98/4B0agaAC5AL/oaACxAL/oaQCxAL/oagCxAL+oawCxAL+gbAIoJdEoaBi7qGsIu+BosPGAbx3QIG07RgAiICEAkCBG//dR/AZGtrkAIOBkAyAhaEhiKUYgRv/3H/4GRl65CCCgZCBoAGhA9EAwIWgIYALgASYQIOBkMEb4vS3p+EUERg1GF0b+94r4gkbU+EiAuPEBDwLQuPECDxfRU0YAIiAhIEYAl//3H/wGRo65KIgABGloQOoBIKloCEPpaAhDIWjB+AACAiCgZALgASYQIOBkMEa96PiFLen4QwRGDUYXRv73XPiARqBsAig40eBosPGAbzTRQ0YAIiAhIEYAl//38vsGRla7IGgAaCDwQFAhaAhgIGiAaCDwgHApaAhDIWiIYChpQPBAYKloCENA9EBgIWjB+AABKGlA8EBgqWgIQ0D0QGAhaMH4gAHoaEAeIWgIZGhoIWiIZAQgoGQC4AEmECDgZDBGvej4gy3p+EUERg5GF0b+9xL4gEYgaADxUAoeuQElCCDgZDrgoGwEKDTRIGgAbEAcIGQgbOBjpmMgaABoIPBAUCFoCGAAv0NGASIEISBGAJf/95b7BUYFsQzgoGsAeIr4AACga0AcoGMgbEAeIGQgbAAo6NEAv4W5Q0YBIgIhIEYAl//3ffsFRj25AiAhaEhioGQC4AElECDgZChGvej4hS3p/E0ERg5GF0b998T/AZAgaADxUAogaND4SIAgaND4ELEeuQElCCDgZFHgoGwEKEvRIGgAbEAcIGQgbOBjpmMgaABoIPBAUEDwgFAhaAhg4Giw8YBvA9EgaMD4SIAM4CBo0PgAAQD04GAYsSBowPhIgALgIGjA+BCxAL8AlwEiBiEgRgGb//cr+wVGBbEM4Jr4AAChawhwoGtAHKBjIGxAHiBkIGwAKOjRAL+FuQCXASICISBGAZv/9xL7BUY9uQIgIWhIYqBkAuABJRAg4GQoRr3o/I0QtQJGACAZuQEgCCPTZB7gk2wEKxjRE2gbbFscE2QTbNNjkWMTaBtoI/BAUxRoI2ADIxRoY2IYI5NkE2gbaEP04CMUaCNgAuABIBAj02QQvXC1AkYAIBVoq2wVaNX4EEEZuQEgCCXVZDPglWwELS3RFWgtbG0cFWQVbNVjkWMVaC1oJfBAVUXwgFUWaDVgAyUWaHViKCWVZBVoLWhF9OAlFmg1YNVotfGAbwLRFWirZA/gFWjV+ABRBfTgZRWxFWirZAbgFWjF+BBBAuABIBAl1WRwvXC1BEYAJqVsBfAIABi5BfAEAAAoPNAgaABoIPT4ECFoCGBP9IBwoGQgaABoAPAEAJixIGgAaCDwBAAhaAhg+Uh4RGFsiGNgbP73jfz4sQIgoGQgRv/3Ovsd4CBoAGrA80AQeLECICFoSGIgaABoQPQAMCFoCGAgaABoQPACACFoCGAI4AIgoGQgRv/3H/sC4AEmECDgZDBGcL1wtQVGrGoAICBkBCDgZCBoAGgg8AQAIWgIYCBG//ej/1CxIGgAaCD04CAhaAhgAiCgZCBG//f8+nC9cEdwR3C1BUasaiBsQAggZKBsKCgD0SBG//fz/wLgIEb/9+7/cL0BRohqACICZAJoEmgi8AQCA2gaYApoEmgi8AECC2gaYAJoEmhC9AAyA2gaYHBHLenwQQRGDkYAJyBoAGxFHB65AScIIOBkeeCgbAQoc9FgbEBpCLklZCTgYGxAabD1gH8N0QXwAQAYuSB5APABABixCCDgZAEnFOBoCCBkEeBgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIIOBkAScB4KgIIGQAL0rRIGzgY6ZjIGgAaCDwQFAhaAhgAyAhaEhiGCCgZJtIeERhbMhimkh4RGFsCGOZSHhEYWxIYwAgYWyIYxAhYGyBYGBsAGgAaCDwEABhbIloCENhbAloCGDjayFoAfFQAjFGYGz+9w77YLkgaABoQPSAMCFoCGAgaABoQPAEACFoCGAJ4AEnBCDgZAIgoGQD4P/nAScQIOBkOEa96PCBLenwRwRGDkYAJyBoAGxFHCBo0PhIgCBo0PgQoR65AScIIOBkkOCgbAQob9FgbEBpCLklZCTgYGxAabD1gH8N0QXwAQAYuSB5APABABixCCDgZAEnFOBoCCBkEeBgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIIOBkAScB4KgIIGQAL2HRIGzgY6ZjIGgAaCDwQFBA8IBQIWgIYAMgIWhIYiggoGRVSHhEYWzIYlRIeERhbAhjU0h4RGFsSGMAIGFsiGMAIWBsgWBgbABoAGgg8BAAYWyJaAhDYWwJaAhg42siaALxUAEyRmBs/vd8+hC7IGgAaED0gDAhaAhg4Giw8YBvBNEgaMD4SIAN4BngIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4EKEgaABoQPAEACFoCGAI4AEnBCDgZAIgoGQC4AEnECDgZDhGvejwhy3p+E8ERg1GF0b99yr9gkYgaND4SIAgaND4ELGgbAQoXNHoaLD1gA9Y0VNGACIgISBGAJf/97r4BkYALlHRKGghaMH4iABoaCFowfiAAChpIWjB+JAA1ekCAQhDQPAAUCFoCWgh8ENRCEMhaAhg4Giw8YBvA9EgaMD4SIAf4CBo0PgAAQD04GCwsSBowPhIgBXgAADAwP/wwP//8Iv2//85////D////8n+//8V/v//6/3//6X9//8gaMD4ELFTRgEiCCEgRgCX//dw+AZGJrkIICFoSGICIKBkAuABJhAg4GQwRr3o+I8t6fhFBEYNRv33t/yARiBoh2wgaND4EKGgbAQoQNEgbUNGACIgIQCQIEb/90v4BkZGuyhoIWjB+IgAaGghaMH4gAAoaSFowfiQANXpAgEIQ0DwAFAhaAloIfBDUQhDIWgIYAkgIWhIYkggoGQgaABoQPQQICFoCGDgaLDxgG8C0SBoh2QP4CBo0PgAAQD04GAQsSBoh2QG4CBowPgQoQLgASYQIOBkMEa96PiF+LUERg1G/fdi/AdGoGwEKCbRIG07RgAiICEAkCBG/vf7/wZG/rmIIKBkKGgIKAzRaGghaMH4MAEQICFoSGIgaABoQPSAECFoCGAgaABo/UkIQCloQfBAUQhDIWgIYALgASYQIOBkMEb4vfi1BEYAJf33LfwHRqZsBvAIABi5BvAEAAAoOdAgaABoAPAEAGCxIGgAaCDwBAAhaAhgYGz+95L5BUYNsQQg4GQgaABqwPNAEPixIGgAaEDwAgAhaAhgIG07RgEiAiEAkCBG/vek/wVGrbkCICFoSGIgbTtGACIgIQCQIEb+95f/BUZFuQIgoGQF4AIgoGQC4AElECDgZChG+L0QtQJGACCTbAPwCANbuVFgE2gbaCP0+FRTaFseROoDIxRoI2AC4AEgECPTZBC9AUYIaABowPMEIEAccEcBRshscEcBRohscEfwtQVGACAAJBWxAi0A2Am5ASBk4AAmDmBOYI5gzmAOYQItCNG1TjZoBvABBg65tEwB4E/0AHQAI0/gsE42HVb4IyAC8AEGPrEC8AIGBPACB75CAdFeHA5gAvAQBj6xAvAgBgTwIAe+QgHRXhxOYAL0gHY+sQL0AHYE9AB3vkIB0V4cjmAC9IA2jrEC9IAmBPSAJ75CC9EC9AA2JrleHEb0gDbOYAPgXhxG8IB2zmAC8IB2jrEC8IBmBPCAZ75CC9EC8AB2JrleHEb0gDYOYQPgXhxG8IB2DmFbHAIrrdPwvS3p8E2MsIJGDEZP8AAL2EaESdr4AACIQgLRACYBJQHgASYAJQAnEOAH60cCa0YD68IBehzQsv/3c/8gsU/wAQsIIMr4TAB4HMeyAi/s07vxAA990XNIAGgA8AEAOLFxSABoIPABAG9JCGBI8AEIbkgAaADwAQA4sWtIAGgg8AEAaUkIYEjwAghkSAAdButGAWpGAuvBAYloSR5Q+CEAIPSAcl5IAB0G60YBa0YD68EBiWhJHkD4ISAAHwBoAPABAAAoZNBVSABoIPABAFNJCGABLVvRCB0F60UBXfgxEEkeUPghAEDwAgJMSAAdBetFAV34MRBJHkD4ISAF60UBakYC68EBSWhJHlD4IQBA8CACQkgAHQXrRQED68EBSWhJHkD4ISAF60UBakYC68EBCXtJHgHwAQFQ+CEAQPSAIjdIAB0F60UBA+vBAQl7SR4A4HDiAfABAUD4ISAF60UBakYC68EBCXxJHgHwAQFQ+CEAQPCAYilIAB0F60UBA+vBAQl8SR4B8AEBQPghIGzgButGAF34MADosyBIAB0G60YBXfgxEEkeUPghACDwAQIbSAAdButGAV34MRBJHkD4ISAG60YBakYC68EBSWhJHlD4IQAg8BACEUgAHQbrRgFrRgPrwQFJaEkeQPghIAbrRgFqRgLrwQEJe0keAfABAVD4IQAg9IAyBUgAHQbrRgED68EBC+Ao4AAA9///zwAcBlAiAgQEABAAoAAUAKAJe0keAfABAUD4ISAG60YBakYC68EBCXxJHgHwAQFQ+CEAIPCAcvpIButGAQPrwQEJfEkeAfABAUD4ISAF60UBXfgxECBoiEIg0AXrRQFqRgLrwQFgaEloiEIX0AXrRQEC68EBoGiJaIhCD9AF60UBAuvBAeBoyWiIQgfQBetFAQLrwQEgaQlpiEIn0QXrRQFd+DEQIGiIQiHRBetFAWpGAuvBAWBoSWiIQhjRBetFAQLrwQHgaMloiEIQ0QXrRQEC68EBIGkJaYhCCNHQSAAfAGhA8AEAzkkJHwhgauDMSAXrRQFd+DEQSR5Q+CEAIPABAsdIBetFAV34MRBJHkD4ISAF60UBakYC68EBSWhJHlD4IQAg8BACvUgF60UBa0YD68EBSWhJHkD4ISAF60UBakYC68EBiWhJHlD4IQAg9IBys0gF60UBA+vBAYloSR5A+CEgBetFAWpGAuvBAQl7SR4B8AEBUPghACD0gDKoSAXrRQED68EBCXtJHgHwAQFA+CEgBetFAWpGAuvBAQl8SR4B8AEBUPghACDwgHKcSAXrRQED68EBCXxJHgHwAQFA+CEglkihaEkeUPghACD0QHBP9IBxQepGIQhDkEmiaFIeQfgiAGBpQB4JHwlowfMHQYhCC9mKSAAfAGgg9H8BoIpAHkHqAECFSQkfCGCESAAfAGgA8AEAACht0IBIIWhJHlD4IQAg8AMAQBx8SSJoUh5B+CIACEZhaEkeUPghACDwMABA8BACdUhhaEkeQPghIOBoAPSAMJCxcUghe0keAfABAVD4IQAg9OAgQPSAMmtIIXtJHgHwAQFA+CEgEeBnSCF7SR4B8AEBUPghACDw4GBA8IByYkghe0keAfABAUD4ISAgaQD0gDCQsVxIIXxJHgHwAQFQ+CEAIPTgIED0QDJXSCF8SR4B8AEBQPghIJDgU0ghfEkeAfABAVD4IQAg8OBgQPBAck1IIXxJHgHwAQFA+CEgfeBJSCFoSR5Q+CEAIPADAAEhQepGAQhDREkiaFIeQfgiAAhGYWhJHlD4IQAg8DAAECFB6kYRCEM8SWJoUh5B+CIA4GgA9IAwqLEIRiF7SR4B8AEBUPghACD04CBP9IAxQeqGQQhDMEkie1IeAvABAkH4IgAU4CxIIXtJHgHwAQFQ+CEAIPDgYU/wgHBA6oZgAUMlSCJ7Uh4C8AECQPgiECBpAPSAMKixIEghfEkeAfABAVD4IQAg9OAgT/RAMUHqhkEIQxlJInxSHgLwAQJB+CIAFOAVSCF8SR4B8AEBUPghACDw4GBP8EBxQeqGYQhDDkkifFIeAvABAkH4IgAI8AEAKLEKSABoQPABAAhJCGAI8AIAKLEGSABoQPABAARJCGBYRgywvejwjQQcBlAAEACgABQAoHxIgGtA8IBQekmIYwhGgGsg8IBQiGNwR3dIAGhA9IBwdUkIYHBHdEgAaCD0gHBySQhgcEcBRnBIQGgg8A4ACmgQQ21KUGBtSABoIPSAMGtKEGAQHwBoIPSAMBIfEGBnSAgwAGgg9IAwZEoIMhBgEB8AaCD0gDASHxBgSGgA9IAwsPWAPwfRXUgAHwBoQPSAMFpKEh8QYEhoAPQAMLD1AD8F0VZIAGhA9IAwVEoQYAh5APABADixUUgAHQBoQPSAME5KEh0QYAh5APACAAIoB9FKSAgwAGhA9IAwSEoIMhBgACBwR0RIQGhA8AEAQklIYHBHQUhAaCDwAQA/SUhgcEc9ScloAPAfApFDQepQETpK0WARRoloAPAfAhFDNkqRYHBHNUmJaADwHwKRQzJKkWBwR3C1BEYNRlS5L0hAaQD0AHCw9QB/CtEA8MT8OLFwvSlIQGnA80AgCLkA8LT8KEgAaCDwBAAmSQhgAS0B0TC/AuBAvyC/IL8Av+jncLUFRgxGtfWATwPRIEYA8OL8AuAgRgDwxPxwvRdIAGgg8AcAwBwVSQhgFkgAaEDwBAAUSQhgAL8AvzC/cEcRSABoQPACAA9JCGBwRw1IAGgg8AIAC0kIYHBHCkgAaEDwEAAISQhgcEcGSABoIPAQAARJCGBwR3BHABACQABwAEAEBAFAEO0A4PhIAGgA9MBgsPWAbwLRT/SAYHBH80iAMABoAPSAcLD1gH8C0U/0AHDz5wAg8ecCRpK77EgAaAD0wGCw9YBvLNHoSIAwAGgg9IBw5kvD+IAAGEYAaCD0wGBA9ABwGGDiSEhEAGgyI1hD4Euw+/PwQRwA4Eke20hAaQD0gGCw9YBvAdEAKfXR10hAaQD0gGCw9YBvUtEDIHBHCODSSIAwAGgg9IBwz0vD+IAARuCy9QB/O9HMSABoAPTAYLD1gG8r0chIgDAAaED0gHDGS8P4gAAYRgBoIPTAYED0AHAYYMJISEQAaDIjWEPAS7D78/BBHADgSR67SEBpAPSAYLD1gG8B0QAp9dG3SEBpAPSAYLD1gG8S0QMgvueySIAwAGhA9IBwsEvD+IAAB+CuSABoIPTAYED0gGCrSxhgACCr56lJyWgh9ABxAUOmStFgEUbJaEH0gHHRYHBHokjAaCD0gHCgSchgcEefSEBoQPSAYJ1JSGBwR5tIQGgg9IBgmUlIYHBHmEhAaED0AHCWSUhgcEeUSEBoIPQAcJJJSGBwR5FIgGhA9ABAj0mIYHBHjUiAaCD0AECLSYhgcEcQtQJGACAJKnHS3+gC8AUUISs1P0lTYACESxtqIfSARCNDgUwjYiNGW2oh9CBEo0N+TGNiXeB8S5tqC0N7TKNiI0bbaiHwEASjQ3dM42JQ4HZLG2sLQ3RMI2MjRltri0NjY0bgcUubawtDb0yjYyNG22uLQ+NjPOBsSxtsC0NqTCNkI0ZbbItDY2Qy4GdLm2wLQ2VMo2QjRttsi0PjZCjgYksbbQtDYEwjZSNGW22LQ2NlHuBdS5ttjLIjQ1tMo2UjRtttjLKjQ1hM42UR4FZLG27B8wsEI0NUTCNmI0ZbbsHzCwSjQ1BMY2YC4P/nASAAvwC/EL0QtQJGACAJKkHS3+gC8AUNExkfJSsxOABGSxtqIfSARKNDREwjYjTgQkubaotDQUyjYi7gP0sba4tDPkwjYyjgPEuba4tDO0yjYyLgOUsbbItDOEwjZBzgNkubbItDNUyjZBbgM0sbbYtDMkwjZRDgMEubbYyyo0MuTKNlCeAtSxtuwfMLBKNDKkwjZgHgASAAvwC/EL0QtQJGACAJKnbS3+gC8AUUICo0Pk5YZQAhS1tqIfQgRCNDHkxjYiNGG2oh9IBEo0MbTCNiYuAZS9tqIfAQBCNDF0zjYiNGm2qLQ6NiVuATS1trC0MSTGNjI0Yba4tDI2NM4A5L22sLQw1M42MjRptri0OjY0LgCUtbbAtDCExjZCNGG2yLQyNkOOAES9tsC0MDTONkI0abbItDo2Qu4ABwAEAYAAAAQEIPAP5LW20LQ/1MY2UjRhtti0MjZR7g+UvbbYyyI0P3TONlI0abbYyyo0P0TKNlEeDzS1tuwfMLBCND8ExjZiNGG27B8wsEo0PtTCNmAuD/5wEgAL8AvxC9ELUCRgAgCSpD0t/oAvAFDRUbISctMzoA40tbaiH0IESjQ+BMY2I24N9L22oh8BAEo0PcTONiLuDbS1tri0PZTGNjKODYS9tri0PWTONjIuDVS1tsi0PTTGNkHODSS9tsi0PQTONkFuDPS1tti0PNTGNlEODMS9ttjLKjQ8pM42UJ4MhLW27B8wsEo0PGTGNmAeABIAC/AL8QvcJIgGhA9IBgwEmIYHBHv0iAaCD0gGC9SYhgcEcBRjG5ukiAaCD0QHC4SpBgGeCx9YB/CNG1SIBoIPRAcED0gHCySpBgDeCx9QB/CNGvSIBoIPRAcED0AHCsSpBgAeABIHBHACD85wC1T/SAcP/31v8AvQC1ACD/99H/AL2jSIBoQPQAYKFJiGBwR6BIgGgg9ABgnkmIYHBHnEjAaED0AFCaSchgcEeZSMBoIPQAUJdJyGBwR5VIAGhA8BAAk0kIYHBHkkgAaCDwEACQSQhgcEeOSEBoQPAQAIxJSGBwR4tIQGgg8BAAiUlIYHBHh0hAaEDwIACFSUhgcEeESEBoIPAgAIJJSGBwR4BIQGhA8EAAfklIYHBHfUhAaCDwQAB7SUhgcEd5SEBoQPCAAHdJSGBwR3ZIQGgg8IAAdElIYHBHAUYAIApoECoG0CAqUtBAKn7QgCp90fDgbUoSaCLwCAJrSxpgGh8SaCLwCAIbHxpgZ0oIMhJoIvAIAmVLCDMaYBofEmgi8AgCGx8aYEpoAvSAMrL1gD8H0V1KEh8SaELwCAJbSxsfGmBKaAL0ADKy9QA/BdFWShJoQvAIAlRLGmAKeQLwAQI6sVFKEh0SaELwCAJPSxsdGmAKeQLwAgICKgfRS0oIMhJoQvAIAkhLCDMaYPTgRkoSaCLwEAJESxpgGh8SaCLwEAIbHxpgQEoIMhJoIvAQAj5LCDMaYBofEmgi8BACGx8aYEpoAvSAMrL1gD8H0TZKEh8SaELwEAI0SxsfGmBKaAL0ADKy9QA/AeAh4MLgBdEuShJoQvAQAixLGmAKeQLwAQI6sSlKEh0SaELwEAImSxsdGmAKeQLwAgICKgfRIkoIMhJoQvAQAiBLCDMaYKPgHkoSaCLwIAIcSxpgGh8SaCLwIAIbHxpgGEoIMhJoIvAgAhVLCDMaYBofEmgi8CACGx8aYEpoAvSAMrL1gD8H0Q5KEh8SaELwIAILSxsfGmBKaAL0ADKy9QA/BdEHShJoQvAgAgVLGmAKeQLwAQJasQJKEh0D4ABwAEAkBAFAEmhC8CACmksaYAp5AvACAgIqB9GWShIdEmhC8CAClEsbHRpgUeCSShIfEmgi8EACj0sbHxpgGh8SaCLwQAIbHxpgi0oSHRJoIvBAAohLGx0aYBofEmgi8EACGx8aYEpoAvSAMrL1gD8H0YFKCDoSaELwQAJ+Swg7GmBKaAL0ADKy9QA/B9F6ShIfEmhC8EACd0sbHxpgCnkC8AECKrF0ShJoQvBAAnJLGmAKeQLwAgICKgfRbkoSHRJoQvBAAmxLGx0aYAHgASAAvwC/cEdpSABoQPSAQGdJCGBwR2VIAGgg9IBAY0oQYGNISEQAaDIiUENiSrD78vBBHADgSR5dSEBpAPQAcLD1AH8B0QAp9dFYSEBpAPQAcLD1AH8B0QMgcEcAIPznU0kJaCHwBwFRShFgU0kJaEHwBAFRShFgASgB0TC/AuBAvyC/IL9MSQloIfAEAUpKEWBwR0ZJCWgh8AcBSRxDShFgRUkJaEHwBAFDShFgASgB0TC/AuBAvyC/IL8/SQloIfAEAT1KEWBwRzhJCWgh8AcBiRw2ShFgOEkJaEHwBAE2ShFgASgB0TC/AuBAvyC/IL8xSQloIfAEAS9KEWBwRytIAGgg8AcAAB0oSQhgKkgAaEDwBAAoSQhgAL8AvzC/cEdwR3BHcEdwRxC1H0gUOABoAPSAMDCx//f8+k/0gDAaSRQ5CGAYSAwwAGgA8AgAKLH/9+n/CCAUSQwxCGASSAwwAGgA8BAAKLH/99z/ECAOSQwxCGAMSAwwAGgA8CAAKLH/98//ICAISQwxCGAGSAwwAGgA8EAAKLH/98L/QCACSQwxCGAQvQAAKAQBQABwAEAYAAAAQEIPABDtAOAQtf5IAGhA8AEA/EkIYPz35vkERgbg/Pfi+QAbAigB2QMgEL31SABoAPACAAAo8tDySABoIPDwAEDwYADvSQhgACCIYO5I70lJRAhg7khIRABo/PfI+QixASDi5/z3v/kERgjg/Pe7+QAbQfKIMYhCAdkDINXn4UiAaADwDAAAKPDR3kgAaOFJCEDcSQhg/Pem+QRGBuD896L5ABsCKAHZAyC+59VIAGgA8ChQACjy0dJJyGAIRsBoQPSAUMhgACAIYQhGAGlA9IBQCGEAIEhhCEZAaUD0gFBIYQhGAGgg9IAgCGAAIIhhQB4IYsNIlDAAaED0AADB+JQAACCR5/C1ACMAIN/49MLc+AjADPAMAd/46MLc+AzADPADBxmxDCkf0QEvHdHf+NTC3PgAwAzwCAy88QAPBtHf+MDC3PiUwMzzAyMF4N/4tMLc+ADAzPMDE9/4vML8RFz4IzBBuRhGBuAEKQHRq0gC4AgpANGpSAwpMtHf+ITC3PgMwAzwAwQBLAnQAiwC0AMsBNEB4KFKBOCgSgLgAL8aRgC/AL/f+FzC3PgMwMzzAxwM8QEG3/hMwtz4DMDM8wYsDPsC/Lz79vLf+DjC3PgMwMzzQWwM8QEMT+pMBbL79fDwvfi1BEYAJoZIgG0A8IBQGLH/98z5BUYW4AC/gUiAbUDwgFB/SYhlCEaAbQDwgFAAkAC/AL//97r5BUZ5SIBtIPCAUHdJiGW19QB/B9GALBDZoCwB2QImDOABJgrggCwB2QMmBuCALAHRAiYC4HAsANEBJnJIAGgg8A8AMENvSQhgCEYAaADwDwCwQgHQASD4vQAg/Oct6fhFBEYUuQEgvej4hV9IgGgA8AwHXUjAaADwAwYgeADwEAAQKHrRH7EML3nRAS530VZIAGgA8AIAGLHgaQi5ASDi51FIYWoAaADwCAAgsU5IAGgA8PAABeBMSJQwAGgA9HBgAAmBQh/ZYGr/937/CLEBIMnnAL9ESABoQPAIAEJJCGAIRgBoIPDwAGFqCEM+SQhgAL8IRkBoIPR/QCFqQOoBIDlJSGAf4AC/N0gAaEDwCAA1SQhgCEYAaCDw8ABhaghDMUkIYAC/CEZAaCD0f0AhakDqASAsSUhgL7lgav/3RP8IsQEgj+f/99D+J0mJaMHzAxEtSnpEUVwB8B8ByEAkSUlECGAjSEhEAGj89zL4gka68QAPYdBQRnXnXuD/5+BpgLMZSABoQPABABdJCGD89xz4BUYG4Pz3GPhAGwIoAdkDIGDnEEgAaADwAgAAKPLQAL8NSABoQPAIAAtJCGAIRgBoIPDwAGFqCEMHSQhgAL8IRkBoIPR/QCFqQOoBIAJJSGAq4BLgAAAAEAJAAAk9ABgAAAAQAAAA//T+6k43AAAAJPQAACACQCQ1AAD+SABoIPABAPxJCGD799f/BUYG4Pv30/9AGwIoAdkDIBvn9kgAaADwAgAAKPLRIHgA8AEAAChc0AgvA9AMLwrRAy4I0e1IAGgA9AAwiLNgaHi7ASAB5wC/YGiw9YA/BtHmSABoQPSAMORJCGAa4GBosPWgLwvR4UgAaED0gCDfSQhgCEYAaED0gDAIYArg20gAaCD0gDDZSQhgCEYAaCD0gCAIYAC/YGiQsfv3iP8FRgfgHuD794P/QBtkKAHZAyDL5s5IAGgA9AAwACjy0BDg+/d1/wVGBuD793H/QBtkKAHZAyC55sVIAGgA9AAwACjy0SB4APACAAIoUtEELwPQDC8U0QIuEtG8SABoAPSAYBix4GgIuQEgn+a4SEBoIPD+QCF8QOoBYLRJSGA54OBoALOySABoQPSAcLBJCGD79z7/BUYG4Pv3Ov9AGwIoAdkDIILmqUgAaAD0gGAAKPLQpkhAaCDw/kAhfEDqAWCjSUhgFuChSABoIPSAcJ9JCGD79x3/BUYG4Pv3Gf9AGwIoAdkDIGHmmUgAaAD0gGAAKPLRIHgA8AgACChx0WBp4LOSSJQw0PgAgAjwEAGgaYhCL9AI8AIAAigE0QjwAQAIuQEgQuYI8AEAyLGISJQwAGgg8AEAhUnB+JQA+/fo/gVGBuD79+T+QBsRKAHZAyAs5n5IlDAAaADwAgAAKPHRe0iUMABoIPAQAKFpCEN3ScH4lAB2SJQwAGgA4BfgQPABAHJJwfiUAPv3wv4FRgbg+/e+/kAbESgB2QMgBuZrSJQwAGgA8AIAACjx0BngZ0iUMABoIPABAGVJwfiUAPv3p/4FRgbg+/ej/kAbESgB2QMg6+VeSJQwAGgA8AIAACjx0SB4APAEAAQoc9FP8AAIV0iAbQDwgFB4uQC/VEiAbUDwgFBSSYhlCEaAbQDwgFAAkAC/AL9P8AEITUgAaAD0gHCwuUtIAGhA9IBwSUkIYPv3bv4FRgbg+/dq/kAbAigB2QMgsuVCSABoAPSAcAAo8tAgegDwAQA4szxIkDAAaCDwgAAhegHwgAEIQzhJkDEIYCB6APAEAHCxCEYAaEDwBAAyScH4kAAIRtD4kABA8AEAwfiQABfgLUiQMABoQPABACpJwfiQAA7gKEiQMABoIPABACZJwfiQAAhG0PiQACDwBADB+JAAoGiosfv3IP4FRgngNuD79xv+QBtB8ogxiEIB2QMgYeUZSJAwAGgA8AIAACjv0Bvg+/cK/gVGCOD79wb+QBtB8ogxiEIB2QMgTOUOSJAwAGgA8AIAACjv0QtIkDAAaCDwgAAIScH4kAC48QEPBdEFSIBtIPCAUANJiGUAvyB4APAgACAoA+AAEAJAAHAAQDTRoGrIsfdIAGhA8AEA9UmYOcH4mAD799D9BUYG4Pv3zP1AGwIoAdkDIBTl7UgAaADwAgAAKPLQGODqSABoIPABAOhJmDnB+JgA+/e2/QVGBuD797L9QBsCKAHZAyD65OBIAGgA8AIAACjy0eBq6LMML3vQ4GoCKFrR2kiYOABoIPCAcNdJmDkIYPv3lv0FRgbg+/eS/UAbAigB2QMg2uTQSJg4AGgA8ABwACjx0dTpDBBAHkHqABGga0HqACFAIABbASLC61AAQepAUUQgAF3C61AAQepAYTwgAF1B6sBgwEmYOclowEoRQADgg+AIQ7xJmDnIYAhGAGhA8IBwCGAIRsBoQPCAcMhg+/dW/QVGBuD791L9QBsCKAHZAyCa5LBImDgAaADwAHAAKPHQYuCsSJg4AGgg8IBwqkmYOQhgCEYAaADwIFAguQhGwGgg8AMAyGCjSJg4wGikSQhAoUmYOchg+/cp/QVGB+AO4Pv3JP1AGwIoAdkDIGzkmUiYOABoAPAAcAAo8dE04OBqASgA0WDkk0iYOMZoBvADASBrgUIm0Qbw8AFga0AesesAHx/RBvT+QaBrsesALxnRBvB4QTwgAF2x68BvEtEG9MABQCAAWwEiwutQALHrQF8I0QbwwGFEIABdwutQALHrQG8B0AEgL+QAIC3kLenwQQRGDUYUuQEgvejwgXlIAGgA8A8AqEIO0nZIAGgg8A8AKENzSQhgCEYAaADwDwCoQgHQASDo5yB4APABAAAoR9BgaAMoB9FnSJg4AGgA8ABw8LkBINjnYGgCKAfRYkiYOABoAPQAMJi5ASDN52BoOLldSJg4AGgA8AIASLkBIMPnWUiYOABoAPSAYAi5ASC751VImDiAaCDwAwBhaAhDUUmYOYhg+/eK/AZGCOD794b8gBtB8ogxiEIB2QMgpOdJSJg4gGgA8AwAYWiw64EP7dEgeADwAgACKAnRQkiYOIBoIPDwAKFoCEM/SZg5iGBASABoAPAPAKhCDtk9SABoIPAPAChDO0kIYAhGAGgA8A8AqEIB0AEgd+cgeADwBAAEKAnRMEiYOIBoIPTgYOFoCEMtSZg5iGAgeADwCAAIKArRKUiYOIBoIPRgUCFpQOrBACVJmDmIYP/3wfoiSZg5iWjB8wMRJEp6RFFcAfAfAchAIklJRAhgIUhIRABo+/ci/AdGOEZA53C1hrAGRg1GFEYAvxRImDjAbEDwAQASSZg5yGQIRsBsAPABAACQAL8Av4gVAZACIAKQBJAAIAOQBZABqU/wkED89zD8BkiYOIBoIPD+QEXqBAEIQwJJmDmIYAawcL0AAJgQAkAMgJ0B///u/gAgAkAELQAAGAAAABAAAACGSEhEAGhwRwC1//f5/4RJiWjB8wIhg0p6RFFcAfAfAchAAL0Atf/36/99SYlowfPCIXxKekQcOlFcAfAfAchAAL0/IQFgdkkJaAH0gCGx9YAvA9FP9KAhQWAM4HBJCWgB9IAxsfWAPwPRT/SAMUFgAeAAIUFgakkJaAHwAQERsQEhwWEB4AAhwWFlSUlowfMHIQFiYkkJaAHw8AFBYmBJCWgB9IBxsfWAfwPRT/SAccFgAeAAIcFgWUlJaMHzBmEBYVdJkDEJaAHwBAEEKQzRU0mQMQloAfCAAYApAtGFIYFgF+AFIYFgFOBNSZAxCWgB8AEBYbFKSZAxCWgB8IABgCkC0YEhgWAE4AEhgWAB4AAhgWBCSZQxCWgB8AEBEbEBIUFhAeAAIUFhPUmUMQloAfAQARApAdGBYQHgACGBYTdJmDEJaAHwAQERsQEhgWIB4AAhgWIySQloAfCAcbHxgH8C0QIhwWIB4AEhwWIsScloAfADAgJjKUnJaMHzAxFJHEFjJknJaMHzBiKCYyRJyWjB80FRSRxKAAJkIEnJaMHzQWFJHEoAQmQdScloyg7CY3BHDyICYBlKkmgC8AMCQmAXSpJoAvDwAoJgFEqSaAL04GLCYBJKkmgC9GBS0ggCYRFKEmgC8A8CCmBwRwxIAGhA9AAgCkkIYHBHcEcQtQdIwGkA9IBwsPWAfwXR//f1/0/0gHACSQhiEL0YAAAAABACQGAsAAAAIAJALenwQQRGD0YAJf5IwGgA8AMAULH7SMBoAPADACFoiEIB0SBoeLsBJS3gIGgBKATQAigJ0AMoGtEN4PJIAGgA8AIAALkBJRTg7kgAaAD0gGAAuQElDeDrSABoAPQAMCi56EgAaAD0gCAAuQElAeABJQC/AL89ueNIwGgg8AMAIWgIQ+BJyGAALXPR3kgAaCDwgFDcSQhg+/d6+gZGBuD793b6gBsCKAHZAyUF4NVIAGgA8ABQACjy0QC/AC1Z0Ye5oGgAAiF7QOrBYWBoQB5B6gAQzElJacxKEUAIQ8lJSGEo4AEvE9GgaAACIYoBIsLrUQFA6kFRYGhAHkHqABDBSUlpwkoRQAhDvklIYRLgoGgAAiF9ASLC61EBQOpBYWBoQB5B6gAQt0lJablKEUAIQ7RJSGGzSABoQPCAULFJCGD79yX6BkYG4Pv3IfqAGwIoAdkDJQXgq0gAaADwAFAAKPLQAL8tuadIQGmhaQhDpUlIYShGvejwgS3p8EEERg9GACWgSMBoAPADAFCxnUjAaADwAwAhaIhCAdEgaHi7ASUt4CBoASgE0AIoCdADKBrRDeCUSABoAPACAAC5ASUU4JBIAGgA9IBgALkBJQ3gjUgAaAD0ADAouYpIAGgA9IAgALkBJQHgASUAvwC/PbmFSMBoIPADACFoCEOCSchgAC1z0YBIAGgg8IBgfkkIYPv3vvkGRgbg+/e6+YAbAigB2QMlBeB3SABoAPAAYAAo8tEAvwAtWdGHuaBoAAIhe0DqwWFgaEAeQeoAEG5JCWluShFACENrSQhhKOABLxPRoGgAAiGKASLC61EBQOpBUWBoQB5B6gAQY0kJaWRKEUAIQ2BJCGES4KBoAAIhfQEiwutRAUDqQWFgaEAeQeoAEFlJCWlbShFACENWSQhhVUgAaEDwgGBTSQhg+/dp+QZGBuD792X5gBsCKAHZAyUF4E1IAGgA8ABgACjy0AC/LblJSABpoWkIQ0dJCGEoRr3o8IEt6fhFBEYAJahGIIgA9ABgsPUAbzLR4G5AKAnQA9xwsSAoG9ER4GAoFtCAKBbRFOA4SMBoQPSAMDZJyGAQ4AAhIB3/9yH/BUYK4AAhBPEgAP/3Xv4FRgPgAL8B4AElAL8Av1W5K0icMABoIPDgAOFuCEMoScH4nAAA4KhGIIgA9IBQsPWAXzbRIG+w9QB/DNAE3IixsPWAfx3RE+Cw9UB/F9Cw9YBvFtEU4BpIwGhA9IAwGEnIYBDgACEgHf/35P4FRgrgACEE8SAA//ch/gVGA+AAvwHgASUAvwC/VbkNSJwwAGgg9OBgIW8IQwlJwficAADgqEYgaAD0ADCw9QA/a9FP8AAKA0iAbQEhIeoQcMCxB+AAEAJAD4D/Bw+An/8PgP/5AL/+SIBtQPCAUPxJiGUIRoBtAPCAUACQAL8Av0/wAQr3SABoQPSAcPVJCGD796X4B0YG4Pv3ofjAGwIoAdkDJQXg70gAaAD0gHAAKPLQAL+Fu+pIkDAAaAD0QHbWsdT4lACwQhbQ5UiQMABoIPRAduJI0PiQAED0gDDgScH4kAAIRtD4kAAg9IAwwfiQAAhGwPiQYAbwAQCwsfv3bvgHRgrg+/dq+MAbQfKIMYhCA9kDJQjgF+Ah4NBIkDAAaADwAgAAKO3QAL9ducxIkDAAaCD0QHDU+JQQCEPIScH4kAAC4KhGAOCoRrrxAQ8F0cNIgG0g8IBQwUmIZQC/IHgA8AEASLG9SIgwAGgg8AMA4WsIQ7pJwfiIACB4APACAAIoCdG2SIgwAGgg8AwAIWwIQ7JJwfiIACB4APAEAAQoCdGuSIgwAGgg8DAAYWwIQ6tJwfiIACB4APAIAAgoCdGnSIgwAGgg8MAAoWwIQ6NJwfiIACB4APAQABAoCdGfSIgwAGgg9EBw4WwIQ5xJwfiIACB4APAgACAoCdGYSIgwAGgg9EBgIW0IQ5RJwfiIACCIAPQAcLD1AH8J0ZBIiDAAaCD0QCBhbghDjEnB+IgAIIgA9IBgsPWAbwnRiEiIMABoIPRAEKFuCEOEScH4iAAgeADwQABAKAnRgEiIMABoIPRAUGFtCEN9ScH4iAAgeADwgACAKAnReUiIMABoIPRAQKFtCEN1ScH4iAAgiAD0gHCw9YB/CdFxSIgwAGgg9EAw4W0IQ21JwfiIACBoAPSAELD1gB8J0WlInDAAaCDwAwAhbghDZUnB+JwAIIgA9ABQsPUAXx/RYUiIMABoIPBAYGFvCENdSYgxCGBgb7DxAG8G0VpIwGhA9IAQWEnIYArgYG+w8YBvBtEBISAd//da/QVGBbGoRiBoAPQAILD1AC9B0QC/oG+w9YBPCNFLSJwwAGhA9IBASUnB+JwAEeBHSJwwAGgg9IBAREnB+JwAQ0iIMABoIPBAYKFvCEM/ScH4iAAAv6BvsPEAbwbRO0jAaED0gBA5SchgFeCgb7D1gE8G0TZIwGhA9IAwNEnIYArgoG+w8YBvBtEBISAd//cS/QVGBbGoRiBoAPSAILD1gC8f0SpIiDAAaCDwQGDhbwhDJkmIMQhg4G+w8QBvBtEjSMBoQPSAECFJyGAK4OBvsPGAbwbRASEgHf/37PwFRgWxqEYgiAD0gECw9YBPFtEXSIgwAGgg8EBQ1PiAEAhDE0mIMQhg1PiAALDxgF8G0QIhIB3/98/8BUYFsahGIGgA9IAwsPWAPwrRCEicMABoIPAEANT4hBAIQwRJwficACBoAPQAELD1AB8P0QPgABACQABwAED+SJwwAGgg8BgA1PiIEAhD+knB+JwAIGgA9IAAsPWADyvR9kgAaCDwgFD0SQhg+vei/gdGBuD6957+wBsCKAHZAyUF4O1IAGgA8ABQACjy0QC/hbnpSJwwAGgg9EAw1PiMEAhD5UnB+JwAAiEE8SAA//e6+wVGBbGoRiBoAPCAcLDxgH8V0d1InDAAaCD0QBDU+JAQCEPZSZwxCGDU+JAAsPUAHwXR1UjAaED0gBDTSchgQEa96PiF0EnJaAHwAwFBYM5JCWnB8wMRSRyBYMtJCWnB8wYiwmDISQlpwfNAQQciAusBEgJhxEkJacHzQVFJHEoAQmHBSQlpwfNBYUkcSgCCYUFoAWK8SUlpwfMDEUkcQWK5SUlpwfMGIoJit0lJacHzQEEHIgLrARLCYrNJSWnB80FRSRxKAAJjr0lJacHzQWFJHEoAQmOsSYgxCWgB8AMBwWOpSYgxCWgB8AwBAWSmSYgxCWgB8DABQWSjSYgxCWgB8MABgWSgSYgxCWgB9EBxwWSdSYgxCWgB9EBhAWWaSYgxCWgB9EBRQWWXSYgxCWgB9EBBgWWUSYgxCWgB9EAxwWWRSZwxCWgB8AMBAWaOSYgxCWgB9EAhQWaLSYgxCWgB9EARgWaISZwxCWgB8OABwWaFSZwxCWgB9OBhAWeCSZAxCWgB9EBxwPiUEH5JiDEJaAHwQGFBZ3tJnDEJaAH0gEERsU/0gEEE4HdJiDEJaAHwQGFA+Hgfc0nR+IgQAfBAYUFgcEnR+IgQAfBAUYFgbUnR+JwQAfAEAcFgaknR+JwQAfRAMUFhZ0nR+JwQAfRAEYFheDhwR/C1BUYORgAgACEAJLX1AG8J0V9PnDc/aAfw4AFgKQ/RS/aAMAzgtfWAXwnRWE+cNz9oB/TgYbH1QH8B0Uv2gDAAKC3RMkZAKQLQsfUAfyjRT08/aAfwAHe38QB/8dFMT/9oB/SANwAvf9BJT/9ox/MDF38csvv38kVP/2jH8wYjQ0//aPwOPLlBT/9oB/QANw+xESQA4AckAvsD97f79PBj4EG7Ok8/aAfwAGe38QBvW9E3Tz9pB/SANwAvVdA0Tz9px/MDF38csvv38jBPP2nH8wYjLk8/afwOPLksTz9pB/QANw+xESQA4AckAvsD97f79PA54IApAtCx9YBvCNEjTz9oB/SAZ7f1gG8t0SFIK+AgKQLQsfWAfybRHE8/aAfwAFe38QBfH9EZT39pB/SAN9exFk9/acfzAxd/HLL79/ITT39px/MGIxFPf2n8Djy5D09/aQf0ADcPsREkAOAHJAL7A/e3+/Tw8L0t6fBNB0ZP8AALt/UAPz7RBEiQMABoAPRAdLT1gH8M0ATgAAAAEAJAACT0ALT1AH8M0LT1QH8o0Rzg+UgAaADwAgACKAHRT/QASx/g9EgAHQBoAPACAAIoC9HxSAAdAGgA8BAAECgC0U/w+gsB4E/0+ksL4OpIkDgAaAD0ADCw9QA/AdHf+JyzAOAAv/Xj5EiQOMBoAPADCrrxAQ8G0LrxAg8k0LrxAw850Szg3EiQOABoAPACAAIoF9HZSJA4AGgA8AgAKLHWSJA4AGgA8PAABeDTSAAdAGgA9HBgAAkACdFJeURR+CBQAOAAJRngzEiQOABoAPSAYLD1gG8B0ctNAOAAJQ3gxkiQOABoAPQAMLD1AD8B0cVNAOAAJQHgACUAvwC/t/WAb3bQGtwgL3TQDNwEL3LQBNwBL3DQAi9v0drhCC9t0BAv+dFZ4kAvatCAL2nQt/WAf2fQt/UAf+7Re+O39YA/fNAM3Lf1AG8W0Lf1gF8a0Lf1AF8e0Lf1gE/d0Zvit/WALxjQt/UAL2nQt/WAH2fQt/GAf9DR3OMpRk/0AGD/93b+g0Yo4ilGT/SAUP/3b/6DRiHiAL+YSAg4AGgA8EBkbLO08YBvW9C08QBvK9C08UBvftGRSJA4AGgA8AIAAigW0Y1IkDgAaADwCAAosYpIkDgAaADw8AAF4IdIAB0AaAD0cGAACQAJiEl5RFH4ILBr4F/jIOKY4T/h7uPB4Vngi+Ks4s3ifEiQOABoAPAAcLDxAH8j0XhIkDjAaAD0gBCw9YAfG9F0SJA4wGjA8wYmBfsG8HFJkDnJaALgX+JG4NHiwfMDEUkcsPvx9WtIkDjAaMDzQVBAHEAAtfvw+zTgZkiQOABoAPAAYLDxAG8f0WJIkDgAaQD0gBCw9YAfF9FeSJA4AGnA8wYmBfsG8FpJkDkJacHzAxFJHLD78fVWSJA4AGnA80FQQBxAALX78PsL4AngUUgIMABoAPACAAIoAdHf+EixAOAAvwC/huNKSAwwAGgA9IBAsPWATzTRRkiQOABoAPAAcLDxAH8r0UJIkDjAaAD0gDCw9YA/I9E+SJA4wGjA8wYmBfsG8DtJkDnJaMHzAxFJHLD78fU3SJA4wGhP6tBouPEADwrRM0iQOMBoAPQAMBCxT/ARCAHgT/AHCLX7+PuX4CxICDgAaADwQGTss7TxgG9d0LTxAG8h0LTxQG970SRIkDgAaADwAgACKBbRIUiQOABoAPAIACixHkiQOABoAPDwAAXgG0gAHQBoAPRwYAAJAAkdSXlEUfggsGjgFUiQOABoAPAAcLDxAH8h0RFIkDjAaAD0gBCw9YAfGdENSJA4wGjA8wYmAOBG4AX7BvAISZA5yWjB8wMRSRyw+/H1BEiQOMBowPNBUEAcQAC1+/D7PeCQEAJAIKEHAIIdAAAAJPQAVBwAAABs3AKiGgAA+UgAaADwAGCw8QBvG9H2SABpAPSAELD1gB8U0fJIAGnA8wYmBfsG8O9JCWnB8wMRSRyw+/H17EgAacDzQVBAHEAAtfvw+wvgCeDnSJgwAGgA8AIAAigB0d/4kLMA4AC/AL+w4uBIiDAAaADwAwQ0sQEsCNACLArQAywc0RHg/vel/oNGGOD+9/z4g0YU4NZIAGgA9IBgsPWAbwHR3/hQswrg0UiQMABoAPACAAIoAdFP9ABLAOAAvwC/hOLKSIgwAGgA8AwENLEELAjQCCwK0AwsHNER4P73a/6DRhjg/vfQ+INGFODASABoAPSAYLD1gG8B0d/4+LIK4LtIkDAAaADwAgACKAHRT/QASwDgAL8Av1jitEiIMABoAPAwBDSxECwI0CAsCtAwLBzREeD+9z/+g0YY4P73pPiDRhTgqkgAaAD0gGCw9YBvAdHf+KCyCuClSJAwAGgA8AIAAigB0U/0AEsA4AC/AL8s4p5IiDAAaADwwAQ0sUAsCNCALArQwCwc0RHg/vcT/oNGGOD+93j4g0YU4JRIAGgA9IBgsPWAbwHR3/hIsgrgj0iQMABoAPACAAIoAdFP9ABLAOAAvwC/AOKISIgwAGgA9EB0TLG09YB/CtC09QB/C9C09UB/HNER4P735P2DRhjg/vdJ+INGFOB8SABoAPSAYLD1gG8B0d/47LEK4HdIkDAAaADwAgACKAHRT/QASwDgAL8Av9HhcUiIMABoAPRAZEyxtPWAbwrQtPUAbwvQtPVAbxzREeD+97X9g0YY4P73GviDRhTgZUgAaAD0gGCw9YBvAdHf+IyxCuBgSJAwAGgA8AIAAigB0U/0AEsA4AC/AL+i4VlIiDAAaADwQFS08YBfBtC08UBfJdH99/T/g0Yi4FJIAGgA8ABgsPEAbxnRTkgAaQDwgHCgsUxIAGnA8wYmBfsG8ElJCWnB8wMRSRyw+/H1RUgAacDzQWBAHEAAtfvw+wDgAL8Av27hP0icMABoAPAEBBy5/vdq/YNGAuD998H/g0Zg4ThIiDAAaAD0QFQ0sbT1gF8H0LT1AF8S0Qfg/vdH/YNGDuD996z/g0YK4C5IAGgA9IBgsPWAbwHR3/iwsADgAL8Avz7hJ0iIMABoAPRARDSxtPWATwfQtPUATxLRB+D+9yX9g0YO4P33iv+DRgrgHUgAaAD0gGCw9YBvAdHf+GywAOAAvwC/HOEWSIgwAGgA9EA0NLG09YA/B9C09QA/EtEH4P73A/2DRg7g/fdo/4NGCuAMSABoAPSAYLD1gG8B0d/4KLAA4AC/AL/64AVInDAAaADwAwRcsQEsDdACLBnRDuAAAAAQAkAAbNwCACT0AP733PyDRg7g/fdB/4NGCuD5SABoAPSAYLD1gG8B0d/43LMA4AC/AL/T4PNIiDAAaAD0QCRUsbT1gC8L0LT1AC8c0LT1QC8t0SLgw+D+97b8g0Yo4OhIlDAAaADwAgACKAvR5UiUMABoAPAQABAoAtFP8PoLAeBP9PpLFODeSABoAPSAYLD1gG8B0d/4cLMK4NlIkDAAaADwAgACKAHRT/QASwDgAL8Av5Pg00iIMABoAPRAFEyxtPWAHwrQtPUAHxvQtPVAHyzRIeD+93f8g0Yo4MlIlDAAaADwAgACKAvRxUiUMABoAPAQABAoAtFP8PoLAeBP9PpLFOC/SABoAPSAYLD1gG8B0d/48LIK4LpIkDAAaADwAgACKAHRT/QASwDgAL8Av1Tgs0icMABoAPRAFDSxtPWAHwfQtPUAH0TRH+D996T+g0ZA4KtIAGgA8AIAAigU0ahIAGgA8AgAILGlSABoAPDwAAXgo0iUMABoAPRwYAAJAAmhSXlEUfggsCTgnUgAaADwAHCw8QB/G9GZSMBoAPSAELD1gB8U0ZZIwGjA8wYmBfsG8JNJyWjB8wMRSRyw+/H1j0jAaMDzQVBAHEAAtfvw+wDgAL8AvwDgAL8Av1hGvejwjXC1BEYAJoVIAGgg8IBgg0kIYPn3v/8FRgbg+fe7/0AbAigB2QMmBeB9SABoAPAAYAAo8tEAv4a7YGhAHgABoWhA6gEgIYoBIsLrUQFA6kFQIX3C61EBQOpBYCF7QOrBYG9JCWlxShFACENsSQhhCEYAaaFpCENpSQhhCEYAaEDwgGAIYPn3hv8FRgfg+feC/0AbAigC2QMmBuAG4GBIAGgA8ABgACjx0AC/MEZwvXC1ACVaSABoIPCAYFhJCGD592n/BEYG4Pn3Zf8AGwIoAdkDJQXgUkgAaADwAGAAKPLRAL9OSABpUUkIQExJCGEIRgBoAPAIUCC5CEbAaCDwAwDIYChGcL1wtQRGACZESABoIPCAUEJJCGD59zz/BUYG4Pn3OP9AGwIoAdkDJgXgO0gAaADwAFAAKPLRAL+Gu2BoQB4AAaFoQOoBICGKASLC61EBQOpBUCF9wutRAUDqQWAhe0DqwWAtSUlpL0oRQAhDK0lIYQhGQGmhaQhDKElIYQhGAGhA8IBQCGD59wP/BUYH4Pn3//5AGwIoAtkDJgbgBuAeSABoAPAAUAAo8dAAvzBGcL1wtQAlGUgAaCDwgFAXSQhg+ffm/gRGBuD59+L+ABsCKAHZAyUF4BBIAGgA8ABQACjy0QC/DUhAaRBJCEALSUhhCEYAaADwIGAguQhGwGgg8AMAyGAoRnC9BEmJaCH0AEEBQwFKkWBwRwAAABACQAAk9AC6FAAAD4CdAf//7v75SQloIfRwYUHqABH2SpQ6wviUEHBH9EgAHwBoQPAgAPFJlDnB+JAAcEfvSAAfAGgg8CAA7EmUOcH4kAAIRoBpIPQAcIhhcEfnSAAfAGhA8CAA5UmUOcH4kAAIRoBpQPQAcIhh4UgAaED0ACDfSQhg3kgIMABoQPQAINxJCDEIYHBHcEcQtdhIlDjAaQD0AHCw9QB/BtH/9/T/T/QAcNJJlDkIYhC9cLWGsARGACUAJgC/zUiUOMBsQPABAMpJlDnIZAhGwGwA8AEAAJAAvwC/BCABkAMgApACIASQACADkAGpT/CQQPr3c/6/SJQ4gG0A8IBQgLkAv7tIlDiAbUDwgFC5SZQ5iGUIRoBtAPCAUACQAL8AvwEltUgAaAD0gHAQufz3/f0BJq9IAB8AaCDwQHBE8IBxCEOrSZQ5wfiQAAEuAdH89/P9AS0H0aZIlDiAbSDwgFCkSZQ5iGUGsHC9OLUAJAAloEiUOIBtAPCAUIC5AL+cSJQ4gG1A8IBQmkmUOYhlCEaAbQDwgFAAkAC/AL8BJJZIAGgA9IBwELn897/9ASWQSAAfAGgg8IBwjkmUOcH4kAABLQHR/Pe4/QEsB9GJSJQ4gG0g8IBQhkmUOYhlOL2ESJQ4AGhA8AQAgkmUOQhgcEeASJQ4AGgg8AQAfUmUOQhgcEd7ShAyEmgi8P8CQOoBExpDd0uUO8P4pCBwR3VKlDqSa0LwgHJyS5Q7mmMaRpJrIvCAcppj0OkAIxpDg2hC6gMBwmgRQwKKQeoCQWxKUWASaCL0fFJDaULqAyJoSxpgGkYSaELwYAIaYHBHZEgAaEDwgABiSQhgcEdgSUloibIBYF5JCWjB8wUhQWBcSYloCQyBYFpJiWgB9ABBwWBwR3C1BUYAJPn3Yf0GRgC/aBwwsfn3W/2AG6hCANgFuQEkT0iAaADwAQAwsUTwAgQAvwEgSknIYAC/SUiAaADwAgACKAXRRPAEBAC/REnIYAC/Q0iAaAD0gGCw9YBvBtFE8CAEAL8EID1JyGAAvzxIgGgA9IBwsPWAfwbRRPAIBAC/BCA2SchgAL81SIBoAPQAcLD1AH8G0UTwEAQAvwQgL0nIYAC/LkiAaADwCAAIKAPRAL8qSchgAL8ALKjQIEZwvXBHcEdwR3BHcLUAJSRIhGgGaATwAQBAsQbwAQAosQEgH0nIYP/37/8y4ATwAgBAsQbwAgAosQIgGUnIYP/34v8m4ATwCABAsQbwCAAosQggE0nIYP/31f8a4ATwBAC4sQbwBACgsQT0gHAIsUXwCAUE9ABwCLFF8BAFBPSAYAixRfAgBQQgBUnIYChG//e4/3C9lBACQAAEAUAAcABAAGAAQEZIAGhA8AEAREkIYAAgiGAIRgBoQkkIQEBJCGCIFMhgCEYAaCD0gCAIYAAgiGHIAzxJCGBwR/C1ACMAIAAiAiQAJQIhNU42aAbwCAYuuTNOlDY2aMbzAyAD4DBONmjG8wMQMU5+RFb4IAAsTrZoBvAMBjaxBC4I0AguC9AMLjnRDeAqTk5EMGA44ClOJ09PRD5gM+AmTiVPT0Q+YC7gH072aAbwAwUdTvZoxvMDFnEcAi0C0AMtCNED4B1Otvvx8gbgG062+/HyAuCw+/HyAL8AvxJO9mjG8wYmckMPTvZoxvNBZnYcdACy+/T2D09PRD5gA+ANTk5EMGAAvwC/B062aMbzAxYLT39Eu10HTk5ENmjeQAVPT0Q+YPC9ABACQP//9uoI7QDgzA0AABgAAAAAJPQAEA0AABC1lrAERgAgApADkEDy+WAEkAQgBZAQIAaQACAHkAmQDZAQkBOQFJAVkEHyiDICqSBG+/e++hCxASAWsBC9QPL6UASQACAIkE/0gGAJkE/0QFAKkAAgC5BP8IBgEJAAIBKQASARkAQgE5AAv0HyiDICqSBG+/ed+gixASDd50HyiDIBqSBG+/cJ/AixASDU5534BAAA8AIAAijn0QAgzOcwtZWwBUYMRgAgAZACkEDy+lADkAQgBJAQIAWQACAGkAeQT/SAYAiQT/RAUAmQACAKkAyQT/CAYA+QACARkAEgEJAEIBKQACATkBSQAL8iRgGpKEb79136ELEBIBWwML0iRmlGKEb798n7CLEBIPXnnfgAAADwAQAAKOjRAL/t5zC1m7AFRgxGACAHkAiQDJBP9EBQD5AAIBCQEpAXkBmQGpAEkBAgBpCABAWQASx50QYgCZABIAqQACALkA6QFZAYkEHyiDIHqShG+/ci+hCxASAbsDC9BSAJkE/wgHAVkAAgF5ABIBaQQfKIMgepKEb79w/6CLEBIOvnAiACkAOQQfKIMgKpKEb79xL+CLEBIN/nciAJkE/0QHANkE/0gHAOkE/0QFAPkAAgEJBB8ogyB6koRvv37fkIsQEgyecHIAGQQfKIMgGpKEb79wn7CLEBIL7nBiAJkAAgDpAVkEHyiDIHqShG+/fU+QixASCw5wUgCZBP8IBwFZBB8ogyB6koRvv3xvkIsQEgoucCIAKQA5BB8ogyAqkoRvv3yf0QsQEgludO4HIgCZAAIA2QT/SAcA6QQfKIMgepKEb796n5CLEBIIXnASABkEHyiDIBqShG+/fF+gixASB65ygg+ffP+kHyiDEoRv/3Cv8IsQEgb+dH8o4QCZAEIAqQECALkIABDpAABBWQBiAYkAIgFpBB8ogyB6n3SEhE+/d6+QixASBW50HyiDJpRvJISET79+X6CLEBIEznnfgAAAEoe9ABIEbn60hIRP/3iv4IsQEgP+dH8o0gCZAEIAqQECALkAAgDZBP9IBgDpAABBWQAiAWkAAgGJCN+AAAjfgBAEHyiDIHqdtISET790P5CLEBIB/nQfKIMmlG1khIRPv3YPoIsQEgFecoIPn3avoFIAmQASAKkAAgC5AOkE/wgHAVkAEgFpAAIBiQApABIAOQQfKIMgepx0hIRPv3G/kIsQEg9+ZB8ogyAqnCSEhE+/cg/QixASDt5nEgCZAAIA2QT/SAcA6QQfKIMgepukhIRPv3APkIsQEg3OZB8ogyaUa1SEhE+/dr+hCxASDS5gTgnfgAAAixASDM5gAgyuYQtZSwBEYAIACQAZABIAOQACAEkAWQB5ALkBCQEZASkBOQDpBmIAKQQfKIMmlGIEb799H4ELEBIBSwEL2ZIAKQQfKIMmlGIEb798X4CLEBIPLnKCD59/b5ACDt5wC1h7AAv5ZIwGxA9IAQlEnIZAhGwGwA9IAQAZAAvwC/AL8IRgBtQPQAcAhlCEYAbQD0AHABkAC/AL8IRgBrQPQAcAhjCEYAayD0AHAIYwC/CEaAbUDwgFCIZQhGgG0A8IBQAZAAvwC/fkhAaED0AHB8SUhgAL96SMBsQPAgAHhJyGQIRsBsAPAgAAGQAL8AvwC/CEbAbEDwQADIZAhGwGwA8EAAAZAAvwC/iBQCkAIgA5ABIASQAyAFkAUgBpACqWlI+vfR+U/0gFACkAKpZ0j698r5PyACkAAgBJACqWNI+vfC+UDyA2ACkAKpXkj697v5B7AAvQC1h7BdSFdJSUQIYAhG+vfO/RCxASAHsAC9//d2/wQgUUlJREhgACFPSEhEgWBP8IBxwWAaIQFhAiFBYQAhgWHBYQFiAiFBYgAhgWJP8IBRwWIAIQFj+vcl/QixASDa5wIgAZACkEVIBZBFSASQAiADkAEgBpBB8ogyAak6SEhE+/fv/QixASDF5zZISET/9w7/CLEBIL7nASD59yr5ASExSEhE//el/QixASCz5wAgsecAtYWwQfI/AS5I+vc++kHyA2ErSPr3OfoAIAGQT/SAUACQACACkAOQaUYlSPr3SPkBIAGQACACkE/0gFAAkGlGIEj69z35ACJP9IBRHUj697b6GUgAa0D0AHAXSQhjCEYAayD0AHAIYwhGAG0g9ABwCGUIRsBsIPSAEMhkBbAAvRC1EUgLSUlECGAIRvv3Hf0CKAbQB0hIRPv3qfwIsQEgEL0AIQNISET/90r9kLEBIPbnAADsAAAAABACQABwAEAAGABIABQASAAUAKACAAABAgABAPdISET69xD9CLEBIN7n//eN/wAg2udwtZSwBEYNRhZGACAAkAGQBCADkBAgBJAAIAWQCZAKkAuQDJANkBCQBiARkAAgEpATkE72E0ACkE/0gGAHkE/0QFAIkE/wgGAOkAaVD5ZB8ogyaUbdSEhE+vdG/xCxASAUsHC9QfKIMiFG10hIRPv3sPgIsQEg8+cAIPHnLenwRZWwgkYNRhZG6LLA9YB4sEUA2bBGLEavGQAgAZACkEHy7SADkAQgBJAQIAWQACAGkAqQC5AMkA2QDpARkBKQE5AUkEHy7SADkE/0gGAIkE/0QFAJkE/wgGAPkAC/B5TN+ECAuUhIRP/3JvwYsQEgFbC96PCFQfKIMgGps0hIRPr38/4IsQEg8udB8ogyUUauSEhE+/cQ+AixASDo50HyiDGqSEhE//dX/AixASDf50REwkQE9YBwuEIB2TgbAeBP9IBwgEa8QsnTACDQ5xC1lLAERgAgAJABkAQgA5AQIASQACAFkAmQCpALkAyQDZAQkBGQEpATkAWQCZBN9iNAApBP9IBgB5BP9EBQCJAGlAAgDpCNSEhE//fO+xCxASAUsBC9QfKIMmlGiEhIRPr3nP4IsQEg8+dP9Pphg0hIRP/3CvwIsQEg6ucAIOjnELWUsARGACAAkAGQBCADkBAgBJAAIAWQCZAKkAuQDJANkBCQEZASkBOQBZAJkLT1gE8C0wEgFLAQvULy3hACkE/0gGAHkE/0QFAIkCADBpAAIA6QakhIRP/3h/sIsQEg6edB8ogyaUZlSEhE+vdW/gixASDf50HyiDFgSEhE//fE+wixASDW5wAg1OcAtZWwACABkAKQBCAEkBAgBZAAIAaQCpALkAyQDZAOkBGQEpATkBSQRvKfAAOQACAIkE/0AFAJkAAgB5APkExISET/90z7ELEBIBWwAL1B8ogyAalHSEhE+vca/gixASDz50RJQ0hIRP/3ifsIsQEg6+cAIOnnALWVsAAgAZACkEL21DADkAQgBJAQIAWQACAHkE/0gGAIkE/0QFAJkAAgDJBP8IBgD5ACIBCQBiASkAAgFJAGkAqQEZATkEHyiDIBqStISET69+P9ELEBIBWwAL1B8ogyaUYmSEhE+vdN/wixASDz5534AAAA8GAACLEBIOznnfgAAADwDAAIsQgg5edA8vpQA5BB8ogyAakYSEhE+ve9/QixASDY50HyiDJpRhNISET69yj/CLEBIM7nnfgAAADwAQAIsQIgx+cAIMXnAUZP8IBgCGCAEkhggBGIYIAQyGCAAghhACBwRwC1l7ADSEhE//e6+jCxASAXsAC97AAAAOCTBAACIAOQACAEkAQgBpAQIAeQACAIkAyQDZAOkA+QEJATkBSQFZAWkAiQDJBB8u0gBZBP9IBgCpBP9EBQC5AAIAmQT/CAYBGQASASkEAHFZBB8ogyA6lnSEhE+vdd/QixASDI5072E0AFkAEgA5AGIBSQACAVkEHyiDIDqV5ISET690r9CLEBILXnCCABkCAgApABqVhISET79xf6CLEBIKnnACCn5wC1lbD/9yj/Aigk0QAgAZACkEvyTwADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAGkEHyiDIBqUZISET69xr9ELEBIBWwAL3/9wf/CCgB0QAg9+cBIPXnACDz5wC1lbD/9/v+CCgk0QAgAZACkEPyzwADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAGkEHyiDIBqS9ISET69+38ELEBIBWwAL3/99r+AigB0QAg9+cBIPXnACDz5wC1lbAAIAGQApAEIASQECAFkAAgBpAKkAuQDJANkA6QEZASkBOQFJBL9kYQA5AAIAiQD5BB8ogyAakYSEhE+ve+/BCxASAVsAC9ACD75wC1lbAAIAGQApAEIASQECAFkAAgBpAKkAuQDJANkA6QEZASkBOQFJD/IAOQACAIkA+QQfKIMgGpBUhIRPr3mPwQsQEgFbAAvQAg++cAAOwAAABP8AACALUTRpRGlkYgOSK/oOgMUKDoDFCx8SABv/T3rwkHKL+g6AxQSL8MwF34BOuJACi/QPgEKwi/cEdIvyD4AisR8IBPGL8A+AErcEcAAAAAAAAAAAAAAQIDBAYHCAkAAAAAAQIDBKCGAQBADQMAgBoGAAA1DABAQg8AgIQeAAAJPQAAEnoAACT0AAA2bgEASOgBAGzcAgAAAAAAAAAAAAAAAAAAAAAQAAAAAQAAAAAJPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    pc_init: 0xef
-    pc_uninit: 0x105
-    pc_program_page: 0x131
-    pc_erase_sector: 0x113
-    pc_erase_all: 0x10b
-    data_section_offset: 0x7690
-    flash_properties:
-      address_range:
-        start: 0x70000000
-        end: 0x74000000
-      page_size: 0x1000
-      erased_byte_value: 0xff
-      program_page_timeout: 0x2710
-      erase_sector_timeout: 0x1770
-      sectors:
-        - size: 0x10000
-          address: 0x0
-  - name: stm32l4rx_2048_dual
-    description: 'STM32L4Rx 2MB Flash Dual '
-    cores:
-      - main
-    default: true
-    instructions: ZkllSIhgZkiIYGZIA2hmSkpEk2ADaEP0AHMDYANoI/SAYwNgCGpAAgTVT/ABYBBgASBQYAhqwAMI1FxIRfJVUQFgBiFBYED2/3GBYAAgcEdSSEFpQfAAQUFhACBwRwEgcEdK9qohUUpMSADgEWADadsD+9RM8vszA2FI8gQDQ2FDaUP0gDNDYQDgEWADadsD+9QCaUTy+jEKQgLQAWEBIHBHQWkh8AQBQWFBaSH0AEFBYQAgcEdwtTtOPEpORDdJdGig8QBlSvaqIwEsAtDF80c0CuDF8wc0NWioQgXTSGlA9ABgSGEA4BNgCGnAA/vUTPL7MAhhSGkg9P9gSGFIaQIlBevEBCBDSGFIaUD0gDBIYQDgE2AIacAD+9QKaUTy+jACQgLQCGEBIHC9SGkg9IAwSGFIaSDwAgBIYUhpIPQAYEhhACBwvRC1yR0TSyHwBwEcaeQD/NRcaUTwAQRcYRHgFGgEYFRoRGAcaeQD/NQcaeQHBNBE8vowGGEBIBC9CDAIOQgyACnr0VhpIPABAFhhACAQvQAAIwFnRQAgAkCrie/NAHAAQAQAAAAAMABAAAAAAAAAEAgAAAAAAAAAAA==
-    pc_init: 0x1
-    pc_uninit: 0x51
-    pc_program_page: 0x149
-    pc_erase_sector: 0xb7
-    pc_erase_all: 0x63
-    data_section_offset: 0x1b0
-    flash_properties:
-      address_range:
-        start: 0x8000000
-        end: 0x8200000
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0x190
-      erase_sector_timeout: 0x190
-      sectors:
-        - size: 0x1000
-          address: 0x0
   - name: stm32l4xx_64
     description: STM32L4xx 64 KB Flash
-    cores:
-      - main
     default: true
     instructions: v/NPj3BHX0gAaMDzCwCg9YBgNTgA0AEgcEdbSABqwPNAUHBHALUBRv/37f8BKAjR//fz/wEoBNFUSIFCAdMBIAC9ACAAvQC1AUb/99z/ASgC0MHzySAAvUDy3zAA6tEgyQP41QD1gHAAvUdISEmBYEhJgWAAIQFgTPL6MQFhAGrAAwjUREhF8lVRAWAGIUFgQPb/cYFgACBwRztJT/AAQEhhACBwRwEgcEc3SEzy+jEBYcETQWFBaUH0gDFBYUr2qiE1SgDgEWADadsD+9QAIUFhCEZwRxC1A0b/96P/AkYYRv/3sP8oSUzy+jQMYQIjA+vAAEDqwiBIYUhpQPSAMEhhv/NPj0r2qiAjSgDgEGALadsD+9QAIEhhCGkgQAHQDGEBIBC98LUXTMkdTPL6NyHwBwEnYU/wAAzE+BTAT/ABDkr2qiUUThfgxPgU4BNoA2BTaENgv/NPjwDgNWAjadsD+9TE+BTAI2k7QgLQJ2EBIPC9CDAIOQgyACnl0QAg8L0AAAAgBOAAIAJAAAABCCMBZ0Wrie/NADAAQAAAAAA=
-    pc_init: 0x6b
-    pc_uninit: 0x9b
-    pc_program_page: 0x127
-    pc_erase_sector: 0xd7
-    pc_erase_all: 0xab
-    data_section_offset: 0x19c
+    load_address: ~
+    pc_init: 107
+    pc_uninit: 155
+    pc_program_page: 295
+    pc_erase_sector: 215
+    pc_erase_all: 171
+    data_section_offset: 412
     flash_properties:
       address_range:
-        start: 0x8000000
-        end: 0x8010000
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0x190
-      erase_sector_timeout: 0x190
+        start: 134217728
+        end: 134283264
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
       sectors:
-        - size: 0x800
-          address: 0x0
-  - name: stm32l4rx_db_opt
-    description: STM32L4Rx Flash Options Dual Bank
-    cores:
-      - main
-    default: false
-    instructions: v/NPj3BHekh4SYFgeUmBYHlJwWB5ScFgACEBYHhJAWEAasADBtR4SHZJAWAGIUFgdkmBYAAgcEcBIW1IyQdBYUEEQWEAIHBHASBwRxC1aEhrTARhbkkBYksVQ2JtSYFibUnBYgFjYkpAMlNgSwSTYNFgEWFZQkFhv/NPj2dJYkoA4BFgA2nbA/vUAWkhQgTQAWkhQwFhASAQvQAgEL0AIHBH+LWgytZovEaXaBRovkYXaVNoAJdRaU1IkmlQTwdhV089QAViZ0b9A+0LRWJRTe1DLECEYlNMI0DDYndGJ0AHY/UDQkvtC0AzXWAAn/0D7QudYCFA2WAiQBphASFJBEFhv/NPj0VJP0oA4BFgA2nbA/vUAWk6ShFCBNABaRFDAWEBIPi9ACD4vfe1UWiCsIxGkWgVaI5G1GgTaVFpAZGRaQCRKk7RaRJqN2o0TjdANUCvQgfRJk99amZGrbK2srVCAtBAHAWw8L0hTa5qKU13Ru1DLkAvQL5CAdCAHPLnG0/9aidONUA0QKVCAdDAHOnnPGszQDRAnEIB0AAd4ucTTEA0Y2idsgGbm7KdQgHQQB3Y56No3QMAm+0L2wPbC51CAdCAHc7n42gxQDNAi0IB0MAdx+chaTJAMUCRQgHQCDDA5wOZQBi95wAAIwFnRQAgAkCrie/NOyoZCH9uXUz6wwAAVVUAAAAwAED/DwAAqvjv/wAA/n///wD/qqoAAP93/w//AP8AAAAAAA==
-    pc_init: 0x7
-    pc_uninit: 0x39
-    pc_program_page: 0xa3
-    pc_erase_sector: 0x9f
-    pc_erase_all: 0x4d
-    data_section_offset: 0x228
-    flash_properties:
-      address_range:
-        start: 0x1ff00000
-        end: 0x1ff00024
-      page_size: 0x24
-      erased_byte_value: 0xff
-      program_page_timeout: 0xbb8
-      erase_sector_timeout: 0xbb8
-      sectors:
-        - size: 0x24
-          address: 0x0
+        - size: 2048
+          address: 0
+    cores: []
   - name: stm32l4xx_sb_opt
     description: STM32L4xx single bank Flash Options
-    cores:
-      - main
     default: false
     instructions: v/NPj3BHUkhQSYFgUUmBYFFJwWBRScFgACEBYFBJAWEAasADBtRQSE5JAWAGIUFgTkmBYAAgcEcBIUVIyQdBYUEEQWEAIHBHASBwRxC1QEhDTARhRkkBYkkVQWIJBIFiREnBYgFjASFJBEFhv/NPj0FJPUoA4BFgA2nbA/vUAWkhQgTQAWkhQwFhASAQvQAgEL0AIHBH8LWUiBVok2jRaCtIEmkuTwdhNE41QAVipLJEYjNMI0CDYjJLGUDBYhpAAmMBIUkEQWG/80+PKkkmSgDgEWADadsD+9QBaTlCBNABaTlDAWEBIPC9ACDwvfC1jEaUaNNoYMoVSZJoD2ofSQ9ADUCvQgbREU1parayibKxQgHQQBzwvalqGU4xQDRAoUIB0IAc8L3sahZJDEALQJxCAdDAHPC9K2sKQAtAk0IB0AAd8L1gRPC9AAAjAWdFACACQKuJ7807KhkIf25dTPrDAABVVQAAADAAQP8PAACq+O////8A/6qqAAD/d/8P//8AgP8A/wAAAAAA
-    pc_init: 0x7
-    pc_uninit: 0x39
-    pc_program_page: 0x97
-    pc_erase_sector: 0x93
-    pc_erase_all: 0x4d
-    data_section_offset: 0x188
+    load_address: ~
+    pc_init: 7
+    pc_uninit: 57
+    pc_program_page: 151
+    pc_erase_sector: 147
+    pc_erase_all: 77
+    data_section_offset: 392
     flash_properties:
       address_range:
-        start: 0x1fff7800
-        end: 0x1fff7814
-      page_size: 0x14
-      erased_byte_value: 0xff
-      program_page_timeout: 0xbb8
-      erase_sector_timeout: 0xbb8
+        start: 536836096
+        end: 536836116
+      page_size: 20
+      erased_byte_value: 255
+      program_page_timeout: 3000
+      erase_sector_timeout: 3000
       sectors:
-        - size: 0x14
-          address: 0x0
-  - name: stm32l4rx_2048
-    description: STM32L4Rx 2MB Flash
-    cores:
-      - main
+        - size: 20
+          address: 0
+    cores: []
+  - name: stm32l4r9i_eval
+    description: MX25LM51245G_STM32L4R9I-EVAL
     default: false
-    instructions: Y0liSIhgY0iIYGNIA2hjSkpEk2ADaEP0AHMDYANoI/SAYwNgCGpAAgTVT/ABYBBgASBQYAhqwAMI1FlIRfJVUQFgBiFBYED2/3GBYAAgcEdPSEFpQfAAQUFhACBwRwEgcEdK9qohTkpJSADgEWADadsD+9RM8vszA2FI8gQDQ2FDaUP0gDNDYQDgEWADadsD+9QCaUTy+jEKQgLQAWEBIHBHQWkh8AQBQWFBaSH0AEFBYQAgcEcwtcDzRzRK9qohN0ozSADgEWADadsD+9RM8vszA2FDaSP0/2NDYUNpAiUF68QEI0NDYUNpQ/SAM0NhAOARYANp2wP71AJpRPL6MQpCAtABYQEgML1BaSH0gDFBYUFpIfACAUFhACAwvXC1yR0h8AcBSvaqIx1MGE0A4CNgLmn2A/vUTPL7Ni5hbmlG8AEGbmET4BZoBmBWaEZgAOAjYC5p9gP71C5p9gcE0ETy+jAoYQEgcL0IMAg5CDIAKenRaGkg8AEAaGEHSAZJSESAaAhgACBwvQAAIwFnRQAgAkCrie/NAHAAQAQAAAAAMABAAAAAAAAAIAgAAAAAAAAAAA==
-    pc_init: 0x1
-    pc_uninit: 0x51
-    pc_program_page: 0x11f
-    pc_erase_sector: 0xb7
-    pc_erase_all: 0x63
-    data_section_offset: 0x1a4
+    instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEdP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEdwtQRGDUYWRgXwI/0IsQAgcL0BIPznAUYAIHBHELUF8C/9EL1wtQRGACYlRukZKEYF8ET9BkYBLgHRACBwvTBG/OdwtQRGDUYWRjJGKUYgRgXwI/0IsQAgcL0BIPznMLUG4BD4AUsS+AFbrEIA0DC9Cx6h8QEB9NEAv/jnAABwR3C1BEYAJaFISEQAePCxn0hIRAB4T/R6cbH78PCdSUlECWix+/D2MEYA8Pj5YLkQLAjSACIhRlAeAPBf+ZZISEQEYATgASUC4AElAOABJShGcL0QtQAkAyAA8D35DyAF8F38CLEBJAHg//fJ/yBGEL1wRxC1AL9P8P8wh0mIY8hjAL8AvwAgiGPIYwC/QB4IZAAgCGRAHohiACCIYkAeyGIAIMhiQB4IYwAgCGP/9+D/ACAQvXpISEQAaHRJSUQJeAhEdklJRAhgcEd0SEhEAGhwR3BISEQAaHBHcLUERgAla0hIRAB4oEIN0GhISEQGeARwaEhIRABoBfAQ/AVGFbFjSEhEBnAoRnC9YEhIRAB4cEdwtQRGBfDx+wZGJUZoHBixWkhIRAB4BUQAvwXw5vuAG6hC+tNwvU/w4CAAaSDwAgBP8OAhCGFwR0/w4CAAaUDwAgBP8OAhCGFwR0/whnBwR09IAGgADHBHTUgAaMDzCwBwR0xIAGhwR0pIAB0AaHBHSEgIMABocEdFSEBoQPABAENJSGBwR0JIQGgg8AEAQElIYHBHPkhAaEDwAgA8SUhgcEc7SEBoIPACADlJSGBwRzdIQGhA8AQANUlIYHBHNEhAaCDwBAAySUhgcEfKIDJJSGJTIEhiASAwSQhgcEcBIC9JCGJwRwAgLUkIYnBHKkkJayHwBAEBQydKEWNwRyZJCWsh8AIBAUMjShFjcEciSUlrIfA/AQFDH0pRY3BHELUdSABrQPABABtJCGMF8F37BEYG4AXwWfsAGwooAdkDIBC9FUgAawDwCAAAKPLQACD25xFIAGsg8AEAD0kIY3BHDUhAaED0gHALSUhgcEcKSEBoIPSAcAhJSGBwRwwAAAAQAAAACAAAAAAQAkAEAAAAACAE4JB1/x8AAAFAAAMgQgAAIEIQtQAoBNsKBxMO5koTVAbgCgcUDuRKAPAPAxsf1FQQvQC/APAHAuBLDDsZaE/2/wMZQN5LC0ND6gIh20sMOxlgAL9wRy3p8E2ARg1GFkYAJwDwovkHRjlGKkYzRgHwBwDA8QcLu/EEDwLZT/AECwHgwPEHC9pGAPEEC7vxBw8C0k/wAAsB4KDxAwvcRk/wAQsL+gr7q/EBCwvqAgsL+gz7T/ABDg76DP6u8QEODuoDDkvqDgQhRkBG//ei/73o8I0BRghGACgN2wC/AL8A8B8DASKaQEMJmwAD8eAjw/gAIQC/AL8Av3BHELUBRghGACgX2wDwHwMBIppArUtECUP4JCAAvwC/AL+/80+PAL8AvwC/AL8AvwC/v/NvjwC/AL8AvwC/EL0AvwC/AL8AvwC/v/NPjwC/AL8Av5tIDDgAaAD04GCZSQhDAB2XSQw5CGAAvwC/AL+/80+PAL8AvwC/AL8Av/3ncLUERiVGaB6w8YB/AdMBIA/gaB5P8OAhSGEPIU/w/zD/9zv/ACBP8OAhiGEHIAhhACBwvRC1APD8+BC9LenwRQRGIEYAKAPbfU8/XD8JB+B8TwDwDwys8QQMF/gMcD8JPUYORgbwBwDA8QcIuPEEDwLZT/AECAHgwPEHCMRGAPEECLjxBw8C0k/wAAgB4KDxAwhHRiX6B/hP8AEKCvoM+qrxAQoI6goIwvgAgE/wAQgI+gf4qPEBCAjqBQjD+ACAAL+96PCFELUBRghGACgI2wDwHwMBIppAXEuAM0QJQ/gkIAC/EL0QtQFGCEYAKA7bVkqAMkMJUvgjIADwHwQBI6NAGkAKsQEiAuAAIgDgACIQRhC9ELUBRghGACgH2wDwHwMBIppASUtECUP4JCAAvxC9ELUBRghGACgO20RKgDJDCVL4IyAA8B8EASOjQBpACrEBIgLgACIA4AAiEEYQvQQoCNFP8OAhCWlB8AQBT/DgIhFhB+BP8OAhCWkh8AQBT/DgIhFhcEdwRxC1//f8/xC9QPABASpKfDIRYAC/AL8Av7/zT48AvwC/AL8AvwC/AL+/82+PAL8AvwC/cEcAvwC/AL+/81+PAL8AvwC/ACAcSXwxCGBwR0F4GUqAMhFgAXj5sRIdQWgRYAF7CQfCekHqAmGCekHqwkFCe0HqgkGCe0HqQkHCe0HqAkFCekHqAiECekHqQgECeBFDCUqIMhFgBeAAIQZKhDIRYBIdEWBwRwNIDDgAaMDzAiBwRwDkAOAY7QDgAAD6BYDhAOCA4gDgeLUCRgAj2uABJp5ADWgF6gYEACxy0E1oAS0I0E1oAi0F0E1oES0C0E1oEi0T0ZBoXgADJbVAqENeAM1otUAoQ5BgUGgBJZ1AqEMNecXzABWdQChDUGDQaF4AAyW1QKhDXgCNaLVAKEPQYE1oAi0C0E1oEi0T0d4IAvEgBVX4JgBdB+4ODyW1QKhDXgf2Dg1ptUAoQ94IAvEgBUX4JgAQaF4AAyW1QKhDDXkF8AMFXgC1QChDEGBNaAXwgFW18YBffNEAv6hNLW5F8AEFpk41ZjVGLW4F8AEFAJUAvwC/T+q2NZ4IVfgmAJ0HLg8PJbVAqEOy8ZBPAtEAJSTgXuCbTapCAdEBJR7gmU2qQgHRAiUZ4JhNqkIB0QMlFOCWTapCAdEEJQ/glU2qQgHRBSUK4JNNqkIB0QYlBeCSTapCAdEHJQDgCCWeBzYPtUAoQ45NnghF+CYAjU0oaKBDTWgF9IA1tfWAPwDRIEOITShgLR0oaKBDTWgF9AA1tfUAPwDRIEOCTS0dKGAtHShooENNaAX0gBW19YAfANEgQ3tNCDUoYC0dKGigQ01oBfQAFbX1AB8A0SBDdU0MNShgWxwNaN1AAC1/9CCveL3wtQtGACGH4AEljUAF6gMCACp+0GpNjghV+CZAjQcuDw8ltUAsQLDxkE8B0QAlI+BcTahCAdEBJR7gWk2oQgHRAiUZ4FlNqEIB0QMlFOBXTahCAdEEJQ/gVk2oQgHRBSUK4FRNqEIB0QYlBeBTTahCAdEHJQDgCCWOBzYPtUClQiHRT00taJVDTk41YDUdLWiVQzYdNWA1HS1olUM2HTVgNR0taJVDNh01YI0HLg8PJQX6BvRCTY4IVfgmUKVDP06PCEb4J1AFaE8AAya+QDVDBWDOCADxIAVV+CZQTgf3Dg8mvkC1Q88IAPEgBkb4J1CFaE8AAya+QLVDhWBGaAEljUCuQ0ZgxWhPAAMmvkC1QwDgAODFYEkcI/oB9QAtf/Rzr/C9AkYTaQtAC7EBIADgACBwRwqxgWEA4IFicEcQtUJpIeoCAwLqAQRD6gRDg2EQvQi1AkZP9IAwAJAAmAhDAJAAmNBh0WEAmNBh0GkAkNBpAPSAMAixACAIvQEg/OdwRxC1BEYOSBQwAGggQCixDEgUMARgIEb/9/L/EL0AEAJAAAQASAAIAEgADABIABAASAAUAEgAGABIABwASAgAAUAABAFALenwQQRGDkYXRphGBp0S4GgcgLEE8HP/oOsIAKhCANhNuU/0AHBgZKBsQPABAKBkASC96PCBIGgAajBACLEBIADgACC4QuPRACDy5wJG0WQAIHBHcEf4tQRGACUE8E//BkYMuQElbeAAIKBkYGwAKGjRIEb/9+7/QfKIMSBG//fl/yCKQB7haEHqAEFgaUAeQeoAICFrCEPhaQhDIWiJaP5KEUAIQyFoiGCgjQAEIWgIYSBoAGgg9PhRYGhAHkHqACAhaAhg4GwzRgAiICEAkCBG//eV/wVGjbsgaMBoIPD/ACFqSR4IQyFoyGAgaABoIPBAAKFoCEMhaAhg1OkJAQhDIWjR+AgRIfCgQQhDIWjB+AgBIGgAaEDwAQAhaAhgoGkCKAXRIGiAaEDwAgAhaIhg4Giw8YBvAtEBIGBkAeACIGBkKEb4vXBHcLUERgAlDLkBJRDgIGgAaCDwAQAhaAhgIGiAaCDwAgAhaIhgIEb/9+r/ACBgZChGcL1wR3BHcEdwtQVGrGoAIOBjYGyw9YB/GtEgaABqwPNAEHixAiAhaEhiIGgAaED0ADAhaAhgIGgAaEDwAgAhaAhgCuACIGBkIEb/99z/BOACIGBkIEb/99X/cL1wR3BHcEdwR3BHLenwQQRGIGgA8VAIIGgFaiBoB2hmbAXwBAA4swf0gCAgsxguCtFgawB4iPgAAGBrQBxgY+BrQB7gYwvgKC4J0Zj4AABhawhwYGtAHGBj4GtAHuBj4GsouSBoAGgg9IAgIWgIYCBG//fK/6XgBfACAAAoS9AH9AAwAChH0CguIdHga2ixBfR8UFCxmPgAAGFrCHBga0AcYGPga0Ae4GOL4OBrACjh0QIgIWhIYiBoAGgg9OAgIWgIYAIgYGQgRv/3nf954AIgIWhIYiBoAGgg9OAgIWgIYAIgYGQYLgPRIEb/94v/aOAILgPRIEb/94T/YuC29YB/X9GgbBi5IEb/90//WeAgRv/3Sv9V4AXwCACwsQf0ACCYsQggIWhIYiBoAGgA9IAAOLEgaABoIPQQICFoCGACIGBkIEb/91z/O+AF8AEAYLMH9IAwSLMBICFoSGIgaABoIPT4ECFoCGACIKBkIGgAaADwBACYsSBoAGgg8AQAIWgIYFFIeEQhbIhjIGwF8Hf4uLECIGBkIEb/9wb/EeACIGBkIEb/9wD/C+AF8BAAQLEH9IAQKLEQICFoSGIgRv/38v696PCBLenwQQNGACAfaD9oJ/BAV9P4AMDM+ABwn2hfuR9oP2gn8IAH0fgEwEfqDAfT+ADAzPgAcA9oAi8M0R9oB/XAch9oB/XEdB9oB/XIdR9oB/XQdgvgH2gH9YByH2gH9YR0H2gH9Yh1H2gH9ZB20ekSfEfqDAcXYM9qj7GPajdg0fg0wM9qR+oMB9H4MMBH6gwH0vgAwCz0fBxH6gwHF2AnaCfwHwfR+ETAR+oMBydgj2s/sQ9oL7nPa38e0/gAwMz4QHDPaAAvfNDPae+zj2tfs9H4FMDPaEfqDAfR+BDAR+oMB9H4HMBH6gwH0fgkwEfqDAfR+CDAR+oMB9H4OMAD4PT44Pgl/v//R+oMB9H4QMBH6gwH0vgAwN/4GIoM6ggMR+oMBxdgKuDR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMAA4CHgR+oMB9H4IMBH6gwH0vgAwEP2P3gs6ggMR+oMBxdgn2q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2CPadP4AMDM+Ehwd+CPa+ex0fgUwM9oR+oMB9H4EMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+HyJDOoIDADgIeBH6gwHF2Aa4NH4FMDPaEfqDAfR+BDAR+oMB9L4AMAs8D8MR+oMBxdgn2q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2A64M9pp7OPa+ex0fgkwM9pR+oMB9H4IMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+PyICPE/CAzqCAxH6gwHF2AP4NH4JMDPaUfqDAfR+CDAR+oMB9L4AMAs9HxcR+oMBxdgj2nT+ADAzPhIcAPg/+cBIAgnn2S96PCBLen4RQRGDUaQRgTwafyCRqBoALkAv+hoALEAv+hpALEAv+hqALEAv6hrGLEoaAC5AL8Av2dsAi8D0eBosPGAbwnRFC8C0ShoAigE0CQvPdEoaAEoOtFTRgAiICEgRs34AID/9778BkYeuwAgoGQpRiBG//eE/gZG3rmoa2C5U0YBIgIhIEbN+ACA//eq/AZGAiAhaEhiHOAoaBC5BCBgZBfgKGgBKAjRYGwkKALRBCBgZA7gFCBgZAvgYGwUKALRBCBgZAXgJCBgZALgASYQIKBkMEa96PiF+LUERg1GBPD/+wdGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsAsQC/YGwCKCXRKGgYu6hrCLvgaLDxgG8d0OBsO0YAIiAhAJAgRv/3XfwGRra5ACCgZAMgIWhIYilGIEb/9yD+BkZeuQggYGQgaABoQPRAMCFoCGAC4AEmECCgZDBG+L0t6fhFBEYNRhdGBPC6+4JG1PhEgLjxAQ8C0LjxAg8X0VNGACIgISBGAJf/9yv8BkaOuSiIAARpaEDqASCpaAhD6WgIQyFowfgAAgIgYGQC4AEmECCgZDBGvej4hS3p+EMERg1GF0YE8Iz7gEZgbAIoONHgaLDxgG800UNGACIgISBGAJf/9/77BkZWuyBoAGgg8EBQIWgIYCBogGgg8IBwKWgIQyFoiGAoaUDwQGCpaAhDQPRAYCFowfgAAShpQPBAYKloCENA9EBgIWjB+IAB6GhAHiFoCGRoaCFoiGQEIGBkAuABJhAgoGQwRr3o+IMt6fhFBEYORhdGBPBC+4BGIGgA8VAKHrkBJQggoGQ64GBsBCg00SBoAGxAHOBj4GugY2ZjIGgAaCDwQFAhaAhgAL9DRgEiBCEgRgCX//ei+wVGBbEM4GBrAHiK+AAAYGtAHGBj4GtAHuBj4GsAKOjRAL+FuUNGASICISBGAJf/94n7BUY9uQIgIWhIYmBkAuABJRAgoGQoRr3o+IUt6fxNBEYORhdGBPD0+gGQIGgA8VAKIGjQ+EiAIGjQ+BCxHrkBJQggoGRR4GBsBChL0SBoAGxAHOBj4GugY2ZjIGgAaCDwQFBA8IBQIWgIYOBosPGAbwPRIGjA+EiADOAgaND4AAEA9OBgGLEgaMD4SIAC4CBowPgQsQC/AJcBIgYhIEYBm//3N/sFRgWxDOCa+AAAYWsIcGBrQBxgY+BrQB7gY+BrACjo0QC/hbkAlwEiAiEgRgGb//ce+wVGPbkCICFoSGJgZALgASUQIKBkKEa96PyNELUCRgAgGbkBIAgjk2Qe4FNsBCsY0RNoG2xbHNNj02uTY1FjE2gbaCPwQFMUaCNgAyMUaGNiGCNTZBNoG2hD9OAjFGgjYALgASAQI5NkEL1wtQJGACAVaKtsFWjV+BBBGbkBIAgllWQz4FVsBC0t0RVoLWxtHNVj1WuVY1FjFWgtaCXwQFVF8IBVFmg1YAMlFmh1YiglVWQVaC1oRfTgJRZoNWDVaLXxgG8C0RVoq2QP4BVo1fgAUQX04GUVsRVoq2QG4BVoxfgQQQLgASAQJZVkcL1wtQRGACZlbAXwCAAYuQXwBAAAKDzQIGgAaCD0+BAhaAhgT/SAcGBkIGgAaADwBACYsSBoAGgg8AQAIWgIYPlIeEQhbIhjIGwE8Kv8+LECIGBkIEb/9zv7HeAgaABqwPNAEHixAiAhaEhiIGgAaED0ADAhaAhgIGgAaEDwAgAhaAhgCOACIGBkIEb/9yD7AuABJhAgoGQwRnC9cLUFRqxqACDgYwQgoGQgaABoIPAEACFoCGAgRv/3o/9QsSBoAGgg9OAgIWgIYAIgYGQgRv/3/fpwvXBHcEdwtQVGrGrga0AI4GNgbCgoA9EgRv/38/8C4CBG//fu/3C9AUaIagAiwmMCaBJoIvAEAgNoGmAKaBJoIvABAgtoGmACaBJoQvQAMgNoGmBwRy3p8EEERg5GACcgaABsRRweuQEnCCCgZHngYGwEKHPRIGxAaQi55WMk4CBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggoGQBJxTgaAjgYxHgIGxAabD1AH8M0QXwAwAYuSB5APADABixCCCgZAEnAeCoCOBjAC9K0eBroGNmYyBoAGgg8EBQIWgIYAMgIWhIYhggYGSbSHhEIWzIYppIeEQhbAhjmUh4RCFsSGMAICFsiGMQISBsgWAgbABoAGgg8BAAIWyJaAhDIWwJaAhgo2shaAHxUAIxRiBsBPAs+2C5IGgAaED0gDAhaAhgIGgAaEDwBAAhaAhgCeABJwQgoGQCIGBkA+D/5wEnECCgZDhGvejwgS3p8EcERg5GACcgaABsRRwgaND4SIAgaND4EKEeuQEnCCCgZJDgYGwEKG/RIGxAaQi55WMk4CBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggoGQBJxTgaAjgYxHgIGxAabD1AH8M0QXwAwAYuSB5APADABixCCCgZAEnAeCoCOBjAC9h0eBroGNmYyBoAGgg8EBQQPCAUCFoCGADICFoSGIoIGBkVUh4RCFsyGJUSHhEIWwIY1NIeEQhbEhjACAhbIhjACEgbIFgIGwAaABoIPAQACFsiWgIQyFsCWgIYKNrImgC8VABMkYgbATwmvoQuyBoAGhA9IAwIWgIYOBosPGAbwTRIGjA+EiADeAZ4CBo0PgAAQD04GAYsSBowPhIgALgIGjA+BChIGgAaEDwBAAhaAhgCOABJwQgoGQCIGBkAuABJxAgoGQ4Rr3o8Ict6fhPBEYNRhdGBPBa+IJGIGjQ+EiAIGjQ+BCxYGwEKFzR6Giw9YAPWNFTRgAiICEgRgCX//fG+AZGAC5R0ShoIWjB+IgAaGghaMH4gAAoaSFowfiQANXpAgEIQ0DwAFAhaAloIfBDUQhDIWgIYOBosPGAbwPRIGjA+EiAH+AgaND4AAEA9OBgsLEgaMD4SIAV4AAAwMD/8MD///CN9v//Of///w/////J/v//Ff7//+v9//+l/f//IGjA+BCxU0YBIgghIEYAl//3fPgGRia5CCAhaEhiAiBgZALgASYQIKBkMEa96PiPLen4RQRGDUYD8Of/gEYgaIdsIGjQ+BChYGwEKEDR4GxDRgAiICEAkCBG//dX+AZGRrsoaCFowfiIAGhoIWjB+IAAKGkhaMH4kADV6QIBCENA8ABQIWgJaCHwQ1EIQyFoCGAJICFoSGJIIGBkIGgAaED0ECAhaAhg4Giw8YBvAtEgaIdkD+AgaND4AAEA9OBgELEgaIdkBuAgaMD4EKEC4AEmECCgZDBGvej4hfi1BEYNRgPwkv8HRmBsBCgm0eBsO0YAIiAhAJAgRv/3B/gGRv65iCBgZChoCCgM0WhoIWjB+DABECAhaEhiIGgAaED0gBAhaAhgIGgAaP5JCEApaEHwQFEIQyFoCGAC4AEmECCgZDBG+L34tQRGACUD8F3/B0ZmbAbwCAAYuQbwBAAAKDnQIGgAaADwBABgsSBoAGgg8AQAIWgIYCBsBPCw+QVGDbEEIKBkIGgAasDzQBD4sSBoAGhA8AIAIWgIYOBsO0YBIgIhAJAgRv73sP8FRq25AiAhaEhi4Gw7RgAiICEAkCBG/vej/wVGRbkCIGBkBeACIGBkAuABJRAgoGQoRvi9ELUCRgAgU2wD8AgDW7lRYBNoG2gj9PhUU2hbHkTqAyMUaCNgAuABIBAjk2QQvQFGCGgAaMDzBCBAHHBHAUaIbHBHAUZIbHBH8LUFRgAgACQVsQItANgJuQEgW+AAJg5gTmCOYM5gDmECLQDRtkwAI07gtk5W+CMgAvABBj6xAvACBgTwAge+QgHRXhwOYALwEAY+sQLwIAYE8CAHvkIB0V4cTmAC9IB2PrEC9AB2BPQAd75CAdFeHI5gAvSANo6xAvSAJgT0gCe+QgvRAvQANia5XhxG9IA2zmAD4F4cRvCAds5gAvCAdo6xAvCAZgTwgGe+QgvRAvAAdia5XhxG9IA2DmED4F4cRvCAdg5hWxwCK67T8L0t6fBNirCCRgxGT/AAC9hGikna+AAAiEIC0QAlASYB4AElACYAJxDgB+uHAmtGA+uCAXoc0LL/93z/ILFP8AELCCDK+EgAeBzHsgIv7NO78QAPfdF5SABoAPABADixdkgAaCDwAQB0SQhgSPABCHNIAGgA8AEAOLFxSABoIPABAG9JCGBI8AIIa0gF64UBakYC64EBiWhJHlD4IQAg9IByZUgF64UBa0YD64EBiWhJHkD4ISAF64UAXfggAAAocdBdSAXrhQFd+CEQSR5Q+CEAIPABAlhIBeuFAV34IRBJHkD4ISAF64UAaUYB64AAQGigsVBIBeuFAWpGAuuBAUloSR5Q+CEAIPAQAkpIBeuFAQPrgQFJaEkeQPghIAXrhQBpRgHrgADAaNixQkgF64UBakYC64EBCXtJHgHwAQFQ+CEAIPSAMjtIBeuFAWtGAOCK4QPrgQEJe0keAfABAUD4ISAF64UAaUYB64AAAGnIsTFIBeuFAWpGAuuBAQl8SR4B8AEBUPghACDwgHIqSAXrhQFrRgPrgQEJfEkeAfABAUD4ISAG64YBXfghECBoiEIg0AbrhgFqRgLrgQFgaEloiEIX0AbrhgEC64EBoGiJaIhCD9AG64YBAuuBAeBoyWiIQgfQBuuGAQLrgQEgaQlpiEJ+0RBIBuuGAV34IRBJHlD4IQAg8AECC0gG64YBXfghEEkeQPghIAbrhgBpRgHrgABAaACzA0gG64YBCeD3///PIgIEBAQcBlAAEACgABQAoGpGAuuBAUloSR5Q+CEAIPAQAodIBuuGAWtGA+uBAUloSR5A+CEggkgG64YBakYC64EBiWhJHlD4IQAg9IByfEgG64YBa0YD64EBiWhJHkD4ISAG64YAaUYB64AAwGjAsXNIBuuGAWpGAuuBAQl7SR4B8AEBUPghACD0gDJsSAbrhgED64EBCXtJHgHwAQFA+CEgBuuGAGlGAeuAAABpOLFjSAbrhgFqRgLrgQEJfADgEuBJHgHwAQFQ+CEAIPCAcltIBuuGAWtGA+uBAQl8SR4B8AEBQPghIFVIoWhJHlD4IQAg9EBwT/SAcUHqRSEIQ09JomhSHkH4IgAIRiFoSR5Q+CEAIPADAQEgQOpFAAFDR0giaFIeQPgiEGBoeLFESGFoSR5Q+CEAIPAwABAhQepFEQhDPkliaFIeQfgiAOBoAPSAMKixOkghe0keAfABAVD4IQAg9OAgT/SAMUHqhUEIQzNJIntSHgLwAQJB+CIAFuDgaKCxLkghe0keAfABAVD4IQAg8OBgT/CAcUHqhWEIQydJIntSHgLwAQJB+CIAIGkA9IAwqLEhSCF8SR4B8AEBUPghACD04CBP9EAxQeqFQQhDGkkifFIeAvABAkH4IgAW4CBpoLEVSCF8SR4B8AEBUPghACDw4GFP8EBwQOqFYAFDDkgifFIeAvABAkD4IhAI8AEAKLEKSABoQPABAAhJCGAI8AIAKLEHSABoQPABAAVJCGBYRgqwvejwjQAABBwGUAAQAKAAFACgfEiAa0DwgFB6SYhjCEaAayDwgFCIY3BHd0gAaED0gHB1SQhgcEd0SABoIPSAcHJJCGBwRwFGcEhAaCDwDgAKaBBDbUpQYG1IAGgg9IAwa0oQYBAfAGgg9IAwEh8QYGdICDAAaCD0gDBkSggyEGAQHwBoIPSAMBIfEGBIaAD0gDCw9YA/B9FdSAAfAGhA9IAwWkoSHxBgSGgA9AAwsPUAPwXRVkgAaED0gDBUShBgCHkA8AEAOLFRSAAdAGhA9IAwTkoSHRBgCHkA8AIAAigH0UpICDAAaED0gDBISggyEGAAIHBHREhAaEDwAQBCSUhgcEdBSEBoIPABAD9JSGBwRz1JyWgA8B8CkUNB6lAROkrRYBFGiWgA8B8CEUM2SpFgcEc1SYloAPAfApFDMkqRYHBHcLUERg1GVLkvSEBpAPQAcLD1AH8K0QDwp/w4sXC9KUhAacDzQCAIuQDwl/woSABoIPAEACZJCGABLQHRML8C4EC/IL8gvwC/6OdwtQVGDEa19YBPA9EgRgDwxfwC4CBGAPCn/HC9F0gAaCDwBwDAHBVJCGAWSABoQPAEABRJCGAAvwC/ML9wRxFIAGhA8AIAD0kIYHBHDUgAaCDwAgALSQhgcEcKSABoQPAQAAhJCGBwRwZIAGgg8BAABEkIYHBHcEcAEAJAAHAAQAQEAUAQ7QDg+EgAaAD0wGCw9YBvAtFP9IBgcEfzSIAwAGgA9IBwsPWAfwLRT/QAcPPnACDx5wJGkrvsSABoAPTAYLD1gG8s0ehIgDAAaCD0gHDmS8P4gAAYRgBoIPTAYED0AHAYYOJISEQAaDIjWEPgS7D78/BBHADgSR7bSEBpAPSAYLD1gG8B0QAp9dHXSEBpAPSAYLD1gG9S0QMgcEcI4NJIgDAAaCD0gHDPS8P4gABG4LL1AH870cxIAGgA9MBgsPWAbyvRyEiAMABoQPSAcMZLw/iAABhGAGgg9MBgQPQAcBhgwkhIRABoMiNYQ8BLsPvz8EEcAOBJHrtIQGkA9IBgsPWAbwHRACn10bdIQGkA9IBgsPWAbxLRAyC+57JIgDAAaED0gHCwS8P4gAAH4K5IAGgg9MBgQPSAYKtLGGAAIKvnqUnJaCH0AHEBQ6ZK0WARRsloQfSAcdFgcEeiSMBoIPSAcKBJyGBwR59IQGhA9IBgnUlIYHBHm0hAaCD0gGCZSUhgcEeYSEBoQPQAcJZJSGBwR5RIQGgg9ABwkklIYHBHkUiAaED0AECPSYhgcEeNSIBoIPQAQItJiGBwRxC1AkYAIAkqcdLf6ALwBRQhKzU/SVNgAIRLG2oh9IBEI0OBTCNiI0ZbaiH0IESjQ35MY2Jd4HxLm2oLQ3tMo2IjRttqIfAQBKNDd0zjYlDgdksbawtDdEwjYyNGW2uLQ2NjRuBxS5trC0NvTKNjI0bba4tD42M84GxLG2wLQ2pMI2QjRltsi0NjZDLgZ0ubbAtDZUyjZCNG22yLQ+NkKOBiSxttC0NgTCNlI0ZbbYtDY2Ue4F1Lm22MsiNDW0yjZSNG222MsqNDWEzjZRHgVksbbsHzCwQjQ1RMI2YjRltuwfMLBKNDUExjZgLg/+cBIAC/AL8QvRC1AkYAIAkqQdLf6ALwBQ0TGR8lKzE4AEZLG2oh9IBEo0NETCNiNOBCS5tqi0NBTKNiLuA/Sxtri0M+TCNjKOA8S5tri0M7TKNjIuA5Sxtsi0M4TCNkHOA2S5tsi0M1TKNkFuAzSxtti0MyTCNlEOAwS5ttjLKjQy5Mo2UJ4C1LG27B8wsEo0MqTCNmAeABIAC/AL8QvRC1AkYAIAkqdtLf6ALwBRQgKjQ+TlhlACFLW2oh9CBEI0MeTGNiI0YbaiH0gESjQxtMI2Ji4BlL22oh8BAEI0MXTONiI0abaotDo2JW4BNLW2sLQxJMY2MjRhtri0MjY0zgDkvbawtDDUzjYyNGm2uLQ6NjQuAJS1tsC0MITGNkI0YbbItDI2Q44ARL22wLQwNM42QjRptsi0OjZC7gAHAAQBAAAABAQg8A+ktbbQtD+UxjZSNGG22LQyNlHuD1S9ttjLIjQ/NM42UjRpttjLKjQ/BMo2UR4O9LW27B8wsEI0PsTGNmI0YbbsHzCwSjQ+lMI2YC4P/nASAAvwC/EL0QtQJGACAJKkPS3+gC8AUNFRshJy0zOgDfS1tqIfQgRKND3ExjYjbg20vbaiHwEASjQ9hM42Iu4NdLW2uLQ9VMY2Mo4NRL22uLQ9JM42Mi4NFLW2yLQ89MY2Qc4M5L22yLQ8xM42QW4MtLW22LQ8lMY2UQ4MhL222MsqNDxkzjZQngxEtbbsHzCwSjQ8JMY2YB4AEgAL8AvxC9vkiAaED0gGC8SYhgcEe7SIBoIPSAYLlJiGBwRwFGMbm2SIBoIPSAcLRKkGAL4LH1gH8G0bFIgGhA9IBwr0qQYAHgASBwRwAg/OcAtU/0gHD/9+T/AL0AtQAg//ff/wC9pkgAaEDwEACkSQhgcEejSABoIPAQAKFJCGBwR59IgGhA9IBQnUmIYHBHnEiAaCD0gFCaSYhgcEeYSEBoQPAQAJZJSGBwR5VIQGgg8BAAk0lIYHBHkUhAaEDwIACPSUhgcEeOSEBoIPAgAIxJSGBwR4pIQGhA8EAAiElIYHBHh0hAaCDwQACFSUhgcEeDSEBoQPCAAIFJSGBwR4BIQGgg8IAAfklIYHBHAUYAIApoECoG0CAqUtBAKn7QgCp90fHgd0oSaCLwCAJ1SxpgGh8SaCLwCAIbHxpgcUoIMhJoIvAIAm9LCDMaYBofEmgi8AgCGx8aYEpoAvSAMrL1gD8H0WdKEh8SaELwCAJlSxsfGmBKaAL0ADKy9QA/BdFgShJoQvAIAl5LGmAKeQLwAQI6sVtKEh0SaELwCAJZSxsdGmAKeQLwAgICKgfRVUoIMhJoQvAIAlJLCDMaYPPgUEoSaCLwEAJOSxpgGh8SaCLwEAIbHxpgSkoIMhJoIvAQAkhLCDMaYBofEmgi8BACGx8aYEpoAvSAMrL1gD8H0UBKEh8SaELwEAI+SxsfGmBKaAL0ADKy9QA/AeAh4MHgBdE4ShJoQvAQAjZLGmAKeQLwAQI6sTNKEh0SaELwEAIwSxsdGmAKeQLwAgICKgfRLEoIMhJoQvAQAipLCDMaYKLgKEoSaCLwIAImSxpgGh8SaCLwIAIbHxpgIkoIMhJoIvAgAh9LCDMaYBofEmgi8CACGx8aYEpoAvSAMrL1gD8H0RhKEh8SaELwIAIVSxsfGmBKaAL0ADKy9QA/BdERShJoQvAgAg9LGmAKeQLwAQI6sQxKEh0SaELwIAIJSxsdGmAKeQLwAgICKgfRBUoIMhJoQvAgAgNLCDMaYFTgAAAAcABAJAQBQJBKEmgi8EACjksaYBofEmgi8EACGx8aYIpKCDISaCLwQAKISwgzGmAaHxJoIvBAAhsfGmBKaAL0gDKy9YA/B9GAShIfEmhC8EACfksbHxpgSmgC9AAysvUAPwXReUoSaELwQAJ3SxpgCnkC8AECOrF0ShIdEmhC8EACcksbHRpgCnkC8AICAioH0W5KCDISaELwQAJrSwgzGmAB4AEgAL8Av3BHaEgAaED0gEBmSQhgcEdlSABoIPSAQGNKEGBjSEhEAGgyIlBDYUqw+/LwQRwA4EkeXEhAaQD0AHCw9QB/AdEAKfXRWEhAaQD0AHCw9QB/AdEDIHBHACD851JJCWgh8AcBUEoRYFJJCWhB8AQBUEoRYAEoAdEwvwLgQL8gvyC/TEkJaCHwBAFKShFgcEdFSQloIfAHAUkcQ0oRYEVJCWhB8AQBQ0oRYAEoAdEwvwLgQL8gvyC/PkkJaCHwBAE8ShFgcEc4SQloIfAHAYkcNUoRYDdJCWhB8AQBNUoRYAEoAdEwvwLgQL8gvyC/MUkJaCHwBAEvShFgcEcqSABoIPAHAAAdKEkIYCpIAGhA8AQAKEkIYAC/AL8wv3BHcEdwR3BHcEcQtR5IEDgAaAD0gDAwsf/3GftP9IAwGUkQOQhgGEgQMABoAPAIACix//fp/wggE0kQMQhgEkgQMABoAPAQACix//fc/xAgDUkQMQhgDEgQMABoAPAgACix//fP/yAgB0kQMQhgBkgQMABoAPBAACix//fC/0AgAUkQMQhgEL0kBAFAAHAAQBAAAABAQg8AEO0A4BC1/EgAaEDwAQD6SQhgAvAi/gRGBuAC8B7+ABsCKAHZAyAQvfNIAGgA8AIAACjy0PBIAGgg8PAAQPBgAO1JCGAAIIhg7EjtSUlECGDsSEhEAGgC8BD+CLEBIOLnAvD7/QRGCOAC8Pf9ABtB8ogxiEIB2QMg1effSIBoAPAMAAAo8NHcSABo30kIQNpJCGAC8OL9BEYG4ALw3v0AGwIoAdkDIL7n00gAaADwKFAAKPLR0EnIYAhGwGhA9IBQyGAAIAhhCEYAaUD0gFAIYQAgSGEIRkBpQPSAUEhhCEYAaCD0gCAIYAAgiGFAHghiwUiUMABoQPQAAMH4lAAAIJHn8LUAIwAg3/jswtz4CMAM8AwB3/jgwtz4DMAM8AMHGbEMKR/RAS8d0d/4zMLc+ADADPAIDLzxAA8G0d/4uMLc+JTAzPMDIwXg3/iswtz4AMDM8wMT3/i0wvxEXPgjMEG5GEYG4AQpAdGpSALgCCkA0ahIDCky0d/4fMLc+AzADPADBAEsCdACLALQAywE0QHgn0oE4J9KAuAAvxpGAL8Av9/4VMLc+AzAzPMDHAzxAQbf+ETC3PgMwMzzBiwM+wL8vPv28t/4MMLc+AzAzPNBbAzxAQxP6kwFsvv18PC9+LUERgAmhEiAbQDwgFAYsf/36vkFRhbgAL9/SIBtQPCAUH1JiGUIRoBtAPCAUACQAL8Av//32PkFRndIgG0g8IBQdUmIZbX1AH8H0YAsDNmgLAHZAiYI4AEmBuCALAHTAiYC4HAsANEBJnNIAGgg8A8AMENwSQhgCEYAaADwDwCwQgHQASD4vQAg/Oct6fhFBEYUuQEgvej4hV9IgGgA8AwGXUjAaADwAwcgeADwEAAQKHrRHrEMLnnRAS930VZIAGgA8AIAGLGgaQi5ASDi51FIIWoAaADwCAAgsU5IAGgA8PAABeBMSJQwAGgA9HBgAAmBQh/ZIGr/94L/CLEBIMnnAL9ESABoQPAIAEJJCGAIRgBoIPDwACFqCEM+SQhgAL8IRkBoIPR/QOFpQOoBIDlJSGAf4AC/N0gAaEDwCAA1SQhgCEYAaCDw8AAhaghDMUkIYAC/CEZAaCD0f0DhaUDqASAsSUhgLrkgav/3SP8IsQEgj+f/99T+J0mJaMHzAxEuSnpEUVwB8B8ByEAkSUlECGAjSEhEAGgC8H78gEa48QAPY9BARnXnYOD/56BpgLMZSABoQPABABdJCGAC8Fz8BUYG4ALwWPxAGwIoAdkDIGDnEEgAaADwAgAAKPLQAL8NSABoQPAIAAtJCGAIRgBoIPDwACFqCEMHSQhgAL8IRkBoIPR/QOFpQOoBIAJJSGAs4BTgAAAAEAJAAAk9ABAAAAAIAAAA//T+6rJBAAAAJPQAABJ6AAAgAkCQPwAA/kgAaCDwAQD8SQhgAvAV/AVGBuAC8BH8QBsCKAHZAyAZ5/ZIAGgA8AIAACjy0SB4APABAAAoXNAILgPQDC4K0QMvCNHtSABoAPQAMIizYGh4uwEg/+YAv2BosPWAPwbR5kgAaED0gDDkSQhgGuBgaLD1oC8L0eFIAGhA9IAg30kIYAhGAGhA9IAwCGAK4NtIAGgg9IAw2UkIYAhGAGgg9IAgCGAAv2BokLEC8Mb7BUYH4B7gAvDB+0AbZCgB2QMgyebOSABoAPQAMAAo8tAQ4ALws/sFRgbgAvCv+0AbZCgB2QMgt+bFSABoAPQAMAAo8tEgeADwAgACKFLRBC4D0AwuFNECLxLRvEgAaAD0gGAYseBoCLkBIJ3muEhAaCDw/kAhfEDqAWC0SUhgOeDgaACzskgAaED0gHCwSQhgAvB8+wVGBuAC8Hj7QBsCKAHZAyCA5qlIAGgA9IBgACjy0KZIQGgg8P5AIXxA6gFgo0lIYBbgoUgAaCD0gHCfSQhgAvBb+wVGBuAC8Ff7QBsCKAHZAyBf5plIAGgA9IBgACjy0SB4APAIAAgoNtFgadCxkkiUMABoQPABAJBJwfiUAALwO/sFRgbgAvA3+0AbAigB2QMgP+aJSJQwAGgA8AIAACjx0BnghUiUMABoIPABAIJJwfiUAALwIPsFRgbgAvAc+0AbAigB2QMgJOZ7SJQwAGgA8AIAACjx0SB4APAEAAQocdFP8AAKdEiAbQDwgFB4uQC/cUiAbUDwgFBvSYhlCEaAbQDwgFAAkAC/AL9P8AEKa0gAaAD0gHCwuWhIAGhA9IBwZkkIYALw5/oFRgbgAvDj+kAbAigB2QMg6+VgSABoAPSAcAAo8tAAv6BoASgI0VpIkDAAaEDwAQBXScH4kAAh4KBoBSgP0VRIkDAAaEDwBABRScH4kAAIRtD4kABA8AEAwfiQAA7gTEiQMABoIPABAElJwfiQAAhG0PiQACDwBADB+JAAAL+gaKixAvCk+gVGCeAC8KD6QBtB8ogxiEIC2QMgpuUl4DxIkDAAaADwAgAAKO7QE+AC8I76BUYI4ALwivpAG0HyiDGIQgHZAyCQ5TFIkDAAaADwAgAAKO/RuvEBDwXRLEiAbSDwgFAqSYhlAL8geADwIAAgKDbRYGrQsSVImDAAaEDwAQAjScH4mAAC8GH6BUYG4ALwXfpAGwIoAdkDIGXlHEiYMABoAPACAAAo8dAZ4BhImDAAaCDwAQAVScH4mAAC8Eb6BUYG4ALwQvpAGwIoAdkDIErlDkiYMABoAPACAAAo8dGgagAofdCgagIoe9EISMdoB/ADAeBqgUIq0Qfw8AEga0AesesAHyPRB/T+QQPgABACQABwAEBga7HrAC8Y0QfweEE4IABdsevAbxHRB/TAAaCPASLC61AAsetAXwjRB/DAYUAgAF3C61AAsetAb2TQDC5g0P5IAGgA8IBgILn7SABoAPCAUAixASD95PhIAGgg8IBw9kkIYALw6PkFRgbgAvDk+UAbAigB2QMg7OTvSABoAPAAcAAo8tHU6QsQQB5B6gARYGtB6gAhoI8BIsLrUABB6kBRQCAAXcLrUABB6kBhOCAAXUHqwGDgSclo4EoRQAhD3knIYAhGAGhA8IBwAeBY4DvgCGAIRsBoQPCAcMhgAvCr+QVGBuAC8Kf5QBsCKAHZAyCv5NFIAGgA8ABwACjy0FDgASCm5MxIAGgA8ABwwLvKSABoQPCAcMhJCGAIRsBoQPCAcMhgAvCH+QVGBuAC8IP5QBsCKAHZAyCL5L9IAGgA8ABwACjy0CzgDC4o0LpIAGgg8IBwuEkIYAhGAGgA8CBQILkIRsBoIPADAMhgskjAaLNJCECwSchgAvBd+QVGB+AP4ALwWPlAGwIoAdkDIGDkqUgAaADwAHAAKPLRAeABIFfkACBV5HC1ACKjTvZoBvADBgEuEtGgTjZoBvAIBi65nU6UNjZoxvMDIgPgmk42aMbzAxKbTn5EVvgiIJZO9mgG8AMDASsJ0AIrAtADKwTRAeCVSQTglUkC4AC/EUYAvwC/jU72aMbzAxZ1HIpO9mjG8wYmTkO2+/Xxh072aMbzQWZ2HHQAsfv08HC9LenwQQRGDUYAJxS5ASC96PCBhEgAaADwDwCoQg7SgUgAaCDwDwAoQ35JCGAIRgBoAPAPAKhCAdABIOjnIHgA8AEAAChz0GBoAygr0W9IAGgA8ABwCLkBINnn//eO/3JJiEJH2WlIgGgA8PAASLlnSIBoIPDwAEDwgABkSYhggCc44CB4APACAAIoM9GgaIi7XkiAaCDw8ABA8IAAW0mIYIAnJ+BgaAIoBtFYSABoAPQAMIi5ASCq52BoMLlTSABoAPACAEC5ASCh51BIAGgA9IBgCLkBIJrn//fr+lJJiEII2UpIgGgg8PAAQPCAAEdJiGCAJ0VIgGgg8AMAYWgIQ0JJiGAC8IH4BkYI4ALwffiAG0HyiDGIQgHZAyB35ztIgGgA8AwAYWiw64EP7tEgeADwAgACKAjRNEiAaCDw8AChaAhDMUmIYAfggC8F0S9IgGgg8PAALUmIYDJIAGgA8A8AqEIO2S9IAGgg8A8AKEMsSQhgCEYAaADwDwCoQgHQASBE5yB4APAEAAQoB9EfSIBoIPTgYOFoCEMcSYhgIHgA8AgACCgI0RhIgGgg9GBQIWlA6sEAFUmIYP/3evoTSYlowfMDERlKekRRXAHwHwHIQBdJSUQIYBZISEQAaALwJPiARkBGEudwtYawBkYNRhRGAL8FSMBsQPABAANJyGQIRsBsAPABAACQFeAAEAJADICdAf//7v4SOQAAACT0AAASegAAIAJAALTEBNw2AAAQAAAACAAAAAC/AL+IFQGQAiACkASQACADkAWQAalP8JBA/PeT/n1IgGgg8P5AReoEAQhDeUmIYAawcL14SEhEAGhwRwC1//f5/3RJiWjB8wIhdEp6RFFcAfAfAchAAL0Atf/36/9tSYlowfPCIW1KekQcOlFcAfAfAchAAL0/IQFgZkkJaAH0gCGx9YAvA9FP9KAhQWAM4GBJCWgB9IAxsfWAPwPRT/SAMUFgAeAAIUFgWkkJaAHwAQERsQEhgWEB4AAhgWFVSUlowfMHIcFhUkkJaAHw8AEBYlBJCWgB9IBxsfWAfwPRT/SAccFgAeAAIcFgSUlJaMHzBmEBYUdJkDEJaAHwBAEEKQLRBSGBYArgQkmQMQloAfABARGxASGBYAHgACGBYDxJlDEJaAHwAQERsQEhQWEB4AAhQWE3SZgxCWgB8AEBEbEBIUFiAeAAIUFiMUkJaAHwgHGx8YB/AtECIYFiAeABIYFiK0nJaAHwAwLCYilJyWjB8wMRSRwBYyZJyWjB8wYiQmMjSclowfNBUUkcSgDCYyBJyWjB80FhSRxKAAJkHEnJaMoOgmNwRw8iAmAZSpJoAvADAkJgFkqSaALw8AKCYBRKkmgC9OBiwmARSpJoAvRgUtIIAmERShJoAvAPAgpgcEcLSABoQPQAIAlJCGBwR3BHELUHSMBpAPSAcLD1gH8F0f/39f9P9IBwAUkIYhC9AAAAEAJAEAAAADA2AAAAIAJALenwQQRGD0YAJf5IwGgA8AMAULH7SMBoAPADACFoiEIB0SBoeLsBJS3gIGgBKATQAigJ0AMoGtEN4PJIAGgA8AIAALkBJRTg7kgAaAD0gGAAuQElDeDrSABoAPQAMCi56EgAaAD0gCAAuQElAeABJQC/AL89ueNIwGgg8AMAIWgIQ+BJyGAALXPR3kgAaCDwgFDcSQhgAfCK/gZGBuAB8Ib+gBsCKAHZAyUF4NVIAGgA8ABQACjy0QC/AC1Z0Ye5oGgAAiF7QOrBYWBoQB5B6gAQzElJacxKEUAIQ8lJSGEo4AEvE9GgaAACIYoBIsLrUQFA6kFRYGhAHkHqABDBSUlpwkoRQAhDvklIYRLgoGgAAiF9ASLC61EBQOpBYWBoQB5B6gAQt0lJablKEUAIQ7RJSGGzSABoQPCAULFJCGAB8DX+BkYG4AHwMf6AGwIoAdkDJQXgq0gAaADwAFAAKPLQAL8tuadIQGmhaQhDpUlIYShGvejwgS3p8EEERg9GACWgSMBoAPADAFCxnUjAaADwAwAhaIhCAdEgaHi7ASUt4CBoASgE0AIoCdADKBrRDeCUSABoAPACAAC5ASUU4JBIAGgA9IBgALkBJQ3gjUgAaAD0ADAouYpIAGgA9IAgALkBJQHgASUAvwC/PbmFSMBoIPADACFoCEOCSchgAC1z0YBIAGgg8IBgfkkIYAHwzv0GRgbgAfDK/YAbAigB2QMlBeB3SABoAPAAYAAo8tEAvwAtWdGHuaBoAAIhe0DqwWFgaEAeQeoAEG5JCWluShFACENrSQhhKOABLxPRoGgAAiGKASLC61EBQOpBUWBoQB5B6gAQY0kJaWRKEUAIQ2BJCGES4KBoAAIhfQEiwutRAUDqQWFgaEAeQeoAEFlJCWlbShFACENWSQhhVUgAaEDwgGBTSQhgAfB5/QZGBuAB8HX9gBsCKAHZAyUF4E1IAGgA8ABgACjy0AC/LblJSABpoWkIQ0dJCGEoRr3o8IEt6fhFBEYAJahGIIgA9ABgsPUAbzLR4G5AKAnQA9xwsSAoG9ER4GAoFtCAKBbRFOA4SMBoQPSAMDZJyGAQ4AAhIB3/9yH/BUYK4AAhBPEgAP/3Xv4FRgPgAL8B4AElAL8Av1W5K0icMABoIPDgAOFuCEMoScH4nAAA4KhGIIgA9IBQsPWAXzbRIG+w9QB/DNAE3IixsPWAfx3RE+Cw9UB/F9Cw9YBvFtEU4BpIwGhA9IAwGEnIYBDgACEgHf/35P4FRgrgACEE8SAA//ch/gVGA+AAvwHgASUAvwC/VbkNSJwwAGgg9OBgIW8IQwlJwficAADgqEYgaAD0ADCw9QA/a9FP8AAKA0iAbQEhIeoQcMCxB+AAEAJAD4D/Bw+An/8PgP/5AL/+SIBtQPCAUPxJiGUIRoBtAPCAUACQAL8Av0/wAQr3SABoQPSAcPVJCGAB8LX8B0YG4AHwsfzAGwIoAdkDJQXg70gAaAD0gHAAKPLQAL+Fu+pIkDAAaAD0QHbWsdT4mACwQhbQ5UiQMABoIPRAduJI0PiQAED0gDDgScH4kAAIRtD4kAAg9IAwwfiQAAhGwPiQYAbwAQCwsQHwfvwHRgrgAfB6/MAbQfKIMYhCA9kDJQjgF+Ah4NBIkDAAaADwAgAAKO3QAL9ducxIkDAAaCD0QHDU+JgQCEPIScH4kAAC4KhGAOCoRrrxAQ8F0cNIgG0g8IBQwUmIZQC/IHgA8AEASLG9SIgwAGgg8AMA4WsIQ7pJwfiIACB4APACAAIoCdG2SIgwAGgg8AwAIWwIQ7JJwfiIACB4APAEAAQoCdGuSIgwAGgg8DAAYWwIQ6tJwfiIACB4APAIAAgoCdGnSIgwAGgg8MAAoWwIQ6NJwfiIACB4APAQABAoCdGfSIgwAGgg9EBw4WwIQ5xJwfiIACB4APAgACAoCdGYSIgwAGgg9EBgIW0IQ5RJwfiIACCIAPQAcLD1AH8J0ZBIiDAAaCD0QCBhbghDjEnB+IgAIIgA9IBgsPWAbwnRiEiIMABoIPRAEKFuCEOEScH4iAAgeADwQABAKAnRgEiIMABoIPRAUGFtCEN9ScH4iAAgeADwgACAKAnReUiIMABoIPRAQKFtCEN1ScH4iAAgiAD0gHCw9YB/CdFxSIgwAGgg9EAw4W0IQ21JwfiIACBoAPSAELD1gB8J0WlInDAAaCDwAwAhbghDZUnB+JwAIIgA9ABQsPUAXx/RYUiIMABoIPBAYGFvCENdSYgxCGBgb7DxAG8G0VpIwGhA9IAQWEnIYArgYG+w8YBvBtEBISAd//da/QVGBbGoRiBoAPQAILD1AC9B0QC/oG+w9YBPCNFLSJwwAGhA9IBASUnB+JwAEeBHSJwwAGgg9IBAREnB+JwAQ0iIMABoIPBAYKFvCEM/ScH4iAAAv6BvsPEAbwbRO0jAaED0gBA5SchgFeCgb7D1gE8G0TZIwGhA9IAwNEnIYArgoG+w8YBvBtEBISAd//cS/QVGBbGoRiBoAPSAILD1gC8f0SpIiDAAaCDwQGDhbwhDJkmIMQhg4G+w8QBvBtEjSMBoQPSAECFJyGAK4OBvsPGAbwbRASEgHf/37PwFRgWxqEYgiAD0gECw9YBPFtEXSIgwAGgg8EBQ1PiAEAhDE0mIMQhg1PiAALDxgF8G0QIhIB3/98/8BUYFsahGIGgA9IAwsPWAPwrRCEicMABoIPAEANT4hBAIQwRJwficACBoAPQAELD1AB8P0QPgABACQABwAED+SJwwAGgg8BgA1PiIEAhD+knB+JwAIGgA9IAAsPWADyvR9kgAaCDwgFD0SQhgAfCy+gdGBuAB8K76wBsCKAHZAyUF4O1IAGgA8ABQACjy0QC/hbnpSJwwAGgg9EAw1PiMEAhD5UnB+JwAAiEE8SAA//e6+wVGBbGoRiBoAPQAALD1AA8X0d1InDAAaCD0gFDU+JAQCEPZSZwxCGDU+JAAsPWAXwfRASEE8SAA//ec+wVGBbGoRiBoAPCAcLDxgH8V0c5InDAAaCD0QBDU+JQQCEPKSZwxCGDU+JQAsPUAHwXRxkjAaED0gBDESchgQEa96PiFwkkBYMBJyWgB8AMBQWC+SQlpwfMDEUkcgWC7SQlpwfMGIsJguEkJacHzQEEHIgLrARICYbRJCWnB80FRSRxKAEJhsUkJacHzQWFJHEoAgmFBaAFirElJacHzAxFJHEFiqUlJacHzBiKCYqdJSWnB80BBByIC6wESwmKjSUlpwfNBUUkcSgACY59JSWnB80FhSRxKAEJjnEmIMQloAfADAcFjmUmIMQloAfAMAQFklkmIMQloAfAwAUFkk0mIMQloAfDAAYFkkEmIMQloAfRAccFkjUmIMQloAfRAYQFlikmIMQloAfRAUUFlh0mIMQloAfRAQYFlhEmIMQloAfRAMcFlgUmcMQloAfADAQFmfkmIMQloAfRAIUFme0mIMQloAfRAEYFmeEmcMQloAfDgAcFmdUmcMQloAfTgYQFnckmQMQloAfRAccD4mBBuSYgxCWgB8EBhQWdrSZwxCWgB9IBBEbFP9IBBBOBnSYgxCWgB8EBhQPh4H2NJ0fiIEAHwQGFBYGBJ0fiIEAHwQFGBYF1J0ficEAHwBAHBYFpJ0ficEAHwGAEBYVdJ0ficEAH0QDFBYVRJ0ficEAH0gFGBYVFJ0ficEAH0QBHBYXg4cEfwtQVGDkYAIAAhACS19QBvCdFJT5w3P2gH8OABYCkP0Uv2gDAM4LX1gF8J0UJPnDc/aAf04GGx9UB/AdFL9oAwACgt0TJGQCkC0LH1AH8o0TlPP2gH8AB3t/EAf/HRNk//aAf0gDcALxrQM0//aMfzAxd/HLL79/IvT/9ox/MGIy1P/2j8Djy5K0//aAf0ADcPsREkAOAHJAL7A/e3+/TwauBBuyRPP2gH8ABnt/EAb2LRIU8/aQf0gDcAL1zQHk8/acfzAxd/HLL79/IaTz9px/MGIxhPP2n8Djy5Fk8/aQf0ADcPsREkAOAHJAL7A/e3+/TwQOCAKQLQsfWAbwjRDU8/aAf0gGe39YBvNNEMSDLgICkC0LH1gH8t0QZPP2gH8ABXt/EAXybRA09/aQf0gDcPswBPBeAAEAJA/3//AQAk9AB/acfzAxd/HLL79/L8T39px/MGI/pPf2n8Djy5+E9/aQf0ADcPsREkAOAHJAL7A/e3+/Tw8L0t6fBNB0ZP8AALt/UAPy7R7kiQMABoAPRAdLT1gH8G0LT1AH8N0LT1QH8e0RPg5kiQMABoAPACAAIoAdFP9ABLFODhSJQwAGgA8AIAAigB0U/0+ksK4NxIAGgA9AAwsPUAPwHR3/hoswDgAL/z49ZIwGgA8AMKuvEBDwbQuvECDyHQuvEDDzTRKODPSABoAPACAAIoFdHMSABoAPAIACCxykgAaADw8AAF4MdIlDAAaAD0cGAACQAJxkl5RFH4IFAA4AAlF+DASABoAPSAYLD1gG8B0cBNAOAAJQzgu0gAaAD0ADCw9QA/AdG7TQDgACUB4AAlAL8Av7f1gG940BrcIC920AzcBC900ATcAS9y0AIvcdHH4Qgvb9AQL/nRRuJAL2vQgC9r0Lf1gH9p0Lf1AH/u0aXjt/WALy7QEdy39QBfKdAG3Lf1AG8X0Lf1gF/f0Rrgt/WAT3jQt/WAP9jRt+K39QAvctC39YAfcNC39QAfbtC38YB/y9Hs4ylGT/QAYP/3gP6DRhDiKUZP9IBQ//d5/oNG9+cAv4tIiDAAaADwQGRcs7TxgG9T0LTxAG8o0LTxQG980YRIAGgA8AIAAigU0YFIAGgA8AgAILF+SABoAPDwAAXgfEiUMABoAPRwYAAJAAl9SXlEUfggsGHgfOML4oPhKuH846zhsuJO4NLi++JxSABoAPAAcLDxAH8b0W1IwGgA9IAQsPWAHxTRakjAaMDzBiYF+wbwZ0nJaMHzAxFJHLD78fVjSMBowPNBUEAcQAC1+/D7M+AN4jPg9uJM4l1IAGgA8ABgsPEAbxvRWUgAaQD0gBCw9YAfFNFWSABpwPMGJgX7BvBTSQlpwfMDEUkcsPvx9U9IAGnA80FQQBxAALX78PsL4AngSkiYMABoAPACAAIoAdHf+DSxAOAAvwC/peNESJwwAGgA9IBAsPWATy7RQEgAaADwAHCw8QB/JtE8SMBoAPSAMLD1gD8f0TlIwGjA8wYmBfsG8DZJyWjB8wMRSRyw+/H1MkjAaE/q0Gi48QAPCdEvSMBoAPQAMBCxT/ARCAHgT/AHCLX7+PuS4ChIiDAAaADwQGTss7TxgG9Y0LTxAG8e0LTxQG920SFIAGgA8AIAAigU0R5IAGgA8AgAILEbSABoAPDwAAXgGUiUMABoAPRwYAAJAAkcSXlEUfggsGbgE0gAaADwAHCw8QB/HdEPSMBoAPSAELD1gB8W0QxIwGjA8wYmBfsG8AlJyWjB8wMRAOBB4EkcsPvx9QRIwGjA80FQQBxAALX78PtA4AAAABACQJDQAwBQJwAAACT0AAASegAiJgAAAGzcApYkAAD3SABoAPAAYLDxAG8b0fRIAGkA9IAQsPWAHxTR8EgAacDzBiYF+wbw7UkJacHzAxFJHLD78fXqSABpwPNBUEAcQAC1+/D7C+AJ4OVImDAAaADwAgACKAHR3/iIswDgAL8Av9ri3kiIMABoAPADBDSxASwI0AIsCtADLBzREeD+97n+g0YY4P73xviDRhTg1EgAaAD0gGCw9YBvAdHf+EizCuDPSJAwAGgA8AIAAigB0U/0AEsA4AC/AL+u4shIiDAAaADwDAQ0sQQsCNAILArQDCwc0RHg/vd//oNGGOD+95r4g0YU4L5IAGgA9IBgsPWAbwHR3/jwsgrguUiQMABoAPACAAIoAdFP9ABLAOAAvwC/guKySIgwAGgA8DAENLEQLAjQICwK0DAsHNER4P73U/6DRhjg/vdu+INGFOCoSABoAPSAYLD1gG8B0d/4mLIK4KNIkDAAaADwAgACKAHRT/QASwDgAL8Av1binEiIMABoAPDABDSxQCwI0IAsCtDALBzREeD+9yf+g0YY4P73QviDRhTgkkgAaAD0gGCw9YBvAdHf+ECyCuCNSJAwAGgA8AIAAigB0U/0AEsA4AC/AL8q4oZIiDAAaAD0QHRMsbT1gH8K0LT1AH8L0LT1QH8c0RHg/vf4/YNGGOD+9xP4g0YU4HpIAGgA9IBgsPWAbwHR3/jksQrgdUiQMABoAPACAAIoAdFP9ABLAOAAvwC/++FvSIgwAGgA9EBkTLG09YBvCtC09QBvC9C09UBvHNER4P73yf2DRhjg/ffk/4NGFOBjSABoAPSAYLD1gG8B0d/4hLEK4F5IkDAAaADwAgACKAHRT/QASwDgAL8Av8zhV0iIMABoAPBAVLTxgF8G0LTxQF8l0f33vv+DRiLgUEgAaADwAGCw8QBvGdFMSABpAPCAcKCxSkgAacDzBiYF+wbwR0kJacHzAxFJHLD78fVDSABpwPNBYEAcQAC1+/D7AOAAvwC/mOE9SJwwAGgA8AQEHLn+9379g0YC4P33i/+DRorhNkicMABoAPAYBCSxCCwl0BAsLdEG4ClGT/QAYP/3vPuDRibgLUgAaADwAgACKBTRKkgAaADwCAAgsShIAGgA8PAABeAlSJQwAGgA9HBgAAkACSVJeURR+CCwCuAfSABoAPSAYLD1gG8B0d/4eLAA4AC/AL9P4RlIiDAAaAD0QFQ0sbT1gF8H0LT1AF8S0Qfg/vcg/YNGDuD99zv/g0YK4A5IAGgA9IBgsPWAbwHR3/g0sADgAL8Avy3hCEiIMABoAPRARDSxtPWATw/QtPUATxrRD+D+9/78g0YW4AAQAkAAbNwCACT0AMggAAD99xH/g0YK4PdIAGgA9IBgsPWAbwHR3/jUswDgAL8AvwPh8UiIMABoAPRANDSxtPWAPwfQtPUAPxLRB+D+99T8g0YO4P337/6DRgrg5kgAaAD0gGCw9YBvAdHf+JCzAOAAvwC/4eDgSJwwAGgA8AMELLEBLAfQAiwT0Qjg1uD+97P8g0YO4P33zv6DRgrg1kgAaAD0gGCw9YBvAdHf+EyzAOAAvwC/wODPSIgwAGgA9EAkTLG09YAvCtC09QAvEdC09UAvItEX4P73jvyDRh7gxUiUMABoAPACAAIoAdFP9PpLFODASABoAPSAYLD1gG8B0d/4+LIK4LtIkDAAaADwAgACKAHRT/QASwDgAL8Av4vgtUiIMABoAPRAFEyxtPWAHwrQtPUAHxHQtPVAHyLRF+D+91n8g0Ye4KtIlDAAaADwAgACKAHRT/T6SxTgpkgAaAD0gGCw9YBvAdHf+IyyCuChSJAwAGgA8AIAAigB0U/0AEsA4AC/AL9W4JpInDAAaAD0QBQ0sbT1gB8H0LT1AB9G0R/g/fdG/oNGQuCSSABoAPACAAIoFNGPSABoAPAIACCxjEgAaADw8AAF4IpIlDAAaAD0cGAACQAJiEl5RFH4ILAm4IRIAGgA8ABwsPEAfx3RgEjAaAD0gBCw9YAfFtF9SMBowPMGJgX7BvB6SclowfMDEUkcsPvx9XZIwGjA80FQQBxAAADgBeC1+/D7AOAAvwC/AOAAvwC/WEa96PCNcLUERgAma0gAaCDwgGBpSQhgAPCb+wVGBuAA8Jf7QBsCKAHZAyYF4GNIAGgA8ABgACjy0QC/hrtgaEAeAAGhaEDqASAhigEiwutRAUDqQVAhfcLrUQFA6kFgIXtA6sFgVUkJaVdKEUAIQ1JJCGEIRgBpoWkIQ09JCGEIRgBoQPCAYAhgAPBi+wVGB+AA8F77QBsCKALZAyYG4AbgRkgAaADwAGAAKPHQAL8wRnC9cLUAJUBIAGgg8IBgPkkIYADwRfsERgbgAPBB+wAbAigB2QMlBeA4SABoAPAAYAAo8tEAvzRIAGk3SQhAMkkIYQhGAGgA8AhQILkIRsBoIPADAMhgKEZwvXC1BEYAJipIAGgg8IBQKEkIYADwGPsFRgbgAPAU+0AbAigB2QMmBeAhSABoAPAAUAAo8tEAv4a7YGhAHgABoWhA6gEgIYoBIsLrUQFA6kFQIX3C61EBQOpBYCF7QOrBYBNJSWkVShFACEMRSUhhCEZAaaFpCEMOSUhhCEYAaEDwgFAIYADw3/oFRgfgAPDb+kAbAigC2QMmBuAG4ARIAGgA8ABQACjx0AC/MEZwvQAAABACQAAk9ABiHgAAD4CdAf//7v5wtQAl90gAaCDwgFD1SQhgAPC3+gRGBuAA8LP6ABsCKAHZAyUF4O9IAGgA8ABQACjy0QC/60hAaetJCEDpSUhhCEYAaADwIGAguQhGwGgg8AMAyGAoRnC94kmJaCH0AEEBQ+BKkWBwR95JlDEJaCH0cGFB6gAR20rC+JQQcEfZSJAwAGhA8CAA1knB+JAAcEfUSJAwAGgg8CAA0knB+JAACEaAaSD0AHCIYXBHzUiQMABoQPAgAMtJwfiQAAhGgGlA9ABwiGHJSABoQPQAIMdJCGDGSAgwAGhA9AAgw0kIMQhgcEdwRxC1vkjAaQD0AHCw9QB/BdH/9/X/T/QAcLlJCGIQvXC1hrAERgAlACYAv7RIwGxA8AEAsknIZAhGwGwA8AEAAJAAvwC/BCABkAMgApACIASQACADkAGpT/CQQPv32PinSIBtAPCAUHC5AL+kSIBtQPCAUKJJiGUIRoBtAPCAUACQAL8AvwEloEgAaAD0gHAQufz3xf0BJplIkDAAaCDwQHBE8IBxCEOVScH4kAABLgHR/Pe8/QEtBdGRSIBtIPCAUI9JiGUGsHC9OLUAJAAli0iAbQDwgFBwuQC/iEiAbUDwgFCGSYhlCEaAbQDwgFAAkAC/AL8BJIRIAGgA9IBwELn89439ASV9SJAwAGgg8IBwe0nB+JAAAS0B0fz3h/0BLAXRdkiAbSDwgFB0SYhlOL1zSABoQPAEAHFJCGBwR29IAGgg8AQAbUkIYHBHbEqkMhJoIvD/AkDqARMaQ2hLw/ikIHBHZkqSa0LwgHJkS5pjGkaSayLwgHKaY9DpACMaQ4NoQuoDAcJoEUMCikHqAkFfSlFgEmgi9HxSQ2lC6gMiW0saYBpGEmhC8GACGmBwR1dIAGhA8IAAVUkIYHBHU0lJaImyAWBRSQlowfMFIUFgT0mJaAkMgWBNSYloAfQAQcFgcEdwtQVGACQA8Ff5BkYAv2gcMLEA8FH5gBuoQgDYBbkBJEJIgGgA8AEAMLFE8AIEAL8BID1JyGAAvzxIgGgA8AIAAigF0UTwBAQAvzdJyGAAvzZIgGgA9IBgsPWAbwbRRPAgBAC/BCAwSchgAL8vSIBoAPSAcLD1gH8G0UTwCAQAvwQgKUnIYAC/KEiAaAD0AHCw9QB/BtFE8BAEAL8EICJJyGAAvyFIgGgA8AgACCgD0QC/HUnIYAC/ACyo0CBGcL1wR3BHcEdwR3C1ACUXSIRoBmgE8AEAQLEG8AEAKLEBIBJJyGD/9+//POAE8AIAQLEG8AIAKLECIAxJyGD/9+L/MOAE8AgAkLEG8AgAeLEIIAZJyGD/99X/JOAAEAJA///u/gAEAUAAcABAAGAAQATwBAC4sQbwBACgsQT0gHAIsUXwCAUE9ABwCLFF8BAFBPSAYAixRfAgBQQgAknIYChG//eu/3C9AGAAQEZIAGhA8AEAREkIYAAgiGAIRgBoQkkIQEBJCGCIFMhgCEYAaCD0gCAIYAAgiGHIAzxJCGBwR/C1ACMAIAAiAiQAJQIhNU42aAbwCAYuuTNOlDY2aMbzAyAD4DBONmjG8wMQMU5+RFb4IAAsTrZoBvAMBjaxBC4I0AguC9AMLjnRDeAqTk5EMGA44ClOJ09PRD5gM+AnTiVPT0Q+YC7gH072aAbwAwUdTvZoxvMDFnEcAi0C0AMtCNED4B1Otvvx8gbgHE62+/HyAuCw+/HyAL8AvxJO9mjG8wYmckMPTvZoxvNBZnYcdACy+/T2D09PRD5gA+ANTk5EMGAAvwC/B062aMbzAxYMT39Eu10HTk5ENmjeQAVPT0Q+YPC9ABACQP//9uoI7QDgnBcAABAAAAAAJPQAABJ6AOAWAAABRgAgAL8A4EAcsPWAX/vbcEcAIQDgSRyx9YBv+9tcSEhEAGhAHFpKSkQQYBBGAGhwRwFGACBwRwC1l7AUIRKoAfAO+0QhAagB8Ar7AL9RSIBtQPCAUE9JiGUIRoBtAPCAUACQAL8AvwAg/Peg/ElIgG0g8IBQR0mIZRAgAZABIAeQACAIkAIgC5ABIQyRYCAJkA2RPCEOkQIhEZEQkQchD5EBqP33vvoIsQC//ucPIBKQAyATkIAgFJAAIBWQFpADIRKo/feg/gixAL/+5wIgEpAAIBSQBSESqP33lf4IsQC//ucXsAC9ELUAJP/36v769zr7//eg/wDwxv8A8Dj/CLEAIBC9AfCy+QRGDLkBIPjnACD25xC1APC2/wDwKP8B8Pz4AL8B8Cr5ACj70RC9cLUERg1GFkYA8Kb/JPBwRADwFv8qRiFGMEYB8A/4ASBwvXC1BEYNRiTwcEQl8HBFoLIkGgDwkP8A8AL/CuAmRjBGAfBh+AC/AfAB+QAo+9EE9YA0pULy0gHwcfkBIHC9BAAAAAAQAkABeUoe+EsD64ICQmX2SkAygmVKHgLwAwMBIppAwmVwR/JLAmiaQgbSQmySCPBLA+uCAoJkBuBCbJII7UscMwPrggKCZAJ4CDoUI7L78/HmSoA6wmQB8B8DASKaQAJlcEdwtQRGDLkBIHC94EkgaIhCC9LgSSBoQBoUIbD78fCAAGBk3EgIOCBkCuDYSSBoQBoUIbD78fCAAGBk1EgIOCBkAiCE+CUAIGgFaEf28HCFQ9TpAgEIQyFpCENhaQhDoWkIQ+FpCEMhaghDBUMgaAVgIEb/96X/oGiw9YBPAdEAIGBgIHmhbAhg1OkTEEhgYGhgsWBoBCgJ2CBG//eB/wAgYW0IYNTpFhBIYAPgACBgZaBl4GUAIOBjASCE+CUAACCE+CQAAL+f5xC1BEYMuQEgEL0gaABoIPABACFoCGCrSSBoiEIL0qtJIGhAGhQhsPvx8IAAYGSnSAg4IGQK4KNJIGhAGhQhsPvx8IAAYGSfSAg4IGQAICFoCGCU+EQAAPAcAQEgiEAhbEhgIEb/90j/ACChbAhg1OkTEEhgYGhYsWBoBCgI2CBG//cq/wAgYW0IYNTpFhBIYAAgYGWgZeBl4GIgY2BjoGPgY4T4JQAAv4T4JAAAvwC/qucwtdDpE1RsYERtFLHQ6RZUbGCQ+ERABPAcBQEkrEAFbGxgBGhjYIRoECwE0QRoomAEaOFgA+AEaKFgBGjiYDC9LenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKBfRAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//e3/yBoAGhA8AEAIWgIYAbgAL8AIIT4JAAAv0/wAghARtTnLenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKD/RAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//d+/yBrMLEgaABoQPAOACFoCGAL4CBoAGgg8AQAIWgIYCBoAGhA8AoAIWgIYKBsAGgA9IAwKLGgbABoQPSAcKFsCGBgbSixYG0AaED0gHBhbQhgIGgAaEDwAQAhaAhgBuAAvwAghPgkAAC/T/ACCEBGrOcBRgAikfglAAIoCNAEIMhjAL8AIIH4JAAAvwEgcEcIaABoIPAOAAtoGGCIbABoIPSAcItsGGAIaABoIPABAAtoGGCR+EQAAPAcAwEgmEALbFhg0ekTMFhgSG1AsUhtAGgg9IBwS20YYNHpFjBYYAEggfglAAC/ACCB+CQAAL8QRszncLUERgAllPglAAIoDNAEIOBjASU94AAAAAkCQAgEAkAACAJACAACQCBoAGgg8A4AIWgIYCBoAGgg8AEAIWgIYKBsAGgg9IBwoWwIYJT4RAAA8BwBASCIQCFsSGDU6RMQSGBgbUCxYG0AaCD0gHBhbQhg1OkWEEhgASCE+CUAAL8AIIT4JAAAv6BrELEgRqFriEcoRnC9LenwQQRGDkYVRpT4JQACKAnQBCDgYwC/ACCE+CQAAL8BIL3o8IEgaABoAPAgACCxT/SAcOBjASDz5z65lPhEAADwHAECIAD6AfgG4JT4RAAA8BwBBCAA+gH4//fb/AdGMOAgbABolPhEEAHwHAIIIZFACECQsZT4RAAA8BwBASCIQCFsSGABIOBjhPglAAC/ACCE+CQAAL8BIMLnaByIsf/3uPzAG6hCANhduSAg4GMBIIT4JQAAvwAghPgkAAC/ASCu5yBsAGgA6ggAACjI0GBtiLGgbQBo4W0IQGCxYG0AaED0gHBhbQhg1OkWEEhg4GtA9IBg4GPgbABoIW0IQDCx1OkTEEhg4GtA9ABw4GOGuZT4RAAA8BwBAiCIQCFsSGAAvwAghPgkAAC/ASCE+CUAB+CU+EQAAPAcAQQgiEAhbEhgACBs53C1BEYgbAVoIGgGaJT4RAAA8BwBBCCIQChA4LEG8AQAyLEgaABoAPAgACi5IGgAaCDwBAAhaAhglPhEAADwHAEEIIhAIWxIYCBrAChW0CBGIWuIR1LglPhEAADwHAECIIhAKEAYswbwAgAAsyBoAGgA8CAAQLkgaABoIPAKACFoCGABIIT4JQCU+EQAAPAcAQIgiEAhbEhgAL8AIIT4JAAAv+BqULMgRuFqiEcm4JT4RAAA8BwBCCCIQChA8LEG8AgA2LEgaABoIPAOACFoCGCU+EQAAPAcAQEgiEAhbEhgASDgY4T4JQAAvwAghPgkAAC/YGsQsSBGYWuIR3C9ELUDRgAkAL+T+CQAASgB0QIgEL0BIIP4JAAAv5P4JQABKBLRMbEBKQbQAikG0AMpCNEF4NpiB+AaYwXgWmMD4JpjAeABJAC/AOABJAC/ACCD+CQAAL8gRtvnAkYAIwC/kvgkAAEoAdECIHBHASCC+CQAAL+S+CUAASgb0QUpFtLf6AHwAwYJDA8AACDQYhDgACAQYw3gACBQYwrgACCQYwfgACDQYhBjUGOQYwHgASMAvwDgASMAvwAggvgkAAC/GEbS5wFGkfglAHBHAUbIa3BHAAAQtZqwBEYAIAaQB5BA8vlgCJAEIAmQECAKkAAgDZARkBSQF5AYkBmQCCALkEHyiDIGqftISET69/D+ELEBIBqwEL0CIAGQApAAIAOQECAFkIAEBJBA8vpQCJAAIAyQT/SAYA2QT/RAUA6QT/CAYBSQAiAVkIACD5AABBaQgAAYkAQgF5AAv0HyiDIGqeRISET698P+CLEBINHnQfKIMmlG30hIRPv3LvgIsQEgx+ed+AAAApkIQAGZiELk0QAgvucwtZuwBEYNRgAgB5AIkEDy+lAJkAQgCpAQIAuQACANkE/0gGAOkE/0QFAPkAAgEpBP8IBgFZACIBaQBiAYkAAgGpAIIAyQAAIQkAAEF5CAABmQACACkAEgA5AAIASQECAGkIAEBZAAv0HyiDIHqbxISET693L+ELEBIBuwML1B8ogyAam2SEhE+vfc/wixASDz5534BAADmQhAApmIQuPRACDq5zC1m7AFRgxGACAHkAiQDJBP9EBQD5AAIBCQEpAXkBmQGpAEkBAgBpCABAWQASxu0QYgCZABIAqQACALkA6QFZAYkEHyiDIHqZxISET69zP+ELEBIBuwML0CIAKQA5AFIAmQT/CAcBWQASAWkEHyiDIHqZJISET69x7+CLEBIOnnQfKIMgKpjUhIRPv3I/oIsQEg3+dyIAmQT/RAcA2QT/SAcA6QByCN+AQAQfKIMgepgkhIRPr3//0IsQEgyudB8ogyAal9SEhE+vcc/wixASDA5wYgCZAAIA6QFZBB8ogyB6l2SEhE+vfm/QixASCx5wUgCZBP8IBwFZBB8ogyB6luSEhE+vfX/RCxASCi52TgQfKIMgKpaUhIRPv32/kIsQEgl+dyIAmQACANkE/0gHAOkAIgjfgEAEHyiDIHqV9ISET697j9CLEBIIPnQfKIMgGpWkhIRPr31f4IsQEgeedB8ogxVUhIRP/3+P4IsQEgcOdH8o4QCZAEIAqQECALkIABDpAABBWQBiAYkAIgFpAAII34BAAIIAyQAAIQkAAEF5CAABmQQfKIMgepQ0hIRPr3gf0IsQEgTOdB8ogyAak+SEhE+vfs/gixASBC5534BAACKHHQASA85zhISET/913+CLEBIDXnR/KNIAmQBCAKkBAgC5AAIA2QT/SAYA6QAAQVkAIgFpAAIBiQjfgEAI34BQAIIAyQAAIQkAAEF5BB8ogyB6klSEhE+vdE/QixASAP50HyiDIBqSBISET692H+CLEBIAXnBSAJkAEgCpAAIAuQDpBP8IBwFZABIBaQACAYkAyQEJAXkAKQASADkEHyiDIHqRFISET69xz9CLEBIOfmQfKIMgKpDEhIRPv3IfkIsQEg3eZxIAmQACANkE/0gHAOkEHyiDIHqQNISET69wH9ILEBIMzmEOAUAAAAQfKIMgGp/EhIRPr3af4IsQEgv+ad+AQACLEBILrmACC45hC1mrAERgAgBpAHkGYgCJABIAmQACAKkAuQDZARkBSQF5AYkBmQQfKIMgap6khIRPr30PwQsQEgGrAQvZkgCJBB8ogyBqnjSEhE+vfD/AixASDx5wUgCJBP8IBwFJABIBWQACAWkAGQASACkAAgA5AQIAWQgAQEkEHyiDIGqdVISET696f8CLEBINXnQfKIMgGp0EhIRPv3rPgIsQEgy+cAIMnnALWHsAC/y0jAbED0gBDJSchkCEbAbAD0gBABkAC/AL8AvwhGAG1A9IBwCGUIRgBtAPSAcAGQAL8AvwhGAGtA9IBwCGMIRgBrIPSAcAhjAL8IRoBtQPCAUIhlCEaAbQDwgFABkAC/AL+0SEBoQPQAcLJJSGAAv69IwGxA8AEArUnIZAhGwGwA8AEAAZAAvwC/AL8IRsBsQPACAMhkCEbAbADwAgABkAC/AL8AvwhGwGxA8AQAyGQIRsBsAPAEAAGQAL8AvwC/CEbAbEDwQADIZAhGwGwA8EAAAZAAvwC/AL8IRsBsQPCAAMhkCEbAbADwgAABkAC/AL8EIAKQAiADkAEgBJADIAWQCiAGkAKpT/CQQPn3Nv8EIAKQAqmISPn3MP/IIAKQACAEkAKpT/CQQPn3J/8DIAKQAqmASPn3If8YIAKQAql+SPn3G/9P9ABgApADIAaQAql7SPn3Ev8EIAKQAql5SPn3DP8HsAC9ELV3SG9JSUQIYAhG+vdv+QixASAQvf/3PP8EIGlJSURIYAAhZ0hIRIFgT/CAYJD6oPCw+oDxY0hIRAFhAiFBYQAhgWHBYQIhAWIAIUFiT/CAccFgCQGBYgAhwWIBY/r3zPgIsQEg1edWSEhE//e//gixBCDO5wEhUkhIRP/3Rv0IsQEgxucAIMTnALWFsMAhT/CQQPn3o/8HIU1I+fef/xghTEj595v/T/QAYUpI+feW/wQhSUj595L/ACABkAQgAJAAIAKQA5BpRk/wkED596H+ASABkAAgApAIIACQaUZP8JBA+feW/gAiCCFP8JBA+vcP+DRIAGtA9IBwMkkIYwhGAGsg9IBwCGMIRgBtIPSAcAhlBbAAvRC1MUgpSUlECGAIRvv3yfgCKAbQJUhIRPv3VfgIsQEgEL0AISFISET/9+T8CLEBIPbnHkhIRPr3zvgIsQEg7+f/95f/ACDr53C1lLAERg1GFkYAIACQAZAEIAOQECAEkAaVgAEHkE/0QFAIkAAgC5BP8IBgDpAPlgYgEZAAIBOQTvYRYAKQCCAFkAACCZAABBCQgAASkEHyiDJpRgNISET69wP7kLEBIBSwcL0UAAAAABACQABwAEAABABIAAgASAAYAEgAHABIABAAoEHyiDIhRv5ISET69138CLEBIOPnACDh5y3p8EWVsIJGDUaQRuiywPWAdkZFANlGRixGBesIBwAgAZACkEHy7SADkAQgBJAQIAWQgAEIkE/0QFAJkAAgDJBP8IBgD5AAIBKQFJAIIAaQAAIKkAAEEZCAABOQAL8HlBCW4UhIRP/3ofsYsQEgFbC96PCFQfKIMgGp20hIRPr3ovoIsQEg8udB8ogyUUbWSEhE+ve/+wixASDo50HyiDHRSEhE//fi+wixASDf5zREskQE9YBwuEIB2TgbAeBP9IBwBka8QsrTACDQ5xC1lLAERgAgAJABkE32I0ACkAQgA5AQIASQBpSAAQeQT/RAUAiQACALkA6QEZASkBOQCCAFkAACCZC4SEhE//dP+xCxASAUsBC9QfKIMmlGskhIRPr3UfoIsQEg8+dP9PphrkhIRP/3m/sIsQEg6ucAIOjnELWUsARGtPWATwLTASAUsBC9ACAAkAGQQvLeEAKQBCADkBAgBJAgAwaQT/SAYAeQT/RAUAiQACALkA6QEZASkBOQCCAFkAACCZCXSEhE//cN+wixASDa50HyiDJpRpJISET69xD6CLEBINDnACDO5wC1lbAAIAGQApBG8p8AA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkINISET/9+X6ELEBIBWwAL1B8ogyAal9SEhE+vfn+QixASDz53tJeUhIRP/3MvsIsQEg6+cAIOnnALWVsAAgAZACkEL21DADkAQgBJAQIAWQACAHkE/0gGAIkE/0QFAJkAAgDJBP8IBgD5ACIBCQBiASkAAgFJAIIAaQAAIKkAAEEZCAABOQQfKIMgGpYEhIRPr3rPkQsQEgFbAAvUHyiDJpRlpISET69xb7CLEBIPPnnfgAAADwYAAIsQEg7Oed+AAAAPAMAAixCCDl50Dy+lADkEHyiDIBqU1ISET694b5CLEBINjnQfKIMmlGSEhIRPr38foIsQEgzued+AAAAPABAAixAiDH5wAgxecBRk/wgGAIYIASSGCAEYhggBDIYIACCGEAIHBHALWXsDhISET/90/6ELEBIBewAL0BIAOQACAEkAQgBpAQIAeQgAEKkE/0QFALkAAgDpBP8IBgEZAGIBSQACAWkE72EWAFkAggCJAAAgyQAAQTkIAAFZBB8ogyA6kiSEhE+vcw+QixASDS5wIgA5BB8u0gBZAAIBSQQfKIMgOpGUhIRPr3H/kIsQEgwecAIAGQAakUSEhE+vfu/QixASC35wAgtecAtZWw//cy/wIoKtEAIAGQApBL8k8AA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkEHyiDIBqQJISET69/D4A+AUAAAA4JMEABCxASAVsAC9//cL/wgoAdEAIPfnASD15wAg8+cAtZWw//f//ggoJdEAIAGQApBD8s8AA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkEHyiDIBqSpISET69734ELEBIBWwAL3/993+AigB0QAg9+cBIPXnACDz5wC1lbAAIAGQApBL9kYQA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkEHyiDIBqRVISET695P4ELEBIBWwAL0AIPvnALWVsAAgAZACkP8gA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkEHyiDIBqQVISET693L4ELEBIBWwAL0AIPvnAAAUAAAAT/AAAgC1E0aURpZGIDkiv6DoDFCg6AxQsfEgAb/0968JByi/oOgMUEi/DMBd+ATriQAov0D4BCsIv3BHSL8g+AIrEfCATxi/APgBK3BHAAAAAAAAAAAAAAECAwQGBwgJAAAAAAECAwSghgEAQA0DAIAaBgAANQwAQEIPAICEHgAACT0AABJ6AAAk9AAANm4BAEjoAQBs3AIAAAAAAAAAABAAAAABAAAAAAk9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    load_address: ~
+    pc_init: 207
+    pc_uninit: 229
+    pc_program_page: 273
+    pc_erase_sector: 243
+    pc_erase_all: 235
+    data_section_offset: 28976
     flash_properties:
       address_range:
-        start: 0x8000000
-        end: 0x8200000
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0x190
-      erase_sector_timeout: 0x190
+        start: 2415919104
+        end: 2483027968
+      page_size: 4096
+      erased_byte_value: 255
+      program_page_timeout: 10000
+      erase_sector_timeout: 6000
       sectors:
-        - size: 0x2000
-          address: 0x0
-  - name: stm32l4rx_sb_opt
-    description: STM32L4Rx Flash Options Single Bank
-    cores:
-      - main
+        - size: 65536
+          address: 0
+    cores: []
+  - name: stm32l4r9i_disco_ospi1
+    description: MX25LM51245G_STM32L4R9I-DK_OSPI1
     default: false
-    instructions: v/NPj3BHU0hRSYFgUkmBYFJJwWBSScFgACEBYFFJAWEAasADBtRRSE9JAWAGIUFgT0mBYAAgcEcBIUZIyQdBYUEEQWEAIHBHASBwRxC1QUhETARhR0kBYkkVQWJGSYFiRknBYgFjASFJBEFhv/NPj0NJPkoA4BFgA2nbA/vUAWkhQgTQAWkhQwFhASAQvQAgEL0AIHBH8LUVaFRok2jRaCxIEmkvTwdhNk41QAVi5APkC0RiMEzkQyNAg2IySxlAwWIaQAJjASFJBEFhv/NPjytJJkoA4BFgA2nbA/vUAWk5QgTQAWk5QwFhASDwvQAg8L3wtYxGlGjTaGDKFUmSaA9qIEkPQA1Ar0IG0RFNaWq2somysUIB0EAc8L2pahZO9kMxQDRAoUIB0IAc8L3sahVJDEALQJxCAdDAHPC9K2sKQAtAk0IB0AAd8L1gRPC9IwFnRQAgAkCrie/NOyoZCH9uXUz6wwAAVVUAAAAwAED/DwAAqvjv/wAA/n///wD/qqoAAP93/w//AP8AAAAAAA==
-    pc_init: 0x7
-    pc_uninit: 0x39
-    pc_program_page: 0x97
-    pc_erase_sector: 0x93
-    pc_erase_all: 0x4d
-    data_section_offset: 0x18c
+    instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEdP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEdwtQRGDUYWRgXwI/0IsQAgcL0BIPznAUYAIHBHELUF8C/9EL1wtQRGACYlRukZKEYF8ET9BkYBLgHRACBwvTBG/OdwtQRGDUYWRjJGKUYgRgXwI/0IsQAgcL0BIPznMLUG4BD4AUsS+AFbrEIA0DC9Cx6h8QEB9NEAv/jnAABwR3C1BEYAJaFISEQAePCxn0hIRAB4T/R6cbH78PCdSUlECWix+/D2MEYA8Pj5YLkQLAjSACIhRlAeAPBf+ZZISEQEYATgASUC4AElAOABJShGcL0QtQAkAyAA8D35DyAF8F38CLEBJAHg//fJ/yBGEL1wRxC1AL9P8P8wh0mIY8hjAL8AvwAgiGPIYwC/QB4IZAAgCGRAHohiACCIYkAeyGIAIMhiQB4IYwAgCGP/9+D/ACAQvXpISEQAaHRJSUQJeAhEdklJRAhgcEd0SEhEAGhwR3BISEQAaHBHcLUERgAla0hIRAB4oEIN0GhISEQGeARwaEhIRABoBfAQ/AVGFbFjSEhEBnAoRnC9YEhIRAB4cEdwtQRGBfDx+wZGJUZoHBixWkhIRAB4BUQAvwXw5vuAG6hC+tNwvU/w4CAAaSDwAgBP8OAhCGFwR0/w4CAAaUDwAgBP8OAhCGFwR0/whnBwR09IAGgADHBHTUgAaMDzCwBwR0xIAGhwR0pIAB0AaHBHSEgIMABocEdFSEBoQPABAENJSGBwR0JIQGgg8AEAQElIYHBHPkhAaEDwAgA8SUhgcEc7SEBoIPACADlJSGBwRzdIQGhA8AQANUlIYHBHNEhAaCDwBAAySUhgcEfKIDJJSGJTIEhiASAwSQhgcEcBIC9JCGJwRwAgLUkIYnBHKkkJayHwBAEBQydKEWNwRyZJCWsh8AIBAUMjShFjcEciSUlrIfA/AQFDH0pRY3BHELUdSABrQPABABtJCGMF8F37BEYG4AXwWfsAGwooAdkDIBC9FUgAawDwCAAAKPLQACD25xFIAGsg8AEAD0kIY3BHDUhAaED0gHALSUhgcEcKSEBoIPSAcAhJSGBwRwwAAAAQAAAACAAAAAAQAkAEAAAAACAE4JB1/x8AAAFAAAMgQgAAIEIQtQAoBNsKBxMO5koTVAbgCgcUDuRKAPAPAxsf1FQQvQC/APAHAuBLDDsZaE/2/wMZQN5LC0ND6gIh20sMOxlgAL9wRy3p8E2ARg1GFkYAJwDwovkHRjlGKkYzRgHwBwDA8QcLu/EEDwLZT/AECwHgwPEHC9pGAPEEC7vxBw8C0k/wAAsB4KDxAwvcRk/wAQsL+gr7q/EBCwvqAgsL+gz7T/ABDg76DP6u8QEODuoDDkvqDgQhRkBG//ei/73o8I0BRghGACgN2wC/AL8A8B8DASKaQEMJmwAD8eAjw/gAIQC/AL8Av3BHELUBRghGACgX2wDwHwMBIppArUtECUP4JCAAvwC/AL+/80+PAL8AvwC/AL8AvwC/v/NvjwC/AL8AvwC/EL0AvwC/AL8AvwC/v/NPjwC/AL8Av5tIDDgAaAD04GCZSQhDAB2XSQw5CGAAvwC/AL+/80+PAL8AvwC/AL8Av/3ncLUERiVGaB6w8YB/AdMBIA/gaB5P8OAhSGEPIU/w/zD/9zv/ACBP8OAhiGEHIAhhACBwvRC1APD8+BC9LenwRQRGIEYAKAPbfU8/XD8JB+B8TwDwDwys8QQMF/gMcD8JPUYORgbwBwDA8QcIuPEEDwLZT/AECAHgwPEHCMRGAPEECLjxBw8C0k/wAAgB4KDxAwhHRiX6B/hP8AEKCvoM+qrxAQoI6goIwvgAgE/wAQgI+gf4qPEBCAjqBQjD+ACAAL+96PCFELUBRghGACgI2wDwHwMBIppAXEuAM0QJQ/gkIAC/EL0QtQFGCEYAKA7bVkqAMkMJUvgjIADwHwQBI6NAGkAKsQEiAuAAIgDgACIQRhC9ELUBRghGACgH2wDwHwMBIppASUtECUP4JCAAvxC9ELUBRghGACgO20RKgDJDCVL4IyAA8B8EASOjQBpACrEBIgLgACIA4AAiEEYQvQQoCNFP8OAhCWlB8AQBT/DgIhFhB+BP8OAhCWkh8AQBT/DgIhFhcEdwRxC1//f8/xC9QPABASpKfDIRYAC/AL8Av7/zT48AvwC/AL8AvwC/AL+/82+PAL8AvwC/cEcAvwC/AL+/81+PAL8AvwC/ACAcSXwxCGBwR0F4GUqAMhFgAXj5sRIdQWgRYAF7CQfCekHqAmGCekHqwkFCe0HqgkGCe0HqQkHCe0HqAkFCekHqAiECekHqQgECeBFDCUqIMhFgBeAAIQZKhDIRYBIdEWBwRwNIDDgAaMDzAiBwRwDkAOAY7QDgAAD6BYDhAOCA4gDgeLUCRgAj2uABJp5ADWgF6gYEACxy0E1oAS0I0E1oAi0F0E1oES0C0E1oEi0T0ZBoXgADJbVAqENeAM1otUAoQ5BgUGgBJZ1AqEMNecXzABWdQChDUGDQaF4AAyW1QKhDXgCNaLVAKEPQYE1oAi0C0E1oEi0T0d4IAvEgBVX4JgBdB+4ODyW1QKhDXgf2Dg1ptUAoQ94IAvEgBUX4JgAQaF4AAyW1QKhDDXkF8AMFXgC1QChDEGBNaAXwgFW18YBffNEAv6hNLW5F8AEFpk41ZjVGLW4F8AEFAJUAvwC/T+q2NZ4IVfgmAJ0HLg8PJbVAqEOy8ZBPAtEAJSTgXuCbTapCAdEBJR7gmU2qQgHRAiUZ4JhNqkIB0QMlFOCWTapCAdEEJQ/glU2qQgHRBSUK4JNNqkIB0QYlBeCSTapCAdEHJQDgCCWeBzYPtUAoQ45NnghF+CYAjU0oaKBDTWgF9IA1tfWAPwDRIEOITShgLR0oaKBDTWgF9AA1tfUAPwDRIEOCTS0dKGAtHShooENNaAX0gBW19YAfANEgQ3tNCDUoYC0dKGigQ01oBfQAFbX1AB8A0SBDdU0MNShgWxwNaN1AAC1/9CCveL3wtQtGACGH4AEljUAF6gMCACp+0GpNjghV+CZAjQcuDw8ltUAsQLDxkE8B0QAlI+BcTahCAdEBJR7gWk2oQgHRAiUZ4FlNqEIB0QMlFOBXTahCAdEEJQ/gVk2oQgHRBSUK4FRNqEIB0QYlBeBTTahCAdEHJQDgCCWOBzYPtUClQiHRT00taJVDTk41YDUdLWiVQzYdNWA1HS1olUM2HTVgNR0taJVDNh01YI0HLg8PJQX6BvRCTY4IVfgmUKVDP06PCEb4J1AFaE8AAya+QDVDBWDOCADxIAVV+CZQTgf3Dg8mvkC1Q88IAPEgBkb4J1CFaE8AAya+QLVDhWBGaAEljUCuQ0ZgxWhPAAMmvkC1QwDgAODFYEkcI/oB9QAtf/Rzr/C9AkYTaQtAC7EBIADgACBwRwqxgWEA4IFicEcQtUJpIeoCAwLqAQRD6gRDg2EQvQi1AkZP9IAwAJAAmAhDAJAAmNBh0WEAmNBh0GkAkNBpAPSAMAixACAIvQEg/OdwRxC1BEYOSBQwAGggQCixDEgUMARgIEb/9/L/EL0AEAJAAAQASAAIAEgADABIABAASAAUAEgAGABIABwASAgAAUAABAFALenwQQRGDkYXRphGBp0S4GgcgLEE8HP/oOsIAKhCANhNuU/0AHBgZKBsQPABAKBkASC96PCBIGgAajBACLEBIADgACC4QuPRACDy5wJG0WQAIHBHcEf4tQRGACUE8E//BkYMuQElbeAAIKBkYGwAKGjRIEb/9+7/QfKIMSBG//fl/yCKQB7haEHqAEFgaUAeQeoAICFrCEPhaQhDIWiJaP5KEUAIQyFoiGCgjQAEIWgIYSBoAGgg9PhRYGhAHkHqACAhaAhg4GwzRgAiICEAkCBG//eV/wVGjbsgaMBoIPD/ACFqSR4IQyFoyGAgaABoIPBAAKFoCEMhaAhg1OkJAQhDIWjR+AgRIfCgQQhDIWjB+AgBIGgAaEDwAQAhaAhgoGkCKAXRIGiAaEDwAgAhaIhg4Giw8YBvAtEBIGBkAeACIGBkKEb4vXBHcLUERgAlDLkBJRDgIGgAaCDwAQAhaAhgIGiAaCDwAgAhaIhgIEb/9+r/ACBgZChGcL1wR3BHcEdwtQVGrGoAIOBjYGyw9YB/GtEgaABqwPNAEHixAiAhaEhiIGgAaED0ADAhaAhgIGgAaEDwAgAhaAhgCuACIGBkIEb/99z/BOACIGBkIEb/99X/cL1wR3BHcEdwR3BHLenwQQRGIGgA8VAIIGgFaiBoB2hmbAXwBAA4swf0gCAgsxguCtFgawB4iPgAAGBrQBxgY+BrQB7gYwvgKC4J0Zj4AABhawhwYGtAHGBj4GtAHuBj4GsouSBoAGgg9IAgIWgIYCBG//fK/6XgBfACAAAoS9AH9AAwAChH0CguIdHga2ixBfR8UFCxmPgAAGFrCHBga0AcYGPga0Ae4GOL4OBrACjh0QIgIWhIYiBoAGgg9OAgIWgIYAIgYGQgRv/3nf954AIgIWhIYiBoAGgg9OAgIWgIYAIgYGQYLgPRIEb/94v/aOAILgPRIEb/94T/YuC29YB/X9GgbBi5IEb/90//WeAgRv/3Sv9V4AXwCACwsQf0ACCYsQggIWhIYiBoAGgA9IAAOLEgaABoIPQQICFoCGACIGBkIEb/91z/O+AF8AEAYLMH9IAwSLMBICFoSGIgaABoIPT4ECFoCGACIKBkIGgAaADwBACYsSBoAGgg8AQAIWgIYFFIeEQhbIhjIGwF8Hf4uLECIGBkIEb/9wb/EeACIGBkIEb/9wD/C+AF8BAAQLEH9IAQKLEQICFoSGIgRv/38v696PCBLenwQQNGACAfaD9oJ/BAV9P4AMDM+ABwn2hfuR9oP2gn8IAH0fgEwEfqDAfT+ADAzPgAcA9oAi8M0R9oB/XAch9oB/XEdB9oB/XIdR9oB/XQdgvgH2gH9YByH2gH9YR0H2gH9Yh1H2gH9ZB20ekSfEfqDAcXYM9qj7GPajdg0fg0wM9qR+oMB9H4MMBH6gwH0vgAwCz0fBxH6gwHF2AnaCfwHwfR+ETAR+oMBydgj2s/sQ9oL7nPa38e0/gAwMz4QHDPaAAvfNDPae+zj2tfs9H4FMDPaEfqDAfR+BDAR+oMB9H4HMBH6gwH0fgkwEfqDAfR+CDAR+oMB9H4OMAD4PT44Pgl/v//R+oMB9H4QMBH6gwH0vgAwN/4GIoM6ggMR+oMBxdgKuDR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMAA4CHgR+oMB9H4IMBH6gwH0vgAwEP2P3gs6ggMR+oMBxdgn2q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2CPadP4AMDM+Ehwd+CPa+ex0fgUwM9oR+oMB9H4EMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+HyJDOoIDADgIeBH6gwHF2Aa4NH4FMDPaEfqDAfR+BDAR+oMB9L4AMAs8D8MR+oMBxdgn2q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2A64M9pp7OPa+ex0fgkwM9pR+oMB9H4IMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+PyICPE/CAzqCAxH6gwHF2AP4NH4JMDPaUfqDAfR+CDAR+oMB9L4AMAs9HxcR+oMBxdgj2nT+ADAzPhIcAPg/+cBIAgnn2S96PCBLen4RQRGDUaQRgTwafyCRqBoALkAv+hoALEAv+hpALEAv+hqALEAv6hrGLEoaAC5AL8Av2dsAi8D0eBosPGAbwnRFC8C0ShoAigE0CQvPdEoaAEoOtFTRgAiICEgRs34AID/9778BkYeuwAgoGQpRiBG//eE/gZG3rmoa2C5U0YBIgIhIEbN+ACA//eq/AZGAiAhaEhiHOAoaBC5BCBgZBfgKGgBKAjRYGwkKALRBCBgZA7gFCBgZAvgYGwUKALRBCBgZAXgJCBgZALgASYQIKBkMEa96PiF+LUERg1GBPD/+wdGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsAsQC/YGwCKCXRKGgYu6hrCLvgaLDxgG8d0OBsO0YAIiAhAJAgRv/3XfwGRra5ACCgZAMgIWhIYilGIEb/9yD+BkZeuQggYGQgaABoQPRAMCFoCGAC4AEmECCgZDBG+L0t6fhFBEYNRhdGBPC6+4JG1PhEgLjxAQ8C0LjxAg8X0VNGACIgISBGAJf/9yv8BkaOuSiIAARpaEDqASCpaAhD6WgIQyFowfgAAgIgYGQC4AEmECCgZDBGvej4hS3p+EMERg1GF0YE8Iz7gEZgbAIoONHgaLDxgG800UNGACIgISBGAJf/9/77BkZWuyBoAGgg8EBQIWgIYCBogGgg8IBwKWgIQyFoiGAoaUDwQGCpaAhDQPRAYCFowfgAAShpQPBAYKloCENA9EBgIWjB+IAB6GhAHiFoCGRoaCFoiGQEIGBkAuABJhAgoGQwRr3o+IMt6fhFBEYORhdGBPBC+4BGIGgA8VAKHrkBJQggoGQ64GBsBCg00SBoAGxAHOBj4GugY2ZjIGgAaCDwQFAhaAhgAL9DRgEiBCEgRgCX//ei+wVGBbEM4GBrAHiK+AAAYGtAHGBj4GtAHuBj4GsAKOjRAL+FuUNGASICISBGAJf/94n7BUY9uQIgIWhIYmBkAuABJRAgoGQoRr3o+IUt6fxNBEYORhdGBPD0+gGQIGgA8VAKIGjQ+EiAIGjQ+BCxHrkBJQggoGRR4GBsBChL0SBoAGxAHOBj4GugY2ZjIGgAaCDwQFBA8IBQIWgIYOBosPGAbwPRIGjA+EiADOAgaND4AAEA9OBgGLEgaMD4SIAC4CBowPgQsQC/AJcBIgYhIEYBm//3N/sFRgWxDOCa+AAAYWsIcGBrQBxgY+BrQB7gY+BrACjo0QC/hbkAlwEiAiEgRgGb//ce+wVGPbkCICFoSGJgZALgASUQIKBkKEa96PyNELUCRgAgGbkBIAgjk2Qe4FNsBCsY0RNoG2xbHNNj02uTY1FjE2gbaCPwQFMUaCNgAyMUaGNiGCNTZBNoG2hD9OAjFGgjYALgASAQI5NkEL1wtQJGACAVaKtsFWjV+BBBGbkBIAgllWQz4FVsBC0t0RVoLWxtHNVj1WuVY1FjFWgtaCXwQFVF8IBVFmg1YAMlFmh1YiglVWQVaC1oRfTgJRZoNWDVaLXxgG8C0RVoq2QP4BVo1fgAUQX04GUVsRVoq2QG4BVoxfgQQQLgASAQJZVkcL1wtQRGACZlbAXwCAAYuQXwBAAAKDzQIGgAaCD0+BAhaAhgT/SAcGBkIGgAaADwBACYsSBoAGgg8AQAIWgIYPlIeEQhbIhjIGwE8Kv8+LECIGBkIEb/9zv7HeAgaABqwPNAEHixAiAhaEhiIGgAaED0ADAhaAhgIGgAaEDwAgAhaAhgCOACIGBkIEb/9yD7AuABJhAgoGQwRnC9cLUFRqxqACDgYwQgoGQgaABoIPAEACFoCGAgRv/3o/9QsSBoAGgg9OAgIWgIYAIgYGQgRv/3/fpwvXBHcEdwtQVGrGrga0AI4GNgbCgoA9EgRv/38/8C4CBG//fu/3C9AUaIagAiwmMCaBJoIvAEAgNoGmAKaBJoIvABAgtoGmACaBJoQvQAMgNoGmBwRy3p8EEERg5GACcgaABsRRweuQEnCCCgZHngYGwEKHPRIGxAaQi55WMk4CBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggoGQBJxTgaAjgYxHgIGxAabD1AH8M0QXwAwAYuSB5APADABixCCCgZAEnAeCoCOBjAC9K0eBroGNmYyBoAGgg8EBQIWgIYAMgIWhIYhggYGSbSHhEIWzIYppIeEQhbAhjmUh4RCFsSGMAICFsiGMQISBsgWAgbABoAGgg8BAAIWyJaAhDIWwJaAhgo2shaAHxUAIxRiBsBPAs+2C5IGgAaED0gDAhaAhgIGgAaEDwBAAhaAhgCeABJwQgoGQCIGBkA+D/5wEnECCgZDhGvejwgS3p8EcERg5GACcgaABsRRwgaND4SIAgaND4EKEeuQEnCCCgZJDgYGwEKG/RIGxAaQi55WMk4CBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggoGQBJxTgaAjgYxHgIGxAabD1AH8M0QXwAwAYuSB5APADABixCCCgZAEnAeCoCOBjAC9h0eBroGNmYyBoAGgg8EBQQPCAUCFoCGADICFoSGIoIGBkVUh4RCFsyGJUSHhEIWwIY1NIeEQhbEhjACAhbIhjACEgbIFgIGwAaABoIPAQACFsiWgIQyFsCWgIYKNrImgC8VABMkYgbATwmvoQuyBoAGhA9IAwIWgIYOBosPGAbwTRIGjA+EiADeAZ4CBo0PgAAQD04GAYsSBowPhIgALgIGjA+BChIGgAaEDwBAAhaAhgCOABJwQgoGQCIGBkAuABJxAgoGQ4Rr3o8Ict6fhPBEYNRhdGBPBa+IJGIGjQ+EiAIGjQ+BCxYGwEKFzR6Giw9YAPWNFTRgAiICEgRgCX//fG+AZGAC5R0ShoIWjB+IgAaGghaMH4gAAoaSFowfiQANXpAgEIQ0DwAFAhaAloIfBDUQhDIWgIYOBosPGAbwPRIGjA+EiAH+AgaND4AAEA9OBgsLEgaMD4SIAV4AAAwMD/8MD///CN9v//Of///w/////J/v//Ff7//+v9//+l/f//IGjA+BCxU0YBIgghIEYAl//3fPgGRia5CCAhaEhiAiBgZALgASYQIKBkMEa96PiPLen4RQRGDUYD8Of/gEYgaIdsIGjQ+BChYGwEKEDR4GxDRgAiICEAkCBG//dX+AZGRrsoaCFowfiIAGhoIWjB+IAAKGkhaMH4kADV6QIBCENA8ABQIWgJaCHwQ1EIQyFoCGAJICFoSGJIIGBkIGgAaED0ECAhaAhg4Giw8YBvAtEgaIdkD+AgaND4AAEA9OBgELEgaIdkBuAgaMD4EKEC4AEmECCgZDBGvej4hfi1BEYNRgPwkv8HRmBsBCgm0eBsO0YAIiAhAJAgRv/3B/gGRv65iCBgZChoCCgM0WhoIWjB+DABECAhaEhiIGgAaED0gBAhaAhgIGgAaP5JCEApaEHwQFEIQyFoCGAC4AEmECCgZDBG+L34tQRGACUD8F3/B0ZmbAbwCAAYuQbwBAAAKDnQIGgAaADwBABgsSBoAGgg8AQAIWgIYCBsBPCw+QVGDbEEIKBkIGgAasDzQBD4sSBoAGhA8AIAIWgIYOBsO0YBIgIhAJAgRv73sP8FRq25AiAhaEhi4Gw7RgAiICEAkCBG/vej/wVGRbkCIGBkBeACIGBkAuABJRAgoGQoRvi9ELUCRgAgU2wD8AgDW7lRYBNoG2gj9PhUU2hbHkTqAyMUaCNgAuABIBAjk2QQvQFGCGgAaMDzBCBAHHBHAUaIbHBHAUZIbHBH8LUFRgAgACQVsQItANgJuQEgW+AAJg5gTmCOYM5gDmECLQDRtkwAI07gtk5W+CMgAvABBj6xAvACBgTwAge+QgHRXhwOYALwEAY+sQLwIAYE8CAHvkIB0V4cTmAC9IB2PrEC9AB2BPQAd75CAdFeHI5gAvSANo6xAvSAJgT0gCe+QgvRAvQANia5XhxG9IA2zmAD4F4cRvCAds5gAvCAdo6xAvCAZgTwgGe+QgvRAvAAdia5XhxG9IA2DmED4F4cRvCAdg5hWxwCK67T8L0t6fBNirCCRgxGT/AAC9hGikna+AAAiEIC0QAlASYB4AElACYAJxDgB+uHAmtGA+uCAXoc0LL/93z/ILFP8AELCCDK+EgAeBzHsgIv7NO78QAPfdF5SABoAPABADixdkgAaCDwAQB0SQhgSPABCHNIAGgA8AEAOLFxSABoIPABAG9JCGBI8AIIa0gF64UBakYC64EBiWhJHlD4IQAg9IByZUgF64UBa0YD64EBiWhJHkD4ISAF64UAXfggAAAocdBdSAXrhQFd+CEQSR5Q+CEAIPABAlhIBeuFAV34IRBJHkD4ISAF64UAaUYB64AAQGigsVBIBeuFAWpGAuuBAUloSR5Q+CEAIPAQAkpIBeuFAQPrgQFJaEkeQPghIAXrhQBpRgHrgADAaNixQkgF64UBakYC64EBCXtJHgHwAQFQ+CEAIPSAMjtIBeuFAWtGAOCK4QPrgQEJe0keAfABAUD4ISAF64UAaUYB64AAAGnIsTFIBeuFAWpGAuuBAQl8SR4B8AEBUPghACDwgHIqSAXrhQFrRgPrgQEJfEkeAfABAUD4ISAG64YBXfghECBoiEIg0AbrhgFqRgLrgQFgaEloiEIX0AbrhgEC64EBoGiJaIhCD9AG64YBAuuBAeBoyWiIQgfQBuuGAQLrgQEgaQlpiEJ+0RBIBuuGAV34IRBJHlD4IQAg8AECC0gG64YBXfghEEkeQPghIAbrhgBpRgHrgABAaACzA0gG64YBCeD3///PIgIEBAQcBlAAEACgABQAoGpGAuuBAUloSR5Q+CEAIPAQAodIBuuGAWtGA+uBAUloSR5A+CEggkgG64YBakYC64EBiWhJHlD4IQAg9IByfEgG64YBa0YD64EBiWhJHkD4ISAG64YAaUYB64AAwGjAsXNIBuuGAWpGAuuBAQl7SR4B8AEBUPghACD0gDJsSAbrhgED64EBCXtJHgHwAQFA+CEgBuuGAGlGAeuAAABpOLFjSAbrhgFqRgLrgQEJfADgEuBJHgHwAQFQ+CEAIPCAcltIBuuGAWtGA+uBAQl8SR4B8AEBQPghIFVIoWhJHlD4IQAg9EBwT/SAcUHqRSEIQ09JomhSHkH4IgAIRiFoSR5Q+CEAIPADAQEgQOpFAAFDR0giaFIeQPgiEGBoeLFESGFoSR5Q+CEAIPAwABAhQepFEQhDPkliaFIeQfgiAOBoAPSAMKixOkghe0keAfABAVD4IQAg9OAgT/SAMUHqhUEIQzNJIntSHgLwAQJB+CIAFuDgaKCxLkghe0keAfABAVD4IQAg8OBgT/CAcUHqhWEIQydJIntSHgLwAQJB+CIAIGkA9IAwqLEhSCF8SR4B8AEBUPghACD04CBP9EAxQeqFQQhDGkkifFIeAvABAkH4IgAW4CBpoLEVSCF8SR4B8AEBUPghACDw4GFP8EBwQOqFYAFDDkgifFIeAvABAkD4IhAI8AEAKLEKSABoQPABAAhJCGAI8AIAKLEHSABoQPABAAVJCGBYRgqwvejwjQAABBwGUAAQAKAAFACgfEiAa0DwgFB6SYhjCEaAayDwgFCIY3BHd0gAaED0gHB1SQhgcEd0SABoIPSAcHJJCGBwRwFGcEhAaCDwDgAKaBBDbUpQYG1IAGgg9IAwa0oQYBAfAGgg9IAwEh8QYGdICDAAaCD0gDBkSggyEGAQHwBoIPSAMBIfEGBIaAD0gDCw9YA/B9FdSAAfAGhA9IAwWkoSHxBgSGgA9AAwsPUAPwXRVkgAaED0gDBUShBgCHkA8AEAOLFRSAAdAGhA9IAwTkoSHRBgCHkA8AIAAigH0UpICDAAaED0gDBISggyEGAAIHBHREhAaEDwAQBCSUhgcEdBSEBoIPABAD9JSGBwRz1JyWgA8B8CkUNB6lAROkrRYBFGiWgA8B8CEUM2SpFgcEc1SYloAPAfApFDMkqRYHBHcLUERg1GVLkvSEBpAPQAcLD1AH8K0QDwp/w4sXC9KUhAacDzQCAIuQDwl/woSABoIPAEACZJCGABLQHRML8C4EC/IL8gvwC/6OdwtQVGDEa19YBPA9EgRgDwxfwC4CBGAPCn/HC9F0gAaCDwBwDAHBVJCGAWSABoQPAEABRJCGAAvwC/ML9wRxFIAGhA8AIAD0kIYHBHDUgAaCDwAgALSQhgcEcKSABoQPAQAAhJCGBwRwZIAGgg8BAABEkIYHBHcEcAEAJAAHAAQAQEAUAQ7QDg+EgAaAD0wGCw9YBvAtFP9IBgcEfzSIAwAGgA9IBwsPWAfwLRT/QAcPPnACDx5wJGkrvsSABoAPTAYLD1gG8s0ehIgDAAaCD0gHDmS8P4gAAYRgBoIPTAYED0AHAYYOJISEQAaDIjWEPgS7D78/BBHADgSR7bSEBpAPSAYLD1gG8B0QAp9dHXSEBpAPSAYLD1gG9S0QMgcEcI4NJIgDAAaCD0gHDPS8P4gABG4LL1AH870cxIAGgA9MBgsPWAbyvRyEiAMABoQPSAcMZLw/iAABhGAGgg9MBgQPQAcBhgwkhIRABoMiNYQ8BLsPvz8EEcAOBJHrtIQGkA9IBgsPWAbwHRACn10bdIQGkA9IBgsPWAbxLRAyC+57JIgDAAaED0gHCwS8P4gAAH4K5IAGgg9MBgQPSAYKtLGGAAIKvnqUnJaCH0AHEBQ6ZK0WARRsloQfSAcdFgcEeiSMBoIPSAcKBJyGBwR59IQGhA9IBgnUlIYHBHm0hAaCD0gGCZSUhgcEeYSEBoQPQAcJZJSGBwR5RIQGgg9ABwkklIYHBHkUiAaED0AECPSYhgcEeNSIBoIPQAQItJiGBwRxC1AkYAIAkqcdLf6ALwBRQhKzU/SVNgAIRLG2oh9IBEI0OBTCNiI0ZbaiH0IESjQ35MY2Jd4HxLm2oLQ3tMo2IjRttqIfAQBKNDd0zjYlDgdksbawtDdEwjYyNGW2uLQ2NjRuBxS5trC0NvTKNjI0bba4tD42M84GxLG2wLQ2pMI2QjRltsi0NjZDLgZ0ubbAtDZUyjZCNG22yLQ+NkKOBiSxttC0NgTCNlI0ZbbYtDY2Ue4F1Lm22MsiNDW0yjZSNG222MsqNDWEzjZRHgVksbbsHzCwQjQ1RMI2YjRltuwfMLBKNDUExjZgLg/+cBIAC/AL8QvRC1AkYAIAkqQdLf6ALwBQ0TGR8lKzE4AEZLG2oh9IBEo0NETCNiNOBCS5tqi0NBTKNiLuA/Sxtri0M+TCNjKOA8S5tri0M7TKNjIuA5Sxtsi0M4TCNkHOA2S5tsi0M1TKNkFuAzSxtti0MyTCNlEOAwS5ttjLKjQy5Mo2UJ4C1LG27B8wsEo0MqTCNmAeABIAC/AL8QvRC1AkYAIAkqdtLf6ALwBRQgKjQ+TlhlACFLW2oh9CBEI0MeTGNiI0YbaiH0gESjQxtMI2Ji4BlL22oh8BAEI0MXTONiI0abaotDo2JW4BNLW2sLQxJMY2MjRhtri0MjY0zgDkvbawtDDUzjYyNGm2uLQ6NjQuAJS1tsC0MITGNkI0YbbItDI2Q44ARL22wLQwNM42QjRptsi0OjZC7gAHAAQBAAAABAQg8A+ktbbQtD+UxjZSNGG22LQyNlHuD1S9ttjLIjQ/NM42UjRpttjLKjQ/BMo2UR4O9LW27B8wsEI0PsTGNmI0YbbsHzCwSjQ+lMI2YC4P/nASAAvwC/EL0QtQJGACAJKkPS3+gC8AUNFRshJy0zOgDfS1tqIfQgRKND3ExjYjbg20vbaiHwEASjQ9hM42Iu4NdLW2uLQ9VMY2Mo4NRL22uLQ9JM42Mi4NFLW2yLQ89MY2Qc4M5L22yLQ8xM42QW4MtLW22LQ8lMY2UQ4MhL222MsqNDxkzjZQngxEtbbsHzCwSjQ8JMY2YB4AEgAL8AvxC9vkiAaED0gGC8SYhgcEe7SIBoIPSAYLlJiGBwRwFGMbm2SIBoIPSAcLRKkGAL4LH1gH8G0bFIgGhA9IBwr0qQYAHgASBwRwAg/OcAtU/0gHD/9+T/AL0AtQAg//ff/wC9pkgAaEDwEACkSQhgcEejSABoIPAQAKFJCGBwR59IgGhA9IBQnUmIYHBHnEiAaCD0gFCaSYhgcEeYSEBoQPAQAJZJSGBwR5VIQGgg8BAAk0lIYHBHkUhAaEDwIACPSUhgcEeOSEBoIPAgAIxJSGBwR4pIQGhA8EAAiElIYHBHh0hAaCDwQACFSUhgcEeDSEBoQPCAAIFJSGBwR4BIQGgg8IAAfklIYHBHAUYAIApoECoG0CAqUtBAKn7QgCp90fHgd0oSaCLwCAJ1SxpgGh8SaCLwCAIbHxpgcUoIMhJoIvAIAm9LCDMaYBofEmgi8AgCGx8aYEpoAvSAMrL1gD8H0WdKEh8SaELwCAJlSxsfGmBKaAL0ADKy9QA/BdFgShJoQvAIAl5LGmAKeQLwAQI6sVtKEh0SaELwCAJZSxsdGmAKeQLwAgICKgfRVUoIMhJoQvAIAlJLCDMaYPPgUEoSaCLwEAJOSxpgGh8SaCLwEAIbHxpgSkoIMhJoIvAQAkhLCDMaYBofEmgi8BACGx8aYEpoAvSAMrL1gD8H0UBKEh8SaELwEAI+SxsfGmBKaAL0ADKy9QA/AeAh4MHgBdE4ShJoQvAQAjZLGmAKeQLwAQI6sTNKEh0SaELwEAIwSxsdGmAKeQLwAgICKgfRLEoIMhJoQvAQAipLCDMaYKLgKEoSaCLwIAImSxpgGh8SaCLwIAIbHxpgIkoIMhJoIvAgAh9LCDMaYBofEmgi8CACGx8aYEpoAvSAMrL1gD8H0RhKEh8SaELwIAIVSxsfGmBKaAL0ADKy9QA/BdERShJoQvAgAg9LGmAKeQLwAQI6sQxKEh0SaELwIAIJSxsdGmAKeQLwAgICKgfRBUoIMhJoQvAgAgNLCDMaYFTgAAAAcABAJAQBQJBKEmgi8EACjksaYBofEmgi8EACGx8aYIpKCDISaCLwQAKISwgzGmAaHxJoIvBAAhsfGmBKaAL0gDKy9YA/B9GAShIfEmhC8EACfksbHxpgSmgC9AAysvUAPwXReUoSaELwQAJ3SxpgCnkC8AECOrF0ShIdEmhC8EACcksbHRpgCnkC8AICAioH0W5KCDISaELwQAJrSwgzGmAB4AEgAL8Av3BHaEgAaED0gEBmSQhgcEdlSABoIPSAQGNKEGBjSEhEAGgyIlBDYUqw+/LwQRwA4EkeXEhAaQD0AHCw9QB/AdEAKfXRWEhAaQD0AHCw9QB/AdEDIHBHACD851JJCWgh8AcBUEoRYFJJCWhB8AQBUEoRYAEoAdEwvwLgQL8gvyC/TEkJaCHwBAFKShFgcEdFSQloIfAHAUkcQ0oRYEVJCWhB8AQBQ0oRYAEoAdEwvwLgQL8gvyC/PkkJaCHwBAE8ShFgcEc4SQloIfAHAYkcNUoRYDdJCWhB8AQBNUoRYAEoAdEwvwLgQL8gvyC/MUkJaCHwBAEvShFgcEcqSABoIPAHAAAdKEkIYCpIAGhA8AQAKEkIYAC/AL8wv3BHcEdwR3BHcEcQtR5IEDgAaAD0gDAwsf/3GftP9IAwGUkQOQhgGEgQMABoAPAIACix//fp/wggE0kQMQhgEkgQMABoAPAQACix//fc/xAgDUkQMQhgDEgQMABoAPAgACix//fP/yAgB0kQMQhgBkgQMABoAPBAACix//fC/0AgAUkQMQhgEL0kBAFAAHAAQBAAAABAQg8AEO0A4BC1/EgAaEDwAQD6SQhgAvAi/gRGBuAC8B7+ABsCKAHZAyAQvfNIAGgA8AIAACjy0PBIAGgg8PAAQPBgAO1JCGAAIIhg7EjtSUlECGDsSEhEAGgC8BD+CLEBIOLnAvD7/QRGCOAC8Pf9ABtB8ogxiEIB2QMg1effSIBoAPAMAAAo8NHcSABo30kIQNpJCGAC8OL9BEYG4ALw3v0AGwIoAdkDIL7n00gAaADwKFAAKPLR0EnIYAhGwGhA9IBQyGAAIAhhCEYAaUD0gFAIYQAgSGEIRkBpQPSAUEhhCEYAaCD0gCAIYAAgiGFAHghiwUiUMABoQPQAAMH4lAAAIJHn8LUAIwAg3/jswtz4CMAM8AwB3/jgwtz4DMAM8AMHGbEMKR/RAS8d0d/4zMLc+ADADPAIDLzxAA8G0d/4uMLc+JTAzPMDIwXg3/iswtz4AMDM8wMT3/i0wvxEXPgjMEG5GEYG4AQpAdGpSALgCCkA0ahIDCky0d/4fMLc+AzADPADBAEsCdACLALQAywE0QHgn0oE4J9KAuAAvxpGAL8Av9/4VMLc+AzAzPMDHAzxAQbf+ETC3PgMwMzzBiwM+wL8vPv28t/4MMLc+AzAzPNBbAzxAQxP6kwFsvv18PC9+LUERgAmhEiAbQDwgFAYsf/36vkFRhbgAL9/SIBtQPCAUH1JiGUIRoBtAPCAUACQAL8Av//32PkFRndIgG0g8IBQdUmIZbX1AH8H0YAsDNmgLAHZAiYI4AEmBuCALAHTAiYC4HAsANEBJnNIAGgg8A8AMENwSQhgCEYAaADwDwCwQgHQASD4vQAg/Oct6fhFBEYUuQEgvej4hV9IgGgA8AwGXUjAaADwAwcgeADwEAAQKHrRHrEMLnnRAS930VZIAGgA8AIAGLGgaQi5ASDi51FIIWoAaADwCAAgsU5IAGgA8PAABeBMSJQwAGgA9HBgAAmBQh/ZIGr/94L/CLEBIMnnAL9ESABoQPAIAEJJCGAIRgBoIPDwACFqCEM+SQhgAL8IRkBoIPR/QOFpQOoBIDlJSGAf4AC/N0gAaEDwCAA1SQhgCEYAaCDw8AAhaghDMUkIYAC/CEZAaCD0f0DhaUDqASAsSUhgLrkgav/3SP8IsQEgj+f/99T+J0mJaMHzAxEuSnpEUVwB8B8ByEAkSUlECGAjSEhEAGgC8H78gEa48QAPY9BARnXnYOD/56BpgLMZSABoQPABABdJCGAC8Fz8BUYG4ALwWPxAGwIoAdkDIGDnEEgAaADwAgAAKPLQAL8NSABoQPAIAAtJCGAIRgBoIPDwACFqCEMHSQhgAL8IRkBoIPR/QOFpQOoBIAJJSGAs4BTgAAAAEAJAAAk9ABAAAAAIAAAA//T+6n5BAAAAJPQAABJ6AAAgAkBcPwAA/kgAaCDwAQD8SQhgAvAV/AVGBuAC8BH8QBsCKAHZAyAZ5/ZIAGgA8AIAACjy0SB4APABAAAoXNAILgPQDC4K0QMvCNHtSABoAPQAMIizYGh4uwEg/+YAv2BosPWAPwbR5kgAaED0gDDkSQhgGuBgaLD1oC8L0eFIAGhA9IAg30kIYAhGAGhA9IAwCGAK4NtIAGgg9IAw2UkIYAhGAGgg9IAgCGAAv2BokLEC8Mb7BUYH4B7gAvDB+0AbZCgB2QMgyebOSABoAPQAMAAo8tAQ4ALws/sFRgbgAvCv+0AbZCgB2QMgt+bFSABoAPQAMAAo8tEgeADwAgACKFLRBC4D0AwuFNECLxLRvEgAaAD0gGAYseBoCLkBIJ3muEhAaCDw/kAhfEDqAWC0SUhgOeDgaACzskgAaED0gHCwSQhgAvB8+wVGBuAC8Hj7QBsCKAHZAyCA5qlIAGgA9IBgACjy0KZIQGgg8P5AIXxA6gFgo0lIYBbgoUgAaCD0gHCfSQhgAvBb+wVGBuAC8Ff7QBsCKAHZAyBf5plIAGgA9IBgACjy0SB4APAIAAgoNtFgadCxkkiUMABoQPABAJBJwfiUAALwO/sFRgbgAvA3+0AbAigB2QMgP+aJSJQwAGgA8AIAACjx0BnghUiUMABoIPABAIJJwfiUAALwIPsFRgbgAvAc+0AbAigB2QMgJOZ7SJQwAGgA8AIAACjx0SB4APAEAAQocdFP8AAKdEiAbQDwgFB4uQC/cUiAbUDwgFBvSYhlCEaAbQDwgFAAkAC/AL9P8AEKa0gAaAD0gHCwuWhIAGhA9IBwZkkIYALw5/oFRgbgAvDj+kAbAigB2QMg6+VgSABoAPSAcAAo8tAAv6BoASgI0VpIkDAAaEDwAQBXScH4kAAh4KBoBSgP0VRIkDAAaEDwBABRScH4kAAIRtD4kABA8AEAwfiQAA7gTEiQMABoIPABAElJwfiQAAhG0PiQACDwBADB+JAAAL+gaKixAvCk+gVGCeAC8KD6QBtB8ogxiEIC2QMgpuUl4DxIkDAAaADwAgAAKO7QE+AC8I76BUYI4ALwivpAG0HyiDGIQgHZAyCQ5TFIkDAAaADwAgAAKO/RuvEBDwXRLEiAbSDwgFAqSYhlAL8geADwIAAgKDbRYGrQsSVImDAAaEDwAQAjScH4mAAC8GH6BUYG4ALwXfpAGwIoAdkDIGXlHEiYMABoAPACAAAo8dAZ4BhImDAAaCDwAQAVScH4mAAC8Eb6BUYG4ALwQvpAGwIoAdkDIErlDkiYMABoAPACAAAo8dGgagAofdCgagIoe9EISMdoB/ADAeBqgUIq0Qfw8AEga0AesesAHyPRB/T+QQPgABACQABwAEBga7HrAC8Y0QfweEE4IABdsevAbxHRB/TAAaCPASLC61AAsetAXwjRB/DAYUAgAF3C61AAsetAb2TQDC5g0P5IAGgA8IBgILn7SABoAPCAUAixASD95PhIAGgg8IBw9kkIYALw6PkFRgbgAvDk+UAbAigB2QMg7OTvSABoAPAAcAAo8tHU6QsQQB5B6gARYGtB6gAhoI8BIsLrUABB6kBRQCAAXcLrUABB6kBhOCAAXUHqwGDgSclo4EoRQAhD3knIYAhGAGhA8IBwAeBY4DvgCGAIRsBoQPCAcMhgAvCr+QVGBuAC8Kf5QBsCKAHZAyCv5NFIAGgA8ABwACjy0FDgASCm5MxIAGgA8ABwwLvKSABoQPCAcMhJCGAIRsBoQPCAcMhgAvCH+QVGBuAC8IP5QBsCKAHZAyCL5L9IAGgA8ABwACjy0CzgDC4o0LpIAGgg8IBwuEkIYAhGAGgA8CBQILkIRsBoIPADAMhgskjAaLNJCECwSchgAvBd+QVGB+AP4ALwWPlAGwIoAdkDIGDkqUgAaADwAHAAKPLRAeABIFfkACBV5HC1ACKjTvZoBvADBgEuEtGgTjZoBvAIBi65nU6UNjZoxvMDIgPgmk42aMbzAxKbTn5EVvgiIJZO9mgG8AMDASsJ0AIrAtADKwTRAeCVSQTglUkC4AC/EUYAvwC/jU72aMbzAxZ1HIpO9mjG8wYmTkO2+/Xxh072aMbzQWZ2HHQAsfv08HC9LenwQQRGDUYAJxS5ASC96PCBhEgAaADwDwCoQg7SgUgAaCDwDwAoQ35JCGAIRgBoAPAPAKhCAdABIOjnIHgA8AEAAChz0GBoAygr0W9IAGgA8ABwCLkBINnn//eO/3JJiEJH2WlIgGgA8PAASLlnSIBoIPDwAEDwgABkSYhggCc44CB4APACAAIoM9GgaIi7XkiAaCDw8ABA8IAAW0mIYIAnJ+BgaAIoBtFYSABoAPQAMIi5ASCq52BoMLlTSABoAPACAEC5ASCh51BIAGgA9IBgCLkBIJrn//fr+lJJiEII2UpIgGgg8PAAQPCAAEdJiGCAJ0VIgGgg8AMAYWgIQ0JJiGAC8IH4BkYI4ALwffiAG0HyiDGIQgHZAyB35ztIgGgA8AwAYWiw64EP7tEgeADwAgACKAjRNEiAaCDw8AChaAhDMUmIYAfggC8F0S9IgGgg8PAALUmIYDJIAGgA8A8AqEIO2S9IAGgg8A8AKEMsSQhgCEYAaADwDwCoQgHQASBE5yB4APAEAAQoB9EfSIBoIPTgYOFoCEMcSYhgIHgA8AgACCgI0RhIgGgg9GBQIWlA6sEAFUmIYP/3evoTSYlowfMDERlKekRRXAHwHwHIQBdJSUQIYBZISEQAaALwJPiARkBGEudwtYawBkYNRhRGAL8FSMBsQPABAANJyGQIRsBsAPABAACQFeAAEAJADICdAf//7v7eOAAAACT0AAASegAAIAJAALTEBKg2AAAQAAAACAAAAAC/AL+IFQGQAiACkASQACADkAWQAalP8JBA/PeT/n1IgGgg8P5AReoEAQhDeUmIYAawcL14SEhEAGhwRwC1//f5/3RJiWjB8wIhdEp6RFFcAfAfAchAAL0Atf/36/9tSYlowfPCIW1KekQcOlFcAfAfAchAAL0/IQFgZkkJaAH0gCGx9YAvA9FP9KAhQWAM4GBJCWgB9IAxsfWAPwPRT/SAMUFgAeAAIUFgWkkJaAHwAQERsQEhgWEB4AAhgWFVSUlowfMHIcFhUkkJaAHw8AEBYlBJCWgB9IBxsfWAfwPRT/SAccFgAeAAIcFgSUlJaMHzBmEBYUdJkDEJaAHwBAEEKQLRBSGBYArgQkmQMQloAfABARGxASGBYAHgACGBYDxJlDEJaAHwAQERsQEhQWEB4AAhQWE3SZgxCWgB8AEBEbEBIUFiAeAAIUFiMUkJaAHwgHGx8YB/AtECIYFiAeABIYFiK0nJaAHwAwLCYilJyWjB8wMRSRwBYyZJyWjB8wYiQmMjSclowfNBUUkcSgDCYyBJyWjB80FhSRxKAAJkHEnJaMoOgmNwRw8iAmAZSpJoAvADAkJgFkqSaALw8AKCYBRKkmgC9OBiwmARSpJoAvRgUtIIAmERShJoAvAPAgpgcEcLSABoQPQAIAlJCGBwR3BHELUHSMBpAPSAcLD1gH8F0f/39f9P9IBwAUkIYhC9AAAAEAJAEAAAAPw1AAAAIAJALenwQQRGD0YAJf5IwGgA8AMAULH7SMBoAPADACFoiEIB0SBoeLsBJS3gIGgBKATQAigJ0AMoGtEN4PJIAGgA8AIAALkBJRTg7kgAaAD0gGAAuQElDeDrSABoAPQAMCi56EgAaAD0gCAAuQElAeABJQC/AL89ueNIwGgg8AMAIWgIQ+BJyGAALXPR3kgAaCDwgFDcSQhgAfCK/gZGBuAB8Ib+gBsCKAHZAyUF4NVIAGgA8ABQACjy0QC/AC1Z0Ye5oGgAAiF7QOrBYWBoQB5B6gAQzElJacxKEUAIQ8lJSGEo4AEvE9GgaAACIYoBIsLrUQFA6kFRYGhAHkHqABDBSUlpwkoRQAhDvklIYRLgoGgAAiF9ASLC61EBQOpBYWBoQB5B6gAQt0lJablKEUAIQ7RJSGGzSABoQPCAULFJCGAB8DX+BkYG4AHwMf6AGwIoAdkDJQXgq0gAaADwAFAAKPLQAL8tuadIQGmhaQhDpUlIYShGvejwgS3p8EEERg9GACWgSMBoAPADAFCxnUjAaADwAwAhaIhCAdEgaHi7ASUt4CBoASgE0AIoCdADKBrRDeCUSABoAPACAAC5ASUU4JBIAGgA9IBgALkBJQ3gjUgAaAD0ADAouYpIAGgA9IAgALkBJQHgASUAvwC/PbmFSMBoIPADACFoCEOCSchgAC1z0YBIAGgg8IBgfkkIYAHwzv0GRgbgAfDK/YAbAigB2QMlBeB3SABoAPAAYAAo8tEAvwAtWdGHuaBoAAIhe0DqwWFgaEAeQeoAEG5JCWluShFACENrSQhhKOABLxPRoGgAAiGKASLC61EBQOpBUWBoQB5B6gAQY0kJaWRKEUAIQ2BJCGES4KBoAAIhfQEiwutRAUDqQWFgaEAeQeoAEFlJCWlbShFACENWSQhhVUgAaEDwgGBTSQhgAfB5/QZGBuAB8HX9gBsCKAHZAyUF4E1IAGgA8ABgACjy0AC/LblJSABpoWkIQ0dJCGEoRr3o8IEt6fhFBEYAJahGIIgA9ABgsPUAbzLR4G5AKAnQA9xwsSAoG9ER4GAoFtCAKBbRFOA4SMBoQPSAMDZJyGAQ4AAhIB3/9yH/BUYK4AAhBPEgAP/3Xv4FRgPgAL8B4AElAL8Av1W5K0icMABoIPDgAOFuCEMoScH4nAAA4KhGIIgA9IBQsPWAXzbRIG+w9QB/DNAE3IixsPWAfx3RE+Cw9UB/F9Cw9YBvFtEU4BpIwGhA9IAwGEnIYBDgACEgHf/35P4FRgrgACEE8SAA//ch/gVGA+AAvwHgASUAvwC/VbkNSJwwAGgg9OBgIW8IQwlJwficAADgqEYgaAD0ADCw9QA/a9FP8AAKA0iAbQEhIeoQcMCxB+AAEAJAD4D/Bw+An/8PgP/5AL/+SIBtQPCAUPxJiGUIRoBtAPCAUACQAL8Av0/wAQr3SABoQPSAcPVJCGAB8LX8B0YG4AHwsfzAGwIoAdkDJQXg70gAaAD0gHAAKPLQAL+Fu+pIkDAAaAD0QHbWsdT4mACwQhbQ5UiQMABoIPRAduJI0PiQAED0gDDgScH4kAAIRtD4kAAg9IAwwfiQAAhGwPiQYAbwAQCwsQHwfvwHRgrgAfB6/MAbQfKIMYhCA9kDJQjgF+Ah4NBIkDAAaADwAgAAKO3QAL9ducxIkDAAaCD0QHDU+JgQCEPIScH4kAAC4KhGAOCoRrrxAQ8F0cNIgG0g8IBQwUmIZQC/IHgA8AEASLG9SIgwAGgg8AMA4WsIQ7pJwfiIACB4APACAAIoCdG2SIgwAGgg8AwAIWwIQ7JJwfiIACB4APAEAAQoCdGuSIgwAGgg8DAAYWwIQ6tJwfiIACB4APAIAAgoCdGnSIgwAGgg8MAAoWwIQ6NJwfiIACB4APAQABAoCdGfSIgwAGgg9EBw4WwIQ5xJwfiIACB4APAgACAoCdGYSIgwAGgg9EBgIW0IQ5RJwfiIACCIAPQAcLD1AH8J0ZBIiDAAaCD0QCBhbghDjEnB+IgAIIgA9IBgsPWAbwnRiEiIMABoIPRAEKFuCEOEScH4iAAgeADwQABAKAnRgEiIMABoIPRAUGFtCEN9ScH4iAAgeADwgACAKAnReUiIMABoIPRAQKFtCEN1ScH4iAAgiAD0gHCw9YB/CdFxSIgwAGgg9EAw4W0IQ21JwfiIACBoAPSAELD1gB8J0WlInDAAaCDwAwAhbghDZUnB+JwAIIgA9ABQsPUAXx/RYUiIMABoIPBAYGFvCENdSYgxCGBgb7DxAG8G0VpIwGhA9IAQWEnIYArgYG+w8YBvBtEBISAd//da/QVGBbGoRiBoAPQAILD1AC9B0QC/oG+w9YBPCNFLSJwwAGhA9IBASUnB+JwAEeBHSJwwAGgg9IBAREnB+JwAQ0iIMABoIPBAYKFvCEM/ScH4iAAAv6BvsPEAbwbRO0jAaED0gBA5SchgFeCgb7D1gE8G0TZIwGhA9IAwNEnIYArgoG+w8YBvBtEBISAd//cS/QVGBbGoRiBoAPSAILD1gC8f0SpIiDAAaCDwQGDhbwhDJkmIMQhg4G+w8QBvBtEjSMBoQPSAECFJyGAK4OBvsPGAbwbRASEgHf/37PwFRgWxqEYgiAD0gECw9YBPFtEXSIgwAGgg8EBQ1PiAEAhDE0mIMQhg1PiAALDxgF8G0QIhIB3/98/8BUYFsahGIGgA9IAwsPWAPwrRCEicMABoIPAEANT4hBAIQwRJwficACBoAPQAELD1AB8P0QPgABACQABwAED+SJwwAGgg8BgA1PiIEAhD+knB+JwAIGgA9IAAsPWADyvR9kgAaCDwgFD0SQhgAfCy+gdGBuAB8K76wBsCKAHZAyUF4O1IAGgA8ABQACjy0QC/hbnpSJwwAGgg9EAw1PiMEAhD5UnB+JwAAiEE8SAA//e6+wVGBbGoRiBoAPQAALD1AA8X0d1InDAAaCD0gFDU+JAQCEPZSZwxCGDU+JAAsPWAXwfRASEE8SAA//ec+wVGBbGoRiBoAPCAcLDxgH8V0c5InDAAaCD0QBDU+JQQCEPKSZwxCGDU+JQAsPUAHwXRxkjAaED0gBDESchgQEa96PiFwkkBYMBJyWgB8AMBQWC+SQlpwfMDEUkcgWC7SQlpwfMGIsJguEkJacHzQEEHIgLrARICYbRJCWnB80FRSRxKAEJhsUkJacHzQWFJHEoAgmFBaAFirElJacHzAxFJHEFiqUlJacHzBiKCYqdJSWnB80BBByIC6wESwmKjSUlpwfNBUUkcSgACY59JSWnB80FhSRxKAEJjnEmIMQloAfADAcFjmUmIMQloAfAMAQFklkmIMQloAfAwAUFkk0mIMQloAfDAAYFkkEmIMQloAfRAccFkjUmIMQloAfRAYQFlikmIMQloAfRAUUFlh0mIMQloAfRAQYFlhEmIMQloAfRAMcFlgUmcMQloAfADAQFmfkmIMQloAfRAIUFme0mIMQloAfRAEYFmeEmcMQloAfDgAcFmdUmcMQloAfTgYQFnckmQMQloAfRAccD4mBBuSYgxCWgB8EBhQWdrSZwxCWgB9IBBEbFP9IBBBOBnSYgxCWgB8EBhQPh4H2NJ0fiIEAHwQGFBYGBJ0fiIEAHwQFGBYF1J0ficEAHwBAHBYFpJ0ficEAHwGAEBYVdJ0ficEAH0QDFBYVRJ0ficEAH0gFGBYVFJ0ficEAH0QBHBYXg4cEfwtQVGDkYAIAAhACS19QBvCdFJT5w3P2gH8OABYCkP0Uv2gDAM4LX1gF8J0UJPnDc/aAf04GGx9UB/AdFL9oAwACgt0TJGQCkC0LH1AH8o0TlPP2gH8AB3t/EAf/HRNk//aAf0gDcALxrQM0//aMfzAxd/HLL79/IvT/9ox/MGIy1P/2j8Djy5K0//aAf0ADcPsREkAOAHJAL7A/e3+/TwauBBuyRPP2gH8ABnt/EAb2LRIU8/aQf0gDcAL1zQHk8/acfzAxd/HLL79/IaTz9px/MGIxhPP2n8Djy5Fk8/aQf0ADcPsREkAOAHJAL7A/e3+/TwQOCAKQLQsfWAbwjRDU8/aAf0gGe39YBvNNEMSDLgICkC0LH1gH8t0QZPP2gH8ABXt/EAXybRA09/aQf0gDcPswBPBeAAEAJA/3//AQAk9AB/acfzAxd/HLL79/L8T39px/MGI/pPf2n8Djy5+E9/aQf0ADcPsREkAOAHJAL7A/e3+/Tw8L0t6fBNB0ZP8AALt/UAPy7R7kiQMABoAPRAdLT1gH8G0LT1AH8N0LT1QH8e0RPg5kiQMABoAPACAAIoAdFP9ABLFODhSJQwAGgA8AIAAigB0U/0+ksK4NxIAGgA9AAwsPUAPwHR3/hoswDgAL/z49ZIwGgA8AMKuvEBDwbQuvECDyHQuvEDDzTRKODPSABoAPACAAIoFdHMSABoAPAIACCxykgAaADw8AAF4MdIlDAAaAD0cGAACQAJxkl5RFH4IFAA4AAlF+DASABoAPSAYLD1gG8B0cBNAOAAJQzgu0gAaAD0ADCw9QA/AdG7TQDgACUB4AAlAL8Av7f1gG940BrcIC920AzcBC900ATcAS9y0AIvcdHH4Qgvb9AQL/nRRuJAL2vQgC9r0Lf1gH9p0Lf1AH/u0aXjt/WALy7QEdy39QBfKdAG3Lf1AG8X0Lf1gF/f0Rrgt/WAT3jQt/WAP9jRt+K39QAvctC39YAfcNC39QAfbtC38YB/y9Hs4ylGT/QAYP/3gP6DRhDiKUZP9IBQ//d5/oNG9+cAv4tIiDAAaADwQGRcs7TxgG9T0LTxAG8o0LTxQG980YRIAGgA8AIAAigU0YFIAGgA8AgAILF+SABoAPDwAAXgfEiUMABoAPRwYAAJAAl9SXlEUfggsGHgfOML4oPhKuH846zhsuJO4NLi++JxSABoAPAAcLDxAH8b0W1IwGgA9IAQsPWAHxTRakjAaMDzBiYF+wbwZ0nJaMHzAxFJHLD78fVjSMBowPNBUEAcQAC1+/D7M+AN4jPg9uJM4l1IAGgA8ABgsPEAbxvRWUgAaQD0gBCw9YAfFNFWSABpwPMGJgX7BvBTSQlpwfMDEUkcsPvx9U9IAGnA80FQQBxAALX78PsL4AngSkiYMABoAPACAAIoAdHf+DSxAOAAvwC/peNESJwwAGgA9IBAsPWATy7RQEgAaADwAHCw8QB/JtE8SMBoAPSAMLD1gD8f0TlIwGjA8wYmBfsG8DZJyWjB8wMRSRyw+/H1MkjAaE/q0Gi48QAPCdEvSMBoAPQAMBCxT/ARCAHgT/AHCLX7+PuS4ChIiDAAaADwQGTss7TxgG9Y0LTxAG8e0LTxQG920SFIAGgA8AIAAigU0R5IAGgA8AgAILEbSABoAPDwAAXgGUiUMABoAPRwYAAJAAkcSXlEUfggsGbgE0gAaADwAHCw8QB/HdEPSMBoAPSAELD1gB8W0QxIwGjA8wYmBfsG8AlJyWjB8wMRAOBB4EkcsPvx9QRIwGjA80FQQBxAALX78PtA4AAAABACQJDQAwAcJwAAACT0AAASegDuJQAAAGzcAmIkAAD3SABoAPAAYLDxAG8b0fRIAGkA9IAQsPWAHxTR8EgAacDzBiYF+wbw7UkJacHzAxFJHLD78fXqSABpwPNBUEAcQAC1+/D7C+AJ4OVImDAAaADwAgACKAHR3/iIswDgAL8Av9ri3kiIMABoAPADBDSxASwI0AIsCtADLBzREeD+97n+g0YY4P73xviDRhTg1EgAaAD0gGCw9YBvAdHf+EizCuDPSJAwAGgA8AIAAigB0U/0AEsA4AC/AL+u4shIiDAAaADwDAQ0sQQsCNAILArQDCwc0RHg/vd//oNGGOD+95r4g0YU4L5IAGgA9IBgsPWAbwHR3/jwsgrguUiQMABoAPACAAIoAdFP9ABLAOAAvwC/guKySIgwAGgA8DAENLEQLAjQICwK0DAsHNER4P73U/6DRhjg/vdu+INGFOCoSABoAPSAYLD1gG8B0d/4mLIK4KNIkDAAaADwAgACKAHRT/QASwDgAL8Av1binEiIMABoAPDABDSxQCwI0IAsCtDALBzREeD+9yf+g0YY4P73QviDRhTgkkgAaAD0gGCw9YBvAdHf+ECyCuCNSJAwAGgA8AIAAigB0U/0AEsA4AC/AL8q4oZIiDAAaAD0QHRMsbT1gH8K0LT1AH8L0LT1QH8c0RHg/vf4/YNGGOD+9xP4g0YU4HpIAGgA9IBgsPWAbwHR3/jksQrgdUiQMABoAPACAAIoAdFP9ABLAOAAvwC/++FvSIgwAGgA9EBkTLG09YBvCtC09QBvC9C09UBvHNER4P73yf2DRhjg/ffk/4NGFOBjSABoAPSAYLD1gG8B0d/4hLEK4F5IkDAAaADwAgACKAHRT/QASwDgAL8Av8zhV0iIMABoAPBAVLTxgF8G0LTxQF8l0f33vv+DRiLgUEgAaADwAGCw8QBvGdFMSABpAPCAcKCxSkgAacDzBiYF+wbwR0kJacHzAxFJHLD78fVDSABpwPNBYEAcQAC1+/D7AOAAvwC/mOE9SJwwAGgA8AQEHLn+9379g0YC4P33i/+DRorhNkicMABoAPAYBCSxCCwl0BAsLdEG4ClGT/QAYP/3vPuDRibgLUgAaADwAgACKBTRKkgAaADwCAAgsShIAGgA8PAABeAlSJQwAGgA9HBgAAkACSVJeURR+CCwCuAfSABoAPSAYLD1gG8B0d/4eLAA4AC/AL9P4RlIiDAAaAD0QFQ0sbT1gF8H0LT1AF8S0Qfg/vcg/YNGDuD99zv/g0YK4A5IAGgA9IBgsPWAbwHR3/g0sADgAL8Avy3hCEiIMABoAPRARDSxtPWATw/QtPUATxrRD+D+9/78g0YW4AAQAkAAbNwCACT0AJQgAAD99xH/g0YK4PdIAGgA9IBgsPWAbwHR3/jUswDgAL8AvwPh8UiIMABoAPRANDSxtPWAPwfQtPUAPxLRB+D+99T8g0YO4P337/6DRgrg5kgAaAD0gGCw9YBvAdHf+JCzAOAAvwC/4eDgSJwwAGgA8AMELLEBLAfQAiwT0Qjg1uD+97P8g0YO4P33zv6DRgrg1kgAaAD0gGCw9YBvAdHf+EyzAOAAvwC/wODPSIgwAGgA9EAkTLG09YAvCtC09QAvEdC09UAvItEX4P73jvyDRh7gxUiUMABoAPACAAIoAdFP9PpLFODASABoAPSAYLD1gG8B0d/4+LIK4LtIkDAAaADwAgACKAHRT/QASwDgAL8Av4vgtUiIMABoAPRAFEyxtPWAHwrQtPUAHxHQtPVAHyLRF+D+91n8g0Ye4KtIlDAAaADwAgACKAHRT/T6SxTgpkgAaAD0gGCw9YBvAdHf+IyyCuChSJAwAGgA8AIAAigB0U/0AEsA4AC/AL9W4JpInDAAaAD0QBQ0sbT1gB8H0LT1AB9G0R/g/fdG/oNGQuCSSABoAPACAAIoFNGPSABoAPAIACCxjEgAaADw8AAF4IpIlDAAaAD0cGAACQAJiEl5RFH4ILAm4IRIAGgA8ABwsPEAfx3RgEjAaAD0gBCw9YAfFtF9SMBowPMGJgX7BvB6SclowfMDEUkcsPvx9XZIwGjA80FQQBxAAADgBeC1+/D7AOAAvwC/AOAAvwC/WEa96PCNcLUERgAma0gAaCDwgGBpSQhgAPCb+wVGBuAA8Jf7QBsCKAHZAyYF4GNIAGgA8ABgACjy0QC/hrtgaEAeAAGhaEDqASAhigEiwutRAUDqQVAhfcLrUQFA6kFgIXtA6sFgVUkJaVdKEUAIQ1JJCGEIRgBpoWkIQ09JCGEIRgBoQPCAYAhgAPBi+wVGB+AA8F77QBsCKALZAyYG4AbgRkgAaADwAGAAKPHQAL8wRnC9cLUAJUBIAGgg8IBgPkkIYADwRfsERgbgAPBB+wAbAigB2QMlBeA4SABoAPAAYAAo8tEAvzRIAGk3SQhAMkkIYQhGAGgA8AhQILkIRsBoIPADAMhgKEZwvXC1BEYAJipIAGgg8IBQKEkIYADwGPsFRgbgAPAU+0AbAigB2QMmBeAhSABoAPAAUAAo8tEAv4a7YGhAHgABoWhA6gEgIYoBIsLrUQFA6kFQIX3C61EBQOpBYCF7QOrBYBNJSWkVShFACEMRSUhhCEZAaaFpCEMOSUhhCEYAaEDwgFAIYADw3/oFRgfgAPDb+kAbAigC2QMmBuAG4ARIAGgA8ABQACjx0AC/MEZwvQAAABACQAAk9AAuHgAAD4CdAf//7v5wtQAl90gAaCDwgFD1SQhgAPC3+gRGBuAA8LP6ABsCKAHZAyUF4O9IAGgA8ABQACjy0QC/60hAaetJCEDpSUhhCEYAaADwIGAguQhGwGgg8AMAyGAoRnC94kmJaCH0AEEBQ+BKkWBwR95JlDEJaCH0cGFB6gAR20rC+JQQcEfZSJAwAGhA8CAA1knB+JAAcEfUSJAwAGgg8CAA0knB+JAACEaAaSD0AHCIYXBHzUiQMABoQPAgAMtJwfiQAAhGgGlA9ABwiGHJSABoQPQAIMdJCGDGSAgwAGhA9AAgw0kIMQhgcEdwRxC1vkjAaQD0AHCw9QB/BdH/9/X/T/QAcLlJCGIQvXC1hrAERgAlACYAv7RIwGxA8AEAsknIZAhGwGwA8AEAAJAAvwC/BCABkAMgApACIASQACADkAGpT/CQQPv32PinSIBtAPCAUHC5AL+kSIBtQPCAUKJJiGUIRoBtAPCAUACQAL8AvwEloEgAaAD0gHAQufz3xf0BJplIkDAAaCDwQHBE8IBxCEOVScH4kAABLgHR/Pe8/QEtBdGRSIBtIPCAUI9JiGUGsHC9OLUAJAAli0iAbQDwgFBwuQC/iEiAbUDwgFCGSYhlCEaAbQDwgFAAkAC/AL8BJIRIAGgA9IBwELn89439ASV9SJAwAGgg8IBwe0nB+JAAAS0B0fz3h/0BLAXRdkiAbSDwgFB0SYhlOL1zSABoQPAEAHFJCGBwR29IAGgg8AQAbUkIYHBHbEqkMhJoIvD/AkDqARMaQ2hLw/ikIHBHZkqSa0LwgHJkS5pjGkaSayLwgHKaY9DpACMaQ4NoQuoDAcJoEUMCikHqAkFfSlFgEmgi9HxSQ2lC6gMiW0saYBpGEmhC8GACGmBwR1dIAGhA8IAAVUkIYHBHU0lJaImyAWBRSQlowfMFIUFgT0mJaAkMgWBNSYloAfQAQcFgcEdwtQVGACQA8Ff5BkYAv2gcMLEA8FH5gBuoQgDYBbkBJEJIgGgA8AEAMLFE8AIEAL8BID1JyGAAvzxIgGgA8AIAAigF0UTwBAQAvzdJyGAAvzZIgGgA9IBgsPWAbwbRRPAgBAC/BCAwSchgAL8vSIBoAPSAcLD1gH8G0UTwCAQAvwQgKUnIYAC/KEiAaAD0AHCw9QB/BtFE8BAEAL8EICJJyGAAvyFIgGgA8AgACCgD0QC/HUnIYAC/ACyo0CBGcL1wR3BHcEdwR3C1ACUXSIRoBmgE8AEAQLEG8AEAKLEBIBJJyGD/9+//POAE8AIAQLEG8AIAKLECIAxJyGD/9+L/MOAE8AgAkLEG8AgAeLEIIAZJyGD/99X/JOAAEAJA///u/gAEAUAAcABAAGAAQATwBAC4sQbwBACgsQT0gHAIsUXwCAUE9ABwCLFF8BAFBPSAYAixRfAgBQQgAknIYChG//eu/3C9AGAAQEZIAGhA8AEAREkIYAAgiGAIRgBoQkkIQEBJCGCIFMhgCEYAaCD0gCAIYAAgiGHIAzxJCGBwR/C1ACMAIAAiAiQAJQIhNU42aAbwCAYuuTNOlDY2aMbzAyAD4DBONmjG8wMQMU5+RFb4IAAsTrZoBvAMBjaxBC4I0AguC9AMLjnRDeAqTk5EMGA44ClOJ09PRD5gM+AnTiVPT0Q+YC7gH072aAbwAwUdTvZoxvMDFnEcAi0C0AMtCNED4B1Otvvx8gbgHE62+/HyAuCw+/HyAL8AvxJO9mjG8wYmckMPTvZoxvNBZnYcdACy+/T2D09PRD5gA+ANTk5EMGAAvwC/B062aMbzAxYMT39Eu10HTk5ENmjeQAVPT0Q+YPC9ABACQP//9uoI7QDgaBcAABAAAAAAJPQAABJ6AKwWAAABRgAgAL8A4EAcsPWAX/vbcEcAIQDgSRyx9YBv+9tcSEhEAGhAHFpKSkQQYBBGAGhwRwFGACBwRwC1l7AUIRKoAfD0+kQhAagB8PD6AL9RSIBtQPCAUE9JiGUIRoBtAPCAUACQAL8AvwAg/Peg/ElIgG0g8IBQR0mIZRAgAZABIAeQACAIkAIgC5ABIQyRYCAJkA2RNyEOkQIhEZEQkQchD5EBqP33vvoIsQC//ucPIBKQAyATkIAgFJAAIBWQFpADIRKo/feg/gixAL/+5wIgEpAAIBSQBSESqP33lf4IsQC//ucXsAC9ELUAJP/36v769zr7//eg/wDwqv8A8AX/CLEAIBC9AfCY+QRGDLkBIPjnACD25xC1APCa/wDw9f4B8OL4AL8B8BD5ACj70RC9cLUERg1GFkYA8Ir/JPBwRADw4/4qRiFGMEYA8PX/ASBwvXC1BEYNRiTwcEQl8HBFoLIkGgDwdP8A8M/+DOAmRjBGAfBH+AC/AfDn+AAo+9EE9YA0AfBZ+aVC8NIBIHC9BAAAAAAQAkABeUoe+EsD64ICQmX2SkAygmVKHgLwAwMBIppAwmVwR/JLAmiaQgbSQmySCPBLA+uCAoJkBuBCbJII7UscMwPrggKCZAJ4CDoUI7L78/HmSoA6wmQB8B8DASKaQAJlcEdwtQRGDLkBIHC94EkgaIhCC9LgSSBoQBoUIbD78fCAAGBk3EgIOCBkCuDYSSBoQBoUIbD78fCAAGBk1EgIOCBkAiCE+CUAIGgFaEf28HCFQ9TpAgEIQyFpCENhaQhDoWkIQ+FpCEMhaghDBUMgaAVgIEb/96X/oGiw9YBPAdEAIGBgIHmhbAhg1OkTEEhgYGhgsWBoBCgJ2CBG//eB/wAgYW0IYNTpFhBIYAPgACBgZaBl4GUAIOBjASCE+CUAACCE+CQAAL+f5xC1BEYMuQEgEL0gaABoIPABACFoCGCrSSBoiEIL0qtJIGhAGhQhsPvx8IAAYGSnSAg4IGQK4KNJIGhAGhQhsPvx8IAAYGSfSAg4IGQAICFoCGCU+EQAAPAcAQEgiEAhbEhgIEb/90j/ACChbAhg1OkTEEhgYGhYsWBoBCgI2CBG//cq/wAgYW0IYNTpFhBIYAAgYGWgZeBl4GIgY2BjoGPgY4T4JQAAv4T4JAAAvwC/qucwtdDpE1RsYERtFLHQ6RZUbGCQ+ERABPAcBQEkrEAFbGxgBGhjYIRoECwE0QRoomAEaOFgA+AEaKFgBGjiYDC9LenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKBfRAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//e3/yBoAGhA8AEAIWgIYAbgAL8AIIT4JAAAv0/wAghARtTnLenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKD/RAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//d+/yBrMLEgaABoQPAOACFoCGAL4CBoAGgg8AQAIWgIYCBoAGhA8AoAIWgIYKBsAGgA9IAwKLGgbABoQPSAcKFsCGBgbSixYG0AaED0gHBhbQhgIGgAaEDwAQAhaAhgBuAAvwAghPgkAAC/T/ACCEBGrOcBRgAikfglAAIoCNAEIMhjAL8AIIH4JAAAvwEgcEcIaABoIPAOAAtoGGCIbABoIPSAcItsGGAIaABoIPABAAtoGGCR+EQAAPAcAwEgmEALbFhg0ekTMFhgSG1AsUhtAGgg9IBwS20YYNHpFjBYYAEggfglAAC/ACCB+CQAAL8QRszncLUERgAllPglAAIoDNAEIOBjASU94AAAAAkCQAgEAkAACAJACAACQCBoAGgg8A4AIWgIYCBoAGgg8AEAIWgIYKBsAGgg9IBwoWwIYJT4RAAA8BwBASCIQCFsSGDU6RMQSGBgbUCxYG0AaCD0gHBhbQhg1OkWEEhgASCE+CUAAL8AIIT4JAAAv6BrELEgRqFriEcoRnC9LenwQQRGDkYVRpT4JQACKAnQBCDgYwC/ACCE+CQAAL8BIL3o8IEgaABoAPAgACCxT/SAcOBjASDz5z65lPhEAADwHAECIAD6AfgG4JT4RAAA8BwBBCAA+gH4//fb/AdGMOAgbABolPhEEAHwHAIIIZFACECQsZT4RAAA8BwBASCIQCFsSGABIOBjhPglAAC/ACCE+CQAAL8BIMLnaByIsf/3uPzAG6hCANhduSAg4GMBIIT4JQAAvwAghPgkAAC/ASCu5yBsAGgA6ggAACjI0GBtiLGgbQBo4W0IQGCxYG0AaED0gHBhbQhg1OkWEEhg4GtA9IBg4GPgbABoIW0IQDCx1OkTEEhg4GtA9ABw4GOGuZT4RAAA8BwBAiCIQCFsSGAAvwAghPgkAAC/ASCE+CUAB+CU+EQAAPAcAQQgiEAhbEhgACBs53C1BEYgbAVoIGgGaJT4RAAA8BwBBCCIQChA4LEG8AQAyLEgaABoAPAgACi5IGgAaCDwBAAhaAhglPhEAADwHAEEIIhAIWxIYCBrAChW0CBGIWuIR1LglPhEAADwHAECIIhAKEAYswbwAgAAsyBoAGgA8CAAQLkgaABoIPAKACFoCGABIIT4JQCU+EQAAPAcAQIgiEAhbEhgAL8AIIT4JAAAv+BqULMgRuFqiEcm4JT4RAAA8BwBCCCIQChA8LEG8AgA2LEgaABoIPAOACFoCGCU+EQAAPAcAQEgiEAhbEhgASDgY4T4JQAAvwAghPgkAAC/YGsQsSBGYWuIR3C9ELUDRgAkAL+T+CQAASgB0QIgEL0BIIP4JAAAv5P4JQABKBLRMbEBKQbQAikG0AMpCNEF4NpiB+AaYwXgWmMD4JpjAeABJAC/AOABJAC/ACCD+CQAAL8gRtvnAkYAIwC/kvgkAAEoAdECIHBHASCC+CQAAL+S+CUAASgb0QUpFtLf6AHwAwYJDA8AACDQYhDgACAQYw3gACBQYwrgACCQYwfgACDQYhBjUGOQYwHgASMAvwDgASMAvwAggvgkAAC/GEbS5wFGkfglAHBHAUbIa3BHAAAQtZqwBEYAIAaQB5BA8vlgCJAEIAmQECAKkAAgDZARkBSQF5AYkBmQCCALkEHyiDIGqfVISET69/D+ELEBIBqwEL0CIAGQApBA8vpQCJAAIAyQT/SAYA2QT/RAUA6QT/CAYBSQAiAVkIACD5AABBaQgAAYkAQgF5AAv0HyiDIGqeFISET698n+CLEBINfnQfKIMmlG3EhIRPv3NPgIsQEgzeed+AAAApkIQAGZiELk0QAgxOcwtZuwBEYNRgAgB5AIkEDy+lAJkAQgCpAQIAuQACANkE/0gGAOkE/0QFAPkAAgEpBP8IBgFZACIBaQBiAYkAAgGpAIIAyQAAIQkAAEF5CAABmQACACkAEgA5AAv0HyiDIHqbxISET6937+ELEBIBuwML1B8ogyAam2SEhE+vfo/wixASDz5534BAADmQhAApmIQuPRACDq5zC1m7AFRgxGACAHkAiQDJBP9EBQD5AAIBCQEpAXkBmQGpAEkBAgBpCABAWQASxu0QYgCZABIAqQACALkA6QFZAYkEHyiDIHqZxISET69z/+ELEBIBuwML0CIAKQA5AFIAmQT/CAcBWQASAWkEHyiDIHqZJISET69yr+CLEBIOnnQfKIMgKpjUhIRPv3L/oIsQEg3+dyIAmQT/RAcA2QT/SAcA6QByCN+AQAQfKIMgepgkhIRPr3C/4IsQEgyudB8ogyAal9SEhE+vco/wixASDA5wYgCZAAIA6QFZBB8ogyB6l2SEhE+vfy/QixASCx5wUgCZBP8IBwFZBB8ogyB6luSEhE+vfj/RCxASCi52TgQfKIMgKpaUhIRPv35/kIsQEgl+dyIAmQACANkE/0gHAOkAIgjfgEAEHyiDIHqV9ISET698T9CLEBIIPnQfKIMgGpWkhIRPr34f4IsQEgeedB8ogxVUhIRP/3/v4IsQEgcOdH8o4QCZAEIAqQECALkIABDpAABBWQBiAYkAIgFpAAII34BAAIIAyQAAIQkAAEF5CAABmQQfKIMgepQ0hIRPr3jf0IsQEgTOdB8ogyAak+SEhE+vf4/gixASBC5534BAACKHHQASA85zhISET/92n+CLEBIDXnR/KNIAmQBCAKkBAgC5AAIA2QT/SAYA6QAAQVkAIgFpAAIBiQjfgEAI34BQAIIAyQAAIQkAAEF5BB8ogyB6klSEhE+vdQ/QixASAP50HyiDIBqSBISET6923+CLEBIAXnBSAJkAEgCpAAIAuQDpBP8IBwFZABIBaQACAYkAyQEJAXkAKQASADkEHyiDIHqRFISET69yj9CLEBIOfmQfKIMgKpDEhIRPv3LfkIsQEg3eZxIAmQACANkE/0gHAOkEHyiDIHqQNISET69w39ILEBIMzmEOAUAAAAQfKIMgGp+UhIRPr3df4IsQEgv+ad+AQACLEBILrmACC45hC1mrAERgAgBpAHkGYgCJABIAmQACAKkAuQDZARkBSQF5AYkBmQQfKIMgap50hIRPr33PwQsQEgGrAQvZkgCJBB8ogyBqngSEhE+vfP/AixASDx5wUgCJBP8IBwFJABIBWQACAWkAGQASACkAAgA5AQIAWQgAQEkEHyiDIGqdJISET697P8CLEBINXnQfKIMgGpzUhIRPv3uPgIsQEgy+cAIMnnALWHsAC/yEjAbED0gBDGSchkCEbAbAD0gBABkAC/AL8AvwhGAG1A9IBwCGUIRgBtAPSAcAGQAL8AvwhGAGtA9IBwCGMIRgBrIPSAcAhjAL8IRoBtQPCAUIhlCEaAbQDwgFABkAC/AL+xSEBoQPQAcK9JSGAAv6xIwGxA8EAAqknIZAhGwGwA8EAAAZAAvwC/AL8IRsBsQPCAAMhkCEbAbADwgAABkAC/AL8AvwhGwGxA9IBwyGQIRsBsAPSAcAGQAL8Av4gUApACIAOQASAEkAMgBZAFIAaQAqmVSPn3Xf9P9ABAApACqZJI+fdW/0/0ZGACkAAgBJACqY5I+fdN/0/04GACkAKpjEj590b/T/TAYAKQAqmGSPn3P/8HsAC9ALWFsBQhaEYA8Iv7UCF9SEhEAPCG+4FIe0lJRAhgCEb695j5ELEBIAWwAL3/91j/BCB0SUlESGAAIXJISESBYE/wgGCQ+qDwsPqA8W5ISEQBYQIhQWEAIYFhwWECIQFiACFBYk/wgHHBYAkBgWIAIcFiAWP69/T4CLEBINTnAiAAkAGQZ0gEkGdIA5ACIAKQQfKIMmlGW0hIRPv3q/kIsQEgwedYSEhE//fI/gixBCC65wEhVEhIRP/3T/0IsQEgsucAILDnALWFsE/0FkFQSPn3uP9P9OBhUEj597P/T/RkYUxI+feu/wAgAZBP9IBQAJAAIAKQA5BpRkVI+fe9/gEgAZAAIAKQT/QAQACQaUZASPn3sv4AIk/0AEE9SPr3K/g5SABrQPSAcDdJCGMIRgBrIPSAcAhjCEYAbSD0gHAIZQWwAL0QtTVILklJRAhgCEb79+X4AigG0CpISET793H4CLEBIBC9ACEmSEhE//f0/AixASD25yNISET69+r4CLEBIO/n//ee/wAg6+dwtZSwBEYNRhZGACAAkAGQBCADkBAgBJAGlYABB5BP9EBQCJAAIAuQT/CAYA6QD5YGIBGQACATkE72EWACkAggBZAAAgmQAAQQkIAAEpBB8ogyaUYISEhE+vcf+xCxASAUsHC9QfKIMiFGA0hIRPr3ifyYsQEg8+cUAAAAABACQABwAEAAGABIACAASAAcAEgAEACgAgAAAQIAAQAAIN/nLenwRZWwgkYNRpBG6LLA9YB2RkUA2UZGLEYF6wgHACABkAKQQfLtIAOQBCAEkBAgBZCAAQiQT/RAUAmQACAMkE/wgGAPkAAgEpAUkAggBpAAAgqQAAQRkIAAE5AAvweUEJb6SEhE//e7+xixASAVsL3o8IVB8ogyAan0SEhE+ve8+gixASDy50HyiDJRRu9ISET699n7CLEBIOjnQfKIMepISET/9/b7CLEBIN/nNESyRAT1gHC4QgHZOBsB4E/0gHAGRrxCytMAINDnELWUsARGACAAkAGQTfYjQAKQBCADkBAgBJAGlIABB5BP9EBQCJAAIAuQDpARkBKQE5AIIAWQAAIJkNFISET/92n7ELEBIBSwEL1B8ogyaUbLSEhE+vdr+gixASDz50/0+mHHSEhE//ev+wixASDq5wAg6OcQtZSwBEa09YBPAtMBIBSwEL0AIACQAZBC8t4QApAEIAOQECAEkCADBpBP9IBgB5BP9EBQCJAAIAuQDpARkBKQE5AIIAWQAAIJkLBISET/9yf7CLEBINrnQfKIMmlGq0hIRPr3KvoIsQEg0OcAIM7nALWVsAAgAZACkEbynwADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQnEhIRP/3//oQsQEgFbAAvUHyiDIBqZZISET69wH6CLEBIPPnlEmSSEhE//dG+wixASDr5wAg6ecAtZWwACABkAKQQvbUMAOQBCAEkBAgBZAAIAeQT/SAYAiQT/RAUAmQACAMkE/wgGAPkAIgEJAGIBKQACAUkAggBpAAAgqQAAQRkIAAE5BB8ogyAal5SEhE+vfG+RCxASAVsAC9QfKIMmlGc0hIRPr3MPsIsQEg8+ed+AAAAPBgAAixASDs5534AAAA8AwACLEIIOXnQPL6UAOQQfKIMgGpZkhIRPr3oPkIsQEg2OdB8ogyaUZhSEhE+vcL+wixASDO5534AAAA8AEACLECIMfnACDF5wFGT/CAYAhggBJIYIARiGCAEMhggAIIYQAgcEcAtZewUUhIRP/3afoQsQEgF7AAvQEgA5AAIASQBCAGkBAgB5CAAQqQT/RAUAuQACAOkE/wgGARkAYgFJAAIBaQTvYRYAWQCCAIkAACDJAABBOQgAAVkEHyiDIDqTtISET690r5CLEBINLnAiADkEHy7SAFkAAgFJBB8ogyA6kySEhE+vc5+QixASDB5wAgAZABqS1ISET69wj+CLEBILfnACC15wC1lbD/9zL/Aigl0QAgAZACkEvyTwADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQQfKIMgGpG0hIRPr3CvkQsQEgFbAAvf/3EP8IKAHRACD35wEg9ecAIPPnALWVsP/3BP8IKCrRACABkAKQQ/LPAAOQBCAEkBAgBZAAIAiQDJAPkBKQE5AUkAggBpBB8ogyAakESEhE+vfc+DixASAVsAC9AAAUAAAA4JMEAP/33f4CKAHRACDy5wEg8OcAIO7nALWVsAAgAZACkEv2RhADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQQfKIMgGpFUhIRPr3rfgQsQEgFbAAvQAg++cAtZWwACABkAKQ/yADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQQfKIMgGpBUhIRPr3jPgQsQEgFbAAvQAg++cAABQAAABP8AACALUTRpRGlkYgOSK/oOgMUKDoDFCx8SABv/T3rwkHKL+g6AxQSL8MwF34BOuJACi/QPgEKwi/cEdIvyD4AisR8IBPGL8A+AErcEcAAAAAAAAAAAAAAQIDBAYHCAkAAAAAAQIDBKCGAQBADQMAgBoGAAA1DABAQg8AgIQeAAAJPQAAEnoAACT0AAA2bgEASOgBAGzcAgAAAAAAAAAAEAAAAAEAAAAACT0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+    load_address: ~
+    pc_init: 207
+    pc_uninit: 229
+    pc_program_page: 273
+    pc_erase_sector: 243
+    pc_erase_all: 235
+    data_section_offset: 28924
     flash_properties:
       address_range:
-        start: 0x1ff00000
-        end: 0x1ff00014
-      page_size: 0x14
-      erased_byte_value: 0xff
-      program_page_timeout: 0xbb8
-      erase_sector_timeout: 0xbb8
+        start: 2415919104
+        end: 2483027968
+      page_size: 4096
+      erased_byte_value: 255
+      program_page_timeout: 10000
+      erase_sector_timeout: 6000
       sectors:
-        - size: 0x14
-          address: 0x0
-  - name: stm32l4p5xx_1m
-    description: STM32L4P5xx_1M Flash
-    cores:
-      - main
+        - size: 65536
+          address: 0
+    cores: []
+  - name: stm32l4r9i_disco_ospi2
+    description: MX25L51245G_STM32L4R9I_DISCO_OSPI2
+    default: false
+    instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAARkgAaEDwAQBESQhgACCIYAhGAGhCSQhAQEkIYMgUyGAIRgBoIPSAIAhgACCIYcgDPEkIYHBH8LUAIwAgACICJAAlAiE1TjZoBvAIBi65M06UNjZoxvMDIAPgME42aMbzAxAxTn5EVvggACxOtmgG8AwGNrEELgjQCC4L0AwuOdEN4CpOTkQwYDjgKU4nT09EPmAz4CdOJU9PRD5gLuAfTvZoBvADBR1O9mjG8wMWcRwCLQLQAy0I0QPgHU62+/HyBuAcTrb78fIC4LD78fIAvwC/Ek72aMbzBiZyQw9O9mjG80Fmdhx0ALL79PYPT09EPmAD4A1OTkQwYAC/AL8HTrZoxvMDFgxPf0S7XQdOTkQ2aN5ABU9PRD5g8L0AEAJA///26gjtAOBwUwAABAAAAAAk9AAAEnoAtFIAAHtIgGtA8IBQeUmIYwhGgGsg8IBQiGNwR3ZIAGhA9IBwdEkIYHBHc0gAaCD0gHBxSQhgcEcBRm9IQGgg8A4ACmgQQ2xKUGBsSABoIPSAMGpKEGAQHwBoIPSAMBIfEGBmSAgwAGgg9IAwY0oIMhBgEB8AaCD0gDASHxBgSGgA9IAwsPWAPwfRXEgAHwBoQPSAMFlKEh8QYEhoAPQAMLD1AD8F0VVIAGhA9IAwU0oQYAh5APABADixUEgAHQBoQPSAME1KEh0QYAh5APACAAIoB9FJSAgwAGhA9IAwR0oIMhBgACBwR0NIQGhA8AEAQUlIYHBHQEhAaCDwAQA+SUhgcEc8ScloAPAfApFDQepQETlK0WARRoloAPAfAhFDNUqRYHBHNEmJaADwHwKRQzFKkWBwR3C1BUYMRk25LkhAaQD0AHCw9QB/CdED8BX5BuApSEBpwPNAIAi5A/AG+SdIAGgg8AQAJUkIYAEsAdEwvwLgQL8gvyC/cL1wtQVGDEa19YBPA9EgRgPwNfkC4CBGA/AX+XC9F0gAaCDwBwDAHBVJCGAWSABoQPAEABRJCGAAvwC/ML9wRxFIAGhA8AIAD0kIYHBHDUgAaCDwAgALSQhgcEcKSABoQPAQAAhJCGBwRwZIAGgg8BAABEkIYHBHcEcAEAJAAHAAQAQEAUAQ7QDgcEdwtQRGhUhIRABoT/R6cbD78fUoRgDwofkAIiFGUB4A8DL5ACBwvRC1fUgAaED0gHB7SQhgAyAA8BT5DyAE8PL///fd/wAgEL1wRxC1T/D/MHRJiGMAIIhjQB4IZAAgCGRAHohiACCIYkAeyGIAIMhiQB4IYwAgCGP/9+b/ACAQvWlISEQAaEAcZ0lJRAhgcEdlSEhEAWgIRkocYktLRBpgcEdwtQRG//fz/wZGJUZoHACxbRwAv//36/+AG6hC+tNwvU/w4CAAaSDwAgBP8OAhCGFwR0/w4CAAaUDwAgBP8OAhCGFwR1BIcEdQSABoAAxwR05IAGjA8wsAcEdNSABocEdLSAAdAGhwR0lICDAAaHBHRkhAaEDwAQBESUhgcEdDSEBoIPABAEFJSGBwRz9IQGhA8AIAPUlIYHBHPEhAaCDwAgA6SUhgcEc4SEBoQPAEADZJSGBwRzVIQGgg8AQAM0lIYHBHyiAzSUhiUyBIYgEgMUkIYHBHASAwSQhicEcAIC5JCGJwRytJCWsh8AQBAUMoShFjcEcnSQlrIfACAQFDJEoRY3BHI0lJayHwPwEBQyBKUWNwRxC1ACQeSABrQPABABxJCGP/92L/BEYG4P/3Xv8AGwooAdkDIBC9FUgAawDwCAAAKPLQACD25xFIAGsg8AEAD0kIY3BHDkhAaED0gHAMSUhgcEcKSEBoIPSAcAhJSGBwRwAABAAAAAAgAkAAEAJACAAAAAUACAEAIATgkHX/HwAAAUAAAyBCAAAgQhC1ACgH2goHFA65SgDwDwMbH9RUA+AKBxMOtkoTVBC9AL8A8AcCsksMOxloT/b/AxlAsUsLQ0PqAiGtSww7GWAAv3BHLenwTYBGDUYWRgAnAPBI+QdGOUYqRjNGAfAHAMDxBwu78QQPAtlP8AQLAeDA8QcL2kYA8QQLu/EHDwLST/AACwHgoPEDC9xGT/ABCwv6Cvur8QELC+oCCwv6DPtP8AEODvoM/q7xAQ4O6gMOS+oOBCFGQEb/96L/vejwjXBHAL8A8B8CASGRQItKQwlC+CMQAL9wRwC/AL8AvwC/AL+/80+PAL8AvwC/gEgMOABoAPTgYIBJCEMAHXxJDDkIYAC/AL8Av7/zT48AvwC/AL8AvwC//edwtQRGJUZoHrDxgH8B0wEgD+BoHk/w4CFIYQ8hT/D/MP/3Yv8AIE/w4CGIYQcgCGEAIHC9ELUA8Mn4EL0t6fBFBEYgRgAoCNpjTwDwDwys8QQMF/gMcD8JAuBgTz9cPwk9Rg5GBvAHAMDxBwi48QQPAtlP8AQIAeDA8QcIxEYA8QQIuPEHDwLST/AACAHgoPEDCEdGJfoH+E/wAQoK+gz6qvEBCgjqCgjC+ACAT/ABCAj6B/io8QEICOoFCMP4AIAAv73o8IUAvwDwHwIBIZFAREqAMkMJQvgjEAC/cEcQtQFGCEY/SoAyQwlS+CMgAPAfBAEjo0AaQAqxASIA4AAiEEYQvQC/APAfAgEhkUA2SkMJQvgjEAC/cEcQtQFGCEYxSoAyQwlS+CMgAPAfBAEjo0AaQAqxASIA4AAiEEYQvQQoCNFP8OAhCWlB8AQBT/DgIhFhB+BP8OAhCWkh8AQBT/DgIhFhcEdwRxC1//f8/xC9QXgYSoAyEWABePmxEh1BaBFgAXsJB8J6QeoCYYJ6QerCQUJ7QeqCQYJ7QepCQcJ7QeoCQUJ6QeoCIQJ6QepCAQJ4EUMISogyEWAF4AAhBUqEMhFgEh0RYHBHAkgMOABowPMCIHBHGO0A4ADkAOAAAPoFgOEA4IDiAOAt6fBHBEYORhdGmEYInf/3nP2CRhPgaByIsS2x//eV/aDrCACoQgrZT/QAcKT4RACgbEDwAQCgZAEgvejwhyBoAGowQAixASAA4AAguELi0QAg8ucCRtFkACBwR3BH+LUERgAl//dx/QZGDLkBJY/gACCgZLT4RABAuSBGBPD6+k/w/zEgRv/35f8FRgAtf9HU6QMQQB5P9PgSkvqi8rL6gvKQQAhDYWlJHk/04GKS+qLysvqC8pFACEOhaQhD4WkIQyFoiWj+ShFACEMhaIhgIGjAaCD04CAhaghDIWjIYE/0+BGR+qHxsfqB8SBriEAhaAhhIGgAaCD0+FFgaEAeT/T4UpL6ovKy+oLykEABQyBoAWDgbDNGACIgIQCQIEb/927/BUZ9uyBowGgg8P8BYGpAHv8ikvqi8rL6gvKQQAFDIGjBYCBoAGgg8EAAoWgIQyFoCGDU6QoBCEMhaNH4CBEh8KBBCEMhaMH4CAEgaABoQPABACFoCGDgaLDxgG8D0QEgpPhEAALgAiCk+EQAKEb4vXBHcLUERgAlDLkBJQvgIGgAaCDwAQAhaAhgIEYE8JD7ACCk+EQAKEZwvXBHcEdwtQVGrGoAIOBjtPhEALD1gH8P0QIgIWhIYiBoAGhA9AAwIWgIYCBoAGhA8AIAIWgIYAXgAiCk+EQAIEb/99//cL1wR3BHcEdwR3BHcEct6fBBBEYgaADxUAggaAVqIGgHaLT4RGAF8AQAKLMH9IAgELMYLgnRYWtIHGBjCHiI+AAA4GtAHuBjCuAoLgjRmPgAEGJrUBxgYxFw4GtAHuBj4GsouSBoAGgg9IAgIWgIYCBG//fL/6LgBfACAAAoTNAH9AAwAChI0CguIdEF9HxQWLHga0ixmPgAEGJrUBxgYxFw4GtAHuBjieDgawAo4tECICFoSGIgaABoIPTgICFoCGACIKT4RAAgRv/3nv924AIgIWhIYiBoAGgg9OAgIWgIYAIgpPhEABguA9EgRv/3i/9k4AguA9EgRv/3hP9e4Lb1gH9b0aBsGLkgRv/3ev9V4CBG//dT/1HgBfAIALixB/QAIKCxCCAhaEhiIGgAaAD0gABAsSBoAGgg9BAgIWgIYAIgpPhEACBG//da/zbgBfABADizB/SAMCCzASAhaEhiIGgAaCD0+BAhaAhgAiCgZCBoAGgA8AQAaLEgaABoIPAEACFoCGBOSHhEIWyIYyBsA/Cu/xLgAiCk+EQAIEb/9w3/C+AF8BAAQLEH9IAQKLEQICFoSGIgRv/3//696PCBLenwQQNGACAfaD9oJ/BAV9P4AMDM+ABwn2hfuR9oP2gn8IAH0fgEwEfqDAfT+ADAzPgAcA9oAi8M0B9oB/WAch9oB/WEdB9oB/WIdR9oB/WQdgvgH2gH9cByH2gH9cR0H2gH9ch1H2gH9dB20ekSfEfqDAcXYM9qj7GPajdg0fg0wM9qR+oMB9H4MMBH6gwH0vgAwCz0fBxH6gwHF2AnaCfwHwfR+ETAR+oMBydgj2s/sQ9oL7nPa38e0/gAwMz4QHDPaAAvfNDPae+zj2tfs9H4FMDPaEfqDAfR+BDAR+oMB9H4HMBH6gwH0fgkwEfqDAfR+CDAR+oMBwPg/Pjg+DP+///R+DjAR+oMB9H4QMBH6gwH0vgAwN/4YIoM6ggMR+oMBxdgKuDR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMAA4CHgR+oMB9H4IMBH6gwH0vgAwEP2P3gs6ggMR+oMBxdg32q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2CPadP4AMDM+Ehwd+CPa+ex0fgUwM9oR+oMB9H4EMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+MSJDOoIDADgIeBH6gwHF2Aa4NH4FMDPaEfqDAfR+BDAR+oMB9L4AMAs8D8MR+oMBxdg32q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2A64M9pp7OPa+ex0fgkwM9pR+oMB9H4IMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+ESJCPE/CAzqCAxH6gwHF2AP4NH4JMDPaUfqDAfR+CDAR+oMB9L4AMAs9HxcR+oMBxdgj2nT+ADAzPhIcAPg/+cBIAgnn2S96PCBLen4QwRGDUYWRgAn//d6+oBGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsYsShoALkAvwC/tPhEAAIoA9HgaLDxgG8N0bT4RAAUKALRKGgCKAbQtPhEACQoQtEoaAEoP9FDRgAiICEgRgCW//el/AdGL7sAIKBkKUYgRv/3f/4HRu+5qGtYuUNGASICISBGAJb/95L8B0YCICFoSGIj4ChoGLkEIKT4RAAd4ChoASgL0bT4RAAkKAPRBCCk+EQAEuAUIKT4RAAO4LT4RAAUKAPRBCCk+EQABuAkIKT4RAAC4AEnECCgZDhGvej4g/i1BEYNRgAm//cF+gdGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsAsQC/tPhEAAIoJtEoaCC7qGsQu+BosPGAbx7Q4Gw7RgAiICEAkCBG//c8/AZGvrkAIKBkAyAhaEhiKUYgRv/3E/4GRma5CCCk+EQAIGgAaED0QDAhaAhgAuABJhAgoGQwRvi9Len4QwRGDUYWRgAn//e9+YBGtPhEAAEoA9C0+EQAAigk0UNGACIgISBGAJb/9wj8B0b3uU/0fwGR+qHxsfqB8ShoiEBP9H9Ckvqi8rL6gvJpaJFACEOpaAhD6WgIQyFowfgAAgIgpPhEAALgAScQIKBkOEa96PiDLen4QwRGDUYWRgAn//eB+YBGtPhEAAIoOdHgaLDxgG810UNGACIgISBGAJb/98z7B0ZfuyBoAGgg8EBQIWgIYCBogGgg8IBwKWgIQyFoiGAoaUDwQGCpaAhDQPRAYCFowfgAAShpQPBAYKloCENA9EBgIWjB+IAB6GhAHiFoCGRoaCFoiGQEIKT4RAAC4AEnECCgZDhGvej4gy3p+EUERg5GF0YAJf/3NPmARiBoAPFQCh65ASUIIKBkO+C0+EQABCg00SBoAGxAHOBj4GugY2ZjIGgAaCDwQFAhaAhgAL9DRgEiBCEgRgCX//dt+wVGBbEL4GFrSBxgYwh4ivgAAOBrQB7gY+BrACjp0QC/jblDRgEiAiEgRgCX//dV+wVGRbkCICFoSGKk+EQAAuABJRAgoGQoRr3o+IUt6fxNBEYORhdGACX/9+T4AZAgaADxUAogaND4SIAgaND4ELEeuQElCCCgZFLgtPhEAAQoS9EgaABsQBzgY+BroGNmYyBoAGgg8EBQQPCAUCFoCGDgaLDxgG8D0SBowPhIgAzgIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4ELEAvwCXASIGISBGAZv/9wD7BUYFsQvgmvgAEGJrUBxgYxFw4GtAHuBj4GsAKOnRAL+NuQCXASICISBGAZv/9+j6BUZFuQIgIWhIYqT4RAAC4AElECCgZChGvej8jRC1AkYAIBm5ASAII5NkIOCy+EQwBCsZ0RNoG2xbHNNj02uTY1FjE2gbaCPwQFMUaCNgAyMUaGNiGCOi+EQwE2gbaEP04CMUaCNgAuABIBAjk2QQvXC1AkYAIBVoq2wVaNX4EEEZuQEgCCWVZDXgsvhEUAQtLtEVaC1sbRzVY9VrlWNRYxVoLWgl8EBVRfCAVRZoNWADJRZodWIoJaL4RFAVaC1oRfTgJRZoNWDVaLXxgG8C0RVoq2QP4BVo1fgAUQX04GUVsRVoq2QG4BVoxfgQQQLgASAQJZVkcL1wtQRGACW0+EQAAPAIACC5tPhEAADwBABgsyBoAGgg9PgQIWgIYE/0gHCk+EQAIGgAaADwBABosSBoAGgg8AQAIWgIYPZIeEQhbIhjIGwD8L37EuACICFoSGIgaABoQPQAMCFoCGAgaABoQPACACFoCGAC4AElECCgZChGcL1wtQVGrGoAIOBjBCCgZCBoAGgg8AQAIWgIYCBG//ex/3C9cEdwR3C1BUasauBrQAjgY7T4RAAoKAPRIEb/9/L/AuAgRv/37f9wvQFGiGoAIsJjAmgSaCLwBAIDaBpgCmgSaCLwAQILaBpgAmgSaEL0ADIDaBpgcEct6fNBBEYAJiBoAGxFHAGYGLkBJgggoGR34LT4RAAEKHDRIGxAaQi55WMk4CBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggoGQBJhTgaAjgYxHgIGxAabD1AH8M0QXwAwAYuSB5APADABixCCCgZAEmAeCoCOBjAC5H0eBroGMBmGBjIGgAaCDwQFAhaAhgAyAhaEhiGCCk+EQApEh4RCFsyGKjSHhEIWwIY6JIeEQhbEhjACAhbIhjECEgbIFgIGwAaABoIPAQACFsiWgIQyFsCWgIYAGvo2vU+ADADPFQAjloIGwD8GH6IGgAaED0gDAhaAhgIGgAaEDwBAAhaAhgA+D/5wEmECCgZDBGvej8gS3p80cERgAmIGgAbEUcIGjQ+EiAIGjQ+BChAZgYuQEmCCCgZI7gtPhEAAQoctEgbEBpCLnlYyTgIGxAabD1gH8N0QXwAQAYuSB5APABABixCCCgZAEmFOBoCOBjEeAgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIIKBkASYB4KgI4GMALl7R4GugYwGYYGMgaABoIPBAUEDwgFAhaAhgAyAhaEhiKCCk+EQAX0h4RCFsyGJeSHhEIWwIY11IeEQhbEhjACAhbIhjACEgbIFgIGwAaABoIPAQACFsiWgIQyFsCWgIYAGvo2s6aNT4AMAM8VABIGwD8NH5IGgAaED0gDAhaAhg4Giw8YBvBNEgaMD4SIAN4BPgIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4EKEgaABoQPAEACFoCGAC4AEmECCgZDBGvej8hy3p+E8ERg1GFkYAJ/73Yf6CRiBo0PhIgCBo0PgQsbT4RAAEKErR6Giw9YAPRtFTRgAiICEgRgCW//em+AdGAC8/0ShoIWjB+IgAaGghaMH4gAAoaSFowfiQANXpAgEIQ0DwAFAhaAloIfBDUQhDIWgIYOBosPGAbwPRIGjA+EiADOAgaND4AAEA9OBgGLEgaMD4SIAC4CBowPgQsVNGASIIISBGAJb/92/4B0ZPuQggIWhIYgIgpPhEAALgAScQIKBkOEa96PiPwMD/8MD///BR9v//M////wf////Z/v//E/7//+f9//+5/f//Len4RQRGDUYAJv737P2ARiBoh2wgaND4EKG0+EQABChB0eBsQ0YAIiAhAJAgRv/3NfgGRk67KGghaMH4iABoaCFowfiAAChpIWjB+JAA1ekCAQhDQPAAUCFoCWgh8ENRCEMhaAhgCSAhaEhiSCCk+EQAIGgAaED0ECAhaAhg4Giw8YBvAtEgaIdkD+AgaND4AAEA9OBgELEgaIdkBuAgaMD4EKEC4AEmECCgZDBGvej4hfi1BEYNRgAm/veU/QdGtPhEAAQoJ9HgbDtGACIgIQCQIEb+9+L/BkYGu4ggpPhEAChoCCgM0WhoIWjB+DABECAhaEhiIGgAaED0gBAhaAhgIGgAaP5JCEApaEHwQFEIQyFoCGAC4AEmECCgZDBG+L34tQRGACX+9139Bka0+EQAAPAIACC5tPhEAADwBACQsyBoAGgA8AQAYLEgaABoIPAEACFoCGAgbAPw5PgFRg2xBCCgZCBoAGhA8AIAIWgIYOBsM0YBIgIhAJAgRv73jf8FRqW5AiAhaEhi4GwzRgAiICEAkCBG/veA/wVGPbkCIKT4RAAD4P/nASUQIKBkKEb4vTC1AkYAILL4RDAD8AgDi7lRYBNoG2gj9PhUU2hbHk/0+FWV+qX1tfqF9atAHEMTaBxgAuABIBAjk2QwvQFGCGgAaAD0+FBP9PhSkvqi8rL6gvLQQEAccEcBRohscEcBRrH4RABwR/C1BEYAIAAiACUAIxSxAiwA3Am5ASBg4AAmDmHOYI5gTmAOYAEsAdEAJQLgAiwA0a5NACNP4K1OVvgjIALwAQY+sQLwAgYF8AIHvkIB0V4cDmAC8BAGPrEC8CAGBfAgB75CAdFeHE5gAvSAdj6xAvQAdgX0AHe+QgHRXhyOYAL0gDaOsQL0gCYF9IAnvkIL0QL0ADYmuV4cRvSANs5gA+BeHEbwgHbOYALwgHaOsQLwgGYF8IBnvkIL0QLwAHYmuV4cRvSANg5hA+BeHEbwgHYOYV4c87ICK63b8L0t6fBNjLCCRgxGT/AAC/73b/wLkAAnuEYAJQAmfkna+AAAiEIC0QC/ASYB4AElACYAJxDgB+uHAgGrA+uCAXoc0LL/92//ILFP8AELCCDK+EgAeBzHsgIv7Nu78QAPftFtSABoAPABADixakgAaCDwAQBoSQhgSPABCGdIAGgA8AEAOLFlSABoIPABAGNJCGBI8AIIBeuFAAGpUfggAAAobdBbSAXrhQEBqlL4IRBJHlD4IQAg8AECVkgF64UBAatT+CEQSR5A+CEgBeuFAQGqAuuBAUloSR5Q+CEAIPAQAkxIBeuFAQPrgQFJaEkeQPghIAXrhQEBqgLrgQGJaEkeUPghACD0gHJCSAXrhQED64EBiWhJHkD4ISAF64UBAaoC64EBCXsB8A8BSR5Q+CEAIPSAMjdIBeuFAQPrgQEJewHwDwFJHkD4ISAF64UBAaoC64EBCXwB8A8BSR4A4HjhUPghACDwgHIqSAXrhQED64EBCXwB8A8BSR5A+CEgBuuGAQGqUvghECBoiEIf0AbrhgEC64EBYGhJaIhCF9AG64YBAuuBAaBoiWiIQg/QBuuGAQLrgQHgaMloiEIH0AbrhgEC64EBIGkJaYhCdtEQSAbrhgEBqlL4IRBJHlD4IQAg8AECC0gG64YBAatT+CEQSR5A+CEgBuuGAQGqAuuBAUloSR5Q+CEACeD3///PIgIEBAQcBlAAEACgABQAoCDwEAKNSAbrhgED64EBSWhJHkD4ISAG64YBAaoC64EBiWhJHlD4IQAg9IByg0gG64YBA+uBAYloSR5A+CEgBuuGAQGqAuuBAQl7AfAPAUkeUPghACD0gDJ4SAbrhgED64EBCXsB8A8BSR5A+CEgBuuGAQGqAuuBAQl8AfAPAUkeUPghACDwgHJsSAbrhgED64EBCXwB8A8BSR5A+CEgZ0ghaEkeUPghACDwAwACIZH6ofGx+oHxBfoB8UHwAQEIQ15JImhSHkH4IgAIRmFoSR5Q+CEAIPAwACAhkfqh8bH6gfEF+gHxQfAQAQhDU0liaFIeQfgiAAhGoWhJHlD4IQAg9EBxT/QAcJD6oPCw+oDwBfoA8ED0gHABQ0hIomhSHkD4IhDgaAD0gDDYsUNIIXsB8A8BSR5Q+CEAIPTgIE/0gCGR+qHxsfqB8QX6AfFB9IAxCEM5SSJ7AvAPAlIeQfgiABrgNUghewHwDwFJHlD4IQAg8OBhT/CAYJD6oPCw+oDwBfoA8EDwgHABQytIInsC8A8CUh5A+CIQIGkA9IAw2LEmSCF8AfAPAUkeUPghACD04CBP9IAhkfqh8bH6gfEF+gHxQfRAMQhDHEkifALwDwJSHkH4IgAa4BhIIXwB8A8BSR5Q+CEAIPDgYE/wgGGR+qHxsfqB8QX6AfFB8EBxCEMOSSJ8AvAPAlIeQfgiAAjwAQAosQpIAGhA8AEACEkIYAjwAgAosQZIAGhA8AEABEkIYFhGDLC96PCNBBwGUAAQAKAAFACgELWasARGACAGkAeQQPL5YAiQBCAJkBAgCpAAIA2QEZAUkBeQGJAZkAggC5BP8P8yBqn+SEhE/vem/xCxASAasBC9AiABkAKQACADkBAgBZCABASQQPL6UAiQACAMkE/0gGANkE/0QFAOkE/wgGAUkAIgFZCAAg+QAAQWkIAAGJAEIBeQAL8BIP73CPpP8P8yBqnmSEhE/vd2/wixASDO50/w/zJpRuFISET/9wL5CLEBIMTnnfgAAAKZCEABmYhC4dEAILvnMLWbsARGDUYAIAeQCJBA8vpQCZAEIAqQECALkAAgDZBP9IBgDpBP9EBQD5AAIBKQT/CAYBWQAiAWkAYgGJAAIBqQCCAMkAACEJAABBeQgAAZkAAgApABIAOQACAEkBAgBpCABAWQAL8BIP73tPlP8P8yB6m8SEhE/vci/xCxASAbsDC9T/D/MgGptkhIRP/3rfgIsQEg8+ed+AQAA5kIQAKZiELg0QAg6ucwtZuwBUYMRgAgB5AIkAyQT/RAUA+QACAQkBKQF5AZkBqQBJAQIAaQgAQFkAEsddEGIAmQASAKkAAgC5AOkBWQGJBCHgepnUhIRP735P4QsQEgG7AwvQIgApADkAUgCZBP8IBwFZABIBaQgh4HqZNISET+99D+CLEBIOrnT/D/MgKpjkhIRP/33/oIsQEg4OdyIAmQT/RAcA2QT/SAcA6QByCN+AQAT/D/Mgepg0hIRP73sf4IsQEgy+dP8P8yAal+SEhE/vft/wixASDB5wYgCZAAIA6QFZBCHgepd0hIRP73mf4IsQEgs+cFIAmQT/CAcBWQT/D/MgepcEhIRP73iv4IsQEgpOdP8P8yAqlrSEhE//eZ+hCxASCa51zgciAJkAAgDZBP9IBwDpACII34BADCHgepYUhIRP73bP4IsQEghudP8P8yAalcSEhE/veo/wixASB85ygg/vfn+E/w/zFWSEhE//f2/gixASBw50fyjhAJkAQgCpAQIAuQgAEOkAAEFZAGIBiQAiAWkAAgjfgEAAggDJAAAhCQAAQXkIAAGZBP8P8yB6lESEhE/vcy/gixASBM50/w/zIBqT9ISET+977/CLEBIELnnfgEAAIoddABIDznOEhIRP/3WP4IsQEgNedH8o0gCZAEIAqQECALkAAgDZBP9IBgDpAABBWQAiAWkAAgGJCN+AQAjfgFAAggDJAAAhCQAAQXkE/w/zIHqSVISET+9/X9CLEBIA/nT/D/MgGpIEhIRP73Mf8IsQEgBecoIP73cPgFIAmQASAKkAAgC5AOkE/wgHAVkAEgFpAAIBiQDJAQkBeQApABIAOQgh4HqRBISET+98v9CLEBIOXmT/D/MgKpC0hIRP/32vkIsQEg2+ZxIAmQACANkE/0gHAOkE/w/zIHqQNISET+97D9ILEBIMrmEAAAAA7gT/D/MgGp/khIRP73Of8IsQEgvead+AQACLEBILjmACC25hC1mrAERgAgBpAHkGYgCJABIAmQACAKkAuQDZARkBSQF5AYkBmQQh4Gqe1ISET+94D9ELEBIBqwEL2ZIAiQT/D/Mgap5khIRP73c/0IsQEg8ecFIAiQT/CAcBSQASAVkAAgFpABkAEgApAAIAOQECAFkIAEBJBP8P8yBqnYSEhE/vdX/QixASDV50/w/zIBqdNISET/92b5CLEBIMvnACDJ5wC1h7AAv85IwGxA9IAQzEnIZAhGwGwA9IAQAZAAvwC/AL8IRgBtQPSAcAhlCEYAbQD0gHABkAC/AL8IRgBrQPSAcAhjCEYAayD0gHAIYwC/CEaAbUDwgFCIZQhGgG0A8IBQAZAAvwC/t0hAaED0AHC1SUhgAL+ySMBsQPBAALBJyGQIRsBsAPBAAAGQAL8AvwC/CEbAbEDwgADIZAhGwGwA8IAAAZAAvwC/AL8IRsBsQPSAcMhkCEbAbAD0gHABkAC/AL+IFAKQAiADkAEgBJADIAWQBSAGkAKpm0gB8J//T/QAQAKQAqmYSAHwmP9P9GRgApAAIASQAqmUSAHwj/9P9OBgApACqZJIAfCI/0/0wGACkAKpjEgB8IH/B7AAvQC1hbCMSIVJSUQIYAhG/vdX+hCxASAFsAC9//dh/wQgf0lJREhgACF9SEhEgWBP8IBgkPqg8LD6gPF4SEhEAWECIUFhACGBYcFhAWICIUFiACGBYk/wgHHBYAkBwWIAIQFj/veR+QixASDU5wIgAJABkHFIBJBxSAOQAiACkMIeaUZmSEhE//d9+gixASDC52NISET/99P+CLEEILvnASFfSEhE//dZ/QixASCz5wAgsecAtYWwT/QWQVtIAvAG+E/04GFbSALwAfhP9GRhV0gB8Pz/ACABkE/0gFAAkAAgApADkGlGUEgB8An/ASABkAAgApBP9ABAAJBpRktIAfD+/gAiT/QAQUhIAvB4+ERIAGtA9IBwQkkIYwhGAGsg9IBwCGMIRgBtIPSAcAhlBbAAvRC1Q0g5SUlECGAIRv/3r/kCKAbQNUhIRP/3MfkIsQEgEL0AITFISET/9/78CLEBIPbnLkhIRP73qvkIsQEg7+f/957/ACDr53C1lLAERg1GFkYAIACQAZAEIAOQECAEkAaVgAEHkE/0QFAIkAAgC5BP8IBgDpAPlgYgEZAAIBOQTvYRYAKQCCAFkAACCZAABBCQgAASkE/w/zJpRhNISET+9837ELEBIBSwcL1P8P8yIUYOSEhE/vdY/QixASDz5wAg8ect6fBFlbCCRg1GkEbossD1gHZGRQDZRkYsRgXrCAcAIAGQApAU4AAAEAAAAAAQAkAAcABAABgASAAgAEgAHABIABQAoAIAAAECAAEAABAAoEHy7SADkAQgBJAQIAWQgAEIkE/0QFAJkAAgDJBP8IBgD5AAIBKQFJAIIAaQAAIKkAAEEZCAABOQAL8HlBCW+UhIRP/3r/sYsQEgFbC96PCFT/D/MgGp80hIRP73ZvsIsQEg8udP8P8yUUbuSEhE/vei/AixASDo50/w/zHpSEhE//fz+wixASDf5zREskQE9YBwuEIB2TgbAeBP9IBwBka8QsrTACDQ5xC1lLAERgAgAJABkE32I0ACkAQgA5AQIASQBpSAAQeQT/RAUAiQACALkA6QEZASkBOQCCAFkAACCZDQSEhE//dd+xCxASAUsBC9T/D/MmlGykhIRP73FfsIsQEg8+dP9PphxkhIRP/3rPsIsQEg6ucAIOjnELWUsARGtPWATwLTASAUsBC9ACAAkAGQQvLeEAKQBCADkBAgBJAgAwaQT/SAYAeQT/RAUAiQACALkA6QEZASkBOQCCAFkAACCZCvSEhE//cb+wixASDa50/w/zJpRqpISET+99T6CLEBINDnACDO5wC1lbAAIAGQApBG8p8AA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkJtISET/9/P6ELEBIBWwAL1P8P8yAamVSEhE/ver+gixASDz55NJkUhIRP/3Q/sIsQEg6+cAIOnnALWVsAAgAZACkEL21DADkAQgBJAQIAWQACAHkE/0gGAIkE/0QFAJkAAgDJBP8IBgD5ACIBCQBiASkAAgFJAIIAaQAAIKkAAEEZCAABOQT/D/MgGpeEhIRP73cPoQsQEgFbAAvU/w/zJpRnJISET+9/v7CLEBIPPnnfgAAADwYAAIsQEg7Oed+AAAAPAMAAixCCDl50Dy+lADkE/w/zIBqWVISET+90r6CLEBINjnT/D/MmlGYEhIRP731vsIsQEgzued+AAAAPABAAixAiDH5wAgxecBRk/wgGAIYIASSGCAEYhggBDIYIACCGEAIHBHALWXsFBISET/9136ELEBIBewAL0BIAOQACAEkAQgBpAQIAeQgAEKkE/0QFALkAAgDpBP8IBgEZAGIBSQACAWkE72EWAFkAggCJAAAgyQAAQTkIAAFZBP8P8yA6k6SEhE/vf0+QixASDS5wIgA5BB8u0gBZAAIBSQQh4DqTJISET+9+T5CLEBIMLnACABkAGpLUhIRP73wv4IsQEguOcAILbnALWVsP/3M/8CKCXRACABkAKQS/JPAAOQBCAEkBAgBZAAIAiQDJAPkBKQE5AUkAggBpBP8P8yAakaSEhE/ve1+RCxASAVsAC9//cR/wgoAdEAIPfnASD15wAg8+cAtZWw//cF/wgoKdEAIAGQApBD8s8AA5AEIASQECAFkAAgCJAMkA+QEpATkBSQCCAGkE/w/zIBqQNISET+94f5MLEBIBWwAL0QAAAA4JMEAP/33/4CKAHRACDz5wEg8ecAIO/nALWVsAAgAZACkEv2RhADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQT/D/MgGpFUhIRP73WfkQsQEgFbAAvQAg++cAtZWwACABkAKQ/yADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAIIAaQT/D/MgGpBUhIRP73OPkQsQEgFbAAvQAg++cAABAAAAD7SABoAPTAYLD1gG8C0U/0gGBwR/ZIgDAAaAD0gHCw9YB/AtFP9ABw8+cAIPHnAkYAIYq77kgAaAD0wGCw9YBvK9HrSIAwAGgg9IBw6EvD+IAAGEYAaCD0wGBA9ABwGGDkSEhEAGjkS7D78/AyIwD7A/EA4EkeMbHdSEBpAPSAYLD1gG/20NpIQGkA9IBgsPWAb1HRAyBwRwjg1UiAMABoIPSAcNJLw/iAAEXgsvUAfzrRz0gAaAD0wGCw9YBvKtHLSIAwAGhA9IBwyUvD+IAAGEYAaCD0wGBA9ABwGGDFSEhEAGjES7D78/AyIwD7A/EA4EkeMbG+SEBpAPSAYLD1gG/20LpIQGkA9IBgsPWAbxLRAyC/57ZIgDAAaED0gHCzS8P4gAAH4LFIAGgg9MBgQPSAYK5LGGAAIKznrEnJaCH0AHEBQ6pK0WARRsloQfSAcdFgcEemSMBoIPSAcKRJyGBwR6JIQGhA9IBgoElIYHBHn0hAaCD0gGCdSUhgcEebSEBoQPQAcJlJSGBwR5hIQGgg9ABwlklIYHBHlEiAaED0AECSSYhgcEeRSIBoIPQAQI9JiGBwRwJGCSpx0t/oAvAFFCErNT9JU2AAiEgAaiH0gEMYQ4ZLGGIYRkBqIfQgQ5hDgktYYl3ggUiAaghDf0uYYhhGwGoh8BADmEN8S9hiUOB6SABrCEN5SxhjGEZAa4hDWGNG4HVIgGsIQ3RLmGMYRsBriEPYYzzgcEgAbAhDb0sYZBhGQGyIQ1hkMuBrSIBsCENqS5hkGEbAbIhD2GQo4GZIAG0IQ2VLGGUYRkBtiENYZR7gYUiAbYuyGENfS5hlGEbAbYuymENcS9hlEeBbSABuwfMLAxhDWEsYZhhGQG7B8wsDmENVS1hmAuD/5wEgcEcAvwAg++cCRgkqQdLf6ALwBQ0TGR8lKzE4AEtIAGoh9IBDmENJSxhiNOBHSIBqiENGS5hiLuBESABriENDSxhjKOBBSIBriENAS5hjIuA+SABsiEM9SxhkHOA7SIBsiEM6S5hkFuA4SABtiEM3SxhlEOA1SIBti7KYQzNLmGUJ4DJIAG7B8wsDmEMvSxhmAeABIHBHAL8AIPvnAkYJKnfS3+gC8AUUICo0PkhZZgAmSEBqIfQgQxhDJEtYYhhGAGoh9IBDmEMgSxhiY+AfSMBqIfAQAxhDHEvYYhhGgGqIQ5hiV+AZSEBrCEMXS1hjGEYAa4hDGGNN4BRIwGsIQxJL2GMYRoBriEOYY0PgD0hAbAhDDUtYZBhGAGyIQxhkOeAKSMBsCEMIS9hkGEaAbIhDmGQv4AVIQG0IQwNLWGUYRgBtiEMYZSXgAAAAcABABAAAAEBCDwD+SMBti7IYQ/xL2GUYRoBti7KYQ/lLmGUR4PhIQG7B8wsDGEP1S1hmGEYAbsHzCwOYQ/JLGGYC4P/nASBwRwC/ACD75wJGCSpD0t/oAvAFDRUbISctMzoA6EhAaiH0IEOYQ+ZLWGI24ORIwGoh8BADmEPiS9hiLuDgSEBriEPfS1hjKODdSMBriEPcS9hjIuDaSEBsiEPZS1hkHODXSMBsiEPWS9hkFuDUSEBtiEPTS1hlEODRSMBti7KYQ89L2GUJ4M5IQG7B8wsDmEPLS1hmAeABIHBHAL8AIPvnx0iAaED0gGDFSYhgcEfESIBoIPSAYMJJiGBwR8BIgGhA9IBwvkmIYHBHvUiAaCD0gHC7SYhgcEe5SABoQPAQALdJCGBwR7ZIAGgg8BAAtEkIYHBHskhAaEDwEACwSUhgcEevSEBoIPAQAK1JSGBwR6tIQGhA8CAAqUlIYHBHqEhAaCDwIACmSUhgcEekSEBoQPBAAKJJSGBwR6FIQGgg8EAAn0lIYHBHnUhAaEDwgACbSUhgcEeaSEBoIPCAAJhJSGBwRwFGCGgQKAbQIChS0EAofNCAKHvR7OCSSABoIPAIAJBKEGAQHwBoIPAIABIfEGCMSAgwAGgg8AgAiUoIMhBgEB8AaCDwCAASHxBgSGgA9IAwsPWAPwfRgkgAHwBoQPAIAH9KEh8QYEhoAPQAMLD1AD8F0XtIAGhA8AgAeUoQYAh5APABADixdkgAHQBoQPAIAHNKEh0QYAh5APACAAIoB9FvSAgwAGhA8AgAbUoIMhBg8eBrSABoIPAQAGlKEGAQHwBoIPAQABIfEGBlSAgwAGgg8BAAYkoIMhBgEB8AaCDwEAASHxBgSGgA9IAwsPWAPwfRW0gAHwBoQPAQAFhKEh8QYEhoAPQAMAHgI+DB4LD1AD8F0VJIAGhA8BAAUEoQYAh5APABADixTUgAHQBoQPAQAEtKEh0QYAh5APACAAIoB9FHSAgwAGhA8BAAREoIMhBgoOBCSABoIPAgAEBKEGAQHwBoIPAgABIfEGA8SAgwAGgg8CAAOkoIMhBgEB8AaCDwIAASHxBgSGgA9IAwsPWAPwfRMkgAHwBoQPAgADBKEh8QYEhoAPQAMLD1AD8F0StIAGhA8CAAKUoQYAh5APABADixJkgAHQBoQPAgACRKEh0QYAh5APACAAIoB9EgSAgwAGhA8CAAHUoIMhBgUuAbSABoIPBAABlKEGAQHwBoIPBAABIfEGAVSAgwAGgg8EAAE0oIMhBgEB8AaCDwQAASHxBgSGgA9IAwsPWAPwfRC0gAHwBoQPBAAAlKEh8QYEhoAPQAMLD1AD8F0QRIAGhA8EAAAkoQYAh5A+AAcABAJAQBQADwAQAosXRIAGhA8EAAckoQYAh5APACAAIoB9FuSAAdAGhA8EAAbEoSHRBgAeABIHBHAL8AIPvnaEgAaED0gEBmSQhgcEcAv2RIAGgg9IBAYkoQYGJISEQAaGJKsPvy8DIiAPsC8QDgSR4xsVtIQGkA9ABwsPUAf/bQWEhAaQD0AHCw9QB/AdEDIHBHACD851JJCWgh8AcBUEoRYFJJCWhB8AQBUEoRYAEoAdEwvwLgQL8gvyC/TEkJaCHwBAFKShFgcEdFSQloIfAHAUkcQ0oRYEVJCWhB8AQBQ0oRYAEoAdEwvwLgQL8gvyC/PkkJaCHwBAE8ShFgcEc4SQloIfAHAYkcNUoRYDdJCWhB8AQBNUoRYAEoAdEwvwLgQL8gvyC/MUkJaCHwBAEvShFgcEcqSABoIPAHAAAdKEkIYCpIAGhA8AQAKEkIYAC/AL8wv3BHcEdwR3BHcEcQtR5IFDgAaAD0gDAwsfz3qf5P9IAwGUkUOQhgGEgMMABoAPAIACix//fp/wggE0kMMQhgEkgMMABoAPAQACix//fc/xAgDUkMMQhgDEgMMABoAPAgACix//fP/yAgB0kMMQhgBkgMMABoAPBAACix//fC/0AgAUkMMQhgEL0oBAFAAHAAQAQAAABAQg8AEO0A4PpIAGhA8AEA+EkIYADgAL/2SABoAPACAAAo+NDzSABoIPDwAEDwYADwSQhgACCIYAhGAGjuSQhA7EkIYAAgyGAIRsBoQPSAUMhgACAIYQhGAGlA9IBQCGEAIEhhCEZAaUD0gFBIYQhGAGgg9IAgCGAAIIhh30jgSUlECGBwR/C1ACEAIwAkAiUCIgAg1062aAbwDAZesdVOtmgG8AwGDC4f0dJO9mgG8AMGAS4Z0c9ONmgG8AgGLrnMTpQ2NmjG8wMhA+DJTjZoxvMDEctOfkRW+CEQxU62aAbwDAaGuQhGDuDCTrZoBvAMBgQuAdHESAbgvk62aAbwDAYILgDRwUi6TrZoBvAMBgwuNtG3TvZoBvADBLVO9mjG8wMWchwBLBnQAiwC0AMsFNEJ4LROtvvy9q5P/2jH8wYnBvsH8xPgsE62+/L2qU//aMfzBicG+wfzCeAAv7H78vakT/9ox/MGJwb7B/MAvwC/oE72aMbzQWZ2HHUAs/v18PC9+LUERgAmACWZSIBtAPCAUBix//dB+gZGFuAAv5RIgG1A8IBQkkmIZQhGgG0A8IBQAJAAvwC///cv+gZGjEiAbSDwgFCKSYhltvUAfwfRgCwM2aAsAdkCJQjgASUG4IAsAdMCJQLgcCwA0QElh0gAaCDwDwAoQ4VJCGAIRgBoAPAPAKhCAdABIPi9ACD85/i1BEYAJSB4APAQABAocNF0SIBoAPAMAAAoa9FxSABoAPACABixoGkIuQEg+L1sSCFqAGgA8AgAILFpSABoAPDwAAXgZ0iUMABoAPRwYAAJgUIf2SBq//eM/wixASDl5wC/X0gAaEDwCABdSQhgCEYAaCDw8AAhaghDWUkIYAC/CEZAaCD0f0DhaUDqASBUSUhgHuAAv1JIAGhA8AgAUEkIYAhGAGgg8PAAIWoIQ0xJCGAAvwhGQGgg9H9A4WlA6gEgR0lIYCBq//dT/wixASCs5//3z/5CSYlowfMDEUhKekRRXMhAQUlJRAhgDyAB8Af9SuCgaYCzOkgAaEDwAQA4SQhg/Pcy/QVGBuD89y79QBsCKAHZAyCI5zFIAGgA8AIAACjy0AC/LkgAaEDwCAAsSQhgCEYAaCDw8AAhaghDKEkIYAC/CEZAaCD0f0DhaUDqASAjSUhgF+D/5yFIAGgg8AEAH0kIYPz3AP0FRgbg/Pf8/EAbAigB2QMgVucYSABoAPACAAAo8tEgeADwAQAAKH7QE0iAaADwDAAIKAvQEEiAaADwDAAMKA7RDUjAaADwAwADKAjRCkgAaAD0ADCIs2BoeLsBIDDnAL9gaLD1gD8Y0QNIAGhA9IAwAUkIYC3gABACQP/0/uoACT0ABAAAAK4cAAAAJPQAABJ6AAAgAkB6GgAAYGiw9aAvDNH9SABoQPSAIPtJCGAIRgBoQPSAMAhgC+A04PdIAGgg9IAw9UkIYAhGAGgg9IAgCGAAv2BomLH895L8BUYI4Pz3jvxAG0HyiDGIQgHZAyDm5ulIAGgA9AAwACjw0BLg/Pd+/AVGCOD893r8QBtB8ogxiEIB2QMg0ubfSABoAPQAMAAo8NEgeADwAgACKF7R2kiAaADwDAAEKAvQ10iAaADwDAAMKBjR1EjAaADwAwACKBLR0UgAaAD0gGAYseBoCLkBIKzmzEhAaCDw/kAhfEDqAWDJSUhgOeDgaACzxkgAaED0gHDESQhg/Pc5/AVGBuD89zX8QBsCKAHZAyCP5r5IAGgA9IBgACjy0LtIQGgg8P5AIXxA6gFgt0lIYBbgtkgAaCD0gHC0SQhg/PcY/AVGBuD89xT8QBsCKAHZAyBu5q1IAGgA9IBgACjy0SB4APAIAAgoNtFgadCxp0iUMABoQPABAKRJwfiUAPz3+PsFRgbg/Pf0+0AbAigB2QMgTuadSJQwAGgA8AIAACjx0BngmUiUMABoIPABAJdJwfiUAPz33fsFRgbg/PfZ+0AbAigB2QMgM+aQSJQwAGgA8AIAACjx0SB4APAEAAQob9EAJolIgG0A8IBQcLkAv4ZIgG1A8IBQhEmIZQhGgG0A8IBQAJAAvwC/ASaASABoAPSAcLC5fkgAaED0gHB8SQhg/Pem+wVGBuD896L7QBsCKAHZAyD85XVIAGgA9IBwACjy0AC/oGgBKAjRb0iQMABoQPABAG1JwfiQACHgoGgFKA/RaUiQMABoQPAEAGdJwfiQAAhG0PiQAEDwAQDB+JAADuBhSJAwAGgg8AEAX0nB+JAACEbQ+JAAIPAEAMH4kAAAv6BoqLH892P7BUYJ4Pz3X/tAG0HyiDGIQgLZAyC35STgUUiQMABoAPACAAAo7tAT4Pz3TfsFRgjg/PdJ+0AbQfKIMYhCAdkDIKHlR0iQMABoAPACAAAo79EBLgXRQkiAbSDwgFBASYhlAL8geADwIAAgKDbRYGrQsTtImDAAaEDwAQA5ScH4mAD89yH7BUYG4Pz3HftAGwIoAdkDIHflMkiYMABoAPACAAAo8dAZ4C5ImDAAaCDwAQArScH4mAD89wb7BUYG4Pz3AvtAGwIoAdkDIFzlJEiYMABoAPACAAAo8dGgavCzIEiAaADwDAAMKHXQoGoCKFPRG0gAaCDwgHAZSQhg/Pfj+gVGBuD899/6QBsCKAHZAyA55RNIAGgA8ABwACjy0SBrQB4BAWBrQeoAIOFqCEOhjwEiwutRAUDqQVFAIABdwutQAEHqQGE4IABdQerAYARJyGAIRgBoQPCAcAXgTOAAAAAQAkAAcABACGAIRsBoQPCAcMhg/Pen+gVGBuD896P6QBsCKAHZAyD95PdIAGgA8ABwACjy0C/g80gAaCDwgHDxSQhgCEYAaADwAGBIuQhGAGgA8ABQILkIRsBoIPADAMhg6UjAaOlJCEDnSchg/Pd6+gVGB+AN4Pz3dfpAGwIoAdkDIM/k4EgAaADwAHAAKPLRAeABIMbkACDE5PC1ACIAIwAkAiUCIQAg1072aAbwAwYBLhLR1E42aAbwCAYuudFOlDY2aMbzAyID4M5ONmjG8wMSzk5+RFb4IiDKTvZoBvADBMhO9mjG8wMWcRwBLBnQAiwC0AMsFNEJ4MVOtvvx9sFP/2jH8wYnBvsH8xPgwU62+/H2vE//aMfzBicG+wfzCeAAv7L78fa3T/9ox/MGJwb7B/MAvwC/s072aMbzQWZ2HHUAs/v18PC9LenwQQRGDUYAJgAnsEawSABoAPAPAKhCD9KtSABoIPAPAChDqkkIYAhGAGgA8A8AqEIC0AEgvejwgSB4APABAAAobtBgaAMoI9GcSABoAPAAcAi5ASDu5//3ev8HRp1Ih0IG2SB4APACAAIoAdGgaCCxkkiAaADw8ACgu49IgGgg8PAAQPCAAIxJiGBP8IAIKeBgaAIoBtGISABoAPQAMIi5ASDH52BoMLmESABoAPACAEC5ASC+54BIAGgA9IBgCLkBILfn//cs+wdGgUiHQgnZekiAaCDw8ABA8IAAd0mIYE/wgAh1SIBoIPADAGFoCENySYhg/PeQ+QZGYGgDKBDRCOD894n5gBtB8ogxiEIB2QMgj+dpSIBoAPAMAAwo8NE24GBoAigQ0Qjg/Pd1+YAbQfKIMYhCAdkDIHvnX0iAaADwDAAIKPDRIuBgaIC5COD892L5gBtB8ogxiEIB2QMgaOdVSIBoAPAMAAAo8NEP4Ajg/PdR+YAbQfKIMYhCAdkDIFfnTUiAaADwDAAEKPDRIHgA8AIAAigI0UdIgGgg8PAAoWgIQ0RJiGAI4LjxgA8F0UFIgGgg8PAAP0mIYENIAGgA8A8AqEIO2UBIAGgg8A8AKEM+SQhgCEYAaADwDwCoQgHQASAl5yB4APAEAAQoB9ExSIBoIPTgYOFoCEMuSYhgIHgA8AgACCgI0StIgGgg9GBQIWlA6sEAJ0mIYP/3f/olSYlowfMDESpKekRRXMhAKUlJRAhgDyAB8Lf4ACD45nC1hrAGRg1GFEYAvxpIwGxA8AEAGEnIZAhGwGwA8AEAAJAAvwC/iBUBkAIgApAEkAAgA5AFkAGpT/CQQADwEPkNSIBoIPD+QEXqBAEIQwpJiGAGsHC9EEhIRABocEcAtf/3+f8ESYlowfMCIQtKekRRXMhAAL0AAAAQAkD//+7+lhQAAAAk9AAAEnoAACACQAC0xATaEQAABAAAAGYRAAAAtf/32P9rSYlowfPCIWpKekRRXMhAAL0/IQFgZUkJaAH0gCGx9YAvA9FP9KAhQWAM4GBJCWgB9IAxsfWAPwPRT/SAMUFgAeAAIUFgWUkJaAHwAQERsQEhgWEB4AAhgWFUSUlowfMHIcFhUkkJaAHw8AEBYk9JCWgB9IBxsfWAfwPRT/SAccFgAeAAIcFgSUlJaMHzBmEBYUZJkDEJaAHwBAEEKQLRBSGBYArgQUmQMQloAfABARGxASGBYAHgACGBYDxJlDEJaAHwAQERsQEhQWEB4AAhQWE2SZgxCWgB8AEBEbEBIUFiAeAAIUFiMUkJaAHwgHGx8YB/AtECIYFiAeABIYFiK0nJaAHwAwLCYihJyWjB8wMRSRwBYyVJyWjB8wYiQmMjSclowfNBUUkcSgDCYx9JyWjB80FhSRxKAAJkHEnJaMoOgmNwRw8iAmAYSpJoAvADAkJgFkqSaALw8AKCYBNKkmgC9OBiwmARSpJoAvRgUtIIAmEQShJoAvAPAgpgcEcLSABoQPQAIAlJCGBwR3BHELUGSMBpAPSAcLD1gH8F0f/39f9P9IBwAUkIYhC9ABACQCQRAAAAIAJAeLUCRgAjACQAINrgASaeQA1oBeoGBAAsctBNaAItAtBNaBItE9HeCALxIAVV+CYAXQfuDg8ltUCoQ14H9g4NabVAKEPeCALxIAVF+CYAEGheAAMltUCoQw15BfADBV4AtUAoQxBgTWgBLQjQTWgCLQXQTWgRLQLQTWgSLRPRkGheAAMltUCoQ14AzWi1QChDkGBQaAElnUCoQw15xfMAFZ1AKENQYNBoXgADJbVAqENeAI1otUAoQ9BgTWgF8IBVtfGAX3zRAL+lTS1uRfABBaNONWY1Ri1uBfABBQCVAL8Av0/qtjWeCFX4JgCdBy4PDyW1QKhDsvGQTwLRACUk4F7gmE2qQgHRASUe4JZNqkIB0QIlGeCVTapCAdEDJRTgk02qQgHRBCUP4JJNqkIB0QUlCuCQTapCAdEGJQXgj02qQgHRByUA4Aglngc2D7VAKEOLTZ4IRfgmAIpNKGigQ01oBfSANbX1gD8A0SBDhU0oYC0dKGigQ01oBfQANbX1AD8A0SBDf00tHShgLR0oaKBDTWgF9IAVtfWAHwDRIEN4TQg1KGAtHShooENNaAX0ABW19QAfANEgQ3JNDDUoYFscDWjdQAAtf/Qgr3i98LULRgAhACIAJITgASWNQAXqAwIAKn3QBWhPAAMmvkA1QwVgzggA8SAFVfgmUE4H9w4PJr5AtUPPCADxIAZG+CdQhWhPAAMmvkC1Q4VgRWgBJo5AtUNFYMVoTwADJr5AtUPFYFNNjghV+CZAjQcuDw8ltUAsQLDxkE8B0QAlI+BFTahCAdEBJR7gQ02oQgHRAiUZ4EJNqEIB0QMlFOBATahCAdEEJQ/gP02oQgHRBSUK4D1NqEIB0QYlBeA8TahCAdEHJQDgCCWOBzYPtUClQiDRjQcuDw8lBfoG9DVNjghV+CZgpkOPCEX4J2AyTS1olUMwTjVgNR0taJVDNh01YDUdLWiVQzYdNWA1HS1olUM2HTVgSRwj+gH1AC1/9Hav8L0CRhNpC0ALsQEgAOAAIHBHCrGBYQDggWJwR0JpSkBCYXBHCLUCRk/0gDAAkACYCEMAkACY0GHRYQCY0GHQaQCQ0GkA9IAwCLEAIAi9ASD853BHELUERg9IFDAAaCBAKLEMSBQwBGAgRv/38v8QvQAAABACQAAEAEgACABIAAwASAAQAEgAFABIABgASAAcAEgIAAFAAAQBQAF5Sh7+SwPrggJCZfxKQDKCZUoeASOTQMNlcEcQtQAi+EwDaKNCAdL3SQHg9kkcMQN4CDsUJLP79PJDbJsIAeuDA4Nk7kuAO8NkASOTQANlEL1wtQRGACUMuQEgcL3pSSBoiEIL0ulJIGhAGhQhsPvx8IAAYGTlSAg4IGQK4OFJIGhAGhQhsPvx8IAAYGTdSAg4IGQCIIT4JQAgaAVoR/bwcIVD1OkCAQhDIWkIQ2FpCEOhaQhD4WkIQyFqCEMFQyBoBWAgRv/3qf+gaLD1gE8B0QAgYGAgeaFsCGDU6RMQSGBgaGCxYGgEKAnYIEb/94f/ACBhbQhg1OkWEEhgA+AAIGBloGXgZQAg4GIgY2BjoGPgYwEghPglAAAghPgkAAC/m+cQtQRGDLkBIBC9IGgAaCDwAQAhaAhgskkgaIhCC9KySSBoQBoUIbD78fCAAGBkrkgIOCBkCuCqSSBoQBoUIbD78fCAAGBkpkgIOCBkACAhaAhglPhEEAEgiEAhbEhgIEb/90r/ACChbAhg1OkTEEhgYG0osQAgYW0IYNTpFhBIYAAgYGWgZeBl4GOE+CUAAL+E+CQAAL8Av7bnMLXQ6RNUbGBEbRSx0OkWVGxgkPhEUAEkrEAFbGxgBGhjYIRoECwE0QRoomAEaOFgA+AEaKFgBGjiYDC9LenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKBfRAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//e5/yBoAGhA8AEAIWgIYAbgAL8AIIT4JAAAv0/wAghARtTnLenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKD/RAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//eA/yBrMLEgaABoQPAOACFoCGAL4CBoAGgg8AQAIWgIYCBoAGhA8AoAIWgIYKBsAGgA9IAwKLGgbABoQPSAcKFsCGBgbSixYG0AaED0gHBhbQhgIGgAaEDwAQAhaAhgBuAAvwAghPgkAAC/T/ACCEBGrOcBRgAiCbkBIHBHCGgAaCDwDgALaBhgiGwAaCD0gHCLbBhgCGgAaCDwAQALaBhgkfhEMAEgmEALbFhg0ekTMFhgSG1AsUhtAGgg9IBwS20YYNHpFjBYYAEggfglAAC/ACCB+CQAAL8QRs7ncLUERgAllPglAAIoA9AEIOBjASU84CBoAGgg8A4AIWgIYCBoAGgg8AEAIWgIYKBsAGgg9IBwoWwIYJT4RBABIIhAIWxIYNTpExBIYGBtQLFgbQBoIPSAcGFtCGDU6RYQSGABIAjgAAAACQJACAQCQAAIAkAIAAJAhPglAAC/ACCE+CQAAL+gaxCxIEaha4hHKEZwvS3p8EEERg5GFUZP8AAIlPglAAIoCdAEIOBjAL8AIIT4JAAAvwEgvejwgSBoAGgA8CAAILFP9IBw4GMBIPPnLrmU+EQQAiAA+gH3BOCU+EQQBCAA+gH3+/e0+4BGLeAgbABolPhEIAghkUAIQICxlPhEEAEgiEAhbEhgASDgY4T4JQAAvwAghPgkAAC/ASDK52gckLEtsfv3lPug6wgAqEIL2SAg4GMBIIT4JQAAvwAghPgkAAC/ASC15yBsAGg4QAAozNBgbYixoG0AaOFtCEBgsWBtAGhA9IBwYW0IYNTpFhBIYOBrQPSAYOBj4GwAaCFtCEAwsdTpExBIYOBrQPQAcOBjTrmU+EQQAiCIQCFsSGABIIT4JQAF4JT4RBAEIIhAIWxIYAC/ACCE+CQAAL8Av3jncLUERiBsBWggaAZolPhEEAQgiEAoQNCxBvAEALixIGgAaADwIAAouSBoAGgg8AQAIWgIYJT4RBAEIIhAIWxIYCBrAChO0CBGIWuIR0rglPhEEAIgiEAoQAizBvACAPCxIGgAaADwIABAuSBoAGgg8AoAIWgIYAEghPglAJT4RBACIIhAIWxIYAC/ACCE+CQAAL/gajCzIEbhaohHIuCU+EQQCCCIQChA4LEG8AgAyLEgaABoIPAOACFoCGCU+EQQASCIQCFsSGABIOBjhPglAAC/ACCE+CQAAL9gaxCxIEZha4hHcL0QtQNGACQAv5P4JAABKAHRAiAQvQEgg/gkAAC/k/glAAEoEtExsQEpBtACKQbQAykI0QXg2mIH4BpjBeBaYwPgmmMB4AEkAL8A4AEkAL8AIIP4JAAAvyBG2+cCRgAjAL+S+CQAASgB0QIgcEcBIIL4JAAAv5L4JQABKBvRBSkW0t/oAfADBgkMDwAAINBiEOAAIBBjDeAAIFBjCuAAIJBjB+AAINBiEGNQY5BjAeABIwC/AOABIwC/ACCC+CQAAL8YRtLnAUaR+CUAcEcBRshrcEcQtYywBEYAv75IAG1A9ABwvEkIZQhGAG0A9ABwAZAAvwC/AL8IRsBsQPSAEMhkCEbAbAD0gBABkAC/AL8IRgBrQPQAcAhjCEYAayD0AHAIYwC/CEaAbUDwgFCIZQhGgG0A8IBQAZAAvwC/p0hAaED0AHClSUhgAL+iSMBsQPBAAKBJyGQIRsBsAPBAAAGQAL8AvwC/CEbAbED0gHDIZAhGwGwA9IBwAZAAvwC/AL8IRsBsQPSAcMhkCEbAbAD0gHABkAC/AL8AvwhGwGxA9IBwyGQIRsBsAPSAcAGQAL8AvwC/CEbAbED0gHDIZAhGwGwA9IBwAZAAvwC/AL8IRsBsQPCAAMhkCEbAbADwgAABkAC/AL8AvwhGwGxA8IAAyGQIRsBsAPCAAAGQAL8AvwC/CEbAbEDwgADIZAhGwGwA8IAAAZAAvwC/AL8IRsBsQPBAAMhkCEbAbADwQAABkAC/AL8AvwhGwGxA8EAAyGQIRsBsAPBAAAGQAL8AvwC/CEbAbEDwQADIZAhGwGwA8EAAAZAAvwC/iBQHkAIgCJABIAmQAiAKkAUgC5AHqVdI//fX+UAgB5AAIAmQB6lUSP/3z/lP9ABgB5AHqVFI//fI+U/0gGAHkAepTUj/98H5T/QAcAeQB6lKSP/3uvlP9IBwB5AHqUdI//ez+U/0AHAHkAepREj/96z5T/SAYAeQB6lASP/3pflP9ABwB5AHqTtI//ee+U/0gGAHkAepN0j/95f5T/QAQAeQB6k0SP/3kPkCIAKQA5A0SAaQNEgFkAIgBJDCHgKpIEb898X8DLAQvRC1BEZMIPv3cPpP9IBRJ0j/9136QCEmSP/3WfpP9ABhI0j/91T6T/SAYSFI//dP+k/0AHEeSP/3SvpP9IBxHUj/90X6T/QAcRpI//dA+k/0gGEYSP/3O/pP9ABxE0j/9zb6T/SAYRFI//cx+k/0AEEOSP/3LPoLSABrQPQAcAlJCGMIRgBrIPQAcAhjCEYAbSD0AHAIZQhGwGwg9IAQyGQQvQAAABACQABwAEAAGABIACAASAAcAEgCAAABAgABAAC1l7AUIRKoAPCm+EQhAagA8KL4ECABkAEgB5AAIAiQAiALkAEhDJFgIAmQDZE3IQ6RAiERkRCRByEPkQGo/vcE+wixF7AAvQ8gEpADIBOQgCAUkAAgFZAWkAMhEqj+953+ALHu5wIgEpAAIBSQBSESqP73k/4AseTnAL/i53y1BEYNRhZGUCExSEhEAPBk+FAhMEhIRADwX/gAIACQAZD791T4//es/wIgKklJRAhgQfLtIIhgT/CAYIhjASDIYwhgTvYTQIhgCCBIZACQICABkP33NvkIsQEgfL0AIPzncLUERgAlJPBwRShG/feg+gAgcL0BRgAgcEcQtf33CvsAIBC9cLUERg1GFkYqRiFGMEb99xH6ACBwvXC1BEYORhVG/feg+wfgFPgBGxX4ASuRQgHQIEZwvTAepvEBBvPRIEb45wNGASBwRwFGACBwRxAAAABgAAAAT/AAAgC1E0aURpZGIDkiv6DoDFCg6AxQsfEgAb/0968JByi/oOgMUEi/DMBd+ATriQAov0D4BCsIv3BHSL8g+AIrEfCATxi/APgBK3BHAAAAAAAAAAAAAAECAwQGBwgJAAAAAAECAwSghgEAQA0DAIAaBgAANQwAQEIPAICEHgAACT0AABJ6AAAk9AAANm4BAEjoAQBs3AIAAAAAAAk9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    load_address: ~
+    pc_init: 21335
+    pc_uninit: 21453
+    pc_program_page: 21469
+    pc_erase_sector: 21433
+    pc_erase_all: 21459
+    data_section_offset: 21704
+    flash_properties:
+      address_range:
+        start: 1879048192
+        end: 1946157056
+      page_size: 256
+      erased_byte_value: 255
+      program_page_timeout: 3000
+      erase_sector_timeout: 3000
+      sectors:
+        - size: 65536
+          address: 0
+    cores: []
+  - name: stm32l4r9i-dk_psram
+    description: STM32L4R9I-DK_PSRAM
+    default: false
+    instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwR3C1BEYNRhZGAPCT+AixACBwvQEg/OcBRgAgcEcAIHBHAUYAIHBHcLUERg1GFkYyRilGIEYA8Iv4CLEAIHC9ASD85zC1BuAQ+AFLEvgBW6xCANAwvQseofEBAfTRAL/45wAAAUYAIAC/AOBAHLD1gF/723BHASBwRwC//ucBRgAgcEcAtZewFCESqAXw7vtEIQGoBfDq+wC/M0iAbUDwgFAxSYhlCEaAbQDwgFAAkAC/AL8AIAHwMvorSIBtIPCAUClJiGUQIAGQASAHkAAgCJACIAuQASEMkWAgCZANkTchDpECIRGREJEHIQ+RAagC8FD4CLH/98D/DyASkAMgE5CAIBSQACAVkBaQAyESqALwMvwIsf/3sP8CIBKQACAUkAUhEqgC8Cf8CLH/96X/F7AAvRC1BPDL/QDwQfj/96H/BfAf+AixACAQvQEg/OdwtQZGDEYVRiJGKUYwRgXw/fgBIHC9AAAAEAJAcEdwtQRGACWhSEhEAHjwsZ9ISEQAeE/0enGx+/DwnUlJRAlosfvw9jBGAPD4+WC5ECwI0gAiIUZQHgDwX/mWSEhEBGAE4AElAuABJQDgASUoRnC9ELUAJAMgAPA9+Q8g//dX/wixASQB4P/3yf8gRhC9cEcQtQC/T/D/MIdJiGPIYwC/AL8AIIhjyGMAv0AeCGQAIAhkQB6IYgAgiGJAHshiACDIYkAeCGMAIAhj//fg/wAgEL16SEhEAGh0SUlECXgIRHZJSUQIYHBHdEhIRABocEdwSEhEAGhwR3C1BEYAJWtISEQAeKBCDdBoSEhEBngEcGhISEQAaP/3Cv8FRhWxY0hIRAZwKEZwvWBISEQAeHBHcLUERv/39/4GRiVGaBwYsVpISEQAeAVEAL//9+z+gBuoQvrTcL1P8OAgAGkg8AIAT/DgIQhhcEdP8OAgAGlA8AIAT/DgIQhhcEdP8IZwcEdPSABoAAxwR01IAGjA8wsAcEdMSABocEdKSAAdAGhwR0hICDAAaHBHRUhAaEDwAQBDSUhgcEdCSEBoIPABAEBJSGBwRz5IQGhA8AIAPElIYHBHO0hAaCDwAgA5SUhgcEc3SEBoQPAEADVJSGBwRzRIQGgg8AQAMklIYHBHyiAySUhiUyBIYgEgMEkIYHBHASAvSQhicEcAIC1JCGJwRypJCWsh8AQBAUMnShFjcEcmSQlrIfACAQFDI0oRY3BHIklJayHwPwEBQx9KUWNwRxC1HUgAa0DwAQAbSQhj//dj/gRGBuD/91/+ABsKKAHZAyAQvRVIAGsA8AgAACjy0AAg9ucRSABrIPABAA9JCGNwRw1IQGhA9IBwC0lIYHBHCkhAaCD0gHAISUhgcEcMAAAAEAAAAAgAAAAAEAJABAAAAAAgBOCQdf8fAAABQAADIEIAACBCELUAKATbCgcTDuZKE1QG4AoHFA7kSgDwDwMbH9RUEL0AvwDwBwLgSww7GWhP9v8DGUDeSwtDQ+oCIdtLDDsZYAC/cEct6fBNgEYNRhZGACcA8KL5B0Y5RipGM0YB8AcAwPEHC7vxBA8C2U/wBAsB4MDxBwvaRgDxBAu78QcPAtJP8AALAeCg8QML3EZP8AELC/oK+6vxAQsL6gILC/oM+0/wAQ4O+gz+rvEBDg7qAw5L6g4EIUZARv/3ov+96PCNAUYIRgAoDdsAvwC/APAfAwEimkBDCZsAA/HgI8P4ACEAvwC/AL9wRxC1AUYIRgAoF9sA8B8DASKaQK1LRAlD+CQgAL8AvwC/v/NPjwC/AL8AvwC/AL8Av7/zb48AvwC/AL8AvxC9AL8AvwC/AL8Av7/zT48AvwC/AL+bSAw4AGgA9OBgmUkIQwAdl0kMOQhgAL8AvwC/v/NPjwC/AL8AvwC/AL/953C1BEYlRmgesPGAfwHTASAP4GgeT/DgIUhhDyFP8P8w//c7/wAgT/DgIYhhByAIYQAgcL0QtQDw/PgQvS3p8EUERiBGACgD231PP1w/CQfgfE8A8A8MrPEEDBf4DHA/CT1GDkYG8AcAwPEHCLjxBA8C2U/wBAgB4MDxBwjERgDxBAi48QcPAtJP8AAIAeCg8QMIR0Yl+gf4T/ABCgr6DPqq8QEKCOoKCML4AIBP8AEICPoH+KjxAQgI6gUIw/gAgAC/vejwhRC1AUYIRgAoCNsA8B8DASKaQFxLgDNECUP4JCAAvxC9ELUBRghGACgO21ZKgDJDCVL4IyAA8B8EASOjQBpACrEBIgLgACIA4AAiEEYQvRC1AUYIRgAoB9sA8B8DASKaQElLRAlD+CQgAL8QvRC1AUYIRgAoDttESoAyQwlS+CMgAPAfBAEjo0AaQAqxASIC4AAiAOAAIhBGEL0EKAjRT/DgIQlpQfAEAU/w4CIRYQfgT/DgIQlpIfAEAU/w4CIRYXBHcEcQtf/3/P8QvUDwAQEqSnwyEWAAvwC/AL+/80+PAL8AvwC/AL8AvwC/v/NvjwC/AL8Av3BHAL8AvwC/v/NfjwC/AL8AvwAgHEl8MQhgcEdBeBlKgDIRYAF4+bESHUFoEWABewkHwnpB6gJhgnpB6sJBQntB6oJBgntB6kJBwntB6gJBQnpB6gIhAnpB6kIBAngRQwlKiDIRYAXgACEGSoQyEWASHRFgcEcDSAw4AGjA8wIgcEcA5ADgGO0A4AAA+gWA4QDggOIA4AF5Sh74SwPrggJCZfZKQDKCZUoeAvADAwEimkDCZXBH8ksCaJpCBtJCbJII8EsD64ICgmQG4EJskgjtSxwzA+uCAoJkAngIOhQjsvvz8eZKgDrCZAHwHwMBIppAAmVwR3C1BEYMuQEgcL3gSSBoiEIL0uBJIGhAGhQhsPvx8IAAYGTcSAg4IGQK4NhJIGhAGhQhsPvx8IAAYGTUSAg4IGQCIIT4JQAgaAVoR/bwcIVD1OkCAQhDIWkIQ2FpCEOhaQhD4WkIQyFqCEMFQyBoBWAgRv/3pf+gaLD1gE8B0QAgYGAgeaFsCGDU6RMQSGBgaGCxYGgEKAnYIEb/94H/ACBhbQhg1OkWEEhgA+AAIGBloGXgZQAg4GMBIIT4JQAAIIT4JAAAv5/nELUERgy5ASAQvSBoAGgg8AEAIWgIYKtJIGiIQgvSq0kgaEAaFCGw+/HwgABgZKdICDggZArgo0kgaEAaFCGw+/HwgABgZJ9ICDggZAAgIWgIYJT4RAAA8BwBASCIQCFsSGAgRv/3SP8AIKFsCGDU6RMQSGBgaFixYGgEKAjYIEb/9yr/ACBhbQhg1OkWEEhgACBgZaBl4GXgYiBjYGOgY+BjhPglAAC/hPgkAAC/AL+q5zC10OkTVGxgRG0UsdDpFlRsYJD4REAE8BwFASSsQAVsbGAEaGNghGgQLATRBGiiYARo4WAD4ARooWAEaOJgML0t6fBBBEYNRhZGH0ZP8AAIAL+U+CQAASgC0QIgvejwgQEghPgkAAC/lPglAAEoF9ECIIT4JQAAIOBjIGgAaCDwAQAhaAhgO0YyRilGIEb/97f/IGgAaEDwAQAhaAhgBuAAvwAghPgkAAC/T/ACCEBG1Oct6fBBBEYNRhZGH0ZP8AAIAL+U+CQAASgC0QIgvejwgQEghPgkAAC/lPglAAEoP9ECIIT4JQAAIOBjIGgAaCDwAQAhaAhgO0YyRilGIEb/937/IGswsSBoAGhA8A4AIWgIYAvgIGgAaCDwBAAhaAhgIGgAaEDwCgAhaAhgoGwAaAD0gDAosaBsAGhA9IBwoWwIYGBtKLFgbQBoQPSAcGFtCGAgaABoQPABACFoCGAG4AC/ACCE+CQAAL9P8AIIQEas5wFGACKR+CUAAigI0AQgyGMAvwAggfgkAAC/ASBwRwhoAGgg8A4AC2gYYIhsAGgg9IBwi2wYYAhoAGgg8AEAC2gYYJH4RAAA8BwDASCYQAtsWGDR6RMwWGBIbUCxSG0AaCD0gHBLbRhg0ekWMFhgASCB+CUAAL8AIIH4JAAAvxBGzOdwtQRGACWU+CUAAigM0AQg4GMBJT3gAAAACQJACAQCQAAIAkAIAAJAIGgAaCDwDgAhaAhgIGgAaCDwAQAhaAhgoGwAaCD0gHChbAhglPhEAADwHAEBIIhAIWxIYNTpExBIYGBtQLFgbQBoIPSAcGFtCGDU6RYQSGABIIT4JQAAvwAghPgkAAC/oGsQsSBGoWuIRyhGcL0t6fBBBEYORhVGlPglAAIoCdAEIOBjAL8AIIT4JAAAvwEgvejwgSBoAGgA8CAAILFP9IBw4GMBIPPnPrmU+EQAAPAcAQIgAPoB+AbglPhEAADwHAEEIAD6Afj/9+v5B0Yw4CBsAGiU+EQQAfAcAgghkUAIQJCxlPhEAADwHAEBIIhAIWxIYAEg4GOE+CUAAL8AIIT4JAAAvwEgwudoHIix//fI+cAbqEIA2F25ICDgYwEghPglAAC/ACCE+CQAAL8BIK7nIGwAaADqCAAAKMjQYG2IsaBtAGjhbQhAYLFgbQBoQPSAcGFtCGDU6RYQSGDga0D0gGDgY+BsAGghbQhAMLHU6RMQSGDga0D0AHDgY4a5lPhEAADwHAECIIhAIWxIYAC/ACCE+CQAAL8BIIT4JQAH4JT4RAAA8BwBBCCIQCFsSGAAIGzncLUERiBsBWggaAZolPhEAADwHAEEIIhAKEDgsQbwBADIsSBoAGgA8CAAKLkgaABoIPAEACFoCGCU+EQAAPAcAQQgiEAhbEhgIGsAKFbQIEYha4hHUuCU+EQAAPAcAQIgiEAoQBizBvACAACzIGgAaADwIABAuSBoAGgg8AoAIWgIYAEghPglAJT4RAAA8BwBAiCIQCFsSGAAvwAghPgkAAC/4GpQsyBG4WqIRybglPhEAADwHAEIIIhAKEDwsQbwCADYsSBoAGgg8A4AIWgIYJT4RAAA8BwBASCIQCFsSGABIOBjhPglAAC/ACCE+CQAAL9gaxCxIEZha4hHcL0QtQNGACQAv5P4JAABKAHRAiAQvQEgg/gkAAC/k/glAAEoEtExsQEpBtACKQbQAykI0QXg2mIH4BpjBeBaYwPgmmMB4AEkAL8A4AEkAL8AIIP4JAAAvyBG2+cCRgAjAL+S+CQAASgB0QIgcEcBIIL4JAAAv5L4JQABKBvRBSkW0t/oAfADBgkMDwAAINBiEOAAIBBjDeAAIFBjCuAAIJBjB+AAINBiEGNQY5BjAeABIwC/AOABIwC/ACCC+CQAAL8YRtLnAUaR+CUAcEcBRshrcEcAAHi1AkYAI9rgASaeQA1oBeoGBAAsctBNaAEtCNBNaAItBdBNaBEtAtBNaBItE9GQaF4AAyW1QKhDXgDNaLVAKEOQYFBoASWdQKhDDXnF8wAVnUAoQ1Bg0GheAAMltUCoQ14AjWi1QChD0GBNaAItAtBNaBItE9HeCALxIAVV+CYAXQfuDg8ltUCoQ14H9g4NabVAKEPeCALxIAVF+CYAEGheAAMltUCoQw15BfADBV4AtUAoQxBgTWgF8IBVtfGAX3zRAL+oTS1uRfABBaZONWY1Ri1uBfABBQCVAL8Av0/qtjWeCFX4JgCdBy4PDyW1QKhDsvGQTwLRACUk4F7gm02qQgHRASUe4JlNqkIB0QIlGeCYTapCAdEDJRTglk2qQgHRBCUP4JVNqkIB0QUlCuCTTapCAdEGJQXgkk2qQgHRByUA4Aglngc2D7VAKEOOTZ4IRfgmAI1NKGigQ01oBfSANbX1gD8A0SBDiE0oYC0dKGigQ01oBfQANbX1AD8A0SBDgk0tHShgLR0oaKBDTWgF9IAVtfWAHwDRIEN7TQg1KGAtHShooENNaAX0ABW19QAfANEgQ3VNDDUoYFscDWjdQAAtf/Qgr3i98LULRgAhh+ABJY1ABeoDAgAqftBqTY4IVfgmQI0HLg8PJbVALECw8ZBPAdEAJSPgXE2oQgHRASUe4FpNqEIB0QIlGeBZTahCAdEDJRTgV02oQgHRBCUP4FZNqEIB0QUlCuBUTahCAdEGJQXgU02oQgHRByUA4Agljgc2D7VApUIh0U9NLWiVQ05ONWA1HS1olUM2HTVgNR0taJVDNh01YDUdLWiVQzYdNWCNBy4PDyUF+gb0Qk2OCFX4JlClQz9OjwhG+CdQBWhPAAMmvkA1QwVgzggA8SAFVfgmUE4H9w4PJr5AtUPPCADxIAZG+CdQhWhPAAMmvkC1Q4VgRmgBJY1ArkNGYMVoTwADJr5AtUMA4ADgxWBJHCP6AfUALX/0c6/wvQJGE2kLQAuxASAA4AAgcEcKsYFhAOCBYnBHELVCaSHqAgMC6gEEQ+oEQ4NhEL0ItQJGT/SAMACQAJgIQwCQAJjQYdFhAJjQYdBpAJDQaQD0gDAIsQAgCL0BIPzncEcQtQRGDkgUMABoIEAosQxIFDAEYCBG//fy/xC9ABACQAAEAEgACABIAAwASAAQAEgAFABIABgASAAcAEgIAAFAAAQBQHxIgGtA8IBQekmIYwhGgGsg8IBQiGNwR3dIAGhA9IBwdUkIYHBHdEgAaCD0gHBySQhgcEcBRnBIQGgg8A4ACmgQQ21KUGBtSABoIPSAMGtKEGAQHwBoIPSAMBIfEGBnSAgwAGgg9IAwZEoIMhBgEB8AaCD0gDASHxBgSGgA9IAwsPWAPwfRXUgAHwBoQPSAMFpKEh8QYEhoAPQAMLD1AD8F0VZIAGhA9IAwVEoQYAh5APABADixUUgAHQBoQPSAME5KEh0QYAh5APACAAIoB9FKSAgwAGhA9IAwSEoIMhBgACBwR0RIQGhA8AEAQklIYHBHQUhAaCDwAQA/SUhgcEc9ScloAPAfApFDQepQETpK0WARRoloAPAfAhFDNkqRYHBHNUmJaADwHwKRQzJKkWBwR3C1BEYNRlS5L0hAaQD0AHCw9QB/CtEA8Kf8OLFwvSlIQGnA80AgCLkA8Jf8KEgAaCDwBAAmSQhgAS0B0TC/AuBAvyC/IL8Av+jncLUFRgxGtfWATwPRIEYA8MX8AuAgRgDwp/xwvRdIAGgg8AcAwBwVSQhgFkgAaEDwBAAUSQhgAL8AvzC/cEcRSABoQPACAA9JCGBwRw1IAGgg8AIAC0kIYHBHCkgAaEDwEAAISQhgcEcGSABoIPAQAARJCGBwR3BHABACQABwAEAEBAFAEO0A4PhIAGgA9MBgsPWAbwLRT/SAYHBH80iAMABoAPSAcLD1gH8C0U/0AHDz5wAg8ecCRpK77EgAaAD0wGCw9YBvLNHoSIAwAGgg9IBw5kvD+IAAGEYAaCD0wGBA9ABwGGDiSEhEAGgyI1hD4Euw+/PwQRwA4Eke20hAaQD0gGCw9YBvAdEAKfXR10hAaQD0gGCw9YBvUtEDIHBHCODSSIAwAGgg9IBwz0vD+IAARuCy9QB/O9HMSABoAPTAYLD1gG8r0chIgDAAaED0gHDGS8P4gAAYRgBoIPTAYED0AHAYYMJISEQAaDIjWEPAS7D78/BBHADgSR67SEBpAPSAYLD1gG8B0QAp9dG3SEBpAPSAYLD1gG8S0QMgvueySIAwAGhA9IBwsEvD+IAAB+CuSABoIPTAYED0gGCrSxhgACCr56lJyWgh9ABxAUOmStFgEUbJaEH0gHHRYHBHokjAaCD0gHCgSchgcEefSEBoQPSAYJ1JSGBwR5tIQGgg9IBgmUlIYHBHmEhAaED0AHCWSUhgcEeUSEBoIPQAcJJJSGBwR5FIgGhA9ABAj0mIYHBHjUiAaCD0AECLSYhgcEcQtQJGACAJKnHS3+gC8AUUISs1P0lTYACESxtqIfSARCNDgUwjYiNGW2oh9CBEo0N+TGNiXeB8S5tqC0N7TKNiI0bbaiHwEASjQ3dM42JQ4HZLG2sLQ3RMI2MjRltri0NjY0bgcUubawtDb0yjYyNG22uLQ+NjPOBsSxtsC0NqTCNkI0ZbbItDY2Qy4GdLm2wLQ2VMo2QjRttsi0PjZCjgYksbbQtDYEwjZSNGW22LQ2NlHuBdS5ttjLIjQ1tMo2UjRtttjLKjQ1hM42UR4FZLG27B8wsEI0NUTCNmI0ZbbsHzCwSjQ1BMY2YC4P/nASAAvwC/EL0QtQJGACAJKkHS3+gC8AUNExkfJSsxOABGSxtqIfSARKNDREwjYjTgQkubaotDQUyjYi7gP0sba4tDPkwjYyjgPEuba4tDO0yjYyLgOUsbbItDOEwjZBzgNkubbItDNUyjZBbgM0sbbYtDMkwjZRDgMEubbYyyo0MuTKNlCeAtSxtuwfMLBKNDKkwjZgHgASAAvwC/EL0QtQJGACAJKnbS3+gC8AUUICo0Pk5YZQAhS1tqIfQgRCNDHkxjYiNGG2oh9IBEo0MbTCNiYuAZS9tqIfAQBCNDF0zjYiNGm2qLQ6NiVuATS1trC0MSTGNjI0Yba4tDI2NM4A5L22sLQw1M42MjRptri0OjY0LgCUtbbAtDCExjZCNGG2yLQyNkOOAES9tsC0MDTONkI0abbItDo2Qu4ABwAEAQAAAAQEIPAPpLW20LQ/lMY2UjRhtti0MjZR7g9UvbbYyyI0PzTONlI0abbYyyo0PwTKNlEeDvS1tuwfMLBCND7ExjZiNGG27B8wsEo0PpTCNmAuD/5wEgAL8AvxC9ELUCRgAgCSpD0t/oAvAFDRUbISctMzoA30tbaiH0IESjQ9xMY2I24NtL22oh8BAEo0PYTONiLuDXS1tri0PVTGNjKODUS9tri0PSTONjIuDRS1tsi0PPTGNkHODOS9tsi0PMTONkFuDLS1tti0PJTGNlEODIS9ttjLKjQ8ZM42UJ4MRLW27B8wsEo0PCTGNmAeABIAC/AL8Qvb5IgGhA9IBgvEmIYHBHu0iAaCD0gGC5SYhgcEcBRjG5tkiAaCD0gHC0SpBgC+Cx9YB/BtGxSIBoQPSAcK9KkGAB4AEgcEcAIPznALVP9IBw//fk/wC9ALUAIP/33/8AvaZIAGhA8BAApEkIYHBHo0gAaCDwEAChSQhgcEefSIBoQPSAUJ1JiGBwR5xIgGgg9IBQmkmIYHBHmEhAaEDwEACWSUhgcEeVSEBoIPAQAJNJSGBwR5FIQGhA8CAAj0lIYHBHjkhAaCDwIACMSUhgcEeKSEBoQPBAAIhJSGBwR4dIQGgg8EAAhUlIYHBHg0hAaEDwgACBSUhgcEeASEBoIPCAAH5JSGBwRwFGACAKaBAqBtAgKlLQQCp+0IAqfdHx4HdKEmgi8AgCdUsaYBofEmgi8AgCGx8aYHFKCDISaCLwCAJvSwgzGmAaHxJoIvAIAhsfGmBKaAL0gDKy9YA/B9FnShIfEmhC8AgCZUsbHxpgSmgC9AAysvUAPwXRYEoSaELwCAJeSxpgCnkC8AECOrFbShIdEmhC8AgCWUsbHRpgCnkC8AICAioH0VVKCDISaELwCAJSSwgzGmDz4FBKEmgi8BACTksaYBofEmgi8BACGx8aYEpKCDISaCLwEAJISwgzGmAaHxJoIvAQAhsfGmBKaAL0gDKy9YA/B9FAShIfEmhC8BACPksbHxpgSmgC9AAysvUAPwHgIeDB4AXROEoSaELwEAI2SxpgCnkC8AECOrEzShIdEmhC8BACMEsbHRpgCnkC8AICAioH0SxKCDISaELwEAIqSwgzGmCi4ChKEmgi8CACJksaYBofEmgi8CACGx8aYCJKCDISaCLwIAIfSwgzGmAaHxJoIvAgAhsfGmBKaAL0gDKy9YA/B9EYShIfEmhC8CACFUsbHxpgSmgC9AAysvUAPwXREUoSaELwIAIPSxpgCnkC8AECOrEMShIdEmhC8CACCUsbHRpgCnkC8AICAioH0QVKCDISaELwIAIDSwgzGmBU4AAAAHAAQCQEAUCQShJoIvBAAo5LGmAaHxJoIvBAAhsfGmCKSggyEmgi8EACiEsIMxpgGh8SaCLwQAIbHxpgSmgC9IAysvWAPwfRgEoSHxJoQvBAAn5LGx8aYEpoAvQAMrL1AD8F0XlKEmhC8EACd0saYAp5AvABAjqxdEoSHRJoQvBAAnJLGx0aYAp5AvACAgIqB9FuSggyEmhC8EACa0sIMxpgAeABIAC/AL9wR2hIAGhA9IBAZkkIYHBHZUgAaCD0gEBjShBgY0hIRABoMiJQQ2FKsPvy8EEcAOBJHlxIQGkA9ABwsPUAfwHRACn10VhIQGkA9ABwsPUAfwHRAyBwRwAg/OdSSQloIfAHAVBKEWBSSQloQfAEAVBKEWABKAHRML8C4EC/IL8gv0xJCWgh8AQBSkoRYHBHRUkJaCHwBwFJHENKEWBFSQloQfAEAUNKEWABKAHRML8C4EC/IL8gvz5JCWgh8AQBPEoRYHBHOEkJaCHwBwGJHDVKEWA3SQloQfAEATVKEWABKAHRML8C4EC/IL8gvzFJCWgh8AQBL0oRYHBHKkgAaCDwBwAAHShJCGAqSABoQPAEAChJCGAAvwC/ML9wR3BHcEdwR3BHELUeSBA4AGgA9IAwMLH/9xn7T/SAMBlJEDkIYBhIEDAAaADwCAAosf/36f8IIBNJEDEIYBJIEDAAaADwEAAosf/33P8QIA1JEDEIYAxIEDAAaADwIAAosf/3z/8gIAdJEDEIYAZIEDAAaADwQAAosf/3wv9AIAFJEDEIYBC9JAQBQABwAEAQAAAAQEIPABDtAOAQtfxIAGhA8AEA+kkIYP73nPgERgbg/veY+AAbAigB2QMgEL3zSABoAPACAAAo8tDwSABoIPDwAEDwYADtSQhgACCIYOxI7UlJRAhg7EhIRABo/vd++AixASDi5/73dfgERgjg/vdx+AAbQfKIMYhCAdkDINXn30iAaADwDAAAKPDR3EgAaN9JCEDaSQhg/vdc+ARGBuD+91j4ABsCKAHZAyC+59NIAGgA8ChQACjy0dBJyGAIRsBoQPSAUMhgACAIYQhGAGlA9IBQCGEAIEhhCEZAaUD0gFBIYQhGAGgg9IAgCGAAIIhhQB4IYsFIlDAAaED0AADB+JQAACCR5/C1ACMAIN/47MLc+AjADPAMAd/44MLc+AzADPADBxmxDCkf0QEvHdHf+MzC3PgAwAzwCAy88QAPBtHf+LjC3PiUwMzzAyMF4N/4rMLc+ADAzPMDE9/4tML8RFz4IzBBuRhGBuAEKQHRqUgC4AgpANGoSAwpMtHf+HzC3PgMwAzwAwQBLAnQAiwC0AMsBNEB4J9KBOCfSgLgAL8aRgC/AL/f+FTC3PgMwMzzAxwM8QEG3/hEwtz4DMDM8wYsDPsC/Lz79vLf+DDC3PgMwMzzQWwM8QEMT+pMBbL79fDwvfi1BEYAJoRIgG0A8IBQGLH/9+r5BUYW4AC/f0iAbUDwgFB9SYhlCEaAbQDwgFAAkAC/AL//99j5BUZ3SIBtIPCAUHVJiGW19QB/B9GALAzZoCwB2QImCOABJgbggCwB0wImAuBwLADRASZzSABoIPAPADBDcEkIYAhGAGgA8A8AsEIB0AEg+L0AIPznLen4RQRGFLkBIL3o+IVfSIBoAPAMBl1IwGgA8AMHIHgA8BAAECh60R6xDC550QEvd9FWSABoAPACABixoGkIuQEg4udRSCFqAGgA8AgAILFOSABoAPDwAAXgTEiUMABoAPRwYAAJgUIf2SBq//eC/wixASDJ5wC/REgAaEDwCABCSQhgCEYAaCDw8AAhaghDPkkIYAC/CEZAaCD0f0DhaUDqASA5SUhgH+AAvzdIAGhA8AgANUkIYAhGAGgg8PAAIWoIQzFJCGAAvwhGQGgg9H9A4WlA6gEgLElIYC65IGr/90j/CLEBII/n//fU/idJiWjB8wMRLkp6RFFcAfAfAchAJElJRAhgI0hIRABo/ffs/oBGuPEAD2PQQEZ152Dg/+egaYCzGUgAaEDwAQAXSQhg/ffW/gVGBuD999L+QBsCKAHZAyBg5xBIAGgA8AIAACjy0AC/DUgAaEDwCAALSQhgCEYAaCDw8AAhaghDB0kIYAC/CEZAaCD0f0DhaUDqASACSUhgLOAU4AAAABACQAAJPQAQAAAACAAAAP/0/upOOAAAACT0AAASegAAIAJALDYAAP5IAGgg8AEA/EkIYP33j/4FRgbg/feL/kAbAigB2QMgGef2SABoAPACAAAo8tEgeADwAQAAKFzQCC4D0AwuCtEDLwjR7UgAaAD0ADCIs2BoeLsBIP/mAL9gaLD1gD8G0eZIAGhA9IAw5EkIYBrgYGiw9aAvC9HhSABoQPSAIN9JCGAIRgBoQPSAMAhgCuDbSABoIPSAMNlJCGAIRgBoIPSAIAhgAL9gaJCx/fdA/gVGB+Ae4P33O/5AG2QoAdkDIMnmzkgAaAD0ADAAKPLQEOD99y3+BUYG4P33Kf5AG2QoAdkDILfmxUgAaAD0ADAAKPLRIHgA8AIAAihS0QQuA9AMLhTRAi8S0bxIAGgA9IBgGLHgaAi5ASCd5rhIQGgg8P5AIXxA6gFgtElIYDng4GgAs7JIAGhA9IBwsEkIYP339v0FRgbg/ffy/UAbAigB2QMggOapSABoAPSAYAAo8tCmSEBoIPD+QCF8QOoBYKNJSGAW4KFIAGgg9IBwn0kIYP331f0FRgbg/ffR/UAbAigB2QMgX+aZSABoAPSAYAAo8tEgeADwCAAIKDbRYGnQsZJIlDAAaEDwAQCQScH4lAD997X9BUYG4P33sf1AGwIoAdkDID/miUiUMABoAPACAAAo8dAZ4IVIlDAAaCDwAQCCScH4lAD995r9BUYG4P33lv1AGwIoAdkDICTme0iUMABoAPACAAAo8dEgeADwBAAEKHHRT/AACnRIgG0A8IBQeLkAv3FIgG1A8IBQb0mIZQhGgG0A8IBQAJAAvwC/T/ABCmtIAGgA9IBwsLloSABoQPSAcGZJCGD992H9BUYG4P33Xf1AGwIoAdkDIOvlYEgAaAD0gHAAKPLQAL+gaAEoCNFaSJAwAGhA8AEAV0nB+JAAIeCgaAUoD9FUSJAwAGhA8AQAUUnB+JAACEbQ+JAAQPABAMH4kAAO4ExIkDAAaCDwAQBJScH4kAAIRtD4kAAg8AQAwfiQAAC/oGiosf33Hv0FRgng/fca/UAbQfKIMYhCAtkDIKblJeA8SJAwAGgA8AIAACju0BPg/fcI/QVGCOD99wT9QBtB8ogxiEIB2QMgkOUxSJAwAGgA8AIAACjv0brxAQ8F0SxIgG0g8IBQKkmIZQC/IHgA8CAAICg20WBq0LElSJgwAGhA8AEAI0nB+JgA/ffb/AVGBuD999f8QBsCKAHZAyBl5RxImDAAaADwAgAAKPHQGeAYSJgwAGgg8AEAFUnB+JgA/ffA/AVGBuD997z8QBsCKAHZAyBK5Q5ImDAAaADwAgAAKPHRoGoAKH3QoGoCKHvRCEjHaAfwAwHgaoFCKtEH8PABIGtAHrHrAB8j0Qf0/kED4AAQAkAAcABAYGux6wAvGNEH8HhBOCAAXbHrwG8R0Qf0wAGgjwEiwutQALHrQF8I0QfwwGFAIABdwutQALHrQG9k0AwuYND+SABoAPCAYCC5+0gAaADwgFAIsQEg/eT4SABoIPCAcPZJCGD992L8BUYG4P33XvxAGwIoAdkDIOzk70gAaADwAHAAKPLR1OkLEEAeQeoAEWBrQeoAIaCPASLC61AAQepAUUAgAF3C61AAQepAYTggAF1B6sBg4EnJaOBKEUAIQ95JyGAIRgBoQPCAcAHgWOA74AhgCEbAaEDwgHDIYP33JfwFRgbg/fch/EAbAigB2QMgr+TRSABoAPAAcAAo8tBQ4AEgpuTMSABoAPAAcMC7ykgAaEDwgHDISQhgCEbAaEDwgHDIYP33AfwFRgbg/ff9+0AbAigB2QMgi+S/SABoAPAAcAAo8tAs4AwuKNC6SABoIPCAcLhJCGAIRgBoAPAgUCC5CEbAaCDwAwDIYLJIwGizSQhAsEnIYP331/sFRgfgD+D999L7QBsCKAHZAyBg5KlIAGgA8ABwACjy0QHgASBX5AAgVeRwtQAio072aAbwAwYBLhLRoE42aAbwCAYuuZ1OlDY2aMbzAyID4JpONmjG8wMSm05+RFb4IiCWTvZoBvADAwErCdACKwLQAysE0QHglUkE4JVJAuAAvxFGAL8Av41O9mjG8wMWdRyKTvZoxvMGJk5Dtvv18YdO9mjG80Fmdhx0ALH79PBwvS3p8EEERg1GACcUuQEgvejwgYRIAGgA8A8AqEIO0oFIAGgg8A8AKEN+SQhgCEYAaADwDwCoQgHQASDo5yB4APABAAAoc9BgaAMoK9FvSABoAPAAcAi5ASDZ5//3jv9ySYhCR9lpSIBoAPDwAEi5Z0iAaCDw8ABA8IAAZEmIYIAnOOAgeADwAgACKDPRoGiIu15IgGgg8PAAQPCAAFtJiGCAJyfgYGgCKAbRWEgAaAD0ADCIuQEgqudgaDC5U0gAaADwAgBAuQEgoedQSABoAPSAYAi5ASCa5//36/pSSYhCCNlKSIBoIPDwAEDwgABHSYhggCdFSIBoIPADAGFoCENCSYhg/ff7+gZGCOD99/f6gBtB8ogxiEIB2QMgd+c7SIBoAPAMAGFosOuBD+7RIHgA8AIAAigI0TRIgGgg8PAAoWgIQzFJiGAH4IAvBdEvSIBoIPDwAC1JiGAySABoAPAPAKhCDtkvSABoIPAPAChDLEkIYAhGAGgA8A8AqEIB0AEgROcgeADwBAAEKAfRH0iAaCD04GDhaAhDHEmIYCB4APAIAAgoCNEYSIBoIPRgUCFpQOrBABVJiGD/93r6E0mJaMHzAxEZSnpEUVwB8B8ByEAXSUlECGAWSEhEAGj995L6gEZARhLncLWGsAZGDUYURgC/BUjAbEDwAQADSchkCEbAbADwAQAAkBXgABACQAyAnQH//+7+ri8AAAAk9AAAEnoAACACQAC0xAR4LQAAEAAAAAgAAAAAvwC/iBUBkAIgApAEkAAgA5AFkAGpT/CQQP73x/l9SIBoIPD+QEXqBAEIQ3lJiGAGsHC9eEhIRABocEcAtf/3+f90SYlowfMCIXRKekRRXAHwHwHIQAC9ALX/9+v/bUmJaMHzwiFtSnpEHDpRXAHwHwHIQAC9PyEBYGZJCWgB9IAhsfWALwPRT/SgIUFgDOBgSQloAfSAMbH1gD8D0U/0gDFBYAHgACFBYFpJCWgB8AEBEbEBIYFhAeAAIYFhVUlJaMHzByHBYVJJCWgB8PABAWJQSQloAfSAcbH1gH8D0U/0gHHBYAHgACHBYElJSWjB8wZhAWFHSZAxCWgB8AQBBCkC0QUhgWAK4EJJkDEJaAHwAQERsQEhgWAB4AAhgWA8SZQxCWgB8AEBEbEBIUFhAeAAIUFhN0mYMQloAfABARGxASFBYgHgACFBYjFJCWgB8IBxsfGAfwLRAiGBYgHgASGBYitJyWgB8AMCwmIpSclowfMDEUkcAWMmSclowfMGIkJjI0nJaMHzQVFJHEoAwmMgSclowfNBYUkcSgACZBxJyWjKDoJjcEcPIgJgGUqSaALwAwJCYBZKkmgC8PACgmAUSpJoAvTgYsJgEUqSaAL0YFLSCAJhEUoSaALwDwIKYHBHC0gAaED0ACAJSQhgcEdwRxC1B0jAaQD0gHCw9YB/BdH/9/X/T/SAcAFJCGIQvQAAABACQBAAAADMLAAAACACQC3p8EEERg9GACX+SMBoAPADAFCx+0jAaADwAwAhaIhCAdEgaHi7ASUt4CBoASgE0AIoCdADKBrRDeDySABoAPACAAC5ASUU4O5IAGgA9IBgALkBJQ3g60gAaAD0ADAouehIAGgA9IAgALkBJQHgASUAvwC/PbnjSMBoIPADACFoCEPgSchgAC1z0d5IAGgg8IBQ3EkIYP33BPkGRgbg/fcA+YAbAigB2QMlBeDVSABoAPAAUAAo8tEAvwAtWdGHuaBoAAIhe0DqwWFgaEAeQeoAEMxJSWnMShFACEPJSUhhKOABLxPRoGgAAiGKASLC61EBQOpBUWBoQB5B6gAQwUlJacJKEUAIQ75JSGES4KBoAAIhfQEiwutRAUDqQWFgaEAeQeoAELdJSWm5ShFACEO0SUhhs0gAaEDwgFCxSQhg/fev+AZGBuD996v4gBsCKAHZAyUF4KtIAGgA8ABQACjy0AC/LbmnSEBpoWkIQ6VJSGEoRr3o8IEt6fBBBEYPRgAloEjAaADwAwBQsZ1IwGgA8AMAIWiIQgHRIGh4uwElLeAgaAEoBNACKAnQAyga0Q3glEgAaADwAgAAuQElFOCQSABoAPSAYAC5ASUN4I1IAGgA9AAwKLmKSABoAPSAIAC5ASUB4AElAL8Avz25hUjAaCDwAwAhaAhDgknIYAAtc9GASABoIPCAYH5JCGD990j4BkYG4P33RPiAGwIoAdkDJQXgd0gAaADwAGAAKPLRAL8ALVnRh7mgaAACIXtA6sFhYGhAHkHqABBuSQlpbkoRQAhDa0kIYSjgAS8T0aBoAAIhigEiwutRAUDqQVFgaEAeQeoAEGNJCWlkShFACENgSQhhEuCgaAACIX0BIsLrUQFA6kFhYGhAHkHqABBZSQlpW0oRQAhDVkkIYVVIAGhA8IBgU0kIYPz38/8GRgbg/Pfv/4AbAigB2QMlBeBNSABoAPAAYAAo8tAAvy25SUgAaaFpCENHSQhhKEa96PCBLen4RQRGACWoRiCIAPQAYLD1AG8y0eBuQCgJ0APccLEgKBvREeBgKBbQgCgW0RTgOEjAaED0gDA2SchgEOAAISAd//ch/wVGCuAAIQTxIAD/917+BUYD4AC/AeABJQC/AL9VuStInDAAaCDw4ADhbghDKEnB+JwAAOCoRiCIAPSAULD1gF820SBvsPUAfwzQBNyIsbD1gH8d0RPgsPVAfxfQsPWAbxbRFOAaSMBoQPSAMBhJyGAQ4AAhIB3/9+T+BUYK4AAhBPEgAP/3If4FRgPgAL8B4AElAL8Av1W5DUicMABoIPTgYCFvCEMJScH4nAAA4KhGIGgA9AAwsPUAP2vRT/AACgNIgG0BISHqEHDAsQfgABACQA+A/wcPgJ//D4D/+QC//kiAbUDwgFD8SYhlCEaAbQDwgFAAkAC/AL9P8AEK90gAaED0gHD1SQhg/Pcv/wdGBuD89yv/wBsCKAHZAyUF4O9IAGgA9IBwACjy0AC/hbvqSJAwAGgA9EB21rHU+JgAsEIW0OVIkDAAaCD0QHbiSND4kABA9IAw4EnB+JAACEbQ+JAAIPSAMMH4kAAIRsD4kGAG8AEAsLH89/j+B0YK4Pz39P7AG0HyiDGIQgPZAyUI4BfgIeDQSJAwAGgA8AIAACjt0AC/XbnMSJAwAGgg9EBw1PiYEAhDyEnB+JAAAuCoRgDgqEa68QEPBdHDSIBtIPCAUMFJiGUAvyB4APABAEixvUiIMABoIPADAOFrCEO6ScH4iAAgeADwAgACKAnRtkiIMABoIPAMACFsCEOyScH4iAAgeADwBAAEKAnRrkiIMABoIPAwAGFsCEOrScH4iAAgeADwCAAIKAnRp0iIMABoIPDAAKFsCEOjScH4iAAgeADwEAAQKAnRn0iIMABoIPRAcOFsCEOcScH4iAAgeADwIAAgKAnRmEiIMABoIPRAYCFtCEOUScH4iAAgiAD0AHCw9QB/CdGQSIgwAGgg9EAgYW4IQ4xJwfiIACCIAPSAYLD1gG8J0YhIiDAAaCD0QBChbghDhEnB+IgAIHgA8EAAQCgJ0YBIiDAAaCD0QFBhbQhDfUnB+IgAIHgA8IAAgCgJ0XlIiDAAaCD0QEChbQhDdUnB+IgAIIgA9IBwsPWAfwnRcUiIMABoIPRAMOFtCENtScH4iAAgaAD0gBCw9YAfCdFpSJwwAGgg8AMAIW4IQ2VJwficACCIAPQAULD1AF8f0WFIiDAAaCDwQGBhbwhDXUmIMQhgYG+w8QBvBtFaSMBoQPSAEFhJyGAK4GBvsPGAbwbRASEgHf/3Wv0FRgWxqEYgaAD0ACCw9QAvQdEAv6BvsPWATwjRS0icMABoQPSAQElJwficABHgR0icMABoIPSAQERJwficAENIiDAAaCDwQGChbwhDP0nB+IgAAL+gb7DxAG8G0TtIwGhA9IAQOUnIYBXgoG+w9YBPBtE2SMBoQPSAMDRJyGAK4KBvsPGAbwbRASEgHf/3Ev0FRgWxqEYgaAD0gCCw9YAvH9EqSIgwAGgg8EBg4W8IQyZJiDEIYOBvsPEAbwbRI0jAaED0gBAhSchgCuDgb7DxgG8G0QEhIB3/9+z8BUYFsahGIIgA9IBAsPWATxbRF0iIMABoIPBAUNT4gBAIQxNJiDEIYNT4gACw8YBfBtECISAd//fP/AVGBbGoRiBoAPSAMLD1gD8K0QhInDAAaCDwBADU+IQQCEMEScH4nAAgaAD0ABCw9QAfD9ED4AAQAkAAcABA/kicMABoIPAYANT4iBAIQ/pJwficACBoAPSAALD1gA8r0fZIAGgg8IBQ9EkIYPz3LP0HRgbg/Pco/cAbAigB2QMlBeDtSABoAPAAUAAo8tEAv4W56UicMABoIPRAMNT4jBAIQ+VJwficAAIhBPEgAP/3uvsFRgWxqEYgaAD0AACw9QAPF9HdSJwwAGgg9IBQ1PiQEAhD2UmcMQhg1PiQALD1gF8H0QEhBPEgAP/3nPsFRgWxqEYgaADwgHCw8YB/FdHOSJwwAGgg9EAQ1PiUEAhDykmcMQhg1PiUALD1AB8F0cZIwGhA9IAQxEnIYEBGvej4hcJJAWDAScloAfADAUFgvkkJacHzAxFJHIFgu0kJacHzBiLCYLhJCWnB80BBByIC6wESAmG0SQlpwfNBUUkcSgBCYbFJCWnB80FhSRxKAIJhQWgBYqxJSWnB8wMRSRxBYqlJSWnB8wYigmKnSUlpwfNAQQciAusBEsJio0lJacHzQVFJHEoAAmOfSUlpwfNBYUkcSgBCY5xJiDEJaAHwAwHBY5lJiDEJaAHwDAEBZJZJiDEJaAHwMAFBZJNJiDEJaAHwwAGBZJBJiDEJaAH0QHHBZI1JiDEJaAH0QGEBZYpJiDEJaAH0QFFBZYdJiDEJaAH0QEGBZYRJiDEJaAH0QDHBZYFJnDEJaAHwAwEBZn5JiDEJaAH0QCFBZntJiDEJaAH0QBGBZnhJnDEJaAHw4AHBZnVJnDEJaAH04GEBZ3JJkDEJaAH0QHHA+JgQbkmIMQloAfBAYUFna0mcMQloAfSAQRGxT/SAQQTgZ0mIMQloAfBAYUD4eB9jSdH4iBAB8EBhQWBgSdH4iBAB8EBRgWBdSdH4nBAB8AQBwWBaSdH4nBAB8BgBAWFXSdH4nBAB9EAxQWFUSdH4nBAB9IBRgWFRSdH4nBAB9EARwWF4OHBH8LUFRg5GACAAIQAktfUAbwnRSU+cNz9oB/DgAWApD9FL9oAwDOC19YBfCdFCT5w3P2gH9OBhsfVAfwHRS/aAMAAoLdEyRkApAtCx9QB/KNE5Tz9oB/AAd7fxAH/x0TZP/2gH9IA3AC8a0DNP/2jH8wMXfxyy+/fyL0//aMfzBiMtT/9o/A48uStP/2gH9AA3D7ERJADgByQC+wP3t/v08GrgQbskTz9oB/AAZ7fxAG9i0SFPP2kH9IA3AC9c0B5PP2nH8wMXfxyy+/fyGk8/acfzBiMYTz9p/A48uRZPP2kH9AA3D7ERJADgByQC+wP3t/v08EDggCkC0LH1gG8I0Q1PP2gH9IBnt/WAbzTRDEgy4CApAtCx9YB/LdEGTz9oB/AAV7fxAF8m0QNPf2kH9IA3D7MATwXgABACQP9//wEAJPQAf2nH8wMXfxyy+/fy/E9/acfzBiP6T39p/A48ufhPf2kH9AA3D7ERJADgByQC+wP3t/v08PC9LenwTQdGT/AAC7f1AD8u0e5IkDAAaAD0QHS09YB/BtC09QB/DdC09UB/HtET4OZIkDAAaADwAgACKAHRT/QASxTg4UiUMABoAPACAAIoAdFP9PpLCuDcSABoAPQAMLD1AD8B0d/4aLMA4AC/8+PWSMBoAPADCrrxAQ8G0LrxAg8h0LrxAw800Sjgz0gAaADwAgACKBXRzEgAaADwCAAgscpIAGgA8PAABeDHSJQwAGgA9HBgAAkACcZJeURR+CBQAOAAJRfgwEgAaAD0gGCw9YBvAdHATQDgACUM4LtIAGgA9AAwsPUAPwHRu00A4AAlAeAAJQC/AL+39YBveNAa3CAvdtAM3AQvdNAE3AEvctACL3HRx+EIL2/QEC/50UbiQC9r0IAva9C39YB/adC39QB/7tGl47f1gC8u0BHct/UAXynQBty39QBvF9C39YBf39Ea4Lf1gE940Lf1gD/Y0bfit/UAL3LQt/WAH3DQt/UAH27Qt/GAf8vR7OMpRk/0AGD/94D+g0YQ4ilGT/SAUP/3ef6DRvfnAL+LSIgwAGgA8EBkXLO08YBvU9C08QBvKNC08UBvfNGESABoAPACAAIoFNGBSABoAPAIACCxfkgAaADw8AAF4HxIlDAAaAD0cGAACQAJfUl5RFH4ILBh4HzjC+KD4Srh/OOs4bLiTuDS4vvicUgAaADwAHCw8QB/G9FtSMBoAPSAELD1gB8U0WpIwGjA8wYmBfsG8GdJyWjB8wMRSRyw+/H1Y0jAaMDzQVBAHEAAtfvw+zPgDeIz4PbiTOJdSABoAPAAYLDxAG8b0VlIAGkA9IAQsPWAHxTRVkgAacDzBiYF+wbwU0kJacHzAxFJHLD78fVPSABpwPNBUEAcQAC1+/D7C+AJ4EpImDAAaADwAgACKAHR3/g0sQDgAL8Av6XjREicMABoAPSAQLD1gE8u0UBIAGgA8ABwsPEAfybRPEjAaAD0gDCw9YA/H9E5SMBowPMGJgX7BvA2SclowfMDEUkcsPvx9TJIwGhP6tBouPEADwnRL0jAaAD0ADAQsU/wEQgB4E/wBwi1+/j7kuAoSIgwAGgA8EBk7LO08YBvWNC08QBvHtC08UBvdtEhSABoAPACAAIoFNEeSABoAPAIACCxG0gAaADw8AAF4BlIlDAAaAD0cGAACQAJHEl5RFH4ILBm4BNIAGgA8ABwsPEAfx3RD0jAaAD0gBCw9YAfFtEMSMBowPMGJgX7BvAJSclowfMDEQDgQeBJHLD78fUESMBowPNBUEAcQAC1+/D7QOAAAAAQAkCQ0AMA7B0AAAAk9AAAEnoAvhwAAABs3AIyGwAA90gAaADwAGCw8QBvG9H0SABpAPSAELD1gB8U0fBIAGnA8wYmBfsG8O1JCWnB8wMRSRyw+/H16kgAacDzQVBAHEAAtfvw+wvgCeDlSJgwAGgA8AIAAigB0d/4iLMA4AC/AL/a4t5IiDAAaADwAwQ0sQEsCNACLArQAywc0RHg/ve5/oNGGOD+98b4g0YU4NRIAGgA9IBgsPWAbwHR3/hIswrgz0iQMABoAPACAAIoAdFP9ABLAOAAvwC/ruLISIgwAGgA8AwENLEELAjQCCwK0AwsHNER4P73f/6DRhjg/vea+INGFOC+SABoAPSAYLD1gG8B0d/48LIK4LlIkDAAaADwAgACKAHRT/QASwDgAL8Av4LiskiIMABoAPAwBDSxECwI0CAsCtAwLBzREeD+91P+g0YY4P73bviDRhTgqEgAaAD0gGCw9YBvAdHf+JiyCuCjSJAwAGgA8AIAAigB0U/0AEsA4AC/AL9W4pxIiDAAaADwwAQ0sUAsCNCALArQwCwc0RHg/vcn/oNGGOD+90L4g0YU4JJIAGgA9IBgsPWAbwHR3/hAsgrgjUiQMABoAPACAAIoAdFP9ABLAOAAvwC/KuKGSIgwAGgA9EB0TLG09YB/CtC09QB/C9C09UB/HNER4P73+P2DRhjg/vcT+INGFOB6SABoAPSAYLD1gG8B0d/45LEK4HVIkDAAaADwAgACKAHRT/QASwDgAL8Av/vhb0iIMABoAPRAZEyxtPWAbwrQtPUAbwvQtPVAbxzREeD+98n9g0YY4P335P+DRhTgY0gAaAD0gGCw9YBvAdHf+ISxCuBeSJAwAGgA8AIAAigB0U/0AEsA4AC/AL/M4VdIiDAAaADwQFS08YBfBtC08UBfJdH9977/g0Yi4FBIAGgA8ABgsPEAbxnRTEgAaQDwgHCgsUpIAGnA8wYmBfsG8EdJCWnB8wMRSRyw+/H1Q0gAacDzQWBAHEAAtfvw+wDgAL8Av5jhPUicMABoAPAEBBy5/vd+/YNGAuD994v/g0aK4TZInDAAaADwGAQksQgsJdAQLC3RBuApRk/0AGD/97z7g0Ym4C1IAGgA8AIAAigU0SpIAGgA8AgAILEoSABoAPDwAAXgJUiUMABoAPRwYAAJAAklSXlEUfggsArgH0gAaAD0gGCw9YBvAdHf+HiwAOAAvwC/T+EZSIgwAGgA9EBUNLG09YBfB9C09QBfEtEH4P73IP2DRg7g/fc7/4NGCuAOSABoAPSAYLD1gG8B0d/4NLAA4AC/AL8t4QhIiDAAaAD0QEQ0sbT1gE8P0LT1AE8a0Q/g/vf+/INGFuAAEAJAAGzcAgAk9ABkFwAA/fcR/4NGCuD3SABoAPSAYLD1gG8B0d/41LMA4AC/AL8D4fFIiDAAaAD0QDQ0sbT1gD8H0LT1AD8S0Qfg/vfU/INGDuD99+/+g0YK4OZIAGgA9IBgsPWAbwHR3/iQswDgAL8Av+Hg4EicMABoAPADBCyxASwH0AIsE9EI4Nbg/vez/INGDuD9987+g0YK4NZIAGgA9IBgsPWAbwHR3/hMswDgAL8Av8Dgz0iIMABoAPRAJEyxtPWALwrQtPUALxHQtPVALyLRF+D+9478g0Ye4MVIlDAAaADwAgACKAHRT/T6SxTgwEgAaAD0gGCw9YBvAdHf+PiyCuC7SJAwAGgA8AIAAigB0U/0AEsA4AC/AL+L4LVIiDAAaAD0QBRMsbT1gB8K0LT1AB8R0LT1QB8i0Rfg/vdZ/INGHuCrSJQwAGgA8AIAAigB0U/0+ksU4KZIAGgA9IBgsPWAbwHR3/iMsgrgoUiQMABoAPACAAIoAdFP9ABLAOAAvwC/VuCaSJwwAGgA9EAUNLG09YAfB9C09QAfRtEf4P33Rv6DRkLgkkgAaADwAgACKBTRj0gAaADwCAAgsYxIAGgA8PAABeCKSJQwAGgA9HBgAAkACYhJeURR+CCwJuCESABoAPAAcLDxAH8d0YBIwGgA9IAQsPWAHxbRfUjAaMDzBiYF+wbweknJaMHzAxFJHLD78fV2SMBowPNBUEAcQAAA4AXgtfvw+wDgAL8AvwDgAL8Av1hGvejwjXC1BEYAJmtIAGgg8IBgaUkIYPv3Ff4FRgbg+/cR/kAbAigB2QMmBeBjSABoAPAAYAAo8tEAv4a7YGhAHgABoWhA6gEgIYoBIsLrUQFA6kFQIX3C61EBQOpBYCF7QOrBYFVJCWlXShFACENSSQhhCEYAaaFpCENPSQhhCEYAaEDwgGAIYPv33P0FRgfg+/fY/UAbAigC2QMmBuAG4EZIAGgA8ABgACjx0AC/MEZwvXC1ACVASABoIPCAYD5JCGD797/9BEYG4Pv3u/0AGwIoAdkDJQXgOEgAaADwAGAAKPLRAL80SABpN0kIQDJJCGEIRgBoAPAIUCC5CEbAaCDwAwDIYChGcL1wtQRGACYqSABoIPCAUChJCGD795L9BUYG4Pv3jv1AGwIoAdkDJgXgIUgAaADwAFAAKPLRAL+Gu2BoQB4AAaFoQOoBICGKASLC61EBQOpBUCF9wutRAUDqQWAhe0DqwWATSUlpFUoRQAhDEUlIYQhGQGmhaQhDDklIYQhGAGhA8IBQCGD791n9BUYH4Pv3Vf1AGwIoAtkDJgbgBuAESABoAPAAUAAo8dAAvzBGcL0AAAAQAkAAJPQA/hQAAA+AnQH//+7+cLUAJfdIAGgg8IBQ9UkIYPv3Mf0ERgbg+/ct/QAbAigB2QMlBeDvSABoAPAAUAAo8tEAv+tIQGnrSQhA6UlIYQhGAGgA8CBgILkIRsBoIPADAMhgKEZwveJJiWgh9ABBAUPgSpFgcEfeSZQxCWgh9HBhQeoAEdtKwviUEHBH2UiQMABoQPAgANZJwfiQAHBH1EiQMABoIPAgANJJwfiQAAhGgGkg9ABwiGFwR81IkDAAaEDwIADLScH4kAAIRoBpQPQAcIhhyUgAaED0ACDHSQhgxkgIMABoQPQAIMNJCDEIYHBHcEcQtb5IwGkA9ABwsPUAfwXR//f1/0/0AHC5SQhiEL1wtYawBEYAJQAmAL+0SMBsQPABALJJyGQIRsBsAPABAACQAL8AvwQgAZADIAKQAiAEkAAgA5ABqU/wkED89wz8p0iAbQDwgFBwuQC/pEiAbUDwgFCiSYhlCEaAbQDwgFAAkAC/AL8BJaBIAGgA9IBwELn898X9ASaZSJAwAGgg8EBwRPCAcQhDlUnB+JAAAS4B0fz3vP0BLQXRkUiAbSDwgFCPSYhlBrBwvTi1ACQAJYtIgG0A8IBQcLkAv4hIgG1A8IBQhkmIZQhGgG0A8IBQAJAAvwC/ASSESABoAPSAcBC5/PeN/QElfUiQMABoIPCAcHtJwfiQAAEtAdH894f9ASwF0XZIgG0g8IBQdEmIZTi9c0gAaEDwBABxSQhgcEdvSABoIPAEAG1JCGBwR2xKpDISaCLw/wJA6gETGkNoS8P4pCBwR2ZKkmtC8IByZEuaYxpGkmsi8IBymmPQ6QAjGkODaELqAwHCaBFDAopB6gJBX0pRYBJoIvR8UkNpQuoDIltLGmAaRhJoQvBgAhpgcEdXSABoQPCAAFVJCGBwR1NJSWiJsgFgUUkJaMHzBSFBYE9JiWgJDIFgTUmJaAH0AEHBYHBHcLUFRgAk+/fR+wZGAL9oHDCx+/fL+4AbqEIA2AW5ASRCSIBoAPABADCxRPACBAC/ASA9SchgAL88SIBoAPACAAIoBdFE8AQEAL83SchgAL82SIBoAPSAYLD1gG8G0UTwIAQAvwQgMEnIYAC/L0iAaAD0gHCw9YB/BtFE8AgEAL8EIClJyGAAvyhIgGgA9ABwsPUAfwbRRPAQBAC/BCAiSchgAL8hSIBoAPAIAAgoA9EAvx1JyGAAvwAsqNAgRnC9cEdwR3BHcEdwtQAlF0iEaAZoBPABAECxBvABACixASASSchg//fv/zzgBPACAECxBvACACixAiAMSchg//fi/zDgBPAIAJCxBvAIAHixCCAGSchg//fV/yTgABACQP//7v4ABAFAAHAAQABgAEAE8AQAuLEG8AQAoLEE9IBwCLFF8AgFBPQAcAixRfAQBQT0gGAIsUXwIAUEIAJJyGAoRv/3rv9wvQBgAEBwtQJGCGhS+CAAIPABAA5oQvgmAIhoCCgB0UAlAOAAJUhoKEOOaDBDzmgwQw5pMENOaTBDjmkwQ85pMEMOajBDTmowQ45qMEPOakDqBgMIawNDSGsDQ8hrA0OIawNDjUxE9IAURPQAFET0QARE9OAkCGhS+CAAoEMYQw5oQvgmAAhrsPWAHwfRCGgosRBoIPSAEA5rMEMQYAhoGLEQaE5rMEMQYAAgcL0QtQNGU/giACDwAQBD+CIAIrlD8tsAQ/giAAPgQ/LSAEP4IgBv8HBEUBxD+CBAIEZB+CIAACAQvTC1A0bR6QAFQOoFEI1oQOoFIA17QOqFcA2KQOoFRYiKQB5F6gBVCH6AHkXqAGDNaShDVRxT+CVQVRxD+CUAGGgA9IAQsPWAHwvRWGgg9HAEiIpAHkTqAFRYaCD0cAAgQ1hgACAwvTC1BEaz9YBPFtHR6QAFQOoFEI1oQOoFIA17QOqFcM1pKEMNikDqBUBU+CJQBfB/ZShDRPgiAAPgb/BwQET4IgAAIDC9AkZS+CEAQPSAUEL4IQAAIHBHAkZS+CEAIPSAUEL4IQAAIHBHELUCRkhoQPAIAItoGEPLaBhDC2kYQ0tpQOpDIItpQOpDMBNoMUwjQBhDEGAAIBC9ELUDRtHpAARA6gQgDIlA6gRADHtA6gRgnGiYYAAgEL0QtQNG0ekABEDqBCAMiUDqBEAMe0DqBGDcaNhgACAQvQJGEGgg8AQAEGAYIBBgQCBQYE/w/DCQYNBgACBwRwJGEGhA8EAAEGAAIHBHAkYQaCDwQAAQYAAgcEct6fBBBUYORpBGHEb79+35B0YK4GAcQLH79+f5wBugQgDYFLkDIL3o8IFoaMDzgBAAKO/QaGkwYAAg9Od/+wgAgQHw/0ZIAGhA8AEAREkIYAAgiGAIRgBoQkkIQEBJCGCIFMhgCEYAaCD0gCAIYAAgiGHIAzxJCGBwR/C1ACMAIAAiAiQAJQIhNU42aAbwCAYuuTNOlDY2aMbzAyAD4DBONmjG8wMQMU5+RFb4IAAsTrZoBvAMBjaxBC4I0AguC9AMLjnRDeAqTk5EMGA44ClOJ09PRD5gM+AnTiVPT0Q+YC7gH072aAbwAwUdTvZoxvMDFnEcAi0C0AMtCNED4B1Otvvx8gbgHE62+/HyAuCw+/HyAL8AvxJO9mjG8wYmckMPTvZoxvNBZnYcdACy+/T2D09PRD5gA+ANTk5EMGAAvwC/B062aMbzAxYMT39Eu10HTk5ENmjeQAVPT0Q+YPC9ABACQP//9uoI7QDgnAsAABAAAAAAJPQAABJ6AOAKAABwtQAlACRESEhEAGgwu0NISERBaYQgiEcKIPv3HflASEhEQWiEIIhHxLJ7LAHQeSwX0TtISEQ4SUlECGAIRgBoAGhgsQhGAGgBaIQgiEcySEhEAGgzScJohCCQRwLgASUA4AElKEZwvQAgK0lJRAhgcEcQtQRGKEhIRABoIUZCaoQgkEcQvRC1BEYjSEhEAGghRoJqhCCQRxC9cLUERg1GHUhIRABoKkYhRgNphCCYRwAgcL1wtQRGDUYXSEhEAGgqRiFGQ2mEIJhHcL0QtQRGEUhIRABoIUaCaYQgkEcQvRC1BEYMSEhEAGghRoJphCCQR0CxCEhIRABoACIhRkNphCCYRwfgBEhIRABoASIhRkNphCCYRxC9FAAAAHQAAABIAAAA//8DADC1h7AERg1GAL/3SIBsQPACAPVJiGQIRoBsAPACAAGQAL8AvwC/CEaAbEDwBACIZAhGgGwA8AQAAZAAvwC/AL8IRgBtQPABAAhlCEYAbQDwAQABkAC/AL8AvwhGwGxA8AIAyGQIRsBsAPACAAGQAL8AvwC/CEbAbEDwCADIZAhGwGwA8AgAAZAAvwC/AL8IRsBsQPAQAMhkCEbAbADwEAABkAC/AL8AvwhGwGxA8CAAyGQIRsBsAPAgAAGQAL8AvwC/CEbAbEDwQADIZAhGwGwA8EAAAZAAvwC/AL8IRoBtQPCAUIhlCEaAbQDwgFABkAC/AL+9SEBoQPQAcLtJSGACIAOQACAEkAMgBZAMIAaQTPIDcAKQAqm1SPv3hf9P9oBwApACqbNI+/d+/0/yPwACkAKpsEj793f/PyACkAKprkj793H/T/RgUAKQAqmoSPv3av8YIAKQAqmmSPv3ZP8BIASQMCACkAKpoUj791z/gCACkAKpnkj791b/T/SwUAKQAqmdSPv3T/8DIAKQASAEkAKpl0j790f/AiAEkEggApACqZJI+/c//4AgApACqZNI+/c5/0/0gEGSSEhEgWBAIcFggCEBYUkAQWGJAIFhACHBYU/0AFEBYotIiUlJRAhgCEb79/T7hkhIRPv3jPuESEhE4GQHIPv3ivkAIhFGOiD795f5OiD799L5B7AwvRC1fkhIRABoyLn/913+ACFP9IBw//ey/gEhCAL/96H+ASD6933/ACFP9IAg//em/gEhiAT/95X+DyD693H/EL0QtQEgbUlJRAhg//fZ/wQga0lJRAhgAiBIYAYgiGABIAhhAiBIYYhhACDIYWVJSUSIYAAhY0hIRMFgBCEBYRAhQWEAIYFhT/QAccFhACEBYk/0gFFBYgAhgWLBYgFjQWNP9IARgWNJAMFjACFBZAFkT/AgQFNJSUQIYFNISGAAIVBISET/95T+TUpKRBFGTUhIRADwxPggsQEgTElJRAhwA+AAIElJSUQIcEhISEQAeBC9ELUGIU/0gCD/9zL+BiFP9IBw//ct/hC9cLUERg1GOiD791n5OEg9SUlECGAIRvv3TvuAITJI+/db/0/2+3ErSPv3Vv9P9ptxKkj791H/T/I/AShI+/dM/0HyP2EnSPv3R/9wvRC1T/AgQClJSUQIYClISGAIRgDwqfggsQEgKElJRAhwA+AAICZJSUQIcAAhIEhIRP/3wP//97L/IUhIRAB4EL1wtQRGDUYWRjNGKkYhRhdISEQA8Pj4CLEBIHC9ACD853C1BEYNRhZGM0YqRiFGD0hIRADw7vkIsQEgcL0AIPznAAAAEAJAAHAAQAAMAEgAEABIABQASAAYAEgABABI0AEAADAEAkAYAAAAsAEAAGABAAAEAQCgHAAAADACAAAdAAAAcLUERg1GFkYzRipGIUYMSEhEAPDx+AixASBwvQAg/OdwtQRGDUYWRjNGKkYhRgRISEQA8Of5CLEBIHC9ACD852ABAABwR3C1BEYORhVGDLkBIHC9lPhJACi5ACCE+EgAIEb/9+//BPEIASBo//c0+zFGomggaP/3n/spRuNq1OkBAv/3zPuhaCBoUPghAEDwAQCiaCFoQfgiAAEghPhJAAAg1udwRxC1BEYgRv/3+v+U6AcA//dk+wAghPhJAAC/hPhIAAC/EL1wR3BH8LUERg1GFkYvRrRGlPhJIAEqAdAEKh/RAL+U+EgAASgB0QIg8L0BIIT4SAAAvwIghPhJABlGBuA4eIz4AAAM8QEMfxxJHgAp9tGE+EkgAL8AIIT4SAAB4AEg4+cAIOHn8LUERg1GLkYXRpT4SQABKB7RAL+U+EgAASgB0QIg8L0BIIT4SAAAvwIghPhJABlGBOA4eDBwfxx2HEkeACn40QEghPhJAAC/ACCE+EgAAeABIOTnACDi5y3p8EEERoxGkEYdRmNGQUaU+ElwAS8B0AQvJ9EAv5T4SAABKALRAiC96PCBASCE+EgAAL8CIIT4SQAF8AEGKkYI4BhoCICJHBhoAAwIgIkcGx2SHrJC9NEOsRhoCICE+ElwAL8AIIT4SAAB4AEg2+cAINnnLenwQQRGD0aURh1GOUZiRpT4SQABKC/RAL+U+EgAASgC0QIgvejwgQEghPhIAAC/AiCE+EkABfABBitGC+AQiAhgkhwIaLL4AIBA6ghACGCSHAkdGx+zQvHRLrGy+ACACGho8w8ACGABIIT4SQAAvwAghPhIAAHgASDT5wAg0efwtQRGDUYWRi9GtEaU+EkgASoB0AQqH9EAv5T4SAABKAHRAiDwvQEghPhIAAC/AiCE+EkAGUYG4DhozPgAAAzxBAw/HUkeACn20YT4SSAAvwAghPhIAAHgASDj5wAg4efwtQRGDUYuRhdGlPhJAAEoHtEAv5T4SAABKAHRAiDwvQEghPhIAAC/AiCE+EkAGUYE4DhoMGA/HTYdSR4AKfjRASCE+EkAAL8AIIT4SAAB4AEg5OcAIOLncLUERqVqIGgAaCDwAQAhaAhgAyCF+EkAIEb/977+cL1wtQRGpWogaABoIPABACFoCGAEIIX4SQAgRv/3rf5wvXC1BEalaiBoAGgg8AEAIWgIYAEghfhJACBG//ed/nC9LenwRwRGDkYXRphGlPhJUAEtAdAELSnRAL+U+EgAASgC0QIgvejwhwEghPhIAAC/AiCE+EkAAS0E0U5IeEThbMhiA+BMSHhE4WzIYktIeEThbEhjQ0Y6RjFG4Gz79475gkYAvwAghPhIAAHgASDZ51BG1+ct6fBBBEYNRhZGH0aU+EkAASgk0QC/lPhIAAEoAtECIL3o8IEBIIT4SAAAvwIghPhJADNIeERsOOFsyGIySHhEZDjhbEhjO0YqRjFG4Gz791v5gEYAvwAghPhIAAHgASDe50BG3OcQtQRGlPhJAAQoGdEAv5T4SAABKAHRAiAQvQEghPhIAAC/AiCE+EkAoWggaP/35PkBIIT4SQAAvwAghPhIAAHgASDp5wAg5+cQtQRGlPhJAAEoGdEAv5T4SAABKAHRAiAQvQEghPhIAAC/AiCE+EkAoWggaP/3yfkEIIT4SQAAvwAghPhIAAHgASDp5wAg5+cBRpH4SQBwRwAAof///3f///9P////T/AAAgC1E0aURpZGIDkiv6DoDFCg6AxQsfEgAb/0968JByi/oOgMUEi/DMBd+ATriQAov0D4BCsIv3BHSL8g+AIrEfCATxi/APgBK3BHAAAAAAAAAAAAAAECAwQGBwgJAAAAAAECAwSghgEAQA0DAIAaBgAANQwAQEIPAICEHgAACT0AABJ6AAAk9AAANm4BAEjoAQBs3AIAAAAAAAAAABAAAAABAAAAAAk9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    load_address: ~
+    pc_init: 239
+    pc_uninit: 261
+    pc_program_page: 277
+    pc_erase_sector: 271
+    pc_erase_all: 267
+    data_section_offset: 23024
+    flash_properties:
+      address_range:
+        start: 1610612736
+        end: 1614807040
+      page_size: 4096
+      erased_byte_value: 255
+      program_page_timeout: 10000
+      erase_sector_timeout: 6000
+      sectors:
+        - size: 4194304
+          address: 0
+    cores: []
+  - name: mx25lm51245g_stm32l4p5-disco
+    description: MX25LM51245G_STM32L4P5G-DK
+    default: false
+    instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEdP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEdwtQRGDUYWRgXwEf8IsQAgcL0BIPznAUYAIHBHELUF8Bv/EL1wtQRGACYlRukZKEYF8DD/BkYBLgHRACBwvTBG/OdwtQRGDUYWRjJGKUYgRgXwD/8IsQAgcL0BIPznMLUG4BD4AUsS+AFbrEIA0DC9Cx6h8QEB9NEAv/jnAABwR3C1BEYAJaFISEQAePCxn0hIRAB4T/R6cbH78PCdSUlECWix+/D2MEYA8Pj5YLkQLAjSACIhRlAeAPBf+ZZISEQEYATgASUC4AElAOABJShGcL0QtQAkAyAA8D35DyAF8Ev+CLEBJAHg//fJ/yBGEL1wRxC1AL9P8P8wh0mIY8hjAL8AvwAgiGPIYwC/QB4IZAAgCGRAHohiACCIYkAeyGIAIMhiQB4IYwAgCGP/9+D/ACAQvXpISEQAaHRJSUQJeAhEdklJRAhgcEd0SEhEAGhwR3BISEQAaHBHcLUERgAla0hIRAB4oEIN0GhISEQGeARwaEhIRABoBfD+/QVGFbFjSEhEBnAoRnC9YEhIRAB4cEdwtQRGBfDf/QZGJUZoHBixWkhIRAB4BUQAvwXw1P2AG6hC+tNwvU/w4CAAaSDwAgBP8OAhCGFwR0/w4CAAaUDwAgBP8OAhCGFwR0/whnBwR09IAGgADHBHTUgAaMDzCwBwR0xIAGhwR0pIAB0AaHBHSEgIMABocEdFSEBoQPABAENJSGBwR0JIQGgg8AEAQElIYHBHPkhAaEDwAgA8SUhgcEc7SEBoIPACADlJSGBwRzdIQGhA8AQANUlIYHBHNEhAaCDwBAAySUhgcEfKIDJJSGJTIEhiASAwSQhgcEcBIC9JCGJwRwAgLUkIYnBHKkkJayHwBAEBQydKEWNwRyZJCWsh8AIBAUMjShFjcEciSUlrIfA/AQFDH0pRY3BHELUdSABrQPABABtJCGMF8Ev9BEYG4AXwR/0AGwooAdkDIBC9FUgAawDwCAAAKPLQACD25xFIAGsg8AEAD0kIY3BHDUhAaED0gHALSUhgcEcKSEBoIPSAcAhJSGBwRwwAAAAQAAAACAAAAAAQAkAEAAAAACAE4JB1/x8AAAFAAAMgQgAAIEIQtQAoBNsKBxMO5koTVAbgCgcUDuRKAPAPAxsf1FQQvQC/APAHAuBLDDsZaE/2/wMZQN5LC0ND6gIh20sMOxlgAL9wRy3p8E2ARg1GFkYAJwDwovkHRjlGKkYzRgHwBwDA8QcLu/EEDwLZT/AECwHgwPEHC9pGAPEEC7vxBw8C0k/wAAsB4KDxAwvcRk/wAQsL+gr7q/EBCwvqAgsL+gz7T/ABDg76DP6u8QEODuoDDkvqDgQhRkBG//ei/73o8I0BRghGACgN2wC/AL8A8B8DASKaQEMJmwAD8eAjw/gAIQC/AL8Av3BHELUBRghGACgX2wDwHwMBIppArUtECUP4JCAAvwC/AL+/80+PAL8AvwC/AL8AvwC/v/NvjwC/AL8AvwC/EL0AvwC/AL8AvwC/v/NPjwC/AL8Av5tIDDgAaAD04GCZSQhDAB2XSQw5CGAAvwC/AL+/80+PAL8AvwC/AL8Av/3ncLUERiVGaB6w8YB/AdMBIA/gaB5P8OAhSGEPIU/w/zD/9zv/ACBP8OAhiGEHIAhhACBwvRC1APD8+BC9LenwRQRGIEYAKAPbfU8/XD8JB+B8TwDwDwys8QQMF/gMcD8JPUYORgbwBwDA8QcIuPEEDwLZT/AECAHgwPEHCMRGAPEECLjxBw8C0k/wAAgB4KDxAwhHRiX6B/hP8AEKCvoM+qrxAQoI6goIwvgAgE/wAQgI+gf4qPEBCAjqBQjD+ACAAL+96PCFELUBRghGACgI2wDwHwMBIppAXEuAM0QJQ/gkIAC/EL0QtQFGCEYAKA7bVkqAMkMJUvgjIADwHwQBI6NAGkAKsQEiAuAAIgDgACIQRhC9ELUBRghGACgH2wDwHwMBIppASUtECUP4JCAAvxC9ELUBRghGACgO20RKgDJDCVL4IyAA8B8EASOjQBpACrEBIgLgACIA4AAiEEYQvQQoCNFP8OAhCWlB8AQBT/DgIhFhB+BP8OAhCWkh8AQBT/DgIhFhcEdwRxC1//f8/xC9QPABASpKfDIRYAC/AL8Av7/zT48AvwC/AL8AvwC/AL+/82+PAL8AvwC/cEcAvwC/AL+/81+PAL8AvwC/ACAcSXwxCGBwR0F4GUqAMhFgAXj5sRIdQWgRYAF7CQfCekHqAmGCekHqwkFCe0HqgkGCe0HqQkHCe0HqAkFCekHqAiECekHqQgECeBFDCUqIMhFgBeAAIQZKhDIRYBIdEWBwRwNIDDgAaMDzAiBwRwDkAOAY7QDgAAD6BYDhAOCA4gDgeLUCRgAj2uABJp5ADWgF6gYEACxy0E1oAS0I0E1oAi0F0E1oES0C0E1oEi0T0ZBoXgADJbVAqENeAM1otUAoQ5BgUGgBJZ1AqEMNecXzABWdQChDUGDQaF4AAyW1QKhDXgCNaLVAKEPQYE1oAi0C0E1oEi0T0d4IAvEgBVX4JgBdB+4ODyW1QKhDXgf2Dg1ptUAoQ94IAvEgBUX4JgAQaF4AAyW1QKhDDXkF8AMFXgC1QChDEGBNaAXwgFW18YBffNEAv6hNLW5F8AEFpk41ZjVGLW4F8AEFAJUAvwC/T+q2NZ4IVfgmAJ0HLg8PJbVAqEOy8ZBPAtEAJSTgXuCbTapCAdEBJR7gmU2qQgHRAiUZ4JhNqkIB0QMlFOCWTapCAdEEJQ/glU2qQgHRBSUK4JNNqkIB0QYlBeCSTapCAdEHJQDgCCWeBzYPtUAoQ45NnghF+CYAjU0oaKBDTWgF9IA1tfWAPwDRIEOITShgLR0oaKBDTWgF9AA1tfUAPwDRIEOCTS0dKGAtHShooENNaAX0gBW19YAfANEgQ3tNCDUoYC0dKGigQ01oBfQAFbX1AB8A0SBDdU0MNShgWxwNaN1AAC1/9CCveL3wtQtGACGH4AEljUAF6gMCACp+0GpNjghV+CZAjQcuDw8ltUAsQLDxkE8B0QAlI+BcTahCAdEBJR7gWk2oQgHRAiUZ4FlNqEIB0QMlFOBXTahCAdEEJQ/gVk2oQgHRBSUK4FRNqEIB0QYlBeBTTahCAdEHJQDgCCWOBzYPtUClQiHRT00taJVDTk41YDUdLWiVQzYdNWA1HS1olUM2HTVgNR0taJVDNh01YI0HLg8PJQX6BvRCTY4IVfgmUKVDP06PCEb4J1AFaE8AAya+QDVDBWDOCADxIAVV+CZQTgf3Dg8mvkC1Q88IAPEgBkb4J1CFaE8AAya+QLVDhWBGaAEljUCuQ0ZgxWhPAAMmvkC1QwDgAODFYEkcI/oB9QAtf/Rzr/C9AkYTaQtAC7EBIADgACBwRwqxgWEA4IFicEcQtUJpIeoCAwLqAQRD6gRDg2EQvQi1AkZP9IAwAJAAmAhDAJAAmNBh0WEAmNBh0GkAkNBpAPSAMAixACAIvQEg/OdwRxC1BEYOSBQwAGggQCixDEgUMARgIEb/9/L/EL0AEAJAAAQASAAIAEgADABIABAASAAUAEgAGABIABwASAgAAUAABAFALenwQQRGDkYXRphGBp0S4GgcgLEF8GH5oOsIAKhCANhNuU/0AHDgZCBtQPABACBlASC96PCBIGgAajBACLEBIADgACC4QuPRACDy5wJGUWUAIHBHcEf4tQRGACUF8D35BkYMuQElcuAAICBl4GwAKG3RIEb/9+7/QfKIMSBG//fl/yCKQB7haEHqAEFgaUAeQeoAICFrCEPhaQhDIWiJaP5KEUAIQyFoiGCgjWFrQeoAQCFoCGEhaKBrSGEgaABoIPT4UWBoQB5B6gAgIWgIYGBtM0YAIiAhAJAgRv/3kP8FRo27IGjAaCDw/wAhakkeCEMhaMhgIGgAaCDwQAChaAhDIWgIYNTpCQEIQyFo0fgIESHwoEEIQyFowfgIASBoAGhA8AEAIWgIYKBpAigF0SBogGhA8AIAIWiIYOBosPGAbwLRASDgZAHgAiDgZChG+L1wR3C1BEYAJQy5ASUQ4CBoAGgg8AEAIWgIYCBogGgg8AIAIWiIYCBG//fq/wAg4GQoRnC9cEdwR3BHcLUFRqxqACBgZOBssPWAfxrRIGgAasDzQBB4sQIgIWhIYiBoAGhA9AAwIWgIYCBoAGhA8AIAIWgIYArgAiDgZCBG//fc/wTgAiDgZCBG//fV/3C9cEdwR3BHcEdwRy3p8EEERiBoAPFQCCBoBWogaAdo5mwF8AQAOLMH9IAgILMYLgrR4GsAeIj4AADga0Ac4GNgbEAeYGQL4CguCdGY+AAA4WsIcOBrQBzgY2BsQB5gZGBsKLkgaABoIPSAICFoCGAgRv/3yv+l4AXwAgAAKEvQB/QAMAAoR9AoLiHRYGxosQX0fFBQsZj4AADhawhw4GtAHOBjYGxAHmBki+BgbAAo4dECICFoSGIgaABoIPTgICFoCGACIOBkIEb/953/eeACICFoSGIgaABoIPTgICFoCGACIOBkGC4D0SBG//eL/2jgCC4D0SBG//eE/2LgtvWAf1/RIG0YuSBG//dP/1ngIEb/90r/VeAF8AgAsLEH9AAgmLEIICFoSGIgaABoAPSAADixIGgAaCD0ECAhaAhgAiDgZCBG//dc/zvgBfABAGCzB/SAMEizASAhaEhiIGgAaCD0+BAhaAhgAiAgZSBoAGgA8AQAmLEgaABoIPAEACFoCGBPSHhEoWyIY6BsBfBe+rixAiDgZCBG//cG/xHgAiDgZCBG//cA/wvgBfAQAECxB/SAECixECAhaEhiIEb/9/L+vejwgS3p8EEDRgAgH2g/aCfwQFfT+ADAzPgAcJ9oX7kfaD9oJ/CAB9H4BMBH6gwH0/gAwMz4AHAPaAIvDNEfaAf1wHIfaAf1xHQfaAf1yHUfaAf10HYL4B9oB/WAch9oB/WEdB9oB/WIdR9oB/WQdtHpEnxH6gwHF2DPao+xj2o3YNH4NMDPakfqDAfR+DDAR+oMB9L4AMAs9HwcR+oMBxdgJ2gn8B8H0fhEwEfqDAcnYI9rP7EPaC+5z2t/HtP4AMDM+EBwz2gAL33Qz2n3s49rZ7PR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMBH6gwHBOAAAPTA4Pgl/v//0fggwEfqDAfR+DjAR+oMB9H4QMBH6gwH0vgAwN/4GIoM6ggMR+oMBxdgKuDR+BTAz2hH6gwH0fgQwEfqDAfR+BzAR+oMB9H4JMAA4CHgR+oMB9H4IMBH6gwH0vgAwEP2P3gs6ggMR+oMBxdgn2q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2CPadP4AMDM+Ehwd+CPa+ex0fgUwM9oR+oMB9H4EMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+HyJDOoIDADgIeBH6gwHF2Aa4NH4FMDPaEfqDAfR+BDAR+oMB9L4AMAs8D8MR+oMBxdgn2q38YBfBtFPaQgvA9EXaEfwAGcXYI9oL2A64M9pp7OPa+ex0fgkwM9pR+oMB9H4IMBH6gwH0fg4wEfqDAfR+EDAR+oMB9L4AMDf+PyICPE/CAzqCAxH6gwHF2AP4NH4JMDPaUfqDAfR+CDAR+oMB9L4AMAs9HxcR+oMBxdgj2nT+ADAzPhIcAPg/+cBIAgnH2W96PCBLen4RQRGDUaQRgTwUf6CRqBoALkAv+hoALEAv+hpALEAv+hqALEAv6hrGLEoaAC5AL8Av+dsAi8D0eBosPGAbwnRFC8C0ShoAigE0CQvPdEoaAEoOtFTRgAiICEgRs34AID/97j8BkYeuwAgIGUpRiBG//eD/gZG3rmoa2C5U0YBIgIhIEbN+ACA//ek/AZGAiAhaEhiHOAoaBC5BCDgZBfgKGgBKAjR4GwkKALRBCDgZA7gFCDgZAvg4GwUKALRBCDgZAXgJCDgZALgASYQICBlMEa96PiF+LUERg1GBPDn/QdGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsAsQC/4GwCKCXRKGgYu6hrCLvgaLDxgG8d0GBtO0YAIiAhAJAgRv/3V/wGRra5ACAgZQMgIWhIYilGIEb/9x/+BkZeuQgg4GQgaABoQPRAMCFoCGAC4AEmECAgZTBG+L0t6fhFBEYNRhdGBPCi/YJG1PhMgLjxAQ8C0LjxAg8X0VNGACIgISBGAJf/9yX8BkaOuSiIAARpaEDqASCpaAhD6WgIQyFowfgAAgIg4GQC4AEmECAgZTBGvej4hS3p+EMERg1GF0YE8HT9gEbgbAIoONHgaLDxgG800UNGACIgISBGAJf/9/j7BkZWuyBoAGgg8EBQIWgIYCBogGgg8IBwKWgIQyFoiGAoaUDwQGCpaAhDQPRAYCFowfgAAShpQPBAYKloCENA9EBgIWjB+IAB6GhAHiFoCGRoaCFoiGQEIOBkAuABJhAgIGUwRr3o+IMt6fhFBEYORhdGBPAq/YBGIGgA8VAKHrkBJQggIGU64OBsBCg00SBoAGxAHGBkYGwgZOZjIGgAaCDwQFAhaAhgAL9DRgEiBCEgRgCX//ec+wVGBbEM4OBrAHiK+AAA4GtAHOBjYGxAHmBkYGwAKOjRAL+FuUNGASICISBGAJf/94P7BUY9uQIgIWhIYuBkAuABJRAgIGUoRr3o+IUt6fxNBEYORhdGBPDc/AGQIGgA8VAKIGjQ+EiAIGjQ+BCxHrkBJQggIGVR4OBsBChL0SBoAGxAHGBkYGwgZOZjIGgAaCDwQFBA8IBQIWgIYOBosPGAbwPRIGjA+EiADOAgaND4AAEA9OBgGLEgaMD4SIAC4CBowPgQsQC/AJcBIgYhIEYBm//3MfsFRgWxDOCa+AAA4WsIcOBrQBzgY2BsQB5gZGBsACjo0QC/hbkAlwEiAiEgRgGb//cY+wVGPbkCICFoSGLgZALgASUQICBlKEa96PyNELUCRgAgGbkBIAgjE2Ue4NNsBCsY0RNoG2xbHFNkU2wTZNFjE2gbaCPwQFMUaCNgAyMUaGNiGCPTZBNoG2hD9OAjFGgjYALgASAQIxNlEL1wtQJGACAVaKtsFWjV+BBBGbkBIAglFWUz4NVsBC0t0RVoLWxtHFVkVWwVZNFjFWgtaCXwQFVF8IBVFmg1YAMlFmh1Yigl1WQVaC1oRfTgJRZoNWDVaLXxgG8C0RVoq2QP4BVo1fgAUQX04GUVsRVoq2QG4BVoxfgQQQLgASAQJRVlcL1wtQRGACblbAXwCAAYuQXwBAAAKDzQIGgAaCD0+BAhaAhgT/SAcOBkIGgAaADwBACYsSBoAGgg8AQAIWgIYPlIeEShbIhjoGwE8JH++LECIOBkIEb/9zr7HeAgaABqwPNAEHixAiAhaEhiIGgAaED0ADAhaAhgIGgAaEDwAgAhaAhgCOACIOBkIEb/9x/7AuABJhAgIGUwRnC9cLUFRqxqACBgZAQgIGUgaABoIPAEACFoCGAgRv/3o/9QsSBoAGgg9OAgIWgIYAIg4GQgRv/3/PpwvXBHcEdwtQVGrGpgbEAIYGTgbCgoA9EgRv/38/8C4CBG//fu/3C9AUaIagAiQmQCaBJoIvAEAgNoGmAKaBJoIvABAgtoGmACaBJoQvQAMgNoGmBwRy3p8EEERg5GACcgaABsRRweuQEnCCAgZXng4GwEKHPRoGxAaQi5ZWQk4KBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggIGUBJxTgaAhgZBHgoGxAabD1AH8M0QXwAwAYuSB5APADABixCCAgZQEnAeCoCGBkAC9K0WBsIGTmYyBoAGgg8EBQIWgIYAMgIWhIYhgg4GSbSHhEoWzIYppIeEShbAhjmUh4RKFsSGMAIKFsiGMQIaBsgWCgbABoAGgg8BAAoWyJaAhDoWwJaAhgI2whaAHxUAIxRqBsBPAS/WC5IGgAaED0gDAhaAhgIGgAaEDwBAAhaAhgCeABJwQgIGUCIOBkA+D/5wEnECAgZThGvejwgS3p8EcERg5GACcgaABsRRwgaND4SIAgaND4EKEeuQEnCCAgZZDg4GwEKG/RoGxAaQi5ZWQk4KBsQGmw9YB/DdEF8AEAGLkgeQDwAQAYsQggIGUBJxTgaAhgZBHgoGxAabD1AH8M0QXwAwAYuSB5APADABixCCAgZQEnAeCoCGBkAC9h0WBsIGTmYyBoAGgg8EBQQPCAUCFoCGADICFoSGIoIOBkVUh4RKFsyGJUSHhEoWwIY1NIeEShbEhjACChbIhjACGgbIFgoGwAaABoIPAQAKFsiWgIQ6FsCWgIYCNsImgC8VABMkagbATwgPwQuyBoAGhA9IAwIWgIYOBosPGAbwTRIGjA+EiADeAZ4CBo0PgAAQD04GAYsSBowPhIgALgIGjA+BChIGgAaEDwBAAhaAhgCOABJwQgIGUCIOBkAuABJxAgIGU4Rr3o8Ict6fhPBEYNRhdGBPBC+oJGIGjQ+EiAIGjQ+BCx4GwEKFzR6Giw9YAPWNFTRgAiICEgRgCX//fA+AZGAC5R0ShoIWjB+IgAaGghaMH4gAAoaSFowfiQANXpAgEIQ0DwAFAhaAloIfBDUQhDIWgIYOBosPGAbwPRIGjA+EiAH+AgaND4AAEA9OBgsLEgaMD4SIAV4AAAwMD/8MD///CL9v//Of///w/////J/v//Ff7//+v9//+l/f//IGjA+BCxU0YBIgghIEYAl//3dvgGRia5CCAhaEhiAiDgZALgASYQICBlMEa96PiPLen4RQRGDUYE8M/5gEYgaIdsIGjQ+BCh4GwEKEDRYG1DRgAiICEAkCBG//dR+AZGRrsoaCFowfiIAGhoIWjB+IAAKGkhaMH4kADV6QIBCENA8ABQIWgJaCHwQ1EIQyFoCGAJICFoSGJIIOBkIGgAaED0ECAhaAhg4Giw8YBvAtEgaIdkD+AgaND4AAEA9OBgELEgaIdkBuAgaMD4EKEC4AEmECAgZTBGvej4hfi1BEYNRgTwevkHRuBsBCgm0WBtO0YAIiAhAJAgRv/3AfgGRv65iCDgZChoCCgM0WhoIWjB+DABECAhaEhiIGgAaED0gBAhaAhgIGgAaP5JCEApaEHwQFEIQyFoCGAC4AEmECAgZTBG+L34tQRGACUE8EX5B0bmbAbwCAAYuQbwBAAAKDnQIGgAaADwBABgsSBoAGgg8AQAIWgIYKBsBPCW+wVGDbEEICBlIGgAasDzQBD4sSBoAGhA8AIAIWgIYGBtO0YBIgIhAJAgRv73qv8FRq25AiAhaEhiYG07RgAiICEAkCBG/ved/wVGRbkCIOBkBeACIOBkAuABJRAgIGUoRvi9ELUCRgAg02wD8AgDW7lRYBNoG2gj9PhUU2hbHkTqAyMUaCNgAuABIBAjE2UQvQFGCGgAaMDzBCBAHHBHAUYIbXBHAUbIbHBH8LUFRgAgACQVsQItANgJuQEgZOAAJg5gTmCOYM5gDmECLQjRtk42aAbwAQYOubVMAeBP9AB0ACNP4LFONh1W+CMgAvABBj6xAvACBgTwAge+QgHRXhwOYALwEAY+sQLwIAYE8CAHvkIB0V4cTmAC9IB2PrEC9AB2BPQAd75CAdFeHI5gAvSANo6xAvSAJgT0gCe+QgvRAvQANia5XhxG9IA2zmAD4F4cRvCAds5gAvCAdo6xAvCAZgTwgGe+QgvRAvAAdia5XhxG9IA2DmED4F4cRvCAdg5hWxwCK63T8L0t6fBNjLCCRgxGT/AAC9hGhUna+AAAiEIC0QAmASUB4AEmACUAJxDgB+tHAmtGA+vCAXoc0LL/93P/ILFP8AELCCDK+FAAeBzHsgIv7NO78QAPfdF0SABoAPABADixckgAaCDwAQBwSQhgSPABCG9IAGgA8AEAOLFsSABoIPABAGpJCGBI8AIIZUgAHQbrRgFqRgLrwQGJaEkeUPghACD0gHJfSAAdButGAWtGA+vBAYloSR5A+CEgAB8AaADwAQAAKH3QVkgAaCDwAQBUSQhgAS120QgdBetFAV34MRBJHlD4IQBA8AICTUgAHQXrRQFd+DEQSR5A+CEgBetFAGlGAevAAEBosLFFSAAdBetFAWpGAuvBAUloSR5Q+CEAQPAgAj9IAB0F60UBA+vBAUloSR5A+CEgBetFAGlGAevAAMBo6LE2SAAdBetFAWpGAODY4gLrwQEJe0keAfABAVD4IQBA9IAiLkgAHQXrRQFrRgPrwQEJe0keAfABAUD4ISAF60UAaUYB68AAAGkAKBjQI0gAHQXrRQFqRgLrwQEJfEkeAfABAVD4IQBA8IBiHEgAHQXrRQFrRgPrwQEJfAHgBuCJ4EkeAfABAUD4ISCG4AbrRgBd+DAAACh90BBIAB0G60YBXfgxEEkeUPghACDwAQILSAAdButGAV34MRBJHkD4ISAG60YAaUYB68AAQGgIswNIAB0G60YBCeD3///PABwGUCICBAQAEACgABQAoGpGAuvBAUloSR5Q+CEAIPAQAv5IButGAWtGA+vBAUloSR5A+CEgButGAGlGAevAAMBoyLH1SAbrRgFqRgLrwQEJe0keAfABAVD4IQAg9IAy7kgG60YBa0YD68EBCXtJHgHwAQFA+CEgButGAGlGAevAAABpwLHlSAbrRgFqRgLrwQEJfEkeAfABAVD4IQAg8IBy3kgG60YBa0YD68EBCXxJHgHwAQEA4AHgQPghIAXrRQFd+DEQIGiIQiDQBetFAWpGAuvBAWBoSWiIQhfQBetFAQLrwQGgaIloiEIP0AXrRQEC68EB4GjJaIhCB9AF60UBAuvBASBpCWmIQifRBetFAV34MRAgaIhCIdEF60UBakYC68EBYGhJaIhCGNEF60UBAuvBAeBoyWiIQhDRBetFAQLrwQEgaQlpiEII0bNIAB8AaEDwAQCwSQkfCGCF4K5IBetFAV34MRBJHlD4IQAg8AECqUgF60UBXfgxEEkeQPghIAXrRQBpRgHrwABAaKixokgF60UBakYC68EBSWhJHlD4IQAg8BACnEgF60UBa0YD68EBSWhJHkD4ISCXSAXrRQFqRgLrwQGJaEkeUPghACD0gHKRSAXrRQFrRgPrwQGJaEkeQPghIAXrRQBpRgHrwADAaMCxiEgF60UBakYC68EBCXtJHgHwAQFQ+CEAIPSAMoFIBetFAQPrwQEJe0keAfABAUD4ISAF60UAaUYB68AAAGnIsXhIBetFAWpGAuvBAQl8SR4B8AEBUPghACDwgHJxSQXrRQBrRgPrwAAAfEAeAPABAEH4ICBrSKFoSR5Q+CEAIPRAcU/0gHBA6kYgAUNlSKJoUh5A+CIQYGlAHmJJCR8JaMHzB0GIQgvZXkgAHwBoIPR/AaCKQB5B6gBAWkkJHwhgWEgAHwBoAPABAAAoddBVSCFoSR5Q+CEAIPADAUkcUUgiaFIeQPgiEGBoaLFNSGFoSR5Q+CEAIPAwAEDwEAJJSGFoSR5A+CEg4GgA9IAwkLFESCF7SR4B8AEBUPghACD04CBA9IAyP0ghe0keAfABAUD4ISAT4OBoiLE6SCF7SR4B8AEBUPghACDw4GBA8IByNEghe0keAfABAUD4ISAgaQD0gDCQsS9IIXxJHgHwAQFQ+CEAIPTgIED0QDIpSCF8SR4B8AEBQPghIJ3gIGkAKBHQJEghfEkeAfABAVD4IQAg8OBgQPBAch5IIXxJHgHwAQFA+CEgh+D/5xpIIWhJHlD4IQAg8AMBASBA6kYAAUMUSCJoUh5A+CIQYGh4sRFIYWhJHlD4IQAg8DAAECFB6kYRCEMLSWJoUh5B+CIA4GgA9IAwwLEHSCF7SR4B8AEBUPghACD04CBP9IAxQeqGQQhDAeAEHAZQMkkie1IeAvABAkH4IgAW4OBooLEtSCF7SR4B8AEBUPghACDw4GBP8IBxQeqGYQhDJkkie1IeAvABAkH4IgAgaQD0gDCosSFIIXxJHgHwAQFQ+CEAIPTgIU/0QDBA6oZAAUMaSCJ8Uh4C8AECQPgiEBbgIGmgsRVIIXxJHgHwAQFQ+CEAIPDgYE/wQHFB6oZhCEMOSSJ8Uh4C8AECQfgiAAjwAQAosQpIAGhA8AEACEkIYAjwAgAosQZIAGhA8AEABEkIYFhGDLC96PCNBBwGUAAQAKAAFACgfEiAa0DwgFB6SYhjCEaAayDwgFCIY3BHd0gAaED0gHB1SQhgcEd0SABoIPSAcHJJCGBwRwFGcEhAaCDwDgAKaBBDbUpQYG1IAGgg9IAwa0oQYBAfAGgg9IAwEh8QYGdICDAAaCD0gDBkSggyEGAQHwBoIPSAMBIfEGBIaAD0gDCw9YA/B9FdSAAfAGhA9IAwWkoSHxBgSGgA9AAwsPUAPwXRVkgAaED0gDBUShBgCHkA8AEAOLFRSAAdAGhA9IAwTkoSHRBgCHkA8AIAAigH0UpICDAAaED0gDBISggyEGAAIHBHREhAaEDwAQBCSUhgcEdBSEBoIPABAD9JSGBwRz1JyWgA8B8CkUNB6lAROkrRYBFGiWgA8B8CEUM2SpFgcEc1SYloAPAfApFDMkqRYHBHcLUERg1GVLkvSEBpAPQAcLD1AH8K0QDwxPw4sXC9KUhAacDzQCAIuQDwtPwoSABoIPAEACZJCGABLQHRML8C4EC/IL8gvwC/6OdwtQVGDEa19YBPA9EgRgDw4vwC4CBGAPDE/HC9F0gAaCDwBwDAHBVJCGAWSABoQPAEABRJCGAAvwC/ML9wRxFIAGhA8AIAD0kIYHBHDUgAaCDwAgALSQhgcEcKSABoQPAQAAhJCGBwRwZIAGgg8BAABEkIYHBHcEcAEAJAAHAAQAQEAUAQ7QDg+EgAaAD0wGCw9YBvAtFP9IBgcEfzSIAwAGgA9IBwsPWAfwLRT/QAcPPnACDx5wJGkrvsSABoAPTAYLD1gG8s0ehIgDAAaCD0gHDmS8P4gAAYRgBoIPTAYED0AHAYYOJISEQAaDIjWEPgS7D78/BBHADgSR7bSEBpAPSAYLD1gG8B0QAp9dHXSEBpAPSAYLD1gG9S0QMgcEcI4NJIgDAAaCD0gHDPS8P4gABG4LL1AH870cxIAGgA9MBgsPWAbyvRyEiAMABoQPSAcMZLw/iAABhGAGgg9MBgQPQAcBhgwkhIRABoMiNYQ8BLsPvz8EEcAOBJHrtIQGkA9IBgsPWAbwHRACn10bdIQGkA9IBgsPWAbxLRAyC+57JIgDAAaED0gHCwS8P4gAAH4K5IAGgg9MBgQPSAYKtLGGAAIKvnqUnJaCH0AHEBQ6ZK0WARRsloQfSAcdFgcEeiSMBoIPSAcKBJyGBwR59IQGhA9IBgnUlIYHBHm0hAaCD0gGCZSUhgcEeYSEBoQPQAcJZJSGBwR5RIQGgg9ABwkklIYHBHkUiAaED0AECPSYhgcEeNSIBoIPQAQItJiGBwRxC1AkYAIAkqcdLf6ALwBRQhKzU/SVNgAIRLG2oh9IBEI0OBTCNiI0ZbaiH0IESjQ35MY2Jd4HxLm2oLQ3tMo2IjRttqIfAQBKNDd0zjYlDgdksbawtDdEwjYyNGW2uLQ2NjRuBxS5trC0NvTKNjI0bba4tD42M84GxLG2wLQ2pMI2QjRltsi0NjZDLgZ0ubbAtDZUyjZCNG22yLQ+NkKOBiSxttC0NgTCNlI0ZbbYtDY2Ue4F1Lm22MsiNDW0yjZSNG222MsqNDWEzjZRHgVksbbsHzCwQjQ1RMI2YjRltuwfMLBKNDUExjZgLg/+cBIAC/AL8QvRC1AkYAIAkqQdLf6ALwBQ0TGR8lKzE4AEZLG2oh9IBEo0NETCNiNOBCS5tqi0NBTKNiLuA/Sxtri0M+TCNjKOA8S5tri0M7TKNjIuA5Sxtsi0M4TCNkHOA2S5tsi0M1TKNkFuAzSxtti0MyTCNlEOAwS5ttjLKjQy5Mo2UJ4C1LG27B8wsEo0MqTCNmAeABIAC/AL8QvRC1AkYAIAkqdtLf6ALwBRQgKjQ+TlhlACFLW2oh9CBEI0MeTGNiI0YbaiH0gESjQxtMI2Ji4BlL22oh8BAEI0MXTONiI0abaotDo2JW4BNLW2sLQxJMY2MjRhtri0MjY0zgDkvbawtDDUzjYyNGm2uLQ6NjQuAJS1tsC0MITGNkI0YbbItDI2Q44ARL22wLQwNM42QjRptsi0OjZC7gAHAAQBAAAABAQg8A/ktbbQtD/UxjZSNGG22LQyNlHuD5S9ttjLIjQ/dM42UjRpttjLKjQ/RMo2UR4PNLW27B8wsEI0PwTGNmI0YbbsHzCwSjQ+1MI2YC4P/nASAAvwC/EL0QtQJGACAJKkPS3+gC8AUNFRshJy0zOgDjS1tqIfQgRKND4ExjYjbg30vbaiHwEASjQ9xM42Iu4NtLW2uLQ9lMY2Mo4NhL22uLQ9ZM42Mi4NVLW2yLQ9NMY2Qc4NJL22yLQ9BM42QW4M9LW22LQ81MY2UQ4MxL222MsqNDykzjZQngyEtbbsHzCwSjQ8ZMY2YB4AEgAL8AvxC9wkiAaED0gGDASYhgcEe/SIBoIPSAYL1JiGBwRwFGMbm6SIBoIPRAcLhKkGAZ4LH1gH8I0bVIgGgg9EBwQPSAcLJKkGAN4LH1AH8I0a9IgGgg9EBwQPQAcKxKkGAB4AEgcEcAIPznALVP9IBw//fW/wC9ALUAIP/30f8AvaNIgGhA9ABgoUmIYHBHoEiAaCD0AGCeSYhgcEecSMBoQPQAUJpJyGBwR5lIwGgg9ABQl0nIYHBHlUgAaEDwEACTSQhgcEeSSABoIPAQAJBJCGBwR45IQGhA8BAAjElIYHBHi0hAaCDwEACJSUhgcEeHSEBoQPAgAIVJSGBwR4RIQGgg8CAAgklIYHBHgEhAaEDwQAB+SUhgcEd9SEBoIPBAAHtJSGBwR3lIQGhA8IAAd0lIYHBHdkhAaCDwgAB0SUhgcEcBRgAgCmgQKgbQICpS0EAqftCAKn3R8OBtShJoIvAIAmtLGmAaHxJoIvAIAhsfGmBnSggyEmgi8AgCZUsIMxpgGh8SaCLwCAIbHxpgSmgC9IAysvWAPwfRXUoSHxJoQvAIAltLGx8aYEpoAvQAMrL1AD8F0VZKEmhC8AgCVEsaYAp5AvABAjqxUUoSHRJoQvAIAk9LGx0aYAp5AvACAgIqB9FLSggyEmhC8AgCSEsIMxpg9OBGShJoIvAQAkRLGmAaHxJoIvAQAhsfGmBASggyEmgi8BACPksIMxpgGh8SaCLwEAIbHxpgSmgC9IAysvWAPwfRNkoSHxJoQvAQAjRLGx8aYEpoAvQAMrL1AD8B4CHgwuAF0S5KEmhC8BACLEsaYAp5AvABAjqxKUoSHRJoQvAQAiZLGx0aYAp5AvACAgIqB9EiSggyEmhC8BACIEsIMxpgo+AeShJoIvAgAhxLGmAaHxJoIvAgAhsfGmAYSggyEmgi8CACFUsIMxpgGh8SaCLwIAIbHxpgSmgC9IAysvWAPwfRDkoSHxJoQvAgAgtLGx8aYEpoAvQAMrL1AD8F0QdKEmhC8CACBUsaYAp5AvABAlqxAkoSHQPgAHAAQCQEAUASaELwIAKaSxpgCnkC8AICAioH0ZZKEh0SaELwIAKUSxsdGmBR4JJKEh8SaCLwQAKPSxsfGmAaHxJoIvBAAhsfGmCLShIdEmgi8EACiEsbHRpgGh8SaCLwQAIbHxpgSmgC9IAysvWAPwfRgUoIOhJoQvBAAn5LCDsaYEpoAvQAMrL1AD8H0XpKEh8SaELwQAJ3SxsfGmAKeQLwAQIqsXRKEmhC8EACcksaYAp5AvACAgIqB9FuShIdEmhC8EACbEsbHRpgAeABIAC/AL9wR2lIAGhA9IBAZ0kIYHBHZUgAaCD0gEBjShBgY0hIRABoMiJQQ2JKsPvy8EEcAOBJHl1IQGkA9ABwsPUAfwHRACn10VhIQGkA9ABwsPUAfwHRAyBwRwAg/OdTSQloIfAHAVFKEWBTSQloQfAEAVFKEWABKAHRML8C4EC/IL8gv0xJCWgh8AQBSkoRYHBHRkkJaCHwBwFJHENKEWBFSQloQfAEAUNKEWABKAHRML8C4EC/IL8gvz9JCWgh8AQBPUoRYHBHOEkJaCHwBwGJHDZKEWA4SQloQfAEATZKEWABKAHRML8C4EC/IL8gvzFJCWgh8AQBL0oRYHBHK0gAaCDwBwAAHShJCGAqSABoQPAEAChJCGAAvwC/ML9wR3BHcEdwR3BHELUfSBQ4AGgA9IAwMLH/9/z6T/SAMBpJFDkIYBhIDDAAaADwCAAosf/36f8IIBRJDDEIYBJIDDAAaADwEAAosf/33P8QIA5JDDEIYAxIDDAAaADwIAAosf/3z/8gIAhJDDEIYAZIDDAAaADwQAAosf/3wv9AIAJJDDEIYBC9AAAoBAFAAHAAQBAAAABAQg8AEO0A4BC1/EgAaEDwAQD6SQhgAvCW/gRGBuAC8JL+ABsCKAHZAyAQvfNIAGgA8AIAACjy0PBIAGgg8PAAQPBgAO1JCGAAIIhg7EjtSUlECGDsSEhEAGgC8IT+CLEBIOLnAvBv/gRGCOAC8Gv+ABtB8ogxiEIB2QMg1effSIBoAPAMAAAo8NHcSABo30kIQNpJCGAC8Fb+BEYG4ALwUv4AGwIoAdkDIL7n00gAaADwKFAAKPLR0EnIYAhGwGhA9IBQyGAAIAhhCEYAaUD0gFAIYQAgSGEIRkBpQPSAUEhhCEYAaCD0gCAIYAAgiGFAHghiwUiUMABoQPQAAMH4lAAAIJHn8LUAIwAg3/jswtz4CMAM8AwB3/jgwtz4DMAM8AMHGbEMKR/RAS8d0d/4zMLc+ADADPAIDLzxAA8G0d/4uMLc+JTAzPMDIwXg3/iswtz4AMDM8wMT3/i0wvxEXPgjMEG5GEYG4AQpAdGpSALgCCkA0ahIDCky0d/4fMLc+AzADPADBAEsCdACLALQAywE0QHgn0oE4J9KAuAAvxpGAL8Av9/4VMLc+AzAzPMDHAzxAQbf+ETC3PgMwMzzBiwM+wL8vPv28t/4MMLc+AzAzPNBbAzxAQxP6kwFsvv18PC9+LUERgAmhEiAbQDwgFAYsf/3zPkFRhbgAL9/SIBtQPCAUH1JiGUIRoBtAPCAUACQAL8Av//3uvkFRndIgG0g8IBQdUmIZbX1AH8H0YAsDNmgLAHZAiYI4AEmBuCALAHTAiYC4HAsANEBJnNIAGgg8A8AMENwSQhgCEYAaADwDwCwQgHQASD4vQAg/Oct6fhFBEYUuQEgvej4hV9IgGgA8AwGXUjAaADwAwcgeADwEAAQKHrRHrEMLnnRAS930VZIAGgA8AIAGLHgaQi5ASDi51FIYWoAaADwCAAgsU5IAGgA8PAABeBMSJQwAGgA9HBgAAmBQh/ZYGr/94L/CLEBIMnnAL9ESABoQPAIAEJJCGAIRgBoIPDwAGFqCEM+SQhgAL8IRkBoIPR/QCFqQOoBIDlJSGAf4AC/N0gAaEDwCAA1SQhgCEYAaCDw8ABhaghDMUkIYAC/CEZAaCD0f0AhakDqASAsSUhgLrlgav/3SP8IsQEgj+f/99T+J0mJaMHzAxEuSnpEUVwB8B8ByEAkSUlECGAjSEhEAGgC8PL8gka68QAPY9BQRnXnYOD/5+BpgLMZSABoQPABABdJCGAC8ND8BUYG4ALwzPxAGwIoAdkDIGDnEEgAaADwAgAAKPLQAL8NSABoQPAIAAtJCGAIRgBoIPDwAGFqCEMHSQhgAL8IRkBoIPR/QCFqQOoBIAJJSGAs4BTgAAAAEAJAAAk9ABAAAAAIAAAA//T+6g5CAAAAJPQAABJ6AAAgAkDsPwAA/kgAaCDwAQD8SQhgAvCJ/AVGBuAC8IX8QBsCKAHZAyAZ5/ZIAGgA8AIAACjy0SB4APABAAAoXNAILgPQDC4K0QMvCNHtSABoAPQAMIizYGh4uwEg/+YAv2BosPWAPwbR5kgAaED0gDDkSQhgGuBgaLD1oC8L0eFIAGhA9IAg30kIYAhGAGhA9IAwCGAK4NtIAGgg9IAw2UkIYAhGAGgg9IAgCGAAv2BokLEC8Dr8BUYH4B7gAvA1/EAbZCgB2QMgyebOSABoAPQAMAAo8tAQ4ALwJ/wFRgbgAvAj/EAbZCgB2QMgt+bFSABoAPQAMAAo8tEgeADwAgACKFLRBC4D0AwuFNECLxLRvEgAaAD0gGAYseBoCLkBIJ3muEhAaCDw/kAhfEDqAWC0SUhgOeDgaACzskgAaED0gHCwSQhgAvDw+wVGBuAC8Oz7QBsCKAHZAyCA5qlIAGgA9IBgACjy0KZIQGgg8P5AIXxA6gFgo0lIYBbgoUgAaCD0gHCfSQhgAvDP+wVGBuAC8Mv7QBsCKAHZAyBf5plIAGgA9IBgACjy0SB4APAIAAgocdFgaeCzkkiUMND4AIAI8BABoGmIQi/QCPACAAIoBNEI8AEACLkBIEDmCPABAMixiEiUMABoIPABAIVJwfiUAALwmvsFRgbgAvCW+0AbESgB2QMgKuZ+SJQwAGgA8AIAACjx0XtIlDAAaCDwEAChaQhDd0nB+JQAdkiUMABoAOAX4EDwAQByScH4lAAC8HT7BUYG4ALwcPtAGxEoAdkDIATma0iUMABoAPACAAAo8dAZ4GdIlDAAaCDwAQBlScH4lAAC8Fn7BUYG4ALwVftAGxEoAdkDIOnlXkiUMABoAPACAAAo8dEgeADwBAAEKHPRT/AACFdIgG0A8IBQeLkAv1RIgG1A8IBQUkmIZQhGgG0A8IBQAJAAvwC/T/ABCE1IAGgA9IBwsLlLSABoQPSAcElJCGAC8CD7BUYG4ALwHPtAGwIoAdkDILDlQkgAaAD0gHAAKPLQIHoA8AEAOLM8SJAwAGgg8IAAIXoB8IABCEM4SZAxCGAgegDwBABwsQhGAGhA8AQAMknB+JAACEbQ+JAAQPABAMH4kAAX4C1IkDAAaEDwAQAqScH4kAAO4ChIkDAAaCDwAQAmScH4kAAIRtD4kAAg8AQAwfiQAKBoqLEC8NL6BUYJ4DbgAvDN+kAbQfKIMYhCAdkDIF/lGUiQMABoAPACAAAo79Ab4ALwvPoFRgjgAvC4+kAbQfKIMYhCAdkDIErlDkiQMABoAPACAAAo79ELSJAwAGgg8IAACEnB+JAAuPEBDwXRBUiAbSDwgFADSYhlAL8geADwIAAgKAPgABACQABwAEA00aBqyLH4SABoQPABAPZJmDnB+JgAAvCC+gVGBuAC8H76QBsCKAHZAyAS5e5IAGgA8AIAACjy0Bjg60gAaCDwAQDpSZg5wfiYAALwaPoFRgbgAvBk+kAbAigB2QMg+OThSABoAPACAAAo8tHgagAoftDgagIofNHbSJg4x2gH8AMBIGuBQibRB/DwAWBrQB6x6wAfH9EH9P5BoGux6wAvGdEH8HhBPCAAXbHrwG8S0Qf0wAFAIABbASLC61AAsetAXwjRB/DAYUQgAF3C61AAsetAb23QDC5p0MNImDgAaADwgGAoucBImDgAaADwgFAIsQEgreS8SJg4AGgg8IBwuUmYOQhgAvAK+gVGBuAC8Ab6QBsCKAHZAyCa5LJImDgAaADwAHAAKPHR1OkMEEAeQeoAEaBrQeoAIUAgAFsBIsLrUABB6kBRRCAAXcLrUABB6kBhPCAAXUHqwGCiSZg5yWiiShFACEOfSZg5yGAB4GTgROAIRgBoQPCAcAhgCEbAaEDwgHDIYALwyfkFRgbgAvDF+UAbAigB2QMgWeSSSJg4AGgA8ABwACjx0FrgASBP5I1ImDgAaADwAHDwu4pImDgAaEDwgHCHSZg5CGAIRsBoQPCAcMhgAvCh+QVGBuAC8J35QBsCKAHZAyAx5H5ImDgAaADwAHAAKPHQMuAMLi7QeUiYOABoIPCAcHZJmDkIYAhGAGgA8CBQILkIRsBoIPADAMhgcEiYOMBocEkIQG1JmDnIYALwcvkA4BLgBUYG4ALwbPlAGwIoAdkDIADkZUiYOABoAPAAcAAo8dEB4AEgEuQAIBDkcLUAIl5OmD72aAbwAwYBLhTRW06YPjZoBvAIBi65WE42HzZoxvMDIgTgVU6YPjZoxvMDElVOfkRW+CIgUE6YPvZoBvADAwErCdACKwLQAysE0QHgTkkE4E5JAuAAvxFGAL8Av0ZOmD72aMbzAxZ1HENOmD72aMbzBiZOQ7b79fE/Tpg+9mjG80Fmdhx0ALH79PBwvS3p8EEERg1GACcUuQEgvejwgTxIAGgA8A8AqEIO0jlIAGgg8A8AKEM2SQhgCEYAaADwDwCoQgHQASDo5yB4APABAAAofNBgaAMoMdEnSJg4AGgA8ABwCLkBINjn//eG/ylJiEJg2SFImDiAaADw8ABYuR5ImDiAaCDw8ABA8IAAGkmYOYhggCdO4CB4APACAAIoSdGgaEC7FEiYOIBoIPDwAEDwgAARSZg5iGCAJzvgYGgCKAfRDUiYOABoAPQAMCC7ASCj52BoOLkISJg4AGgA8AIA0LkBIJnnBEiYOABoAPSAYJC5ASCR5x3gmBACQAyAnQH//+7+pjgAAAAk9AAAEnoAACACQAC0xAT/92n630mIQgjZ30iAaCDw8ABA8IAA3EmIYIAn2kiAaCDwAwBhaAhD10mIYALwc/gGRgngEOAC8G74gBtB8ogxiEIB2QMgXOfPSIBoAPAMAGFosOuBD+7RIHgA8AIAAigI0clIgGgg8PAAoWgIQ8ZJiGAH4IAvBdHDSIBoIPDwAMFJiGDBSABoAPAPAKhCDtm+SABoIPAPAChDvEkIYAhGAGgA8A8AqEIB0AEgKecgeADwBAAEKAfRs0iAaCD04GDhaAhDsEmIYCB4APAIAAgoCNGtSIBoIPRgUCFpQOrBAKlJiGD/9/f5p0mJaMHzAxGnSnpEUVwB8B8ByEClSUlECGClSEhEAGgC8BX4gEZARvfmcLWGsAZGDUYURgC/mkjAbEDwAQCYSchkCEbAbADwAQAAkAC/AL+IFQGQAiACkASQACADkAWQAalP8JBA/Pet/I1IgGgg8P5AReoEAQhDiUmIYAawcL2KSEhEAGhwRwC1//f5/4RJiWjB8wIhh0p6RFFcAfAfAchAAL0Atf/36/99SYlowfPCIYBKekQcOlFcAfAfAchAAL0/IQFgdkkJaAH0gCGx9YAvA9FP9KAhQWAM4HBJCWgB9IAxsfWAPwPRT/SAMUFgAeAAIUFgakkJaAHwAQERsQEhwWEB4AAhwWFlSUlowfMHIQFiYkkJaAHw8AFBYmBJCWgB9IBxsfWAfwPRT/SAccFgAeAAIcFgWUlJaMHzBmEBYVdJkDEJaAHwBAEEKQzRU0mQMQloAfCAAYApAtGFIYFgF+AFIYFgFOBNSZAxCWgB8AEBYbFKSZAxCWgB8IABgCkC0YEhgWAE4AEhgWAB4AAhgWBCSZQxCWgB8AEBEbEBIUFhAeAAIUFhPUmUMQloAfAQARApAdGBYQHgACGBYTdJmDEJaAHwAQERsQEhgWIB4AAhgWIySQloAfCAcbHxgH8C0QIhwWIB4AEhwWIsScloAfADAgJjKUnJaMHzAxFJHEFjJknJaMHzBiKCYyRJyWjB80FRSRxKAAJkIEnJaMHzQWFJHEoAQmQdScloyg7CY3BHDyICYBlKkmgC8AMCQmAXSpJoAvDwAoJgFEqSaAL04GLCYBJKkmgC9GBS0ggCYRBKEmgC8A8CCmBwRwxIAGhA9AAgCkkIYHBHcEcQtQdIwGkA9IBwsPWAfwXR//f1/0/0gHACSQhiEL0AtMQEABACQAAgAkAyNgAAEAAAAAgAAAC0NQAALenwQQRGD0YAJf5IwGgA8AMAULH7SMBoAPADACFoiEIB0SBoeLsBJS3gIGgBKATQAigJ0AMoGtEN4PJIAGgA8AIAALkBJRTg7kgAaAD0gGAAuQElDeDrSABoAPQAMCi56EgAaAD0gCAAuQElAeABJQC/AL89ueNIwGgg8AMAIWgIQ+BJyGAALXPR3kgAaCDwgFDcSQhgAfBu/gZGBuAB8Gr+gBsCKAHZAyUF4NVIAGgA8ABQACjy0QC/AC1Z0Ye5oGgAAiF7QOrBYWBoQB5B6gAQzElJacxKEUAIQ8lJSGEo4AEvE9GgaAACIYoBIsLrUQFA6kFRYGhAHkHqABDBSUlpwkoRQAhDvklIYRLgoGgAAiF9ASLC61EBQOpBYWBoQB5B6gAQt0lJablKEUAIQ7RJSGGzSABoQPCAULFJCGAB8Bn+BkYG4AHwFf6AGwIoAdkDJQXgq0gAaADwAFAAKPLQAL8tuadIQGmhaQhDpUlIYShGvejwgS3p8EEERg9GACWgSMBoAPADAFCxnUjAaADwAwAhaIhCAdEgaHi7ASUt4CBoASgE0AIoCdADKBrRDeCUSABoAPACAAC5ASUU4JBIAGgA9IBgALkBJQ3gjUgAaAD0ADAouYpIAGgA9IAgALkBJQHgASUAvwC/PbmFSMBoIPADACFoCEOCSchgAC1z0YBIAGgg8IBgfkkIYAHwsv0GRgbgAfCu/YAbAigB2QMlBeB3SABoAPAAYAAo8tEAvwAtWdGHuaBoAAIhe0DqwWFgaEAeQeoAEG5JCWluShFACENrSQhhKOABLxPRoGgAAiGKASLC61EBQOpBUWBoQB5B6gAQY0kJaWRKEUAIQ2BJCGES4KBoAAIhfQEiwutRAUDqQWFgaEAeQeoAEFlJCWlbShFACENWSQhhVUgAaEDwgGBTSQhgAfBd/QZGBuAB8Fn9gBsCKAHZAyUF4E1IAGgA8ABgACjy0AC/LblJSABpoWkIQ0dJCGEoRr3o8IEt6fhFBEYAJahGIIgA9ABgsPUAbzLR4G5AKAnQA9xwsSAoG9ER4GAoFtCAKBbRFOA4SMBoQPSAMDZJyGAQ4AAhIB3/9yH/BUYK4AAhBPEgAP/3Xv4FRgPgAL8B4AElAL8Av1W5K0icMABoIPDgAOFuCEMoScH4nAAA4KhGIIgA9IBQsPWAXzbRIG+w9QB/DNAE3IixsPWAfx3RE+Cw9UB/F9Cw9YBvFtEU4BpIwGhA9IAwGEnIYBDgACEgHf/35P4FRgrgACEE8SAA//ch/gVGA+AAvwHgASUAvwC/VbkNSJwwAGgg9OBgIW8IQwlJwficAADgqEYgaAD0ADCw9QA/a9FP8AAKA0iAbQEhIeoQcMCxB+AAEAJAD4D/Bw+An/8PgP/5AL/+SIBtQPCAUPxJiGUIRoBtAPCAUACQAL8Av0/wAQr3SABoQPSAcPVJCGAB8Jn8B0YG4AHwlfzAGwIoAdkDJQXg70gAaAD0gHAAKPLQAL+Fu+pIkDAAaAD0QHbWsdT4lACwQhbQ5UiQMABoIPRAduJI0PiQAED0gDDgScH4kAAIRtD4kAAg9IAwwfiQAAhGwPiQYAbwAQCwsQHwYvwHRgrgAfBe/MAbQfKIMYhCA9kDJQjgF+Ah4NBIkDAAaADwAgAAKO3QAL9ducxIkDAAaCD0QHDU+JQQCEPIScH4kAAC4KhGAOCoRrrxAQ8F0cNIgG0g8IBQwUmIZQC/IHgA8AEASLG9SIgwAGgg8AMA4WsIQ7pJwfiIACB4APACAAIoCdG2SIgwAGgg8AwAIWwIQ7JJwfiIACB4APAEAAQoCdGuSIgwAGgg8DAAYWwIQ6tJwfiIACB4APAIAAgoCdGnSIgwAGgg8MAAoWwIQ6NJwfiIACB4APAQABAoCdGfSIgwAGgg9EBw4WwIQ5xJwfiIACB4APAgACAoCdGYSIgwAGgg9EBgIW0IQ5RJwfiIACCIAPQAcLD1AH8J0ZBIiDAAaCD0QCBhbghDjEnB+IgAIIgA9IBgsPWAbwnRiEiIMABoIPRAEKFuCEOEScH4iAAgeADwQABAKAnRgEiIMABoIPRAUGFtCEN9ScH4iAAgeADwgACAKAnReUiIMABoIPRAQKFtCEN1ScH4iAAgiAD0gHCw9YB/CdFxSIgwAGgg9EAw4W0IQ21JwfiIACBoAPSAELD1gB8J0WlInDAAaCDwAwAhbghDZUnB+JwAIIgA9ABQsPUAXx/RYUiIMABoIPBAYGFvCENdSYgxCGBgb7DxAG8G0VpIwGhA9IAQWEnIYArgYG+w8YBvBtEBISAd//da/QVGBbGoRiBoAPQAILD1AC9B0QC/oG+w9YBPCNFLSJwwAGhA9IBASUnB+JwAEeBHSJwwAGgg9IBAREnB+JwAQ0iIMABoIPBAYKFvCEM/ScH4iAAAv6BvsPEAbwbRO0jAaED0gBA5SchgFeCgb7D1gE8G0TZIwGhA9IAwNEnIYArgoG+w8YBvBtEBISAd//cS/QVGBbGoRiBoAPSAILD1gC8f0SpIiDAAaCDwQGDhbwhDJkmIMQhg4G+w8QBvBtEjSMBoQPSAECFJyGAK4OBvsPGAbwbRASEgHf/37PwFRgWxqEYgiAD0gECw9YBPFtEXSIgwAGgg8EBQ1PiAEAhDE0mIMQhg1PiAALDxgF8G0QIhIB3/98/8BUYFsahGIGgA9IAwsPWAPwrRCEicMABoIPAEANT4hBAIQwRJwficACBoAPQAELD1AB8P0QPgABACQABwAED+SJwwAGgg8BgA1PiIEAhD+knB+JwAIGgA9IAAsPWADyvR9kgAaCDwgFD0SQhgAfCW+gdGBuAB8JL6wBsCKAHZAyUF4O1IAGgA8ABQACjy0QC/hbnpSJwwAGgg9EAw1PiMEAhD5UnB+JwAAiEE8SAA//e6+wVGBbGoRiBoAPCAcLDxgH8V0d1InDAAaCD0QBDU+JAQCEPZSZwxCGDU+JAAsPUAHwXR1UjAaED0gBDTSchgQEa96PiF0EnJaAHwAwFBYM5JCWnB8wMRSRyBYMtJCWnB8wYiwmDISQlpwfNAQQciAusBEgJhxEkJacHzQVFJHEoAQmHBSQlpwfNBYUkcSgCCYUFoAWK8SUlpwfMDEUkcQWK5SUlpwfMGIoJit0lJacHzQEEHIgLrARLCYrNJSWnB80FRSRxKAAJjr0lJacHzQWFJHEoAQmOsSYgxCWgB8AMBwWOpSYgxCWgB8AwBAWSmSYgxCWgB8DABQWSjSYgxCWgB8MABgWSgSYgxCWgB9EBxwWSdSYgxCWgB9EBhAWWaSYgxCWgB9EBRQWWXSYgxCWgB9EBBgWWUSYgxCWgB9EAxwWWRSZwxCWgB8AMBAWaOSYgxCWgB9EAhQWaLSYgxCWgB9EARgWaISZwxCWgB8OABwWaFSZwxCWgB9OBhAWeCSZAxCWgB9EBxwPiUEH5JiDEJaAHwQGFBZ3tJnDEJaAH0gEERsU/0gEEE4HdJiDEJaAHwQGFA+Hgfc0nR+IgQAfBAYUFgcEnR+IgQAfBAUYFgbUnR+JwQAfAEAcFgaknR+JwQAfRAMUFhZ0nR+JwQAfRAEYFheDhwR/C1BUYORgAgACEAJLX1AG8J0V9PnDc/aAfw4AFgKQ/RS/aAMAzgtfWAXwnRWE+cNz9oB/TgYbH1QH8B0Uv2gDAAKC3RMkZAKQLQsfUAfyjRT08/aAfwAHe38QB/8dFMT/9oB/SANwAvf9BJT/9ox/MDF38csvv38kVP/2jH8wYjQ0//aPwOPLlBT/9oB/QANw+xESQA4AckAvsD97f79PBj4EG7Ok8/aAfwAGe38QBvW9E3Tz9pB/SANwAvVdA0Tz9px/MDF38csvv38jBPP2nH8wYjLk8/afwOPLksTz9pB/QANw+xESQA4AckAvsD97f79PA54IApAtCx9YBvCNEjTz9oB/SAZ7f1gG8t0SFIK+AgKQLQsfWAfybRHE8/aAfwAFe38QBfH9EZT39pB/SAN9exFk9/acfzAxd/HLL79/ITT39px/MGIxFPf2n8Djy5D09/aQf0ADcPsREkAOAHJAL7A/e3+/Tw8L0t6fBNB0ZP8AALt/UAPz7RBEiQMABoAPRAdLT1gH8M0ATgAAAAEAJAACT0ALT1AH8M0LT1QH8o0Rzg+UgAaADwAgACKAHRT/QASx/g9EgAHQBoAPACAAIoC9HxSAAdAGgA8BAAECgC0U/w+gsB4E/0+ksL4OpIkDgAaAD0ADCw9QA/AdHf+JyzAOAAv/fj5EiQOMBoAPADCrrxAQ8G0LrxAg8k0LrxAw850Szg3EiQOABoAPACAAIoF9HZSJA4AGgA8AgAKLHWSJA4AGgA8PAABeDTSAAdAGgA9HBgAAkACdFJeURR+CBQAOAAJRngzEiQOABoAPSAYLD1gG8B0ctNAOAAJQ3gxkiQOABoAPQAMLD1AD8B0cZNAOAAJQHgACUAvwC/t/WAb3bQGtwgL3TQDNwEL3LQBNwBL3DQAi9v0dzhCC9t0BAv+dFb4kAvatCAL2nQt/WAf2fQt/UAf+7RfeO39YA/fNAM3Lf1AG8W0Lf1gF8a0Lf1AF8e0Lf1gE/d0Z3it/WALxjQt/UAL2nQt/WAH2fQt/GAf9DR3uMpRk/0AGD/93b+g0Yq4ilGT/SAUP/3b/6DRiPiAL+YSAg4AGgA8EBkbLO08YBvW9C08QBvK9C08UBvftGRSJA4AGgA8AIAAigW0Y1IkDgAaADwCAAosYpIkDgAaADw8AAF4IdIAB0AaAD0cGAACQAJiUl5RFH4ILBr4GHjIuKa4UHh8OPD4VngjeKu4s/ifEiQOABoAPAAcLDxAH8j0XhIkDjAaAD0gBCw9YAfG9F0SJA4wGjA8wYmBfsG8HFJkDnJaALgYeJG4NPiwfMDEUkcsPvx9WtIkDjAaMDzQVBAHEAAtfvw+zTgZkiQOABoAPAAYLDxAG8f0WJIkDgAaQD0gBCw9YAfF9FeSJA4AGnA8wYmBfsG8FpJkDkJacHzAxFJHLD78fVWSJA4AGnA80FQQBxAALX78PsL4AngUUgIMABoAPACAAIoAdHf+EyxAOAAvwC/ieNKSAwwAGgA9IBAsPWATzTRRkiQOABoAPAAcLDxAH8r0UJIkDjAaAD0gDCw9YA/I9E+SJA4wGjA8wYmBfsG8DtJkDnJaMHzAxFJHLD78fU3SJA4wGhP6tBouPEADwrRM0iQOMBoAPQAMBCxT/ARCAHgT/AHCLX7+PuZ4CxICDgAaADwQGTss7TxgG9f0LTxAG8h0LTxQG990SRIkDgAaADwAgACKBbRIUiQOABoAPAIACixHkiQOABoAPDwAAXgG0gAHQBoAPRwYAAJAAkeSXlEUfggsGrgFUiQOABoAPAAcLDxAH8h0RFIkDjAaAD0gBCw9YAfGdENSJA4wGjA8wYmAOBI4AX7BvAISZA5yWjB8wMRSRyw+/H1BEiQOMBowPNBUEAcQAC1+/D7P+CQEAJAkNADAMomAAAAJPQAABJ6AJwlAAAAbNwC6iMAAPlIAGgA8ABgsPEAbxvR9kgAaQD0gBCw9YAfFNHySABpwPMGJgX7BvDvSQlpwfMDEUkcsPvx9exIAGnA80FQQBxAALX78PsL4Ang50iYMABoAPACAAIoAdHf+JCzAOAAvwC/seLgSIgwAGgA8AMENLEBLAjQAiwK0AMsHNER4P73nf6DRhjg/vc++INGFODWSABoAPSAYLD1gG8B0d/4ULMK4NFIkDAAaADwAgACKAHRT/QASwDgAL8Av4XiykiIMABoAPAMBDSxBCwI0AgsCtAMLBzREeD+92P+g0YY4P73EviDRhTgwEgAaAD0gGCw9YBvAdHf+PiyCuC7SJAwAGgA8AIAAigB0U/0AEsA4AC/AL9Z4rRIiDAAaADwMAQ0sRAsCNAgLArQMCwc0RHg/vc3/oNGGOD99+b/g0YU4KpIAGgA9IBgsPWAbwHR3/igsgrgpUiQMABoAPACAAIoAdFP9ABLAOAAvwC/LeKeSIgwAGgA8MAENLFALAjQgCwK0MAsHNER4P73C/6DRhjg/fe6/4NGFOCUSABoAPSAYLD1gG8B0d/4SLIK4I9IkDAAaADwAgACKAHRT/QASwDgAL8AvwHiiEiIMABoAPRAdEyxtPWAfwrQtPUAfwvQtPVAfxzREeD+99z9g0YY4P33i/+DRhTgfEgAaAD0gGCw9YBvAdHf+OyxCuB3SJAwAGgA8AIAAigB0U/0AEsA4AC/AL/S4XFIiDAAaAD0QGRMsbT1gG8K0LT1AG8L0LT1QG8c0RHg/vet/YNGGOD991z/g0YU4GVIAGgA9IBgsPWAbwHR3/iMsQrgYEiQMABoAPACAAIoAdFP9ABLAOAAvwC/o+FZSIgwAGgA8EBUtPGAXwbQtPFAXyXR/fc2/4NGIuBSSABoAPAAYLDxAG8Z0U5IAGkA8IBwoLFMSABpwPMGJgX7BvBJSQlpwfMDEUkcsPvx9UVIAGnA80FgQBxAALX78PsA4AC/AL9v4T9InDAAaADwBAQcuf73Yv2DRgLg/fcD/4NGYeE4SIgwAGgA9EBUNLG09YBfB9C09QBfEtEH4P73P/2DRg7g/ffu/oNGCuAuSABoAPSAYLD1gG8B0d/4sLAA4AC/AL8/4SdIiDAAaAD0QEQ0sbT1gE8H0LT1AE8S0Qfg/vcd/YNGDuD998z+g0YK4B1IAGgA9IBgsPWAbwHR3/hssADgAL8Avx3hFkiIMABoAPRANDSxtPWAPwfQtPUAPxLRB+D+9/v8g0YO4P33qv6DRgrgDEgAaAD0gGCw9YBvAdHf+CiwAOAAvwC/++AFSJwwAGgA8AMEXLEBLA3QAiwZ0Q7gAAAAEAJAAGzcAgAk9AD+99T8g0YO4P33g/6DRgrg+UgAaAD0gGCw9YBvAdHf+NyzAOAAvwC/1ODzSIgwAGgA9EAkVLG09YAvC9C09QAvHNC09UAvLdEi4MTg/veu/INGKODoSJQwAGgA8AIAAigL0eVIlDAAaADwEAAQKALRT/D6CwHgT/T6SxTg3kgAaAD0gGCw9YBvAdHf+HCzCuDZSJAwAGgA8AIAAigB0U/0AEsA4AC/AL+U4NNIiDAAaAD0QBRMsbT1gB8K0LT1AB8b0LT1QB8s0SHg/vdv/INGKODJSJQwAGgA8AIAAigL0cVIlDAAaADwEAAQKALRT/D6CwHgT/T6SxTgv0gAaAD0gGCw9YBvAdHf+PCyCuC6SJAwAGgA8AIAAigB0U/0AEsA4AC/AL9V4LNInDAAaAD0QBQ0sbT1gB8H0LT1AB9E0R/g/ffm/YNGQOCrSABoAPACAAIoFNGoSABoAPAIACCxpUgAaADw8AAF4KNIlDAAaAD0cGAACQAJoUl5RFH4ILAk4J1IAGgA8ABwsPEAfxvRmUjAaAD0gBCw9YAfFNGWSMBowPMGJgX7BvCTSclowfMDEUkcsPvx9Y9IwGjA80FQQBxAALX78PsA4AC/AL8B4P/nAL8Av1hGvejwjXC1BEYAJoVIAGgg8IBgg0kIYADwsPsFRgbgAPCs+0AbAigB2QMmBeB8SABoAPAAYAAo8tEAv4a7YGhAHgABoWhA6gEgIYoBIsLrUQFA6kFQIX3C61EBQOpBYCF7QOrBYG5JCWlwShFACENsSQhhCEYAaaFpCENpSQhhCEYAaEDwgGAIYADwd/sFRgfgAPBz+0AbAigC2QMmBuAG4F9IAGgA8ABgACjx0AC/MEZwvXC1ACVaSABoIPCAYFhJCGAA8Fr7BEYG4ADwVvsAGwIoAdkDJQXgUUgAaADwAGAAKPLRAL9OSABpUUkIQExJCGEIRgBoAPAIUCC5CEbAaCDwAwDIYChGcL1wtQRGACZDSABoIPCAUEFJCGAA8C37BUYG4ADwKftAGwIoAdkDJgXgO0gAaADwAFAAKPLRAL+Gu2BoQB4AAaFoQOoBICGKASLC61EBQOpBUCF9wutRAUDqQWAhe0DqwWAtSUlpL0oRQAhDKklIYQhGQGmhaQhDJ0lIYQhGAGhA8IBQCGAA8PT6BUYH4ADw8PpAGwIoAtkDJgbgBuAeSABoAPAAUAAo8dAAvzBGcL1wtQAlGEgAaCDwgFAWSQhgAPDX+gRGBuAA8NP6ABsCKAHZAyUF4BBIAGgA8ABQACjy0QC/DEhAaQ9JCEAKSUhhCEYAaADwIGAguQhGwGgg8AMAyGAoRnC9A0mJaCH0AEEBQwFKkWBwRwAQAkAAJPQA/h0AAA+AnQH//+7++UkJaCH0cGFB6gAR9kqUOsL4lBBwR/RIAB8AaEDwIADxSZQ5wfiQAHBH70gAHwBoIPAgAOxJlDnB+JAACEaAaSD0AHCIYXBH50gAHwBoQPAgAOVJlDnB+JAACEaAaUD0AHCIYeFIAGhA9AAg30kIYN5ICDAAaED0ACDcSQgxCGBwR3BHELXYSJQ4wGkA9ABwsPUAfwbR//f0/0/0AHDSSZQ5CGIQvXC1hrAERgAlACYAv81IlDjAbEDwAQDKSZQ5yGQIRsBsAPABAACQAL8AvwQgAZADIAKQAiAEkAAgA5ABqU/wkED69/n+v0iUOIBtAPCAUIC5AL+7SJQ4gG1A8IBQuUmUOYhlCEaAbQDwgFAAkAC/AL8BJbVIAGgA9IBwELn89z/9ASavSAAfAGgg8EBwRPCAcQhDq0mUOcH4kAABLgHR/Pc1/QEtB9GmSJQ4gG0g8IBQpEmUOYhlBrBwvTi1ACQAJaBIlDiAbQDwgFCAuQC/nEiUOIBtQPCAUJpJlDmIZQhGgG0A8IBQAJAAvwC/ASSWSABoAPSAcBC5/PcB/QElkEgAHwBoIPCAcI5JlDnB+JAAAS0B0fz3+vwBLAfRiUiUOIBtIPCAUIZJlDmIZTi9hEiUOABoQPAEAIJJlDkIYHBHgEiUOABoIPAEAH1JlDkIYHBHe0oQMhJoIvD/AkDqARMaQ3dLlDvD+KQgcEd1SpQ6kmtC8IByckuUO5pjGkaSayLwgHKaY9DpACMaQ4NoQuoDAcJoEUMCikHqAkFsSlFgEmgi9HxSQ2lC6gMiaEsaYBpGEmhC8GACGmBwR2RIAGhA8IAAYkkIYHBHYElJaImyAWBeSQlowfMFIUFgXEmJaAkMgWBaSYloAfQAQcFgcEdwtQVGACQA8FP5BkYAv2gcMLEA8E35gBuoQgDYBbkBJE9IgGgA8AEAMLFE8AIEAL8BIEpJyGAAv0lIgGgA8AIAAigF0UTwBAQAv0RJyGAAv0NIgGgA9IBgsPWAbwbRRPAgBAC/BCA9SchgAL88SIBoAPSAcLD1gH8G0UTwCAQAvwQgNknIYAC/NUiAaAD0AHCw9QB/BtFE8BAEAL8EIC9JyGAAvy5IgGgA8AgACCgD0QC/KknIYAC/ACyo0CBGcL1wR3BHcEdwR3C1ACUkSIRoBmgE8AEAQLEG8AEAKLEBIB9JyGD/9+//MuAE8AIAQLEG8AIAKLECIBlJyGD/9+L/JuAE8AgAQLEG8AgAKLEIIBNJyGD/99X/GuAE8AQAuLEG8AQAoLEE9IBwCLFF8AgFBPQAcAixRfAQBQT0gGAIsUXwIAUEIAVJyGAoRv/3uP9wvZQQAkAABAFAAHAAQABgAEBGSABoQPABAERJCGAAIIhgCEYAaEJJCEBASQhgiBTIYAhGAGgg9IAgCGAAIIhhyAM8SQhgcEfwtQAjACAAIgIkACUCITVONmgG8AgGLrkzTpQ2NmjG8wMgA+AwTjZoxvMDEDFOfkRW+CAALE62aAbwDAY2sQQuCNAILgvQDC450Q3gKk5ORDBgOOApTidPT0Q+YDPgJ04lT09EPmAu4B9O9mgG8AMFHU72aMbzAxZxHAItAtADLQjRA+AdTrb78fIG4BxOtvvx8gLgsPvx8gC/AL8STvZoxvMGJnJDD072aMbzQWZ2HHQAsvv09g9PT0Q+YAPgDU5ORDBgAL8AvwdOtmjG8wMWDE9/RLtdB05ORDZo3kAFT09EPmDwvQAQAkD///bqCO0A4BAXAAAQAAAAACT0AAASegBUFgAAAUYAIAC/AOBAHLD1gF/723BHACEA4EkcsfWAb/vbW0hIRABoQBxZSkpEEGAQRgBocEcBRgAgcEcAtZmwFCEUqAHwyPpIIQKoAfDE+gC/UEiAbUDwgFBOSYhlCEaAbQDwgFABkAC/AL8AIPz3DvxISIBtIPCAUEZJiGUQIAKQASAJkAAgCpACIA2QASEOkWAgC5APkTchEJECIROREpEHIRGRAqj990r6CLEAv/7nDyAUkAMgFZCAIBaQACAXkBiQAyEUqP33lP4IsQC//ucCIBSQACAWkAUhFKj994n+CLEAv/7nGbAAvRC1ACT/9+r++vdM+f/3oP8A8Kz+CLEAIBC9AfBh+QRGDLkBIPjnACD25xC1APBE/wDwnP4B8KH4AL8B8Nn4ACj70RC9cLUERg1GFkYA8DT/JPBwRADwiv4qRiFGMEYA8J7/ASBwvXC1BEYNRiTwcEQl8HBFoLIkGgDwHv8A8Hb+DOAmRjBGAPDy/wC/AfCw+AAo+9EE9YA0AfAi+aVC8NIBIHC9BAAAAAAQAkABeUoe+EsD64ICQmX2SkAygmVKHgLwAwMBIppAwmVwR/JLAmiaQgbSQmySCPBLA+uCAoJkBuBCbJII7UscMwPrggKCZAJ4CDoUI7L78/HmSoA6wmQB8B8DASKaQAJlcEdwtQRGDLkBIHC94EkgaIhCC9LgSSBoQBoUIbD78fCAAGBk3EgIOCBkCuDYSSBoQBoUIbD78fCAAGBk1EgIOCBkAiCE+CUAIGgFaEf28HCFQ9TpAgEIQyFpCENhaQhDoWkIQ+FpCEMhaghDBUMgaAVgIEb/96X/oGiw9YBPAdEAIGBgIHmhbAhg1OkTEEhgYGhgsWBoBCgJ2CBG//eB/wAgYW0IYNTpFhBIYAPgACBgZaBl4GUAIOBjASCE+CUAACCE+CQAAL+f5xC1BEYMuQEgEL0gaABoIPABACFoCGCrSSBoiEIL0qtJIGhAGhQhsPvx8IAAYGSnSAg4IGQK4KNJIGhAGhQhsPvx8IAAYGSfSAg4IGQAICFoCGCU+EQAAPAcAQEgiEAhbEhgIEb/90j/ACChbAhg1OkTEEhgYGhYsWBoBCgI2CBG//cq/wAgYW0IYNTpFhBIYAAgYGWgZeBl4GIgY2BjoGPgY4T4JQAAv4T4JAAAvwC/qucwtdDpE1RsYERtFLHQ6RZUbGCQ+ERABPAcBQEkrEAFbGxgBGhjYIRoECwE0QRoomAEaOFgA+AEaKFgBGjiYDC9LenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKBfRAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//e3/yBoAGhA8AEAIWgIYAbgAL8AIIT4JAAAv0/wAghARtTnLenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKD/RAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//d+/yBrMLEgaABoQPAOACFoCGAL4CBoAGgg8AQAIWgIYCBoAGhA8AoAIWgIYKBsAGgA9IAwKLGgbABoQPSAcKFsCGBgbSixYG0AaED0gHBhbQhgIGgAaEDwAQAhaAhgBuAAvwAghPgkAAC/T/ACCEBGrOcBRgAikfglAAIoCNAEIMhjAL8AIIH4JAAAvwEgcEcIaABoIPAOAAtoGGCIbABoIPSAcItsGGAIaABoIPABAAtoGGCR+EQAAPAcAwEgmEALbFhg0ekTMFhgSG1AsUhtAGgg9IBwS20YYNHpFjBYYAEggfglAAC/ACCB+CQAAL8QRszncLUERgAllPglAAIoDNAEIOBjASU94AAAAAkCQAgEAkAACAJACAACQCBoAGgg8A4AIWgIYCBoAGgg8AEAIWgIYKBsAGgg9IBwoWwIYJT4RAAA8BwBASCIQCFsSGDU6RMQSGBgbUCxYG0AaCD0gHBhbQhg1OkWEEhgASCE+CUAAL8AIIT4JAAAv6BrELEgRqFriEcoRnC9LenwQQRGDkYVRpT4JQACKAnQBCDgYwC/ACCE+CQAAL8BIL3o8IEgaABoAPAgACCxT/SAcOBjASDz5z65lPhEAADwHAECIAD6AfgG4JT4RAAA8BwBBCAA+gH4//fd/AdGMOAgbABolPhEEAHwHAIIIZFACECQsZT4RAAA8BwBASCIQCFsSGABIOBjhPglAAC/ACCE+CQAAL8BIMLnaByIsf/3uvzAG6hCANhduSAg4GMBIIT4JQAAvwAghPgkAAC/ASCu5yBsAGgA6ggAACjI0GBtiLGgbQBo4W0IQGCxYG0AaED0gHBhbQhg1OkWEEhg4GtA9IBg4GPgbABoIW0IQDCx1OkTEEhg4GtA9ABw4GOGuZT4RAAA8BwBAiCIQCFsSGAAvwAghPgkAAC/ASCE+CUAB+CU+EQAAPAcAQQgiEAhbEhgACBs53C1BEYgbAVoIGgGaJT4RAAA8BwBBCCIQChA4LEG8AQAyLEgaABoAPAgACi5IGgAaCDwBAAhaAhglPhEAADwHAEEIIhAIWxIYCBrAChW0CBGIWuIR1LglPhEAADwHAECIIhAKEAYswbwAgAAsyBoAGgA8CAAQLkgaABoIPAKACFoCGABIIT4JQCU+EQAAPAcAQIgiEAhbEhgAL8AIIT4JAAAv+BqULMgRuFqiEcm4JT4RAAA8BwBCCCIQChA8LEG8AgA2LEgaABoIPAOACFoCGCU+EQAAPAcAQEgiEAhbEhgASDgY4T4JQAAvwAghPgkAAC/YGsQsSBGYWuIR3C9ELUDRgAkAL+T+CQAASgB0QIgEL0BIIP4JAAAv5P4JQABKBLRMbEBKQbQAikG0AMpCNEF4NpiB+AaYwXgWmMD4JpjAeABJAC/AOABJAC/ACCD+CQAAL8gRtvnAkYAIwC/kvgkAAEoAdECIHBHASCC+CQAAL+S+CUAASgb0QUpFtLf6AHwAwYJDA8AACDQYhDgACAQYw3gACBQYwrgACCQYwfgACDQYhBjUGOQYwHgASMAvwDgASMAvwAggvgkAAC/GEbS5wFGkfglAHBHAUbIa3BHAAAQtZawBEYAIAKQA5BA8vlgBJAEIAWQECAGkAAgB5AJkA2QEJATkBSQFZBB8ogyAqkgRvr3DP0QsQEgFrAQvUDy+lAEkAAgCJBP9IBgCZBP9EBQCpAAIAuQT/CAYBCQACASkAEgEZAEIBOQAL9B8ogyAqkgRvr36/wIsQEg3edB8ogyAakgRvr3V/4IsQEg1Oed+AQAAPACAAIo59EAIMznMLWVsAVGDEYAIAGQApBA8vpQA5AEIASQECAFkAAgBpAHkE/0gGAIkE/0QFAJkAAgCpAMkE/wgGAPkAAgEZABIBCQBCASkAAgE5AUkAC/IkYBqShG+ver/BCxASAVsDC9IkZpRihG+vcX/gixASD15534AAAA8AEAACjo0QC/7ecwtZuwBUYMRgAgB5AIkAyQT/RAUA+QACAQkBKQF5AZkBqQBJAQIAaQgAQFkAEsedEGIAmQASAKkAAgC5AOkBWQGJBB8ogyB6koRvr3cPwQsQEgG7AwvQUgCZBP8IBwFZAAIBeQASAWkEHyiDIHqShG+vdd/AixASDr5wIgApADkEHyiDICqShG+/dg+AixASDf53IgCZBP9EBwDZBP9IBwDpBP9EBQD5AAIBCQQfKIMgepKEb69zv8CLEBIMnnByABkEHyiDIBqShG+vdX/QixASC+5wYgCZAAIA6QFZBB8ogyB6koRvr3IvwIsQEgsOcFIAmQT/CAcBWQQfKIMgepKEb69xT8CLEBIKLnAiACkAOQQfKIMgKpKEb79xf4ELEBIJbnUeByIAmQACANkE/0gHAOkEHyiDIHqShG+vf3+wixASCF5wEgAZBB8ogyAakoRvr3E/0IsQEgeucAIADgQByw9QAf+9tB8ogxKEb/9wf/CLEBIGznR/KOEAmQBCAKkBAgC5CAAQ6QAAQVkAYgGJACIBaQQfKIMgep/EhIRPr3xfsIsQEgU+dB8ogyaUb3SEhE+vcw/QixASBJ5534AAABKH7QASBD5/FISET/94f+CLEBIDznR/KNIAmQBCAKkBAgC5AAIA2QT/SAYA6QAAQVkAIgFpAAIBiQjfgAAI34AQBB8ogyB6nhSEhE+veO+wixASAc50HyiDJpRtxISET696v8CLEBIBLnACAA4EAcsPUAH/vbBSAJkAEgCpAAIAuQDpBP8IBwFZABIBaQACAYkAKQASADkEHyiDIHqctISET692P7CLEBIPHmQfKIMgKpxkhIRPr3aP8IsQEg5+ZxIAmQACANkE/0gHAOkEHyiDIHqb5ISET690j7CLEBINbmQfKIMmlGuUhIRPr3s/wQsQEgzOYE4J34AAAIsQEgxuYAIMTmELWUsARGACAAkAGQASADkAAgBJAFkAeQC5AQkBGQEpATkA6QZiACkEHyiDJpRiBG+vcZ+xCxASAUsBC9mSACkEHyiDJpRiBG+vcN+wixASDy5wAgAOBAHLD1AB/72wAg6ucAtYewAL+YSMBsQPSAEJZJyGQIRsBsAPSAEAGQAL8AvwC/CEYAbUD0AHAIZQhGAG0A9ABwAZAAvwC/CEYAa0D0AHAIYwhGAGsg9ABwCGMAvwhGgG1A8IBQiGUIRoBtAPCAUAGQAL8Av4FIQGhA9ABwf0lIYAC/fEjAbEDwIAB6SchkCEbAbADwIAABkAC/AL8AvwhGwGxA8EAAyGQIRsBsAPBAAAGQAL8Av4gUApACIAOQASAEkAMgBZAFIAaQAqlsSPn3wv1P9IBQApACqWlI+fe7/T8gApAAIASQAqllSPn3s/1A8gNgApACqWFI+fes/QewAL0AtYewWCFaSEhEAPC5+xghAagA8LX7W0hVSUlECGAIRvr3CvgQsQEgB7AAvf/3bf8EIE9JSURIYAAhTUhIRIFgT/CAccFgGiEBYQIhQWEAIYFhwWECIQFiACFBYk/wgFGBYgAhwWIBY0Fj+fdm/wixASDZ5wIgAZACkENIBZBDSASQAiADkAEgBpBB8ogyAak3SEhE+/cq+AixASDE5zRISET/9wH/CLEBIL3nACAA4EAcsPUAH/vbASEtSEhE//eP/QixASCv5wAgrecAtYWwQfI/ASpI+fci/kHyA2EnSPn3Hf4AIAGQT/SAUACQACACkAOQaUYhSPn3LP0BIAGQACACkE/0gFAAkGlGHEj59yH9ACJP9IBRGUj595r+FUgAa0D0AHATSQhjCEYAayD0AHAIYwhGAG0g9ABwCGUIRsBsIPSAEMhkBbAAvRC1DUgHSUlECGAIRvr3Vf8CKBfQA0hIRPr34f6QsQEgEL0AABQAAAAAEAJAAHAAQAAYAEgAFABIABQAoAIAAAECAAEAACH2SEhE//cj/QixASDl5/JISET590j/CLEBIN7n//eN/wAg2udwtZSwBEYNRhZGACAAkAGQBCADkBAgBJAAIAWQCZAKkAuQDJANkBCQBiARkAAgEpATkE72E0ACkE/0gGAHkE/0QFAIkE/wgGAOkAaVD5ZB8ogyaUbYSEhE+vd++RCxASAUsHC9QfKIMiFG0khIRPr36PoIsQEg8+cAIPHnLenwRZWwgkYNRhZG6LLA9YB4sEUA2bBGLEavGQAgAZACkEHy7SADkAQgBJAQIAWQACAGkAqQC5AMkA2QDpARkBKQE5AUkEHy7SADkE/0gGAIkE/0QFAJkE/wgGAPkAC/B5TN+ECAtEhIRP/3EPwYsQEgFbC96PCFQfKIMgGprkhIRPr3K/kIsQEg8udB8ogyUUapSEhE+vdI+gixASDo50HyiDGlSEhE//dB/AixASDf50REwkQE9YBwuEIB2TgbAeBP9IBwgEa8QsnTACDQ5xC1lLAERgAgAJABkAQgA5AQIASQACAFkAmQCpALkAyQDZAQkBGQEpATkAWQCZBN9iNAApBP9IBgB5BP9EBQCJAGlAAgDpCISEhE//e4+xCxASAUsBC9QfKIMmlGg0hIRPr31PgIsQEg8+dP9PphfkhIRP/39PsIsQEg6ucAIOjnELWUsARGACAAkAGQBCADkBAgBJAAIAWQCZAKkAuQDJANkBCQEZASkBOQBZAJkLT1gE8C0wEgFLAQvULy3hACkE/0gGAHkE/0QFAIkCADBpAAIA6QZUhIRP/3cfsIsQEg6edB8ogyaUZgSEhE+veO+AixASDf50HyiDFbSEhE//eu+wixASDW5wAg1OcAtZWwACABkAKQBCAEkBAgBZAAIAaQCpALkAyQDZAOkBGQEpATkBSQRvKfAAOQACAIkE/0AFAJkAAgB5APkEdISET/9zb7ELEBIBWwAL1B8ogyAalCSEhE+vdS+AixASDz5z9JPkhIRP/3c/sIsQEg6+cAIOnnALWVsAAgAZACkEL21DADkAQgBJAQIAWQACAHkE/0gGAIkE/0QFAJkAAgDJBP8IBgD5ACIBCQBiASkAAgFJAGkAqQEZATkEHyiDIBqSZISET69xv4ELEBIBWwAL1B8ogyaUYhSEhE+veF+QixASDz5534AAAA8GAACLEBIOznnfgAAADwDAAIsQgg5edA8vpQA5BB8ogyAakTSEhE+ff1/wixASDY50HyiDJpRg5ISET692D5CLEBIM7nnfgAAADwAQAIsQIgx+cAIMXnAUZP8IBgCGCAEkhggBGIYIAQyGCAAghhACBwRxQAAADgkwQAALWXsIBISET/96D6ELEBIBewAL0CIAOQACAEkAQgBpAQIAeQACAIkAyQDZAOkA+QEJATkBSQFZAWkAiQDJBB8u0gBZBP9IBgCpBP9EBQC5AAIAmQT/CAYBGQASASkEAHFZBB8ogyA6lnSEhE+feV/wixASDM5072E0AFkAEgA5AGIBSQACAVkEHyiDIDqV5ISET594L/CLEBILnnCCABkCAgApABqVhISET690/8CLEBIK3nACCr5wC1lbD/9yj/Aigk0QAgAZACkEvyTwADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAGkEHyiDIBqUZISET591L/ELEBIBWwAL3/9wf/CCgB0QAg9+cBIPXnACDz5wC1lbD/9/v+CCgk0QAgAZACkEPyzwADkAQgBJAQIAWQACAIkAyQD5ASkBOQFJAGkEHyiDIBqS9ISET59yX/ELEBIBWwAL3/99r+AigB0QAg9+cBIPXnACDz5wC1lbAAIAGQApAEIASQECAFkAAgBpAKkAuQDJANkA6QEZASkBOQFJBL9kYQA5AAIAiQD5BB8ogyAakYSEhE+ff2/hCxASAVsAC9ACD75wC1lbAAIAGQApAEIASQECAFkAAgBpAKkAuQDJANkA6QEZASkBOQFJD/IAOQACAIkA+QQfKIMgGpBUhIRPn30P4QsQEgFbAAvQAg++cAABQAAABP8AACALUTRpRGlkYgOSK/oOgMUKDoDFCx8SABv/T3rwkHKL+g6AxQSL8MwF34BOuJACi/QPgEKwi/cEdIvyD4AisR8IBPGL8A+AErcEcAAAAAAAAAAAAAAQIDBAYHCAkAAAAAAQIDBKCGAQBADQMAgBoGAAA1DABAQg8AgIQeAAAJPQAAEnoAACT0AAA2bgEASOgBAGzcAgAAAAAAAAAAEAAAAAEAAAAACT0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    load_address: ~
+    pc_init: 207
+    pc_uninit: 229
+    pc_program_page: 273
+    pc_erase_sector: 243
+    pc_erase_all: 235
+    data_section_offset: 29824
+    flash_properties:
+      address_range:
+        start: 1879048192
+        end: 1946157056
+      page_size: 4096
+      erased_byte_value: 255
+      program_page_timeout: 10000
+      erase_sector_timeout: 6000
+      sectors:
+        - size: 65536
+          address: 0
+    cores: []
+  - name: aps6408l-3ob_stm32l4p5g-dk
+    description: STM32L4P5G-DK_PSRAM
+    default: false
+    instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwR3C1BEYNRhZGAPCT+AixACBwvQEg/OcBRgAgcEcAIHBHAUYAIHBHcLUERg1GFkYyRilGIEYA8JL4CLEAIHC9ASD85zC1BuAQ+AFLEvgBW6xCANAwvQseofEBAfTRAL/45wAAAUYAIAC/AOBAHLD1gF/723BHASBwRwC//ucBRgAgcEcAtZmwFCEUqAfwNPtIIQKoB/Aw+wC/OUiAbUDwgFA3SYhlCEaAbQDwgFABkAC/AL8AIAHwPvoxSIBtIPCAUC9JiGUQIAKQASAJkAAgCpACIA2QASEOkWAgC5APkTchEJECIROREpEHIRGRAqgC8Hr4CLH/98D/DyAUkAMgFZCAIBaQACAXkBiQAyEUqALwxPwIsf/3sP8CIBSQACAWkAUhFKgC8Ln8CLH/96X/GbAAvRC1ACQE8ID/APBM+P/3oP8G8Mf/CLEAIBC9B/Dn+ARGDLEgRvjnASD253C1BkYMRhVGJvBwRgfwu/gG8LL/IkYpRjBGB/Dl+QEgcL0AEAJAcEdwtQRGACWhSEhEAHjwsZ9ISEQAeE/0enGx+/DwnUlJRAlosfvw9jBGAPD4+WC5ECwI0gAiIUZQHgDwX/mWSEhEBGAE4AElAuABJQDgASUoRnC9ELUAJAMgAPA9+Q8g//dL/wixASQB4P/3yf8gRhC9cEcQtQC/T/D/MIdJiGPIYwC/AL8AIIhjyGMAv0AeCGQAIAhkQB6IYgAgiGJAHshiACDIYkAeCGMAIAhj//fg/wAgEL16SEhEAGh0SUlECXgIRHZJSUQIYHBHdEhIRABocEdwSEhEAGhwR3C1BEYAJWtISEQAeKBCDdBoSEhEBngEcGhISEQAaP/3/v4FRhWxY0hIRAZwKEZwvWBISEQAeHBHcLUERv/36/4GRiVGaBwYsVpISEQAeAVEAL//9+D+gBuoQvrTcL1P8OAgAGkg8AIAT/DgIQhhcEdP8OAgAGlA8AIAT/DgIQhhcEdP8IZwcEdPSABoAAxwR01IAGjA8wsAcEdMSABocEdKSAAdAGhwR0hICDAAaHBHRUhAaEDwAQBDSUhgcEdCSEBoIPABAEBJSGBwRz5IQGhA8AIAPElIYHBHO0hAaCDwAgA5SUhgcEc3SEBoQPAEADVJSGBwRzRIQGgg8AQAMklIYHBHyiAySUhiUyBIYgEgMEkIYHBHASAvSQhicEcAIC1JCGJwRypJCWsh8AQBAUMnShFjcEcmSQlrIfACAQFDI0oRY3BHIklJayHwPwEBQx9KUWNwRxC1HUgAa0DwAQAbSQhj//dX/gRGBuD/91P+ABsKKAHZAyAQvRVIAGsA8AgAACjy0AAg9ucRSABrIPABAA9JCGNwRw1IQGhA9IBwC0lIYHBHCkhAaCD0gHAISUhgcEcMAAAAEAAAAAgAAAAAEAJABAAAAAAgBOCQdf8fAAABQAADIEIAACBCELUAKATbCgcTDuZKE1QG4AoHFA7kSgDwDwMbH9RUEL0AvwDwBwLgSww7GWhP9v8DGUDeSwtDQ+oCIdtLDDsZYAC/cEct6fBNgEYNRhZGACcA8KL5B0Y5RipGM0YB8AcAwPEHC7vxBA8C2U/wBAsB4MDxBwvaRgDxBAu78QcPAtJP8AALAeCg8QML3EZP8AELC/oK+6vxAQsL6gILC/oM+0/wAQ4O+gz+rvEBDg7qAw5L6g4EIUZARv/3ov+96PCNAUYIRgAoDdsAvwC/APAfAwEimkBDCZsAA/HgI8P4ACEAvwC/AL9wRxC1AUYIRgAoF9sA8B8DASKaQK1LRAlD+CQgAL8AvwC/v/NPjwC/AL8AvwC/AL8Av7/zb48AvwC/AL8AvxC9AL8AvwC/AL8Av7/zT48AvwC/AL+bSAw4AGgA9OBgmUkIQwAdl0kMOQhgAL8AvwC/v/NPjwC/AL8AvwC/AL/953C1BEYlRmgesPGAfwHTASAP4GgeT/DgIUhhDyFP8P8w//c7/wAgT/DgIYhhByAIYQAgcL0QtQDw/PgQvS3p8EUERiBGACgD231PP1w/CQfgfE8A8A8MrPEEDBf4DHA/CT1GDkYG8AcAwPEHCLjxBA8C2U/wBAgB4MDxBwjERgDxBAi48QcPAtJP8AAIAeCg8QMIR0Yl+gf4T/ABCgr6DPqq8QEKCOoKCML4AIBP8AEICPoH+KjxAQgI6gUIw/gAgAC/vejwhRC1AUYIRgAoCNsA8B8DASKaQFxLgDNECUP4JCAAvxC9ELUBRghGACgO21ZKgDJDCVL4IyAA8B8EASOjQBpACrEBIgLgACIA4AAiEEYQvRC1AUYIRgAoB9sA8B8DASKaQElLRAlD+CQgAL8QvRC1AUYIRgAoDttESoAyQwlS+CMgAPAfBAEjo0AaQAqxASIC4AAiAOAAIhBGEL0EKAjRT/DgIQlpQfAEAU/w4CIRYQfgT/DgIQlpIfAEAU/w4CIRYXBHcEcQtf/3/P8QvUDwAQEqSnwyEWAAvwC/AL+/80+PAL8AvwC/AL8AvwC/v/NvjwC/AL8Av3BHAL8AvwC/v/NfjwC/AL8AvwAgHEl8MQhgcEdBeBlKgDIRYAF4+bESHUFoEWABewkHwnpB6gJhgnpB6sJBQntB6oJBgntB6kJBwntB6gJBQnpB6gIhAnpB6kIBAngRQwlKiDIRYAXgACEGSoQyEWASHRFgcEcDSAw4AGjA8wIgcEcA5ADgGO0A4AAA+gWA4QDggOIA4AF5Sh74SwPrggJCZfZKQDKCZUoeAvADAwEimkDCZXBH8ksCaJpCBtJCbJII8EsD64ICgmQG4EJskgjtSxwzA+uCAoJkAngIOhQjsvvz8eZKgDrCZAHwHwMBIppAAmVwR3C1BEYMuQEgcL3gSSBoiEIL0uBJIGhAGhQhsPvx8IAAYGTcSAg4IGQK4NhJIGhAGhQhsPvx8IAAYGTUSAg4IGQCIIT4JQAgaAVoR/bwcIVD1OkCAQhDIWkIQ2FpCEOhaQhD4WkIQyFqCEMFQyBoBWAgRv/3pf+gaLD1gE8B0QAgYGAgeaFsCGDU6RMQSGBgaGCxYGgEKAnYIEb/94H/ACBhbQhg1OkWEEhgA+AAIGBloGXgZQAg4GMBIIT4JQAAIIT4JAAAv5/nELUERgy5ASAQvSBoAGgg8AEAIWgIYKtJIGiIQgvSq0kgaEAaFCGw+/HwgABgZKdICDggZArgo0kgaEAaFCGw+/HwgABgZJ9ICDggZAAgIWgIYJT4RAAA8BwBASCIQCFsSGAgRv/3SP8AIKFsCGDU6RMQSGBgaFixYGgEKAjYIEb/9yr/ACBhbQhg1OkWEEhgACBgZaBl4GXgYiBjYGOgY+BjhPglAAC/hPgkAAC/AL+q5zC10OkTVGxgRG0UsdDpFlRsYJD4REAE8BwFASSsQAVsbGAEaGNghGgQLATRBGiiYARo4WAD4ARooWAEaOJgML0t6fBBBEYNRhZGH0ZP8AAIAL+U+CQAASgC0QIgvejwgQEghPgkAAC/lPglAAEoF9ECIIT4JQAAIOBjIGgAaCDwAQAhaAhgO0YyRilGIEb/97f/IGgAaEDwAQAhaAhgBuAAvwAghPgkAAC/T/ACCEBG1Oct6fBBBEYNRhZGH0ZP8AAIAL+U+CQAASgC0QIgvejwgQEghPgkAAC/lPglAAEoP9ECIIT4JQAAIOBjIGgAaCDwAQAhaAhgO0YyRilGIEb/937/IGswsSBoAGhA8A4AIWgIYAvgIGgAaCDwBAAhaAhgIGgAaEDwCgAhaAhgoGwAaAD0gDAosaBsAGhA9IBwoWwIYGBtKLFgbQBoQPSAcGFtCGAgaABoQPABACFoCGAG4AC/ACCE+CQAAL9P8AIIQEas5wFGACKR+CUAAigI0AQgyGMAvwAggfgkAAC/ASBwRwhoAGgg8A4AC2gYYIhsAGgg9IBwi2wYYAhoAGgg8AEAC2gYYJH4RAAA8BwDASCYQAtsWGDR6RMwWGBIbUCxSG0AaCD0gHBLbRhg0ekWMFhgASCB+CUAAL8AIIH4JAAAvxBGzOdwtQRGACWU+CUAAigM0AQg4GMBJT3gAAAACQJACAQCQAAIAkAIAAJAIGgAaCDwDgAhaAhgIGgAaCDwAQAhaAhgoGwAaCD0gHChbAhglPhEAADwHAEBIIhAIWxIYNTpExBIYGBtQLFgbQBoIPSAcGFtCGDU6RYQSGABIIT4JQAAvwAghPgkAAC/oGsQsSBGoWuIRyhGcL0t6fBBBEYORhVGlPglAAIoCdAEIOBjAL8AIIT4JAAAvwEgvejwgSBoAGgA8CAAILFP9IBw4GMBIPPnPrmU+EQAAPAcAQIgAPoB+AbglPhEAADwHAEEIAD6Afj/99/5B0Yw4CBsAGiU+EQQAfAcAgghkUAIQJCxlPhEAADwHAEBIIhAIWxIYAEg4GOE+CUAAL8AIIT4JAAAvwEgwudoHIix//e8+cAbqEIA2F25ICDgYwEghPglAAC/ACCE+CQAAL8BIK7nIGwAaADqCAAAKMjQYG2IsaBtAGjhbQhAYLFgbQBoQPSAcGFtCGDU6RYQSGDga0D0gGDgY+BsAGghbQhAMLHU6RMQSGDga0D0AHDgY4a5lPhEAADwHAECIIhAIWxIYAC/ACCE+CQAAL8BIIT4JQAH4JT4RAAA8BwBBCCIQCFsSGAAIGzncLUERiBsBWggaAZolPhEAADwHAEEIIhAKEDgsQbwBADIsSBoAGgA8CAAKLkgaABoIPAEACFoCGCU+EQAAPAcAQQgiEAhbEhgIGsAKFbQIEYha4hHUuCU+EQAAPAcAQIgiEAoQBizBvACAACzIGgAaADwIABAuSBoAGgg8AoAIWgIYAEghPglAJT4RAAA8BwBAiCIQCFsSGAAvwAghPgkAAC/4GpQsyBG4WqIRybglPhEAADwHAEIIIhAKEDwsQbwCADYsSBoAGgg8A4AIWgIYJT4RAAA8BwBASCIQCFsSGABIOBjhPglAAC/ACCE+CQAAL9gaxCxIEZha4hHcL0QtQNGACQAv5P4JAABKAHRAiAQvQEgg/gkAAC/k/glAAEoEtExsQEpBtACKQbQAykI0QXg2mIH4BpjBeBaYwPgmmMB4AEkAL8A4AEkAL8AIIP4JAAAvyBG2+cCRgAjAL+S+CQAASgB0QIgcEcBIIL4JAAAv5L4JQABKBvRBSkW0t/oAfADBgkMDwAAINBiEOAAIBBjDeAAIFBjCuAAIJBjB+AAINBiEGNQY5BjAeABIwC/AOABIwC/ACCC+CQAAL8YRtLnAUaR+CUAcEcBRshrcEcAAHi1AkYAI9rgASaeQA1oBeoGBAAsctBNaAEtCNBNaAItBdBNaBEtAtBNaBItE9GQaF4AAyW1QKhDXgDNaLVAKEOQYFBoASWdQKhDDXnF8wAVnUAoQ1Bg0GheAAMltUCoQ14AjWi1QChD0GBNaAItAtBNaBItE9HeCALxIAVV+CYAXQfuDg8ltUCoQ14H9g4NabVAKEPeCALxIAVF+CYAEGheAAMltUCoQw15BfADBV4AtUAoQxBgTWgF8IBVtfGAX3zRAL+oTS1uRfABBaZONWY1Ri1uBfABBQCVAL8Av0/qtjWeCFX4JgCdBy4PDyW1QKhDsvGQTwLRACUk4F7gm02qQgHRASUe4JlNqkIB0QIlGeCYTapCAdEDJRTglk2qQgHRBCUP4JVNqkIB0QUlCuCTTapCAdEGJQXgkk2qQgHRByUA4Aglngc2D7VAKEOOTZ4IRfgmAI1NKGigQ01oBfSANbX1gD8A0SBDiE0oYC0dKGigQ01oBfQANbX1AD8A0SBDgk0tHShgLR0oaKBDTWgF9IAVtfWAHwDRIEN7TQg1KGAtHShooENNaAX0ABW19QAfANEgQ3VNDDUoYFscDWjdQAAtf/Qgr3i98LULRgAhh+ABJY1ABeoDAgAqftBqTY4IVfgmQI0HLg8PJbVALECw8ZBPAdEAJSPgXE2oQgHRASUe4FpNqEIB0QIlGeBZTahCAdEDJRTgV02oQgHRBCUP4FZNqEIB0QUlCuBUTahCAdEGJQXgU02oQgHRByUA4Agljgc2D7VApUIh0U9NLWiVQ05ONWA1HS1olUM2HTVgNR0taJVDNh01YDUdLWiVQzYdNWCNBy4PDyUF+gb0Qk2OCFX4JlClQz9OjwhG+CdQBWhPAAMmvkA1QwVgzggA8SAFVfgmUE4H9w4PJr5AtUPPCADxIAZG+CdQhWhPAAMmvkC1Q4VgRmgBJY1ArkNGYMVoTwADJr5AtUMA4ADgxWBJHCP6AfUALX/0c6/wvQJGE2kLQAuxASAA4AAgcEcKsYFhAOCBYnBHELVCaSHqAgMC6gEEQ+oEQ4NhEL0ItQJGT/SAMACQAJgIQwCQAJjQYdFhAJjQYdBpAJDQaQD0gDAIsQAgCL0BIPzncEcQtQRGDkgUMABoIEAosQxIFDAEYCBG//fy/xC9ABACQAAEAEgACABIAAwASAAQAEgAFABIABgASAAcAEgIAAFAAAQBQHxIgGtA8IBQekmIYwhGgGsg8IBQiGNwR3dIAGhA9IBwdUkIYHBHdEgAaCD0gHBySQhgcEcBRnBIQGgg8A4ACmgQQ21KUGBtSABoIPSAMGtKEGAQHwBoIPSAMBIfEGBnSAgwAGgg9IAwZEoIMhBgEB8AaCD0gDASHxBgSGgA9IAwsPWAPwfRXUgAHwBoQPSAMFpKEh8QYEhoAPQAMLD1AD8F0VZIAGhA9IAwVEoQYAh5APABADixUUgAHQBoQPSAME5KEh0QYAh5APACAAIoB9FKSAgwAGhA9IAwSEoIMhBgACBwR0RIQGhA8AEAQklIYHBHQUhAaCDwAQA/SUhgcEc9ScloAPAfApFDQepQETpK0WARRoloAPAfAhFDNkqRYHBHNUmJaADwHwKRQzJKkWBwR3C1BEYNRlS5L0hAaQD0AHCw9QB/CtEA8MT8OLFwvSlIQGnA80AgCLkA8LT8KEgAaCDwBAAmSQhgAS0B0TC/AuBAvyC/IL8Av+jncLUFRgxGtfWATwPRIEYA8OL8AuAgRgDwxPxwvRdIAGgg8AcAwBwVSQhgFkgAaEDwBAAUSQhgAL8AvzC/cEcRSABoQPACAA9JCGBwRw1IAGgg8AIAC0kIYHBHCkgAaEDwEAAISQhgcEcGSABoIPAQAARJCGBwR3BHABACQABwAEAEBAFAEO0A4PhIAGgA9MBgsPWAbwLRT/SAYHBH80iAMABoAPSAcLD1gH8C0U/0AHDz5wAg8ecCRpK77EgAaAD0wGCw9YBvLNHoSIAwAGgg9IBw5kvD+IAAGEYAaCD0wGBA9ABwGGDiSEhEAGgyI1hD4Euw+/PwQRwA4Eke20hAaQD0gGCw9YBvAdEAKfXR10hAaQD0gGCw9YBvUtEDIHBHCODSSIAwAGgg9IBwz0vD+IAARuCy9QB/O9HMSABoAPTAYLD1gG8r0chIgDAAaED0gHDGS8P4gAAYRgBoIPTAYED0AHAYYMJISEQAaDIjWEPAS7D78/BBHADgSR67SEBpAPSAYLD1gG8B0QAp9dG3SEBpAPSAYLD1gG8S0QMgvueySIAwAGhA9IBwsEvD+IAAB+CuSABoIPTAYED0gGCrSxhgACCr56lJyWgh9ABxAUOmStFgEUbJaEH0gHHRYHBHokjAaCD0gHCgSchgcEefSEBoQPSAYJ1JSGBwR5tIQGgg9IBgmUlIYHBHmEhAaED0AHCWSUhgcEeUSEBoIPQAcJJJSGBwR5FIgGhA9ABAj0mIYHBHjUiAaCD0AECLSYhgcEcQtQJGACAJKnHS3+gC8AUUISs1P0lTYACESxtqIfSARCNDgUwjYiNGW2oh9CBEo0N+TGNiXeB8S5tqC0N7TKNiI0bbaiHwEASjQ3dM42JQ4HZLG2sLQ3RMI2MjRltri0NjY0bgcUubawtDb0yjYyNG22uLQ+NjPOBsSxtsC0NqTCNkI0ZbbItDY2Qy4GdLm2wLQ2VMo2QjRttsi0PjZCjgYksbbQtDYEwjZSNGW22LQ2NlHuBdS5ttjLIjQ1tMo2UjRtttjLKjQ1hM42UR4FZLG27B8wsEI0NUTCNmI0ZbbsHzCwSjQ1BMY2YC4P/nASAAvwC/EL0QtQJGACAJKkHS3+gC8AUNExkfJSsxOABGSxtqIfSARKNDREwjYjTgQkubaotDQUyjYi7gP0sba4tDPkwjYyjgPEuba4tDO0yjYyLgOUsbbItDOEwjZBzgNkubbItDNUyjZBbgM0sbbYtDMkwjZRDgMEubbYyyo0MuTKNlCeAtSxtuwfMLBKNDKkwjZgHgASAAvwC/EL0QtQJGACAJKnbS3+gC8AUUICo0Pk5YZQAhS1tqIfQgRCNDHkxjYiNGG2oh9IBEo0MbTCNiYuAZS9tqIfAQBCNDF0zjYiNGm2qLQ6NiVuATS1trC0MSTGNjI0Yba4tDI2NM4A5L22sLQw1M42MjRptri0OjY0LgCUtbbAtDCExjZCNGG2yLQyNkOOAES9tsC0MDTONkI0abbItDo2Qu4ABwAEAQAAAAQEIPAP5LW20LQ/1MY2UjRhtti0MjZR7g+UvbbYyyI0P3TONlI0abbYyyo0P0TKNlEeDzS1tuwfMLBCND8ExjZiNGG27B8wsEo0PtTCNmAuD/5wEgAL8AvxC9ELUCRgAgCSpD0t/oAvAFDRUbISctMzoA40tbaiH0IESjQ+BMY2I24N9L22oh8BAEo0PcTONiLuDbS1tri0PZTGNjKODYS9tri0PWTONjIuDVS1tsi0PTTGNkHODSS9tsi0PQTONkFuDPS1tti0PNTGNlEODMS9ttjLKjQ8pM42UJ4MhLW27B8wsEo0PGTGNmAeABIAC/AL8QvcJIgGhA9IBgwEmIYHBHv0iAaCD0gGC9SYhgcEcBRjG5ukiAaCD0QHC4SpBgGeCx9YB/CNG1SIBoIPRAcED0gHCySpBgDeCx9QB/CNGvSIBoIPRAcED0AHCsSpBgAeABIHBHACD85wC1T/SAcP/31v8AvQC1ACD/99H/AL2jSIBoQPQAYKFJiGBwR6BIgGgg9ABgnkmIYHBHnEjAaED0AFCaSchgcEeZSMBoIPQAUJdJyGBwR5VIAGhA8BAAk0kIYHBHkkgAaCDwEACQSQhgcEeOSEBoQPAQAIxJSGBwR4tIQGgg8BAAiUlIYHBHh0hAaEDwIACFSUhgcEeESEBoIPAgAIJJSGBwR4BIQGhA8EAAfklIYHBHfUhAaCDwQAB7SUhgcEd5SEBoQPCAAHdJSGBwR3ZIQGgg8IAAdElIYHBHAUYAIApoECoG0CAqUtBAKn7QgCp90fDgbUoSaCLwCAJrSxpgGh8SaCLwCAIbHxpgZ0oIMhJoIvAIAmVLCDMaYBofEmgi8AgCGx8aYEpoAvSAMrL1gD8H0V1KEh8SaELwCAJbSxsfGmBKaAL0ADKy9QA/BdFWShJoQvAIAlRLGmAKeQLwAQI6sVFKEh0SaELwCAJPSxsdGmAKeQLwAgICKgfRS0oIMhJoQvAIAkhLCDMaYPTgRkoSaCLwEAJESxpgGh8SaCLwEAIbHxpgQEoIMhJoIvAQAj5LCDMaYBofEmgi8BACGx8aYEpoAvSAMrL1gD8H0TZKEh8SaELwEAI0SxsfGmBKaAL0ADKy9QA/AeAh4MLgBdEuShJoQvAQAixLGmAKeQLwAQI6sSlKEh0SaELwEAImSxsdGmAKeQLwAgICKgfRIkoIMhJoQvAQAiBLCDMaYKPgHkoSaCLwIAIcSxpgGh8SaCLwIAIbHxpgGEoIMhJoIvAgAhVLCDMaYBofEmgi8CACGx8aYEpoAvSAMrL1gD8H0Q5KEh8SaELwIAILSxsfGmBKaAL0ADKy9QA/BdEHShJoQvAgAgVLGmAKeQLwAQJasQJKEh0D4ABwAEAkBAFAEmhC8CACmksaYAp5AvACAgIqB9GWShIdEmhC8CAClEsbHRpgUeCSShIfEmgi8EACj0sbHxpgGh8SaCLwQAIbHxpgi0oSHRJoIvBAAohLGx0aYBofEmgi8EACGx8aYEpoAvSAMrL1gD8H0YFKCDoSaELwQAJ+Swg7GmBKaAL0ADKy9QA/B9F6ShIfEmhC8EACd0sbHxpgCnkC8AECKrF0ShJoQvBAAnJLGmAKeQLwAgICKgfRbkoSHRJoQvBAAmxLGx0aYAHgASAAvwC/cEdpSABoQPSAQGdJCGBwR2VIAGgg9IBAY0oQYGNISEQAaDIiUENiSrD78vBBHADgSR5dSEBpAPQAcLD1AH8B0QAp9dFYSEBpAPQAcLD1AH8B0QMgcEcAIPznU0kJaCHwBwFRShFgU0kJaEHwBAFRShFgASgB0TC/AuBAvyC/IL9MSQloIfAEAUpKEWBwR0ZJCWgh8AcBSRxDShFgRUkJaEHwBAFDShFgASgB0TC/AuBAvyC/IL8/SQloIfAEAT1KEWBwRzhJCWgh8AcBiRw2ShFgOEkJaEHwBAE2ShFgASgB0TC/AuBAvyC/IL8xSQloIfAEAS9KEWBwRytIAGgg8AcAAB0oSQhgKkgAaEDwBAAoSQhgAL8AvzC/cEdwR3BHcEdwRxC1H0gUOABoAPSAMDCx//f8+k/0gDAaSRQ5CGAYSAwwAGgA8AgAKLH/9+n/CCAUSQwxCGASSAwwAGgA8BAAKLH/99z/ECAOSQwxCGAMSAwwAGgA8CAAKLH/98//ICAISQwxCGAGSAwwAGgA8EAAKLH/98L/QCACSQwxCGAQvQAAKAQBQABwAEAQAAAAQEIPABDtAOAQtfxIAGhA8AEA+kkIYP73cvgERgbg/vdu+AAbAigB2QMgEL3zSABoAPACAAAo8tDwSABoIPDwAEDwYADtSQhgACCIYOxI7UlJRAhg7EhIRABo/vdU+AixASDi5/73S/gERgjg/vdH+AAbQfKIMYhCAdkDINXn30iAaADwDAAAKPDR3EgAaN9JCEDaSQhg/vcy+ARGBuD+9y74ABsCKAHZAyC+59NIAGgA8ChQACjy0dBJyGAIRsBoQPSAUMhgACAIYQhGAGlA9IBQCGEAIEhhCEZAaUD0gFBIYQhGAGgg9IAgCGAAIIhhQB4IYsFIlDAAaED0AADB+JQAACCR5/C1ACMAIN/47MLc+AjADPAMAd/44MLc+AzADPADBxmxDCkf0QEvHdHf+MzC3PgAwAzwCAy88QAPBtHf+LjC3PiUwMzzAyMF4N/4rMLc+ADAzPMDE9/4tML8RFz4IzBBuRhGBuAEKQHRqUgC4AgpANGoSAwpMtHf+HzC3PgMwAzwAwQBLAnQAiwC0AMsBNEB4J9KBOCfSgLgAL8aRgC/AL/f+FTC3PgMwMzzAxwM8QEG3/hEwtz4DMDM8wYsDPsC/Lz79vLf+DDC3PgMwMzzQWwM8QEMT+pMBbL79fDwvfi1BEYAJoRIgG0A8IBQGLH/98z5BUYW4AC/f0iAbUDwgFB9SYhlCEaAbQDwgFAAkAC/AL//97r5BUZ3SIBtIPCAUHVJiGW19QB/B9GALAzZoCwB2QImCOABJgbggCwB0wImAuBwLADRASZzSABoIPAPADBDcEkIYAhGAGgA8A8AsEIB0AEg+L0AIPznLen4RQRGFLkBIL3o+IVfSIBoAPAMBl1IwGgA8AMHIHgA8BAAECh60R6xDC550QEvd9FWSABoAPACABix4GkIuQEg4udRSGFqAGgA8AgAILFOSABoAPDwAAXgTEiUMABoAPRwYAAJgUIf2WBq//eC/wixASDJ5wC/REgAaEDwCABCSQhgCEYAaCDw8ABhaghDPkkIYAC/CEZAaCD0f0AhakDqASA5SUhgH+AAvzdIAGhA8AgANUkIYAhGAGgg8PAAYWoIQzFJCGAAvwhGQGgg9H9AIWpA6gEgLElIYC65YGr/90j/CLEBII/n//fU/idJiWjB8wMRLkp6RFFcAfAfAchAJElJRAhgI0hIRABo/ffC/oJGuvEAD2PQUEZ152Dg/+fgaYCzGUgAaEDwAQAXSQhg/fes/gVGBuD996j+QBsCKAHZAyBg5xBIAGgA8AIAACjy0AC/DUgAaEDwCAALSQhgCEYAaCDw8ABhaghDB0kIYAC/CEZAaCD0f0AhakDqASACSUhgLOAU4AAAABACQAAJPQAQAAAACAAAAP/0/uqGVgAAACT0AAASegAAIAJAZFQAAP5IAGgg8AEA/EkIYP33Zf4FRgbg/fdh/kAbAigB2QMgGef2SABoAPACAAAo8tEgeADwAQAAKFzQCC4D0AwuCtEDLwjR7UgAaAD0ADCIs2BoeLsBIP/mAL9gaLD1gD8G0eZIAGhA9IAw5EkIYBrgYGiw9aAvC9HhSABoQPSAIN9JCGAIRgBoQPSAMAhgCuDbSABoIPSAMNlJCGAIRgBoIPSAIAhgAL9gaJCx/fcW/gVGB+Ae4P33Ef5AG2QoAdkDIMnmzkgAaAD0ADAAKPLQEOD99wP+BUYG4P33//1AG2QoAdkDILfmxUgAaAD0ADAAKPLRIHgA8AIAAihS0QQuA9AMLhTRAi8S0bxIAGgA9IBgGLHgaAi5ASCd5rhIQGgg8P5AIXxA6gFgtElIYDng4GgAs7JIAGhA9IBwsEkIYP33zP0FRgbg/ffI/UAbAigB2QMggOapSABoAPSAYAAo8tCmSEBoIPD+QCF8QOoBYKNJSGAW4KFIAGgg9IBwn0kIYP33q/0FRgbg/fen/UAbAigB2QMgX+aZSABoAPSAYAAo8tEgeADwCAAIKHHRYGngs5JIlDDQ+ACACPAQAaBpiEIv0AjwAgACKATRCPABAAi5ASBA5gjwAQDIsYhIlDAAaCDwAQCFScH4lAD993b9BUYG4P33cv1AGxEoAdkDICrmfkiUMABoAPACAAAo8dF7SJQwAGgg8BAAoWkIQ3dJwfiUAHZIlDAAaADgF+BA8AEAcknB+JQA/fdQ/QVGBuD990z9QBsRKAHZAyAE5mtIlDAAaADwAgAAKPHQGeBnSJQwAGgg8AEAZUnB+JQA/fc1/QVGBuD99zH9QBsRKAHZAyDp5V5IlDAAaADwAgAAKPHRIHgA8AQABChz0U/wAAhXSIBtAPCAUHi5AL9USIBtQPCAUFJJiGUIRoBtAPCAUACQAL8Av0/wAQhNSABoAPSAcLC5S0gAaED0gHBJSQhg/ff8/AVGBuD99/j8QBsCKAHZAyCw5UJIAGgA9IBwACjy0CB6APABADizPEiQMABoIPCAACF6AfCAAQhDOEmQMQhgIHoA8AQAcLEIRgBoQPAEADJJwfiQAAhG0PiQAEDwAQDB+JAAF+AtSJAwAGhA8AEAKknB+JAADuAoSJAwAGgg8AEAJknB+JAACEbQ+JAAIPAEAMH4kACgaKix/feu/AVGCeA24P33qfxAG0HyiDGIQgHZAyBf5RlIkDAAaADwAgAAKO/QG+D995j8BUYI4P33lPxAG0HyiDGIQgHZAyBK5Q5IkDAAaADwAgAAKO/RC0iQMABoIPCAAAhJwfiQALjxAQ8F0QVIgG0g8IBQA0mIZQC/IHgA8CAAICgD4AAQAkAAcABANNGgasix+EgAaEDwAQD2SZg5wfiYAP33XvwFRgbg/fda/EAbAigB2QMgEuXuSABoAPACAAAo8tAY4OtIAGgg8AEA6UmYOcH4mAD990T8BUYG4P33QPxAGwIoAdkDIPjk4UgAaADwAgAAKPLR4GoAKH7Q4GoCKHzR20iYOMdoB/ADASBrgUIm0Qfw8AFga0AesesAHx/RB/T+QaBrsesALxnRB/B4QTwgAF2x68BvEtEH9MABQCAAWwEiwutQALHrQF8I0QfwwGFEIABdwutQALHrQG9t0AwuadDDSJg4AGgA8IBgKLnASJg4AGgA8IBQCLEBIK3kvEiYOABoIPCAcLlJmDkIYP335vsFRgbg/ffi+0AbAigB2QMgmuSySJg4AGgA8ABwACjx0dTpDBBAHkHqABGga0HqACFAIABbASLC61AAQepAUUQgAF3C61AAQepAYTwgAF1B6sBgokmYOclookoRQAhDn0mYOchgAeBk4ETgCEYAaEDwgHAIYAhGwGhA8IBwyGD996X7BUYG4P33oftAGwIoAdkDIFnkkkiYOABoAPAAcAAo8dBa4AEgT+SNSJg4AGgA8ABw8LuKSJg4AGhA8IBwh0mYOQhgCEbAaEDwgHDIYP33ffsFRgbg/fd5+0AbAigB2QMgMeR+SJg4AGgA8ABwACjx0DLgDC4u0HlImDgAaCDwgHB2SZg5CGAIRgBoAPAgUCC5CEbAaCDwAwDIYHBImDjAaHBJCEBtSZg5yGD99077AOAS4AVGBuD990j7QBsCKAHZAyAA5GVImDgAaADwAHAAKPHRAeABIBLkACAQ5HC1ACJeTpg+9mgG8AMGAS4U0VtOmD42aAbwCAYuuVhONh82aMbzAyIE4FVOmD42aMbzAxJVTn5EVvgiIFBOmD72aAbwAwMBKwnQAisC0AMrBNEB4E5JBOBOSQLgAL8RRgC/AL9GTpg+9mjG8wMWdRxDTpg+9mjG8wYmTkO2+/XxP06YPvZoxvNBZnYcdACx+/TwcL0t6fBBBEYNRgAnFLkBIL3o8IE8SABoAPAPAKhCDtI5SABoIPAPAChDNkkIYAhGAGgA8A8AqEIB0AEg6OcgeADwAQAAKHzQYGgDKDHRJ0iYOABoAPAAcAi5ASDY5//3hv8pSYhCYNkhSJg4gGgA8PAAWLkeSJg4gGgg8PAAQPCAABpJmDmIYIAnTuAgeADwAgACKEnRoGhAuxRImDiAaCDw8ABA8IAAEUmYOYhggCc74GBoAigH0Q1ImDgAaAD0ADAguwEgo+dgaDi5CEiYOABoAPACANC5ASCZ5wRImDgAaAD0gGCQuQEgkecd4JgQAkAMgJ0B///u/h5NAAAAJPQAABJ6AAAgAkAAtMQE//dp+t9JiEII2d9IgGgg8PAAQPCAANxJiGCAJ9pIgGgg8AMAYWgIQ9dJiGD990/6BkYJ4BDg/fdK+oAbQfKIMYhCAdkDIFznz0iAaADwDABhaLDrgQ/u0SB4APACAAIoCNHJSIBoIPDwAKFoCEPGSYhgB+CALwXRw0iAaCDw8ADBSYhgwUgAaADwDwCoQg7ZvkgAaCDwDwAoQ7xJCGAIRgBoAPAPAKhCAdABICnnIHgA8AQABCgH0bNIgGgg9OBg4WgIQ7BJiGAgeADwCAAIKAjRrUiAaCD0YFAhaUDqwQCpSYhg//f3+adJiWjB8wMRp0p6RFFcAfAfAchApUlJRAhgpUhIRABo/ffl+YBGQEb35nC1hrAGRg1GFEYAv5pIwGxA8AEAmEnIZAhGwGwA8AEAAJAAvwC/iBUBkAIgApAEkAAgA5AFkAGpT/CQQP73PfmNSIBoIPD+QEXqBAEIQ4lJiGAGsHC9ikhIRABocEcAtf/3+f+ESYlowfMCIYdKekRRXAHwHwHIQAC9ALX/9+v/fUmJaMHzwiGASnpEHDpRXAHwHwHIQAC9PyEBYHZJCWgB9IAhsfWALwPRT/SgIUFgDOBwSQloAfSAMbH1gD8D0U/0gDFBYAHgACFBYGpJCWgB8AEBEbEBIcFhAeAAIcFhZUlJaMHzByEBYmJJCWgB8PABQWJgSQloAfSAcbH1gH8D0U/0gHHBYAHgACHBYFlJSWjB8wZhAWFXSZAxCWgB8AQBBCkM0VNJkDEJaAHwgAGAKQLRhSGBYBfgBSGBYBTgTUmQMQloAfABAWGxSkmQMQloAfCAAYApAtGBIYFgBOABIYFgAeAAIYFgQkmUMQloAfABARGxASFBYQHgACFBYT1JlDEJaAHwEAEQKQHRgWEB4AAhgWE3SZgxCWgB8AEBEbEBIYFiAeAAIYFiMkkJaAHwgHGx8YB/AtECIcFiAeABIcFiLEnJaAHwAwICYylJyWjB8wMRSRxBYyZJyWjB8wYigmMkSclowfNBUUkcSgACZCBJyWjB80FhSRxKAEJkHUnJaMoOwmNwRw8iAmAZSpJoAvADAkJgF0qSaALw8AKCYBRKkmgC9OBiwmASSpJoAvRgUtIIAmEQShJoAvAPAgpgcEcMSABoQPQAIApJCGBwR3BHELUHSMBpAPSAcLD1gH8F0f/39f9P9IBwAkkIYhC9ALTEBAAQAkAAIAJAqkoAABAAAAAIAAAALEoAAC3p8EEERg9GACX+SMBoAPADAFCx+0jAaADwAwAhaIhCAdEgaHi7ASUt4CBoASgE0AIoCdADKBrRDeDySABoAPACAAC5ASUU4O5IAGgA9IBgALkBJQ3g60gAaAD0ADAouehIAGgA9IAgALkBJQHgASUAvwC/PbnjSMBoIPADACFoCEPgSchgAC1z0d5IAGgg8IBQ3EkIYP33SvgGRgbg/fdG+IAbAigB2QMlBeDVSABoAPAAUAAo8tEAvwAtWdGHuaBoAAIhe0DqwWFgaEAeQeoAEMxJSWnMShFACEPJSUhhKOABLxPRoGgAAiGKASLC61EBQOpBUWBoQB5B6gAQwUlJacJKEUAIQ75JSGES4KBoAAIhfQEiwutRAUDqQWFgaEAeQeoAELdJSWm5ShFACEO0SUhhs0gAaEDwgFCxSQhg/Pf1/wZGBuD89/H/gBsCKAHZAyUF4KtIAGgA8ABQACjy0AC/LbmnSEBpoWkIQ6VJSGEoRr3o8IEt6fBBBEYPRgAloEjAaADwAwBQsZ1IwGgA8AMAIWiIQgHRIGh4uwElLeAgaAEoBNACKAnQAyga0Q3glEgAaADwAgAAuQElFOCQSABoAPSAYAC5ASUN4I1IAGgA9AAwKLmKSABoAPSAIAC5ASUB4AElAL8Avz25hUjAaCDwAwAhaAhDgknIYAAtc9GASABoIPCAYH5JCGD8947/BkYG4Pz3iv+AGwIoAdkDJQXgd0gAaADwAGAAKPLRAL8ALVnRh7mgaAACIXtA6sFhYGhAHkHqABBuSQlpbkoRQAhDa0kIYSjgAS8T0aBoAAIhigEiwutRAUDqQVFgaEAeQeoAEGNJCWlkShFACENgSQhhEuCgaAACIX0BIsLrUQFA6kFhYGhAHkHqABBZSQlpW0oRQAhDVkkIYVVIAGhA8IBgU0kIYPz3Of8GRgbg/Pc1/4AbAigB2QMlBeBNSABoAPAAYAAo8tAAvy25SUgAaaFpCENHSQhhKEa96PCBLen4RQRGACWoRiCIAPQAYLD1AG8y0eBuQCgJ0APccLEgKBvREeBgKBbQgCgW0RTgOEjAaED0gDA2SchgEOAAISAd//ch/wVGCuAAIQTxIAD/917+BUYD4AC/AeABJQC/AL9VuStInDAAaCDw4ADhbghDKEnB+JwAAOCoRiCIAPSAULD1gF820SBvsPUAfwzQBNyIsbD1gH8d0RPgsPVAfxfQsPWAbxbRFOAaSMBoQPSAMBhJyGAQ4AAhIB3/9+T+BUYK4AAhBPEgAP/3If4FRgPgAL8B4AElAL8Av1W5DUicMABoIPTgYCFvCEMJScH4nAAA4KhGIGgA9AAwsPUAP2vRT/AACgNIgG0BISHqEHDAsQfgABACQA+A/wcPgJ//D4D/+QC//kiAbUDwgFD8SYhlCEaAbQDwgFAAkAC/AL9P8AEK90gAaED0gHD1SQhg/Pd1/gdGBuD893H+wBsCKAHZAyUF4O9IAGgA9IBwACjy0AC/hbvqSJAwAGgA9EB21rHU+JQAsEIW0OVIkDAAaCD0QHbiSND4kABA9IAw4EnB+JAACEbQ+JAAIPSAMMH4kAAIRsD4kGAG8AEAsLH89z7+B0YK4Pz3Ov7AG0HyiDGIQgPZAyUI4BfgIeDQSJAwAGgA8AIAACjt0AC/XbnMSJAwAGgg9EBw1PiUEAhDyEnB+JAAAuCoRgDgqEa68QEPBdHDSIBtIPCAUMFJiGUAvyB4APABAEixvUiIMABoIPADAOFrCEO6ScH4iAAgeADwAgACKAnRtkiIMABoIPAMACFsCEOyScH4iAAgeADwBAAEKAnRrkiIMABoIPAwAGFsCEOrScH4iAAgeADwCAAIKAnRp0iIMABoIPDAAKFsCEOjScH4iAAgeADwEAAQKAnRn0iIMABoIPRAcOFsCEOcScH4iAAgeADwIAAgKAnRmEiIMABoIPRAYCFtCEOUScH4iAAgiAD0AHCw9QB/CdGQSIgwAGgg9EAgYW4IQ4xJwfiIACCIAPSAYLD1gG8J0YhIiDAAaCD0QBChbghDhEnB+IgAIHgA8EAAQCgJ0YBIiDAAaCD0QFBhbQhDfUnB+IgAIHgA8IAAgCgJ0XlIiDAAaCD0QEChbQhDdUnB+IgAIIgA9IBwsPWAfwnRcUiIMABoIPRAMOFtCENtScH4iAAgaAD0gBCw9YAfCdFpSJwwAGgg8AMAIW4IQ2VJwficACCIAPQAULD1AF8f0WFIiDAAaCDwQGBhbwhDXUmIMQhgYG+w8QBvBtFaSMBoQPSAEFhJyGAK4GBvsPGAbwbRASEgHf/3Wv0FRgWxqEYgaAD0ACCw9QAvQdEAv6BvsPWATwjRS0icMABoQPSAQElJwficABHgR0icMABoIPSAQERJwficAENIiDAAaCDwQGChbwhDP0nB+IgAAL+gb7DxAG8G0TtIwGhA9IAQOUnIYBXgoG+w9YBPBtE2SMBoQPSAMDRJyGAK4KBvsPGAbwbRASEgHf/3Ev0FRgWxqEYgaAD0gCCw9YAvH9EqSIgwAGgg8EBg4W8IQyZJiDEIYOBvsPEAbwbRI0jAaED0gBAhSchgCuDgb7DxgG8G0QEhIB3/9+z8BUYFsahGIIgA9IBAsPWATxbRF0iIMABoIPBAUNT4gBAIQxNJiDEIYNT4gACw8YBfBtECISAd//fP/AVGBbGoRiBoAPSAMLD1gD8K0QhInDAAaCDwBADU+IQQCEMEScH4nAAgaAD0ABCw9QAfD9ED4AAQAkAAcABA/kicMABoIPAYANT4iBAIQ/pJwficACBoAPSAALD1gA8r0fZIAGgg8IBQ9EkIYPz3cvwHRgbg/Pdu/MAbAigB2QMlBeDtSABoAPAAUAAo8tEAv4W56UicMABoIPRAMNT4jBAIQ+VJwficAAIhBPEgAP/3uvsFRgWxqEYgaADwgHCw8YB/FdHdSJwwAGgg9EAQ1PiQEAhD2UmcMQhg1PiQALD1AB8F0dVIwGhA9IAQ00nIYEBGvej4hdBJyWgB8AMBQWDOSQlpwfMDEUkcgWDLSQlpwfMGIsJgyEkJacHzQEEHIgLrARICYcRJCWnB80FRSRxKAEJhwUkJacHzQWFJHEoAgmFBaAFivElJacHzAxFJHEFiuUlJacHzBiKCYrdJSWnB80BBByIC6wESwmKzSUlpwfNBUUkcSgACY69JSWnB80FhSRxKAEJjrEmIMQloAfADAcFjqUmIMQloAfAMAQFkpkmIMQloAfAwAUFko0mIMQloAfDAAYFkoEmIMQloAfRAccFknUmIMQloAfRAYQFlmkmIMQloAfRAUUFll0mIMQloAfRAQYFllEmIMQloAfRAMcFlkUmcMQloAfADAQFmjkmIMQloAfRAIUFmi0mIMQloAfRAEYFmiEmcMQloAfDgAcFmhUmcMQloAfTgYQFngkmQMQloAfRAccD4lBB+SYgxCWgB8EBhQWd7SZwxCWgB9IBBEbFP9IBBBOB3SYgxCWgB8EBhQPh4H3NJ0fiIEAHwQGFBYHBJ0fiIEAHwQFGBYG1J0ficEAHwBAHBYGpJ0ficEAH0QDFBYWdJ0ficEAH0QBGBYXg4cEfwtQVGDkYAIAAhACS19QBvCdFfT5w3P2gH8OABYCkP0Uv2gDAM4LX1gF8J0VhPnDc/aAf04GGx9UB/AdFL9oAwACgt0TJGQCkC0LH1AH8o0U9PP2gH8AB3t/EAf/HRTE//aAf0gDcAL3/QSU//aMfzAxd/HLL79/JFT/9ox/MGI0NP/2j8Djy5QU//aAf0ADcPsREkAOAHJAL7A/e3+/TwY+BBuzpPP2gH8ABnt/EAb1vRN08/aQf0gDcAL1XQNE8/acfzAxd/HLL79/IwTz9px/MGIy5PP2n8Djy5LE8/aQf0ADcPsREkAOAHJAL7A/e3+/TwOeCAKQLQsfWAbwjRI08/aAf0gGe39YBvLdEhSCvgICkC0LH1gH8m0RxPP2gH8ABXt/EAXx/RGU9/aQf0gDfXsRZPf2nH8wMXfxyy+/fyE09/acfzBiMRT39p/A48uQ9Pf2kH9AA3D7ERJADgByQC+wP3t/v08PC9LenwTQdGT/AAC7f1AD8+0QRIkDAAaAD0QHS09YB/DNAE4AAAABACQAAk9AC09QB/DNC09UB/KNEc4PlIAGgA8AIAAigB0U/0AEsf4PRIAB0AaADwAgACKAvR8UgAHQBoAPAQABAoAtFP8PoLAeBP9PpLC+DqSJA4AGgA9AAwsPUAPwHR3/icswDgAL/34+RIkDjAaADwAwq68QEPBtC68QIPJNC68QMPOdEs4NxIkDgAaADwAgACKBfR2UiQOABoAPAIACix1kiQOABoAPDwAAXg00gAHQBoAPRwYAAJAAnRSXlEUfggUADgACUZ4MxIkDgAaAD0gGCw9YBvAdHLTQDgACUN4MZIkDgAaAD0ADCw9QA/AdHGTQDgACUB4AAlAL8Av7f1gG920BrcIC900AzcBC9y0ATcAS9w0AIvb9Hc4QgvbdAQL/nRW+JAL2rQgC9p0Lf1gH9n0Lf1AH/u0X3jt/WAP3zQDNy39QBvFtC39YBfGtC39QBfHtC39YBP3dGd4rf1gC8Y0Lf1AC9p0Lf1gB9n0LfxgH/Q0d7jKUZP9ABg//d2/oNGKuIpRk/0gFD/92/+g0Yj4gC/mEgIOABoAPBAZGyztPGAb1vQtPEAbyvQtPFAb37RkUiQOABoAPACAAIoFtGNSJA4AGgA8AgAKLGKSJA4AGgA8PAABeCHSAAdAGgA9HBgAAkACYlJeURR+CCwa+Bh4yLimuFB4fDjw+FZ4I3iruLP4nxIkDgAaADwAHCw8QB/I9F4SJA4wGgA9IAQsPWAHxvRdEiQOMBowPMGJgX7BvBxSZA5yWgC4GHiRuDT4sHzAxFJHLD78fVrSJA4wGjA80FQQBxAALX78Ps04GZIkDgAaADwAGCw8QBvH9FiSJA4AGkA9IAQsPWAHxfRXkiQOABpwPMGJgX7BvBaSZA5CWnB8wMRSRyw+/H1VkiQOABpwPNBUEAcQAC1+/D7C+AJ4FFICDAAaADwAgACKAHR3/hMsQDgAL8Av4njSkgMMABoAPSAQLD1gE800UZIkDgAaADwAHCw8QB/K9FCSJA4wGgA9IAwsPWAPyPRPkiQOMBowPMGJgX7BvA7SZA5yWjB8wMRSRyw+/H1N0iQOMBoT+rQaLjxAA8K0TNIkDjAaAD0ADAQsU/wEQgB4E/wBwi1+/j7meAsSAg4AGgA8EBk7LO08YBvX9C08QBvIdC08UBvfdEkSJA4AGgA8AIAAigW0SFIkDgAaADwCAAosR5IkDgAaADw8AAF4BtIAB0AaAD0cGAACQAJHkl5RFH4ILBq4BVIkDgAaADwAHCw8QB/IdERSJA4wGgA9IAQsPWAHxnRDUiQOMBowPMGJgDgSOAF+wbwCEmQOclowfMDEUkcsPvx9QRIkDjAaMDzQVBAHEAAtfvw+z/gkBACQJDQAwBCOwAAACT0AAASegAUOgAAAGzcAmI4AAD5SABoAPAAYLDxAG8b0fZIAGkA9IAQsPWAHxTR8kgAacDzBiYF+wbw70kJacHzAxFJHLD78fXsSABpwPNBUEAcQAC1+/D7C+AJ4OdImDAAaADwAgACKAHR3/iQswDgAL8Av7Hi4EiIMABoAPADBDSxASwI0AIsCtADLBzREeD+953+g0YY4P73PviDRhTg1kgAaAD0gGCw9YBvAdHf+FCzCuDRSJAwAGgA8AIAAigB0U/0AEsA4AC/AL+F4spIiDAAaADwDAQ0sQQsCNAILArQDCwc0RHg/vdj/oNGGOD+9xL4g0YU4MBIAGgA9IBgsPWAbwHR3/j4sgrgu0iQMABoAPACAAIoAdFP9ABLAOAAvwC/WeK0SIgwAGgA8DAENLEQLAjQICwK0DAsHNER4P73N/6DRhjg/ffm/4NGFOCqSABoAPSAYLD1gG8B0d/4oLIK4KVIkDAAaADwAgACKAHRT/QASwDgAL8Avy3inkiIMABoAPDABDSxQCwI0IAsCtDALBzREeD+9wv+g0YY4P33uv+DRhTglEgAaAD0gGCw9YBvAdHf+EiyCuCPSJAwAGgA8AIAAigB0U/0AEsA4AC/AL8B4ohIiDAAaAD0QHRMsbT1gH8K0LT1AH8L0LT1QH8c0RHg/vfc/YNGGOD994v/g0YU4HxIAGgA9IBgsPWAbwHR3/jssQrgd0iQMABoAPACAAIoAdFP9ABLAOAAvwC/0uFxSIgwAGgA9EBkTLG09YBvCtC09QBvC9C09UBvHNER4P73rf2DRhjg/fdc/4NGFOBlSABoAPSAYLD1gG8B0d/4jLEK4GBIkDAAaADwAgACKAHRT/QASwDgAL8Av6PhWUiIMABoAPBAVLTxgF8G0LTxQF8l0f33Nv+DRiLgUkgAaADwAGCw8QBvGdFOSABpAPCAcKCxTEgAacDzBiYF+wbwSUkJacHzAxFJHLD78fVFSABpwPNBYEAcQAC1+/D7AOAAvwC/b+E/SJwwAGgA8AQEHLn+92L9g0YC4P33A/+DRmHhOEiIMABoAPRAVDSxtPWAXwfQtPUAXxLRB+D+9z/9g0YO4P337v6DRgrgLkgAaAD0gGCw9YBvAdHf+LCwAOAAvwC/P+EnSIgwAGgA9EBENLG09YBPB9C09QBPEtEH4P73Hf2DRg7g/ffM/oNGCuAdSABoAPSAYLD1gG8B0d/4bLAA4AC/AL8d4RZIiDAAaAD0QDQ0sbT1gD8H0LT1AD8S0Qfg/vf7/INGDuD996r+g0YK4AxIAGgA9IBgsPWAbwHR3/gosADgAL8Av/vgBUicMABoAPADBFyxASwN0AIsGdEO4AAAABACQABs3AIAJPQA/vfU/INGDuD994P+g0YK4PlIAGgA9IBgsPWAbwHR3/jcswDgAL8Av9Tg80iIMABoAPRAJFSxtPWALwvQtPUALxzQtPVALy3RIuDE4P73rvyDRijg6EiUMABoAPACAAIoC9HlSJQwAGgA8BAAECgC0U/w+gsB4E/0+ksU4N5IAGgA9IBgsPWAbwHR3/hwswrg2UiQMABoAPACAAIoAdFP9ABLAOAAvwC/lODTSIgwAGgA9EAUTLG09YAfCtC09QAfG9C09UAfLNEh4P73b/yDRijgyUiUMABoAPACAAIoC9HFSJQwAGgA8BAAECgC0U/w+gsB4E/0+ksU4L9IAGgA9IBgsPWAbwHR3/jwsgrgukiQMABoAPACAAIoAdFP9ABLAOAAvwC/VeCzSJwwAGgA9EAUNLG09YAfB9C09QAfRNEf4P335v2DRkDgq0gAaADwAgACKBTRqEgAaADwCAAgsaVIAGgA8PAABeCjSJQwAGgA9HBgAAkACaFJeURR+CCwJOCdSABoAPAAcLDxAH8b0ZlIwGgA9IAQsPWAHxTRlkjAaMDzBiYF+wbwk0nJaMHzAxFJHLD78fWPSMBowPNBUEAcQAC1+/D7AOAAvwC/AeD/5wC/AL9YRr3o8I1wtQRGACaFSABoIPCAYINJCGD794z9BUYG4Pv3iP1AGwIoAdkDJgXgfEgAaADwAGAAKPLRAL+Gu2BoQB4AAaFoQOoBICGKASLC61EBQOpBUCF9wutRAUDqQWAhe0DqwWBuSQlpcEoRQAhDbEkIYQhGAGmhaQhDaUkIYQhGAGhA8IBgCGD791P9BUYH4Pv3T/1AGwIoAtkDJgbgBuBfSABoAPAAYAAo8dAAvzBGcL1wtQAlWkgAaCDwgGBYSQhg+/c2/QRGBuD79zL9ABsCKAHZAyUF4FFIAGgA8ABgACjy0QC/TkgAaVFJCEBMSQhhCEYAaADwCFAguQhGwGgg8AMAyGAoRnC9cLUERgAmQ0gAaCDwgFBBSQhg+/cJ/QVGBuD79wX9QBsCKAHZAyYF4DtIAGgA8ABQACjy0QC/hrtgaEAeAAGhaEDqASAhigEiwutRAUDqQVAhfcLrUQFA6kFgIXtA6sFgLUlJaS9KEUAIQypJSGEIRkBpoWkIQydJSGEIRgBoQPCAUAhg+/fQ/AVGB+D798z8QBsCKALZAyYG4AbgHkgAaADwAFAAKPHQAL8wRnC9cLUAJRhIAGgg8IBQFkkIYPv3s/wERgbg+/ev/AAbAigB2QMlBeAQSABoAPAAUAAo8tEAvwxIQGkPSQhACklIYQhGAGgA8CBgILkIRsBoIPADAMhgKEZwvQNJiWgh9ABBAUMBSpFgcEcAEAJAACT0AHYyAAAPgJ0B///u/vlJCWgh9HBhQeoAEfZKlDrC+JQQcEf0SAAfAGhA8CAA8UmUOcH4kABwR+9IAB8AaCDwIADsSZQ5wfiQAAhGgGkg9ABwiGFwR+dIAB8AaEDwIADlSZQ5wfiQAAhGgGlA9ABwiGHhSABoQPQAIN9JCGDeSAgwAGhA9AAg3EkIMQhgcEdwRxC12EiUOMBpAPQAcLD1AH8G0f/39P9P9ABw0kmUOQhiEL1wtYawBEYAJQAmAL/NSJQ4wGxA8AEAykmUOchkCEbAbADwAQAAkAC/AL8EIAGQAyACkAIgBJAAIAOQAalP8JBA/PeJ+79IlDiAbQDwgFCAuQC/u0iUOIBtQPCAULlJlDmIZQhGgG0A8IBQAJAAvwC/ASW1SABoAPSAcBC5/Pc//QEmr0gAHwBoIPBAcETwgHEIQ6tJlDnB+JAAAS4B0fz3Nf0BLQfRpkiUOIBtIPCAUKRJlDmIZQawcL04tQAkACWgSJQ4gG0A8IBQgLkAv5xIlDiAbUDwgFCaSZQ5iGUIRoBtAPCAUACQAL8AvwEklkgAaAD0gHAQufz3Af0BJZBIAB8AaCDwgHCOSZQ5wfiQAAEtAdH89/r8ASwH0YlIlDiAbSDwgFCGSZQ5iGU4vYRIlDgAaEDwBACCSZQ5CGBwR4BIlDgAaCDwBAB9SZQ5CGBwR3tKEDISaCLw/wJA6gETGkN3S5Q7w/ikIHBHdUqUOpJrQvCAcnJLlDuaYxpGkmsi8IBymmPQ6QAjGkODaELqAwHCaBFDAopB6gJBbEpRYBJoIvR8UkNpQuoDImhLGmAaRhJoQvBgAhpgcEdkSABoQPCAAGJJCGBwR2BJSWiJsgFgXkkJaMHzBSFBYFxJiWgJDIFgWkmJaAH0AEHBYHBHcLUFRgAk+/cv+wZGAL9oHDCx+/cp+4AbqEIA2AW5ASRPSIBoAPABADCxRPACBAC/ASBKSchgAL9JSIBoAPACAAIoBdFE8AQEAL9ESchgAL9DSIBoAPSAYLD1gG8G0UTwIAQAvwQgPUnIYAC/PEiAaAD0gHCw9YB/BtFE8AgEAL8EIDZJyGAAvzVIgGgA9ABwsPUAfwbRRPAQBAC/BCAvSchgAL8uSIBoAPAIAAgoA9EAvypJyGAAvwAsqNAgRnC9cEdwR3BHcEdwtQAlJEiEaAZoBPABAECxBvABACixASAfSchg//fv/zLgBPACAECxBvACACixAiAZSchg//fi/ybgBPAIAECxBvAIACixCCATSchg//fV/xrgBPAEALixBvAEAKCxBPSAcAixRfAIBQT0AHAIsUXwEAUE9IBgCLFF8CAFBCAFSchgKEb/97j/cL2UEAJAAAQBQABwAEAAYABAcEdwtQRGDkYVRgy5ASBwvZT4UQAouQAghPhQACBG//fv/wTxCAEgaAHwfv8xRqJoIGgC8DD4KUbjatTpAQIC8F34oWggaFD4IQBA8AEAomghaEH4IgABIIT4UQAAINbncEcQtQRGIEb/9/r/lOgHAAHw1/8AIIT4UQAAv4T4UAAAvxC9cEdwR/C1BEYNRhZGL0a0RpT4USABKgHQBCof0QC/lPhQAAEoAdECIPC9ASCE+FAAAL8CIIT4UQAZRgbgOHiM+AAADPEBDH8cSR4AKfbRhPhRIAC/ACCE+FAAAeABIOPnACDh5/C1BEYNRi5GF0aU+FEAASge0QC/lPhQAAEoAdECIPC9ASCE+FAAAL8CIIT4UQAZRgTgOHgwcH8cdhxJHgAp+NEBIIT4UQAAvwAghPhQAAHgASDk5wAg4uct6fBBBEaMRpBGHUZjRkFGlPhRcAEvAdAELyfRAL+U+FAAASgC0QIgvejwgQEghPhQAAC/AiCE+FEABfABBipGCOAYaAiAiRwYaAAMCICJHBsdkh6yQvTRDrEYaAiAhPhRcAC/ACCE+FAAAeABINvnACDZ5y3p8EEERg9GlEYdRjlGYkaU+FEAASgv0QC/lPhQAAEoAtECIL3o8IEBIIT4UAAAvwIghPhRAAXwAQYrRgvgEIgIYJIcCGiy+ACAQOoIQAhgkhwJHZses0Lx0S6xsvgAgAhoaPMPAAhgASCE+FEAAL8AIIT4UAAB4AEg0+cAINHn8LUERg1GFkYvRrRGlPhRIAEqAdAEKh/RAL+U+FAAASgB0QIg8L0BIIT4UAAAvwIghPhRABlGBuA4aMz4AAAM8QQMPx1JHgAp9tGE+FEgAL8AIIT4UAAB4AEg4+cAIOHn8LUERg1GLkYXRpT4UQABKB7RAL+U+FAAASgB0QIg8L0BIIT4UAAAvwIghPhRABlGBOA4aDBgPx02HUkeACn40QEghPhRAAC/ACCE+FAAAeABIOTnACDi53C1BEalaiBoAGgg8AEAIWgIYAMghfhRACBG//e+/nC9cLUERqVqIGgAaCDwAQAhaAhgBCCF+FEAIEb/963+cL1wtQRGpWogaABoIPABACFoCGABIIX4UQAgRv/3nf5wvS3p8EcERg5GF0aYRpT4UVABLQHQBC0p0QC/lPhQAAEoAtECIL3o8IcBIIT4UAAAvwIghPhRAAEtBNFOSHhEYW3IYgPgTEh4RGFtyGJLSHhEYW1IY0NGOkYxRmBt+/ey/YJGAL8AIIT4UAAB4AEg2edQRtfnLenwQQRGDUYWRh9GlPhRAAEoJNEAv5T4UAABKALRAiC96PCBASCE+FAAAL8CIIT4UQAzSHhEbDhhbchiMkh4RGQ4YW1IYztGKkYxRmBt+/d//YBGAL8AIIT4UAAB4AEg3udARtznELUERpT4UQAEKBnRAL+U+FAAASgB0QIgEL0BIIT4UAAAvwIghPhRAKFoIGgB8HX+ASCE+FEAAL8AIIT4UAAB4AEg6ecAIOfnELUERpT4UQABKBnRAL+U+FAAASgB0QIgEL0BIIT4UAAAvwIghPhRAKFoIGgB8Fr+BCCE+FEAAL8AIIT4UAAB4AEg6ecAIOfnAUaR+FEAcEcAAKH///93////T////0ZIAGhA8AEAREkIYAAgiGAIRgBoQkkIQEBJCGCIFMhgCEYAaCD0gCAIYAAgiGHIAzxJCGBwR/C1ACMAIAAiAiQAJQIhNU42aAbwCAYuuTNOlDY2aMbzAyAD4DBONmjG8wMQMU5+RFb4IAAsTrZoBvAMBjaxBC4I0AguC9AMLjnRDeAqTk5EMGA44ClOJ09PRD5gM+AnTiVPT0Q+YC7gH072aAbwAwUdTvZoxvMDFnEcAi0C0AMtCNED4B1Otvvx8gbgHE62+/HyAuCw+/HyAL8AvxJO9mjG8wYmckMPTvZoxvNBZnYcdACy+/T2D09PRD5gA+ANTk5EMGAAvwC/B062aMbzAxYMT39Eu10HTk5ENmjeQAVPT0Q+YPC9ABACQP//9uoI7QDgvCYAABAAAAAAJPQAABJ6AAAmAAAt6fBBBEYORhdGmEYGnRLgaByAsfr3c/+g6wgAqEIA2E25T/QAcOBkIG1A8AEAIGUBIL3o8IEgaABqMEAIsQEgAOAAILhC49EAIPLnAkZRZQAgcEdwR/i1BEYAJfr3T/8GRgy5ASVy4AAgIGXgbAAobdEgRv/37v9B8ogxIEb/9+X/IIpAHuFoQeoAQWBpQB5B6gAgIWsIQ+FpCEMhaIlo/koRQAhDIWiIYKCNYWtB6gBAIWgIYSFooGtIYSBoAGgg9PhRYGhAHkHqACAhaAhgYG0zRgAiICEAkCBG//eQ/wVGjbsgaMBoIPD/ACFqSR4IQyFoyGAgaABoIPBAAKFoCEMhaAhg1OkJAQhDIWjR+AgRIfCgQQhDIWjB+AgBIGgAaEDwAQAhaAhgoGkCKAXRIGiAaEDwAgAhaIhg4Giw8YBvAtEBIOBkAeACIOBkKEb4vXBHcLUERgAlDLkBJRDgIGgAaCDwAQAhaAhgIGiAaCDwAgAhaIhgIEb/9+r/ACDgZChGcL1wR3BHcEdwtQVGrGoAIGBk4Gyw9YB/GtEgaABqwPNAEHixAiAhaEhiIGgAaED0ADAhaAhgIGgAaEDwAgAhaAhgCuACIOBkIEb/99z/BOACIOBkIEb/99X/cL1wR3BHcEdwR3BHLenwQQRGIGgA8VAIIGgFaiBoB2jmbAXwBAA4swf0gCAgsxguCtHgawB4iPgAAOBrQBzgY2BsQB5gZAvgKC4J0Zj4AADhawhw4GtAHOBjYGxAHmBkYGwouSBoAGgg9IAgIWgIYCBG//fK/6XgBfACAAAoS9AH9AAwAChH0CguIdFgbGixBfR8UFCxmPgAAOFrCHDga0Ac4GNgbEAeYGSL4GBsACjh0QIgIWhIYiBoAGgg9OAgIWgIYAIg4GQgRv/3nf954AIgIWhIYiBoAGgg9OAgIWgIYAIg4GQYLgPRIEb/94v/aOAILgPRIEb/94T/YuC29YB/X9EgbRi5IEb/90//WeAgRv/3Sv9V4AXwCACwsQf0ACCYsQggIWhIYiBoAGgA9IAAOLEgaABoIPQQICFoCGACIOBkIEb/91z/O+AF8AEAYLMH9IAwSLMBICFoSGIgaABoIPT4ECFoCGACICBlIGgAaADwBACYsSBoAGgg8AQAIWgIYE9IeEShbIhjoGz79277uLECIOBkIEb/9wb/EeACIOBkIEb/9wD/C+AF8BAAQLEH9IAQKLEQICFoSGIgRv/38v696PCBLenwQQNGACAfaD9oJ/BAV9P4AMDM+ABwn2hfuR9oP2gn8IAH0fgEwEfqDAfT+ADAzPgAcA9oAi8M0R9oB/XAch9oB/XEdB9oB/XIdR9oB/XQdgvgH2gH9YByH2gH9YR0H2gH9Yh1H2gH9ZB20ekSfEfqDAcXYM9qj7GPajdg0fg0wM9qR+oMB9H4MMBH6gwH0vgAwCz0fBxH6gwHF2AnaCfwHwfR+ETAR+oMBydgj2s/sQ9oL7nPa38e0/gAwMz4QHDPaAAvfdDPafezj2tns9H4FMDPaEfqDAfR+BDAR+oMB9H4HMBH6gwH0fgkwEfqDAcE4AAA9MDg+CX+///R+CDAR+oMB9H4OMBH6gwH0fhAwEfqDAfS+ADA3/gYigzqCAxH6gwHF2Aq4NH4FMDPaEfqDAfR+BDAR+oMB9H4HMBH6gwH0fgkwADgIeBH6gwH0fggwEfqDAfS+ADAQ/Y/eCzqCAxH6gwHF2CfarfxgF8G0U9pCC8D0RdoR/AAZxdgj2gvYI9p0/gAwMz4SHB34I9r57HR+BTAz2hH6gwH0fgQwEfqDAfR+DjAR+oMB9H4QMBH6gwH0vgAwN/4fIkM6ggMAOAh4EfqDAcXYBrg0fgUwM9oR+oMB9H4EMBH6gwH0vgAwCzwPwxH6gwHF2CfarfxgF8G0U9pCC8D0RdoR/AAZxdgj2gvYDrgz2mns49r57HR+CTAz2lH6gwH0fggwEfqDAfR+DjAR+oMB9H4QMBH6gwH0vgAwN/4/IgI8T8IDOoIDEfqDAcXYA/g0fgkwM9pR+oMB9H4IMBH6gwH0vgAwCz0fFxH6gwHF2CPadP4AMDM+EhwA+D/5wEgCCcfZb3o8IEt6fhFBEYNRpBG+vdj/IJGoGgAuQC/6GgAsQC/6GkAsQC/6GoAsQC/qGsYsShoALkAvwC/52wCLwPR4Giw8YBvCdEULwLRKGgCKATQJC890ShoASg60VNGACIgISBGzfgAgP/3uPwGRh67ACAgZSlGIEb/94P+BkbeuahrYLlTRgEiAiEgRs34AID/96T8BkYCICFoSGIc4ChoELkEIOBkF+AoaAEoCNHgbCQoAtEEIOBkDuAUIOBkC+DgbBQoAtEEIOBkBeAkIOBkAuABJhAgIGUwRr3o+IX4tQRGDUb69/n7B0agaAC5AL/oaACxAL/oaQCxAL/oagCxAL+oawCxAL/gbAIoJdEoaBi7qGsIu+BosPGAbx3QYG07RgAiICEAkCBG//dX/AZGtrkAICBlAyAhaEhiKUYgRv/3H/4GRl65CCDgZCBoAGhA9EAwIWgIYALgASYQICBlMEb4vS3p+EUERg1GF0b697T7gkbU+EyAuPEBDwLQuPECDxfRU0YAIiAhIEYAl//3JfwGRo65KIgABGloQOoBIKloCEPpaAhDIWjB+AACAiDgZALgASYQICBlMEa96PiFLen4QwRGDUYXRvr3hvuARuBsAig40eBosPGAbzTRQ0YAIiAhIEYAl//3+PsGRla7IGgAaCDwQFAhaAhgIGiAaCDwgHApaAhDIWiIYChpQPBAYKloCENA9EBgIWjB+AABKGlA8EBgqWgIQ0D0QGAhaMH4gAHoaEAeIWgIZGhoIWiIZAQg4GQC4AEmECAgZTBGvej4gy3p+EUERg5GF0b69zz7gEYgaADxUAoeuQElCCAgZTrg4GwEKDTRIGgAbEAcYGRgbCBk5mMgaABoIPBAUCFoCGAAv0NGASIEISBGAJf/95z7BUYFsQzg4GsAeIr4AADga0Ac4GNgbEAeYGRgbAAo6NEAv4W5Q0YBIgIhIEYAl//3g/sFRj25AiAhaEhi4GQC4AElECAgZShGvej4hS3p/E0ERg5GF0b69+76AZAgaADxUAogaND4SIAgaND4ELEeuQElCCAgZVHg4GwEKEvRIGgAbEAcYGRgbCBk5mMgaABoIPBAUEDwgFAhaAhg4Giw8YBvA9EgaMD4SIAM4CBo0PgAAQD04GAYsSBowPhIgALgIGjA+BCxAL8AlwEiBiEgRgGb//cx+wVGBbEM4Jr4AADhawhw4GtAHOBjYGxAHmBkYGwAKOjRAL+FuQCXASICISBGAZv/9xj7BUY9uQIgIWhIYuBkAuABJRAgIGUoRr3o/I0QtQJGACAZuQEgCCMTZR7g02wEKxjRE2gbbFscU2RTbBNk0WMTaBtoI/BAUxRoI2ADIxRoY2IYI9NkE2gbaEP04CMUaCNgAuABIBAjE2UQvXC1AkYAIBVoq2wVaNX4EEEZuQEgCCUVZTPg1WwELS3RFWgtbG0cVWRVbBVk0WMVaC1oJfBAVUXwgFUWaDVgAyUWaHViKCXVZBVoLWhF9OAlFmg1YNVotfGAbwLRFWirZA/gFWjV+ABRBfTgZRWxFWirZAbgFWjF+BBBAuABIBAlFWVwvXC1BEYAJuVsBfAIABi5BfAEAAAoPNAgaABoIPT4ECFoCGBP9IBw4GQgaABoAPAEAJixIGgAaCDwBAAhaAhg+Uh4RKFsiGOgbPr3of/4sQIg4GQgRv/3Ovsd4CBoAGrA80AQeLECICFoSGIgaABoQPQAMCFoCGAgaABoQPACACFoCGAI4AIg4GQgRv/3H/sC4AEmECAgZTBGcL1wtQVGrGoAIGBkBCAgZSBoAGgg8AQAIWgIYCBG//ej/1CxIGgAaCD04CAhaAhgAiDgZCBG//f8+nC9cEdwR3C1BUasamBsQAhgZOBsKCgD0SBG//fz/wLgIEb/9+7/cL0BRohqACJCZAJoEmgi8AQCA2gaYApoEmgi8AECC2gaYAJoEmhC9AAyA2gaYHBHLenwQQRGDkYAJyBoAGxFHB65AScIICBleeDgbAQoc9GgbEBpCLllZCTgoGxAabD1gH8N0QXwAQAYuSB5APABABixCCAgZQEnFOBoCGBkEeCgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIICBlAScB4KgIYGQAL0rRYGwgZOZjIGgAaCDwQFAhaAhgAyAhaEhiGCDgZJtIeEShbMhimkh4RKFsCGOZSHhEoWxIYwAgoWyIYxAhoGyBYKBsAGgAaCDwEAChbIloCEOhbAloCGAjbCFoAfFQAjFGoGz69yL+YLkgaABoQPSAMCFoCGAgaABoQPAEACFoCGAJ4AEnBCAgZQIg4GQD4P/nAScQICBlOEa96PCBLenwRwRGDkYAJyBoAGxFHCBo0PhIgCBo0PgQoR65AScIICBlkODgbAQob9GgbEBpCLllZCTgoGxAabD1gH8N0QXwAQAYuSB5APABABixCCAgZQEnFOBoCGBkEeCgbEBpsPUAfwzRBfADABi5IHkA8AMAGLEIICBlAScB4KgIYGQAL2HRYGwgZOZjIGgAaCDwQFBA8IBQIWgIYAMgIWhIYigg4GRVSHhEoWzIYlRIeEShbAhjU0h4RKFsSGMAIKFsiGMAIaBsgWCgbABoAGgg8BAAoWyJaAhDoWwJaAhgI2wiaALxUAEyRqBs+veQ/RC7IGgAaED0gDAhaAhg4Giw8YBvBNEgaMD4SIAN4BngIGjQ+AABAPTgYBixIGjA+EiAAuAgaMD4EKEgaABoQPAEACFoCGAI4AEnBCAgZQIg4GQC4AEnECAgZThGvejwhy3p+E8ERg1GF0b691T4gkYgaND4SIAgaND4ELHgbAQoXNHoaLD1gA9Y0VNGACIgISBGAJf/98D4BkYALlHRKGghaMH4iABoaCFowfiAAChpIWjB+JAA1ekCAQhDQPAAUCFoCWgh8ENRCEMhaAhg4Giw8YBvA9EgaMD4SIAf4CBo0PgAAQD04GCwsSBowPhIgBXgAADAwP/wwP//8Iv2//85////D////8n+//8V/v//6/3//6X9//8gaMD4ELFTRgEiCCEgRgCX//d2+AZGJrkIICFoSGICIOBkAuABJhAgIGUwRr3o+I8t6fhFBEYNRvn34f+ARiBoh2wgaND4EKHgbAQoQNFgbUNGACIgIQCQIEb/91H4BkZGuyhoIWjB+IgAaGghaMH4gAAoaSFowfiQANXpAgEIQ0DwAFAhaAloIfBDUQhDIWgIYAkgIWhIYkgg4GQgaABoQPQQICFoCGDgaLDxgG8C0SBoh2QP4CBo0PgAAQD04GAQsSBoh2QG4CBowPgQoQLgASYQICBlMEa96PiF+LUERg1G+feM/wdG4GwEKCbRYG07RgAiICEAkCBG//cB+AZG/rmIIOBkKGgIKAzRaGghaMH4MAEQICFoSGIgaABoQPSAECFoCGAgaABo/kkIQCloQfBAUQhDIWgIYALgASYQICBlMEb4vfi1BEYAJfn3V/8HRuZsBvAIABi5BvAEAAAoOdAgaABoAPAEAGCxIGgAaCDwBAAhaAhgoGz696b8BUYNsQQgIGUgaABqwPNAEPixIGgAaEDwAgAhaAhgYG07RgEiAiEAkCBG/veq/wVGrbkCICFoSGJgbTtGACIgIQCQIEb+953/BUZFuQIg4GQF4AIg4GQC4AElECAgZShG+L0QtQJGACDTbAPwCANbuVFgE2gbaCP0+FRTaFseROoDIxRoI2AC4AEgECMTZRC9AUYIaABowPMEIEAccEcBRghtcEcBRshscEfwtQVGACAAJBWxAi0A2Am5ASBk4AAmDmBOYI5gzmAOYQItCNG2TjZoBvABBg65tUwB4E/0AHQAI0/gsU42HVb4IyAC8AEGPrEC8AIGBPACB75CAdFeHA5gAvAQBj6xAvAgBgTwIAe+QgHRXhxOYAL0gHY+sQL0AHYE9AB3vkIB0V4cjmAC9IA2jrEC9IAmBPSAJ75CC9EC9AA2JrleHEb0gDbOYAPgXhxG8IB2zmAC8IB2jrEC8IBmBPCAZ75CC9EC8AB2JrleHEb0gDYOYQPgXhxG8IB2DmFbHAIrrdPwvS3p8E2MsIJGDEZP8AAL2EaFSdr4AACIQgLRACYBJQHgASYAJQAnEOAH60cCa0YD68IBehzQsv/3c/8gsU/wAQsIIMr4UAB4HMeyAi/s07vxAA990XRIAGgA8AEAOLFySABoIPABAHBJCGBI8AEIb0gAaADwAQA4sWxIAGgg8AEAakkIYEjwAghlSAAdButGAWpGAuvBAYloSR5Q+CEAIPSAcl9IAB0G60YBa0YD68EBiWhJHkD4ISAAHwBoAPABAAAofdBWSABoIPABAFRJCGABLXbRCB0F60UBXfgxEEkeUPghAEDwAgJNSAAdBetFAV34MRBJHkD4ISAF60UAaUYB68AAQGiwsUVIAB0F60UBakYC68EBSWhJHlD4IQBA8CACP0gAHQXrRQED68EBSWhJHkD4ISAF60UAaUYB68AAwGjosTZIAB0F60UBakYA4NjiAuvBAQl7SR4B8AEBUPghAED0gCIuSAAdBetFAWtGA+vBAQl7SR4B8AEBQPghIAXrRQBpRgHrwAAAaQAoGNAjSAAdBetFAWpGAuvBAQl8SR4B8AEBUPghAEDwgGIcSAAdBetFAWtGA+vBAQl8AeAG4IngSR4B8AEBQPghIIbgButGAF34MAAAKH3QEEgAHQbrRgFd+DEQSR5Q+CEAIPABAgtIAB0G60YBXfgxEEkeQPghIAbrRgBpRgHrwABAaAizA0gAHQbrRgEJ4Pf//88AHAZQIgIEBAAQAKAAFACgakYC68EBSWhJHlD4IQAg8BAC/kgG60YBa0YD68EBSWhJHkD4ISAG60YAaUYB68AAwGjIsfVIButGAWpGAuvBAQl7SR4B8AEBUPghACD0gDLuSAbrRgFrRgPrwQEJe0keAfABAUD4ISAG60YAaUYB68AAAGnAseVIButGAWpGAuvBAQl8SR4B8AEBUPghACDwgHLeSAbrRgFrRgPrwQEJfEkeAfABAQDgAeBA+CEgBetFAV34MRAgaIhCINAF60UBakYC68EBYGhJaIhCF9AF60UBAuvBAaBoiWiIQg/QBetFAQLrwQHgaMloiEIH0AXrRQEC68EBIGkJaYhCJ9EF60UBXfgxECBoiEIh0QXrRQFqRgLrwQFgaEloiEIY0QXrRQEC68EB4GjJaIhCENEF60UBAuvBASBpCWmIQgjRs0gAHwBoQPABALBJCR8IYIXgrkgF60UBXfgxEEkeUPghACDwAQKpSAXrRQFd+DEQSR5A+CEgBetFAGlGAevAAEBoqLGiSAXrRQFqRgLrwQFJaEkeUPghACDwEAKcSAXrRQFrRgPrwQFJaEkeQPghIJdIBetFAWpGAuvBAYloSR5Q+CEAIPSAcpFIBetFAWtGA+vBAYloSR5A+CEgBetFAGlGAevAAMBowLGISAXrRQFqRgLrwQEJe0keAfABAVD4IQAg9IAygUgF60UBA+vBAQl7SR4B8AEBQPghIAXrRQBpRgHrwAAAacixeEgF60UBakYC68EBCXxJHgHwAQFQ+CEAIPCAcnFJBetFAGtGA+vAAAB8QB4A8AEAQfggIGtIoWhJHlD4IQAg9EBxT/SAcEDqRiABQ2VIomhSHkD4IhBgaUAeYkkJHwlowfMHQYhCC9leSAAfAGgg9H8BoIpAHkHqAEBaSQkfCGBYSAAfAGgA8AEAACh10FVIIWhJHlD4IQAg8AMBSRxRSCJoUh5A+CIQYGhosU1IYWhJHlD4IQAg8DAAQPAQAklIYWhJHkD4ISDgaAD0gDCQsURIIXtJHgHwAQFQ+CEAIPTgIED0gDI/SCF7SR4B8AEBQPghIBPg4GiIsTpIIXtJHgHwAQFQ+CEAIPDgYEDwgHI0SCF7SR4B8AEBQPghICBpAPSAMJCxL0ghfEkeAfABAVD4IQAg9OAgQPRAMilIIXxJHgHwAQFA+CEgneAgaQAoEdAkSCF8SR4B8AEBUPghACDw4GBA8EByHkghfEkeAfABAUD4ISCH4P/nGkghaEkeUPghACDwAwEBIEDqRgABQxRIImhSHkD4IhBgaHixEUhhaEkeUPghACDwMAAQIUHqRhEIQwtJYmhSHkH4IgDgaAD0gDDAsQdIIXtJHgHwAQFQ+CEAIPTgIE/0gDFB6oZBCEMB4AQcBlAySSJ7Uh4C8AECQfgiABbg4GigsS1IIXtJHgHwAQFQ+CEAIPDgYE/wgHFB6oZhCEMmSSJ7Uh4C8AECQfgiACBpAPSAMKixIUghfEkeAfABAVD4IQAg9OAhT/RAMEDqhkABQxpIInxSHgLwAQJA+CIQFuAgaaCxFUghfEkeAfABAVD4IQAg8OBgT/BAcUHqhmEIQw5JInxSHgLwAQJB+CIACPABACixCkgAaEDwAQAISQhgCPACACixBkgAaEDwAQAESQhgWEYMsL3o8I0EHAZQABAAoAAUAKBwtQJGCGhS+CAAIPABAA5oQvgmAIhoCCgB0UAlAOAAJUhoKEOOaDBDzmgwQw5pMENOaTBDjmkwQ85pMEMOajBDTmowQ45qMEPOakDqBgMIawNDSGsDQ8hrA0OIawNDsUxE9IAURPQAFET0QARE9OAkCGhS+CAAoEMYQw5oQvgmAAhrsPWAHwfRCGgosRBoIPSAEA5rMEMQYAhoGLEQaE5rMEMQYJH4QAABKCTREGpv8w8ATmwwQxBiCGgwsQIoCdAEKAzQBigU0Q7gEGpA9IAwEGIP4BBqQPQAMBBiCuAQakD0gCAQYgXgEGpA9AAgEGIA4AC/AL8AIHC9ELUDRlP4IgAg8AEAQ/giACK5Q/LbAEP4IgAD4EPy0gBD+CIAb/BwRFAcQ/ggQCBGQfgiADKxAioJ0AQqDNAGKhTRDuAYaiD0gDAYYg/gGGog9AAwGGIK4BhqIPSAIBhiBeAYaiD0ACAYYgDgAL8AvwAgEL0wtQNG0ekABUDqBRCNaEDqBSANe0DqhXANikDqBUWIikAeReoAVQh+gB5F6gBgzWkoQ1UcU/glUFUcQ/glABhoAPSAELD1gB8L0VhoIPRwBIiKQB5E6gBUWGgg9HAAIENYYAAgML0wtQRGs/WATxbR0ekABUDqBRCNaEDqBSANe0DqhXDNaShDDYpA6gVAVPgiUAXwf2UoQ0T4IgAD4G/wcEBE+CIAACAwvQJGUvghAED0gFBC+CEAACBwRwJGUvghACD0gFBC+CEAACBwRxC1AkZIaEDwCACLaBhDy2gYQwtpGENLaUDqQyCLaUDqQzATaDFMI0AYQxBgACAQvRC1A0bR6QAEQOoEIAyJQOoEQAx7QOoEYJxomGAAIBC9ELUDRtHpAARA6gQgDIlA6gRADHtA6gRg3GjYYAAgEL0CRhBoIPAEABBgGCAQYEAgUGBP8PwwkGDQYAAgcEcCRhBoQPBAABBgACBwRwJGEGgg8EAAEGAAIHBHLenwQQVGDkaQRhxG+fd0+QdGCuBgHECx+fdu+cAboEIA2BS5AyC96PCBaGjA84AQACjv0GhpMGAAIPTnAAB/+wgAgQHw/wC1h7AAv/5IgGxA8AEA/EmIZAhGgGwA8AEAAZAAvwC/AL8IRoBsQPAEAIhkCEaAbADwBAABkAC/AL8CIAOQAyAFkAAgBJAAvwhGwGxA9IAQyGQIRsBsAPSAEAGQAL8AvwC/CEaAbUDwgFCIZQhGgG0A8IBQAZAAvwC/4khAaED0AHDgSUhgAL/dSMBsQPAQANtJyGQIRsBsAPAQAAGQAL8AvwC/CEbAbEDwEADIZAhGwGwA8BAAAZAAvwC/AL8IRsBsQPAQAMhkCEbAbADwEAABkAC/AL8AvwhGwGxA8BAAyGQIRsBsAPAQAAGQAL8AvwC/CEbAbEDwEADIZAhGwGwA8BAAAZAAvwC/AL8IRsBsQPABAMhkCEbAbADwAQABkAC/AL8AvwhGwGxA8AEAyGQIRsBsAPABAAGQAL8AvwC/CEbAbEDwCADIZAhGwGwA8AgAAZAAvwC/AL8IRsBsQPAIAMhkCEbAbADwCAABkAC/AL8AvwhGwGxA8AQAyGQIRsBsAPAEAAGQAL8AvwC/CEbAbEDwCADIZAhGwGwA8AgAAZAAvwC/AL8IRsBsQPBAAMhkCEbAbADwQAABkAC/AL8KIAaQASAEkMACApACqY5I+ffu/wAgBJBP9IBgApACqYlI+ffl/wAgBJBP9ABwApACqYVI+ffc/0/0gFACkAKpgUj599X/T/QAUAKQAql+SPn3zv+AIAKQAqlP8JBA+ffH/0AgApACqU/wkED598D/CCACkAKpdUj597r/gCACkAKpc0j597T/ECACkAKpcEj5967/ICACkAKpbUj596j/AyAGkEAgApACqWpI+feg/wC/Y0gAbUD0gHBhSQhlCEYAbQD0gHABkAC/AL8IRgBrQPSAcAhjCEYAayD0gHAIYwAiDyFHIPn3CfpHIPn3RPoAIVlISETBYIAhAWEAIUFhgWHBYU/0AFEBYikgUklJREhgUkgIYAhG+fc+/AC/TkhIRE9JSUSIZAhGS0lJRIhiAL8IRvn3zPsHIPn3zfkAIhFGDyD599r5DyD59xX6B7AAvQC1m7BQIQGoAPAL+0FISEQAaAAoadH/92r+ASAVkBaQPUgZkE/wARAYkAEgF5AakDpINklJRAhgCEb+99z4AiAzSUlESGAAITFISESBYE/wAHHBYBchAWEBIUFhACGBYcFhAyEBYgAhQWJP8IBRgWIBIcFiACEBY0FjQfKIMhWp//cT+RCxASAbsAC9IEhIRP73MvgIsQEg9ucAIAGQApAEIASQACAFkAaQT/SAYAiQT/RAUAmQT/QAYAqQACAMkE/wgGAPkEAAEZCAABOQACAUkEAgA5AAIAeQAiAQkAUgEpBB8ogyAakZ4EvgAAAAEAJAAHAAQAAQAEgACABIAAwASAAYAEh0AAAAWAACQBwAAAAUAAAAAQAAAQAQAKD+SEhE/vfT+gixASCt50HyiDJpRvlISET+9z78CLEBIKPnwCADkAAgEpCd+AAAIPADAI34AABB8ogyAanvSEhE/ve1+gixASCP50HyiDJpRupISET+99L7CLEBIIXnASDnSUlECGAAIH/nELUPIPn3X/nkSORJSUQIYAhG+fdU+0/0AGHhSPn3YP9P9IBh30j591v/T/QAcdxI+fdW/0/0gFHaSPn3Uf9P9ABR10j590z/gCFP8JBA+fdH/0AhT/CQQPn3Qv8QIdFI+fc+/yAhz0j59zr/CCHOSPn3Nv+AIctI+fcy/0Ahy0j59y7/EL0QtcNISEQAaAEoE9G/SEhE/ffq/yCxASDESUlECHAD4AAgwklJRAhw//en/wAguElJRAhgvUhIRAB4EL0AtZewUCEDqADw5vkAIAGQApACIAOQACAEkAQgBpAAIAeQCJBP9IBgCpBP9EBQC5BP9ABgDJAAIA6QT/CAYBGQQAATkIAAFZAAIBaQCZAKIBKQwCAFkAQgFJBB8ogyA6mbSEhE/vcN+hCxASAXsAC9ASADkAAgBZAFIBSQQfKIMgOpk0hIRP73/PkIsQEg7ecAIAGQAamOSEhE/vfL/gixASDj5wAg4edwtZSwBEYORhVGUCFoRgDwj/kAIACQAZAEIAOQACAEkAWQT/SAYAeQT/RAUAiQT/QAYAmQACALkE/wgGAOkEAAEJCAABKQACATkAKQBpQPlQUgEZBB8ogyaUZzSEhE/ve8+RCxASAUsHC9QfKIMjFGbUhIRP73JvsIsQEg8+cAIPHncLWUsARGDkYVRlAhaEYA8E75ACAAkAGQBCADkAAgBJAFkE/0gGAHkE/0QFAIkE/0AGAJkAAgC5BP8IBgDpBAABCQgAASkAAgE5ACkAaUD5UFIBGQQfKIMmlGUkhIRP73e/kQsQEgFLBwvTFGTkhIRP73evsIsQEg9ecAIPPncLWUsARGDkYVRlAhaEYA8A/5ACAAkAGQBCADkAAgBJAFkE/0gGAHkE/0QFAIkE/0AGAJkAAgC5BP8IBgDpBAABCQgAASkAAgE5ACkAaUD5UFIBGQQfKIMmlGM0hIRP73PPkQsQEgFLBwvTFGLkhIRP73m/wIsQEg9ecAIPPncLWUsARGDkYVRlAhaEYA8ND4ACAAkAGQBCADkAAgBJAFkE/0gGAHkE/0QFAIkE/0AGAJkAAgC5BP8IBgDpBAABCQgAASkAAgE5CAIAKQBpQPlQQgEZBB8ogyaUYTSEhE/vf8+BCxASAUsHC9QfKIMjFGDUhIRP73GPoIsQEg8+cAIPHncLWUsARGDkYVRlAhaEYA8I74ACAAkAGQBCADkAAgBJAFkBLgAAAcAAAAFAAAAFgAAkDUAAAAABAASAAMAEgACABIABgASBgAAABP9IBgB5BP9EBQCJBP9ABgCZAAIAuQT/CAYA6QQAAQkIAAEpAAIBOQgCACkAaUD5UEIBGQQfKIMmlGKUhIRP73pvgQsQEgFLBwvTFGJEhIRP73ffoIsQEg9ecAIPPncLWUsARGDkYVRlAhaEYA8Dr4ACAAkAGQBCADkAAgBJAFkE/0gGAHkE/0QFAIkE/0AGAJkAAgC5BP8IBgDpBAABCQgAASkAAgE5CAIAKQBpQPlQQgEZBB8ogyaUYJSEhE/vdm+BCxASAUsHC9MUYESEhE/vc7+wixASD15wAg8+cAABwAAABP8AACALUTRpRGlkYgOSK/oOgMUKDoDFCx8SABv/T3rwkHKL+g6AxQSL8MwF34BOuJACi/QPgEKwi/cEdIvyD4AisR8IBPGL8A+AErcEcAAAAAAAAAAAAAAQIDBAYHCAkAAAAAAQIDBKCGAQBADQMAgBoGAAA1DABAQg8AgIQeAAAJPQAAEnoAACT0AAA2bgEASOgBAGzcAgAAAAAAAAAAEAAAAAEAAAAACT0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    load_address: ~
+    pc_init: 239
+    pc_uninit: 261
+    pc_program_page: 277
+    pc_erase_sector: 271
+    pc_erase_all: 267
+    data_section_offset: 30844
+    flash_properties:
+      address_range:
+        start: 2415919104
+        end: 2424307712
+      page_size: 4096
+      erased_byte_value: 255
+      program_page_timeout: 10000
+      erase_sector_timeout: 6000
+      sectors:
+        - size: 8388608
+          address: 0
+    cores: []
+  - name: n25q128a_stm32l476-disco
+    description: N25Q128A_STM32L476G-Disco
+    default: false
+    instructions: QLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR0C6cEdAunBHQLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEfAunBHwLpwR8C6cEdP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEcAAE/qMABwRwAAT+owAHBHAABP6jAAcEdwtQRGDUYWRgDwjPgIsQAgcL0BIPznAUYAIHBHELUA8Jb4EL1wtQRGACYlRukZKEYA8Kf4BkYBLgHRACBwvTBG/OdwtQRGDUYWRjJGKUYgRgDwiPgIsQAgcL0BIPznMLUG4BD4AUsS+AFbrEIA0DC9Cx6h8QEB9NEAv/jnAAABRgAgAL8A4EAcsPWAX/vbcEcAIQDgSRyx9YBv+9tISEhEAGhAHEZKSkQQYBBGAGhwRwFGACBwRwC1l7AUIRKoBfBk/UQhAagF8GD9ECABkAEgB5BgIAmQACAIkAIgC5ABIQyRDZEoIQ6RAiERkQchD5EEIRCRAagD8OL4CLEAv/7nDyASkAMgE5AAIBSQFZAWkAQhEqgD8En8CLEAv/7nASAXsAC9ELUAJADwE/kA8En4//fB/wXwpfoIsQAgEL0F8J78BEYMuQEg+OcAIPbnELUF8Jf6BfAa/AC/BfBC/AAo+9EQvXC1BEYNRhZGJPBwRAXwh/oqRiFGMEYF8EP7ASBwvXC1BEYNRiTwcEQl8HBFoLIkGgXwdfoK4CYMMEYF8Mf7AL8F8B38ACj70QT1gDSlQvLSBfBj/AEgcL0AABAAAABGSABoQPABAERJCGAAIIhgCEYAaEJJCEBASQhgiBTIYAhGAGgg9IAgCGAAIIhhyAM8SQhgcEfwtQAjACAAIgIkACUCITVONmgG8AgGLrkzTpQ2NmjG8wMgA+AwTjZoxvMDEDFOfkRW+CAALE62aAbwDAY2sQQuCNAILgvQDC450Q3gKk5ORDBgOOApTidPT0Q+YDPgJ04lT09EPmAu4B9O9mgG8AMFHU72aMbzAhZxHAItAtADLQjRA+AdTrb78fIG4BxOtvvx8gLgsPvx8gC/AL8STvZoxvMGJnJDD072aMbzQWZ2HHQAsvv09g9PT0Q+YAPgDU5ORDBgAL8AvwdOtmjG8wMWDE9/RLtdB05ORDZo3kAFT09EPmDwvQAQAkD///bqCO0A4MhZAAAMAAAAACT0AAASegAMWQAAcEdwtQRGACWhSEhEAHjwsZ9ISEQAeE/0enGx+/DwnUlJRAlosfvw9jBGAPD4+WC5ECwI0gAiIUZQHgDwX/mWSEhEBGAE4AElAuABJQDgASUoRnC9ELUAJAMgAPA9+Q8g//en/gixASQB4P/3yf8gRhC9cEcQtQC/T/D/MIdJiGPIYwC/AL8AIIhjyGMAv0AeCGQAIAhkQB6IYgAgiGJAHshiACDIYkAeCGMAIAhj//fg/wAgEL16SEhEAGh0SUlECXgIRHZJSUQIYHBHdEhIRABocEdwSEhEAGhwR3C1BEYAJWtISEQAeKBCDdBoSEhEBngEcGhISEQAaP/3Wv4FRhWxY0hIRAZwKEZwvWBISEQAeHBHcLUERv/3O/4GRiVGaBwYsVpISEQAeAVEAL//9zD+gBuoQvrTcL1P8OAgAGkg8AIAT/DgIQhhcEdP8OAgAGlA8AIAT/DgIQhhcEdP8IZwcEdPSABoAAxwR01IAGjA8wsAcEdMSABocEdKSAAdAGhwR0hICDAAaHBHRUhAaEDwAQBDSUhgcEdCSEBoIPABAEBJSGBwRz5IQGhA8AIAPElIYHBHO0hAaCDwAgA5SUhgcEc3SEBoQPAEADVJSGBwRzRIQGgg8AQAMklIYHBHyiAySUhiUyBIYgEgMEkIYHBHASAvSQhicEcAIC1JCGJwRypJCWsh8AQBAUMnShFjcEcmSQlrIfACAQFDI0oRY3BHIklJayHwPwEBQx9KUWNwRxC1HUgAa0DwAQAbSQhj//en/QRGBuD/96P9ABsKKAHZAyAQvRVIAGsA8AgAACjy0AAg9ucRSABrIPABAA9JCGNwRw1IQGhA9IBwC0lIYHBHCkhAaCD0gHAISUhgcEcYAAAADAAAABQAAAAAEAJAEAAAAAAgBOCQdf8fAAABQAADIEIAACBCELUAKATbCgcTDuZKE1QG4AoHFA7kSgDwDwMbH9RUEL0AvwDwBwLgSww7GWhP9v8DGUDeSwtDQ+oCIdtLDDsZYAC/cEct6fBNgEYNRhZGACcA8KL5B0Y5RipGM0YB8AcAwPEHC7vxBA8C2U/wBAsB4MDxBwvaRgDxBAu78QcPAtJP8AALAeCg8QML3EZP8AELC/oK+6vxAQsL6gILC/oM+0/wAQ4O+gz+rvEBDg7qAw5L6g4EIUZARv/3ov+96PCNAUYIRgAoDdsAvwC/APAfAwEimkBDCZsAA/HgI8P4ACEAvwC/AL9wRxC1AUYIRgAoF9sA8B8DASKaQK1LRAlD+CQgAL8AvwC/v/NPjwC/AL8AvwC/AL8Av7/zb48AvwC/AL8AvxC9AL8AvwC/AL8Av7/zT48AvwC/AL+bSAw4AGgA9OBgmUkIQwAdl0kMOQhgAL8AvwC/v/NPjwC/AL8AvwC/AL/953C1BEYlRmgesPGAfwHTASAP4GgeT/DgIUhhDyFP8P8w//c7/wAgT/DgIYhhByAIYQAgcL0QtQDw/PgQvS3p8EUERiBGACgD231PP1w/CQfgfE8A8A8MrPEEDBf4DHA/CT1GDkYG8AcAwPEHCLjxBA8C2U/wBAgB4MDxBwjERgDxBAi48QcPAtJP8AAIAeCg8QMIR0Yl+gf4T/ABCgr6DPqq8QEKCOoKCML4AIBP8AEICPoH+KjxAQgI6gUIw/gAgAC/vejwhRC1AUYIRgAoCNsA8B8DASKaQFxLgDNECUP4JCAAvxC9ELUBRghGACgO21ZKgDJDCVL4IyAA8B8EASOjQBpACrEBIgLgACIA4AAiEEYQvRC1AUYIRgAoB9sA8B8DASKaQElLRAlD+CQgAL8QvRC1AUYIRgAoDttESoAyQwlS+CMgAPAfBAEjo0AaQAqxASIC4AAiAOAAIhBGEL0EKAjRT/DgIQlpQfAEAU/w4CIRYQfgT/DgIQlpIfAEAU/w4CIRYXBHcEcQtf/3/P8QvUDwAQEqSnwyEWAAvwC/AL+/80+PAL8AvwC/AL8AvwC/v/NvjwC/AL8Av3BHAL8AvwC/v/NfjwC/AL8AvwAgHEl8MQhgcEdBeBlKgDIRYAF4+bESHUFoEWABewkHwnpB6gJhgnpB6sJBQntB6oJBgntB6kJBwntB6gJBQnpB6gIhAnpB6kIBAngRQwlKiDIRYAXgACEGSoQyEWASHRFgcEcDSAw4AGjA8wIgcEcA5ADgGO0A4AAA+gWA4QDggOIA4BC1AUYJuQEgEL34SwhomEIL0vdLCGjAGhQjsPvz8IAASGTzSAg4CGQK4PBLCGjAGhQjsPvz8IAASGTsSAg4CGQCIIH4JQAIaAJoR/bwcIJD0ekCAxhDC2kYQ0tpGEOLaRhDy2kYQwtqGEMCQwhoAmCIaLD1gE860N1LCDsIbJhCG9HQ+KgAkfhEMAPwHAQPI6NAmEPWS6AzGGCR+EQwA/AcA0homEDSSwg70/ioMBhDz0sIO8P4qAAZ4MxIoDAAaJH4RDAD8BwEDyOjQJhDx0ugMxhgkfhEMAPwHANIaJhAwkugMxtoGEPAS6AzGGAAIMhjASCB+CUAACCB+CQAAL+C5wFGCbkBIHBHCGgAaCDwAQAKaBBgtUoIaJBCC9K0SghogBoUIrD78vCAAEhksEgIOAhkCuCtSghogBoUIrD78vCAAEhkqUgIOAhkACAKaBBgkfhEAADwHAIBIJBACmxQYKNKCDoIbJBCDdHQ+KgAkfhEIALwHAMPIppAkEOcSgg6wvioAAzgmEigMABokfhEIALwHAMPIppAkEOTSqAyEGAAIMhiCGNIY4hjyGOB+CUAAL+B+CQAAL8Av6TnMLWQ+ERABPAcBQEkrEAFbGxgBGhjYIRoECwE0QRoomAEaOFgA+AEaKFgBGjiYDC9LenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKBfRAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//e//yBoAGhA8AEAIWgIYAbgAL8AIIT4JAAAv0/wAghARtTnLenwQQRGDUYWRh9GT/AACAC/lPgkAAEoAtECIL3o8IEBIIT4JAAAv5T4JQABKCzRAiCE+CUAACDgYyBoAGgg8AEAIWgIYDtGMkYpRiBG//eG/yBrMLEgaABoQPAOACFoCGAL4CBoAGgg8AQAIWgIYCBoAGhA8AoAIWgIYCBoAGhA8AEAIWgIYAbgAL8AIIT4JAAAv0/wAghARr/nAUYAIpH4JQACKAjQBCDIYwC/ACCB+CQAAL8BIHBHCGgAaCDwDgALaBhgCGgAaCDwAQALaBhgkfhEAADwHAMBIJhAC2xYYAEggfglAAC/ACCB+CQAAL8QRuDncLUERgAllPglAAIoA9AEIOBjASUg4CBoAGgg8A4AIWgIYCBoAGgg8AEAIWgIYJT4RAAA8BwBASCIQCFsSGABIIT4JQAAvwAghPgkAAC/oGsQsSBGoWuIRyhGcL0t6fBBBEYORhVGlPglAAIoCdAEIOBjAL8AIIT4JAAAvwEgvejwgSBoAGgA8CAAQLFP9IBw4GMBIPPnCAQCQAgAAkA+uZT4RAAA8BwBAiAA+gH4BuCU+EQAAPAcAQQgAPoB+P/3hfkHRjDgIGwAaJT4RBAB8BwCCCGRQAhAkLGU+EQAAPAcAQEgiEAhbEhgASDgY4T4JQAAvwAghPgkAAC/ASC+52gciLH/92L5wBuoQgDYXbkgIOBjASCE+CUAAL8AIIT4JAAAvwEgqucgbABoAOoIAAAoyNCGuZT4RAAA8BwBAiCIQCFsSGAAvwAghPgkAAC/ASCE+CUAB+CU+EQAAPAcAQQgiEAhbEhgACCI53C1BEYgbAVoIGgGaJT4RAAA8BwBBCCIQChA4LEG8AQAyLEgaABoAPAgACi5IGgAaCDwBAAhaAhglPhEAADwHAEEIIhAIWxIYCBrAChW0CBGIWuIR1LglPhEAADwHAECIIhAKEAYswbwAgAAsyBoAGgA8CAAQLkgaABoIPAKACFoCGABIIT4JQCU+EQAAPAcAQIgiEAhbEhgAL8AIIT4JAAAv+BqULMgRuFqiEcm4JT4RAAA8BwBCCCIQChA8LEG8AgA2LEgaABoIPAOACFoCGCU+EQAAPAcAQEgiEAhbEhgASDgY4T4JQAAvwAghPgkAAC/YGsQsSBGYWuIR3C9ELUDRgAkAL+T+CQAASgB0QIgEL0BIIP4JAAAv5P4JQABKBLRMbEBKQbQAikG0AMpCNEF4NpiB+AaYwXgWmMD4JpjAeABJAC/AOABJAC/ACCD+CQAAL8gRtvnAkYAIwC/kvgkAAEoAdECIHBHASCC+CQAAL+S+CUAASgb0QUpFtLf6AHwAwYJDA8AACDQYhDgACAQYw3gACBQYwrgACCQYwfgACDQYhBjUGOQYwHgASMAvwDgASMAvwAggvgkAAC/GEbS5wFGkfglAHBHAUbIa3BHAAB4tQNGACLl4AEmlkANaAXqBgQALH3QTWgBLQjQTWgCLQXQTWgRLQLQTWgSLRPRmGhWAAMltUCoQ1YAzWi1QChDmGBYaAEllUCoQw15xfMAFZVAKENYYA15BfADBQMtCdHYagEllUCoQw15xfPABZVAKEPYYthoVgADJbVAqENWAI1otUAoQ9hgTWgCLQLQTWgSLRPR1ggD8SAFVfgmAFUH7g4PJbVAqENWB/YODWm1QChD1ggD8SAFRfgmABhoVgADJbVAqEMNeQXwAwVWALVAKEMYYE1oBfCAVbXxgF940QC/p00tbkXwAQWlTjVmNUYtbgXwAQUAlQC/AL9P6rY1lghV+CYAlQcuDw8ltUCoQwDgXuCz8ZBPAdEAJR7gmU2rQgHRASUZ4JdNq0IB0QIlFOCWTatCAdEDJQ/glE2rQgHRBCUK4JNNq0IB0QUlBeCRTatCAdEGJQDgByWWBzYPtUAoQ41NlghF+CYAjE0oaKBDTWgF9IA1tfWAPwDRIEOHTShgLR0oaKBDTWgF9AA1tfUAPwDRIEOBTS0dKGAtHShooENNaAX0gBW19YAfANEgQ3tNCDUoYC0dKGigQ01oBfQAFbX1AB8A0SBDdE0MNShgUhwNaNVAAC1/9BWveL3wtQtGACGH4AEljUAF6gMCACp90GlNjghV+CZAjQcuDw8ltUAsQLDxkE8B0QAlHuBcTahCAdEBJRngW02oQgHRAiUU4FlNqEIB0QMlD+BYTahCAdEEJQrgVk2oQgHRBSUF4FVNqEIB0QYlAOAHJY4HNg+1QKVCIdFRTS1olUNQTjVgNR0taJVDNh01YDUdLWiVQzYdNWA1HS1olUM2HTVgjQcuDw8lBfoG9ERNjghV+CZQpUNBTo8IRvgnUAVoTwADJr5ANUMFYM4IAPEgBVX4JlBOB/cODya+QLVDzwgA8SAGRvgnUIVoTwADJr5AtUOFYEZoASWNQK5DRmDFaE8AAya+QLVDxWDFagEmjkAA4AHgtUPFYkkcI/oB9QAtf/Rzr/C9AkYTaQtAC7EBIADgACBwRwqxgWEA4IFicEcQtUJpIeoCAwLqAQRD6gRDg2EQvQi1AkZP9IAwAJAAmAhDAJAAmNBh0WEAmNBh0GkAkNBpAPSAMAixACAIvQEg/OdwRxC1BEYOSBQwAGggQCixC0gUMARgIEb/9/L/EL0AAAAQAkAABABIAAgASAAMAEgAEABIABQASAAYAEgIAAFAAAQBQHxIgGtA8IBQekmIYwhGgGsg8IBQiGNwR3dIAGhA9IBwdUkIYHBHdEgAaCD0gHBySQhgcEcBRnBIQGgg8A4ACmgQQ21KUGBtSABoIPSAMGtKEGAQHwBoIPSAMBIfEGBnSAgwAGgg9IAwZEoIMhBgEB8AaCD0gDASHxBgSGgA9IAwsPWAPwfRXUgAHwBoQPSAMFpKEh8QYEhoAPQAMLD1AD8F0VZIAGhA9IAwVEoQYAh5APABADixUUgAHQBoQPSAME5KEh0QYAh5APACAAIoB9FKSAgwAGhA9IAwSEoIMhBgACBwR0RIQGhA8AEAQklIYHBHQUhAaCDwAQA/SUhgcEc9ScloAPAfApFDQepQETpK0WARRoloAPAfAhFDNkqRYHBHNUmJaADwHwKRQzJKkWBwR3C1BEYNRlS5L0hAaQD0AHCw9QB/CtEA8AD8OLFwvSlIQGnA80AgCLkA8PD7KEgAaCDwBAAmSQhgAS0B0TC/AuBAvyC/IL8Av+jncLUFRgxGtfWATwPRIEYA8B78AuAgRgDwAPxwvRdIAGgg8AcAwBwVSQhgFkgAaEDwBAAUSQhgAL8AvzC/cEcRSABoQPACAA9JCGBwRw1IAGgg8AIAC0kIYHBHCkgAaEDwEAAISQhgcEcGSABoIPAQAARJCGBwR3BHABACQABwAEAEBAFAEO0A4PhIAGgA9MBgcEcCRrL1AH8r0fRIAGgA9MBgsPUAfzPQ8EgAaCD0wGBA9ABw7UsYYO1ISEQAaDIjWEPsS7D78/BBHADgSR7nSEBpAPSAYLD1gG8B0QAp9dHiSEBpAPSAYLD1gG8Q0QMgcEfeSABoAPTAYLD1gG8H0NpIAGgg9MBgQPSAYNdLGGAAIO3n1UnJaCH0AHEBQ9NK0WARRsloQfSAcdFgcEfPSMBoIPSAcM1JyGBwR8tIQGhA9IBgyUlIYHBHyEhAaCD0gGDGSUhgcEfESEBoQPQAcMJJSGBwR8FIQGgg9ABwv0lIYHBHvUiAaED0AEC7SYhgcEe6SIBoIPQAQLhJiGBwRxC1AkYAIAgqYtLf6ALwBBMgKjQ+SFKxSxtqIfSARCNDrkwjYiNGW2oh9CBEo0OrTGNiT+CpS5tqC0OoTKNiI0bbaiHwEASjQ6RM42JC4KNLG2sLQ6FMI2MjRltri0NjYzjgnkubawtDnEyjYyNG22uLQ+NjLuCZSxtsC0OXTCNkI0ZbbItDY2Qk4JRLm2wLQ5JMo2QjRttsi0PjZBrgj0sbbQtDjUwjZSNGW22LQ2NlEOCKS5ttAfADBCNDh0yjZSNG220B8AMEo0OETONlAeABIAC/AL8QvRC1AkYAIAgqOdLf6ALwBAwSGB4kKjB7SxtqIfSARKNDeEwjYi3gd0ubaotDdUyjYifgdEsba4tDckwjYyHgcUuba4tDb0yjYxvgbksbbItDbEwjZBXga0ubbItDaUyjZA/gaEsbbYtDZkwjZQngZUubbQHwAwSjQ2JMo2UB4AEgAL8AvxC9ELUCRgAgCCph0t/oAvAEEx8pMz1HUVlLW2oh9CBEI0NXTGNiI0YbaiH0gESjQ1NMI2JO4FJL22oh8BAEI0NPTONiI0abaotDo2JC4ExLW2sLQ0pMY2MjRhtri0MjYzjgR0vbawtDRUzjYyNGm2uLQ6NjLuBCS1tsC0NATGNkI0YbbItDI2Qk4D1L22wLQztM42QjRptsi0OjZBrgOEtbbQtDNkxjZSNGG22LQyNlEOAzS9ttAfADBCNDMEzjZSNGm20B8AMEo0MtTKNlAeABIAC/AL8QvRC1AkYAIAgqO9Lf6ALwBAwUGiAmLDIkS1tqIfQgRKNDIUxjYi/gIEvbaiHwEASjQx1M42In4BxLW2uLQxpMY2Mh4BlL22uLQxdM42Mb4BZLW2yLQxRMY2QV4BNL22yLQxFM42QP4BBLW22LQw5MY2UJ4A1L220B8AMEo0MKTONlAeABIAC/AL8QvQdIgGhA9IBgBUmIYHBHA0iAaCD0gGABSYhgcEcAAABwAEAMAAAAQEIPAAFGMbn8SIBoIPSAcPpKkGAL4LH1gH8G0fdIgGhA9IBw9UqQYAHgASBwRwAg/OcAtU/0gHD/9+T/AL0AtQAg//ff/wC97EhAaEDwEADqSUhgcEfpSEBoIPAQAOdJSGBwR+VIQGhA8CAA40lIYHBH4khAaCDwIADgSUhgcEfeSEBoQPBAANxJSGBwR9tIQGgg8EAA2UlIYHBH10hAaEDwgADVSUhgcEfUSEBoIPCAANJJSGBwRwFGACAKaBAqBtAgKlLQQCp+0IAqfdHs4MtKEmgi8AgCyUsaYBofEmgi8AgCGx8aYMVKCDISaCLwCALDSwgzGmAaHxJoIvAIAhsfGmBKaAL0gDKy9YA/B9G7ShIfEmhC8AgCuUsbHxpgSmgC9AAysvUAPwXRtEoSaELwCAKySxpgCnkC8AECOrGvShIdEmhC8AgCrUsbHRpgCnkC8AICAioH0alKCDISaELwCAKmSwgzGmDu4KRKEmgi8BACoksaYBofEmgi8BACGx8aYJ5KCDISaCLwEAKcSwgzGmAaHxJoIvAQAhsfGmBKaAL0gDKy9YA/B9GUShIfEmhC8BACkksbHxpgSmgC9AAysvUAPwHgIeC84AXRjEoSaELwEAKKSxpgCnkC8AECOrGHShIdEmhC8BAChEsbHRpgCnkC8AICAioH0YBKCDISaELwEAJ+SwgzGmCd4HxKEmgi8CACeksaYBofEmgi8CACGx8aYHZKCDISaCLwIAJzSwgzGmAaHxJoIvAgAhsfGmBKaAL0gDKy9YA/B9FsShIfEmhC8CACaUsbHxpgSmgC9AAysvUAPwXRZUoSaELwIAJjSxpgCnkC8AECOrFgShIdEmhC8CACXUsbHRpgCnkC8AICAioH0VlKCDISaELwIAJXSwgzGmBP4FVKEmgi8EACU0saYBofEmgi8EACGx8aYE9KCDISaCLwQAJMSwgzGmAaHxJoIvBAAhsfGmBKaAL0gDKy9YA/B9FFShIfEmhC8EACQksbHxpgSmgC9AAysvUAPwXRPkoSaELwQAI8SxpgCnkC8AECOrE5ShIdEmhC8EACNksbHRpgCnkC8AICAioH0TJKCDISaELwQAIwSwgzGmAB4AEgAL8Av3BHK0gAaED0gEApSQhgcEcnSABoIPSAQCVKEGAmSEhEAGgyIlBDJUqw+/LwQRwA4EkeH0hAaQD0AHCw9QB/AdEAKfXRGkhAaQD0AHCw9QB/AdEDIHBHACD85xVJCWgh8AcBE0oRYBZJCWhB8AQBFEoRYAEoAdEwvwLgQL8gvyC/D0kJaCHwBAENShFgcEcISQloIfAHAUkcBUoRYAhJCWhB8AQBBkoRYAEoC9EwvwzgAHAAQCQEAUAMAAAAQEIPABDtAOBAvyC/IL86SQloIfAEAThKEWBwRzdJCWgh8AcBiRw1ShFgM0kJaEHwBAExShFgASgB0TC/AuBAvyC/IL8sSQloIfAEASpKEWBwRypIAGgg8AcAAB0nSQhgJUgAaEDwBAAjSQhgAL8AvzC/cEdwR3BHcEdwRxC1IEgAaAD0gDAosf/3t/tP9IAwG0kIYBpIIDAAaADwCAAosf/36/8IIBZJIDEIYBRIIDAAaADwEAAosf/33v8QIBBJIDEIYA5IIDAAaADwIAAosf/30f8gIApJIDEIYAhIIDAAaADwQAAosf/3xP9AIARJIDEIYBC9AAAQ7QDgAHAAQBQEAUAt6fBBBEYORhdGmEYGnRLgaByAsf736/ig6wgAqEIA2E25BCCE+DkA4GtA8AEA4GMBIL3o8IEgaIBoMEAIsQEgAOAAILhC49EAIPLnAWRwR3BH+LUERv73yvgGRgy5ASD4vZT4OQBQuQAghPg4ACBG//fu/0HyiDEgRv/35/8gaABoIPRwYaBoQB5B6gAgIWgIYCBsM0YAIiAhAJAgRv/3r/8FRhW7IXngaEDqAWAhaAlo/koRQAhDIWgIYCCKYWlB6gBAoWkIQyFoSWj4ShFACEMhaEhgIGgAaEDwAQAhaAhgACDgYwEghPg5AAC/ACCE+DgAAL8oRrLncEcQtQRGDLkBIBC9IGgAaCDwAQAhaAhgIEb/9/H/ACDgY4T4OQAAv4T4OAAAvwC/6+dwR3BHcLUFRqxqACAgY2BilPg5AAgoD9ECICFoyGAgaABoQPQAMCFoCGAgaABoQPACACFoCGAF4AEghPg5ACBG//ff/3C9cEdwR3BHcEdwtQRGACWU+DkAAPACADCzAL8AIIT4OAAAvwgghPg5ACBoAGgg9PgQIWgIYCBoAGgA8AQAoLEgaABoIPAEACFoCGC9SHhEYWuIY2Br/vcs/iixASCE+DkAIEb/987/DuACICFoyGAgaABoQPQAMCFoCGAgaABoQPACACFoCGAoRnC9cEdwRy3p8EEERiBohmggaAdoBvAEAAAoSNAH9IAgAChE0CBoAPEgBZT4OQASKBrREuBgakix4GkAeChw4GlAHOBhYGpAHmBiBuAgaABoIPSAICFoCGAF4CBogGjA84AAACjm0R7glPg5ACIoGtES4CBrSLEoeKFqCHCgakAcoGIga0AeIGMG4CBoAGgg9IAgIWgIYAXgIGiAaMDzgAAAKObRAL8gRv/3rP/u4AbwAgAAKHLQB/QAMAAobtACICFoyGAgaABoIPTgICFoCGCU+DkAEigc0SBoAGgA8AQAaLEgaABoIPAEACFoCGBgawBoAGgg8AEAYWsJaAhgIEb/9z7/ASCE+DkAIEb/93n/vOCU+DkAIig10SBoAGgA8AQAcLEgaABoIPAEACFoCGBgawBoAGgg8AEAYWsJaAhgF+AgaADxIAUM4CBrSLEoeKFqCHCgakAcoGIga0AeIGMA4AXgIGiAaAD0+FAAKOzRAL8gRv/3BP8BIIT4OQAgRv/3/f6C4JT4OQACKAfRASCE+DkAIEb/9/H+d+AW4JT4OQAIKHLRIGhAaSDwQGAhaEhhASCE+DkA4GsYuSBG//fc/mPgIEb/97X+X+AG8AgAuLEH9AAgoLEIICFoyGAgaABoAPSAAECxIGgAaCD0ECAhaAhgASCE+DkAIEb/97z+ROAG8AEAoLMH9IAwiLMBICFoyGAgaABoIPRwICFoCGDga0DwAgDgYyBoAGgA8AQAwLEgaABoIPAEACFoCGAfSHhEYWuIY2Br/vfu/PCx4GtA8AQA4GMBIIT4OQAgRv/3af4T4AEghPg5ACBG//di/gzg/+cG8BAAQLEH9IAQKLEQICFoyGAgRv/3U/696PCBELVLajOxsvFAbwPQi2pbHgRoI2GLaQArfdALauuzi2gH4O///wD++OD/b/////P8//8EaONhy2n7sdHpCzQjQ0xrI0NMaiNDjIpD6oRDDGkjQwxqI0PMaCNDzGkjQ4xpI0MMaCNDE0MEaGNhsvFAbwLQS2gEaKNhwODR6Qs0I0NMayNDTGojQ4yKQ+qEQwxpI0MMaiNDzGkA4AjgI0OMaSNDDGgjQxNDBGhjYabgy2nrsdHpCzQjQ0xrI0NMaiNDjIpD6oRDDGojQ8xoI0PMaSNDjGkjQwxoI0MTQwRoY2Gy8UBvyNBLaARoo2GG4NHpCzQjQ0xrI0NMaiNDjIpD6oRDDGojQ8xpI0OMaSNDDGgjQxNDAOAC4ARoY2Fu4Atqw7OLaARo42HLaeux0ekLNCNDTGsjQ0xqI0OMikPqhEMMaSNDDGojQ8xoI0PMaSNDjGkjQxNDBGhjYbLxQG9N0EtoBGijYUng0ekLNCNDTGsjQ0xqI0OMikPqhEMMaSNDDGojQ8xpI0OMaSNDE0MEaGNhM+D/58tp27HR6Qs0I0NMayNDTGojQ4yKQ+qEQwxqI0PMaCNDzGkjQ4xpI0MTQwRoY2Gy8UBvGNBLaARoo2EU4Etqk7HR6Qs0I0NMayNDTGojQ4yKQ+qEQwxqI0PMaSNDjGkjQxNDBGhjYRC9Len4QwRGDUYXRv33rP2ARqhpALEAv+hpALEAvyhqALEAvwC/lPg4AAEoAtECIL3o+IMBIIT4OAAAv5T4OQABKCjRACDgYwIghPg5AENGACIgISBGAJf/94/8BkbeuQAiKUYgRv/3zf5oani5Q0YBIgIhIEYAl//3f/wGRl65AiAhaMhgASCE+DkABOABIIT4OQAA4AImAL8AIIT4OAAAvzBGxOf4tQRGDUb991z9B0aoaQCxAL/oaQCxAL8oagCxAL8Av5T4OAABKAHRAiD4vQEghPg4AAC/lPg5AAEoM9EAIOBjAiCE+DkAIGw7RgAiICEAkCBG//c//AZG/rloahC5AyAhaMhgACIpRiBG//d4/mhqWLkAvwAghPg4AAC/IGgAaED0QDAhaAhgEuABIIT4OQAAvwAghPg4AArgAL8AIIT4OAAF4AImAL8AIIT4OAAAvzBGuuf4tQRGACX99wL9BkaU+DkAAPACAAAoPtAAvwAghPg4AAC/IGgAaADwBABwsSBoAGgg8AQAIWgIYGBr/vfV+gVGHbHga0DwBADgYyBoAGhA8AIAIWgIYCBsM0YBIgIhAJAgRv/33fsFRl25AiAhaMhgIGwzRgAiICEAkCBG//fQ+wVGRbkgaEBpIPBAYCFoSGEBIIT4OQAoRvi9Len4RQRGDkYXRgAl/fey/IBGIGgA8SAKAL+U+DgAASgC0QIgvej4hQEghPg4AAC/lPg5AAEoSdEAIOBjAC4/0BIghPg5ACBoAGlAHGBiIGgAaUAcIGLmYSBoQGkg8EBgIWhIYRPgQ0YBIgQhIEYAl//3ifsFRgWxDODgaQB4ivgAAOBpQBzgYWBqQB5gYmBqACjo0QC/fblDRgEiAiEgRgCX//dw+wVGNbkCICFoyGAgRv/3WP8FRgEghPg5AAbg4GtA8AgA4GMBJQDgAiUAvwAghPg4AAC/KEaj5y3p+E8ERg5GF0YAJf33RPyARiBo0PgYoCBoAPEgCwC/lPg4AAEoAtECIL3o+I8BIIT4OAAAv5T4OQABKE7RACDgYwAuRNAiIIT4OQAgaABpQBwgYyBoAGlAHOBipmIgaEBpIPBAYEDwgGAhaEhhIGjA+BigE+BDRgEiBiEgRgCX//cT+wVGBbEM4Jv4AAChaghwoGpAHKBiIGtAHiBjIGsAKOjRAL99uUNGASICISBGAJf/9/r6BUY1uQIgIWjIYCBG//fi/gVGASCE+DkABuDga0DwCADgYwElAOACJQC/ACCE+DgAAL8oRp7nELUCRgAjAL+S+DgAASgB0QIgEL0BIIL4OAAAv5L4OQABKC3RACDQYwGzEiCC+DkAEGgAaUAcUGIQaABpQBwQYtFhAyAUaOBgEGhAaSDwQGAUaGBhAL8AIIL4OAAAvxBoAGhA9OAgFGggYA/g0GtA8AgA0GMBIwC/ACCC+DgABeACIwC/ACCC+DgAAL8YRsDnMLUCRgAjEGiEaQC/kvg4AAEoAdECIDC9ASCC+DgAAL+S+DkAASgx0QAg0GMhsyIggvg5ABBoAGlAHBBjEGgAaUAc0GKRYgMgFWjoYBBoQGkg8EBgQPCAYBVoaGEQaIRhAL8AIIL4OAAAvxBoAGhA9OAgFWgoYA/g0GtA8AgA0GMBIwC/ACCC+DgABeACIwC/ACCC+DgAAL8YRrzncLUFRqxqACAgY2Bi4GtA8AQA4GMgaABoIPAEACFoCGAgRv/38/pwvXBHcLUERqVqKEb/9/n/cL0BRohqACJCYgJoEmhC9AAyA2gaYHBHLenwQQRGDkYAJyBoAGlFHAC/lPg4AAEoAtECIL3o8IEBIIT4OAAAv5T4OQABKH3RACDgYwAuetBga0BpCLllYjDgYGtAabD1gH8T0QXwAQAYuSB6APABAEix4GtA8AgA4GMBJwC/ACCE+DgAGuBoCGBiF+Bga0BpsPUAfxLRBfADABi5IHoA8AMASLHga0DwCADgYwEnAL8AIIT4OAAB4KgIYGIAL2bREiCE+DkAAyAhaMhgYGogYuZhIGhAaSDwQGAhaEhh+Eh4RGFryGL3SHhEYWsIY/ZIeERha0hjACBha4hjECFga4FgYGsAaABoIPAQAGFriWgIQ2FrCWgIYCNqIWgB8SACMUZga/73MPiguQC/ACCE+DgAAL8gaABoQPSAMCFoCGAgaAHgHeAS4ABoQPAEACFoCGAc4AEn4GtA8AQA4GMBIIT4OQAAvwAghPg4AA/g4GtA8AgA4GMBJwC/ACCE+DgABeACJwC/ACCE+DgAAL84RlDncEdwtQRGpWooRv/3+f9wvQFGiGoAIgJjAmgSaEL0ADIDaBpgcEct6fBBBEYORgAnIGjQ+BiAIGgAaUUcAL+U+DgAASgC0QIgvejwgQEghPg4AAC/lPg5AAEofdEAIOBjAC560GBrQGkIuSVjMOBga0BpsPWAfxPRBfABABi5IHoA8AEASLHga0DwCADgYwEnAL8AIIT4OAAa4GgIIGMX4GBrQGmw9QB/EtEF8AMAGLkgegDwAwBIseBrQPAIAOBjAScAvwAghPg4AAHgqAggYwAva9EiIIT4OQADICFoyGAga+BipmKUSHhEYWvIYpNIeERhawhjkkh4RGFrSGMAIGFriGMAIWBrgWBgawBoAGgg8BAAYWuJaAhDYWsJaAhg42oiaALxIAEyRmBr/fdj//i5IGhAaSDwQGBA8IBgIWhIYSBowPgYgAC/ACCE+DgAAL8gaABoAeAi4BfgQPSAMCFoCGAgaABoQPAEACFoCGAc4AEn4GtA8AQA4GMBIIT4OQAAvwAghPg4AA/g4GtA8AgA4GMBJwC/ACCE+DgABeACJwC/ACCE+DgAAL84RkvnLen4RQRGDkYVRphG/fd8+YJGsGkAsQC/8GkAsQC/MGoAsQC/AL+U+DgAASgC0QIgvej4hQEghPg4AAC/lPg5AAEoOtEAIOBjQiCE+DkAU0YAIiAhIEbN+ACA//de+AdGV7soaCFoiGJoaCFoSGKoaCFoyGIgaABoIPRAAClpQfSAAQhDIWgIYOhosGJP8ABiMUYgRv/3hvpTRgEiCCEgRs34AID/9zn4B0YvuQggIWjIYAEghPg5AADgAicAvwAghPg4AAC/OEay5y3p+EMERg5GFUb99xj5gEawaQCxAL/waQCxAL8wagCxAL8Av5T4OAABKALRAiC96PiDASCE+DgAAL+U+DkAAShK0QAg4GNCIIT4OQAgbENGACIgIQCQIEb+9/r/B0avuyhoIWiIYmhoIWhIYqhoIWjIYtXpBAEIQyFoCWgh9EABCEMhaAhgCSAhaMhg6GiwYk/wAGIxRiBG//cf+gC/ACCE+DgAAL8gaABoQPQQICFoCGAX4B////8J////1/7//yX///8P////Pf3////nAL8AIIT4OAAF4AInAL8AIIT4OAAAvzhGouct6fhDBEYNRhZG/fek+IBGqGkAsQC/6GkAsQC/KGoAsQC/AL+U+DgAASgC0QIgvej4gwEghPg4AAC/lPg5AAEoLNEAIOBjgiCE+DkAIGxDRgAiICEAkCBG/veG/wdG97kgaABoIPAIAHFoCEMhaAhgcGgIKAvRMGghaAhjECAhaMhgIGgAaED0gBAhaAhgT/BAYilGIEb/96z5AOACJwC/ACCE+DgAAL84RsDnAUaR+DkAcEcBRshrcEcQtQJGACMAv5L4OAABKAHRAiAQvQEggvg4AAC/kvg5AAEoC9GRYBBoAGgg9HBkkGhAHkTqACAUaCBgAOACIwC/ACCC+DgAAL8YRuLnAUYIaABowPMDIEAccEcQtf5IAGhA8AEA/EkIYP33GPgERgbg/fcU+AAbAigB2QMgEL31SABoAPACAAAo8tDySABoIPDwAEDwYADvSQhgACCIYO5I70lJRAhg7khIRABo/fcG+AixASDi5/z38f8ERgjg/Pft/wAbQfKIMYhCAdkDINXn4UiAaADwDAAAKPDR3kgAaOFJCEDcSQhg/PfY/wRGBuD899T/ABsCKAHZAyC+59VIAGgA8ChQACjy0dJJyGAIRsBoQPSAUMhgACAIYQhGAGlA9IBQCGEAIEhhCEZAaUD0gFBIYQhGAGgg9IAgCGAAIIhhQB4IYsNIlDAAaED0AADB+JQAACCR5/C1ACMAIN/49MLc+AjADPAMAd/46MLc+AzADPADBxmxDCkf0QEvHdHf+NTC3PgAwAzwCAy88QAPBtHf+MDC3PiUwMzzAyMF4N/4tMLc+ADAzPMDE9/4vML8RFz4IzBBuRhGBuAEKQHRq0gC4AgpANGqSAwpMtHf+ITC3PgMwAzwAwQBLAnQAiwC0AMsBNEB4KFKBOChSgLgAL8aRgC/AL/f+FzC3PgMwMzzAhwM8QEG3/hMwtz4DMDM8wYsDPsC/Lz79vLf+DjC3PgMwMzzQWwM8QEMT+pMBbL79fDwvfi1BEYAJoZIgG0A8IBQGLH+97b5BUYW4AC/gUiAbUDwgFB/SYhlCEaAbQDwgFAAkAC/AL/+96T5BUZ5SIBtIPCAUHdJiGW19QB/B9GALBDZoCwB2QImDOABJgrggCwB2QMmBuCALAHRAiYC4HAsANEBJnNIAGgg8AcAMENwSQhgCEYAaADwBwCwQgHQASD4vQAg/Oct6fhFBEYUuQEgvej4hV9IgGgA8AwGXUjAaADwAwcgeADwEAAQKHrRHrEMLnnRAS930VZIAGgA8AIAGLGgaQi5ASDi51FIIWoAaADwCAAgsU5IAGgA8PAABeBMSJQwAGgA9HBgAAmBQh/ZIGr/937/CLEBIMnnAL9ESABoQPAIAEJJCGAIRgBoIPDwACFqCEM+SQhgAL8IRkBoIPR/QOFpQOoBIDlJSGAf4AC/N0gAaEDwCAA1SQhgCEYAaCDw8AAhaghDMUkIYAC/CEZAaCD0f0DhaUDqASAsSUhgLrkgav/3RP8IsQEgj+f/99D+J0mJaMHzAxEuSnpEUVwB8B8ByEAkSUlECGAjSEhEAGj893D+gEa48QAPY9BARnXnYOD/56BpgLMZSABoQPABABdJCGD8907+BUYG4Pz3Sv5AGwIoAdkDIGDnEEgAaADwAgAAKPLQAL8NSABoQPAIAAtJCGAIRgBoIPDwACFqCEMHSQhgAL8IRkBoIPR/QOFpQOoBIAJJSGAs4BTgAAAAEAJAAAk9AAwAAAAUAAAA//T+6koqAAAAJPQAABJ6AAAgAkAgKAAA90gAaCDwAQD1SQhg/PcH/gVGBuD89wP+QBsCKAHZAyAZ5+9IAGgA8AIAACjy0SB4APABAAAoXNAILgPQDC4K0QMvCNHmSABoAPQAMIizYGh4uwEg/+YAv2BosPWAPwbR30gAaED0gDDdSQhgGuBgaLD1oC8L0dpIAGhA9IAg2EkIYAhGAGhA9IAwCGAK4NRIAGgg9IAw0kkIYAhGAGgg9IAgCGAAv2BokLH897j9BUYH4B7g/Pez/UAbZCgB2QMgyebHSABoAPQAMAAo8tAQ4Pz3pf0FRgbg/Peh/UAbZCgB2QMgt+a+SABoAPQAMAAo8tEgeADwAgACKFLRBC4D0AwuFNECLxLRtUgAaAD0gGAYseBoCLkBIJ3msUhAaCDw+FAhfEDqAWCtSUhgOeDgaACzq0gAaED0gHCpSQhg/Pdu/QVGBuD892r9QBsCKAHZAyCA5qJIAGgA9IBgACjy0J9IQGgg8PhQIXxA6gFgnElIYBbgmkgAaCD0gHCYSQhg/PdN/QVGBuD890n9QBsCKAHZAyBf5pJIAGgA9IBgACjy0SB4APAIAAgoNtFgadCxi0iUMABoQPABAIlJwfiUAPz3Lf0FRgbg/Pcp/UAbAigB2QMgP+aCSJQwAGgA8AIAACjx0BngfkiUMABoIPABAHtJwfiUAPz3Ev0FRgbg/PcO/UAbAigB2QMgJOZ0SJQwAGgA8AIAACjx0SB4APAEAAQocdFP8AAKbUiAbQDwgFB4uQC/akiAbUDwgFBoSYhlCEaAbQDwgFAAkAC/AL9P8AEKZEgAaAD0gHCwuWFIAGhA9IBwX0kIYPz32fwFRgbg/PfV/EAbAigB2QMg6+VZSABoAPSAcAAo8tAAv6BoASgI0VNIkDAAaEDwAQBQScH4kAAh4KBoBSgP0U1IkDAAaEDwBABKScH4kAAIRtD4kABA8AEAwfiQAA7gRUiQMABoIPABAEJJwfiQAAhG0PiQACDwBADB+JAAAL+gaKix/PeW/AVGCeD895L8QBtB8ogxiEIC2QMgpuUl4DVIkDAAaADwAgAAKO7QE+D894D8BUYI4Pz3fPxAG0HyiDGIQgHZAyCQ5SpIkDAAaADwAgAAKO/RuvEBDwXRJUiAbSDwgFAjSYhlAL+gagAofdCgagIoe9EfSMdoB/ADAeBqgUIo0QfwcAEga0AesesAHyHRB/T+QWBrsesALxvRB/QAMaBrBygB0AEgAOAAIIFCEdEH9MABoI8BIsLrUACx60BfCNEH8MBhQCAAXcLrUACx60BvadAMLmXQBkgAaADwgGAguQNIAGgA8IBQMLEBIDvlAAAAEAJAAHAAQPpIAGgg8IBw+EkIYPz3E/wFRgbg/PcP/EAbAigB2QMgJeXySABoAPAAcAAo8tHU6QsQQB5B6gARYGtB6gAhoI8BIsLrUABB6kBRQCAAXcLrUABB6kBhoGsACUHqQEDjSclo40oRQAhD4EnIYAhGAeBb4D7gAGhA8IBwCGAIRsBoQPCAcMhg/PfW+wVGBuD899L7QBsCKAHZAyDo5NNIAGgA8ABwACjy0FDgASDf5M9IAGgA8ABwwLvMSABoQPCAcMpJCGAIRsBoQPCAcMhg/Pey+wVGBuD89677QBsCKAHZAyDE5MFIAGgA8ABwACjy0CzgDC4o0L1IAGgg8IBwu0kIYAhGAGgA8CBQILkIRsBoIPADAMhgtUjAaLZJCECzSchg/PeI+wVGB+AP4Pz3g/tAGwIoAdkDIJnkrEgAaADwAHAAKPLRAeABIJDkACCO5C3p8EEERg1GFLkBIL3o8IGlSABoAPAHAKhCDtKiSABoIPAHAChDoEkIYAhGAGgA8AcAqEIB0AEg6OcgeADwAQAAKEDQYGgDKAbRlEgAaADwAHDYuQEg2edgaAIoBtGPSABoAPQAMIi5ASDP52BoMLmKSABoAPACAEC5ASDG54dIAGgA9IBgCLkBIL/ng0iAaCDwAwBhaAhDgEmIYPz3I/sGRgjg/Pcf+4AbQfKIMYhCAdkDIKrneUiAaADwDABhaLDrgQ/u0SB4APACAAIoB9FySIBoIPDwAKFoCENvSYhgcUgAaADwBwCoQg7ZbkgAaCDwBwAoQ2xJCGAIRgBoAPAHAKhCAdABIIDnIHgA8AQABCgH0WFIgGgg9OBg4WgIQ15JiGAgeADwCAAIKAjRW0iAaCD0YFAhaUDqwQBXSYhg//cv+1VJiWjB8wMRV0p6RFFcAfAfAchAVUlJRAhgVUhIRABo/PfP+gdGOEZO53C1hrAGRg1GFEYAv0hIwGxA8AEARknIZAhGwGwA8AEAAJAAvwC/iBUBkAIgApAEkAAgA5AFkAGpT/CQQP33Vfo7SIBoIPDuQEXqBAEIQzdJiGAGsHC9OkhIRABocEcAtf/3+f8ySYlowfMCITdKekRRXAHwHwHIQAC9ALX/9+v/K0mJaMHzwiEwSnpEHDpRXAHwHwHIQAC9HyEBYCRJCWgB9IAhsfWALwPRT/SgIUFgDOAeSQloAfSAMbH1gD8D0U/0gDFBYAHgACFBYBhJCWgB8AEBEbEBIYFhAeAAIYFhE0lJaMHzByHBYRBJCWgB8PABAWIOSQloAfSAcbH1gH8D0U/0gHHBYAHgACHBYAdJSWjB8wRhAWEFSZAxCWgB8AQBBCkT0QUhgWAa4AAAABACQIyAnfn//+7+ACACQN4gAAAMAAAAFAAAAGAgAABHSQloAfABARGxASGBYAHgACGBYEJJCR0JaAHwAQERsQEhQWEB4AAhQWEAIUFiPEmQOQloAfCAcbHxgH8C0QIhgWIB4AEhgWI1SZA5yWgB8AMCwmIySZA5yWjB8wIRSRwBYy9JkDnJaMHzBiJCYyxJkDnJaMHzQVFJHEoAwmMoSZA5yWjB80FhSRxKAAJkJEmQOcloAfQAMRGxESKCYwHgByKCY3BHDyICYB1KkDqSaALwAwJCYBpKkDqSaALw8AKCYBdKkDqSaAL04GLCYBRKkDqSaAL0YFLSCAJhEUoSaALwBwIKYHBHDUiQOABoQPQAIAtJkDkIYHBHcEcQtQhIkDjAaQD0gHCw9YB/BtH/9/T/T/SAcAJJkDkIYhC9AACQEAJAACACQC3p8EEERg9GACX+SMBoAPADAJCx+0jAaADwAwAhaIhCCdEgaDix90jAaMDzAhBAHGFoiEIz0AElMeAgaAEoBNACKAnQAyga0Q3g7kgAaADwAgAAuQElFODqSABoAPSAYAC5ASUN4OdIAGgA9AAwKLnkSABoAPSAIAC5ASUB4AElAL8Av1251OkAEEAeQeoAENxJyWgh8HMBCEPaSchgAC1W0dhIAGgg8IBQ1kkIYPz3KPkGRgbg/Pck+YAbAigB2QMlBeDPSABoAPAAUAAo8tEAv3W7b7mgaAAC4WgJCUDqQUDISUlpyEoRQAhDxUlIYQ7goGgAAiF8ASLC61EBQOpBYMBJSWnBShFACEO9SUhhvEgAaEDwgFC6SQhg/Pfx+AZGB+D89+34gBsCKALZAyUG4A3gs0gAaADwAFAAKPHQAL8tua9IQGlhaQhDrUlIYShGvejwgS3p8EEERg9GACWoSMBoAPADAJCxpkjAaADwAwAhaIhCCdEgaDixoUjAaMDzAhBAHGFoiEIz0AElMeAgaAEoBNACKAnQAyga0Q3gmEgAaADwAgAAuQElFOCVSABoAPSAYAC5ASUN4JFIAGgA9AAwKLmPSABoAPSAIAC5ASUB4AElAL8Av1251OkAEEAeQeoAEIdJyWgh8HMBCEOESchgAC1o0YJIAGgg8IBggEkIYPz3ffgGRgbg/Pd5+IAbAigB2QMlBeB6SABoAPAAYAAo8tEAv827b7mgaAAC4WgJCUDqQUBySQlpckoRQAhDcEkIYSDgAS8P0aBoAAIhigEiwutRAUDqQVBpSQlpa0oRQAhDZ0kIYQ7goGgAAiF9ASLC61EBQOpBYGFJCWliShFACENfSQhhXkgAaEDwgGBcSQhg/Pc0+AZGB+AU4Pz3L/iAGwIoAdkDJQXgVUgAaADwAGAAKPLQAL8tuVFIAGmhaQhDT0kIYShGvejwgS3p+EUERgAlqEYgiAD0AGCw9QBvMNFgboCxsPWADxPQsPUADwPQsPVADxXRE+BBSMBoQPSAMD9JyGAP4AAhIB3/9yH/BUYJ4AAhBPEgAP/3b/4FRgLgAeABJQC/AL9VuTRIiDAAaCD0QABhbghDMUnB+IgAAOCoRiCIAPSAULD1gF8w0aBugLGw8YB/E9Cw8QB/A9Cw8UB/FdET4CVIwGhA9IAwI0nIYA/gACEgHf/36v4FRgngACEE8SAA//c4/gVGAuAB4AElAL8Av1W5GUiIMABoIPBAcKFuCEMVScH4iAAA4KhGIGgA9AAwsPUAP23RT/AACg9IgG0BISHqEHB4sQC/C0iAbUDwgFAJSYhlCEaAbQDwgFAAkAC/AL9P8AEKCEgAaED0gHAGSQhg+/eA/wngABACQP+A/f//gP/5/4Cf/wBwAEAHRgbg+/dx/8AbAigB2QMlBeD+SABoAPSAcAAo8tAAv4W7+0gAaAD0QHbesdT4hACwQhfQ9kgAaCD0QHb0SJA40PiQAED0gDDxSZA5wfiQAAhG0PiQACD0gDDB+JAACEbA+JBgBvABAKix+/c+/wdGCuD79zr/wBtB8ogxiEID2QMlB+AW4CLg4UgAaADwAgAAKO7QAL9dud1IAGgg9EBw1PiEEAhD2kmQOcH4kAAC4KhGAOCoRrrxAQ8H0dRIkDiAbSDwgFDSSZA5iGUAvyB4APABAFCxzkgIOABoIPADAKFrCEPKSZA5wfiIACB4APACAAIoCtHGSAg4AGgg8AwA4WsIQ8JJkDnB+IgAIHgA8AQABCgK0b5ICDgAaCDwMAAhbAhDukmQOcH4iAAgeADwCAAIKArRtkgIOABoIPDAAGFsCEOySZA5wfiIACB4APAQABAoCtGuSAg4AGgg9EBwoWwIQ6pJkDnB+IgAIHgA8CAAICgK0aZICDgAaCD0QGDhbAhDokmQOcH4iAAgiAD0AHCw9QB/CtGdSAg4AGgg9EAg4W0IQ5pJkDnB+IgAIIgA9IBgsPWAbwrRlUgIOABoIPRAECFuCEORSZA5wfiIACB4APBAAEAoCtGNSAg4AGgg9EBQIW0IQ4lJkDnB+IgAIHgA8IAAgCgK0YVICDgAaCD0QEBhbQhDgUmQOcH4iAAgiAD0gHCw9YB/CtF8SAg4AGgg9EAwoW0IQ3lJkDnB+IgAIIgA9ABQsPUAXyHRdEgIOABoIPBAYOFuCENwSQg5CGDgbrDxAG8I0W1IkDjAaED0gBBqSZA5yGAK4OBusPGAbwbRASEgHf/3Yf0FRgWxqEYgaAD0ACCw9QAvIdFgSAg4AGgg8EBgIW8IQ1xJCDkIYCBvsPEAbwjRWUiQOMBoQPSAEFZJkDnIYArgIG+w8YBvBtEBISAd//c5/QVGBbGoRiBoAPSAILD1gC8h0UxICDgAaCDwQGBhbwhDSEkIOQhgYG+w8QBvCNFFSJA4wGhA9IAQQkmQOchgCuBgb7DxgG8G0QEhIB3/9xH9BUYFsahGIIgA9IBAsPWATyHROEgIOABoIPBAUKFvCEM0SQg5CGCgb7DxgF8H0QIhIB3/9/b8BUZtsahGC+Cgb7DxAF8H0QIhBPEgAP/3PvwFRgWxqEYgiAD0AECw9QBPCtEkSAg4AGgg8IBA4W8IQyBJkDnB+IgAIGgA9IAwsPWAPwvRG0gIOABoIPAAQNT4gBAIQxdJkDnB+IgAQEa96PiFFUkBYBNJkDnJaAHwAwFBYBBJkDnJaMHzAhFJHIFgDEmQOQlpwfMGIsJgCUmQOQlpwfNAQQciAusBEgJhBUmQOQlpwfNBUUkcSgBCYQXgAHAAQJAQAkD//w8A/UmQOQlpwfNBYUkcSgCCYUFoAWKCaEJi90mQOUlpwfMGIoJi9EmQOUlpwfNAQQciAusBEsJi8EmQOUlpwfNBYUkcSgACY+xJCDkJaAHwAwGBY+lJCDkJaAHwDAHBY+ZJCDkJaAHwMAEBZONJCDkJaAHwwAFBZOBJCDkJaAH0QHGBZN1JCDkJaAH0QGHBZNpJCDkJaAH0QFEBZddJCDkJaAH0QEFBZdRJCDkJaAH0QDGBZdFJCDkJaAH0QCHBZc5JCDkJaAH0QBEBZstJCDkJaAH0QAFBZshJCDkJaAHwQHGBZsVJCWgB9EBxwPiEEMJJCDkJaAHwQGHBZr9JCDkJaAHwQGEBZ7xJCDkJaAHwQGFBZ7lJCDkJaAHwQFGBZ7ZJCDkJaAHwgEHBZ7NJCDkJaAHwAEHA+IAQcEfwtQVGDkYAIAAhACS19QBvCtGqTwg/P2gH9EABsfVADw/RS/aAMAzgtfWAXwnRo08IPz9oB/BAcbHxQH8B0Uv2gDAAKDDRMkax9QAPAtCx8QB/KtGaT5A/P2gH8AB3t/EAf37Rlk+QP/9oB/SANwAvd9CST5A//2jH8wIXfxyy+/fyjk+QP/9ox/MGI0S5i0+QP/9oB/QANw+xESQA4AckAvsD97f79PBb4Em7hE+QPz9oB/AAZ7fxAG9S0YBPkD8/aQf0gDf3s31PkD//aMfzAhd/HLL79/J5T5A/P2nH8wYjRLl2T5A/P2kH9AA3D7ERJADgByQC+wP3t/v08DDgsfWADwLQsfGAfyrRbE+QPz9oB/AAV7fxAF8i0WhPkD9/aQf0gDd3sWVPkD//aMfzAhd/HLL79/JhT5A/f2nH8wYjVLkA4AzgXU+QP39pB/QANw+xESQA4AckAvsD97f79PDwvS3p8EcHRk/wAAq39QA/LdFSSABoAPRAdLT1gH8G0LT1AH8M0LT1QH8e0RLgS0gAaADwAgACKAHRT/QAShXgRkgAHQBoAPACAAIoAdFP9PpKC+BBSJA4AGgA9AAwsPUAPwHR3/j4oADgAL+d4ztIkDjAaADwAwi48QEPBtC48QIPJNC48QMPOdEs4DNIkDgAaADwAgACKBfRMEiQOABoAPAIACixLUiQOABoAPDwAAXgKkgAHQBoAPRwYAAJAAkoSXlEUfggUADgACUZ4CNIkDgAaAD0gGCw9YBvAdEiTQDgACUN4B1IkDgAaAD0ADCw9QA/AdEdTQDgACUB4AAlAL8Av7f1AH9v0BXcEC9t0AjcAS9r0AIvatAEL2nQCC9o0VXhIC9y0EAvcdCAL3DQt/WAf/TRj+K39YBPatAX3Lf1gG9n0Lf1AG8e0Lf1gF8i0Lf1AF/j0SXgAACQEAJAkNADANISAAAAJPQAABJ6ALf1AE950Lf1gD930Lf1gC8S0Lf1AC/L0Q/gKUZP9ABg//eF/oJGB+MpRk/0gFD/937+gkYA4wC/AL/+SABoAPBAZLTxgG9a0LTxAG8s0LTxQG9+0fdIiDgAaADwAgACKBzR9EiIOABoAPAIAFix8UiIOABoAPDwAAvgV+Ic4WvgluDB4Nfi60gMMABoAPRwYAAJAAnoSXlEUfggoFrgOuHe4f/hZuF24uJIiDgAaADwAHCw8QB/H9HeSIg4wGgA9IAQsPWAHxfR2kiIOMBowPMGJgX7BvDXSYg5yWjB8wIRSRyw+/H100iIOMBowPNBUEAcQAC1+/D6LOCB4qPhzUiIOABoAPAAYLDxAG8f0clIiDgAaQD0gBCw9YAfF9HFSIg4AGnA8wYmBfsG8MFJiDnJaMHzAhFJHLD78fW9SIg4AGnA80FQQBxAALX78PoB4P/nAL8Av2/itkgAaADwAwQ0sQEsCNACLArQAywd0RLg//cq+IJGGeD+9wP7gkYV4KxIiDgAaAD0gGCw9YBvAdHf+KiiCuCnSAgwAGgA8AIAAigB0U/0AEoA4AC/AL9D4qBIAGgA8AwENLEELAjQCCwK0AwsHdES4P738P+CRhng/vfX+oJGFeCWSIg4AGgA9IBgsPWAbwHR3/hQogrgkUgIMABoAPACAAIoAdFP9ABKAOAAvwC/F+KKSABoAPAwBDSxECwI0CAsCtAwLB3REuD+98T/gkYZ4P73q/qCRhXggEiIOABoAPSAYLD1gG8B0d/4+KEK4HtICDAAaADwAgACKAHRT/QASgDgAL8Av+vhdEgAaADwwAQ0sUAsCNCALArQwCwd0RLg/veY/4JGGeD+93/6gkYV4GpIiDgAaAD0gGCw9YBvAdHf+KChCuBlSAgwAGgA8AIAAigB0U/0AEoA4AC/AL+/4V5IAGgA9EB0TLG09YB/CtC09QB/C9C09UB/HdES4P73af+CRhng/vdQ+oJGFeBTSIg4AGgA9IBgsPWAbwHR3/hEoQrgTUgIMABoAPACAAIoAdFP9ABKAOAAvwC/kOFHSABoAPRAZEyxtPWAbwrQtPUAbwvQtPVAbx3REuD+9zr/gkYZ4P73IfqCRhXgO0iIOABoAPSAYLD1gG8B0d/45KAK4DZICDAAaADwAgACKAHRT/QASgDgAL8Av2HhL0gAaADwQFS08YBfCdC08QBfLdC08UBfWNH+9/j5gkZV4CdIiDgAaADwAGCw8QBvHdEjSIg4AGkA8IBwuLEgSIg4AGnA8wYmBfsG8BxJiDnJaMHzAhFJHLD78fUYSIg4AGnA80FgQBxAALX78Pou4BNIiDgAaADwAFCw8QBfHdEPSIg4QGkA8IBwuLEMSIg4QGnA8wYmBfsG8AlJiDnJaMHzAhFJHLD78fUFSIg4QGnA80FgQBxAALX78PoH4AAAiBACQI4RAAAAJPQAAL8Av/jg+UgAaADwAEQcuf73uv6CRgLg/veT+YJG6+DySABoAPRAVDSxtPWAXwfQtPUAXxPRB+D+95j+gkYP4P73f/mCRgvg6EiIOABoAPSAYLD1gG8B0d/4lKMA4AC/AL/J4OFIAGgA9EBENLG09YBPB9C09QBPE9EH4P73dv6CRg/g/vdd+YJGC+DXSIg4AGgA9IBgsPWAbwHR3/hQowDgAL8Av6fg0EgAaAD0QDQ0sbT1gD8H0LT1AD8T0Qfg/vdU/oJGD+D+9zv5gkYL4MZIiDgAaAD0gGCw9YBvAdHf+AyjAOAAvwC/heC/SABoAPRAJEyxtPWALwrQtPUALxHQtPVALyPRGOD+9y/+gkYf4LZIDDAAaADwAgACKAHRT/T6ShXgsUiIOABoAPSAYLD1gG8B0d/4uKIK4KtICDAAaADwAgACKAHRT/QASgDgAL8Av1DgpUgAaAD0QBRMsbT1gB8K0LT1AB8R0LT1QB8j0Rjg/vf6/YJGH+CbSAwwAGgA8AIAAigB0U/0+koV4JZIiDgAaAD0gGCw9YBvAdHf+EyiCuCRSAgwAGgA8AIAAigB0U/0AEoA4AC/AL8b4IpIAGgA8IBEHLG08YBPD9ED4P73y/2CRgvghEiIOABoAPSAYLD1gG8B0d/4BKIA4AC/AL8A4AC/AL9QRr3o8IdwtQRGACZ5SIg4AGgg8IBgdkmIOQhg+/c2+AVGBuD79zL4QBsCKAHZAyYG4G9IiDgAaADwAGAAKPHRAL+Gu6BoAAIhigEiwutRAUDqQVAhfcLrUQFA6kFg4WgJCUDqQUBiSYg5CWljShFACENfSYg5CGEIRgBpoWkIQ1xJiDkIYQhGAGhA8IBgCGD69/z/BUYH4Pr3+P9AGwIoAtkDJgfgB+BSSIg4AGgA8ABgACjw0AC/MEZwvXC1ACVMSIg4AGgg8IBgSUmIOQhg+vfc/wRGBuD699j/ABsCKAHZAyUG4EJIiDgAaADwAGAAKPHRAL8+SIg4AGlASQhAPEmIOQhhCEYAaADwCFAguQhGwGgg8AMAyGAoRnC9cLUERgAmM0iIOABoIPCAUDBJiDkIYPr3qv8FRgbg+vem/0AbAigB2QMmBuApSIg4AGgA8ABQACjx0QC/nrugaAACIXwBIsLrUQFA6kFg4WgJCUDqQUAfSYg5SWkhShFACEMcSYg5SGEIRkBpYWkIQxhJiDlIYQhGAGhA8IBQCGD693X/BUYG4Pr3cf9AGwIoAdkDJgbgD0iIOABoAPAAUAAo8dAAvzBGcL1wtQAlCUiIOABoIPCAUAZJiDkIYPr3Vv8ERhDg+vdS/wAbAigL2QMlD+CIEAJAACT0AP+Anfn//+7+/4D9+YJIAGgA8ABQACjo0QC/f0hAaX9JCEB9SUhhCEYAaADwIGAguQhGwGgg8AMAyGAoRnC9dkmJaCH0AEEBQ3NKkWBwR3JJlDEJaCH0cGFB6gARbkrC+JQQcEdsSJAwAGhA8CAAaknB+JAAcEdoSJAwAGgg8CAAZUnB+JAACEaAaSD0AHCIYXBHYUiQMABoQPAgAF5JwfiQAAhGgGlA9ABwiGFcSABoQPQAIFpJCGBZSAgwAGhA9AAgV0kIMQhgcEdwRxC1UkjAaQD0AHCw9QB/BdH/9/X/T/QAcExJCGIQvXC1hrAERgAlACYAv0hIwGxA8AEARknIZAhGwGwA8AEAAJAAvwC/BCABkAMgApACIASQACADkAGpT/CQQPv3bf47SIBtAPCAUHC5AL84SIBtQPCAUDZJiGUIRoBtAPCAUACQAL8AvwElNEgAaAD0gHAQufz3MPgBJi1IkDAAaCDwQHBE8IBxCEMpScH4kAABLgHR/Pcn+AEtBdEkSIBtIPCAUCJJiGUGsHC9OLUAJAAlH0iAbQDwgFBwuQC/HEiAbUDwgFAaSYhlCEaAbQDwgFAAkAC/AL8BJBhIAGgA9IBwELn79/j/ASURSJAwAGgg8IBwDknB+JAAAS0B0fv38v8BLAXRCkiAbSDwgFAISYhlOL0GSABoQPAEAARJCGBwRwNIAGgg8AQAAUkIYHBHABACQP///v4ABAFAAHAAQBC1lLAERk/0gHAMkAYgBpAAIA2QDpAPkAuQEZASkBOQQfKIMgap/khIRP33a/gQsQEgFLAQvQIgAJABkAAgBJABIAOQECACkIAEBZAFIAaQT/CAcA+QQfKIM2pGBqnwSEhE/fd+/AixASDi5wAg4OcQtZCwBEZP9IBwCJCFIAKQACAJkAqQT/CAcAuQACAHkAEgDJAAIA2QDpAPkEHyiDICqd9ISET99y34ELEBIBCwEL1B8ogyAanZSEhE/feJ+QixASDz59ZISET/95n/CLEBIOzngSACkJ34BAAg8PAACiHwIpL6ovKy+oLykUAIQ8CyAZBB8ogyAqnJSEhE/fcB+AixASDS50HyiDIBqcRISET99/D4CLEBIMjnACDG5zC1lbAFRgxGT/SAcA2QBSAHkAAgDpAPkE/wgHAQkAAgDJASkBOQFJABkAEgApAAIAWQASAEkBAgA5CABAaQI0YBqgeprkhIRP33+/sQsQEgFbAwvQAg++cQtY6wBEZP9IBwBpBmIACQACAHkAiQCZAFkAuQDJANkEHyiDJpRqBISET896//ELEBIA6wEL2ZIACQQfKIMmlGmUhIRPz3ov8IsQEg8edB8ogxlUhIRP/3p/8IsQEg6OcAIObnALWHsAC/kEgAbUD0gHCOSQhlCEYAbQD0gHABkAC/AL8IRgBrQPSAcAhjCEYAayD0gHAIYwC/CEbAbEDwEADIZAhGwGwA8BAAAZAAvwC/yBQCkAIgA5ABIASQAyAFkAogBpACqXlI+/fL/E/0dEACkAAgBJACqXVI+/fC/AewAL0QtXNIb0lJRAhgCEb894b8CLEBIBC9//ez/wEgaUlJREhgBCFnSEhEgWAQIcFgCAWQ+qDwsPqA8EAeYklJRAhhACFgSEhEQWGBYfz3EvwIsQEg3+dbSEhE//dg/wixBCDY51hISET/99X+CLEEINHnACDP5wC1h7AAv1NIwGxA8BAAUUnIZAhGwGwA8BAAAZAAvwC/T/RwQUxI+/dh/QAgA5BP9ABgApAAIASQBZACqUZI+/dl/AEgA5AAIASQT/SAYAKQAqlBSPv3WvwAIk/0gGE+SPv33v07SABrQPSAcDlJCGMIRgBrIPSAcAhjCEYAbSD0gHAIZQewAL0QtTRIMElJRAhgCEb89wj8CLEBIBC9//ev/wAg+udwtY6wBEYNRhZGT/SAcAaQ6yAAkE/0QGAHkE/0AFADkAGVACAIkE/wQHAJkAogBZAKlgAgC5AMkA2QQfKIMmlGGkhIRPz3o/4QsQEgDrBwvUHyiDIhRhRISET89///CLEBIPPnACDx5y3p8EWPsIJGDUYWRuiywPWAeLBFANmwRixGrxlP9IBwB5ASIAGQT/RAYAiQT/QAUASQACAJkE/wQHAKkAAgBpAH4FQAAAAAEAJAABAASAAQAKAMkA2QDpAAvwKUzfgsgMdISET/9939GLEBIA+wvejwhUHyiDIBqcFISET891P+CLEBIPLnQfKIMlFGvEhIRPz3Qv8IsQEg6OdB8ogxt0hIRP/3Tv4IsQEg3+dERMJEBPWAcLhCAdk4GwHgT/SAcIBGvELJ0wAg0OcQtY6wBEZP9IBwBpAgIACQQAEHkMAAA5ABlAAgCJAJkAWQC5AMkA2QokhIRP/3lP0QsQEgDrAQvUHyiDJpRp1ISET89wv+CLEBIPPnT/RIcZhISET/9xD+CLEBIOrnACDo5xC1jrAERv8sAtkBIA6wEL1P9IBwBpDYIACQT/SAYAeQwAADkCAEAZAAIAiQCZAFkAuQDJANkIZISET/91z9CLEBIOPnQfKIMmlGgUhIRPz31P0IsQEg2ecAINfnALWPsE/0gHAHkMcgAZAAIAiQCZAKkAaQDJANkA6Qdkl1SEhE//fJ/RCxASAPsAC9cUhIRP/3Mf0IsQEg9udB8ogyAalsSEhE/Pep/QixASDs5wAg6ucAtY+wT/SAcAeQcCABkAAgCJAJkE/wgHAKkAAgBpABIAuQACAMkA2QDpBB8ogyAalbSEhE/PeI/RCxASAPsAC9QfKIMmlGVkhIRPz35P4IsQEg8+ed+AAAAPA6AAixASDs5534AAAA8EQACLEIIOXnnfgAAADwgAAIsQAg3ucCINznAUZP8IBwCGAAE0hgiGAAEchgAAIIYQAgcEcAtZGwT/SAcAmQ6yADkE/0QGAKkE/0AFAGkAAgC5BP8EBwDJAKIAiQACAOkA+QEJACkAGqA6kzSEhE/fc/+hCxASARsAC9ACD75wC1j7D/94n/Aigl0cABB5B1IAGQACAIkAmQCpAGkAyQDZAOkCVISET/95n8ELEBIA+wAL1B8ogyAakfSEhE/PcQ/QixASDz5//3Z/8IKAHRACDt5wEg6+cAIOnnALWPsP/3W/8IKCXRQAEHkHogAZAAIAiQCZAKkAaQDJANkA6QDkhIRP/3a/wQsQEgD7AAvUHyiDIBqQhISET89+L8CLEBIPPn//c5/wIoAdEAIO3nASDr5wAg6ecAAFQAAACQ0AMAT/AAAgC1E0aURpZGIDkiv6DoDFCg6AxQsfEgAb/0968JByi/oOgMUEi/DMBd+ATriQAov0D4BCsIv3BHSL8g+AIrEfCATxi/APgBK3BHAAAAAAAAAAAAAAECAwQGBwgJAAAAAAECAwSghgEAQA0DAIAaBgAANQwAQEIPAICEHgAACT0AABJ6AAAk9AAANm4BAEjoAQBs3AIAAAAAAAAAAAAAAAAACT0AAAAAABAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    load_address: ~
+    pc_init: 207
+    pc_uninit: 229
+    pc_program_page: 273
+    pc_erase_sector: 243
+    pc_erase_all: 235
+    data_section_offset: 23792
+    flash_properties:
+      address_range:
+        start: 2415919104
+        end: 2432696320
+      page_size: 4096
+      erased_byte_value: 255
+      program_page_timeout: 10000
+      erase_sector_timeout: 6000
+      sectors:
+        - size: 65536
+          address: 0
+    cores: []
+  - name: stm32l4xx_128
+    description: STM32L4xx 128 KB Flash
     default: true
-    instructions: aEkQtWZKimBnSopgCmrSsqoqGNBlSspgZUrKYApqIvD/AgpiCmpC8KoCCmJKaUL0ADJKYUppQvAAYkphv/NPj0ppEgH81App0gP81FlMTEQgYFlIAIgABIAJYGBACKBgAPCY+AEoBNBP9ABQ4GAAIBC9T/SAUPnnSkhBaUHwAEFBYb/zT48AIHBHASBwR0VITPL6MQFhwRNBYUFpQfSAMUFhv/NPjwFpyQP81AAgcEdwtQZGAPBu+D5NAShNRAbRqWgoaAFEsUIB2AEkAOAAJADwYPgBKB7QaGhAHgZAcgswSEzy+jMDYQIhAevCAUHqBDFBYUFpQfSAMUFhv/NPjwFpyQP81AFpGUIc0elosfWAXwXQGuCoaEAeBkAyC9/nA2EKIQHrwgFB6gQxQWFBaUH0gDFBYb/zT48BackD/NQBaRlCAtADYQEgcL0AIHC9MLUUS8kdTPL6NSHwBwEdYQEkXGER4BRoBGBUaERgv/NPjxxp5AP81BxpLEIC0B1hASAwvQgwCDkIMgAp69EAIFhhML0DSABqwPOAUHBHAAAjAWdFACACQKuJ7807KhkIf25dTAQAAADgdf8fAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-    pc_init: 0x1
-    pc_uninit: 0x79
-    pc_program_page: 0x151
-    pc_erase_sector: 0xb1
-    pc_erase_all: 0x8f
-    data_section_offset: 0x1bc
+    instructions: v/NPj3BHW0gAaFtJAAUADUAYBdAtKAPQLygB0AEgcEcAIHBHVUgAaoACwA9wRwC1Akb/9+j/ASgI0f/38/8BKATRT0iCQgHTASAAvQAgAL0AtQJG//fX/wEoAtDQAoANAL1ISdAKCEDRA/nV/zABMAC9QkhESYFgREmBYAAhAWBDSQFhAGrAAwbUQ0hBSQFgBiFBYEFJgWAAIHBHASA3ScAHSGEAIHBHASBwRzNIOEkBYcETQWFBaQEiEgQRQ0FhN0k1SgDgEWADadsD+9QAIUFhCEZwRxC1BEb/96j/A0YgRv/3tf8lSSlMDGHCANgCkhwCQ0phSGkBIhIEEENIYb/zT48mSCRKAOAQYAtp2wP71AAgSGEIaSBAAdAMYQEgEL3wtckdFU3JCBlPyQAvYQAja2EaTBjgASNrYRNoA2BTaENgv/NPjxNLAOAcYC5p9gP71AAja2EraTtCAtAvYQEg8L0IMAg5CDIAKeTRACDwvQAAACAE4Mv7//8AIAJAAAABCN8DAAAjAWdFq4nvzfrDAABVVQAAADAAQP8PAACqqgAAAAAAAA==
+    load_address: ~
+    pc_init: 115
+    pc_uninit: 157
+    pc_program_page: 291
+    pc_erase_sector: 215
+    pc_erase_all: 173
+    data_section_offset: 420
     flash_properties:
       address_range:
-        start: 0x8000000
-        end: 0x8100000
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0x190
-      erase_sector_timeout: 0x190
+        start: 134217728
+        end: 134348800
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
       sectors:
-        - size: 0x2000
-          address: 0x0
+        - size: 2048
+          address: 0
+    cores: []
+  - name: stm32l4xx_256
+    description: STM32L4xx 256 KB Flash
+    default: true
+    instructions: v/NPj3BHWEgAaFhJAAUADUAYANABIHBHVUgAaoACwA9wRwC1Akb/9+7/ASgI0f/38/8BKATRT0iCQgHTASAAvQAgAL0AtQJG//fd/wEoAtDQAoANAL1ISdAKCECRA/nV/zABMAC9QkhESYFgREmBYAAhAWBDSQFhAGrAAwbUQ0hBSQFgBiFBYEFJgWAAIHBHASA3ScAHSGEAIHBHASBwRzNIOEkBYcETQWFBaQEiEgQRQ0FhN0k1SgDgEWADadsD+9QAIUFhCEZwRxC1BEb/96j/A0YgRv/3tf8lSSlMDGHCANgCkhwCQ0phSGkBIhIEEENIYb/zT48mSCRKAOAQYAtp2wP71AAgSGEIaSBAAdAMYQEgEL3wtckdFU3JCBlPyQAvYQAja2EaTBjgASNrYRNoA2BTaENgv/NPjxNLAOAcYC5p9gP71AAja2EraTtCAtAvYQEg8L0IMAg5CDIAKeTRACDwvQAAACAE4Mv7//8AIAJAAAACCL8DAAAjAWdFq4nvzfrDAABVVQAAADAAQP8PAACqqgAAAAAAAA==
+    load_address: ~
+    pc_init: 103
+    pc_uninit: 145
+    pc_program_page: 279
+    pc_erase_sector: 203
+    pc_erase_all: 161
+    data_section_offset: 408
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 134479872
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 2048
+          address: 0
+    cores: []
+  - name: stm32l4xx_512
+    description: STM32L4xx 512 KB Flash
+    default: true
+    instructions: v/NPj3BHW0gAaFtJAAUADUAYBdAtKAPQLygB0AEgcEcAIHBHVUgAaoACwA9wRwC1Akb/9+j/ASgI0f/38/8BKATRT0iCQgHTASAAvQAgAL0AtQJG//fX/wEoAtDQAoANAL1ISdAKCEBRA/nV/zABMAC9QkhESYFgREmBYAAhAWBDSQFhAGrAAwbUQ0hBSQFgBiFBYEFJgWAAIHBHASA3ScAHSGEAIHBHASBwRzNIOEkBYcETQWFBaQEiEgQRQ0FhN0k1SgDgEWADadsD+9QAIUFhCEZwRxC1BEb/96j/A0YgRv/3tf8lSSlMDGHCANgCkhwCQ0phSGkBIhIEEENIYb/zT48mSCRKAOAQYAtp2wP71AAgSGEIaSBAAdAMYQEgEL3wtckdFU3JCBlPyQAvYQAja2EaTBjgASNrYRNoA2BTaENgv/NPjxNLAOAcYC5p9gP71AAja2EraTtCAtAvYQEg8L0IMAg5CDIAKeTRACDwvQAAACAE4Mv7//8AIAJAAAAECH8DAAAjAWdFq4nvzfrDAABVVQAAADAAQP8PAACqqgAAAAAAAA==
+    load_address: ~
+    pc_init: 115
+    pc_uninit: 157
+    pc_program_page: 291
+    pc_erase_sector: 215
+    pc_erase_all: 173
+    data_section_offset: 420
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 134742016
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 2048
+          address: 0
+    cores: []
   - name: stm32l4xx_db_opt
     description: STM32L4xx dual bank Flash Options
-    cores:
-      - main
     default: false
     instructions: v/NPj3BHdkh0SYFgdUmBYHVJwWB1ScFgACEBYHRJAWEAasADBtR0SHJJAWAGIUFgckmBYAAgcEcBIWlIyQdBYUEEQWEAIHBHASBwRzC1ZEhnTARhakkBYksVQ2IdBIViaEnBYgFjXkpAMlNglWDRYBFhASFJBEFhv/NPj2JJXkoA4BFgA2nbA/vUAWkhQgTQAWkhQwFhASAwvQAgML0AIHBH+LWXiBZovEYXaZVovkaXitRoAJeTadFpSUgSakxPB2FSTz5ABmJnRr6yRmJQTjVAhWJPTSxAxGJ3Ri9AB2MAnz9Mv7JANGdgM0CjYClA4WAqQCJhASFJBEFhv/NPj0FJPUoA4BFgA2nbA/vUAmk3SQpCBNACaQpDAmEBIPi9ACD4vfe1UWiCsI5GFWiUaNFoAZERaSpOjEZRaQCRk2nRaRJqN2oxTjdANUCvQgfRI099anZGrbK2srVCAtBAHAWw8L29aipONUA0QKVCAdCAHPXn/monTAGdJkAlQK5CAdDAHOznPmtlRiZAJUCuQgHQAB3k5xJNQDVuaLeyAJ62srdCAdBAHdrnrmgYTz5AO0CeQgHQgB3S5+toIUAjQItCAdDAHcvnKWkiQCFAkUIB0AgwxOcDmUAYwecjAWdFACACQKuJ7807KhkIf25dTPrDAABVVQAAADAAQP8PAACq+O////8A/6qqAAD/d/8P//8AgP8A/wAAAAAA
-    pc_init: 0x7
-    pc_uninit: 0x39
-    pc_program_page: 0xa3
-    pc_erase_sector: 0x9f
-    pc_erase_all: 0x4d
-    data_section_offset: 0x218
+    load_address: ~
+    pc_init: 7
+    pc_uninit: 57
+    pc_program_page: 163
+    pc_erase_sector: 159
+    pc_erase_all: 77
+    data_section_offset: 536
     flash_properties:
       address_range:
-        start: 0x1fff7800
-        end: 0x1fff7824
-      page_size: 0x24
-      erased_byte_value: 0xff
-      program_page_timeout: 0xbb8
-      erase_sector_timeout: 0xbb8
+        start: 536836096
+        end: 536836132
+      page_size: 36
+      erased_byte_value: 255
+      program_page_timeout: 3000
+      erase_sector_timeout: 3000
       sectors:
-        - size: 0x24
-          address: 0x0
+        - size: 36
+          address: 0
+    cores: []
+  - name: stm32l4xx_1024
+    description: STM32L4xx 1MB Flash
+    default: true
+    instructions: v/NPj3BHWEgAaFhJAAUADUAYANABIHBHVUgAaoACwA9wRwC1Akb/9+7/ASgI0f/38/8BKATRT0iCQgHTASAAvQAgAL0AtQJG//fd/wEoAtDQAoANAL1ISdAKCEARA/nV/zABMAC9QkhESYFgREmBYAAhAWBDSQFhAGrAAwbUQ0hBSQFgBiFBYEFJgWAAIHBHASA3ScAHSGEAIHBHASBwRzNIOEkBYcETQWFBaQEiEgQRQ0FhN0k1SgDgEWADadsD+9QAIUFhCEZwRxC1BEb/96j/A0YgRv/3tf8lSSlMDGHCANgCkhwCQ0phSGkBIhIEEENIYb/zT48mSCRKAOAQYAtp2wP71AAgSGEIaSBAAdAMYQEgEL3wtckdFU3JCBlPyQAvYQAja2EaTBjgASNrYRNoA2BTaENgv/NPjxNLAOAcYC5p9gP71AAja2EraTtCAtAvYQEg8L0IMAg5CDIAKeTRACDwvQAAACAE4Mv7//8AIAJAAAAICP8CAAAjAWdFq4nvzfrDAABVVQAAADAAQP8PAACqqgAAAAAAAA==
+    load_address: ~
+    pc_init: 103
+    pc_uninit: 145
+    pc_program_page: 279
+    pc_erase_sector: 203
+    pc_erase_all: 161
+    data_section_offset: 408
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 135266304
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 2048
+          address: 0
+    cores: []
+  - name: stm32l4p5xx_512
+    description: STM32L4P5xx_512 Flash
+    default: true
+    instructions: YUkQtV9KimBgSopgCmrSsqoqGNBeSspgXkrKYApqIvD/AgpiCmpC8KoCCmJKaUL0ADJKYUppQvAAYkphv/NPj0ppEgH81App0gP81FJMTEQgYFJIAIgABIAJYGBACKBgAPCK+AEoBNBP9ABQ4GAAIBC9T/SAUPnnQ0hBaUHwAEFBYb/zT48AIHBHASBwRz5ITPL6MQFhwRNBYUFpQfSAMUFhv/NPjwFpyQP81AAgcEdwtQVGAPBg+DdOAShORAbRsWgwaAFEqUIB2AEkAOAAJADwUvgBKHBooPEBAAXqAAUk0GoLKEgBackD/NRM8vozA2ECIQHrwgFB6sQhQWFBaUH0gDFBYb/zT48BackD/NRBaSHwAgFBYUFpIfQAYUFhAWkZQgTQA2EBIHC9KgvZ5wAgcL0wtRRLyR1M8vo1IfAHAR1hASRcYRHgFGgEYFRoRGC/80+PHGnkA/zUHGksQgLQHWEBIDC9CDAIOQgyACnr0QAgWGEwvQNIAGrA84BQcEcAACMBZ0UAIAJAq4nvzTsqGQh/bl1MBAAAAOB1/x8AAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    load_address: ~
+    pc_init: 1
+    pc_uninit: 121
+    pc_program_page: 309
+    pc_erase_sector: 177
+    pc_erase_all: 143
+    data_section_offset: 416
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 134742016
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 4096
+          address: 0
+    cores: []
+  - name: stm32l4p5xx_1m
+    description: STM32L4P5xx_1M Flash
+    default: true
+    instructions: YUkQtV9KimBgSopgCmrSsqoqGNBeSspgXkrKYApqIvD/AgpiCmpC8KoCCmJKaUL0ADJKYUppQvAAYkphv/NPj0ppEgH81App0gP81FJMTEQgYFJIAIgABIAJYGBACKBgAPCK+AEoBNBP9ABQ4GAAIBC9T/SAUPnnQ0hBaUHwAEFBYb/zT48AIHBHASBwRz5ITPL6MQFhwRNBYUFpQfSAMUFhv/NPjwFpyQP81AAgcEdwtQVGAPBg+DdOAShORAbRsWgwaAFEqUIB2AEkAOAAJADwUvgBKHBooPEBAAXqAAUk0GoLKEgBackD/NRM8vozA2ECIQHrwgFB6sQhQWFBaUH0gDFBYb/zT48BackD/NRBaSHwAgFBYUFpIfQAYUFhAWkZQgTQA2EBIHC9KgvZ5wAgcL0wtRRLyR1M8vo1IfAHAR1hASRcYRHgFGgEYFRoRGC/80+PHGnkA/zUHGksQgLQHWEBIDC9CDAIOQgyACnr0QAgWGEwvQNIAGrA84BQcEcAACMBZ0UAIAJAq4nvzTsqGQh/bl1MBAAAAOB1/x8AAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    load_address: ~
+    pc_init: 1
+    pc_uninit: 121
+    pc_program_page: 309
+    pc_erase_sector: 177
+    pc_erase_all: 143
+    data_section_offset: 416
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 135266304
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 4096
+          address: 0
+    cores: []
+  - name: stm32l4rx_2048_dual
+    description: "STM32L4Rx 2MB Flash Dual "
+    default: true
+    instructions: ZkllSIhgZkiIYGZIA2hmSkpEk2ADaEP0AHMDYANoI/SAYwNgCGpAAgTVT/ABYBBgASBQYAhqwAMI1FxIRfJVUQFgBiFBYED2/3GBYAAgcEdSSEFpQfAAQUFhACBwRwEgcEdK9qohUUpMSADgEWADadsD+9RM8vszA2FI8gQDQ2FDaUP0gDNDYQDgEWADadsD+9QCaUTy+jEKQgLQAWEBIHBHQWkh8AQBQWFBaSH0AEFBYQAgcEdwtTtOPEpORDdJdGig8QBlSvaqIwEsAtDF80c0CuDF8wc0NWioQgXTSGlA9ABgSGEA4BNgCGnAA/vUTPL7MAhhSGkg9P9gSGFIaQIlBevEBCBDSGFIaUD0gDBIYQDgE2AIacAD+9QKaUTy+jACQgLQCGEBIHC9SGkg9IAwSGFIaSDwAgBIYUhpIPQAYEhhACBwvRC1yR0TSyHwBwEcaeQD/NRcaUTwAQRcYRHgFGgEYFRoRGAcaeQD/NQcaeQHBNBE8vowGGEBIBC9CDAIOQgyACnr0VhpIPABAFhhACAQvQAAIwFnRQAgAkCrie/NAHAAQAQAAAAAMABAAAAAAAAAEAgAAAAAAAAAAA==
+    load_address: ~
+    pc_init: 1
+    pc_uninit: 81
+    pc_program_page: 329
+    pc_erase_sector: 183
+    pc_erase_all: 99
+    data_section_offset: 432
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 136314880
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 4096
+          address: 0
+    cores: []
+  - name: stm32l4rx_sb_opt
+    description: STM32L4Rx Flash Options Single Bank
+    default: false
+    instructions: v/NPj3BHU0hRSYFgUkmBYFJJwWBSScFgACEBYFFJAWEAasADBtRRSE9JAWAGIUFgT0mBYAAgcEcBIUZIyQdBYUEEQWEAIHBHASBwRxC1QUhETARhR0kBYkkVQWJGSYFiRknBYgFjASFJBEFhv/NPj0NJPkoA4BFgA2nbA/vUAWkhQgTQAWkhQwFhASAQvQAgEL0AIHBH8LUVaFRok2jRaCxIEmkvTwdhNk41QAVi5APkC0RiMEzkQyNAg2IySxlAwWIaQAJjASFJBEFhv/NPjytJJkoA4BFgA2nbA/vUAWk5QgTQAWk5QwFhASDwvQAg8L3wtYxGlGjTaGDKFUmSaA9qIEkPQA1Ar0IG0RFNaWq2somysUIB0EAc8L2pahZO9kMxQDRAoUIB0IAc8L3sahVJDEALQJxCAdDAHPC9K2sKQAtAk0IB0AAd8L1gRPC9IwFnRQAgAkCrie/NOyoZCH9uXUz6wwAAVVUAAAAwAED/DwAAqvjv/wAA/n///wD/qqoAAP93/w//AP8AAAAAAA==
+    load_address: ~
+    pc_init: 7
+    pc_uninit: 57
+    pc_program_page: 151
+    pc_erase_sector: 147
+    pc_erase_all: 77
+    data_section_offset: 396
+    flash_properties:
+      address_range:
+        start: 535822336
+        end: 535822356
+      page_size: 20
+      erased_byte_value: 255
+      program_page_timeout: 3000
+      erase_sector_timeout: 3000
+      sectors:
+        - size: 20
+          address: 0
+    cores: []
+  - name: stm32l4rx_db_opt
+    description: STM32L4Rx Flash Options Dual Bank
+    default: false
+    instructions: v/NPj3BHekh4SYFgeUmBYHlJwWB5ScFgACEBYHhJAWEAasADBtR4SHZJAWAGIUFgdkmBYAAgcEcBIW1IyQdBYUEEQWEAIHBHASBwRxC1aEhrTARhbkkBYksVQ2JtSYFibUnBYgFjYkpAMlNgSwSTYNFgEWFZQkFhv/NPj2dJYkoA4BFgA2nbA/vUAWkhQgTQAWkhQwFhASAQvQAgEL0AIHBH+LWgytZovEaXaBRovkYXaVNoAJdRaU1IkmlQTwdhV089QAViZ0b9A+0LRWJRTe1DLECEYlNMI0DDYndGJ0AHY/UDQkvtC0AzXWAAn/0D7QudYCFA2WAiQBphASFJBEFhv/NPj0VJP0oA4BFgA2nbA/vUAWk6ShFCBNABaRFDAWEBIPi9ACD4vfe1UWiCsIxGkWgVaI5G1GgTaVFpAZGRaQCRKk7RaRJqN2o0TjdANUCvQgfRJk99amZGrbK2srVCAtBAHAWw8L0hTa5qKU13Ru1DLkAvQL5CAdCAHPLnG0/9aidONUA0QKVCAdDAHOnnPGszQDRAnEIB0AAd4ucTTEA0Y2idsgGbm7KdQgHQQB3Y56No3QMAm+0L2wPbC51CAdCAHc7n42gxQDNAi0IB0MAdx+chaTJAMUCRQgHQCDDA5wOZQBi95wAAIwFnRQAgAkCrie/NOyoZCH9uXUz6wwAAVVUAAAAwAED/DwAAqvjv/wAA/n///wD/qqoAAP93/w//AP8AAAAAAA==
+    load_address: ~
+    pc_init: 7
+    pc_uninit: 57
+    pc_program_page: 163
+    pc_erase_sector: 159
+    pc_erase_all: 77
+    data_section_offset: 552
+    flash_properties:
+      address_range:
+        start: 535822336
+        end: 535822372
+      page_size: 36
+      erased_byte_value: 255
+      program_page_timeout: 3000
+      erase_sector_timeout: 3000
+      sectors:
+        - size: 36
+          address: 0
+    cores: []
+  - name: stm32l4rx_2048
+    description: STM32L4Rx 2MB Flash
+    default: false
+    instructions: Y0liSIhgY0iIYGNIA2hjSkpEk2ADaEP0AHMDYANoI/SAYwNgCGpAAgTVT/ABYBBgASBQYAhqwAMI1FlIRfJVUQFgBiFBYED2/3GBYAAgcEdPSEFpQfAAQUFhACBwRwEgcEdK9qohTkpJSADgEWADadsD+9RM8vszA2FI8gQDQ2FDaUP0gDNDYQDgEWADadsD+9QCaUTy+jEKQgLQAWEBIHBHQWkh8AQBQWFBaSH0AEFBYQAgcEcwtcDzRzRK9qohN0ozSADgEWADadsD+9RM8vszA2FDaSP0/2NDYUNpAiUF68QEI0NDYUNpQ/SAM0NhAOARYANp2wP71AJpRPL6MQpCAtABYQEgML1BaSH0gDFBYUFpIfACAUFhACAwvXC1yR0h8AcBSvaqIx1MGE0A4CNgLmn2A/vUTPL7Ni5hbmlG8AEGbmET4BZoBmBWaEZgAOAjYC5p9gP71C5p9gcE0ETy+jAoYQEgcL0IMAg5CDIAKenRaGkg8AEAaGEHSAZJSESAaAhgACBwvQAAIwFnRQAgAkCrie/NAHAAQAQAAAAAMABAAAAAAAAAIAgAAAAAAAAAAA==
+    load_address: ~
+    pc_init: 1
+    pc_uninit: 81
+    pc_program_page: 287
+    pc_erase_sector: 183
+    pc_erase_all: 99
+    data_section_offset: 420
+    flash_properties:
+      address_range:
+        start: 134217728
+        end: 136314880
+      page_size: 1024
+      erased_byte_value: 255
+      program_page_timeout: 400
+      erase_sector_timeout: 400
+      sectors:
+        - size: 8192
+          address: 0
+    cores: []


### PR DESCRIPTION
This PR contains an updated `STM32L4_Series.yaml` target-gen'ed from Keil.STM32L4xx_DFP.2.5.0.

It contains fixes issues with STM32L475VGTx's flash algorithm once crossing into Bank 2.

Fixes #1074 