### PR TITLE
Update to cmsis-pack 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ram_download` example now uses clap syntax.
 - Refactored `probe-rs/src/debug/mod.rs` into several smaller files. (#1082)
 - Update STM32L4 series yaml from Keil.STM32L4xx_DFP.2.5.0. (#1086)
+- Updated cmsis-pack dependency to version 0.6.0. (#1089)
 
 ### Fixed
 

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 probe-rs = { path = "../probe-rs", version = "0.12.0", default-features = false }
 probe-rs-target = { path = "../probe-rs-target", version = "0.12.0", default-features = false }
-cmsis-pack = { version = "0.5.0" }
+cmsis-pack = { version = "0.6.0" }
 
 # , path = "../cmsis-pack-manager/rust/cmsis-pack"
 # , git = "https://github.com/probe-rs/cmsis-pack-manager.git"

--- a/target-gen/src/fetch.rs
+++ b/target-gen/src/fetch.rs
@@ -8,7 +8,7 @@ pub(crate) fn get_vidx() -> Result<Vidx> {
         .send()?
         .text()?;
 
-    let vidx = Vidx::from_string(&reader).map_err(|e| e.compat())?;
+    let vidx = Vidx::from_string(&reader)?;
 
     Ok(vidx)
 }

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -192,7 +192,7 @@ pub(crate) fn visit_dirs(path: &Path, families: &mut Vec<ChipFamily>) -> Result<
                 log::info!("Found .pdsc file: {}", path.display());
 
                 handle_package::<std::fs::File>(
-                    Package::from_path(&entry.path()).map_err(|e| e.compat())?,
+                    Package::from_path(&entry.path())?,
                     Kind::Directory(path),
                     families,
                 )


### PR DESCRIPTION
cmsis-pack 0.6.0 contains the following changes:
- pyocd/cmsis-pack-manager#183 (from @Yatekii + @mbrossard)
- pyocd/cmsis-pack-manager#186 (from @david-sawatzke)
- pyocd/cmsis-pack-manager#189 (from @Tiwalun)

