### PR TITLE
probe-rs-debugger: Poll RTT only once after halting.

### DIFF
--- a/debugger/src/peripherals/mod.rs
+++ b/debugger/src/peripherals/mod.rs
@@ -1,9 +1,7 @@
 /// Notes about SVD:
-/// Peripherals:
-/// - Are 'grouped', but many only belong to a single group.
-/// - The 'derived from' properties need to be read first, then overlay the specified properties
-/// Start off with everything being read-only.
-/// We only have to build the structure once down to 'fields' level.
-/// Fields need to be read every stacktrace, because they will change value.
-/// Once an SVD file has been parsed, it's structure is loaded as a hierarchical set of variables.
+/// - Peripherals are 'grouped', but many only belong to a single group.
+/// - We only have to build the structure once down to 'fields' level.
+/// - Once an SVD file has been parsed, it's structure is loaded as a hierarchical set of variables.
+/// - Fields need to be read every stacktrace, because they will change value.
+// TODO: Implement 'lazy load' of registers, to only read target registers for peripherals that are expanded in the VSCode variable view.
 pub(crate) mod svd_variables;


### PR DESCRIPTION
Currently the debugger continuously polls the target for RTT data, even while halted. 

This change will poll only once after halting, to drain the RTT buffers, and then won't poll again until the next time the core status has changed.