### PR TITLE
Fix debugger breakpoints for multiple files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Debugger: Improved RTT reliability between debug adapter and VSCode (#1035)
   - Fixed missing `derive` feature for examples using `clap`.
   - Increase SWD wait timeout (#994)
+  - Debugger: Fix `Source` breakpoints only worked for a single source file. (#1098)
 
 ## [0.12.0]
 

--- a/debugger/src/debug_adapter/dap_adapter.rs
+++ b/debugger/src/debug_adapter/dap_adapter.rs
@@ -634,8 +634,9 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
         let source_path = args.source.path.as_ref().map(Path::new);
 
-        // Always clear existing breakpoints before setting new ones. The DAP Specification doesn't make allowances for deleting and setting individual breakpoints.
-        match target_core.clear_breakpoints(BreakpointType::SourceBreakpoint) {
+        // Always clear existing breakpoints for the specified `[crate::debug_adapter::dap_types::Source]` before setting new ones.
+        // The DAP Specification doesn't make allowances for deleting and setting individual breakpoints for a specific `Source`.
+        match target_core.clear_breakpoints(BreakpointType::SourceBreakpoint(args.source.clone())) {
             Ok(_) => {}
             Err(error) => {
                 return self.send_response::<()>(
@@ -680,7 +681,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                             {
                                 match target_core.set_breakpoint(
                                     breakpoint_address as u32,
-                                    BreakpointType::SourceBreakpoint,
+                                    BreakpointType::SourceBreakpoint(args.source.clone()),
                                 ) {
                                     Ok(_) => (
                                         Some(valid_breakpoint_location),

--- a/debugger/src/debugger/session_data.rs
+++ b/debugger/src/debugger/session_data.rs
@@ -3,7 +3,7 @@ use super::{
     core_data::{CoreData, CoreHandle},
 };
 use crate::{
-    debug_adapter::{dap_adapter::DebugAdapter, protocol::ProtocolAdapter},
+    debug_adapter::{dap_adapter::DebugAdapter, dap_types::Source, protocol::ProtocolAdapter},
     DebuggerError,
 };
 use anyhow::{anyhow, Result};
@@ -21,7 +21,7 @@ use std::env::set_current_dir;
 #[derive(Debug, PartialEq)]
 pub enum BreakpointType {
     InstructionBreakpoint,
-    SourceBreakpoint,
+    SourceBreakpoint(Source),
 }
 
 /// Provide the storage and methods to handle various [`BreakPointType`]


### PR DESCRIPTION
The DAP Specification states the following for the `set_breakpoints()` request:
```
Sets multiple breakpoints for a single source and clears all previous breakpoints in that source.
```

The current probe-rs-debugger implementation sets and clears breakpoints on a 'per session' basis, as opposed to the specified 'per source' basis. This results in a behaviour where breakpoints for the any source is cleared when breakpoitns for any subsequent source is set.

With this fix, the breakpoints are now set and cleared 'per source'. 
