### PR TITLE
[WIP] build: removes libusb1-sys vendored as a default feature

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["embedded"]
 license = "MIT OR Apache-2.0"
 
 [features]
-default = ["builtin-targets", "vendored-libusb"]
+default = ["builtin-targets"]
 
 vendored-libusb = ["rusb/vendored"]
 


### PR DESCRIPTION
This commit removes the use of `libusb1-sys`'s "vendored" feature by
default. In short, this was causing problems in building libusb v0.6.3.
The issue needs to be reported to the upstream dependency, but in the
meantime, it can be fixed by disabling this default feature.

It should be noted that, without this feature, `libusb1-sys` first
checks to see if you have installed `libusb` yourself. If that does not
exist, it continues to try to install the library from source. So, just
to confirm, nothing is lost here—removing this feature only allows
`libusb1-sys` to first check if you've already installed the library.