### PR TITLE
Convert core register access to handle 64-bit values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debugger: SVD uses new `expand` feature of `svd-parser` crate to expand arrays and clusters. (#1090)
 - Updated cmsis-pack dependency to version 0.6.0. (#1089)
 - Updated all parameters and fields that refer to memory addresses from u32 to u64 in preparation for 64-bit target support. (#1115)
+- Updated `Core::read_core_reg` and `Core::write_core_reg` to work with both 32 and 64-bit values (#1119)
 
 ### Fixed
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -121,7 +121,7 @@ impl DebugCli {
                 println!("Status: {:?}", &status);
 
                 if status.is_halted() {
-                    let pc = cli_data
+                    let pc: u64 = cli_data
                         .core
                         .read_core_reg(cli_data.core.registers().program_counter())?;
                     println!("Core halted at address {:#010x}", pc);
@@ -132,7 +132,7 @@ impl DebugCli {
                         match cli_data.core.core_type() {
                             CoreType::Armv6m | CoreType::Armv7em | CoreType::Armv7m | CoreType::Armv8m | CoreType::Armv7a | CoreType::Armv8a => {
                                 // Cortex-M and v7-A targets define the PSR as register 16
-                                let xpsr = cli_data.core.read_core_reg(
+                                let xpsr: u64 = cli_data.core.read_core_reg(
                                     16,
                                 )?;
 
@@ -153,7 +153,7 @@ impl DebugCli {
                                             println!("Hard Fault!");
 
 
-                                            let return_address = cli_data.core.read_core_reg(cli_data.core.registers().return_address())?;
+                                            let return_address: u64 = cli_data.core.read_core_reg(cli_data.core.registers().return_address())?;
 
                                             println!("Return address (LR): {:#010x}", return_address);
 
@@ -345,13 +345,12 @@ impl DebugCli {
                 match cli_data.state {
                     DebugState::Halted(ref mut halted_state) => {
                         let regs = cli_data.core.registers();
-                        let program_counter =
+                        let program_counter: u64 =
                             cli_data.core.read_core_reg(regs.program_counter())?;
 
                         if let Some(di) = &mut cli_data.debug_info {
-                            halted_state.stack_frames = di
-                                .unwind(&mut cli_data.core, u64::from(program_counter))
-                                .unwrap();
+                            halted_state.stack_frames =
+                                di.unwind(&mut cli_data.core, program_counter).unwrap();
 
                             halted_state.frame_indices = halted_state
                                 .stack_frames
@@ -418,7 +417,7 @@ impl DebugCli {
                 let register_file = cli_data.core.registers();
 
                 for register in register_file.registers() {
-                    let value = cli_data.core.read_core_reg(register)?;
+                    let value: u64 = cli_data.core.read_core_reg(register)?;
 
                     println!("{}: {:#010x}", register.name(), value)
                 }

--- a/debugger/src/debug_adapter/dap_adapter.rs
+++ b/debugger/src/debug_adapter/dap_adapter.rs
@@ -74,7 +74,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             }
         };
         if status.is_halted() {
-            let pc = target_core
+            let pc: Result<u64, crate::Error> = target_core
                 .core
                 .read_core_reg(target_core.core.registers().program_counter());
             match pc {
@@ -919,7 +919,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 // We do the actual stack trace here, because VSCode sometimes sends multiple StackTrace requests, which lead to unnecessary unwind processing.
                 // By doing it here, we do it once, and serve up the results when we get the StackTrace requests.
                 let regs = target_core.core.registers();
-                let pc = match target_core.core.read_core_reg(regs.program_counter()) {
+                let pc: u64 = match target_core.core.read_core_reg(regs.program_counter()) {
                     Ok(pc) => pc,
                     Err(error) => {
                         return self
@@ -934,7 +934,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 target_core.core_data.stack_frames = target_core
                     .core_data
                     .debug_info
-                    .unwind(&mut target_core.core, u64::from(pc))?;
+                    .unwind(&mut target_core.core, pc)?;
             }
             CoreStatus::Running | CoreStatus::LockedUp | CoreStatus::Sleeping => {
                 return self.send_response::<()>(

--- a/gdb-server/src/handlers.rs
+++ b/gdb-server/src/handlers.rs
@@ -55,7 +55,8 @@ pub(crate) fn read_general_registers(mut core: Core) -> Option<String> {
     for reg in 0..core.num_general_registers() {
         let (probe_rs_number, bytesize) = core.translate_gdb_register_number(reg as u32)?;
 
-        let mut value = core.read_core_reg(probe_rs_number).unwrap();
+        // TODO 64-bit - handle different sized values
+        let mut value: u32 = core.read_core_reg(probe_rs_number).unwrap();
 
         for _ in 0..bytesize {
             let byte = value as u8;
@@ -97,7 +98,8 @@ pub(crate) fn read_register(register: u32, mut core: Core) -> Option<String> {
 
     let (probe_rs_number, bytesize) = core.translate_gdb_register_number(register)?;
 
-    let mut value = core.read_core_reg(probe_rs_number).unwrap();
+    // TODO 64-bit - handle different sized values
+    let mut value: u32 = core.read_core_reg(probe_rs_number).unwrap();
 
     let mut register_value = String::new();
 
@@ -140,6 +142,7 @@ pub(crate) fn write_general_registers(reg_values: &str, mut core: Core) -> Optio
     for reg_num in 0..core.num_general_registers() as u32 {
         let (addr, bytesize) = core.translate_gdb_register_number(reg_num)?;
 
+        // TODO 64-bit - rework this
         // TODO: remove, when `Core::write_core_reg()` supports larger registers
         if bytesize as usize > std::mem::size_of::<u32>() {
             // Currently registers larger than 32 bits are not supported
@@ -213,6 +216,7 @@ pub(crate) fn write_register(register: u32, hex_value: &str, mut core: Core) -> 
 
     let (probe_rs_number, bytesize) = core.translate_gdb_register_number(register)?;
 
+    // TODO 64-bit - rework this
     // TODO: remove, when `Core::write_core_reg()` supports larger registers
     if bytesize as usize > std::mem::size_of::<u32>() {
         // Currently registers larger than 32 bits are not supported

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -1,5 +1,8 @@
 use crate::{
-    core::{CoreRegister, CoreRegisterAddress, RegisterDescription, RegisterFile, RegisterKind},
+    core::{
+        CoreRegister, CoreRegisterAddress, RegisterDataType, RegisterDescription, RegisterFile,
+        RegisterKind,
+    },
     CoreStatus, HaltReason,
 };
 
@@ -38,7 +41,7 @@ impl Dump {
 
 pub(crate) mod register {
     use crate::{
-        core::{RegisterDescription, RegisterKind},
+        core::{RegisterDataType, RegisterDescription, RegisterKind},
         CoreRegisterAddress,
     };
 
@@ -46,36 +49,48 @@ pub(crate) mod register {
         name: "PC",
         _kind: RegisterKind::PC,
         address: CoreRegisterAddress(15),
+        _type: RegisterDataType::UnsignedInteger,
+        size_in_bits: 32,
     };
 
     pub const XPSR: RegisterDescription = RegisterDescription {
         name: "XPSR",
         _kind: RegisterKind::General,
         address: CoreRegisterAddress(0b1_0000),
+        _type: RegisterDataType::UnsignedInteger,
+        size_in_bits: 32,
     };
 
     pub const SP: RegisterDescription = RegisterDescription {
         name: "SP",
         _kind: RegisterKind::General,
         address: CoreRegisterAddress(13),
+        _type: RegisterDataType::UnsignedInteger,
+        size_in_bits: 32,
     };
 
     pub const LR: RegisterDescription = RegisterDescription {
         name: "LR",
         _kind: RegisterKind::General,
         address: CoreRegisterAddress(14),
+        _type: RegisterDataType::UnsignedInteger,
+        size_in_bits: 32,
     };
 
     pub const MSP: RegisterDescription = RegisterDescription {
         name: "MSP",
         _kind: RegisterKind::General,
         address: CoreRegisterAddress(0b10001),
+        _type: RegisterDataType::UnsignedInteger,
+        size_in_bits: 32,
     };
 
     pub const PSP: RegisterDescription = RegisterDescription {
         name: "PSP",
         _kind: RegisterKind::General,
         address: CoreRegisterAddress(0b10010),
+        _type: RegisterDataType::UnsignedInteger,
+        size_in_bits: 32,
     };
 
     // CONTROL bits [31:24], FAULTMASK bits [23:16],
@@ -84,6 +99,8 @@ pub(crate) mod register {
         name: "EXTRA",
         _kind: RegisterKind::General,
         address: CoreRegisterAddress(0b10100),
+        _type: RegisterDataType::UnsignedInteger,
+        size_in_bits: 32,
     };
 
     // TODO: Floating point support
@@ -91,6 +108,8 @@ pub(crate) mod register {
         name: "FP",
         _kind: RegisterKind::General,
         address: CoreRegisterAddress(7),
+        _type: RegisterDataType::FloatingPoint,
+        size_in_bits: 32,
     };
 }
 
@@ -100,81 +119,113 @@ static ARM_REGISTER_FILE: RegisterFile = RegisterFile {
             name: "R0",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R1",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(1),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R2",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(2),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R3",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(3),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R4",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(4),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R5",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(5),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R6",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(6),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R7",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(7),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R8",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(8),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R9",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(9),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R10",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(10),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R11",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(11),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R12",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(12),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R13",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(13),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R14",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(14),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "R15",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(15),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
     ],
 
@@ -188,21 +239,29 @@ static ARM_REGISTER_FILE: RegisterFile = RegisterFile {
             name: "a1",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "a2",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(1),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "a3",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(2),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "a4",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(3),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
     ],
 
@@ -211,11 +270,15 @@ static ARM_REGISTER_FILE: RegisterFile = RegisterFile {
             name: "a1",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "a2",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(1),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
     ],
 

--- a/probe-rs/src/architecture/riscv/register.rs
+++ b/probe-rs/src/architecture/riscv/register.rs
@@ -1,6 +1,6 @@
 use crate::core::RegisterDescription;
 use crate::{
-    core::{RegisterFile, RegisterKind},
+    core::{RegisterDataType, RegisterFile, RegisterKind},
     CoreRegisterAddress,
 };
 
@@ -57,6 +57,8 @@ static PC: RegisterDescription = RegisterDescription {
     _kind: RegisterKind::PC,
     /// This is a CSR register
     address: CoreRegisterAddress(0x7b1),
+    _type: RegisterDataType::UnsignedInteger,
+    size_in_bits: 32,
 };
 
 static RA: RegisterDescription = RegisterDescription {
@@ -64,6 +66,8 @@ static RA: RegisterDescription = RegisterDescription {
     _kind: RegisterKind::General,
     /// This is a CSR register
     address: CoreRegisterAddress(0x1001),
+    _type: RegisterDataType::UnsignedInteger,
+    size_in_bits: 32,
 };
 
 static SP: RegisterDescription = RegisterDescription {
@@ -71,6 +75,8 @@ static SP: RegisterDescription = RegisterDescription {
     _kind: RegisterKind::General,
     /// This is a CSR register
     address: CoreRegisterAddress(0x1002),
+    _type: RegisterDataType::UnsignedInteger,
+    size_in_bits: 32,
 };
 
 static FP: RegisterDescription = RegisterDescription {
@@ -78,6 +84,8 @@ static FP: RegisterDescription = RegisterDescription {
     _kind: RegisterKind::General,
     /// This is a CSR register
     address: CoreRegisterAddress(0x1008),
+    _type: RegisterDataType::UnsignedInteger,
+    size_in_bits: 32,
 };
 
 pub static S0: RegisterDescription = RegisterDescription {
@@ -85,6 +93,8 @@ pub static S0: RegisterDescription = RegisterDescription {
     _kind: RegisterKind::General,
     /// This is a CSR register
     address: CoreRegisterAddress(0x1008),
+    _type: RegisterDataType::UnsignedInteger,
+    size_in_bits: 32,
 };
 
 pub static S1: RegisterDescription = RegisterDescription {
@@ -92,6 +102,8 @@ pub static S1: RegisterDescription = RegisterDescription {
     _kind: RegisterKind::General,
     /// This is a CSR register
     address: CoreRegisterAddress(0x1009),
+    _type: RegisterDataType::UnsignedInteger,
+    size_in_bits: 32,
 };
 
 pub(super) static RISCV_REGISTERS: RegisterFile = RegisterFile {
@@ -100,161 +112,225 @@ pub(super) static RISCV_REGISTERS: RegisterFile = RegisterFile {
             name: "x0",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1000),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x1",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1001),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x2",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1002),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x3",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1003),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x4",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1004),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x5",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1005),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x6",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1006),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x7",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1007),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x8",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1008),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x9",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1009),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x10",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100A),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x11",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100B),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x12",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100C),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x13",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100D),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x14",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100E),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x15",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100F),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x16",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1010),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x17",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1011),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x18",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1012),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x19",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1013),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x20",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1014),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x21",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1015),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x22",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1016),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x23",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1017),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x24",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1018),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x25",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1019),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x26",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x101A),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x27",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x101B),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x28",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x101C),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x29",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x101D),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x30",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x101E),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "x31",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x101F),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
     ],
 
@@ -271,41 +347,57 @@ pub(super) static RISCV_REGISTERS: RegisterFile = RegisterFile {
             name: "a0",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100A),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "a1",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100B),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "a2",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100C),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "a3",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100D),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "a4",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100E),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "a5",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100F),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "a6",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1010),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "a7",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x1011),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
     ],
 
@@ -314,11 +406,15 @@ pub(super) static RISCV_REGISTERS: RegisterFile = RegisterFile {
             name: "a0",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100A),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
         RegisterDescription {
             name: "a1",
             _kind: RegisterKind::General,
             address: CoreRegisterAddress(0x100B),
+            _type: RegisterDataType::UnsignedInteger,
+            size_in_bits: 32,
         },
     ],
 

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -280,7 +280,7 @@ pub(crate) fn _print_all_attributes(
                             register,
                             base_type,
                         } => {
-                            let raw_value = core
+                            let raw_value: u64 = core
                                 .read_core_reg(register.0 as u16)
                                 .expect("Failed to read memory");
 
@@ -290,7 +290,7 @@ pub(crate) fn _print_all_attributes(
                                 )
                             }
                             evaluation
-                                .resume_with_register(gimli::Value::Generic(raw_value as u64))
+                                .resume_with_register(gimli::Value::Generic(raw_value))
                                 .unwrap()
                         }
                         RequiresRelocatedAddress(address_index) => {

--- a/probe-rs/src/debug/registers.rs
+++ b/probe-rs/src/debug/registers.rs
@@ -11,6 +11,7 @@ use crate::core::RegisterFile;
 pub struct Registers {
     pub(crate) register_description: &'static RegisterFile,
 
+    // TODO 64-bit - handle larger values
     pub(crate) values: HashMap<u32, u32>,
 
     pub(crate) architecture: Architecture,
@@ -29,8 +30,11 @@ impl Registers {
             architecture: core.architecture(),
         };
 
+        // TODO 64-bit - support other sizes
         for i in 0..num_platform_registers {
-            match core.read_core_reg(register_file.platform_register(i)) {
+            let result: Result<u32, crate::Error> =
+                core.read_core_reg(register_file.platform_register(i));
+            match result {
                 Ok(value) => registers.values.insert(i as u32, value),
                 Err(e) => {
                     log::warn!("Failed to read value for register {}: {}", i, e);

--- a/probe-rs/src/debug/stepping_mode.rs
+++ b/probe-rs/src/debug/stepping_mode.rs
@@ -39,7 +39,7 @@ impl SteppingMode {
             .map_err(|error| DebugError::Other(anyhow::anyhow!(error)))?;
         let (mut program_counter, mut return_address) = match core_status {
             CoreStatus::Halted(_) => (
-                core.read_core_reg(core.registers().program_counter())? as u64,
+                core.read_core_reg(core.registers().program_counter())?,
                 core.read_core_reg(core.registers().return_address())?,
             ),
             _ => {
@@ -69,7 +69,7 @@ impl SteppingMode {
         // Sometimes the target program_counter is at a location where the debug_info program row data does not contain valid statements for halt points.
         // When DebugError::NoValidHaltLocation happens, we will step to the next instruction and try again(until we can reasonably expect to have passed out of an epilogue), before giving up.
         for _ in 0..10 {
-            match debug_info.get_halt_locations(program_counter, Some(return_address as u64)) {
+            match debug_info.get_halt_locations(program_counter, Some(return_address)) {
                 Ok(program_row_data) => {
                     match self {
                         SteppingMode::OverStatement => {
@@ -135,9 +135,8 @@ impl SteppingMode {
                         Ok(core_status) => {
                             match core_status {
                                 CoreStatus::Halted(_) => {
-                                    program_counter = core
-                                        .read_core_reg(core.registers().program_counter())?
-                                        as u64
+                                    program_counter =
+                                        core.read_core_reg(core.registers().program_counter())?
                                 }
                                 other => {
                                     log::error!(

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -621,7 +621,10 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
                     "content of {} {:#x}: 0x{:08x} should be: 0x{:08x}",
                     description.name,
                     description.address.0,
-                    self.core.read_core_reg(description.address)?,
+                    {
+                        let value: u32 = self.core.read_core_reg(description.address)?;
+                        value
+                    },
                     *v
                 );
             }
@@ -629,7 +632,7 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
 
         if self.core.architecture() == Architecture::Riscv {
             // Ensure ebreak enters debug mode, this is necessary for soft breakpoints to work.
-            let dcsr = self.core.read_core_reg(CoreRegisterAddress::from(0x7b0))?;
+            let dcsr: u32 = self.core.read_core_reg(CoreRegisterAddress::from(0x7b0))?;
 
             self.core.write_core_reg(
                 CoreRegisterAddress::from(0x7b0),
@@ -649,7 +652,7 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
 
         self.core.wait_for_core_halted(timeout)?;
 
-        let r = self.core.read_core_reg(regs.result_register(0).address)?;
+        let r: u32 = self.core.read_core_reg(regs.result_register(0).address)?;
         Ok(r)
     }
 }

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -88,7 +88,7 @@ pub use crate::config::{CoreType, InstructionSet, Target};
 pub use crate::core::{
     Architecture, BreakpointId, CommunicationInterface, Core, CoreInformation, CoreInterface,
     CoreRegister, CoreRegisterAddress, CoreState, CoreStatus, HaltReason, RegisterFile,
-    SpecificCoreState,
+    RegisterValue, SpecificCoreState,
 };
 pub use crate::error::Error;
 pub use crate::memory::{Memory, MemoryInterface};

--- a/smoke-tester/src/tests.rs
+++ b/smoke-tester/src/tests.rs
@@ -30,7 +30,7 @@ pub fn test_register_access(tracker: &TestTracker, core: &mut Core) -> Result<()
 
         core.write_core_reg(register.into(), test_value)?;
 
-        let readback = core.read_core_reg(register)?;
+        let readback: u64 = core.read_core_reg(register)?;
 
         assert_eq!(
             test_value, readback,

--- a/smoke-tester/src/tests/stepping.rs
+++ b/smoke-tester/src/tests/stepping.rs
@@ -35,7 +35,7 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
 
     let registers = core.registers();
 
-    core.write_core_reg(registers.program_counter().into(), code_load_address as u32)?;
+    core.write_core_reg(registers.program_counter().into(), code_load_address)?;
 
     let core_information = core.step()?;
 
@@ -47,7 +47,7 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
         log::warn!("Unexpected core status: {:?}!", core_status);
     }
 
-    let r0_value = core.read_core_reg(registers.platform_register(0))?;
+    let r0_value: u64 = core.read_core_reg(registers.platform_register(0))?;
 
     assert_eq!(r0_value, 0);
 
@@ -68,14 +68,13 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
             println!("Core did not halt after timeout!");
             core.halt(Duration::from_millis(100))?;
 
-            let pc = core.read_core_reg(registers.program_counter())?;
+            let pc: u64 = core.read_core_reg(registers.program_counter())?;
 
             println!("Core stopped at: {:#08x}", pc);
 
-            println!(
-                "$r2 = {:#08x}",
-                core.read_core_reg(registers.platform_register(2))?
-            );
+            let r2_val: u64 = core.read_core_reg(registers.platform_register(2))?;
+
+            println!("$r2 = {:#08x}", r2_val);
         }
         Err(other) => anyhow::bail!(other),
     }
@@ -86,9 +85,9 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
 
     assert_eq!(core_status, CoreStatus::Halted(HaltReason::Breakpoint));
 
-    let pc = core.read_core_reg(registers.program_counter())?;
+    let pc: u64 = core.read_core_reg(registers.program_counter())?;
 
-    assert_eq!(pc as u64, break_address);
+    assert_eq!(pc, break_address);
 
     println!("Core halted at {:#08x}, now trying to run...", pc);
 
@@ -110,14 +109,13 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
             println!("Core did not halt after timeout!");
             core.halt(Duration::from_millis(100))?;
 
-            let pc = core.read_core_reg(registers.program_counter())?;
+            let pc: u64 = core.read_core_reg(registers.program_counter())?;
 
             println!("Core stopped at: {:#08x}", pc);
 
-            println!(
-                "$r2 = {:#08x}",
-                core.read_core_reg(registers.platform_register(2))?
-            );
+            let r2_val: u64 = core.read_core_reg(registers.platform_register(2))?;
+
+            println!("$r2 = {:#08x}", r2_val);
         }
         Err(other) => anyhow::bail!(other),
     }
@@ -126,16 +124,13 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
 
     assert_eq!(core_status, CoreStatus::Halted(HaltReason::Breakpoint));
 
-    let pc = core.read_core_reg(registers.program_counter())?;
+    let pc: u64 = core.read_core_reg(registers.program_counter())?;
 
-    assert_eq!(
-        pc as u64, break_address,
-        "{:#08x} != {:#08x}",
-        pc, break_address
-    );
+    assert_eq!(pc, break_address, "{:#08x} != {:#08x}", pc, break_address);
 
     // Register r2 should be 1 to indicate end of test.
-    assert_eq!(1, core.read_core_reg(registers.platform_register(2))?);
+    let r2_val: u64 = core.read_core_reg(registers.platform_register(2))?;
+    assert_eq!(1, r2_val);
 
     Ok(())
 }


### PR DESCRIPTION
* ArmProbe::read_core_reg / write_core_reg now use an enum to support different sized registers
* Core::read_core_reg / write_core_reg are generic to support working with u32 and u64
* New methods on RegisterDescription allow inspecting register size

Signed-off-by: Ryan Fairfax <ryan@thefaxman.net>