### PR TITLE
Move probe.inner_attach before hardware reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue with ARMv7-a/v8-a where some register values might be corrupted. (#1131)
 - Fixed an issue where `probe-rs-cli`'s debug console didn't detect if the core is halted (#1131)
 - Fix GDB interface to require a Mutex to enable multi-threaded usage (#1144)
+- Fix connection ordering so `--connect-under-reset` is able to minipulate the reset pin.
 
 ## [0.12.0]
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -154,6 +154,9 @@ impl Session {
                     }
                 };
 
+                // Attach to the probe first so manipulating the reset pin works.
+                probe.inner_attach()?;
+
                 if AttachMethod::UnderReset == attach_method {
                     if let Some(dap_probe) = probe.try_as_dap_probe() {
                         sequence_handle.reset_hardware_assert(dap_probe)?;
@@ -166,8 +169,6 @@ impl Session {
                         probe.target_reset_assert()?;
                     }
                 }
-
-                probe.inner_attach()?;
 
                 let interface = probe.try_into_arm_interface().map_err(|(_, err)| err)?;
 


### PR DESCRIPTION
Before this change the manipulation of the reset pin on my MAX32625PICO programmer doesn't actually work. The reset pin stays high during the entire connection phase.

I'm working on getting support for the Microchip ATSAML10 family working in probe-rs. This is a preliminary fix that I've found along the way. I'm not sure how much this is unique to my situation, but it feels likely that it's an artifact of the programmer more than the chip I'm attempting to connect to.

Below are a couple of logic analyzer screen shots before and after the fix. I'm running the command `cargo flash --chip ATSAML10E16A --connect-under-reset` using a build of cargo-flash that is linked against a [fork of probe-rs](https://github.com/neonquill/probe-rs/tree/atsaml10) that includes this commit plus the chip definition for the ATSAML10.

Note that in the first screenshot the reset line (bottom row, labeled D2 and RESET and colored red) never changes when starting to connect to the chip. In the second screenshot the reset line goes low.

<img width="1330" alt="fix_connect_under_reset_before" src="https://user-images.githubusercontent.com/845294/177002520-432c7fa9-231a-46aa-82f3-c751f811551a.png">

<img width="1330" alt="fix_connect_under_reset_after" src="https://user-images.githubusercontent.com/845294/177002529-6a46dcc1-daf7-45ed-a034-66a9e653ee30.png">

There's more work to be done to get the connection to actually work for this chip, but this seemed like an obvious bug fix to get in before I finish the rest of the work. I'm way out of my element here, so any suggestions on how to do this differently are very welcome.
