### PR TITLE
Fixes for ARMv7-a and ARMv8-a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - GDB: Fix assumptions for ARM cores
 - Fixed access to Arm CoreSight components being completed through the wrong AP (#1114)
 - Fixed a possible endless recursion in the J-Link code, when no chip is connected. (#1123)
+- Fixed an issue with ARMv7-a/v8-a where some register values might be corrupted. (#1131)
+- Fixed an issue where `probe-rs-cli`'s debug console didn't detect if the core is halted (#1131)
 
 ## [0.12.0]
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -701,6 +701,12 @@ impl DebugCli {
         args: &[&str],
     ) -> Result<CliState, CliError> {
         match (command.function)(cli_data, args) {
+            Ok(cli_state) => {
+                // Resync status from core
+                cli_data.update_debug_status_from_core()?;
+
+                Ok(cli_state)
+            }
             Err(CliError::MissingArgument) => {
                 println!("Error: Missing argument\n\n{}", command.help_text);
                 Ok(CliState::Continue)
@@ -727,13 +733,26 @@ pub struct CliData<'p> {
 }
 
 impl<'p> CliData<'p> {
-    pub fn new(mut core: Core<'p>, debug_info: Option<DebugInfo>) -> Result<CliData, CliError> {
-        let status = core.status()?;
+    pub fn new(core: Core<'p>, debug_info: Option<DebugInfo>) -> Result<CliData, CliError> {
+        let mut cli_data = CliData {
+            core,
+            debug_info,
+            state: DebugState::default(),
+        };
 
+        cli_data.update_debug_status_from_core()?;
+
+        Ok(cli_data)
+    }
+
+    /// Fill out DebugStatus for a given core
+    fn update_debug_status_from_core(&mut self) -> Result<(), CliError> {
         // TODO: In halted state we should get the backtrace here.
-        let debug_state = match status {
+        let status = self.core.status()?;
+
+        self.state = match status {
             probe_rs::CoreStatus::Halted(_) => {
-                let registers = Registers::from_core(&mut core);
+                let registers = Registers::from_core(&mut self.core);
 
                 DebugState::Halted(HaltedState {
                     program_counter: registers.get_program_counter().unwrap_or_default(),
@@ -745,12 +764,7 @@ impl<'p> CliData<'p> {
             _other => DebugState::Running,
         };
 
-        // TODO: Find initial state
-        Ok(CliData {
-            core,
-            debug_info,
-            state: debug_state,
-        })
+        Ok(())
     }
 
     pub fn print_state(&mut self) -> Result<(), CliError> {
@@ -774,6 +788,12 @@ impl<'p> CliData<'p> {
 enum DebugState {
     Running,
     Halted(HaltedState),
+}
+
+impl std::default::Default for DebugState {
+    fn default() -> Self {
+        DebugState::Running
+    }
 }
 
 struct HaltedState {

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -391,6 +391,11 @@ pub trait CoreInterface: MemoryInterface {
     /// This must be queried while halted as this is a runtime
     /// decision for some core types.
     fn fpu_support(&mut self) -> Result<bool, error::Error>;
+
+    /// Called during session stop to do any pending cleanup
+    fn on_session_stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl<'probe> MemoryInterface for Core<'probe> {
@@ -833,6 +838,11 @@ impl<'probe> Core<'probe> {
     /// decision for some core types.
     pub fn fpu_support(&mut self) -> Result<bool, error::Error> {
         self.inner.fpu_support()
+    }
+
+    /// Called during session tear down to do any pending cleanup
+    pub(crate) fn on_session_stop(&mut self) -> Result<(), Error> {
+        self.inner.on_session_stop()
     }
 }
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -532,6 +532,12 @@ impl Drop for Session {
             log::warn!("Could not clear all hardware breakpoints: {:?}", err);
         }
 
+        if let Err(err) = { 0..self.cores.len() }
+            .try_for_each(|i| self.core(i).and_then(|mut core| core.on_session_stop()))
+        {
+            log::warn!("Error during on_session_stop: {:?}", err);
+        }
+
         // Disable tracing for all Cortex-M cores.
         if let Err(err) = { 0..self.cores.len() }.try_for_each(|i| {
             let is_cortex_m = self.core(i)?.core_type().is_cortex_m();


### PR DESCRIPTION
* Add a new session cleanup hook to write out any pending cached writes.  This ensures when a probe-rs based program exits data isn't lost.
* Fix a bug where ARMv8-a was resetting its cached registers each time it was accessed
* Fix bug that caused failures in `halt()` or `run()` if the target was already in the desired state
* Update CLI debugger to read core state after every command.  This fixes issues where the CLI things the core is halted but it isn't, or vise-versa.

Signed-off-by: Ryan Fairfax <ryan@thefaxman.net>