### PR TITLE
Updating tracing to support M4 architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added PartialEq Trait to the struct DebugProbeInfo. (#1173)
 - Added support for configuring trace data destinations (#1177)
+    * Tracing on M4 architectures utilize the TPIU for all hardware tracing (#1182)
 - ITM tracing can now be completed using the probe-rs CLI (#1180)
 
 ### Changed


### PR DESCRIPTION
The M4 architecture pre-dates the CoreSight Technical Reference Manual. Because of this, the Cortex-M4 Trace Port Interface Unit (TPIU) is responsible for controlling both serial (SWO) and parallel trace (TRACED).

To accomodate this, this PR updates the configuration functions to configure the TPIU if the SWO peripheral is not found, as is the case on M4 devices.

I tested this by tracing an STM32F407ZGTx device (M4) architecture using the CLI tool. On `master`, I received:
```
$ cargo run -- itm --chip STM32F407ZGTx 100 swo 168000000 115200
    Finished dev [unoptimized + debuginfo] target(s) in 9.05s
     Running `C:\Users\rsummers\Documents\repositories\probe-rs\probe-rs\target\debug\probe-rs-cli.exe itm --chip STM32F407ZGTx 100 swo 168000000 115200`
Error: A core architecture specific error occurred

Caused by:
    The requested component 'Swo (Single Wire Output)' was not found
```

After the updates, I wa able to properly collect SWO data over the SWO pin:
```
$ cargo run -- itm --chip STM32F407ZGTx 100 swo 168000000 115200
    Finished dev [unoptimized + debuginfo] target(s) in 0.29s
     Running `C:\Users\rsummers\Documents\repositories\probe-rs\probe-rs\target\debug\probe-rs-cli.exe itm --chip STM32F407ZGTx 100 swo 168000000 115200`
TimestampedTracePackets { timestamp: Timestamp { base: None, delta: Some(2), data_relation: Some(Sync), diverged: false }, packets: [Instrumentation { port: 3, payload: [14, 206, 243, 156] }, Instrumentation { port: 1, payload: [14, 15] }], malformed_packets: [], packets_consumed: 3 }
TimestampedTracePackets { timestamp: Timestamp { base: None, delta: Some(207), data_relation: Some(Sync), diverged: false }, packets: [], malformed_packets: [], packets_consumed: 1 }
TimestampedTracePackets { timestamp: Timestamp { base: None, delta: Some(208), data_relation: Some(Sync), diverged: false }, packets: [Extension { page: 0 }], malformed_packets: [InvalidPCSampleSize { payload: [48, 192] }], packets_consumed: 6 }
TimestampedTracePackets { timestamp: Timestamp { base: None, delta: Some(210), data_relation: Some(Sync), diverged: false }, packets: [DataTraceValue { comparator: 1, access_type: Write, value: [10, 14] }], malformed_packets: [InvalidHardwareDisc { disc_id: 29, size: 1 }], packets_consumed: 5 }

```