### PR TITLE
ITM Tracing CLI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added PartialEq Trait to the struct DebugProbeInfo. (#1173)
 - Added support for configuring trace data destinations (#1177)
+- ITM tracing can now be completed using the probe-rs CLI (#1180)
 
 ### Changed
 - SWV vendor configuration has been refactored into sequences and trace functions have been renamed:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,3 +34,4 @@ parse_int = "0.6.0"
 num-traits = "0.2.14"
 bitfield = "0.14.0"
 jep106 = "0.2.6"
+itm-decode = { version = "0.6", default-features = false }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -173,6 +173,8 @@ enum Cli {
         #[structopt(flatten)]
         common: ProbeOptions,
 
+        #[structopt(parse(try_from_str = parse_u64))]
+        duration_ms: u64,
         // TODO: Allow specifying trace sink
     },
     #[clap(subcommand)]
@@ -261,8 +263,14 @@ fn main() -> Result<()> {
         } => trace_u32_on_target(&shared, &common, loc),
         Cli::Itm {
             shared,
-            common
-        } => trace::itm_trace(&shared, &common, TraceSink::TraceMemory),
+            common,
+            duration_ms,
+        } => trace::itm_trace(
+            &shared,
+            &common,
+            TraceSink::TraceMemory,
+            std::time::Duration::from_millis(duration_ms),
+        ),
         Cli::Chip(Chip::List) => print_families(io::stdout()).map_err(Into::into),
         Cli::Chip(Chip::Info { name }) => print_chip_info(name, io::stdout()),
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -176,6 +176,9 @@ enum Cli {
         #[structopt(parse(try_from_str = parse_u64))]
         duration_ms: u64,
 
+        #[structopt(long)]
+        output_file: Option<String>,
+
         #[clap(subcommand)]
         source: ItmSource,
     },
@@ -286,6 +289,7 @@ fn main() -> Result<()> {
             common,
             duration_ms,
             source,
+            output_file,
         } => {
             let sink = match source {
                 ItmSource::TraceMemory => TraceSink::TraceMemory,
@@ -296,6 +300,7 @@ fn main() -> Result<()> {
                 &common,
                 sink,
                 std::time::Duration::from_millis(duration_ms),
+                output_file,
             )
         }
         Cli::Chip(Chip::List) => print_families(io::stdout()).map_err(Into::into),

--- a/cli/src/trace.rs
+++ b/cli/src/trace.rs
@@ -1,0 +1,30 @@
+//! Provides ITM tracing capabilities.
+
+use super::{CoreOptions, ProbeOptions};
+use probe_rs::architecture::arm::component::TraceSink;
+
+pub(crate) fn itm_trace(
+    shared_options: &CoreOptions,
+    common: &ProbeOptions,
+    sink: TraceSink,
+) -> anyhow::Result<()> {
+    let mut session = common.simple_attach()?;
+    session.setup_tracing(shared_options.core, sink)?;
+
+    let mut decoder = itm_decode::Decoder::new(itm_decode::DecoderOptions::default());
+
+    loop {
+        let itm_data = session.read_trace_data()?;
+        if itm_data.is_empty() {
+            log::info!("No trace data read, exitting");
+            break;
+        }
+        decoder.push(&itm_data);
+
+        while let Some(packet) = decoder.pull_with_timestamp() {
+            log::info!("{packet:?}");
+        }
+    }
+
+    Ok(())
+}

--- a/cli/src/trace.rs
+++ b/cli/src/trace.rs
@@ -2,12 +2,22 @@
 
 use super::{CoreOptions, ProbeOptions};
 use probe_rs::architecture::arm::component::TraceSink;
+use std::io::Write;
 
+/// Trace the application using ITM.
+///
+/// # Args
+/// * `shared_options` - Specifies information about which core to trace.
+/// * `common` - Specifies information about the probe to use for tracing.
+/// * `sink` - Specifies the destination for trace data.
+/// * `duration` - Specifies the duration to trace for.
+/// * `output_file` - An optionally specified filename to write ITM binary data into.
 pub(crate) fn itm_trace(
     shared_options: &CoreOptions,
     common: &ProbeOptions,
     sink: TraceSink,
     duration: std::time::Duration,
+    output_file: Option<String>,
 ) -> anyhow::Result<()> {
     let mut session = common.simple_attach()?;
 
@@ -15,17 +25,35 @@ pub(crate) fn itm_trace(
 
     let mut decoder = itm_decode::Decoder::new(itm_decode::DecoderOptions::default());
 
+    // If the user specified an output file, create it and open it for writing now.
+    let mut output = if let Some(destination) = output_file {
+        Some(
+            std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .open(destination)?,
+        )
+    } else {
+        None
+    };
+
     let start = std::time::Instant::now();
 
     while start.elapsed() < duration {
         let itm_data = session.read_trace_data()?;
+
         if itm_data.is_empty() {
             log::info!("No trace data read, exitting");
             break;
         }
 
-        decoder.push(&itm_data);
+        // Write the raw ITM data to the output file if one was opened.
+        if let Some(ref mut output) = output {
+            output.write_all(&itm_data)?;
+        }
 
+        // Decode and print the ITM data for display.
+        decoder.push(&itm_data);
         while let Some(packet) = decoder.pull_with_timestamp() {
             println!("{packet:?}");
         }

--- a/cli/src/trace.rs
+++ b/cli/src/trace.rs
@@ -7,22 +7,27 @@ pub(crate) fn itm_trace(
     shared_options: &CoreOptions,
     common: &ProbeOptions,
     sink: TraceSink,
+    duration: std::time::Duration,
 ) -> anyhow::Result<()> {
     let mut session = common.simple_attach()?;
+
     session.setup_tracing(shared_options.core, sink)?;
 
     let mut decoder = itm_decode::Decoder::new(itm_decode::DecoderOptions::default());
 
-    loop {
+    let start = std::time::Instant::now();
+
+    while start.elapsed() < duration {
         let itm_data = session.read_trace_data()?;
         if itm_data.is_empty() {
             log::info!("No trace data read, exitting");
             break;
         }
+
         decoder.push(&itm_data);
 
         while let Some(packet) = decoder.pull_with_timestamp() {
-            log::info!("{packet:?}");
+            println!("{packet:?}");
         }
     }
 


### PR DESCRIPTION
This PR brings initial ITM tracing support to the probe-rs-cli. Specifically, the ITM tracer lets you:
* Specify a trace destination (SWO or TraceMemory)
* Configure SWO when needed
* Specify trace duration


TODO:
- [x] Allow saving ITM data to a file for offline parsing

Future work:
* Support ITM stimulus ports
* Allow other DWT tracing, such as PC sampling and memory watching
* Support TPIU+SWO combinations