### PR TITLE
added PartialEq Trait to struct DebugProbeInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- added PartialEq Trait to the struct DebugProbeInfo
+
 
 ## [0.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- added PartialEq Trait to the struct DebugProbeInfo
+
+[Added]
+
+- Added PartialEq Trait to the struct DebugProbeInfo. (#1173)
 
 
 ## [0.13.0]

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -634,7 +634,7 @@ pub enum DebugProbeType {
 }
 
 /// Gathers some information about a debug probe which was found during a scan.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct DebugProbeInfo {
     /// The name of the debug probe.
     pub identifier: String,


### PR DESCRIPTION
I submit this PR because I'm using egui ComboBox and the selectable_value function require  the comparison Trait.
Here is the example:

                egui::ComboBox::from_label("Take your pick")
                .selected_text(format!("{:?}", self.get_probe_name(&self.probe_selected)))
                .show_ui(ui, |ui| {

                    for (i, pr) in self.probes.iter().enumerate() {

                        ui.selectable_value(&mut self.probe_selected, Some(pr.clone()), pr.identifier.clone());

                    }

                });

Definitions:

				struct MyApp {
					probes: Vec<probe_rs::DebugProbeInfo>,
					probe_selected: Option<probe_rs::DebugProbeInfo>,
				}

				impl Default for MyApp {
					fn default() -> Self {
						Self {
							probes: Probe::list_all(),
							probe_selected: None,
						}
					}
				}

				impl MyApp {
					pub fn get_probe_name(&self, probe: &Option<probe_rs::DebugProbeInfo>) -> String {
						match probe {
							Some(p) => p.identifier.clone(),
							_ => "No probe selected".to_string()
						}
					}
				}

I don't know if it's the best way to do (I'm new to Rust), but it's straightforward