### PR TITLE
Updating Arm Serial-Wire-View configuration

### DIFF
--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -5,9 +5,9 @@ mod itm;
 mod tpiu;
 mod swo;
 
-use super::memory::romtable::{Component, PeripheralType, RomTableError};
+use super::memory::romtable::{CoresightComponent, PeripheralType, RomTableError};
 use crate::architecture::arm::core::armv6m::Demcr;
-use crate::architecture::arm::{SwoConfig, SwoMode};
+use crate::architecture::arm::{ArmProbeInterface, SwoConfig, SwoMode};
 use crate::{Core, CoreRegister, Error, MemoryInterface};
 pub use dwt::Dwt;
 pub use itm::Itm;
@@ -30,33 +30,53 @@ pub trait DebugRegister: Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug
     const NAME: &'static str;
 
     /// Loads the register value from the given debug component via the given core.
-    fn load(component: &Component, core: &mut Core) -> Result<Self, Error> {
-        Ok(Self::from(component.read_reg(core, Self::ADDRESS)?))
+    fn load(
+        component: &CoresightComponent,
+        interface: &mut Box<dyn ArmProbeInterface>,
+    ) -> Result<Self, Error> {
+        Ok(Self::from(component.read_reg(interface, Self::ADDRESS)?))
     }
 
     /// Loads the register value from the given component in given unit via the given core.
-    fn load_unit(component: &Component, core: &mut Core, unit: usize) -> Result<Self, Error> {
+    fn load_unit(
+        component: &CoresightComponent,
+        interface: &mut Box<dyn ArmProbeInterface>,
+        unit: usize,
+    ) -> Result<Self, Error> {
         Ok(Self::from(
-            component.read_reg(core, Self::ADDRESS + 16 * unit as u32)?,
+            component.read_reg(interface, Self::ADDRESS + 16 * unit as u32)?,
         ))
     }
 
     /// Stores the register value to the given debug component via the given core.
-    fn store(&self, component: &Component, core: &mut Core) -> Result<(), Error> {
-        component.write_reg(core, Self::ADDRESS, self.clone().into())
+    fn store(
+        &self,
+        component: &CoresightComponent,
+        interface: &mut Box<dyn ArmProbeInterface>,
+    ) -> Result<(), Error> {
+        component.write_reg(interface, Self::ADDRESS, self.clone().into())
     }
 
     /// Stores the register value to the given component in given unit via the given core.
-    fn store_unit(&self, component: &Component, core: &mut Core, unit: usize) -> Result<(), Error> {
-        component.write_reg(core, Self::ADDRESS + 16 * unit as u32, self.clone().into())
+    fn store_unit(
+        &self,
+        component: &CoresightComponent,
+        interface: &mut Box<dyn ArmProbeInterface>,
+        unit: usize,
+    ) -> Result<(), Error> {
+        component.write_reg(
+            interface,
+            Self::ADDRESS + 16 * unit as u32,
+            self.clone().into(),
+        )
     }
 }
 
 /// Goes through every component in the vector and tries to find the first component with the given type
 fn find_component(
-    components: &[Component],
+    components: &[CoresightComponent],
     peripheral_type: PeripheralType,
-) -> Result<&Component, Error> {
+) -> Result<&CoresightComponent, Error> {
     components
         .iter()
         .find_map(|component| component.find_component(peripheral_type))
@@ -69,18 +89,15 @@ fn find_component(
 ///
 /// Expects to be given a list of all ROM table `components` as the second argument.
 pub(crate) fn setup_swv(
-    core: &mut Core,
-    components: &[Component],
+    interface: &mut Box<dyn ArmProbeInterface>,
+    components: &[CoresightComponent],
     config: &SwoConfig,
 ) -> Result<(), Error> {
-    // Enable tracing
-    enable_tracing(core)?;
-
     // Perform vendor-specific SWV setup
-    setup_swv_vendor(core, components, config)?;
+    setup_swv_vendor(interface, components, config)?;
 
     // Configure TPIU
-    let mut tpiu = Tpiu::new(core, find_component(components, PeripheralType::Tpiu)?);
+    let mut tpiu = Tpiu::new(interface, find_component(components, PeripheralType::Tpiu)?);
 
     tpiu.set_port_size(1)?;
     let prescaler = (config.tpiu_clk() / config.baud()) - 1;
@@ -117,24 +134,26 @@ pub(crate) fn setup_swv(
     }
 
     // Configure ITM
-    let mut itm = Itm::new(core, find_component(components, PeripheralType::Itm)?);
+    let mut itm = Itm::new(interface, find_component(components, PeripheralType::Itm)?);
     itm.unlock()?;
     itm.tx_enable()?;
 
     // Configure DWT
-    let mut dwt = Dwt::new(core, find_component(components, PeripheralType::Dwt)?);
+    let mut dwt = Dwt::new(interface, find_component(components, PeripheralType::Dwt)?);
     dwt.enable()?;
     dwt.enable_exception_trace()?;
 
-    core.flush()
+    // TODO: Replace flush
+    //interface.flush()
+    Ok(())
 }
 
 /// Sets up all vendor specific bit of all the SWV components.
 ///
 /// Expects to be given a list of all ROM table `components` as the second argument.
 fn setup_swv_vendor(
-    core: &mut Core,
-    components: &[Component],
+    interface: &mut Box<dyn ArmProbeInterface>,
+    components: &[CoresightComponent],
     config: &SwoConfig,
 ) -> Result<(), Error> {
     if components.is_empty() {
@@ -142,16 +161,21 @@ fn setup_swv_vendor(
     }
 
     for component in components.iter() {
-        match component.id().peripheral_id().jep106() {
+        let mut memory = interface.memory_interface(component.ap)?;
+
+        match component.component.id().peripheral_id().jep106() {
             Some(id) if id == jep106::JEP106Code::new(0x00, 0x20) => {
+                // TODO: The following statements are only valid for specific revisions - e.g. F4
+                // and F7 families. H7 components have a different DBGMCU architecture.
+
                 // STMicroelectronics:
                 // STM32 parts need TRACE_IOEN set to 1 and TRACE_MODE set to 00.
                 log::debug!("STMicroelectronics part detected, configuring DBGMCU");
                 const DBGMCU: u32 = 0xE004_2004;
-                let mut dbgmcu = core.read_word_32(DBGMCU)?;
+                let mut dbgmcu = memory.read_word_32(DBGMCU)?;
                 dbgmcu |= 1 << 5;
                 dbgmcu &= !(0b00 << 6);
-                return core.write_word_32(DBGMCU, dbgmcu);
+                return memory.write_word_32(DBGMCU, dbgmcu);
             }
             Some(id) if id == jep106::JEP106Code::new(0x02, 0x44) => {
                 // Nordic VLSI ASA
@@ -170,7 +194,7 @@ fn setup_swv_vendor(
                     }
                 };
                 traceconfig |= 1 << 16; // tracemux : serial = 1
-                return core.write_word_32(CLOCK_TRACECONFIG, traceconfig);
+                return memory.write_word_32(CLOCK_TRACECONFIG, traceconfig);
             }
             _ => {
                 continue;
@@ -186,12 +210,12 @@ fn setup_swv_vendor(
 ///
 /// Expects to be given a list of all ROM table `components` as the second argument.
 pub(crate) fn add_swv_data_trace(
-    core: &mut Core,
-    components: &[Component],
+    interface: &mut Box<dyn ArmProbeInterface>,
+    components: &[CoresightComponent],
     unit: usize,
     address: u32,
 ) -> Result<(), Error> {
-    let mut dwt = Dwt::new(core, find_component(components, PeripheralType::Dwt)?);
+    let mut dwt = Dwt::new(interface, find_component(components, PeripheralType::Dwt)?);
     dwt.enable_data_trace(unit, address)
 }
 
@@ -200,11 +224,11 @@ pub(crate) fn add_swv_data_trace(
 ///
 /// Expects to be given a list of all ROM table `components` as the second argument.
 pub fn remove_swv_data_trace(
-    core: &mut Core,
-    components: &[Component],
+    interface: &mut Box<dyn ArmProbeInterface>,
+    components: &[CoresightComponent],
     unit: usize,
 ) -> Result<(), Error> {
-    let mut dwt = Dwt::new(core, find_component(components, PeripheralType::Dwt)?);
+    let mut dwt = Dwt::new(interface, find_component(components, PeripheralType::Dwt)?);
     dwt.disable_data_trace(unit)
 }
 

--- a/probe-rs/src/architecture/arm/component/swo.rs
+++ b/probe-rs/src/architecture/arm/component/swo.rs
@@ -1,0 +1,49 @@
+use super::super::memory::romtable::Component;
+use crate::{Core, Error};
+
+const REGISTER_OFFSET_SWO_CODR: u32 = 0x10;
+const REGISTER_OFFSET_SWO_SPPR: u32 = 0xF0;
+const REGISTER_OFFSET_ACCESS: u32 = 0xFB0;
+
+/// SWO unit
+///
+/// Serial Wire Output unit.
+pub struct Swo<'probe: 'core, 'core> {
+    component: &'core Component,
+    core: &'core mut Core<'probe>,
+}
+
+impl <'probe: 'core, 'core> Swo<'probe, 'core> {
+    /// Construct a new SWO component.
+    pub fn new(core: &'core mut Core<'probe>, component: &'core Component) -> Self {
+        Swo { component, core }
+    }
+
+    /// Unlock the SWO and enable it for tracing the target.
+    ///
+    /// This function enables the SWOunit as a whole. It does not actually send any data after enabling it.
+    pub fn unlock(&mut self) -> Result<(), Error> {
+        self.component
+            .write_reg(self.core, REGISTER_OFFSET_ACCESS, 0xC5AC_CE55)?;
+
+        Ok(())
+    }
+
+    /// Set the prescaler of the SWO.
+    pub fn set_prescaler(&mut self, value: u32) -> Result<(), Error> {
+        self.component
+            .write_reg(self.core, REGISTER_OFFSET_SWO_CODR, value)?;
+        Ok(())
+    }
+
+    /// Set the SWO protocol.
+    /// 0 = sync trace mode
+    /// 1 = async SWO (manchester)
+    /// 2 = async SWO (NRZ)
+    /// 3 = reserved
+    pub fn set_pin_protocol(&mut self, value: u32) -> Result<(), Error> {
+        self.component
+            .write_reg(self.core, REGISTER_OFFSET_SWO_SPPR, value)?;
+        Ok(())
+    }
+}

--- a/probe-rs/src/architecture/arm/component/tpiu.rs
+++ b/probe-rs/src/architecture/arm/component/tpiu.rs
@@ -1,5 +1,6 @@
-use super::super::memory::romtable::Component;
-use crate::{Core, Error};
+use super::super::memory::romtable::CoresightComponent;
+use crate::architecture::arm::ArmProbeInterface;
+use crate::Error;
 
 pub const _TPIU_PID: [u8; 8] = [0xA1, 0xB9, 0x0B, 0x0, 0x4, 0x0, 0x0, 0x0];
 
@@ -12,28 +13,34 @@ const REGISTER_OFFSET_TPIU_FFCR: u32 = 0x304;
 /// TPIU unit
 ///
 /// Trace port interface unit unit.
-pub struct Tpiu<'probe: 'core, 'core> {
-    component: &'core Component,
-    core: &'core mut Core<'probe>,
+pub struct Tpiu<'a> {
+    component: &'a CoresightComponent,
+    interface: &'a mut Box<dyn ArmProbeInterface>,
 }
 
-impl<'probe: 'core, 'core> Tpiu<'probe, 'core> {
+impl<'a> Tpiu<'a> {
     /// Create a new TPIU interface from a probe and a ROM table component.
-    pub fn new(core: &'core mut Core<'probe>, component: &'core Component) -> Self {
-        Tpiu { component, core }
+    pub fn new(
+        interface: &'a mut Box<dyn ArmProbeInterface>,
+        component: &'a CoresightComponent,
+    ) -> Self {
+        Tpiu {
+            interface,
+            component,
+        }
     }
 
     /// Set the port size of the TPIU.
     pub fn set_port_size(&mut self, value: u32) -> Result<(), Error> {
         self.component
-            .write_reg(self.core, REGISTER_OFFSET_TPIU_CSPSR, value)?;
+            .write_reg(self.interface, REGISTER_OFFSET_TPIU_CSPSR, value)?;
         Ok(())
     }
 
     /// Set the prescaler of the TPIU.
     pub fn set_prescaler(&mut self, value: u32) -> Result<(), Error> {
         self.component
-            .write_reg(self.core, REGISTER_OFFSET_TPIU_ACPR, value)?;
+            .write_reg(self.interface, REGISTER_OFFSET_TPIU_ACPR, value)?;
         Ok(())
     }
 
@@ -44,14 +51,14 @@ impl<'probe: 'core, 'core> Tpiu<'probe, 'core> {
     /// 3 = reserved
     pub fn set_pin_protocol(&mut self, value: u32) -> Result<(), Error> {
         self.component
-            .write_reg(self.core, REGISTER_OFFSET_TPIU_SPPR, value)?;
+            .write_reg(self.interface, REGISTER_OFFSET_TPIU_SPPR, value)?;
         Ok(())
     }
 
     /// Set the TPIU formatter.
     pub fn set_formatter(&mut self, value: u32) -> Result<(), Error> {
         self.component
-            .write_reg(self.core, REGISTER_OFFSET_TPIU_FFCR, value)?;
+            .write_reg(self.interface, REGISTER_OFFSET_TPIU_FFCR, value)?;
         Ok(())
     }
 }

--- a/probe-rs/src/architecture/arm/component/trace_funnel.rs
+++ b/probe-rs/src/architecture/arm/component/trace_funnel.rs
@@ -1,0 +1,76 @@
+//! Arm trace funnel CoreSight Component
+//!
+//! # Description
+//! This module provides access and control of the trace funnel CoreSight component block.
+use super::DebugRegister;
+use crate::architecture::arm::memory::romtable::CoresightComponent;
+use crate::architecture::arm::ArmProbeInterface;
+use crate::Error;
+use bitfield::bitfield;
+
+const REGISTER_OFFSET_ACCESS: u32 = 0xFB0;
+
+/// Trace funnel unit
+pub struct TraceFunnel<'a> {
+    component: &'a CoresightComponent,
+    interface: &'a mut Box<dyn ArmProbeInterface>,
+}
+
+impl<'a> TraceFunnel<'a> {
+    /// Construct a new SWO component.
+    pub fn new(
+        interface: &'a mut Box<dyn ArmProbeInterface>,
+        component: &'a CoresightComponent,
+    ) -> Self {
+        TraceFunnel {
+            component,
+            interface,
+        }
+    }
+
+    /// Unlock the SWO and enable it for tracing the target.
+    ///
+    /// This function enables the SWOunit as a whole. It does not actually send any data after enabling it.
+    pub fn unlock(&mut self) -> Result<(), Error> {
+        self.component
+            .write_reg(self.interface, REGISTER_OFFSET_ACCESS, 0xC5AC_CE55)?;
+
+        Ok(())
+    }
+
+    /// Enable funnel input sources.
+    ///
+    /// # Note
+    /// The trace funnel acts as a selector for multiple sources. This function allows you to block
+    /// or pass specific trace sources selectively.
+    pub fn enable_port(&mut self, mask: u8) -> Result<(), Error> {
+        let mut control = Control::load(self.component, self.interface)?;
+        control.set_slave_enable(mask);
+        control.store(self.component, self.interface)
+    }
+}
+
+bitfield! {
+    #[derive(Clone, Default)]
+    pub struct Control(u32);
+    impl Debug;
+    pub u8, min_hold_time, set_min_hold_time: 11, 8;
+    pub u8, enable_slave_port, set_slave_enable: 7, 0;
+}
+
+impl DebugRegister for Control {
+    const ADDRESS: u32 = 0x00;
+    const NAME: &'static str = "CSTF/CTRL";
+}
+
+impl From<u32> for Control {
+    fn from(raw: u32) -> Control {
+        Control(raw)
+    }
+}
+
+impl From<Control> for u32 {
+    fn from(control: Control) -> u32 {
+        control.0
+    }
+}

--- a/probe-rs/src/architecture/arm/memory/mod.rs
+++ b/probe-rs/src/architecture/arm/memory/mod.rs
@@ -4,4 +4,4 @@ pub(crate) mod adi_v5_memory_interface;
 pub(crate) mod romtable;
 
 use super::ap::AccessPortError;
-pub use romtable::{Component, PeripheralType};
+pub use romtable::{Component, CoresightComponent, PeripheralType};

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -643,7 +643,10 @@ impl PeripheralID {
             ("ARM Ltd", 0x910, 0x00, 0x0000) => Some(PartInfo::new("CoreSight ETM9", PeripheralType::Etm)),
             ("ARM Ltd", 0x912, 0x11, 0x0000) => Some(PartInfo::new("CoreSight TPIU", PeripheralType::Tpiu)),
             ("ARM Ltd", 0x913, 0x00, 0x0000) => Some(PartInfo::new("CoreSight ITM", PeripheralType::Itm)),
+
             ("ARM Ltd", 0x914, 0x00, 0x0000) => Some(PartInfo::new("CoreSight SWO", PeripheralType::Swo)),
+            ("ARM Ltd", 0x914, 0x11, 0x0000) => Some(PartInfo::new("CoreSight SWO", PeripheralType::Swo)),
+
             ("ARM Ltd", 0x920, 0x00, 0x0000) => Some(PartInfo::new("CoreSight ETM11", PeripheralType::Etm)),
             ("ARM Ltd", 0x923, 0x11, 0x0000) => Some(PartInfo::new("Cortex-M3 TPIU", PeripheralType::Tpiu)),
             ("ARM Ltd", 0x924, 0x13, 0x0000) => Some(PartInfo::new("Cortex-M3 ETM", PeripheralType::Etm)),

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -706,6 +706,7 @@ impl PeripheralID {
             ("ARM Ltd", 0xD21, 0x00, 0x1A03) => Some(PartInfo::new("Cortex-M33 BPU", PeripheralType::Bpu)),
             ("ARM Ltd", 0xD21, 0x13, 0x4A13) => Some(PartInfo::new("Cortex-M33 ETM", PeripheralType::Etm)),
             ("ARM Ltd", 0xD21, 0x11, 0x0000) => Some(PartInfo::new("Cortex-M33 TPIU", PeripheralType::Tpiu)),
+            // TODO: Add support for trace funnel detection.
             _ => None,
         }
     }
@@ -770,6 +771,8 @@ pub enum PeripheralType {
     Rom,
     /// Serial Wire Output
     Swo,
+    /// CoreSight Trace funnel
+    TraceFunnel,
     /// Unknown
     Stm,
     /// Unknown
@@ -790,6 +793,7 @@ impl std::fmt::Display for PeripheralType {
             PeripheralType::Rom => write!(f, "Rom"),
             PeripheralType::Swo => write!(f, "Swo (Single Wire Output)"),
             PeripheralType::Stm => write!(f, "Stm (System Trace Macrocell)"),
+            PeripheralType::TraceFunnel => write!(f, "Trace Funnel"),
             PeripheralType::Tsgen => write!(f, "Tsgen (Time Stamp Generator)"),
         }
     }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -7,7 +7,7 @@ use crate::{
         arm::{
             ap::{GenericAp, MemoryAp},
             communication_interface::{ArmProbeInterface, MemoryApInformation},
-            memory::Component,
+            memory::{Component, CoresightComponent},
             ApInformation, SwoConfig, SwoReader,
         },
         riscv::communication_interface::RiscvCommunicationInterface,
@@ -370,7 +370,7 @@ impl Session {
     ///
     /// This will recursively parse the Romtable of the attached target
     /// and create a list of all the contained components.
-    pub fn get_arm_components(&mut self) -> Result<Vec<Component>, Error> {
+    pub fn get_arm_components(&mut self) -> Result<Vec<CoresightComponent>, Error> {
         let interface = self.get_arm_interface()?;
 
         let mut components = Vec::new();
@@ -394,9 +394,11 @@ impl Session {
                     debug_base_address,
                     supports_hnonsec: _,
                 }) => {
-                    let mut memory = interface.memory_interface(MemoryAp::new(address))?;
-                    Component::try_parse(&mut memory, debug_base_address)
-                        .map_err(Error::architecture_specific)
+                    let ap = MemoryAp::new(address);
+                    let mut memory = interface.memory_interface(ap)?;
+                    let component = Component::try_parse(&mut memory, debug_base_address)
+                        .map_err(Error::architecture_specific)?;
+                    Ok(CoresightComponent::new(component, ap))
                 }
                 ApInformation::Other { address } => {
                     // Return an error, only possible to get Component from MemoryAP
@@ -441,8 +443,8 @@ impl Session {
 
         // Configure SWV on the target
         let components = self.get_arm_components()?;
-        let mut core = self.core(core_index)?;
-        crate::architecture::arm::component::setup_swv(&mut core, &components, config)
+        let interface = self.get_arm_interface()?;
+        crate::architecture::arm::component::setup_swv(interface, &components, config)
     }
 
     /// Configure the target to stop emitting SWV trace data.
@@ -451,16 +453,11 @@ impl Session {
     }
 
     /// Begin tracing a memory address over SWV.
-    pub fn add_swv_data_trace(
-        &mut self,
-        core_index: usize,
-        unit: usize,
-        address: u32,
-    ) -> Result<(), Error> {
+    pub fn add_swv_data_trace(&mut self, unit: usize, address: u32) -> Result<(), Error> {
         let components = self.get_arm_components()?;
-        let mut core = self.core(core_index)?;
+        let interface = self.get_arm_interface()?;
         crate::architecture::arm::component::add_swv_data_trace(
-            &mut core,
+            interface,
             &components,
             unit,
             address,
@@ -468,10 +465,10 @@ impl Session {
     }
 
     /// Stop tracing from a given SWV unit
-    pub fn remove_swv_data_trace(&mut self, core_index: usize, unit: usize) -> Result<(), Error> {
+    pub fn remove_swv_data_trace(&mut self, unit: usize) -> Result<(), Error> {
         let components = self.get_arm_components()?;
-        let mut core = self.core(core_index)?;
-        crate::architecture::arm::component::remove_swv_data_trace(&mut core, &components, unit)
+        let interface = self.get_arm_interface()?;
+        crate::architecture::arm::component::remove_swv_data_trace(interface, &components, unit)
     }
 
     /// Returns the memory map of the target.


### PR DESCRIPTION
This PR revamps control of the Arm SWV setup to properly handle a number of new use cases:
* Devices with multiple memory APs, where CoreSight components may be distributed across APs
* Handle of trace funnels (currently, all trace sources are enabled)
* Enable and configure SWO CoreSight peripherals (to control TRACESWO when not connected to the TPIU)

This PR builds on the changes in https://github.com/probe-rs/probe-rs/pull/1114.

This PR fixes #1113