### PR TITLE
Add preliminary ARMv8-A support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added GD32F3x0 series support (#1079)
 - Added support for connecting to ARM devices via JTAG to the JLink probe
 - Added preliminary support for ARM v7-A cores
+- Added preliminary support for ARM v8-A cores
 - CLI Debugger: Added 8-bit read / write memory commands
 
 ### Changed

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -130,7 +130,7 @@ impl DebugCli {
 
                     if cli_data.core.architecture() == probe_rs::Architecture::Arm {
                         match cli_data.core.core_type() {
-                            CoreType::Armv6m | CoreType::Armv7em | CoreType::Armv7m | CoreType::Armv8m | CoreType::Armv7a => {
+                            CoreType::Armv6m | CoreType::Armv7em | CoreType::Armv7m | CoreType::Armv8m | CoreType::Armv7a | CoreType::Armv8a => {
                                 // Cortex-M and v7-A targets define the PSR as register 16
                                 let xpsr = cli_data.core.read_core_reg(
                                     16,

--- a/gdb-server/src/architecture.rs
+++ b/gdb-server/src/architecture.rs
@@ -78,6 +78,7 @@ impl<'probe> GdbArchitectureExt for Core<'probe> {
                 match self.core_type() {
                     // 16 general purpose regs
                     CoreType::Armv7a => 16,
+                    CoreType::Armv8a => 16,
                     // 16 general purpose regs, 8 FP regs
                     _ => 24,
                 }
@@ -154,6 +155,7 @@ impl GdbTargetExt for probe_rs::Target {
             CoreType::Armv7a => "armv7",
             CoreType::Armv7m => "armv7",
             CoreType::Armv7em => "armv7e-m",
+            CoreType::Armv8a => "armv8-a",
             CoreType::Armv8m => "armv8-m.main",
             CoreType::Riscv => "riscv:rv32",
         };

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -85,6 +85,9 @@ pub struct ArmCoreAccessOptions {
     /// The base address of the debug registers for the core.
     /// Required for Cortex-A, optional for Cortex-M
     pub debug_base: Option<u32>,
+    /// The base address of the cross trigger interface (CTI) for the core.
+    /// Required in ARMv8-A
+    pub cti_base: Option<u32>,
 }
 
 /// The data required to access a Risc-V core

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -1,6 +1,6 @@
 //! Register types and the core interface for armv6-M
 
-use super::{Dfsr, State, ARM_REGISTER_FILE};
+use super::{CortexMState, Dfsr, ARM_REGISTER_FILE};
 
 use crate::architecture::arm::sequences::ArmDebugSequence;
 use crate::core::{RegisterDescription, RegisterFile, RegisterKind};
@@ -445,7 +445,7 @@ const XPSR: RegisterDescription = RegisterDescription {
 pub(crate) struct Armv6m<'probe> {
     memory: Memory<'probe>,
 
-    state: &'probe mut State,
+    state: &'probe mut CortexMState,
 
     sequence: Arc<dyn ArmDebugSequence>,
 }
@@ -453,7 +453,7 @@ pub(crate) struct Armv6m<'probe> {
 impl<'probe> Armv6m<'probe> {
     pub(crate) fn new(
         mut memory: Memory<'probe>,
-        state: &'probe mut State,
+        state: &'probe mut CortexMState,
         sequence: Arc<dyn ArmDebugSequence>,
     ) -> Result<Self, Error> {
         if !state.initialized() {

--- a/probe-rs/src/architecture/arm/core/armv7a_debug_regs.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a_debug_regs.rs
@@ -1,0 +1,720 @@
+//! Debug register definitions
+use bitfield::bitfield;
+use std::mem::size_of;
+
+use crate::HaltReason;
+
+/// A debug register that is accessible to the external debugger
+pub trait Armv7DebugRegister {
+    /// Register number
+    const NUMBER: u32;
+
+    /// The register's name.
+    const NAME: &'static str;
+
+    /// Get the address in the memory map
+    fn get_mmio_address(base_address: u32) -> u32 {
+        base_address + (Self::NUMBER * size_of::<u32>() as u32)
+    }
+}
+
+bitfield! {
+    /// DBGDSCR - Debug Status and Control Registers
+    #[derive(Copy, Clone)]
+    pub struct Dbgdscr(u32);
+    impl Debug;
+
+    /// DBGDTRRX register full. The possible values of this bit are:
+    ///
+    /// 0
+    /// DBGDTRRX register empty.
+    ///
+    /// 1
+    /// DBGDTRRX register full.
+    pub rxfull, _: 30;
+
+    /// DBGDTRTX register full. The possible values of this bit are:
+    /// 0
+    /// DBGDTRTX register empty.
+    ///
+    /// 1
+    /// DBGDTRTX register full.
+    pub txfull, _: 29;
+
+    /// Latched RXfull. This controls the behavior of the processor on writes to DBGDTRRXext.
+    pub rxfull_l, set_rxfull_l: 27;
+
+    /// Latched TXfull. This controls the behavior of the processor on reads of DBGDTRTXext.
+    pub txfull_l, set_txfull_l: 26;
+
+    /// Sticky Pipeline Advance bit. This bit is set to 1 whenever the processor pipeline advances by retiring one or more instructions. It is cleared to 0 only by a write to DBGDRCR.CSPA.
+    pub pipeadv, _: 25;
+
+    /// Latched Instruction Complete. This is a copy of the internal InstrCompl flag, taken on each read of DBGDSCRext. InstrCompl signals whether the processor has completed execution of an instruction issued through DBGITR. InstrCompl is not visible directly in any register.
+    ///
+    /// On a read of DBGDSCRext when the processor is in Debug state, InstrCompl_l always returns the current value of InstrCompl. The meanings of the values of InstrCompl_l are:
+    ///
+    /// 0
+    /// An instruction previously issued through the DBGITR has not completed its changes to the architectural state of the processor.
+    ///
+    /// 1
+    /// All instructions previously issued through the DBGITR have completed their changes to the architectural state of the processor.
+    pub instrcoml_l, set_instrcoml_l: 24;
+
+    /// External DCC access mode. This field controls the access mode for the external views of the DCC registers and the DBGITR. Possible values are:
+    ///
+    /// 0b00
+    /// Non-blocking mode.
+    ///
+    /// 0b01
+    /// Stall mode.
+    ///
+    /// 0b10
+    /// Fast mode.
+    ///
+    /// The value 0b11 is reserved.
+    pub extdccmode, _: 21, 20;
+
+    /// Asynchronous Aborts Discarded. The possible values of this bit are:
+    ///
+    /// 0
+    /// Asynchronous aborts handled normally.
+    ///
+    /// 1
+    /// On an asynchronous abort to which this bit applies, the processor sets the Sticky Asynchronous Abort bit, ADABORT_l, to 1 but otherwise discards the abort.
+    pub adadiscard, _: 19;
+
+    /// Non-secure state status. If the implementation includes the Security Extensions, this bit indicates whether the processor is in the Secure state. The possible values of this bit are:
+    ///
+    /// 0
+    /// The processor is in the Secure state.
+    ///
+    /// 1
+    /// The processor is in the Non-secure state.
+    pub ns, _: 18;
+
+    /// Secure PL1 Non-Invasive Debug Disabled. This bit shows if non-invasive debug is permitted in Secure PL1 modes. The possible values of the bit are:
+    ///
+    /// 0
+    /// Non-invasive debug is permitted in Secure PL1 modes.
+    ///
+    /// 1
+    /// Non-invasive debug is not permitted in Secure PL1 modes.
+    pub spniddis, _: 17;
+
+    /// Secure PL1 Invasive Debug Disabled bit. This bit shows if invasive debug is permitted in Secure PL1 modes. The possible values of the bit are:
+    ///
+    /// 0
+    /// Invasive debug is permitted in Secure PL1 modes.
+    ///
+    /// 1
+    /// Invasive debug is not permitted in Secure PL1 modes.
+    pub spiddis, _: 16;
+
+    /// Monitor debug-mode enable. The possible values of this bit are:
+    ///
+    /// 0
+    /// Monitor debug-mode disabled.
+    ///
+    /// 1
+    /// Monitor debug-mode enabled.
+    pub mdbgen, set_mdbgen: 15;
+
+    ///Halting debug-mode enable. The possible values of this bit are:
+    ///
+    /// 0
+    /// Halting debug-mode disabled.
+    ///
+    /// 1
+    /// Halting debug-mode enabled.
+    pub hdbgen, set_hdbgen: 14;
+
+    /// Execute ARM instruction enable. This bit enables the execution of ARM instructions through the DBGITR. The possible values of this bit are:
+    ///
+    /// 0
+    /// ITR mechanism disabled.
+    ///
+    /// 1
+    /// The ITR mechanism for forcing the processor to execute instructions in Debug state via the external debug interface is enabled.
+    pub itren, set_itren: 13;
+
+    /// User mode access to Debug Communications Channel (DCC) disable. The possible values of this bit are:
+    ///
+    /// 0
+    /// User mode access to DCC enabled.
+    ///
+    /// 1
+    /// User mode access to DCC disabled.
+    pub udccdis, set_udccdis: 12;
+
+    /// Interrupts Disable. Setting this bit to 1 masks the taking of IRQs and FIQs. The possible values of this bit are:
+    ///
+    /// 0
+    /// Interrupts enabled.
+    ///
+    /// 1
+    /// Interrupts disabled.
+    pub intdis, set_intdis: 11;
+
+    /// Force Debug Acknowledge. A debugger can use this bit to force any implemented debug acknowledge output signals to be asserted. The possible values of this bit are:
+    ///
+    /// 0
+    /// Debug acknowledge signals under normal processor control.
+    ///
+    /// 1
+    /// Debug acknowledge signals asserted, regardless of the processor state.
+    pub dbgack, set_dbgack: 10;
+
+    /// Fault status. This bit is updated on every Data Abort exception generated in Debug state, and might indicate that the exception syndrome information was written to the PL2 exception syndrome registers. The possible values are:
+    ///
+    /// 0
+    /// Software must use the current state and mode and the value of HCR.TGE to determine which of the following sets of registers holds information about the Data Abort exception:
+    ///
+    /// The PL1 fault reporting registers, meaning the DFSR and DFAR, and the ADFSR if it is implemented.
+    /// The PL2 fault syndrome registers, meaning the HSR, HDFAR, and HPFAR, and the HADFSR if it is implemented.
+    /// 1
+    /// Fault status information was written to the PL2 fault syndrome registers.
+    pub fs, _: 9;
+
+    /// Sticky Undefined Instruction. This bit is set to 1 by any Undefined Instruction exceptions generated by instructions issued to the processor while in Debug state. The possible values of this bit are:
+    ///
+    /// 0
+    /// No Undefined Instruction exception has been generated since the last time this bit was cleared to 0.
+    ///
+    /// 1
+    /// An Undefined Instruction exception has been generated since the last time this bit was cleared to 0.
+    pub und_l, _: 8;
+
+    /// Sticky Asynchronous Abort. When the ADAdiscard bit, bit[19], is set to 1, ADABORT_l is set to 1 by any asynchronous abort that occurs when the processor is in Debug state.
+    ///
+    /// The possible values of this bit are:
+    ///
+    /// 0
+    /// No asynchronous abort has been generated since the last time this bit was cleared to 0.
+    ///
+    /// 1
+    /// Since the last time this bit was cleared to 0, an asynchronous abort has been generated while ADAdiscard was set to 1.
+    pub adabort_l, _e: 7;
+
+    /// Sticky Synchronous Data Abort. This bit is set to 1 by any Data Abort exception that is generated synchronously when the processor is in Debug state. The possible values of this bit are:
+    ///
+    /// 0
+    /// No synchronous Data Abort exception has been generated since the last time this bit was cleared to 0.
+    ///
+    /// 1
+    /// A synchronous Data Abort exception has been generated since the last time this bit was cleared to 0.
+    pub sdabort_l, _: 6;
+
+    /// Method of Debug entry.
+    pub moe, _: 5, 2;
+
+    /// Processor Restarted. The possible values of this bit are:
+    ///
+    /// 0
+    /// The processor is exiting Debug state. This bit only reads as 0 between receiving a restart request, and restarting Non-debug state operation.
+    ///
+    /// 1
+    /// The processor has exited Debug state. This bit remains set to 1 if the processor re-enters Debug state.
+    pub restarted, set_restarted: 1;
+
+    /// Processor Halted. The possible values of this bit are:
+    ///
+    /// 0
+    /// The processor is in Non-debug state.
+    ///
+    /// 1
+    /// The processor is in Debug state.
+    pub halted, set_halted: 0;
+}
+
+impl Dbgdscr {
+    /// Decode the MOE register into HaltReason
+    pub fn halt_reason(&self) -> HaltReason {
+        if self.halted() {
+            match self.moe() {
+                // Halt request from debugger
+                0b0000 => HaltReason::Request,
+                // Breakpoint debug event
+                0b0001 => HaltReason::Breakpoint,
+                // Async watchpoint debug event
+                0b0010 => HaltReason::Watchpoint,
+                // BKPT instruction
+                0b0011 => HaltReason::Breakpoint,
+                // External halt request
+                0b0100 => HaltReason::External,
+                // Vector catch
+                0b0101 => HaltReason::Exception,
+                // OS Unlock vector catch
+                0b1000 => HaltReason::Exception,
+                // Sync watchpoint debug event
+                0b1010 => HaltReason::Breakpoint,
+                // All other values are reserved
+                _ => HaltReason::Unknown,
+            }
+        } else {
+            // Not halted or cannot detect
+            HaltReason::Unknown
+        }
+    }
+}
+
+impl Armv7DebugRegister for Dbgdscr {
+    const NUMBER: u32 = 34;
+    const NAME: &'static str = "DBGDSCR";
+}
+
+impl From<u32> for Dbgdscr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgdscr> for u32 {
+    fn from(value: Dbgdscr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGDIDR - Debug ID Register
+    #[derive(Copy, Clone)]
+    pub struct Dbgdidr(u32);
+    impl Debug;
+
+    /// The number of watchpoints implemented. The number of implemented watchpoints is one more than the value of this field.
+    pub wrps, _: 31, 28;
+
+    /// The number of breakpoints implemented. The number of implemented breakpoints is one more than value of this field.
+    pub brps, set_brps: 27, 24;
+
+    /// The number of breakpoints that can be used for Context matching. This is one more than the value of this field.
+    pub ctx_cmps, _: 23, 20;
+
+    /// The Debug architecture version. The permitted values of this field are:
+    ///
+    /// 0b0001
+    /// ARMv6, v6 Debug architecture.
+    ///
+    /// 0b0010
+    /// ARMv6, v6.1 Debug architecture.
+    ///
+    /// 0b0011
+    /// ARMv7, v7 Debug architecture, with all CP14 registers implemented.
+    ///
+    /// 0b0100
+    /// ARMv7, v7 Debug architecture, with only the baseline CP14 registers implemented.
+    ///
+    /// 0b0101
+    /// ARMv7, v7.1 Debug architecture.
+    ///
+    /// All other values are reserved.
+    pub version, _: 19, 16;
+
+    /// Debug Device ID Register, DBGDEVID, implemented.
+    pub devid_imp, _: 15;
+
+    /// Secure User halting debug not implemented
+    pub nsuhd_imp, _: 14;
+
+    /// Program Counter Sampling Register, DBGPCSR, implemented as register 33.
+    pub pcsr_imp, _: 13;
+
+    /// Security Extensions implemented.
+    pub se_imp, _: 12;
+
+    /// This field holds an implementation defined variant number.
+    pub variant, _: 7, 4;
+
+    /// This field holds an implementation defined revision number.
+    pub revision, _: 3, 0;
+}
+
+impl Armv7DebugRegister for Dbgdidr {
+    const NUMBER: u32 = 0;
+    const NAME: &'static str = "DBGDIDR";
+}
+
+impl From<u32> for Dbgdidr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgdidr> for u32 {
+    fn from(value: Dbgdidr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGDRCR - Debug Run Control Register
+    #[derive(Copy, Clone)]
+    pub struct Dbgdrcr(u32);
+    impl Debug;
+
+    /// Cancel Bus Requests Request
+    pub cbrrq, set_cbrrq: 4;
+
+    /// Clear Sticky Pipeline Advance
+    pub cspa, set_cspa: 3;
+
+    /// Clear Sticky Exceptions
+    pub cse, set_cse: 2;
+
+    /// Restart request
+    pub rrq, set_rrq: 1;
+
+    /// Halt request
+    pub hrq, set_hrq: 0;
+}
+
+impl Armv7DebugRegister for Dbgdrcr {
+    const NUMBER: u32 = 36;
+    const NAME: &'static str = "DBGDRCR";
+}
+
+impl From<u32> for Dbgdrcr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgdrcr> for u32 {
+    fn from(value: Dbgdrcr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGBVR - Breakpoint Value Register
+    #[derive(Copy, Clone)]
+    pub struct Dbgbvr(u32);
+    impl Debug;
+
+    /// Breakpoint address
+    pub value, set_value : 31, 0;
+}
+
+impl Armv7DebugRegister for Dbgbvr {
+    const NUMBER: u32 = 64;
+    const NAME: &'static str = "DBGBVR";
+}
+
+impl From<u32> for Dbgbvr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgbvr> for u32 {
+    fn from(value: Dbgbvr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGBCR - Breakpoint Control Register
+    #[derive(Copy, Clone)]
+    pub struct Dbgbcr(u32);
+    impl Debug;
+
+    /// Address range mask. Whether masking is supported is implementation defined.
+    pub mask, set_mask : 28, 24;
+
+    /// Breakpoint type
+    pub bt, set_bt : 23, 20;
+
+    /// Linked breakpoint number
+    pub lbn, set_lbn : 19, 16;
+
+    /// Security state control
+    pub ssc, set_ssc : 15, 14;
+
+    /// Hyp mode control bit
+    pub hmc, set_hmc: 13;
+
+    /// Byte address select
+    pub bas, set_bas: 8, 5;
+
+    /// Privileged mode control
+    pub pmc, set_pmc: 2, 1;
+
+    /// Breakpoint enable
+    pub e, set_e: 0;
+}
+
+impl Armv7DebugRegister for Dbgbcr {
+    const NUMBER: u32 = 80;
+    const NAME: &'static str = "DBGBCR";
+}
+
+impl From<u32> for Dbgbcr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgbcr> for u32 {
+    fn from(value: Dbgbcr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGLAR - Lock Access Register
+    #[derive(Copy, Clone)]
+    pub struct Dbglar(u32);
+    impl Debug;
+
+    /// Lock value
+    pub value, set_value : 31, 0;
+
+}
+
+impl Armv7DebugRegister for Dbglar {
+    const NUMBER: u32 = 1004;
+    const NAME: &'static str = "DBGLAR";
+}
+
+impl From<u32> for Dbglar {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbglar> for u32 {
+    fn from(value: Dbglar) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGDSCCR - State Cache Control Register
+    #[derive(Copy, Clone)]
+    pub struct Dbgdsccr(u32);
+    impl Debug;
+
+    /// Force Write-Through
+    pub nwt, set_nwt: 2;
+
+    /// Instruction cache
+    pub nil, set_nil: 1;
+
+    /// Data or unified cache.
+    pub ndl, set_ndl: 0;
+}
+
+impl Armv7DebugRegister for Dbgdsccr {
+    const NUMBER: u32 = 10;
+    const NAME: &'static str = "DBGDSCCR";
+}
+
+impl From<u32> for Dbgdsccr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgdsccr> for u32 {
+    fn from(value: Dbgdsccr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGDSMCR - Debug State MMU Control Register
+    #[derive(Copy, Clone)]
+    pub struct Dbgdsmcr(u32);
+    impl Debug;
+
+    /// Instruction TLB matching bit
+    pub nium, set_nium: 3;
+
+    /// Data or Unified TLB matching bit
+    pub ndum, set_ndum: 2;
+
+    /// Instruction TLB loading bit
+    pub niul, set_niul: 1;
+
+    /// Data or Unified TLB loading bit
+    pub ndul, set_ndul: 0;
+}
+
+impl Armv7DebugRegister for Dbgdsmcr {
+    const NUMBER: u32 = 11;
+    const NAME: &'static str = "DBGDSMCR";
+}
+
+impl From<u32> for Dbgdsmcr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgdsmcr> for u32 {
+    fn from(value: Dbgdsmcr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGITR - Instruction Transfer Register
+    #[derive(Copy, Clone)]
+    pub struct Dbgitr(u32);
+    impl Debug;
+
+    /// Instruction value
+    pub value, set_value: 31, 0;
+}
+
+impl Armv7DebugRegister for Dbgitr {
+    const NUMBER: u32 = 33;
+    const NAME: &'static str = "DBGITR";
+}
+
+impl From<u32> for Dbgitr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgitr> for u32 {
+    fn from(value: Dbgitr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGDTRTX - Target to Host data transfer register
+    #[derive(Copy, Clone)]
+    pub struct Dbgdtrtx(u32);
+    impl Debug;
+
+    /// Value
+    pub value, set_value: 31, 0;
+}
+
+impl Armv7DebugRegister for Dbgdtrtx {
+    const NUMBER: u32 = 35;
+    const NAME: &'static str = "DBGDTRTX";
+}
+
+impl From<u32> for Dbgdtrtx {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgdtrtx> for u32 {
+    fn from(value: Dbgdtrtx) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGDTRRX - Host to Target data transfer register
+    #[derive(Copy, Clone)]
+    pub struct Dbgdtrrx(u32);
+    impl Debug;
+
+    /// Value
+    pub value, set_value: 31, 0;
+}
+
+impl Armv7DebugRegister for Dbgdtrrx {
+    const NUMBER: u32 = 32;
+    const NAME: &'static str = "DBGDTRRX";
+}
+
+impl From<u32> for Dbgdtrrx {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgdtrrx> for u32 {
+    fn from(value: Dbgdtrrx) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGPRCR - Powerdown and Reset Control Register
+    #[derive(Copy, Clone)]
+    pub struct Dbgprcr(u32);
+    impl Debug;
+
+    /// Core powerup request
+    pub corepurq, set_corepurq : 3;
+
+    /// Hold core in warm reset
+    pub hcwr, set_hcwr : 2;
+
+    /// Core warm reset request
+    pub cwrr, set_cwrr : 1;
+
+    /// Core no powerdown request
+    pub corenpdrq, set_corenpdrq : 0;
+}
+
+impl Armv7DebugRegister for Dbgprcr {
+    const NUMBER: u32 = 196;
+    const NAME: &'static str = "DBGPRCR";
+}
+
+impl From<u32> for Dbgprcr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgprcr> for u32 {
+    fn from(value: Dbgprcr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGPRSR - Powerdown and Reset Status Register
+    #[derive(Copy, Clone)]
+    pub struct Dbgprsr(u32);
+    impl Debug;
+
+    /// OS Double Lock Status
+    pub dlk, _ : 6;
+
+    /// OS Lock Status
+    pub oslk, _ : 5;
+
+    /// Halted
+    pub halted, _ : 4;
+
+    /// Stick reset status
+    pub sr, _ : 3;
+
+    /// Reset status
+    pub r, _ : 2;
+
+    /// Stick power down status
+    pub spd, _ : 1;
+
+    /// Power up status
+    pub pu, _ : 0;
+}
+
+impl Armv7DebugRegister for Dbgprsr {
+    const NUMBER: u32 = 197;
+    const NAME: &'static str = "DBGPRSR";
+}
+
+impl From<u32> for Dbgprsr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgprsr> for u32 {
+    fn from(value: Dbgprsr) -> Self {
+        value.0
+    }
+}

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -8,7 +8,7 @@ use crate::error::Error;
 use crate::memory::Memory;
 use crate::{CoreType, DebugProbeError, InstructionSet};
 
-use super::{register, Dfsr, State, ARM_REGISTER_FILE};
+use super::{register, CortexMState, Dfsr, ARM_REGISTER_FILE};
 use crate::{
     core::{Architecture, CoreStatus, HaltReason},
     MemoryInterface,
@@ -587,7 +587,7 @@ pub const PSP: CoreRegisterAddress = CoreRegisterAddress(0b000_1010);
 pub struct Armv7m<'probe> {
     memory: Memory<'probe>,
 
-    state: &'probe mut State,
+    state: &'probe mut CortexMState,
 
     sequence: Arc<dyn ArmDebugSequence>,
 }
@@ -595,7 +595,7 @@ pub struct Armv7m<'probe> {
 impl<'probe> Armv7m<'probe> {
     pub(crate) fn new(
         mut memory: Memory<'probe>,
-        state: &'probe mut State,
+        state: &'probe mut CortexMState,
         sequence: Arc<dyn ArmDebugSequence>,
     ) -> Result<Self, Error> {
         if !state.initialized() {

--- a/probe-rs/src/architecture/arm/core/armv8a_debug_regs.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a_debug_regs.rs
@@ -1,0 +1,719 @@
+//! Debug register definitions for ARMv8-A
+use bitfield::bitfield;
+use std::mem::size_of;
+
+use crate::HaltReason;
+
+/// A debug register that is accessible to the external debugger
+pub trait Armv8DebugRegister {
+    /// Register number
+    const NUMBER: u32;
+
+    /// The register's name.
+    const NAME: &'static str;
+
+    /// Get the address in the memory map
+    fn get_mmio_address(base_address: u32) -> u32 {
+        base_address + (Self::NUMBER * size_of::<u32>() as u32)
+    }
+}
+
+bitfield! {
+    /// EDSCR - Debug Status and Control Register
+    #[derive(Copy, Clone)]
+    pub struct Edscr(u32);
+    impl Debug;
+
+    /// Trace Filter Override. Overrides the Trace Filter controls allowing the external debugger to trace any visible Exception level.
+    pub tfo, set_tfo: 31;
+
+    /// DTRRX full.
+    pub rxfull, set_rxfull: 30;
+
+    /// DTRTX full.
+    pub txfull, set_txfull: 29;
+
+    /// ITR overrun.
+    pub ito, _: 28;
+
+    /// DTRRX overrun.
+    pub rxo, _: 27;
+
+    /// DTRTX underrun.
+    pub txu, _: 26;
+
+    /// Pipeline Advance. Indicates that software execution is progressing.
+    pub pipeadv, _: 25;
+
+    /// ITR empty.
+    pub ite, set_ite: 24;
+
+    /// Interrupt disable. Disables taking interrupts in Non-debug state.
+    pub intdis, set_intdis: 23, 22;
+
+    /// Traps accesses to the following debug System registers:
+    ///
+    /// AArch64: DBGBCR<n>_EL1, DBGBVR<n>_EL1, DBGWCR<n>_EL1, DBGWVR<n>_EL1.
+    /// AArch32: DBGBCR<n>, DBGBVR<n>, DBGBXVR<n>, DBGWCR<n>, DBGWVR<n>.
+    pub tda, set_tda: 21;
+
+    /// Memory access mode. Controls the use of memory-access mode for accessing ITR and the DCC.
+    pub ma, set_ma: 20;
+
+    /// Sample CONTEXTIDR_EL2. Controls whether the PC Sample-based Profiling Extension samples CONTEXTIDR_EL2 or VTTBR_EL2.VMID.
+    pub sc2, set_sc2: 19;
+
+    /// Non-secure status. In Debug state, gives the current Security state
+    pub ns, _: 18;
+
+    /// Secure debug disabled.
+    pub sdd, _: 16;
+
+    /// Halting debug enable.
+    pub hde, set_hde: 14;
+
+    /// Exception level Execution state status.
+    pub rw, _: 13, 10;
+
+    /// Exception level.
+    pub el, _: 9, 8;
+
+    /// SError interrupt pending.
+    pub a, _: 7;
+
+    /// Cumulative error flag.
+    pub err, _: 6;
+
+    /// Debug status flags.
+    pub status, set_status: 5, 0;
+}
+
+impl Edscr {
+    /// Is the core currently in a 64-bit mode?
+    /// This is only accurate if inspected while halted
+    pub fn currently_64_bit(&self) -> bool {
+        // RW is a bitfield for each EL where bit n is ELn
+        // If the bit is 1, that EL is Aarch64
+        self.rw() & (1 << self.el()) > 0
+    }
+
+    /// Is the core halted?
+    pub fn halted(&self) -> bool {
+        match self.status() {
+            // PE is restarting, exiting Debug state.
+            0b000001 => false,
+            // PE is in Non-debug state.
+            0b000010 => false,
+            // Breakpoint
+            0b000111 => true,
+            // External debug request.
+            0b010011 => true,
+            // Halting step, normal.
+            0b011011 => true,
+            // Halting step, exclusive.
+            0b011111 => true,
+            // OS Unlock catch.
+            0b100011 => true,
+            // Reset catch.
+            0b100111 => true,
+            // Watchpoint
+            0b101011 => true,
+            // HLT instruction.
+            0b101111 => true,
+            // Software access to debug register.
+            0b110011 => true,
+            // Exception Catch.
+            0b110111 => true,
+            // Halting step, no syndrome.
+            0b111011 => true,
+            // Everything else is running
+            _ => false,
+        }
+    }
+
+    /// Decode the MOE register into HaltReason
+    pub fn halt_reason(&self) -> HaltReason {
+        match self.status() {
+            // Breakpoint debug event
+            0b000111 => HaltReason::Breakpoint,
+            // External debug request.
+            0b010011 => HaltReason::Request,
+            // Halting step
+            0b011011 => HaltReason::Step,
+            0b011111 => HaltReason::Step,
+            0b111011 => HaltReason::Step,
+            // OS Unlock catch.
+            0b100011 => HaltReason::Exception,
+            // Reset catch.
+            0b100111 => HaltReason::Exception,
+            // Watchpoint
+            0b101011 => HaltReason::Watchpoint,
+            // HLT instruction.
+            0b101111 => HaltReason::Breakpoint,
+            // Software access to debug register.
+            0b110011 => HaltReason::Exception,
+            // Exception Catch.
+            0b110111 => HaltReason::Exception,
+            // All other values are reserved or running
+            _ => HaltReason::Unknown,
+        }
+    }
+}
+
+impl Armv8DebugRegister for Edscr {
+    const NUMBER: u32 = 34;
+    const NAME: &'static str = "EDSCR";
+}
+
+impl From<u32> for Edscr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Edscr> for u32 {
+    fn from(value: Edscr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// EDLAR - Lock Access Register
+    #[derive(Copy, Clone)]
+    pub struct Edlar(u32);
+    impl Debug;
+
+    /// Lock value
+    pub value, set_value : 31, 0;
+
+}
+
+impl Armv8DebugRegister for Edlar {
+    const NUMBER: u32 = 1004;
+    const NAME: &'static str = "EDLAR";
+}
+
+impl From<u32> for Edlar {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Edlar> for u32 {
+    fn from(value: Edlar) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGBVR - Breakpoint Value Register
+    #[derive(Copy, Clone)]
+    pub struct Dbgbvr(u32);
+    impl Debug;
+
+    /// Breakpoint address
+    pub value, set_value : 31, 0;
+}
+
+impl Armv8DebugRegister for Dbgbvr {
+    const NUMBER: u32 = 256;
+    const NAME: &'static str = "DBGBVR";
+}
+
+impl From<u32> for Dbgbvr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgbvr> for u32 {
+    fn from(value: Dbgbvr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGBCR - Breakpoint Control Register
+    #[derive(Copy, Clone)]
+    pub struct Dbgbcr(u32);
+    impl Debug;
+
+    /// Breakpoint type
+    pub bt, set_bt : 23, 20;
+
+    /// Linked breakpoint number
+    pub lbn, set_lbn : 19, 16;
+
+    /// Security state control
+    pub ssc, set_ssc : 15, 14;
+
+    /// Hyp mode control bit
+    pub hmc, set_hmc: 13;
+
+    /// Byte address select
+    pub bas, set_bas: 8, 5;
+
+    /// Privileged mode control
+    pub pmc, set_pmc: 2, 1;
+
+    /// Breakpoint enable
+    pub e, set_e: 0;
+}
+
+impl Armv8DebugRegister for Dbgbcr {
+    const NUMBER: u32 = 258;
+    const NAME: &'static str = "DBGBCR";
+}
+
+impl From<u32> for Dbgbcr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgbcr> for u32 {
+    fn from(value: Dbgbcr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// EDDFR - External Debug Feature Register
+    #[derive(Copy, Clone)]
+    pub struct Eddfr(u32);
+    impl Debug;
+
+    /// Number of breakpoints that are context-aware, minus 1.
+    pub ctx_cmps, _: 31, 28;
+
+    /// Number of watchpoints, minus 1.
+    pub wrps, _: 23, 20;
+
+    /// Number of breakpoints, minus 1
+    pub brps, set_brps: 15, 12;
+
+    /// PMU Version
+    pub pmuver, _: 11, 8;
+
+    /// Trace Version
+    pub tracever, _: 7, 4;
+}
+
+impl Armv8DebugRegister for Eddfr {
+    const NUMBER: u32 = 842;
+    const NAME: &'static str = "EDDFR";
+}
+
+impl From<u32> for Eddfr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Eddfr> for u32 {
+    fn from(value: Eddfr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// EDITR - External Debug Instruction Transfer Register
+    #[derive(Copy, Clone)]
+    pub struct Editr(u32);
+    impl Debug;
+
+    /// Instruction value
+    pub value, set_value: 31, 0;
+}
+
+impl Armv8DebugRegister for Editr {
+    const NUMBER: u32 = 33;
+    const NAME: &'static str = "EDITR";
+}
+
+impl From<u32> for Editr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Editr> for u32 {
+    fn from(value: Editr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// EDRCR - External Debug Reserve Control Register
+    #[derive(Copy, Clone)]
+    pub struct Edrcr(u32);
+    impl Debug;
+
+    /// Allow imprecise entry to Debug state.
+    pub cbrrq, set_cbrrq: 4;
+
+    /// Clear Sticky Pipeline Advance.
+    pub cpsa, set_cpsa: 3;
+
+    /// Clear Sticky Error.
+    pub cse, set_cse: 2;
+}
+
+impl Armv8DebugRegister for Edrcr {
+    const NUMBER: u32 = 36;
+    const NAME: &'static str = "EDRCR";
+}
+
+impl From<u32> for Edrcr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Edrcr> for u32 {
+    fn from(value: Edrcr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// EDECR - External Debug Execution Control Register
+    #[derive(Copy, Clone)]
+    pub struct Edecr(u32);
+    impl Debug;
+
+    /// Halting step enable.
+    pub ss, set_ss : 2;
+
+    /// Reset Catch Enable.
+    pub rce, set_rce : 1;
+
+    /// OS Unlock Catch Enable.
+    pub osuce, set_osuce : 0;
+}
+
+impl Armv8DebugRegister for Edecr {
+    const NUMBER: u32 = 9;
+    const NAME: &'static str = "EDECR";
+}
+
+impl From<u32> for Edecr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Edecr> for u32 {
+    fn from(value: Edecr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// EDPRCR - External Debug Power/Reset Control Register
+    #[derive(Copy, Clone)]
+    pub struct Edprcr(u32);
+    impl Debug;
+
+    /// COREPURQ
+    pub corepurq, set_corepurq : 3;
+
+    /// Warm reset request.
+    pub cwrr, set_cwrr : 1;
+
+    /// Core no powerdown request.
+    pub corenpdrq, set_corenpdrq : 0;
+}
+
+impl Armv8DebugRegister for Edprcr {
+    const NUMBER: u32 = 196;
+    const NAME: &'static str = "EDPRCR";
+}
+
+impl From<u32> for Edprcr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Edprcr> for u32 {
+    fn from(value: Edprcr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGDTRTX - Debug Data Transfer Register, Transmi
+    #[derive(Copy, Clone)]
+    pub struct Dbgdtrtx(u32);
+    impl Debug;
+
+    /// Instruction value
+    pub value, set_value: 31, 0;
+}
+
+impl Armv8DebugRegister for Dbgdtrtx {
+    const NUMBER: u32 = 35;
+    const NAME: &'static str = "DBGDTRTX";
+}
+
+impl From<u32> for Dbgdtrtx {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgdtrtx> for u32 {
+    fn from(value: Dbgdtrtx) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// DBGDTRRX - Debug Data Transfer Register, Receive
+    #[derive(Copy, Clone)]
+    pub struct Dbgdtrrx(u32);
+    impl Debug;
+
+    /// Instruction value
+    pub value, set_value: 31, 0;
+}
+
+impl Armv8DebugRegister for Dbgdtrrx {
+    const NUMBER: u32 = 32;
+    const NAME: &'static str = "DBGDTRRX";
+}
+
+impl From<u32> for Dbgdtrrx {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dbgdtrrx> for u32 {
+    fn from(value: Dbgdtrrx) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// EDPRSR - External Debug Processor Status Register
+    #[derive(Copy, Clone)]
+    pub struct Edprsr(u32);
+    impl Debug;
+
+    /// Sticky Debug Restart.
+    pub sdr, set_sdr: 11;
+
+    /// Sticky EPMAD error.
+    pub spmad, _: 10;
+
+    /// External Performance Monitors Non-secure Access Disable status.
+    pub epmad, _: 9;
+
+    /// Sticky EDAD error.
+    pub sdad, _: 8;
+
+    /// External Debug Access Disable status.
+    pub edad, _: 7;
+
+    /// Double Lock.
+    pub dlk, _: 6;
+
+    /// OS Lock status bit.
+    pub oslk, _: 5;
+
+    /// Halted status bit.
+    pub halted, _: 4;
+
+    /// Sticky core Reset status bit.
+    pub sr, _: 3;
+
+    /// PE Reset status bit.
+    pub r, _: 2;
+
+    /// Sticky core Powerdown status bit.
+    pub spd, _: 1;
+
+    /// Core powerup status bit.
+    pub pu, _: 0;
+}
+
+impl Armv8DebugRegister for Edprsr {
+    const NUMBER: u32 = 197;
+    const NAME: &'static str = "EDPRSR";
+}
+
+impl From<u32> for Edprsr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Edprsr> for u32 {
+    fn from(value: Edprsr) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// CTICONTROL - CTI control register
+    #[derive(Copy, Clone)]
+    pub struct CtiControl(u32);
+    impl Debug;
+
+    /// Enables or disables the CTI mapping functions.
+    pub glben, set_glben : 0;
+}
+
+impl Armv8DebugRegister for CtiControl {
+    const NUMBER: u32 = 0;
+    const NAME: &'static str = "CTICONTROL";
+}
+
+impl From<u32> for CtiControl {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<CtiControl> for u32 {
+    fn from(value: CtiControl) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// CTIGATE - CTI gate register
+    #[derive(Copy, Clone)]
+    pub struct CtiGate(u32);
+    impl Debug;
+
+    /// Enables or disables the CTI mapping functions.
+    pub en, set_en : 0, 0, 32;
+}
+
+impl Armv8DebugRegister for CtiGate {
+    const NUMBER: u32 = 80;
+    const NAME: &'static str = "CTIGATE";
+}
+
+impl From<u32> for CtiGate {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<CtiGate> for u32 {
+    fn from(value: CtiGate) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// CTIOUTEN<n> - CTI output enable register
+    #[derive(Copy, Clone)]
+    pub struct CtiOuten(u32);
+    impl Debug;
+
+    /// Enables or disables input <n> generating this output
+    pub outen, set_outen : 0, 0, 32;
+}
+
+impl Armv8DebugRegister for CtiOuten {
+    const NUMBER: u32 = 40;
+    const NAME: &'static str = "CTIOUTEN";
+}
+
+impl From<u32> for CtiOuten {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<CtiOuten> for u32 {
+    fn from(value: CtiOuten) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// CTIAPPPULSE - CTI application pulse register
+    #[derive(Copy, Clone)]
+    pub struct CtiApppulse(u32);
+    impl Debug;
+
+    /// Generate a pulse on channel N
+    pub apppulse, set_apppulse : 0, 0, 32;
+}
+
+impl Armv8DebugRegister for CtiApppulse {
+    const NUMBER: u32 = 7;
+    const NAME: &'static str = "CTIAPPPULSE";
+}
+
+impl From<u32> for CtiApppulse {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<CtiApppulse> for u32 {
+    fn from(value: CtiApppulse) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// CTIINTACK - CTI Output Trigger Acknowledge register
+    #[derive(Copy, Clone)]
+    pub struct CtiIntack(u32);
+    impl Debug;
+
+    /// Ack trigger on channel N
+    pub ack, set_ack : 0, 0, 32;
+}
+
+impl Armv8DebugRegister for CtiIntack {
+    const NUMBER: u32 = 4;
+    const NAME: &'static str = "CTIINTACK";
+}
+
+impl From<u32> for CtiIntack {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<CtiIntack> for u32 {
+    fn from(value: CtiIntack) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// CTITRIGOUTSTATUS - CTI Trigger Out Status register
+    #[derive(Copy, Clone)]
+    pub struct CtiTrigoutstatus(u32);
+    impl Debug;
+
+    /// Status on channel N
+    pub status, _ : 0, 0, 32;
+}
+
+impl Armv8DebugRegister for CtiTrigoutstatus {
+    const NUMBER: u32 = 77;
+    const NAME: &'static str = "CTITRIGOUTSTATUS";
+}
+
+impl From<u32> for CtiTrigoutstatus {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<CtiTrigoutstatus> for u32 {
+    fn from(value: CtiTrigoutstatus) -> Self {
+        value.0
+    }
+}

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -14,7 +14,7 @@ use anyhow::Result;
 
 use bitfield::bitfield;
 
-use super::{Dfsr, State, ARM_REGISTER_FILE};
+use super::{CortexMState, Dfsr, ARM_REGISTER_FILE};
 use std::sync::Arc;
 use std::{
     mem::size_of,
@@ -25,7 +25,7 @@ use std::{
 pub struct Armv8m<'probe> {
     memory: Memory<'probe>,
 
-    state: &'probe mut State,
+    state: &'probe mut CortexMState,
 
     sequence: Arc<dyn ArmDebugSequence>,
 }
@@ -33,7 +33,7 @@ pub struct Armv8m<'probe> {
 impl<'probe> Armv8m<'probe> {
     pub(crate) fn new(
         mut memory: Memory<'probe>,
-        state: &'probe mut State,
+        state: &'probe mut CortexMState,
         sequence: Arc<dyn ArmDebugSequence>,
     ) -> Result<Self, Error> {
         if !state.initialized() {

--- a/probe-rs/src/architecture/arm/core/instructions.rs
+++ b/probe-rs/src/architecture/arm/core/instructions.rs
@@ -1,0 +1,198 @@
+//! Contains helpers to build instructions for debugger use
+pub(crate) mod aarch32 {
+    /// Build a MOV instruction
+    pub(crate) fn build_mov(rd: u16, rm: u16) -> u32 {
+        let mut ret = 0b1110_0001_1010_0000_0000_0000_0000_0000;
+
+        ret |= (rd as u32) << 12;
+        ret |= rm as u32;
+
+        ret
+    }
+
+    /// Build a MCR instruction
+    pub(crate) fn build_mcr(
+        coproc: u8,
+        opcode1: u8,
+        reg: u16,
+        ctrl_reg_n: u8,
+        ctrl_reg_m: u8,
+        opcode2: u8,
+    ) -> u32 {
+        let mut ret = 0b1110_1110_0000_0000_0000_0000_0001_0000;
+
+        ret |= (coproc as u32) << 8;
+        ret |= (opcode1 as u32) << 21;
+        ret |= (reg as u32) << 12;
+        ret |= (ctrl_reg_n as u32) << 16;
+        ret |= ctrl_reg_m as u32;
+        ret |= (opcode2 as u32) << 5;
+
+        ret
+    }
+
+    pub(crate) fn build_mrc(
+        coproc: u8,
+        opcode1: u8,
+        reg: u16,
+        ctrl_reg_n: u8,
+        ctrl_reg_m: u8,
+        opcode2: u8,
+    ) -> u32 {
+        let mut ret = 0b1110_1110_0001_0000_0000_0000_0001_0000;
+
+        ret |= (coproc as u32) << 8;
+        ret |= (opcode1 as u32) << 21;
+        ret |= (reg as u32) << 12;
+        ret |= (ctrl_reg_n as u32) << 16;
+        ret |= ctrl_reg_m as u32;
+        ret |= (opcode2 as u32) << 5;
+
+        ret
+    }
+
+    pub(crate) fn build_bx(reg: u16) -> u32 {
+        let mut ret = 0b1110_0001_0010_1111_1111_1111_0001_0000;
+
+        ret |= reg as u32;
+
+        ret
+    }
+
+    pub(crate) fn build_ldc(coproc: u8, ctrl_reg: u8, reg: u16, imm: u8) -> u32 {
+        let mut ret = 0b1110_1100_1011_0000_0000_0000_0000_0000;
+
+        ret |= (reg as u32) << 16;
+        ret |= (ctrl_reg as u32) << 12;
+        ret |= (coproc as u32) << 8;
+        ret |= (imm as u32) >> 2;
+
+        ret
+    }
+
+    pub(crate) fn build_stc(coproc: u8, ctrl_reg: u8, reg: u16, imm: u8) -> u32 {
+        let mut ret = 0b1110_1100_1010_0000_0000_0000_0000_0000;
+
+        ret |= (reg as u32) << 16;
+        ret |= (ctrl_reg as u32) << 12;
+        ret |= (coproc as u32) << 8;
+        ret |= (imm as u32) >> 2;
+
+        ret
+    }
+
+    pub(crate) fn build_mrs(reg: u16) -> u32 {
+        let mut ret = 0b1110_0001_0000_1111_0000_0000_0000_0000;
+
+        ret |= (reg as u32) << 12;
+
+        ret
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn gen_mcr_instruction() {
+            let instr = build_mcr(14, 0, 2, 1, 2, 3);
+
+            // MCR p14, 0, r2, c1, c2, 3
+            assert_eq!(0xEE012E72, instr);
+        }
+
+        #[test]
+        fn gen_mrc_instruction() {
+            let instr = build_mrc(14, 0, 2, 1, 2, 3);
+
+            // MRC p14, 0, r2, c1, c2, 3
+            assert_eq!(0xEE112E72, instr);
+        }
+
+        #[test]
+        fn gen_mov_instruction() {
+            let instr = build_mov(2, 15);
+
+            // MOV r2, pc
+            assert_eq!(0xE1A0200F, instr);
+        }
+
+        #[test]
+        fn gen_bx_instruction() {
+            let instr = build_bx(2);
+
+            // BX r2
+            assert_eq!(0xE12FFF12, instr);
+        }
+
+        #[test]
+        fn gen_ldc_instruction() {
+            let instr = build_ldc(14, 5, 2, 4);
+
+            // LDC p14, c5, [r2], #4
+            assert_eq!(0xECB25E01, instr);
+        }
+
+        #[test]
+        fn gen_stc_instruction() {
+            let instr = build_stc(14, 5, 2, 4);
+
+            // STC p14, c5, [r2], #4
+            assert_eq!(0xECA25E01, instr);
+        }
+
+        #[test]
+        fn gen_mrs_instruction() {
+            let instr = build_mrs(2);
+
+            // MRS r2, CPSR
+            assert_eq!(0xE10F2000, instr);
+        }
+    }
+}
+
+pub(crate) mod thumb2 {
+    // These are the same encoding in thumb2
+    pub(crate) use super::aarch32::{build_mcr, build_mrc};
+
+    pub(crate) fn build_ldr(reg_target: u16, reg_source: u16, imm: u8) -> u32 {
+        let mut ret = 0b1111_1000_0101_0000_0000_1011_0000_0000;
+
+        ret |= (reg_source as u32) << 16;
+        ret |= (reg_target as u32) << 12;
+        ret |= imm as u32;
+
+        ret
+    }
+
+    pub(crate) fn build_str(reg_target: u16, reg_source: u16, imm: u8) -> u32 {
+        let mut ret = 0b1111_1000_0100_0000_0000_1011_0000_0000;
+
+        ret |= (reg_source as u32) << 16;
+        ret |= (reg_target as u32) << 12;
+        ret |= imm as u32;
+
+        ret
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn gen_ldr_instruction() {
+            let instr = build_ldr(2, 3, 4);
+
+            // LDR r2, [r3], #4
+            assert_eq!(0xF8532B04, instr);
+        }
+
+        #[test]
+        fn gen_str_instruction() {
+            let instr = build_str(2, 3, 4);
+
+            // STR r2, [r3], #4
+            assert_eq!(0xF8432B04, instr);
+        }
+    }
+}

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -8,7 +8,12 @@ use bitfield::bitfield;
 pub mod armv6m;
 pub mod armv7a;
 pub mod armv7m;
+pub mod armv8a;
 pub mod armv8m;
+
+pub(crate) mod armv7a_debug_regs;
+pub(crate) mod armv8a_debug_regs;
+pub(crate) mod instructions;
 
 /// Core information data which is downloaded from the target, represents its state and can be used for debugging.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -292,7 +297,7 @@ impl CoreRegister for Dfsr {
 }
 
 #[derive(Debug)]
-pub struct State {
+pub struct CortexMState {
     initialized: bool,
 
     hw_breakpoints_enabled: bool,
@@ -300,12 +305,43 @@ pub struct State {
     current_state: CoreStatus,
 }
 
-impl State {
+impl CortexMState {
     pub(crate) fn new() -> Self {
         Self {
             initialized: false,
             hw_breakpoints_enabled: false,
             current_state: CoreStatus::Unknown,
+        }
+    }
+
+    fn initialize(&mut self) {
+        self.initialized = true;
+    }
+
+    fn initialized(&self) -> bool {
+        self.initialized
+    }
+}
+
+#[derive(Debug)]
+pub struct CortexAState {
+    initialized: bool,
+
+    current_state: CoreStatus,
+
+    // Is the core currently in a 64-bit mode?
+    is_64_bit: bool,
+
+    register_cache: Vec<Option<(u32, bool)>>,
+}
+
+impl CortexAState {
+    pub(crate) fn new() -> Self {
+        Self {
+            initialized: false,
+            current_state: CoreStatus::Unknown,
+            is_64_bit: false,
+            register_cache: vec![],
         }
     }
 

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -19,6 +19,7 @@ pub use traits::*;
 pub use self::core::armv6m;
 pub use self::core::armv7a;
 pub use self::core::armv7m;
+pub use self::core::armv8a;
 pub use self::core::armv8m;
 pub use self::core::Dump;
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -100,12 +100,7 @@ impl ArchitectureInterface {
                 };
                 let memory = state.memory_interface(MemoryAp::new(ap))?;
 
-                core.attach_arm(
-                    core_state,
-                    memory,
-                    arm_core_access_options.debug_base,
-                    target,
-                )
+                core.attach_arm(core_state, memory, target)
             }
             ArchitectureInterface::Riscv(state) => core.attach_riscv(core_state, state),
         }
@@ -129,7 +124,7 @@ impl Session {
             .map(|(id, core)| {
                 (
                     SpecificCoreState::from_core_type(core.core_type),
-                    Core::create_state(id),
+                    Core::create_state(id, core.core_access_options.clone()),
                 )
             })
             .collect();
@@ -189,6 +184,7 @@ impl Session {
                         &mut memory_interface,
                         config.core_type,
                         arm_core_access_options.debug_base,
+                        arm_core_access_options.cti_base,
                     )?;
                 }
 
@@ -203,18 +199,6 @@ impl Session {
                         )?;
                         sequence_handle.reset_hardware_deassert(&mut memory_interface)?;
                     }
-
-                    let cores = target
-                        .cores
-                        .iter()
-                        .enumerate()
-                        .map(|(id, core)| {
-                            (
-                                SpecificCoreState::from_core_type(core.core_type),
-                                Core::create_state(id),
-                            )
-                        })
-                        .collect();
 
                     let mut session = Session {
                         target,

--- a/probe-rs/targets/BCM2711.yaml
+++ b/probe-rs/targets/BCM2711.yaml
@@ -1,0 +1,49 @@
+name: BCM2711
+variants:
+  - name: RaspberryPi4B
+    cores:
+      - name: core0
+        type: armv8a
+        core_access_options:
+          Arm:
+            ap: 0x0
+            psel: 0x0
+            debug_base: 0x80410000
+            cti_base: 0x80420000
+      - name: core1
+        type: armv8a
+        core_access_options:
+          Arm:
+            ap: 0x0
+            psel: 0x0
+            debug_base: 0x80510000
+            cti_base: 0x80520000
+      - name: core2
+        type: armv8a
+        core_access_options:
+          Arm:
+            ap: 0x0
+            psel: 0x0
+            debug_base: 0x80610000
+            cti_base: 0x80620000
+      - name: core3
+        type: armv8a
+        core_access_options:
+          Arm:
+            ap: 0x0
+            psel: 0x0
+            debug_base: 0x80710000
+            cti_base: 0x80720000
+    memory_map:
+      - Ram:
+          range:
+            start: 0x00000000
+            end: 0x3b3fffff
+          is_boot_memory: false
+          cores:
+            - core0
+            - core1
+            - core2
+            - core3
+    flash_algorithms: []
+flash_algorithms: []

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -158,6 +158,7 @@ fn create_core(processor: &Processor) -> Result<ProbeCore> {
                 ap: processor.ap,
                 psel: 0,
                 debug_base: None,
+                cti_base: None,
             }),
             Architecture::Riscv => CoreAccessOptions::Riscv(RiscvCoreAccessOptions {}),
         },

--- a/target-gen/src/main.rs
+++ b/target-gen/src/main.rs
@@ -167,6 +167,7 @@ fn cmd_elf(
                         ap: 0,
                         psel: 0,
                         debug_base: None,
+                        cti_base: None,
                     }),
                 }],
                 part: None,


### PR DESCRIPTION
* 32-bit only for now
* Tested with a Raspberry Pi 4 (target included)
* All basic debugger operations work
* This includes minor refactoring to share code between v7-a and v8-a
* Both Cortex-A targets have updated register cache logic to fix some bugs
  found while testing

Signed-off-by: Ryan Fairfax <ryan@thefaxman.net>