### PR TITLE
Use new svd-parser `expand` feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ram_download` example now uses clap syntax.
 - Refactored `probe-rs/src/debug/mod.rs` into several smaller files. (#1082)
 - Update STM32L4 series yaml from Keil.STM32L4xx_DFP.2.5.0. (#1086)
+- Debugger: SVD uses new `expand` feature of `svd-parser` crate to expand arrays and clusters. (#1090)
 
 ### Fixed
 

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -39,8 +39,15 @@ schemafy = "^0.6"
 chrono = { version = "0.4", features = ["serde"] }
 goblin = "0.5.1"
 base64 = "0.13"
-svd-parser = "0.13.1"
-svd-rs = { version = "0.13.1", features = ["derive-from"] }
+svd-parser = { git = "https://github.com/rust-embedded/svd", folder = "svd-parser", branch = "expand2", features = [
+    "expand",
+] }
+svd-rs = { git = "https://github.com/rust-embedded/svd", folder = "svd-rs", branch = "expand2", features = [
+    "derive-from",
+] }
+
+# svd-parser = "0.13.1"
+# svd-rs = { version = "0.13.1", features = ["derive-from"] }
 
 [dev-dependencies]
 insta = "1.8.0"

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -39,15 +39,8 @@ schemafy = "^0.6"
 chrono = { version = "0.4", features = ["serde"] }
 goblin = "0.5.1"
 base64 = "0.13"
-svd-parser = { git = "https://github.com/rust-embedded/svd", folder = "svd-parser", branch = "expand2", features = [
-    "expand",
-] }
-svd-rs = { git = "https://github.com/rust-embedded/svd", folder = "svd-rs", branch = "expand2", features = [
-    "derive-from",
-] }
-
-# svd-parser = "0.13.1"
-# svd-rs = { version = "0.13.1", features = ["derive-from"] }
+svd-parser = { version = "0.13.2", features = ["expand"] }
+svd-rs = { cersion = "0.13.2", features = ["derive-from"] }
 
 [dev-dependencies]
 insta = "1.8.0"


### PR DESCRIPTION
`probe-rs-debugger` now uses the `expand` feature of the `svd-parser` crate. 

The primary impact is that we were able to loose about 120 lines of obsolete code in probe-rs, as well as gain the ability to navigate clusters and arrays in SVD files.