### PR TITLE
Fix CMSIS-DAP connect under reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fix: Using `restart` request from VSCode now works for both states of `halt_after_rest`.
   - Partial Fix: Set breakpoints and step on RISC-V. Breakpoints work but stepping only works for some breakpoints. This will be addressed in a future PR.
 - Fix nrf9160 target file so it can erase UICR section (#1151)
+- Fix connect under reset for CMSIS-DAP probes(#1159)
 
 ## [0.12.0]
 


### PR DESCRIPTION
The CMSIS-DAP firmware does not configure the nRESET pin for output
until it receives the DAP_Connect command. In the connect under reset
flow we try to toggle the pins via swj_pins before calling connect.
This fix addresses that by connecting if needed during swj_pins calls.