### PR TITLE
Add Mutex back to GDB run method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a possible endless recursion in the J-Link code, when no chip is connected. (#1123)
 - Fixed an issue with ARMv7-a/v8-a where some register values might be corrupted. (#1131)
 - Fixed an issue where `probe-rs-cli`'s debug console didn't detect if the core is halted (#1131)
+- Fix GDB interface to require a Mutex to enable multi-threaded usage (#1144)
 
 ## [0.12.0]
 

--- a/cli/src/gdb.rs
+++ b/cli/src/gdb.rs
@@ -1,3 +1,4 @@
+use std::sync::Mutex;
 use std::time::Duration;
 
 use probe_rs_cli_util::common_options::ProbeOptions;
@@ -29,7 +30,9 @@ pub fn run_gdb_server(
         );
     }
 
-    if let Err(e) = probe_rs_gdb_server::run(session, instances.iter()) {
+    let session = Mutex::new(session);
+
+    if let Err(e) = probe_rs_gdb_server::run(&session, instances.iter()) {
         eprintln!("During the execution of GDB an error was encountered:");
         eprintln!("{:?}", e);
     }

--- a/gdb-server/src/target/base.rs
+++ b/gdb-server/src/target/base.rs
@@ -16,7 +16,7 @@ impl MultiThreadBase for RuntimeTarget<'_> {
         regs: &mut RuntimeRegisters,
         tid: Tid,
     ) -> gdbstub::target::TargetResult<(), Self> {
-        let mut session = self.session.borrow_mut();
+        let mut session = self.session.lock().unwrap();
         let mut core = session.core(tid.get() - 1).into_target_result()?;
 
         regs.pc = core
@@ -47,7 +47,7 @@ impl MultiThreadBase for RuntimeTarget<'_> {
         regs: &RuntimeRegisters,
         tid: Tid,
     ) -> gdbstub::target::TargetResult<(), Self> {
-        let mut session = self.session.borrow_mut();
+        let mut session = self.session.lock().unwrap();
         let mut core = session.core(tid.get() - 1).into_target_result()?;
 
         core.write_core_reg(core.registers().program_counter().into(), regs.pc)
@@ -94,7 +94,7 @@ impl MultiThreadBase for RuntimeTarget<'_> {
         data: &mut [u8],
         tid: Tid,
     ) -> gdbstub::target::TargetResult<(), Self> {
-        let mut session = self.session.borrow_mut();
+        let mut session = self.session.lock().unwrap();
         let mut core = session.core(tid.get() - 1).into_target_result()?;
 
         core.read(start_addr, data).into_target_result_non_fatal()
@@ -106,7 +106,7 @@ impl MultiThreadBase for RuntimeTarget<'_> {
         data: &[u8],
         tid: Tid,
     ) -> gdbstub::target::TargetResult<(), Self> {
-        let mut session = self.session.borrow_mut();
+        let mut session = self.session.lock().unwrap();
         let mut core = session.core(tid.get() - 1).into_target_result()?;
 
         core.write_8(start_addr, data)
@@ -142,7 +142,7 @@ impl SingleRegisterAccess<Tid> for RuntimeTarget<'_> {
         reg_id: RuntimeRegId,
         buf: &mut [u8],
     ) -> gdbstub::target::TargetResult<usize, Self> {
-        let mut session = self.session.borrow_mut();
+        let mut session = self.session.lock().unwrap();
         let mut core = session.core(tid.get() - 1).into_target_result()?;
 
         let reg = self.target_desc.get_register(reg_id.into());
@@ -166,7 +166,7 @@ impl SingleRegisterAccess<Tid> for RuntimeTarget<'_> {
         reg_id: RuntimeRegId,
         val: &[u8],
     ) -> gdbstub::target::TargetResult<(), Self> {
-        let mut session = self.session.borrow_mut();
+        let mut session = self.session.lock().unwrap();
         let mut core = session.core(tid.get() - 1).into_target_result()?;
 
         let reg = self.target_desc.get_register(reg_id.into());

--- a/gdb-server/src/target/breakpoints.rs
+++ b/gdb-server/src/target/breakpoints.rs
@@ -24,7 +24,7 @@ impl HwBreakpoint for RuntimeTarget<'_> {
         addr: u64,
         _kind: <Self::Arch as gdbstub::arch::Arch>::BreakpointKind,
     ) -> gdbstub::target::TargetResult<bool, Self> {
-        let mut session = self.session.borrow_mut();
+        let mut session = self.session.lock().unwrap();
 
         for core_id in &self.cores {
             let mut core = session.core(*core_id).into_target_result()?;
@@ -40,7 +40,7 @@ impl HwBreakpoint for RuntimeTarget<'_> {
         addr: u64,
         _kind: <Self::Arch as gdbstub::arch::Arch>::BreakpointKind,
     ) -> gdbstub::target::TargetResult<bool, Self> {
-        let mut session = self.session.borrow_mut();
+        let mut session = self.session.lock().unwrap();
 
         for core_id in &self.cores {
             let mut core = session.core(*core_id).into_target_result()?;

--- a/gdb-server/src/target/desc/mod.rs
+++ b/gdb-server/src/target/desc/mod.rs
@@ -56,7 +56,7 @@ impl TargetDescriptionXmlOverride for RuntimeTarget<'_> {
 
 impl RuntimeTarget<'_> {
     pub(crate) fn load_target_desc(&mut self) -> Result<(), probe_rs::Error> {
-        let mut session = self.session.borrow_mut();
+        let mut session = self.session.lock().unwrap();
         let mut core = session.core(self.cores[0])?;
 
         self.target_desc =
@@ -73,7 +73,7 @@ impl MemoryMap for RuntimeTarget<'_> {
         length: usize,
         buf: &mut [u8],
     ) -> gdbstub::target::TargetResult<usize, Self> {
-        let mut session = self.session.borrow_mut();
+        let mut session = self.session.lock().unwrap();
         let xml = gdb_memory_map(&mut session, self.cores[0]).into_target_result()?;
         let xml_data = xml.as_bytes();
 

--- a/gdb-server/src/target/monitor.rs
+++ b/gdb-server/src/target/monitor.rs
@@ -18,7 +18,11 @@ impl MonitorCmd for RuntimeTarget<'_> {
 
         match cmd.as_ref() {
             "info" => {
-                outputln!(out, "Target info:\n\n{:#?}", self.session.borrow().target());
+                outputln!(
+                    out,
+                    "Target info:\n\n{:#?}",
+                    self.session.lock().unwrap().target()
+                );
             }
             _ => {
                 outputln!(out, "{}", HELP_TEXT);

--- a/gdb-server/src/target/resume.rs
+++ b/gdb-server/src/target/resume.rs
@@ -5,7 +5,7 @@ use gdbstub::target::ext::base::multithread::{MultiThreadResume, MultiThreadSing
 
 impl MultiThreadResume for RuntimeTarget<'_> {
     fn resume(&mut self) -> Result<(), Self::Error> {
-        let mut session = self.session.borrow_mut();
+        let mut session = self.session.lock().unwrap();
 
         match self.resume_action {
             (_, ResumeAction::Resume) => {


### PR DESCRIPTION
In the last round of refactoring Mutex was removed from the run() function signature due to no longer needing within the GDB logic.  However, consumers of this API, such as cargo-embed, depend on being able to run multiple threads so the GDB code cannot take exclusive ownership of the Session object.

Signed-off-by: Ryan Fairfax <ryan@thefaxman.net>