### PR TITLE
Fix VSCode `wireProtocol` setting is ignored.

### DIFF
--- a/debugger/src/debugger/configuration.rs
+++ b/debugger/src/debugger/configuration.rs
@@ -34,8 +34,7 @@ pub struct SessionConfig {
     pub(crate) speed: Option<u32>,
 
     /// Protocol to use for target connection
-    #[serde(rename = "wire_protocol")]
-    pub(crate) protocol: Option<WireProtocol>,
+    pub(crate) wire_protocol: Option<WireProtocol>,
 
     ///Allow the session to erase all memory of the chip or reset it to factory default.
     #[serde(default)]

--- a/debugger/src/debugger/session_data.rs
+++ b/debugger/src/debugger/session_data.rs
@@ -83,8 +83,8 @@ impl SessionData {
         };
 
         // Set the protocol, if the user explicitly selected a protocol. Otherwise, use the default protocol of the probe.
-        if let Some(protocol) = config.protocol {
-            target_probe.select_protocol(protocol)?;
+        if let Some(wire_protocol) = config.wire_protocol {
+            target_probe.select_protocol(wire_protocol)?;
         }
 
         // Set the speed.


### PR DESCRIPTION
To fix VSCode `wireProtocol` setting is ignored by `probe-rs-debugger`