### PR TITLE
Fixing nrf9160 target file so it can erase UICR section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue with ARMv7-a/v8-a where some register values might be corrupted. (#1131)
 - Fixed an issue where `probe-rs-cli`'s debug console didn't detect if the core is halted (#1131)
 - Fix GDB interface to require a Mutex to enable multi-threaded usage (#1144)
+- Fix nrf9160 target file so it can erase UICR section (#1151)
 
 ## [0.12.0]
 

--- a/probe-rs/targets/nRF91_Series.yaml
+++ b/probe-rs/targets/nRF91_Series.yaml
@@ -23,6 +23,13 @@ variants:
           is_boot_memory: true
           cores:
             - main
+      - Nvm:
+          range:
+            start: 0xff8000
+            end: 0xff9000
+          is_boot_memory: true
+          cores:
+            - main
     flash_algorithms:
       - nrf91xx
       - nrf91xx_uicr


### PR DESCRIPTION
The UICR section was missing from the memory_map, I've added it now.