### PR TITLE
CLI fixes for ARMv7-A support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added GD32F3x0 series support (#1079)
 - Added support for connecting to ARM devices via JTAG to the JLink probe
 - Added preliminary support for ARM v7-A cores
+- CLI Debugger: Added 8-bit read / write memory commands
 
 ### Changed
 
@@ -73,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed missing `derive` feature for examples using `clap`.
   - Increase SWD wait timeout (#994)
   - Debugger: Fix `Source` breakpoints only worked for a single source file. (#1098)
+  - Debugger: Fix assumptions for ARM cores
+  - GDB: Fix assumptions for ARM cores
 
 ## [0.12.0]
 

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -22,4 +22,6 @@ pub enum CliError {
     },
     #[error(transparent)]
     ProbeRs(#[from] Error),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -19,10 +19,9 @@ use probe_rs_cli_util::{
     flash::run_flash_download,
 };
 
-use capstone::{arch::arm::ArchMode, prelude::*, Capstone, Endian};
 use rustyline::Editor;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 
 use std::{fs::File, path::PathBuf};
 use std::{io, time::Instant};
@@ -422,13 +421,6 @@ fn trace_u32_on_target(
 fn debug(shared_options: &CoreOptions, common: &ProbeOptions, exe: Option<PathBuf>) -> Result<()> {
     let mut session = common.simple_attach()?;
 
-    let cs = Capstone::new()
-        .arm()
-        .mode(ArchMode::Thumb)
-        .endian(Endian::Little)
-        .build()
-        .map_err(|err| anyhow!("Error creating capstone: {:?}", err))?;
-
     let di = exe
         .as_ref()
         .and_then(|path| DebugInfo::from_file(path).ok());
@@ -437,7 +429,7 @@ fn debug(shared_options: &CoreOptions, common: &ProbeOptions, exe: Option<PathBu
 
     let core = session.core(shared_options.core)?;
 
-    let mut cli_data = debugger::CliData::new(core, di, cs)?;
+    let mut cli_data = debugger::CliData::new(core, di)?;
 
     let mut rl = Editor::<()>::new();
 

--- a/debugger/src/debugger/core_data.rs
+++ b/debugger/src/debugger/core_data.rs
@@ -6,7 +6,6 @@ use crate::{
     DebuggerError,
 };
 use anyhow::Result;
-use capstone::Capstone;
 use probe_rs::{debug::debug_info::DebugInfo, Core};
 use probe_rs_cli_util::rtt;
 
@@ -26,7 +25,6 @@ pub struct CoreData {
 /// Usage: To get access to this structure please use the [SessionData::attach_core] method. Please keep access/locks to this to a minumum duration.
 pub struct CoreHandle<'p> {
     pub(crate) core: Core<'p>,
-    pub(crate) capstone: &'p Capstone,
     pub(crate) core_data: &'p mut CoreData,
 }
 

--- a/gdb-server/src/architecture.rs
+++ b/gdb-server/src/architecture.rs
@@ -74,7 +74,14 @@ impl<'probe> GdbArchitectureExt for Core<'probe> {
 
     fn num_general_registers(&self) -> usize {
         match self.architecture() {
-            probe_rs::Architecture::Arm => 24,
+            probe_rs::Architecture::Arm => {
+                match self.core_type() {
+                    // 16 general purpose regs
+                    CoreType::Armv7a => 16,
+                    // 16 general purpose regs, 8 FP regs
+                    _ => 24,
+                }
+            }
             probe_rs::Architecture::Riscv => 33,
         }
     }
@@ -144,7 +151,7 @@ impl GdbTargetExt for probe_rs::Target {
         // TODO: what if they're not all equal?
         let architecture = match self.cores[0].core_type {
             CoreType::Armv6m => "armv6-m",
-            CoreType::Armv7a => "armv7-a",
+            CoreType::Armv7a => "armv7",
             CoreType::Armv7m => "armv7",
             CoreType::Armv7em => "armv7e-m",
             CoreType::Armv8m => "armv8-m.main",

--- a/probe-rs-target/src/chip_family.rs
+++ b/probe-rs-target/src/chip_family.rs
@@ -40,6 +40,16 @@ pub enum CoreType {
     Riscv,
 }
 
+impl CoreType {
+    /// Returns true if the core type is an ARM Cortex-M
+    pub fn is_cortex_m(&self) -> bool {
+        matches!(
+            self,
+            CoreType::Armv6m | CoreType::Armv7em | CoreType::Armv7m | CoreType::Armv8m
+        )
+    }
+}
+
 /// The architecture family of a specific [`CoreType`].
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Architecture {
@@ -57,6 +67,17 @@ impl CoreType {
             _ => Architecture::Arm,
         }
     }
+}
+
+/// Instruction set used by a core
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum InstructionSet {
+    /// ARM Thumb 2 instruction set
+    Thumb2,
+    /// ARM A32 (often just called ARM) instruction set
+    A32,
+    /// RISC-V 32-bit instruction set
+    RV32,
 }
 
 /// This describes a chip family with all its variants.

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -18,7 +18,9 @@ mod flash_properties;
 mod memory;
 
 pub use chip::{ArmCoreAccessOptions, Chip, Core, CoreAccessOptions, RiscvCoreAccessOptions};
-pub use chip_family::{Architecture, ChipFamily, CoreType, TargetDescriptionSource};
+pub use chip_family::{
+    Architecture, ChipFamily, CoreType, InstructionSet, TargetDescriptionSource,
+};
 pub use flash_algorithm::RawFlashAlgorithm;
 pub use flash_properties::FlashProperties;
 pub use memory::{

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -8,7 +8,7 @@ use crate::error::Error;
 use crate::memory::Memory;
 use crate::{
     Architecture, CoreInformation, CoreInterface, CoreRegister, CoreRegisterAddress, CoreStatus,
-    DebugProbeError, HaltReason, MemoryInterface,
+    CoreType, DebugProbeError, HaltReason, InstructionSet, MemoryInterface,
 };
 use anyhow::Result;
 use bitfield::bitfield;
@@ -694,6 +694,14 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
 
     fn architecture(&self) -> Architecture {
         Architecture::Arm
+    }
+
+    fn core_type(&self) -> CoreType {
+        CoreType::Armv6m
+    }
+
+    fn instruction_set(&mut self) -> Result<InstructionSet, Error> {
+        Ok(InstructionSet::Thumb2)
     }
 
     fn status(&mut self) -> Result<crate::core::CoreStatus, Error> {

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -6,7 +6,7 @@ use crate::core::{
 };
 use crate::error::Error;
 use crate::memory::Memory;
-use crate::DebugProbeError;
+use crate::{CoreType, DebugProbeError, InstructionSet};
 
 use super::{register, Dfsr, State, ARM_REGISTER_FILE};
 use crate::{
@@ -947,6 +947,14 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
 
     fn architecture(&self) -> Architecture {
         Architecture::Arm
+    }
+
+    fn core_type(&self) -> CoreType {
+        CoreType::Armv7m
+    }
+
+    fn instruction_set(&mut self) -> Result<InstructionSet, Error> {
+        Ok(InstructionSet::Thumb2)
     }
 
     /// See docs on the [`CoreInterface::hw_breakpoints`] trait.

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -9,7 +9,7 @@ use crate::{
     architecture::arm::core::register, CoreStatus, DebugProbeError, HaltReason, MemoryInterface,
 };
 use crate::{Architecture, CoreInformation};
-use crate::{CoreInterface, CoreRegister};
+use crate::{CoreInterface, CoreRegister, CoreType, InstructionSet};
 use anyhow::Result;
 
 use bitfield::bitfield;
@@ -276,6 +276,14 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
 
     fn architecture(&self) -> Architecture {
         Architecture::Arm
+    }
+
+    fn core_type(&self) -> CoreType {
+        CoreType::Armv8m
+    }
+
+    fn instruction_set(&mut self) -> Result<InstructionSet, Error> {
+        Ok(InstructionSet::Thumb2)
     }
 
     fn status(&mut self) -> Result<crate::core::CoreStatus, Error> {

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::inconsistent_digit_grouping)]
 
 use crate::core::Architecture;
-use crate::CoreInterface;
+use crate::{CoreInterface, CoreType, InstructionSet};
 use anyhow::{anyhow, Result};
 use communication_interface::{
     AbstractCommandErrorKind, DebugRegister, RiscvCommunicationInterface, RiscvError,
@@ -446,6 +446,14 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
 
     fn architecture(&self) -> Architecture {
         Architecture::Riscv
+    }
+
+    fn core_type(&self) -> CoreType {
+        CoreType::Riscv
+    }
+
+    fn instruction_set(&mut self) -> Result<InstructionSet, Error> {
+        Ok(InstructionSet::RV32)
     }
 
     fn status(&mut self) -> Result<crate::core::CoreStatus, crate::Error> {

--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -27,8 +27,9 @@ mod registry;
 mod target;
 
 pub use probe_rs_target::{
-    Chip, ChipFamily, Core, CoreType, FlashProperties, MemoryRange, MemoryRegion, NvmRegion,
-    PageInfo, RamRegion, RawFlashAlgorithm, SectorDescription, SectorInfo, TargetDescriptionSource,
+    Chip, ChipFamily, Core, CoreType, FlashProperties, InstructionSet, MemoryRange, MemoryRegion,
+    NvmRegion, PageInfo, RamRegion, RawFlashAlgorithm, SectorDescription, SectorInfo,
+    TargetDescriptionSource,
 };
 
 pub use registry::{

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) mod communication_interface;
 
+use crate::{CoreType, InstructionSet};
 pub use communication_interface::CommunicationInterface;
 pub use probe_rs_target::Architecture;
-use probe_rs_target::CoreType;
 
 use crate::architecture::arm::sequences::ArmDebugSequenceError;
 use crate::architecture::{
@@ -268,6 +268,14 @@ pub trait CoreInterface: MemoryInterface {
 
     /// Get the `Architecture` of the Core.
     fn architecture(&self) -> Architecture;
+
+    /// Get the `CoreType` of the Core
+    fn core_type(&self) -> CoreType;
+
+    /// Determine the instruction set the core is operating in
+    /// This must be queried while halted as this is a runtime
+    /// decision for some core types
+    fn instruction_set(&mut self) -> Result<InstructionSet, error::Error>;
 }
 
 impl<'probe> MemoryInterface for Core<'probe> {
@@ -636,6 +644,18 @@ impl<'probe> Core<'probe> {
     /// Returns the architecture of the core.
     pub fn architecture(&self) -> Architecture {
         self.inner.architecture()
+    }
+
+    /// Returns the core type of the core
+    pub fn core_type(&self) -> CoreType {
+        self.inner.core_type()
+    }
+
+    /// Determine the instruction set the core is operating in
+    /// This must be queried while halted as this is a runtime
+    /// decision for some core types
+    pub fn instruction_set(&mut self) -> Result<InstructionSet, error::Error> {
+        self.inner.instruction_set()
     }
 }
 

--- a/probe-rs/src/debug/registers.rs
+++ b/probe-rs/src/debug/registers.rs
@@ -41,23 +41,17 @@ impl Registers {
         registers
     }
 
-    // TODO: These get_ and set_ functions should probably be implemented as Traits, with architecture specific implementations.
-
     /// Get the canonical frame address, as specified in the [DWARF](https://dwarfstd.org) specification, section 6.4.
     /// [DWARF](https://dwarfstd.org)
     pub fn get_frame_pointer(&self) -> Option<u32> {
-        match self.architecture {
-            Architecture::Arm => self.values.get(&7).copied(),
-            Architecture::Riscv => self.values.get(&8).copied(),
-        }
+        let reg_num = self.register_description.frame_pointer().address.0 as u32;
+
+        self.values.get(&reg_num).copied()
     }
     /// Set the canonical frame address, as specified in the [DWARF](https://dwarfstd.org) specification, section 6.4.
     /// [DWARF](https://dwarfstd.org)
     pub fn set_frame_pointer(&mut self, value: Option<u32>) {
-        let register_address = match self.architecture {
-            Architecture::Arm => 7,
-            Architecture::Riscv => 8,
-        };
+        let register_address = self.register_description.frame_pointer().address.0 as u32;
 
         if let Some(value) = value {
             self.values.insert(register_address, value);
@@ -66,21 +60,16 @@ impl Registers {
         }
     }
 
-    // TODO: FIX Riscv .... PC is a separate register, and NOT r1 (which is the return address)
     /// Get the program counter.
     pub fn get_program_counter(&self) -> Option<u32> {
-        match self.architecture {
-            Architecture::Arm => self.values.get(&15).copied(),
-            Architecture::Riscv => self.values.get(&1).copied(),
-        }
+        let reg_num = self.register_description.program_counter().address.0 as u32;
+
+        self.values.get(&reg_num).copied()
     }
 
     /// Set the program counter.
     pub fn set_program_counter(&mut self, value: Option<u32>) {
-        let register_address = match self.architecture {
-            Architecture::Arm => 15,
-            Architecture::Riscv => 1,
-        };
+        let register_address = self.register_description.program_counter().address.0 as u32;
 
         if let Some(value) = value {
             self.values.insert(register_address, value);
@@ -91,18 +80,14 @@ impl Registers {
 
     /// Get the stack pointer.
     pub fn get_stack_pointer(&self) -> Option<u32> {
-        match self.architecture {
-            Architecture::Arm => self.values.get(&13).copied(),
-            Architecture::Riscv => self.values.get(&2).copied(),
-        }
+        let reg_num = self.register_description.stack_pointer().address.0 as u32;
+
+        self.values.get(&reg_num).copied()
     }
 
     /// Set the stack pointer.
     pub fn set_stack_pointer(&mut self, value: Option<u32>) {
-        let register_address = match self.architecture {
-            Architecture::Arm => 13,
-            Architecture::Riscv => 2,
-        };
+        let register_address = self.register_description.stack_pointer().address.0 as u32;
 
         if let Some(value) = value {
             self.values.insert(register_address, value);
@@ -113,18 +98,14 @@ impl Registers {
 
     /// Get the return address.
     pub fn get_return_address(&self) -> Option<u32> {
-        match self.architecture {
-            Architecture::Arm => self.values.get(&14).copied(),
-            Architecture::Riscv => self.values.get(&1).copied(),
-        }
+        let reg_num = self.register_description.return_address().address.0 as u32;
+
+        self.values.get(&reg_num).copied()
     }
 
     /// Set the return address.
     pub fn set_return_address(&mut self, value: Option<u32>) {
-        let register_address = match self.architecture {
-            Architecture::Arm => 14,
-            Architecture::Riscv => 1,
-        };
+        let register_address = self.register_description.return_address().address.0 as u32;
 
         if let Some(value) = value {
             self.values.insert(register_address, value);

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -8,7 +8,7 @@ use crate::memory::MemoryInterface;
 use crate::{
     core::{Architecture, RegisterFile},
     session::Session,
-    Core, CoreRegisterAddress,
+    Core, CoreRegisterAddress, InstructionSet,
 };
 use std::{fmt::Debug, time::Duration};
 
@@ -584,7 +584,7 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
                 regs.return_address(),
                 // For ARM Cortex-M cores, we have to add 1 to the return address,
                 // to ensure that we stay in Thumb mode.
-                if self.core.architecture() == Architecture::Arm {
+                if self.core.instruction_set()? == InstructionSet::Thumb2 {
                     Some(algo.load_address + 1)
                 } else {
                     Some(algo.load_address)

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -84,7 +84,7 @@ mod probe;
 #[warn(missing_docs)]
 mod session;
 
-pub use crate::config::{CoreType, Target};
+pub use crate::config::{CoreType, InstructionSet, Target};
 pub use crate::core::{
     Architecture, BreakpointId, CommunicationInterface, Core, CoreInformation, CoreInterface,
     CoreRegister, CoreRegisterAddress, CoreState, CoreStatus, HaltReason, RegisterFile,


### PR DESCRIPTION
* Break assumptions around ARM being Cortex-M only in CLI debugger programs
* Fix ARMv7-A race condition related to data transfer between CPU and probe
* Memory accesses on ARMv-7A now go through the CPU to ensure consistency with the MMU
* Expose instruction set so programs can use it for things like disassembly
* Generalize some logic for register access
* Update debugger CLI to support 8 bit memory access and re-enable disassembly
* GDB server support for ARMv7-A

Signed-off-by: Ryan Fairfax <ryan@thefaxman.net>