### PR TITLE
passthrough probe-rs features to parent crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for configuring trace data destinations (#1177)
     * Tracing on M4 architectures utilize the TPIU for all hardware tracing (#1182)
 - ITM tracing can now be completed using the probe-rs CLI (#1180)
+- Added `vendored-libusb`, `builtin-targets`, and `ftdi-vendored` pass-through features to `probe-rs-debugger`, `gdb-server`, `probe-rs-cli-util`, and `probe-rs-rtt`.
 
 ### Changed
 - SWV vendor configuration has been refactored into sequences and trace functions have been renamed:

--- a/debugger/Cargo.toml
+++ b/debugger/Cargo.toml
@@ -17,7 +17,12 @@ keywords = ["embedded"]
 license = "MIT OR Apache-2.0"
 
 [features]
+default = ["builtin-targets", "vendored-libusb"]
+
+vendored-libusb = ["probe-rs/vendored-libusb"]
+builtin-targets = ["probe-rs/builtin-targets"]
 ftdi = ["probe-rs/ftdi"]
+ftdi-vendored = ["probe-rs/ftdi-vendored"]
 
 [dependencies]
 probe-rs = { version = "0.13.0", path = "../probe-rs" }

--- a/gdb-server/Cargo.toml
+++ b/gdb-server/Cargo.toml
@@ -17,10 +17,15 @@ name = "probe_rs_gdb_server"
 path = "src/lib.rs"
 
 [features]
+default = ["builtin-targets", "vendored-libusb"]
+
+vendored-libusb = ["probe-rs/vendored-libusb"]
+builtin-targets = ["probe-rs/builtin-targets"]
 ftdi = ["probe-rs/ftdi"]
+ftdi-vendored = ["probe-rs/ftdi-vendored"]
 
 [dependencies]
-probe-rs = { path = "../probe-rs", version = "0.13.0" }
+probe-rs = { path = "../probe-rs", version = "0.13.0", default-features = false }
 log = "0.4.0"
 anyhow = "1.0.31"
 itertools = "0.10.3"

--- a/probe-rs-cli-util/Cargo.toml
+++ b/probe-rs-cli-util/Cargo.toml
@@ -16,11 +16,16 @@ keywords = ["embedded"]
 license = "MIT OR Apache-2.0"
 
 [features]
-default = ["anyhow"]
+default = ["anyhow", "builtin-targets", "vendored-libusb"]
+
+vendored-libusb = ["probe-rs/vendored-libusb", "probe-rs-rtt/vendored-libusb"]
+builtin-targets = ["probe-rs/builtin-targets", "probe-rs-rtt/builtin-targets"]
+ftdi = ["probe-rs/ftdi", "probe-rs-rtt/ftdi"]
+ftdi-vendored = ["probe-rs/ftdi-vendored", "probe-rs-rtt/ftdi-vendored"]
 
 [dependencies]
-probe-rs-rtt = { version = "0.13.0", path = "../rtt" }
-probe-rs = { version = "0.13.0", path = "../probe-rs" }
+probe-rs-rtt = { version = "0.13.0", path = "../rtt", default-features = false }
+probe-rs = { version = "0.13.0", path = "../probe-rs", default-features = false }
 
 thiserror = "1.0"
 anyhow = { version = "1.0", optional = true }

--- a/rtt/Cargo.toml
+++ b/rtt/Cargo.toml
@@ -9,9 +9,17 @@ license = "MIT"
 authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
 repository = "https://github.com/probe-rs/probe-rs"
 
+[features]
+default = ["builtin-targets", "vendored-libusb"]
+
+vendored-libusb = ["probe-rs/vendored-libusb"]
+builtin-targets = ["probe-rs/builtin-targets"]
+ftdi = ["probe-rs/ftdi"]
+ftdi-vendored = ["probe-rs/ftdi-vendored"]
+
 [dependencies]
 log = "0.4.8"
-probe-rs = { version = "0.13.0", path = "../probe-rs" }
+probe-rs = { version = "0.13.0", path = "../probe-rs", default-features = false }
 scroll = "0.10.1"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.11"


### PR DESCRIPTION
I was trying to dynamically link libusb, but currently the parent crates of `probe-rs`, such as `probe-rs-rtt`, do not pass-through these features.  I _thought_ resolver version 2 was supposed to fix this, but with this in `Cargo.toml` libusb will still end up statically linked; there is still some sort of feature unification going on.

```toml
[package]
name = "testing"
version = "0.1.0"
edition = "2021"
resolver = "2"

[dependencies]
probe-rs = { version = "0.13", default-features = false }
probe-rs-rtt = "0.13"
```

I also added this to the binary packages because probe-rs based binaries are being distributed in Linux package managers where dynamic linking is preferred.