### PR TITLE
Bump svd-parser to 0.13.4

### DIFF
--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -39,8 +39,8 @@ schemafy = "^0.6"
 chrono = { version = "0.4", features = ["serde"] }
 goblin = "0.5.1"
 base64 = "0.13"
-svd-parser = { version = "0.13.2", features = ["expand"] }
-svd-rs = { version = "0.13.2", features = ["derive-from"] }
+svd-parser = { version = "0.13.4", features = ["expand"] }
+
 
 [dev-dependencies]
 insta = "1.8.0"

--- a/debugger/src/peripherals/svd_variables.rs
+++ b/debugger/src/peripherals/svd_variables.rs
@@ -9,8 +9,11 @@ use probe_rs::{
     Core,
 };
 use std::{fmt::Debug, fs::File, io::Read, path::Path};
-use svd_parser::{self as svd, Config};
-use svd_rs::{Access, Device};
+use svd_parser::{
+    self as svd,
+    svd::{Access, Device},
+    Config,
+};
 
 /// The SVD file contents and related data
 #[derive(Debug)]


### PR DESCRIPTION
Tested improvements made by `svd-parser` for  nested `deriveFrom`

@burrbull