### PR TITLE
Refactoring Arm components to reference specific access points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a panic when cmsisdap probes return more transfers than requested (#922, #923)
-- Fixed access to Arm CoreSight components being completed through the wrong AP (#1114)
 - `probe-rs-debugger` Various fixes in PR. (#895)
   - Fix stack overflow when unwinding circular references in data structures. (#894)
   - Reworked the stack unwind in `StackFrameIterator::new()` and `StackFrameIterator::next()`
@@ -78,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Debugger: Fix `Source` breakpoints only worked for a single source file. (#1098)
   - Debugger: Fix assumptions for ARM cores
   - GDB: Fix assumptions for ARM cores
+- Fixed access to Arm CoreSight components being completed through the wrong AP (#1114)
 
 ## [0.12.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a panic when cmsisdap probes return more transfers than requested (#922, #923)
+- Fixed access to Arm CoreSight components being completed through the wrong AP (#1114)
 - `probe-rs-debugger` Various fixes in PR. (#895)
   - Fix stack overflow when unwinding circular references in data structures. (#894)
   - Reworked the stack unwind in `StackFrameIterator::new()` and `StackFrameIterator::next()`

--- a/probe-rs/src/architecture/arm/component/tpiu.rs
+++ b/probe-rs/src/architecture/arm/component/tpiu.rs
@@ -1,5 +1,6 @@
-use super::super::memory::romtable::Component;
-use crate::{Core, Error};
+use super::super::memory::romtable::CoresightComponent;
+use crate::architecture::arm::ArmProbeInterface;
+use crate::Error;
 
 pub const _TPIU_PID: [u8; 8] = [0xA1, 0xB9, 0x0B, 0x0, 0x4, 0x0, 0x0, 0x0];
 
@@ -12,28 +13,34 @@ const REGISTER_OFFSET_TPIU_FFCR: u32 = 0x304;
 /// TPIU unit
 ///
 /// Trace port interface unit unit.
-pub struct Tpiu<'probe: 'core, 'core> {
-    component: &'core Component,
-    core: &'core mut Core<'probe>,
+pub struct Tpiu<'a> {
+    component: &'a CoresightComponent,
+    interface: &'a mut Box<dyn ArmProbeInterface>,
 }
 
-impl<'probe: 'core, 'core> Tpiu<'probe, 'core> {
+impl<'a> Tpiu<'a> {
     /// Create a new TPIU interface from a probe and a ROM table component.
-    pub fn new(core: &'core mut Core<'probe>, component: &'core Component) -> Self {
-        Tpiu { component, core }
+    pub fn new(
+        interface: &'a mut Box<dyn ArmProbeInterface>,
+        component: &'a CoresightComponent,
+    ) -> Self {
+        Tpiu {
+            interface,
+            component,
+        }
     }
 
     /// Set the port size of the TPIU.
     pub fn set_port_size(&mut self, value: u32) -> Result<(), Error> {
         self.component
-            .write_reg(self.core, REGISTER_OFFSET_TPIU_CSPSR, value)?;
+            .write_reg(self.interface, REGISTER_OFFSET_TPIU_CSPSR, value)?;
         Ok(())
     }
 
     /// Set the prescaler of the TPIU.
     pub fn set_prescaler(&mut self, value: u32) -> Result<(), Error> {
         self.component
-            .write_reg(self.core, REGISTER_OFFSET_TPIU_ACPR, value)?;
+            .write_reg(self.interface, REGISTER_OFFSET_TPIU_ACPR, value)?;
         Ok(())
     }
 
@@ -44,14 +51,14 @@ impl<'probe: 'core, 'core> Tpiu<'probe, 'core> {
     /// 3 = reserved
     pub fn set_pin_protocol(&mut self, value: u32) -> Result<(), Error> {
         self.component
-            .write_reg(self.core, REGISTER_OFFSET_TPIU_SPPR, value)?;
+            .write_reg(self.interface, REGISTER_OFFSET_TPIU_SPPR, value)?;
         Ok(())
     }
 
     /// Set the TPIU formatter.
     pub fn set_formatter(&mut self, value: u32) -> Result<(), Error> {
         self.component
-            .write_reg(self.core, REGISTER_OFFSET_TPIU_FFCR, value)?;
+            .write_reg(self.interface, REGISTER_OFFSET_TPIU_FFCR, value)?;
         Ok(())
     }
 }

--- a/probe-rs/src/architecture/arm/memory/mod.rs
+++ b/probe-rs/src/architecture/arm/memory/mod.rs
@@ -4,4 +4,4 @@ pub(crate) mod adi_v5_memory_interface;
 pub(crate) mod romtable;
 
 use super::ap::AccessPortError;
-pub use romtable::{Component, PeripheralType};
+pub use romtable::{Component, CoresightComponent, PeripheralType};

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -348,7 +348,8 @@ impl Session {
         Ok(SwoReader::new(interface))
     }
 
-    fn get_arm_interface(&mut self) -> Result<&mut Box<dyn ArmProbeInterface>, Error> {
+    /// Get the Arm probe interface.
+    pub fn get_arm_interface(&mut self) -> Result<&mut Box<dyn ArmProbeInterface>, Error> {
         let interface = match &mut self.interface {
             ArchitectureInterface::Arm(state) => state,
             _ => return Err(Error::ArchitectureRequired(&["ARMv7", "ARMv8"])),

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -7,7 +7,7 @@ use crate::{
         arm::{
             ap::{GenericAp, MemoryAp},
             communication_interface::{ArmProbeInterface, MemoryApInformation},
-            memory::Component,
+            memory::{Component, CoresightComponent},
             ApInformation, SwoConfig, SwoReader,
         },
         riscv::communication_interface::RiscvCommunicationInterface,
@@ -370,7 +370,7 @@ impl Session {
     ///
     /// This will recursively parse the Romtable of the attached target
     /// and create a list of all the contained components.
-    pub fn get_arm_components(&mut self) -> Result<Vec<Component>, Error> {
+    pub fn get_arm_components(&mut self) -> Result<Vec<CoresightComponent>, Error> {
         let interface = self.get_arm_interface()?;
 
         let mut components = Vec::new();
@@ -394,9 +394,11 @@ impl Session {
                     debug_base_address,
                     supports_hnonsec: _,
                 }) => {
-                    let mut memory = interface.memory_interface(MemoryAp::new(address))?;
-                    Component::try_parse(&mut memory, debug_base_address)
-                        .map_err(Error::architecture_specific)
+                    let ap = MemoryAp::new(address);
+                    let mut memory = interface.memory_interface(ap)?;
+                    let component = Component::try_parse(&mut memory, debug_base_address)
+                        .map_err(Error::architecture_specific)?;
+                    Ok(CoresightComponent::new(component, ap))
                 }
                 ApInformation::Other { address } => {
                     // Return an error, only possible to get Component from MemoryAP
@@ -441,8 +443,8 @@ impl Session {
 
         // Configure SWV on the target
         let components = self.get_arm_components()?;
-        let mut core = self.core(core_index)?;
-        crate::architecture::arm::component::setup_swv(&mut core, &components, config)
+        let interface = self.get_arm_interface()?;
+        crate::architecture::arm::component::setup_swv(interface, &components, config)
     }
 
     /// Configure the target to stop emitting SWV trace data.
@@ -451,16 +453,11 @@ impl Session {
     }
 
     /// Begin tracing a memory address over SWV.
-    pub fn add_swv_data_trace(
-        &mut self,
-        core_index: usize,
-        unit: usize,
-        address: u32,
-    ) -> Result<(), Error> {
+    pub fn add_swv_data_trace(&mut self, unit: usize, address: u32) -> Result<(), Error> {
         let components = self.get_arm_components()?;
-        let mut core = self.core(core_index)?;
+        let interface = self.get_arm_interface()?;
         crate::architecture::arm::component::add_swv_data_trace(
-            &mut core,
+            interface,
             &components,
             unit,
             address,
@@ -468,10 +465,10 @@ impl Session {
     }
 
     /// Stop tracing from a given SWV unit
-    pub fn remove_swv_data_trace(&mut self, core_index: usize, unit: usize) -> Result<(), Error> {
+    pub fn remove_swv_data_trace(&mut self, unit: usize) -> Result<(), Error> {
         let components = self.get_arm_components()?;
-        let mut core = self.core(core_index)?;
-        crate::architecture::arm::component::remove_swv_data_trace(&mut core, &components, unit)
+        let interface = self.get_arm_interface()?;
+        crate::architecture::arm::component::remove_swv_data_trace(interface, &components, unit)
     }
 
     /// Returns the memory map of the target.


### PR DESCRIPTION
This PR works towards supporting the SWV (#1113) configuration on Arm components by refactoring CoreSight component access to be associated with specific DAP access points. This ensures that accessing the registers of the component is done through the correct AP so that addresses specified in ROM tables are usable.

I'm opening this PR as a draft in case anyone has any opinions on this subject - I'm fairly new to Arm's CoreSight components and debug architecture, so feedback is welcome!

TODO:
- [x] Verify that ROM table entries always exist through the same AP as the ROM table, even in recursive tables
- [x] Test component access on the H7