### PR TITLE
Update address size from 32 to 64 bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update STM32L4 series yaml from Keil.STM32L4xx_DFP.2.5.0. (#1086)
 - Debugger: SVD uses new `expand` feature of `svd-parser` crate to expand arrays and clusters. (#1090)
 - Updated cmsis-pack dependency to version 0.6.0. (#1089)
-- Updated all parameters and fields that refer to memory addresses from u32 to u64 in preparation for 64-bit target support.
+- Updated all parameters and fields that refer to memory addresses from u32 to u64 in preparation for 64-bit target support. (#1115)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update STM32L4 series yaml from Keil.STM32L4xx_DFP.2.5.0. (#1086)
 - Debugger: SVD uses new `expand` feature of `svd-parser` crate to expand arrays and clusters. (#1090)
 - Updated cmsis-pack dependency to version 0.6.0. (#1089)
+- Updated all parameters and fields that refer to memory addresses from u32 to u64 in preparation for 64-bit target support.
 
 ### Fixed
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -87,7 +87,7 @@ impl DebugCli {
                 .map_err(|err| anyhow!("Error creating capstone: {:?}", err))?;
 
                 // Attempt to dissassemble
-                match cs.disasm_all(&code, u64::from(cpu_info.pc)) {
+                match cs.disasm_all(&code, cpu_info.pc) {
                     Ok(instructions) => {
                         for i in instructions.iter() {
                             println!("{}", i);
@@ -100,7 +100,7 @@ impl DebugCli {
                         for (offset, instruction) in code.iter().enumerate() {
                             println!(
                                 "{:#010x}: {:010x}",
-                                cpu_info.pc + offset as u32,
+                                cpu_info.pc + offset as u64,
                                 instruction
                             );
                         }
@@ -245,7 +245,7 @@ impl DebugCli {
                 }
 
                 for (offset, word) in buff.iter().enumerate() {
-                    println!("0x{:08x} = 0x{:08x}", address + (offset * 4) as u32, word);
+                    println!("0x{:08x} = 0x{:08x}", address + (offset * 4) as u64, word);
                 }
 
                 Ok(CliState::Continue)
@@ -274,7 +274,7 @@ impl DebugCli {
                 }
 
                 for (offset, byte) in buff.iter().enumerate() {
-                    println!("0x{:08x} = 0x{:02x}", address + (offset) as u32, byte);
+                    println!("0x{:08x} = 0x{:02x}", address + (offset) as u64, byte);
                 }
 
                 Ok(CliState::Continue)
@@ -553,7 +553,7 @@ impl DebugCli {
 
                 let mut stack = vec![0u8; (stack_top - stack_bot) as usize];
 
-                cli_data.core.read(stack_bot, &mut stack[..])?;
+                cli_data.core.read(stack_bot.into(), &mut stack[..])?;
 
                 let mut dump = Dump::new(stack_bot, stack);
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -90,8 +90,8 @@ enum Cli {
         common: ProbeOptions,
 
         /// The address of the memory to dump from the target.
-        #[structopt(parse(try_from_str = parse_u32))]
-        loc: u32,
+        #[structopt(parse(try_from_str = parse_u64))]
+        loc: u64,
         /// The amount of memory (in words) to dump.
         #[structopt(parse(try_from_str = parse_u32))]
         words: u32,
@@ -106,8 +106,8 @@ enum Cli {
         format: DownloadFileType,
 
         /// The address in memory where the binary will be put at. This is only considered when `bin` is selected as the format.
-        #[structopt(long, parse(try_from_str = parse_u32))]
-        base_address: Option<u32>,
+        #[structopt(long, parse(try_from_str = parse_u64))]
+        base_address: Option<u64>,
         /// The number of bytes to skip at the start of the binary file. This is only considered when `bin` is selected as the format.
         #[structopt(long, parse(try_from_str = parse_u32))]
         skip_bytes: Option<u32>,
@@ -159,8 +159,8 @@ enum Cli {
         common: ProbeOptions,
 
         /// The address of the memory to dump from the target.
-        #[structopt(parse(try_from_str = parse_u32))]
-        loc: u32,
+        #[structopt(parse(try_from_str = parse_u64))]
+        loc: u64,
     },
     #[clap(subcommand)]
     Chip(Chip),
@@ -270,7 +270,7 @@ fn list_connected_devices() -> Result<()> {
 fn dump_memory(
     shared_options: &CoreOptions,
     common: &ProbeOptions,
-    loc: u32,
+    loc: u64,
     words: u32,
 ) -> Result<()> {
     let mut session = common.simple_attach()?;
@@ -292,7 +292,7 @@ fn dump_memory(
     for word in 0..words {
         println!(
             "Addr 0x{:08x?}: 0x{:08x}",
-            loc + 4 * word,
+            loc + 4 * word as u64,
             data[word as usize]
         );
     }
@@ -373,7 +373,7 @@ fn reset_target_of_device(
 fn trace_u32_on_target(
     shared_options: &CoreOptions,
     common: &ProbeOptions,
-    loc: u32,
+    loc: u64,
 ) -> Result<()> {
     use scroll::{Pwrite, LE};
     use std::io::prelude::*;
@@ -475,7 +475,7 @@ enum DownloadFileType {
 }
 
 impl DownloadFileType {
-    fn into(self, base_address: Option<u32>, skip: Option<u32>) -> Format {
+    fn into(self, base_address: Option<u64>, skip: Option<u32>) -> Format {
         match self {
             DownloadFileType::Elf => Format::Elf,
             DownloadFileType::Hex => Format::Hex,
@@ -488,5 +488,9 @@ impl DownloadFileType {
 }
 
 fn parse_u32(input: &str) -> Result<u32, ParseIntError> {
+    parse_int::parse(input)
+}
+
+fn parse_u64(input: &str) -> Result<u64, ParseIntError> {
     parse_int::parse(input)
 }

--- a/debugger/src/debugger/core_data.rs
+++ b/debugger/src/debugger/core_data.rs
@@ -85,7 +85,7 @@ impl<'p> CoreHandle<'p> {
     /// Set a single breakpoint in target configuration as well as [`CoreHandle::breakpoints`]
     pub(crate) fn set_breakpoint(
         &mut self,
-        address: u32,
+        address: u64,
         breakpoint_type: session_data::BreakpointType,
     ) -> Result<(), DebuggerError> {
         self.core
@@ -101,7 +101,7 @@ impl<'p> CoreHandle<'p> {
     }
 
     /// Clear a single breakpoint from target configuration as well as [`CoreHandle::breakpoints`]
-    pub(crate) fn clear_breakpoint(&mut self, address: u32) -> Result<()> {
+    pub(crate) fn clear_breakpoint(&mut self, address: u64) -> Result<()> {
         self.core
             .clear_hw_breakpoint(address)
             .map_err(DebuggerError::ProbeRs)?;
@@ -131,7 +131,7 @@ impl<'p> CoreHandle<'p> {
             .iter()
             .filter(|breakpoint| breakpoint.breakpoint_type == breakpoint_type)
             .map(|breakpoint| breakpoint.breakpoint_address)
-            .collect::<Vec<u32>>();
+            .collect::<Vec<u64>>();
         for breakpoint in target_breakpoints {
             self.clear_breakpoint(breakpoint).ok();
         }

--- a/debugger/src/debugger/session_data.rs
+++ b/debugger/src/debugger/session_data.rs
@@ -24,7 +24,7 @@ pub enum BreakpointType {
 #[derive(Debug)]
 pub struct ActiveBreakpoint {
     pub(crate) breakpoint_type: BreakpointType,
-    pub(crate) breakpoint_address: u32,
+    pub(crate) breakpoint_address: u64,
 }
 
 /// SessionData is designed to be similar to [probe_rs::Session], in as much that it provides handles to the [CoreHandle] instances for each of the available [probe_rs::Core] involved in the debug session.

--- a/debugger/src/peripherals/svd_variables.rs
+++ b/debugger/src/peripherals/svd_variables.rs
@@ -149,8 +149,7 @@ pub(crate) fn variable_cache_from_svd<P: ProtocolAdapter>(
         ));
         peripheral_variable.type_name = VariableType::Other("Peripheral".to_string());
         peripheral_variable.variable_node_type = VariableNodeType::SvdPeripheral;
-        peripheral_variable.memory_location =
-            VariableLocation::Address(peripheral.base_address as u32);
+        peripheral_variable.memory_location = VariableLocation::Address(peripheral.base_address);
         peripheral_variable.set_value(probe_rs::debug::VariableValue::Valid(
             peripheral
                 .description
@@ -174,7 +173,7 @@ pub(crate) fn variable_cache_from_svd<P: ProtocolAdapter>(
             );
             register_variable.variable_node_type = VariableNodeType::SvdRegister;
             register_variable.memory_location =
-                VariableLocation::Address(peripheral.base_address as u32 + register.address_offset);
+                VariableLocation::Address(peripheral.base_address + register.address_offset as u64);
             let mut register_has_restricted_read = false;
             if register.read_action.is_some()
                 || (if let Some(register_access) = register.properties.access {

--- a/gdb-server/src/handlers.rs
+++ b/gdb-server/src/handlers.rs
@@ -236,7 +236,7 @@ pub(crate) fn write_register(register: u32, hex_value: &str, mut core: Core) -> 
     reply_ok()
 }
 
-pub(crate) fn read_memory(address: u32, length: u32, mut core: Core) -> Option<String> {
+pub(crate) fn read_memory(address: u64, length: u32, mut core: Core) -> Option<String> {
     let mut readback_data = vec![0u8; length as usize];
     match core.read(address, &mut readback_data) {
         Ok(_) => Some(
@@ -286,17 +286,17 @@ pub(crate) fn step(mut core: Core, awaits_halt: &mut bool) -> Option<String> {
     Some("S05".into())
 }
 
-pub(crate) fn insert_hardware_break(address: u32, _kind: u32, mut core: Core) -> Option<String> {
+pub(crate) fn insert_hardware_break(address: u64, _kind: u32, mut core: Core) -> Option<String> {
     core.set_hw_breakpoint(address).unwrap();
     Some("OK".into())
 }
 
-pub(crate) fn remove_hardware_break(address: u32, _kind: u32, mut core: Core) -> Option<String> {
+pub(crate) fn remove_hardware_break(address: u64, _kind: u32, mut core: Core) -> Option<String> {
     core.clear_hw_breakpoint(address).unwrap();
     Some("OK".into())
 }
 
-pub(crate) fn write_memory(address: u32, data: &[u8], mut core: Core) -> Option<String> {
+pub(crate) fn write_memory(address: u64, data: &[u8], mut core: Core) -> Option<String> {
     core.write_8(address, data).unwrap();
 
     Some("OK".into())

--- a/gdb-server/src/parser/mod.rs
+++ b/gdb-server/src/parser/mod.rs
@@ -102,19 +102,19 @@ pub enum Packet {
     V(VPacket),
     // Packet 'X'
     WriteMemoryBinary {
-        address: u32,
+        address: u64,
         data: Vec<u8>,
     },
     // Packet 'z'
     RemoveBreakpoint {
         breakpoint_type: BreakpointType,
-        address: u32,
+        address: u64,
         kind: u32,
     },
     // Packet 'Z'
     InsertBreakpoint {
         breakpoint_type: BreakpointType,
-        address: u32,
+        address: u64,
         kind: u32,
     },
     // Byte 0x03
@@ -260,7 +260,7 @@ fn insert_breakpoint(input: &[u8]) -> IResult<&[u8], Packet> {
 
     let (input, _) = char(',')(input)?;
 
-    let (input, address) = hex_u32(input)?;
+    let (input, address) = hex_u64(input)?;
 
     let (input, _) = char(',')(input)?;
 
@@ -282,7 +282,7 @@ fn remove_breakpoint(input: &[u8]) -> IResult<&[u8], Packet> {
 
     let (input, _) = char(',')(input)?;
 
-    let (input, address) = hex_u32(input)?;
+    let (input, address) = hex_u64(input)?;
     let (input, _) = char(',')(input)?;
 
     let (input, kind) = hex_u32(input)?;
@@ -300,7 +300,7 @@ fn remove_breakpoint(input: &[u8]) -> IResult<&[u8], Packet> {
 fn write_memory_binary(input: &[u8]) -> IResult<&[u8], Packet> {
     let (input, _) = char('X')(input)?;
 
-    let (input, address) = hex_u32(input)?;
+    let (input, address) = hex_u64(input)?;
     let (input, _) = char(',')(input)?;
     let (input, length) = hex_u32(input)?;
     let (input, _) = char(':')(input)?;

--- a/gdb-server/src/worker.rs
+++ b/gdb-server/src/worker.rs
@@ -5,7 +5,6 @@ use futures::future::FutureExt;
 use futures::select;
 use gdb_protocol::packet::{CheckedPacket, Kind as PacketKind};
 use probe_rs::Session;
-use std::convert::TryFrom;
 use std::{sync::Mutex, time::Duration};
 
 use crate::parser::parse_packet;
@@ -95,15 +94,7 @@ pub async fn handler(
                     handlers::write_register(address, &value, session.core(0)?)
                 }
                 ReadMemory { address, length } => {
-                    // LLDB will send 64 bit addresses, which are not supported by probe-rs
-                    // yet.
-
-                    if let Ok(address) = u32::try_from(address) {
-                        handlers::read_memory(address, length, session.core(0)?)
-                    } else {
-                        //
-                        handlers::reply_empty()
-                    }
+                    handlers::read_memory(address, length, session.core(0)?)
                 }
                 Detach => handlers::detach(&mut break_due),
                 V(VPacket::Continue(action)) => match action {

--- a/probe-rs-cli-util/src/common_options.rs
+++ b/probe-rs-cli-util/src/common_options.rs
@@ -555,6 +555,10 @@ pub fn print_families(mut f: impl Write) -> Result<(), OperationError> {
     Ok(())
 }
 
+fn get_range_len(range: &std::ops::Range<u64>) -> u64 {
+    range.end - range.start
+}
+
 /// Print all the available families and their contained chips to the
 /// commandline.
 pub fn print_chip_info(name: impl AsRef<str>, mut f: impl Write) -> anyhow::Result<()> {
@@ -575,19 +579,19 @@ pub fn print_chip_info(name: impl AsRef<str>, mut f: impl Write) -> anyhow::Resu
                 f,
                 "RAM: {:#010x?} ({})",
                 &region.range,
-                Byte::from_bytes(region.range.len() as u128).get_appropriate_unit(true)
+                Byte::from_bytes(get_range_len(&region.range) as u128).get_appropriate_unit(true)
             )?,
             probe_rs::config::MemoryRegion::Generic(region) => writeln!(
                 f,
                 "Generic: {:#010x?} ({})",
                 &region.range,
-                Byte::from_bytes(region.range.len() as u128).get_appropriate_unit(true)
+                Byte::from_bytes(get_range_len(&region.range) as u128).get_appropriate_unit(true)
             )?,
             probe_rs::config::MemoryRegion::Nvm(region) => writeln!(
                 f,
                 "NVM: {:#010x?} ({})",
                 &region.range,
-                Byte::from_bytes(region.range.len() as u128).get_appropriate_unit(true)
+                Byte::from_bytes(get_range_len(&region.range) as u128).get_appropriate_unit(true)
             )?,
         };
     }

--- a/probe-rs-cli-util/src/flash.rs
+++ b/probe-rs-cli-util/src/flash.rs
@@ -69,10 +69,10 @@ pub fn run_flash_download(
                 Initialized { flash_layout } => {
                     let total_page_size: u32 = flash_layout.pages().iter().map(|s| s.size()).sum();
 
-                    let total_sector_size: u32 =
+                    let total_sector_size: u64 =
                         flash_layout.sectors().iter().map(|s| s.size()).sum();
 
-                    let total_fill_size: u32 = flash_layout.fills().iter().map(|s| s.size()).sum();
+                    let total_fill_size: u64 = flash_layout.fills().iter().map(|s| s.size()).sum();
 
                     if let Some(fp) = fill_progress.as_ref() {
                         fp.set_length(total_fill_size as u64)

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -84,10 +84,10 @@ pub struct ArmCoreAccessOptions {
     pub psel: u32,
     /// The base address of the debug registers for the core.
     /// Required for Cortex-A, optional for Cortex-M
-    pub debug_base: Option<u32>,
+    pub debug_base: Option<u64>,
     /// The base address of the cross trigger interface (CTI) for the core.
     /// Required in ARMv8-A
-    pub cti_base: Option<u32>,
+    pub cti_base: Option<u64>,
 }
 
 /// The data required to access a Risc-V core

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -21,19 +21,19 @@ pub struct RawFlashAlgorithm {
     #[serde(serialize_with = "serialize")]
     pub instructions: Vec<u8>,
     /// Address to load algo into RAM. Optional.
-    pub load_address: Option<u32>,
+    pub load_address: Option<u64>,
     /// Address of the `Init()` entry point. Optional.
-    pub pc_init: Option<u32>,
+    pub pc_init: Option<u64>,
     /// Address of the `UnInit()` entry point. Optional.
-    pub pc_uninit: Option<u32>,
+    pub pc_uninit: Option<u64>,
     /// Address of the `ProgramPage()` entry point.
-    pub pc_program_page: u32,
+    pub pc_program_page: u64,
     /// Address of the `EraseSector()` entry point.
-    pub pc_erase_sector: u32,
+    pub pc_erase_sector: u64,
     /// Address of the `EraseAll()` entry point. Optional.
-    pub pc_erase_all: Option<u32>,
+    pub pc_erase_all: Option<u64>,
     /// The offset from the start of RAM to the data section.
-    pub data_section_offset: u32,
+    pub data_section_offset: u64,
     /// The properties of the flash on the device.
     pub flash_properties: FlashProperties,
     /// List of cores that can use this algorithm

--- a/probe-rs-target/src/flash_properties.rs
+++ b/probe-rs-target/src/flash_properties.rs
@@ -10,7 +10,7 @@ use std::ops::Range;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct FlashProperties {
     /// The range of the device flash.
-    pub address_range: Range<u32>,
+    pub address_range: Range<u64>,
     /// The page size of the device flash.
     pub page_size: u32,
     /// The value of a byte in flash that was just erased.

--- a/probe-rs-target/src/memory.rs
+++ b/probe-rs-target/src/memory.rs
@@ -7,7 +7,7 @@ pub struct NvmRegion {
     /// A name to describe the region
     pub name: Option<String>,
     /// Address range of the region
-    pub range: Range<u32>,
+    pub range: Range<u64>,
     /// True if the chip boots from this memory
     pub is_boot_memory: bool,
     /// List of cores that can access this region
@@ -29,7 +29,7 @@ pub struct RamRegion {
     /// A name to describe the region
     pub name: Option<String>,
     /// Address range of the region
-    pub range: Range<u32>,
+    pub range: Range<u64>,
     /// True if the chip boots from this memory
     pub is_boot_memory: bool,
     /// List of cores that can access this region
@@ -42,7 +42,7 @@ pub struct GenericRegion {
     /// A name to describe the region
     pub name: Option<String>,
     /// Address range of the region
-    pub range: Range<u32>,
+    pub range: Range<u64>,
     /// List of cores that can access this region
     pub cores: Vec<String>,
 }
@@ -52,9 +52,9 @@ pub struct GenericRegion {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct SectorInfo {
     /// Base address of the flash sector
-    pub base_address: u32,
+    pub base_address: u64,
     /// Size of the flash sector
-    pub size: u32,
+    pub size: u64,
 }
 
 /// Information about a group of flash sectors, which
@@ -70,17 +70,17 @@ pub struct SectorInfo {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SectorDescription {
     /// Size of each individual flash sector
-    pub size: u32,
+    pub size: u64,
     /// Start address of the group of flash sectors, relative
     /// to the start address of the flash.
-    pub address: u32,
+    pub address: u64,
 }
 
 /// Holds information about a page in flash.
 #[derive(Debug, Copy, Clone)]
 pub struct PageInfo {
     /// Base address of the page in flash.
-    pub base_address: u32,
+    pub base_address: u64,
     /// Size of the page
     pub size: u32,
 }
@@ -88,20 +88,20 @@ pub struct PageInfo {
 /// Holds information about the entire flash.
 #[derive(Debug, Copy, Clone)]
 pub struct NvmInfo {
-    pub rom_start: u32,
+    pub rom_start: u64,
 }
 
 /// Enables the user to do range intersection testing.
 pub trait MemoryRange {
     /// Returns true if `self` contains `range` fully.
-    fn contains_range(&self, range: &Range<u32>) -> bool;
+    fn contains_range(&self, range: &Range<u64>) -> bool;
 
     /// Returns true if `self` intersects `range` partially.
-    fn intersects_range(&self, range: &Range<u32>) -> bool;
+    fn intersects_range(&self, range: &Range<u64>) -> bool;
 }
 
-impl MemoryRange for Range<u32> {
-    fn contains_range(&self, range: &Range<u32>) -> bool {
+impl MemoryRange for Range<u64> {
+    fn contains_range(&self, range: &Range<u64>) -> bool {
         if range.end == 0 {
             false
         } else {
@@ -109,7 +109,7 @@ impl MemoryRange for Range<u32> {
         }
     }
 
-    fn intersects_range(&self, range: &Range<u32>) -> bool {
+    fn intersects_range(&self, range: &Range<u64>) -> bool {
         if range.end == 0 {
             false
         } else {

--- a/probe-rs/examples/benchmark.rs
+++ b/probe-rs/examples/benchmark.rs
@@ -15,7 +15,7 @@ struct Cli {
     #[clap(long = "chip")]
     chip: Option<String>,
     #[clap(long = "address", parse(try_from_str = parse_hex))]
-    address: u32,
+    address: u64,
     #[clap(long = "speed")]
     speed: Option<u32>,
     #[clap(long = "protocol")]
@@ -24,8 +24,8 @@ struct Cli {
     pr: Option<u64>,
 }
 
-fn parse_hex(src: &str) -> Result<u32, ParseIntError> {
-    u32::from_str_radix(src.trim_start_matches("0x"), 16)
+fn parse_hex(src: &str) -> Result<u64, ParseIntError> {
+    u64::from_str_radix(src.trim_start_matches("0x"), 16)
 }
 
 const SIZE: usize = 0x1000;

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -13,7 +13,7 @@ struct Cli {
     #[clap(long = "chip")]
     chip: Option<String>,
     #[clap(long = "address", parse(try_from_str = parse_hex))]
-    address: u32,
+    address: u64,
     #[clap(long = "size")]
     size: usize,
     #[clap(long = "speed")]
@@ -22,8 +22,8 @@ struct Cli {
     protocol: Option<String>,
 }
 
-fn parse_hex(src: &str) -> Result<u32, ParseIntError> {
-    u32::from_str_radix(src.trim_start_matches("0x"), 16)
+fn parse_hex(src: &str) -> Result<u64, ParseIntError> {
+    u64::from_str_radix(src.trim_start_matches("0x"), 16)
 }
 
 fn main() -> Result<()> {
@@ -114,7 +114,7 @@ fn main() -> Result<()> {
         sample_data.iter().zip(readback_data.iter()).enumerate()
     {
         if sample_data != readback_data {
-            let mismatch_address = matches.address + index as u32 * 4;
+            let mismatch_address = matches.address + index as u64 * 4;
 
             eprintln!(
                 "Readback data differs at address {:08x}: expected word {:08x}, got word {:08x}",

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -444,3 +444,20 @@ define_ap_register!(
     from: value => TAR { address: value },
     to: value => value.address
 );
+
+define_ap_register!(
+    type: MemoryAp,
+    /// Transfer Address Register - upper word
+    ///
+    /// The transfer address register (TAR) holds the memory
+    /// address which will be accessed through a read or
+    /// write of the DRW register.
+    name: TAR2,
+    address: 0x08,
+    fields: [
+        /// The uppper 32-bits of the register address to be used for the next access to DRW.
+        address: u32,
+    ],
+    from: value => TAR2 { address: value },
+    to: value => value.address
+);

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -10,7 +10,7 @@ use crate::DebugProbeError;
 
 pub use generic_ap::{ApClass, ApType, GenericAp, IDR};
 pub use memory_ap::{
-    AddressIncrement, BaseaddrFormat, DataSize, MemoryAp, BASE, BASE2, CSW, DRW, TAR,
+    AddressIncrement, BaseaddrFormat, DataSize, MemoryAp, BASE, BASE2, CSW, DRW, TAR, TAR2,
 };
 
 use super::{ApAddress, DapAccess, DpAddress, Register};
@@ -23,7 +23,7 @@ pub enum AccessPortError {
     #[error("Failed to access address 0x{address:08x} as it is not aligned to the requirement of {alignment} bytes.")]
     MemoryNotAligned {
         /// The address of the register.
-        address: u32,
+        address: u64,
         /// The required alignment in bytes (address increments).
         alignment: usize,
     },
@@ -84,7 +84,7 @@ impl AccessPortError {
     }
 
     /// Constructs a [`AccessPortError::MemoryNotAligned`] from the address and the required alignment.
-    pub fn alignment_error(address: u32, alignment: usize) -> Self {
+    pub fn alignment_error(address: u64, alignment: usize) -> Self {
         AccessPortError::MemoryNotAligned { address, alignment }
     }
 }

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -225,11 +225,17 @@ impl ApInformation {
 
             log::debug!("HNONSEC supported: {}", supports_hnonsec);
 
+            // TODO 64-bit - read the real state of the large data / address extensions from CFG
+            let has_large_address_extension = false;
+            let has_large_data_extension = false;
+
             Ok(ApInformation::MemoryAp(MemoryApInformation {
                 address: access_port.ap_address(),
                 only_32bit_data_size,
                 debug_base_address: base_address,
                 supports_hnonsec,
+                has_large_address_extension,
+                has_large_data_extension,
             }))
         } else {
             Ok(ApInformation::Other {
@@ -262,6 +268,12 @@ pub struct MemoryApInformation {
     ///
     /// [ARM Debug Interface Architecture Specification]: https://developer.arm.com/documentation/ihi0031/d/
     pub supports_hnonsec: bool,
+
+    /// This AP has the large address extension present, supporting 64-bit addresses
+    pub has_large_address_extension: bool,
+
+    /// This AP has the large data extension present, supporting 64-bit data access
+    pub has_large_data_extension: bool,
 }
 
 /// An implementation of the communication protocol between probe and target.

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -152,7 +152,7 @@ fn setup_swv_vendor(
                 // STMicroelectronics:
                 // STM32 parts need TRACE_IOEN set to 1 and TRACE_MODE set to 00.
                 log::debug!("STMicroelectronics part detected, configuring DBGMCU");
-                const DBGMCU: u32 = 0xE004_2004;
+                const DBGMCU: u64 = 0xE004_2004;
                 let mut dbgmcu = memory.read_word_32(DBGMCU)?;
                 dbgmcu |= 1 << 5;
                 dbgmcu &= !(0b00 << 6);
@@ -161,7 +161,7 @@ fn setup_swv_vendor(
             Some(id) if id == jep106::JEP106Code::new(0x02, 0x44) => {
                 // Nordic VLSI ASA
                 log::debug!("Nordic part detected, configuring CLOCK TRACECONFIG");
-                const CLOCK_TRACECONFIG: u32 = 0x4000_055C;
+                const CLOCK_TRACECONFIG: u64 = 0x4000_055C;
                 let mut traceconfig: u32 = 0;
                 traceconfig |= match config.tpiu_clk() {
                     4_000_000 => 3,

--- a/probe-rs/src/architecture/arm/core/armv7a_debug_regs.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a_debug_regs.rs
@@ -7,14 +7,14 @@ use crate::HaltReason;
 /// A debug register that is accessible to the external debugger
 pub trait Armv7DebugRegister {
     /// Register number
-    const NUMBER: u32;
+    const NUMBER: usize;
 
     /// The register's name.
     const NAME: &'static str;
 
     /// Get the address in the memory map
-    fn get_mmio_address(base_address: u32) -> u32 {
-        base_address + (Self::NUMBER * size_of::<u32>() as u32)
+    fn get_mmio_address(base_address: u64) -> u64 {
+        base_address + (Self::NUMBER * size_of::<u32>()) as u64
     }
 }
 
@@ -259,7 +259,7 @@ impl Dbgdscr {
 }
 
 impl Armv7DebugRegister for Dbgdscr {
-    const NUMBER: u32 = 34;
+    const NUMBER: usize = 34;
     const NAME: &'static str = "DBGDSCR";
 }
 
@@ -330,7 +330,7 @@ bitfield! {
 }
 
 impl Armv7DebugRegister for Dbgdidr {
-    const NUMBER: u32 = 0;
+    const NUMBER: usize = 0;
     const NAME: &'static str = "DBGDIDR";
 }
 
@@ -369,7 +369,7 @@ bitfield! {
 }
 
 impl Armv7DebugRegister for Dbgdrcr {
-    const NUMBER: u32 = 36;
+    const NUMBER: usize = 36;
     const NAME: &'static str = "DBGDRCR";
 }
 
@@ -396,7 +396,7 @@ bitfield! {
 }
 
 impl Armv7DebugRegister for Dbgbvr {
-    const NUMBER: u32 = 64;
+    const NUMBER: usize = 64;
     const NAME: &'static str = "DBGBVR";
 }
 
@@ -444,7 +444,7 @@ bitfield! {
 }
 
 impl Armv7DebugRegister for Dbgbcr {
-    const NUMBER: u32 = 80;
+    const NUMBER: usize = 80;
     const NAME: &'static str = "DBGBCR";
 }
 
@@ -472,7 +472,7 @@ bitfield! {
 }
 
 impl Armv7DebugRegister for Dbglar {
-    const NUMBER: u32 = 1004;
+    const NUMBER: usize = 1004;
     const NAME: &'static str = "DBGLAR";
 }
 
@@ -505,7 +505,7 @@ bitfield! {
 }
 
 impl Armv7DebugRegister for Dbgdsccr {
-    const NUMBER: u32 = 10;
+    const NUMBER: usize = 10;
     const NAME: &'static str = "DBGDSCCR";
 }
 
@@ -541,7 +541,7 @@ bitfield! {
 }
 
 impl Armv7DebugRegister for Dbgdsmcr {
-    const NUMBER: u32 = 11;
+    const NUMBER: usize = 11;
     const NAME: &'static str = "DBGDSMCR";
 }
 
@@ -568,7 +568,7 @@ bitfield! {
 }
 
 impl Armv7DebugRegister for Dbgitr {
-    const NUMBER: u32 = 33;
+    const NUMBER: usize = 33;
     const NAME: &'static str = "DBGITR";
 }
 
@@ -595,7 +595,7 @@ bitfield! {
 }
 
 impl Armv7DebugRegister for Dbgdtrtx {
-    const NUMBER: u32 = 35;
+    const NUMBER: usize = 35;
     const NAME: &'static str = "DBGDTRTX";
 }
 
@@ -622,7 +622,7 @@ bitfield! {
 }
 
 impl Armv7DebugRegister for Dbgdtrrx {
-    const NUMBER: u32 = 32;
+    const NUMBER: usize = 32;
     const NAME: &'static str = "DBGDTRRX";
 }
 
@@ -658,7 +658,7 @@ bitfield! {
 }
 
 impl Armv7DebugRegister for Dbgprcr {
-    const NUMBER: u32 = 196;
+    const NUMBER: usize = 196;
     const NAME: &'static str = "DBGPRCR";
 }
 
@@ -703,7 +703,7 @@ bitfield! {
 }
 
 impl Armv7DebugRegister for Dbgprsr {
-    const NUMBER: u32 = 197;
+    const NUMBER: usize = 197;
     const NAME: &'static str = "DBGPRSR";
 }
 

--- a/probe-rs/src/architecture/arm/core/armv8a_debug_regs.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a_debug_regs.rs
@@ -7,14 +7,14 @@ use crate::HaltReason;
 /// A debug register that is accessible to the external debugger
 pub trait Armv8DebugRegister {
     /// Register number
-    const NUMBER: u32;
+    const NUMBER: usize;
 
     /// The register's name.
     const NAME: &'static str;
 
     /// Get the address in the memory map
-    fn get_mmio_address(base_address: u32) -> u32 {
-        base_address + (Self::NUMBER * size_of::<u32>() as u32)
+    fn get_mmio_address(base_address: u64) -> u64 {
+        base_address + (Self::NUMBER * size_of::<u32>()) as u64
     }
 }
 
@@ -161,7 +161,7 @@ impl Edscr {
 }
 
 impl Armv8DebugRegister for Edscr {
-    const NUMBER: u32 = 34;
+    const NUMBER: usize = 34;
     const NAME: &'static str = "EDSCR";
 }
 
@@ -189,7 +189,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for Edlar {
-    const NUMBER: u32 = 1004;
+    const NUMBER: usize = 1004;
     const NAME: &'static str = "EDLAR";
 }
 
@@ -216,7 +216,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for Dbgbvr {
-    const NUMBER: u32 = 256;
+    const NUMBER: usize = 256;
     const NAME: &'static str = "DBGBVR";
 }
 
@@ -261,7 +261,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for Dbgbcr {
-    const NUMBER: u32 = 258;
+    const NUMBER: usize = 258;
     const NAME: &'static str = "DBGBCR";
 }
 
@@ -300,7 +300,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for Eddfr {
-    const NUMBER: u32 = 842;
+    const NUMBER: usize = 842;
     const NAME: &'static str = "EDDFR";
 }
 
@@ -327,7 +327,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for Editr {
-    const NUMBER: u32 = 33;
+    const NUMBER: usize = 33;
     const NAME: &'static str = "EDITR";
 }
 
@@ -360,7 +360,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for Edrcr {
-    const NUMBER: u32 = 36;
+    const NUMBER: usize = 36;
     const NAME: &'static str = "EDRCR";
 }
 
@@ -393,7 +393,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for Edecr {
-    const NUMBER: u32 = 9;
+    const NUMBER: usize = 9;
     const NAME: &'static str = "EDECR";
 }
 
@@ -426,7 +426,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for Edprcr {
-    const NUMBER: u32 = 196;
+    const NUMBER: usize = 196;
     const NAME: &'static str = "EDPRCR";
 }
 
@@ -453,7 +453,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for Dbgdtrtx {
-    const NUMBER: u32 = 35;
+    const NUMBER: usize = 35;
     const NAME: &'static str = "DBGDTRTX";
 }
 
@@ -480,7 +480,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for Dbgdtrrx {
-    const NUMBER: u32 = 32;
+    const NUMBER: usize = 32;
     const NAME: &'static str = "DBGDTRRX";
 }
 
@@ -540,7 +540,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for Edprsr {
-    const NUMBER: u32 = 197;
+    const NUMBER: usize = 197;
     const NAME: &'static str = "EDPRSR";
 }
 
@@ -567,7 +567,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for CtiControl {
-    const NUMBER: u32 = 0;
+    const NUMBER: usize = 0;
     const NAME: &'static str = "CTICONTROL";
 }
 
@@ -594,7 +594,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for CtiGate {
-    const NUMBER: u32 = 80;
+    const NUMBER: usize = 80;
     const NAME: &'static str = "CTIGATE";
 }
 
@@ -621,7 +621,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for CtiOuten {
-    const NUMBER: u32 = 40;
+    const NUMBER: usize = 40;
     const NAME: &'static str = "CTIOUTEN";
 }
 
@@ -648,7 +648,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for CtiApppulse {
-    const NUMBER: u32 = 7;
+    const NUMBER: usize = 7;
     const NAME: &'static str = "CTIAPPPULSE";
 }
 
@@ -675,7 +675,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for CtiIntack {
-    const NUMBER: u32 = 4;
+    const NUMBER: usize = 4;
     const NAME: &'static str = "CTIINTACK";
 }
 
@@ -702,7 +702,7 @@ bitfield! {
 }
 
 impl Armv8DebugRegister for CtiTrigoutstatus {
-    const NUMBER: u32 = 77;
+    const NUMBER: usize = 77;
     const NAME: &'static str = "CTITRIGOUTSTATUS";
 }
 

--- a/probe-rs/src/architecture/arm/core/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/cortex_m.rs
@@ -1,0 +1,146 @@
+//! Common functions and data types for Cortex-M core variants
+
+use crate::{CoreRegister, CoreRegisterAddress, DebugProbeError, Error, Memory};
+
+use bitfield::bitfield;
+use std::time::{Duration, Instant};
+
+bitfield! {
+    #[derive(Copy, Clone)]
+    pub struct Dhcsr(u32);
+    impl Debug;
+    pub s_reset_st, _: 25;
+    pub s_retire_st, _: 24;
+    pub s_lockup, _: 19;
+    pub s_sleep, _: 18;
+    pub s_halt, _: 17;
+    pub s_regrdy, _: 16;
+    pub c_maskints, set_c_maskints: 3;
+    pub c_step, set_c_step: 2;
+    pub c_halt, set_c_halt: 1;
+    pub c_debugen, set_c_debugen: 0;
+}
+
+impl Dhcsr {
+    /// This function sets the bit to enable writes to this register.
+    ///
+    /// C1.6.3 Debug Halting Control and Status Register, DHCSR:
+    /// Debug key:
+    /// Software must write 0xA05F to this field to enable write accesses to bits
+    /// [15:0], otherwise the processor ignores the write access.
+    pub fn enable_write(&mut self) {
+        self.0 &= !(0xffff << 16);
+        self.0 |= 0xa05f << 16;
+    }
+}
+
+impl From<u32> for Dhcsr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dhcsr> for u32 {
+    fn from(value: Dhcsr) -> Self {
+        value.0
+    }
+}
+
+impl CoreRegister for Dhcsr {
+    const ADDRESS: u64 = 0xE000_EDF0;
+    const NAME: &'static str = "DHCSR";
+}
+
+bitfield! {
+    #[derive(Copy, Clone)]
+    pub struct Dcrsr(u32);
+    impl Debug;
+    pub _, set_regwnr: 16;
+    pub _, set_regsel: 4,0;
+}
+
+impl From<u32> for Dcrsr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dcrsr> for u32 {
+    fn from(value: Dcrsr) -> Self {
+        value.0
+    }
+}
+
+impl CoreRegister for Dcrsr {
+    const ADDRESS: u64 = 0xE000_EDF4;
+    const NAME: &'static str = "DCRSR";
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct Dcrdr(u32);
+
+impl From<u32> for Dcrdr {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Dcrdr> for u32 {
+    fn from(value: Dcrdr) -> Self {
+        value.0
+    }
+}
+
+impl CoreRegister for Dcrdr {
+    const ADDRESS: u64 = 0xE000_EDF8;
+    const NAME: &'static str = "DCRDR";
+}
+
+pub(crate) fn read_core_reg(memory: &mut Memory, addr: CoreRegisterAddress) -> Result<u32, Error> {
+    // Write the DCRSR value to select the register we want to read.
+    let mut dcrsr_val = Dcrsr(0);
+    dcrsr_val.set_regwnr(false); // Perform a read.
+    dcrsr_val.set_regsel(addr.into()); // The address of the register to read.
+
+    memory.write_word_32(Dcrsr::ADDRESS, dcrsr_val.into())?;
+
+    wait_for_core_register_transfer(memory, Duration::from_millis(100))?;
+
+    let value = memory.read_word_32(Dcrdr::ADDRESS)?;
+
+    Ok(value)
+}
+
+pub(crate) fn write_core_reg(
+    memory: &mut Memory,
+    addr: CoreRegisterAddress,
+    value: u32,
+) -> Result<(), Error> {
+    memory.write_word_32(Dcrdr::ADDRESS, value)?;
+
+    // write the DCRSR value to select the register we want to write.
+    let mut dcrsr_val = Dcrsr(0);
+    dcrsr_val.set_regwnr(true); // Perform a write.
+    dcrsr_val.set_regsel(addr.into()); // The address of the register to write.
+
+    memory.write_word_32(Dcrsr::ADDRESS, dcrsr_val.into())?;
+
+    wait_for_core_register_transfer(memory, Duration::from_millis(100))?;
+
+    Ok(())
+}
+
+fn wait_for_core_register_transfer(memory: &mut Memory, timeout: Duration) -> Result<(), Error> {
+    // now we have to poll the dhcsr register, until the dhcsr.s_regrdy bit is set
+    // (see C1-292, cortex m0 arm)
+    let start = Instant::now();
+
+    while start.elapsed() < timeout {
+        let dhcsr_val = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
+
+        if dhcsr_val.s_regrdy() {
+            return Ok(());
+        }
+    }
+    Err(Error::Probe(DebugProbeError::Timeout))
+}

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -13,6 +13,7 @@ pub mod armv8m;
 
 pub(crate) mod armv7a_debug_regs;
 pub(crate) mod armv8a_debug_regs;
+pub(crate) mod cortex_m;
 pub(crate) mod instructions;
 
 /// Core information data which is downloaded from the target, represents its state and can be used for debugging.
@@ -292,7 +293,7 @@ impl From<Dfsr> for u32 {
 }
 
 impl CoreRegister for Dfsr {
-    const ADDRESS: u32 = 0xE000_ED30;
+    const ADDRESS: u64 = 0xE000_ED30;
     const NAME: &'static str = "DFSR";
 }
 

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -78,7 +78,7 @@ impl<'probe, 'memory, 'reader> Iterator for RomTableIterator<'probe, 'memory, 'r
         if let Err(e) = self
             .rom_table_reader
             .memory
-            .read_32(component_address as u32, &mut entry_data)
+            .read_32(component_address as u64, &mut entry_data)
         {
             return Some(Err(RomTableError::Memory(e)));
         }
@@ -266,7 +266,7 @@ impl<'probe: 'memory, 'memory> ComponentInformationReader<'probe, 'memory> {
         let mut cidr = [0u32; 4];
 
         self.memory
-            .read_32(self.base_address as u32 + 0xFF0, &mut cidr)
+            .read_32(self.base_address + 0xFF0, &mut cidr)
             .map_err(RomTableError::Memory)?;
 
         log::debug!("CIDR: {:x?}", cidr);
@@ -310,30 +310,30 @@ impl<'probe: 'memory, 'memory> ComponentInformationReader<'probe, 'memory> {
         );
 
         self.memory
-            .read_32(self.base_address as u32 + 0xFD0, &mut data[4..])
+            .read_32(self.base_address + 0xFD0, &mut data[4..])
             .map_err(RomTableError::Memory)?;
         self.memory
-            .read_32(self.base_address as u32 + 0xFE0, &mut data[..4])
+            .read_32(self.base_address + 0xFE0, &mut data[..4])
             .map_err(RomTableError::Memory)?;
 
         log::debug!("Raw peripheral id: {:x?}", data);
 
-        const DEV_TYPE_OFFSET: u32 = 0xFCC;
+        const DEV_TYPE_OFFSET: u64 = 0xFCC;
         const DEV_TYPE_MASK: u32 = 0xFF;
 
         let dev_type = self
             .memory
-            .read_word_32(self.base_address as u32 + DEV_TYPE_OFFSET)
+            .read_word_32(self.base_address + DEV_TYPE_OFFSET)
             .map(|v| (v & DEV_TYPE_MASK) as u8)
             .map_err(RomTableError::Memory)?;
 
-        const ARCH_ID_OFFSET: u32 = 0xFBC;
+        const ARCH_ID_OFFSET: u64 = 0xFBC;
         const ARCH_ID_MASK: u32 = 0xFFFF;
         const ARCH_ID_PRESENT_BIT: u32 = 1 << 20;
 
         let arch_id = self
             .memory
-            .read_word_32(self.base_address as u32 + ARCH_ID_OFFSET)
+            .read_word_32(self.base_address + ARCH_ID_OFFSET)
             .map(|v| {
                 if v & ARCH_ID_PRESENT_BIT > 0 {
                     (v & ARCH_ID_MASK) as u16
@@ -476,7 +476,7 @@ impl CoresightComponent {
         offset: u32,
     ) -> Result<u32, Error> {
         let mut memory = interface.memory_interface(self.ap)?;
-        let value = memory.read_word_32(self.component.id().component_address as u32 + offset)?;
+        let value = memory.read_word_32(self.component.id().component_address + offset as u64)?;
         Ok(value)
     }
 
@@ -488,7 +488,7 @@ impl CoresightComponent {
         value: u32,
     ) -> Result<(), Error> {
         let mut memory = interface.memory_interface(self.ap)?;
-        memory.write_word_32(self.component.id().component_address as u32 + offset, value)?;
+        memory.write_word_32(self.component.id().component_address + offset as u64, value)?;
         Ok(())
     }
 

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -46,7 +46,7 @@ impl DefaultArmSequence {
 impl ArmDebugSequence for DefaultArmSequence {}
 
 /// ResetCatchSet for Cortex-A devices
-fn armv7a_reset_catch_set(core: &mut Memory, debug_base: Option<u32>) -> Result<(), crate::Error> {
+fn armv7a_reset_catch_set(core: &mut Memory, debug_base: Option<u64>) -> Result<(), crate::Error> {
     use crate::architecture::arm::core::armv7a_debug_regs::Dbgprcr;
 
     let debug_base = debug_base.ok_or_else(|| {
@@ -66,7 +66,7 @@ fn armv7a_reset_catch_set(core: &mut Memory, debug_base: Option<u32>) -> Result<
 /// ResetCatchClear for Cortex-A devices
 fn armv7a_reset_catch_clear(
     core: &mut Memory,
-    debug_base: Option<u32>,
+    debug_base: Option<u64>,
 ) -> Result<(), crate::Error> {
     use crate::architecture::arm::core::armv7a_debug_regs::Dbgprcr;
 
@@ -86,7 +86,7 @@ fn armv7a_reset_catch_clear(
 
 fn armv7a_reset_system(
     interface: &mut Memory,
-    debug_base: Option<u32>,
+    debug_base: Option<u64>,
 ) -> Result<(), crate::Error> {
     use crate::architecture::arm::core::armv7a_debug_regs::{Dbgprcr, Dbgprsr};
 
@@ -116,7 +116,7 @@ fn armv7a_reset_system(
 }
 
 /// DebugCoreStart for v7 Cortex-A devices
-fn armv7a_core_start(core: &mut Memory, debug_base: Option<u32>) -> Result<(), crate::Error> {
+fn armv7a_core_start(core: &mut Memory, debug_base: Option<u64>) -> Result<(), crate::Error> {
     use crate::architecture::arm::core::armv7a_debug_regs::{Dbgdsccr, Dbgdscr, Dbgdsmcr, Dbglar};
 
     let debug_base = debug_base.ok_or_else(|| {
@@ -155,7 +155,7 @@ fn armv7a_core_start(core: &mut Memory, debug_base: Option<u32>) -> Result<(), c
 }
 
 /// ResetCatchSet for ARMv8-A devices
-fn armv8a_reset_catch_set(core: &mut Memory, debug_base: Option<u32>) -> Result<(), crate::Error> {
+fn armv8a_reset_catch_set(core: &mut Memory, debug_base: Option<u64>) -> Result<(), crate::Error> {
     use crate::architecture::arm::core::armv8a_debug_regs::{Armv8DebugRegister, Edecr};
 
     let debug_base = debug_base.ok_or_else(|| {
@@ -175,7 +175,7 @@ fn armv8a_reset_catch_set(core: &mut Memory, debug_base: Option<u32>) -> Result<
 /// ResetCatchClear for ARMv8-a devices
 fn armv8a_reset_catch_clear(
     core: &mut Memory,
-    debug_base: Option<u32>,
+    debug_base: Option<u64>,
 ) -> Result<(), crate::Error> {
     use crate::architecture::arm::core::armv8a_debug_regs::{Armv8DebugRegister, Edecr};
 
@@ -195,7 +195,7 @@ fn armv8a_reset_catch_clear(
 
 fn armv8a_reset_system(
     interface: &mut Memory,
-    debug_base: Option<u32>,
+    debug_base: Option<u64>,
 ) -> Result<(), crate::Error> {
     use crate::architecture::arm::core::armv8a_debug_regs::{Armv8DebugRegister, Edprcr, Edprsr};
 
@@ -227,8 +227,8 @@ fn armv8a_reset_system(
 /// DebugCoreStart for v8 Cortex-A devices
 fn armv8a_core_start(
     core: &mut Memory,
-    debug_base: Option<u32>,
-    cti_base: Option<u32>,
+    debug_base: Option<u64>,
+    cti_base: Option<u64>,
 ) -> Result<(), crate::Error> {
     use crate::architecture::arm::core::armv8a_debug_regs::{
         Armv8DebugRegister, CtiControl, CtiGate, CtiOuten, Edlar, Edscr,
@@ -554,8 +554,8 @@ pub trait ArmDebugSequence: Send + Sync {
         &self,
         core: &mut Memory,
         core_type: CoreType,
-        debug_base: Option<u32>,
-        cti_base: Option<u32>,
+        debug_base: Option<u64>,
+        cti_base: Option<u64>,
     ) -> Result<(), crate::Error> {
         // Dispatch based on core type (Cortex-A vs M)
         match core_type {
@@ -581,7 +581,7 @@ pub trait ArmDebugSequence: Send + Sync {
         &self,
         core: &mut Memory,
         core_type: CoreType,
-        debug_base: Option<u32>,
+        debug_base: Option<u64>,
     ) -> Result<(), crate::Error> {
         // Dispatch based on core type (Cortex-A vs M)
         match core_type {
@@ -607,7 +607,7 @@ pub trait ArmDebugSequence: Send + Sync {
         &self,
         core: &mut Memory,
         core_type: CoreType,
-        debug_base: Option<u32>,
+        debug_base: Option<u64>,
     ) -> Result<(), crate::Error> {
         // Dispatch based on core type (Cortex-A vs M)
         match core_type {
@@ -633,7 +633,7 @@ pub trait ArmDebugSequence: Send + Sync {
         &self,
         interface: &mut Memory,
         core_type: CoreType,
-        debug_base: Option<u32>,
+        debug_base: Option<u64>,
     ) -> Result<(), crate::Error> {
         // Dispatch based on core type (Cortex-A vs M)
         match core_type {

--- a/probe-rs/src/architecture/arm/sequences/nrf53.rs
+++ b/probe-rs/src/architecture/arm/sequences/nrf53.rs
@@ -53,7 +53,7 @@ impl Nrf5340 {
     /// The `ap_address` must be of the ahb ap of the application core.
     fn set_network_core_running(&self, interface: &mut crate::Memory) -> Result<(), crate::Error> {
         interface.write_32(
-            Self::APPLICATION_RESET_S_NETWORK_FORCEOFF_REGISTER,
+            Self::APPLICATION_RESET_S_NETWORK_FORCEOFF_REGISTER as u64,
             &[Self::RELEASE_FORCEOFF],
         )?;
         Ok(())

--- a/probe-rs/src/architecture/arm/sequences/nxp.rs
+++ b/probe-rs/src/architecture/arm/sequences/nxp.rs
@@ -100,7 +100,7 @@ impl ArmDebugSequence for LPC55S69 {
         &self,
         interface: &mut crate::Memory,
         _core_type: crate::CoreType,
-        _debug_base: Option<u32>,
+        _debug_base: Option<u64>,
     ) -> Result<(), crate::Error> {
         use crate::architecture::arm::core::armv7m::{Demcr, Dhcsr};
 
@@ -179,7 +179,7 @@ impl ArmDebugSequence for LPC55S69 {
         &self,
         interface: &mut crate::Memory,
         _core_type: crate::CoreType,
-        _debug_base: Option<u32>,
+        _debug_base: Option<u64>,
     ) -> Result<(), crate::Error> {
         use crate::architecture::arm::core::armv7m::Demcr;
 
@@ -197,7 +197,7 @@ impl ArmDebugSequence for LPC55S69 {
         &self,
         interface: &mut crate::Memory,
         _core_type: crate::CoreType,
-        _debug_base: Option<u32>,
+        _debug_base: Option<u64>,
     ) -> Result<(), crate::Error> {
         use crate::architecture::arm::core::armv7m::Aircr;
 

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -17,6 +17,8 @@ use crate::{MemoryInterface, Probe};
 
 use crate::{probe::JTAGAccess, CoreRegisterAddress, Error as ProbeRsError};
 
+use crate::memory::valid_32_address;
+
 use bitfield::bitfield;
 use std::{
     collections::HashMap,
@@ -1699,42 +1701,50 @@ impl RiscvValue for u128 {
 }
 
 impl MemoryInterface for RiscvCommunicationInterface {
-    fn read_word_32(&mut self, address: u32) -> Result<u32, crate::Error> {
+    fn read_word_32(&mut self, address: u64) -> Result<u32, crate::Error> {
+        let address = valid_32_address(address)?;
         self.read_word(address)
     }
 
-    fn read_word_8(&mut self, address: u32) -> Result<u8, crate::Error> {
+    fn read_word_8(&mut self, address: u64) -> Result<u8, crate::Error> {
+        let address = valid_32_address(address)?;
         log::debug!("read_word_8 from {:#08x}", address);
         self.read_word(address)
     }
 
-    fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), crate::Error> {
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), crate::Error> {
+        let address = valid_32_address(address)?;
         log::debug!("read_32 from {:#08x}", address);
         self.read_multiple(address, data)
     }
 
     /// Read 8-bit values from target memory.
-    fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), crate::Error> {
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), crate::Error> {
+        let address = valid_32_address(address)?;
         log::debug!("read_8 from {:#08x}", address);
 
         self.read_multiple(address, data)
     }
 
-    fn write_word_32(&mut self, address: u32, data: u32) -> Result<(), crate::Error> {
+    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), crate::Error> {
+        let address = valid_32_address(address)?;
         self.write_word(address, data)
     }
 
-    fn write_word_8(&mut self, address: u32, data: u8) -> Result<(), crate::Error> {
+    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), crate::Error> {
+        let address = valid_32_address(address)?;
         self.write_word(address, data)
     }
 
-    fn write_32(&mut self, address: u32, data: &[u32]) -> Result<(), crate::Error> {
+    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), crate::Error> {
+        let address = valid_32_address(address)?;
         log::debug!("write_32 to {:#08x}", address);
 
         self.write_multiple(address, data)
     }
 
-    fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), crate::Error> {
+    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), crate::Error> {
+        let address = valid_32_address(address)?;
         log::debug!("write_8 to {:#08x}", address);
 
         self.write_multiple(address, data)

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -149,7 +149,7 @@ impl Target {
     }
 
     /// Gets the first found [MemoryRegion] that contains the given address
-    pub(crate) fn get_memory_region_by_address(&self, address: u32) -> Option<&MemoryRegion> {
+    pub(crate) fn get_memory_region_by_address(&self, address: u64) -> Option<&MemoryRegion> {
         self.memory_map.iter().find(|region| match region {
             MemoryRegion::Ram(rr) if rr.range.contains(&address) => true,
             MemoryRegion::Generic(gr) if gr.range.contains(&address) => true,

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 /// A core register (e.g. Stack Pointer).
 pub trait CoreRegister: Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug {
     /// The register's address.
-    const ADDRESS: u32;
+    const ADDRESS: u64;
     /// The register's name.
     const NAME: &'static str;
 }
@@ -42,7 +42,7 @@ impl From<u16> for CoreRegisterAddress {
 #[derive(Debug, Clone)]
 pub struct CoreInformation {
     /// The current Program Counter.
-    pub pc: u32,
+    pub pc: u64,
 }
 
 /// Describes a register with its properties.
@@ -249,13 +249,13 @@ pub trait CoreInterface: MemoryInterface {
     /// Read the hardware breakpoints from FpComp registers, and adds them to the Result Vector.
     /// A value of None in any position of the Vector indicates that the position is unset/available.
     /// We intentionally return all breakpoints, irrespective of whether they are enabled or not.
-    fn hw_breakpoints(&mut self) -> Result<Vec<Option<u32>>, error::Error>;
+    fn hw_breakpoints(&mut self) -> Result<Vec<Option<u64>>, error::Error>;
 
     /// Enables breakpoints on this core. If a breakpoint is set, it will halt as soon as it is hit.
     fn enable_breakpoints(&mut self, state: bool) -> Result<(), error::Error>;
 
     /// Sets a breakpoint at `addr`. It does so by using unit `bp_unit_index`.
-    fn set_hw_breakpoint(&mut self, unit_index: usize, addr: u32) -> Result<(), error::Error>;
+    fn set_hw_breakpoint(&mut self, unit_index: usize, addr: u64) -> Result<(), error::Error>;
 
     /// Clears the breakpoint configured in unit `unit_index`.
     fn clear_hw_breakpoint(&mut self, unit_index: usize) -> Result<(), error::Error>;
@@ -279,35 +279,35 @@ pub trait CoreInterface: MemoryInterface {
 }
 
 impl<'probe> MemoryInterface for Core<'probe> {
-    fn read_word_32(&mut self, address: u32) -> Result<u32, Error> {
+    fn read_word_32(&mut self, address: u64) -> Result<u32, Error> {
         self.inner.read_word_32(address)
     }
 
-    fn read_word_8(&mut self, address: u32) -> Result<u8, Error> {
+    fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
         self.inner.read_word_8(address)
     }
 
-    fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), Error> {
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
         self.inner.read_32(address, data)
     }
 
-    fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), Error> {
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
         self.inner.read_8(address, data)
     }
 
-    fn write_word_32(&mut self, addr: u32, data: u32) -> Result<(), Error> {
+    fn write_word_32(&mut self, addr: u64, data: u32) -> Result<(), Error> {
         self.inner.write_word_32(addr, data)
     }
 
-    fn write_word_8(&mut self, addr: u32, data: u8) -> Result<(), Error> {
+    fn write_word_8(&mut self, addr: u64, data: u8) -> Result<(), Error> {
         self.inner.write_word_8(addr, data)
     }
 
-    fn write_32(&mut self, addr: u32, data: &[u32]) -> Result<(), Error> {
+    fn write_32(&mut self, addr: u64, data: &[u32]) -> Result<(), Error> {
         self.inner.write_32(addr, data)
     }
 
-    fn write_8(&mut self, addr: u32, data: &[u8]) -> Result<(), Error> {
+    fn write_8(&mut self, addr: u64, data: &[u8]) -> Result<(), Error> {
         self.inner.write_8(addr, data)
     }
 
@@ -599,7 +599,7 @@ impl<'probe> Core<'probe> {
     ///
     /// The amount of hardware breakpoints which are supported is chip specific,
     /// and can be queried using the `get_available_breakpoint_units` function.
-    pub fn set_hw_breakpoint(&mut self, address: u32) -> Result<(), error::Error> {
+    pub fn set_hw_breakpoint(&mut self, address: u64) -> Result<(), error::Error> {
         if !self.inner.hw_breakpoints_enabled() {
             self.enable_breakpoints(true)?;
         }
@@ -630,7 +630,7 @@ impl<'probe> Core<'probe> {
     /// Set a hardware breakpoint
     ///
     /// This function will try to clear a hardware breakpoint at `address` if there exists a breakpoint at that address.
-    pub fn clear_hw_breakpoint(&mut self, address: u32) -> Result<(), error::Error> {
+    pub fn clear_hw_breakpoint(&mut self, address: u64) -> Result<(), error::Error> {
         let bp_position = self
             .inner
             .hw_breakpoints()?

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -582,7 +582,7 @@ impl DebugInfo {
                                     .read_word_32(*address)
                                 {
                                     Ok(memory_location) => {
-                                        VariableLocation::Address(memory_location)
+                                        VariableLocation::Address(memory_location as u64)
                                     }
                                     Err(error) => {
                                         log::error!("Failed to read referenced variable address from memory location {} : {}.", parent_variable.memory_location , error);
@@ -1133,7 +1133,7 @@ impl DebugInfo {
                                         i64::from(unwind_cfa) + address_offset;
                                     let mut buff = [0u8; 4];
                                     if let Err(e) =
-                                        core.read(previous_frame_register_address as u32, &mut buff)
+                                        core.read(previous_frame_register_address as u64, &mut buff)
                                     {
                                         log::error!(
                                                         "UNWIND: Failed to read from address {:#010x} ({} bytes): {}",
@@ -1259,7 +1259,7 @@ impl DebugInfo {
                                         i64::from(unwind_cfa) + address_offset;
                                     let mut buff = [0u8; 4];
                                     if let Err(e) =
-                                        core.read(previous_frame_register_address as u32, &mut buff)
+                                        core.read(previous_frame_register_address as u64, &mut buff)
                                     {
                                         log::error!(
                                                         "UNWIND: Failed to read from address {:#010x} ({} bytes): {}",

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -243,7 +243,7 @@ pub(crate) fn _print_all_attributes(
                         Complete => break,
                         RequiresMemory { address, size, .. } => {
                             let mut buff = vec![0u8; size as usize];
-                            core.read(address as u32, &mut buff)
+                            core.read(address, &mut buff)
                                 .expect("Failed to read memory");
                             match size {
                                 1 => evaluation

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -829,7 +829,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                             VariableLocation::Address(address) => {
                                 // This is a member of an array type, and needs special handling.
                                 let (location, has_overflowed) = address.overflowing_add(
-                                    child_member_index as u32 * child_variable.byte_size as u32,
+                                    child_member_index as u64 * child_variable.byte_size as u64,
                                 );
 
                                 if has_overflowed {
@@ -910,7 +910,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                             VariableLocation::Address(address) => {
                                 // This is a member of an array type, and needs special handling.
                                 let (location, has_overflowed) = address.overflowing_add(
-                                    child_member_index as u32 * child_variable.byte_size as u32,
+                                    child_member_index as u64 * child_variable.byte_size as u64,
                                 );
 
                                 // TODO:
@@ -1145,7 +1145,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                             VariableLocation::Address(address) => {
                                 // This is a member of an array type, and needs special handling.
                                 let (location, has_overflowed) = address.overflowing_add(
-                                    child_member_index as u32 * child_variable.byte_size as u32,
+                                    child_member_index as u64 * child_variable.byte_size as u64,
                                 );
 
                                 // TODO:
@@ -1298,7 +1298,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                         match &parent_variable.memory_location {
                             VariableLocation::Address(address) => {
                                 child_variable.memory_location =
-                                    VariableLocation::Address(address + offset_from_parent as u32)
+                                    VariableLocation::Address(address + offset_from_parent)
                             }
                             _other => {
                                 child_variable.memory_location = VariableLocation::Unavailable;
@@ -1425,7 +1425,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                     if *address == u32::MAX as u64 {
                         return Err(DebugError::Other(anyhow::anyhow!("BUG: Cannot resolve due to rust-lang issue https://github.com/rust-lang/rust/issues/32574".to_string())));
                     } else {
-                        child_variable.memory_location = VariableLocation::Address(*address as u32);
+                        child_variable.memory_location = VariableLocation::Address(*address);
                     }
                 }
                 Location::Value { value } => {
@@ -1506,7 +1506,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 Complete => break,
                 RequiresMemory { address, size, .. } => {
                     let mut buff = vec![0u8; size as usize];
-                    core.read(address as u32, &mut buff).map_err(|_| {
+                    core.read(address, &mut buff).map_err(|_| {
                         DebugError::Other(anyhow::anyhow!("Unexpected error while reading debug expressions from target memory. Please report this as a bug."))
                     })?;
                     match size {

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -13,7 +13,7 @@ use crate::session::Session;
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct BinOptions {
     /// The address in memory where the binary will be put at.
-    pub base_address: Option<u32>,
+    pub base_address: Option<u64>,
     /// The number of bytes to skip at the start of the binary file.
     pub skip: u32,
 }
@@ -234,8 +234,7 @@ pub(super) fn extract_from_elf<'data>(
 
             let (segment_offset, segment_filesize) = segment.file_range(endian);
 
-            let sector: core::ops::Range<u32> =
-                segment_offset as u32..segment_offset as u32 + segment_filesize as u32;
+            let sector: core::ops::Range<u64> = segment_offset..segment_offset + segment_filesize;
 
             for section in binary.sections() {
                 let (section_offset, section_filesize) = match section.file_range() {
@@ -243,9 +242,7 @@ pub(super) fn extract_from_elf<'data>(
                     None => continue,
                 };
 
-                if sector.contains_range(
-                    &(section_offset as u32..section_offset as u32 + section_filesize as u32),
-                ) {
+                if sector.contains_range(&(section_offset..section_offset + section_filesize)) {
                     log::info!("Matching section: {:?}", section.name()?);
 
                     #[cfg(feature = "hexdump")]

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -11,9 +11,9 @@ pub enum FlashError {
     )]
     NoSuitableNvm {
         /// The start of the requested memory range.
-        start: u32,
+        start: u64,
         /// The end of the requested memory range.
-        end: u32,
+        end: u64,
         /// The source of this target description (was it a built in target or one loaded externally and from what file path?).
         description_source: TargetDescriptionSource,
     },
@@ -27,7 +27,7 @@ pub enum FlashError {
     #[error("Failed to erase flash sector at address {sector_address:#010x}.")]
     EraseFailed {
         /// The address of the sector that should have been erased.
-        sector_address: u32,
+        sector_address: u64,
         /// The source error of this error.
         #[source]
         source: Box<dyn std::error::Error + 'static + Send + Sync>,
@@ -36,7 +36,7 @@ pub enum FlashError {
     #[error("The page write of the page at address {page_address:#010x} failed.")]
     PageWrite {
         /// The address of the page that should have been written.
-        page_address: u32,
+        page_address: u64,
         /// The source error of this error.
         #[source]
         source: Box<dyn std::error::Error + 'static + Send + Sync>,
@@ -82,7 +82,7 @@ pub enum FlashError {
     )]
     InvalidFlashAlgorithmLoadAddress {
         /// The address where the algorithm was supposed to be loaded to.
-        address: u32,
+        address: u64,
     },
     /// The given page size is not valid. Only page sizes multiples of 4 bytes are allowed.
     #[error("Invalid page size {size:08X?}. Must be a multiple of 4 bytes.")]
@@ -138,9 +138,9 @@ pub enum FlashError {
     #[error("Adding data for addresses {added_addresses:08X?} overlaps previously added data for addresses {existing_addresses:08X?}.")]
     DataOverlaps {
         /// The address range that was tried to be added.
-        added_addresses: Range<u32>,
+        added_addresses: Range<u64>,
         /// The address range that was already present.
-        existing_addresses: Range<u32>,
+        existing_addresses: Range<u64>,
     },
     /// No core can access this NVM region.
     #[error("No core can access the NVM region {0:?}.")]
@@ -148,4 +148,7 @@ pub enum FlashError {
     /// No core can access this RAM region.
     #[error("No core can access the ram region {0:?}.")]
     NoRamCoreAccess(RamRegion),
+    /// The register value supplied for this flash algorithm is out of the supported range.
+    #[error("The register value {0:08X?} is out of the supported range.")]
+    RegisterValueNotSupported(u64),
 }

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -57,12 +57,12 @@ impl FlashProgress {
     }
 
     /// Signalize that the sector erasing procedure has made progress.
-    pub(super) fn sector_erased(&self, size: u32, time: Duration) {
+    pub(super) fn sector_erased(&self, size: u64, time: Duration) {
         self.emit(ProgressEvent::SectorErased { size, time });
     }
 
     /// Signalize that the page filling procedure has made progress.
-    pub(super) fn page_filled(&self, size: u32, time: Duration) {
+    pub(super) fn page_filled(&self, size: u64, time: Duration) {
         self.emit(ProgressEvent::PageFilled { size, time });
     }
 
@@ -130,7 +130,7 @@ pub enum ProgressEvent {
     /// Only its contents are determined at this point!
     PageFilled {
         /// The size of the page in bytes.
-        size: u32,
+        size: u64,
         /// The time it took to fill this flash page.
         time: Duration,
     },
@@ -143,7 +143,7 @@ pub enum ProgressEvent {
     /// A sector has been erased successfully.
     SectorErased {
         /// The size of the sector in bytes.
-        size: u32,
+        size: u64,
         /// The time it took to erase this sector.
         time: Duration,
     },

--- a/probe-rs/src/flashing/visualizer.rs
+++ b/probe-rs/src/flashing/visualizer.rs
@@ -18,7 +18,7 @@ impl<'layout> FlashVisualizer<'layout> {
 
     /// Calculates the position in a [0, 100] range
     /// depending on the given address and the highest known sector end address.
-    fn memory_to_local(&self, address: u32) -> f32 {
+    fn memory_to_local(&self, address: u64) -> f32 {
         let top_sector_address = self
             .flash_layout
             .sectors()
@@ -28,7 +28,7 @@ impl<'layout> FlashVisualizer<'layout> {
         address as f32 / top_sector_address as f32 * 100.0
     }
 
-    fn memory_block(&self, address: u32, size: u32, dimensions: (u32, u32)) -> Group {
+    fn memory_block(&self, address: u64, size: u64, dimensions: (u32, u32)) -> Group {
         let height = self.memory_to_local(size);
         let start = 100.0 - self.memory_to_local(address) - height;
 
@@ -83,7 +83,7 @@ impl<'layout> FlashVisualizer<'layout> {
 
         for page in self.flash_layout.pages() {
             let rectangle = self
-                .memory_block(page.address(), page.size(), (100, 50))
+                .memory_block(page.address(), page.size() as u64, (100, 50))
                 .set("fill", "Crimson");
             // .set("stroke", "Black")
             // .set("stroke-width", 1);

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -1,10 +1,7 @@
-use crate::{
-    architecture::arm::{
-        ap::{AccessPort, MemoryAp},
-        memory::adi_v5_memory_interface::ArmProbe,
-        ApAddress,
-    },
-    CoreRegisterAddress,
+use crate::architecture::arm::{
+    ap::{AccessPort, MemoryAp},
+    memory::adi_v5_memory_interface::ArmProbe,
+    ApAddress,
 };
 use crate::{
     architecture::arm::{communication_interface::Initialized, ArmCommunicationInterface},
@@ -20,24 +17,24 @@ pub trait MemoryInterface {
     ///
     /// The address where the read should be performed at has to be word aligned.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    fn read_word_32(&mut self, address: u32) -> Result<u32, error::Error>;
+    fn read_word_32(&mut self, address: u64) -> Result<u32, error::Error>;
 
     /// Read an 8bit word of at `address`.
-    fn read_word_8(&mut self, address: u32) -> Result<u8, error::Error>;
+    fn read_word_8(&mut self, address: u64) -> Result<u8, error::Error>;
 
     /// Read a block of 32bit words at `address`.
     ///
     /// The number of words read is `data.len()`.
     /// The address where the read should be performed at has to be word aligned.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), error::Error>;
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), error::Error>;
 
     /// Read a block of 8bit words at `address`.
-    fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error>;
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), error::Error>;
 
     /// Reads bytes using 32 bit memory access. Address must be 32 bit aligned
     /// and data must be an exact multiple of 4.
-    fn read_mem_32bit(&mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error> {
+    fn read_mem_32bit(&mut self, address: u64, data: &mut [u8]) -> Result<(), error::Error> {
         // Default implementation uses `read_32`, then converts u32 values back
         // to bytes. Assumes target is little endian. May be overridden to
         // provide an implementation that avoids heap allocation and endian
@@ -58,14 +55,14 @@ pub trait MemoryInterface {
     /// Read a block of 8bit words at `address`. May use 32 bit memory access,
     /// so should only be used if reading memory locations that don't have side
     /// effects. Generally faster than `read_8`.
-    fn read(&mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error> {
+    fn read(&mut self, address: u64, data: &mut [u8]) -> Result<(), error::Error> {
         if address % 4 == 0 && data.len() % 4 == 0 {
             // Avoid heap allocation and copy if we don't need it.
             self.read_mem_32bit(address, data)?;
         } else {
             let start_extra_count = (address % 4) as usize;
             let mut buffer = vec![0u8; (start_extra_count + data.len() + 3) / 4 * 4];
-            self.read_mem_32bit(address - start_extra_count as u32, &mut buffer)?;
+            self.read_mem_32bit(address - start_extra_count as u64, &mut buffer)?;
             data.copy_from_slice(&buffer[start_extra_count..start_extra_count + data.len()]);
         }
         Ok(())
@@ -75,20 +72,20 @@ pub trait MemoryInterface {
     ///
     /// The address where the write should be performed at has to be word aligned.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    fn write_word_32(&mut self, address: u32, data: u32) -> Result<(), error::Error>;
+    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), error::Error>;
 
     /// Write an 8bit word at `address`.
-    fn write_word_8(&mut self, address: u32, data: u8) -> Result<(), error::Error>;
+    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), error::Error>;
 
     /// Write a block of 32bit words at `address`.
     ///
     /// The number of words written is `data.len()`.
     /// The address where the write should be performed at has to be word aligned.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
-    fn write_32(&mut self, address: u32, data: &[u32]) -> Result<(), error::Error>;
+    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), error::Error>;
 
     /// Write a block of 8bit words at `address`.
-    fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), error::Error>;
+    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), error::Error>;
 
     /// Flush any outstanding operations.
     ///
@@ -103,35 +100,35 @@ impl<T> MemoryInterface for &mut T
 where
     T: MemoryInterface,
 {
-    fn read_word_32(&mut self, address: u32) -> Result<u32, error::Error> {
+    fn read_word_32(&mut self, address: u64) -> Result<u32, error::Error> {
         (*self).read_word_32(address)
     }
 
-    fn read_word_8(&mut self, address: u32) -> Result<u8, error::Error> {
+    fn read_word_8(&mut self, address: u64) -> Result<u8, error::Error> {
         (*self).read_word_8(address)
     }
 
-    fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), error::Error> {
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), error::Error> {
         (*self).read_32(address, data)
     }
 
-    fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error> {
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), error::Error> {
         (*self).read_8(address, data)
     }
 
-    fn write_word_32(&mut self, address: u32, data: u32) -> Result<(), error::Error> {
+    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), error::Error> {
         (*self).write_word_32(address, data)
     }
 
-    fn write_word_8(&mut self, address: u32, data: u8) -> Result<(), error::Error> {
+    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), error::Error> {
         (*self).write_word_8(address, data)
     }
 
-    fn write_32(&mut self, address: u32, data: &[u32]) -> Result<(), error::Error> {
+    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), error::Error> {
         (*self).write_32(address, data)
     }
 
-    fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), error::Error> {
+    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), error::Error> {
         (*self).write_8(address, data)
     }
 
@@ -156,7 +153,7 @@ impl<'probe> Memory<'probe> {
     }
 
     /// Reads a 32 bit word from `address`.
-    pub fn read_word_32(&mut self, address: u32) -> Result<u32, error::Error> {
+    pub fn read_word_32(&mut self, address: u64) -> Result<u32, error::Error> {
         let mut buff = [0];
         self.inner.read_32(self.ap_sel, address, &mut buff)?;
 
@@ -164,7 +161,7 @@ impl<'probe> Memory<'probe> {
     }
 
     /// Reads an 8 bit word from `address`.
-    pub fn read_word_8(&mut self, address: u32) -> Result<u8, error::Error> {
+    pub fn read_word_8(&mut self, address: u64) -> Result<u8, error::Error> {
         let mut buff = [0];
         self.inner.read_8(self.ap_sel, address, &mut buff)?;
 
@@ -172,32 +169,32 @@ impl<'probe> Memory<'probe> {
     }
 
     /// Reads `data.len()` 32 bit words from `address` into `data`.
-    pub fn read_32(&mut self, address: u32, data: &mut [u32]) -> Result<(), error::Error> {
+    pub fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), error::Error> {
         self.inner.read_32(self.ap_sel, address, data)
     }
 
     /// Reads `data.len()` 8 bit words from `address` into `data`.
-    pub fn read_8(&mut self, address: u32, data: &mut [u8]) -> Result<(), error::Error> {
+    pub fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), error::Error> {
         self.inner.read_8(self.ap_sel, address, data)
     }
 
     /// Writes a 32 bit word to `address`.
-    pub fn write_word_32(&mut self, address: u32, data: u32) -> Result<(), error::Error> {
+    pub fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), error::Error> {
         self.inner.write_32(self.ap_sel, address, &[data])
     }
 
     /// Writes a 8 bit word to `address`.
-    pub fn write_word_8(&mut self, address: u32, data: u8) -> Result<(), error::Error> {
+    pub fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), error::Error> {
         self.inner.write_8(self.ap_sel, address, &[data])
     }
 
     /// Writes `data.len()` 32 bit words from `data` to `address`.
-    pub fn write_32(&mut self, address: u32, data: &[u32]) -> Result<(), error::Error> {
+    pub fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), error::Error> {
         self.inner.write_32(self.ap_sel, address, data)
     }
 
     /// Writes `data.len()` 8 bit words from `data` to `address`.
-    pub fn write_8(&mut self, address: u32, data: &[u8]) -> Result<(), error::Error> {
+    pub fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), error::Error> {
         self.inner.write_8(self.ap_sel, address, data)
     }
 
@@ -206,20 +203,6 @@ impl<'probe> Memory<'probe> {
     /// This method is necessary when the underlying probe driver implements batching.
     pub fn flush(&mut self) -> Result<(), error::Error> {
         self.inner.flush()
-    }
-
-    /// Reads the core register at `address`.
-    pub fn read_core_reg(&mut self, address: CoreRegisterAddress) -> Result<u32, error::Error> {
-        self.inner.read_core_reg(self.ap_sel, address)
-    }
-
-    /// Writes `value` to the core register at `address`.
-    pub fn write_core_reg(
-        &mut self,
-        address: CoreRegisterAddress,
-        value: u32,
-    ) -> Result<(), error::Error> {
-        self.inner.write_core_reg(self.ap_sel, address, value)
     }
 
     /// Tries to borrow the underlying [`ArmCommunicationInterface`].
@@ -238,4 +221,15 @@ impl<'probe> Memory<'probe> {
     pub fn get_ap(&mut self) -> ApAddress {
         self.ap_sel.ap_address()
     }
+}
+
+// Helper functions to validate address space constraints
+
+/// Validate that an input address is valid for 32-bit only systems
+pub(crate) fn valid_32_address(address: u64) -> Result<u32, error::Error> {
+    let address: u32 = address
+        .try_into()
+        .map_err(|_| anyhow!("Address {:#08x} out of range", address))?;
+
+    Ok(address)
 }

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -289,6 +289,8 @@ impl ArmProbeInterface for FakeArmInterface<Initialized> {
             only_32bit_data_size: false,
             debug_base_address: 0xf000_0000,
             supports_hnonsec: false,
+            has_large_data_extension: false,
+            has_large_address_extension: false,
         };
 
         let memory = ADIMemoryInterface::new(&mut self.memory_ap, &ap_information)?;

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -391,9 +391,8 @@ impl Session {
                 }) => Err(Error::Other(anyhow!("AP has a base address of 0"))),
                 ApInformation::MemoryAp(MemoryApInformation {
                     address,
-                    only_32bit_data_size: _,
                     debug_base_address,
-                    supports_hnonsec: _,
+                    ..
                 }) => {
                     let ap = MemoryAp::new(address);
                     let mut memory = interface.memory_interface(ap)?;

--- a/rtt/src/rtt.rs
+++ b/rtt/src/rtt.rs
@@ -79,7 +79,7 @@ impl Rtt {
             None => {
                 // If memory wasn't passed in, read the minimum header size
                 let mut mem = vec![0u8; Self::MIN_SIZE];
-                core.read(ptr, &mut mem)?;
+                core.read(ptr.into(), &mut mem)?;
                 Cow::Owned(mem)
             }
         };
@@ -114,7 +114,7 @@ impl Rtt {
             // If memory wasn't passed in, read the rest of the control block
             mem.resize(cb_len, 0);
             core.read(
-                ptr + Self::MIN_SIZE as u32,
+                (ptr + Self::MIN_SIZE as u32).into(),
                 &mut mem[Self::MIN_SIZE..cb_len],
             )?;
         }
@@ -190,7 +190,10 @@ impl Rtt {
                 memory_map
                     .iter()
                     .filter_map(|r| match r {
-                        MemoryRegion::Ram(r) => Some(r.range.clone()),
+                        MemoryRegion::Ram(r) => Some(Range {
+                            start: r.range.start as u32,
+                            end: r.range.end as u32,
+                        }),
                         _ => None,
                     })
                     .collect()
@@ -212,7 +215,7 @@ impl Rtt {
 
             mem.resize(range.len(), 0);
             {
-                core.read(range.start, mem.as_mut())?;
+                core.read(range.start.into(), mem.as_mut())?;
             }
 
             for offset in 0..(mem.len() - Self::MIN_SIZE) {

--- a/smoke-tester/src/tests.rs
+++ b/smoke-tester/src/tests.rs
@@ -56,8 +56,8 @@ pub fn test_memory_access(
             probe_rs::config::MemoryRegion::Ram(ram)
                 if ram.cores.iter().any(|c| c == core_name) =>
             {
-                let ram_start = ram.range.start;
-                let ram_size = ram.range.end - ram.range.start;
+                let ram_start = ram.range.start as u64;
+                let ram_size = (ram.range.end - ram.range.start) as u64;
 
                 println_test_status!(tracker, blue, "Test - RAM Start 32");
                 // Write first word
@@ -123,25 +123,25 @@ pub fn test_hw_breakpoints(
     for region in memory_regions {
         match region {
             probe_rs::config::MemoryRegion::Nvm(nvm) => {
-                let initial_breakpoint_addr = nvm.range.start;
+                let initial_breakpoint_addr = nvm.range.start as u64;
 
                 let num_breakpoints = core.available_breakpoint_units()?;
 
                 println_test_status!(tracker, blue, "{} breakpoints supported", num_breakpoints);
 
                 for i in 0..num_breakpoints {
-                    core.set_hw_breakpoint(initial_breakpoint_addr + 4 * i)?;
+                    core.set_hw_breakpoint(initial_breakpoint_addr + 4 * i as u64)?;
                 }
 
                 // Try to set an additional breakpoint, which should fail
-                core.set_hw_breakpoint(initial_breakpoint_addr + num_breakpoints * 4)
+                core.set_hw_breakpoint(initial_breakpoint_addr + num_breakpoints as u64 * 4)
                     .expect_err(
                         "Trying to use more than supported number of breakpoints should fail.",
                     );
 
                 // Clear all breakpoints again
                 for i in 0..num_breakpoints {
-                    core.clear_hw_breakpoint(initial_breakpoint_addr + 4 * i)?;
+                    core.clear_hw_breakpoint(initial_breakpoint_addr + 4 * i as u64)?;
                 }
             }
 

--- a/smoke-tester/src/tests/stepping.rs
+++ b/smoke-tester/src/tests/stepping.rs
@@ -29,17 +29,17 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
 
     core.halt(Duration::from_millis(100))?;
 
-    let code_load_address = ram_region.range.start as u32;
+    let code_load_address = ram_region.range.start as u64;
 
     core.write_8(code_load_address, TEST_CODE)?;
 
     let registers = core.registers();
 
-    core.write_core_reg(registers.program_counter().into(), code_load_address)?;
+    core.write_core_reg(registers.program_counter().into(), code_load_address as u32)?;
 
     let core_information = core.step()?;
 
-    assert_eq!(core_information.pc, code_load_address + 2);
+    assert_eq!(core_information.pc as u64, code_load_address + 2);
 
     let core_status = core.status()?;
 
@@ -88,7 +88,7 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
 
     let pc = core.read_core_reg(registers.program_counter())?;
 
-    assert_eq!(pc, break_address);
+    assert_eq!(pc as u64, break_address);
 
     println!("Core halted at {:#08x}, now trying to run...", pc);
 
@@ -128,7 +128,11 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
 
     let pc = core.read_core_reg(registers.program_counter())?;
 
-    assert_eq!(pc, break_address, "{:#08x} != {:#08x}", pc, break_address);
+    assert_eq!(
+        pc as u64, break_address,
+        "{:#08x} != {:#08x}",
+        pc, break_address
+    );
 
     // Register r2 should be 1 to indicate end of test.
     assert_eq!(1, core.read_core_reg(registers.platform_register(2))?);

--- a/target-gen/src/algorithm_binary.rs
+++ b/target-gen/src/algorithm_binary.rs
@@ -48,11 +48,11 @@ impl AlgorithmBinary {
             // Only regard sections that contain at least one byte.
             // And are marked loadable (this filters out debug symbols).
             if ph.p_type == PT_LOAD && ph.p_filesz > 0 {
-                let sector = ph.p_offset as u32..ph.p_offset as u32 + ph.p_filesz as u32;
+                let sector = ph.p_offset..ph.p_offset + ph.p_filesz;
 
                 // Scan all sectors if they contain any part of the sections found.
                 for sh in &elf.section_headers {
-                    let range = sh.sh_offset as u32..sh.sh_offset as u32 + sh.sh_size as u32;
+                    let range = sh.sh_offset..sh.sh_offset + sh.sh_size;
                     if sector.contains_range(&range) {
                         // If we found a valid section, store its contents.
                         let data =

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -390,7 +390,7 @@ pub(crate) fn get_ram(device: &Device) -> Option<RamRegion> {
     for memory in device.memories.0.values() {
         if memory.default && memory.access.read && memory.access.write {
             regions.push(RamRegion {
-                range: memory.start as u32..memory.start as u32 + memory.size as u32,
+                range: memory.start..memory.start + memory.size,
                 is_boot_memory: memory.startup,
                 cores: vec!["main".to_owned()],
                 name: None,
@@ -427,7 +427,7 @@ pub(crate) fn get_flash(device: &Device) -> Option<NvmRegion> {
     for memory in device.memories.0.values() {
         if memory.default && memory.access.read && memory.access.execute && !memory.access.write {
             regions.push(NvmRegion {
-                range: memory.start as u32..memory.start as u32 + memory.size as u32,
+                range: memory.start..memory.start + memory.size,
                 is_boot_memory: memory.startup,
                 cores: vec!["main".to_owned()],
                 name: None,

--- a/target-gen/src/parser.rs
+++ b/target-gen/src/parser.rs
@@ -86,11 +86,11 @@ pub fn extract_flash_algo(
         let name = &elf.strtab[sym.st_name];
 
         match name {
-            "Init" => algo.pc_init = Some(sym.st_value as u32 - code_section_offset),
-            "UnInit" => algo.pc_uninit = Some(sym.st_value as u32 - code_section_offset),
-            "EraseChip" => algo.pc_erase_all = Some(sym.st_value as u32 - code_section_offset),
-            "EraseSector" => algo.pc_erase_sector = sym.st_value as u32 - code_section_offset,
-            "ProgramPage" => algo.pc_program_page = sym.st_value as u32 - code_section_offset,
+            "Init" => algo.pc_init = Some(sym.st_value - code_section_offset as u64),
+            "UnInit" => algo.pc_uninit = Some(sym.st_value - code_section_offset as u64),
+            "EraseChip" => algo.pc_erase_all = Some(sym.st_value - code_section_offset as u64),
+            "EraseSector" => algo.pc_erase_sector = sym.st_value - code_section_offset as u64,
+            "ProgramPage" => algo.pc_program_page = sym.st_value - code_section_offset as u64,
             _ => {}
         }
     }
@@ -103,20 +103,20 @@ pub fn extract_flash_algo(
         .unwrap()
         .to_lowercase();
     algo.default = default;
-    algo.data_section_offset = algorithm_binary.data_section.start;
+    algo.data_section_offset = algorithm_binary.data_section.start as u64;
 
     let sectors = flash_device
         .sectors
         .iter()
         .map(|si| SectorDescription {
-            address: si.address,
-            size: si.size,
+            address: si.address.into(),
+            size: si.size.into(),
         })
         .collect();
 
     let properties = FlashProperties {
-        address_range: flash_device.start_address
-            ..(flash_device.start_address + flash_device.device_size),
+        address_range: flash_device.start_address as u64
+            ..(flash_device.start_address as u64 + flash_device.device_size as u64),
 
         page_size: flash_device.page_size,
         erased_byte_value: flash_device.erased_default_value,


### PR DESCRIPTION
* Update all types that refer to an address from u32 to u64
* Add validation to current targets for values out of range
* Clean up some shared Cortex-M code

Signed-off-by: Ryan Fairfax <ryan@thefaxman.net>