### PR TITLE
jlink: Avoid endless recursion in line_reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Debugger: Fix assumptions for ARM cores
   - GDB: Fix assumptions for ARM cores
 - Fixed access to Arm CoreSight components being completed through the wrong AP (#1114)
+- Fixed a possible endless recursion in the J-Link code, when no chip is connected. (#1123)
 
 ## [0.12.0]
 


### PR DESCRIPTION
When no chip is connected, the J-Link ends up in an endless loop, because no
answer is received. To avoid this, we can't call the register read function in the
line_reset function.

This might help with #531.
