### PR TITLE
Fix scan-region range scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * (#350) Flashing and debugging on STM32 chips using WFI instructions should now be stable (fixed in #1177)
-
+* Fixed rtthost --scan-region to properly support memory range scannig. (#1192)
 
 ## [0.13.0]
 

--- a/rtt/src/rtt.rs
+++ b/rtt/src/rtt.rs
@@ -219,12 +219,14 @@ impl Rtt {
             }
 
             for offset in 0..(mem.len() - Self::MIN_SIZE) {
-                if let Some(rtt) = Rtt::from(
+                if let Some(Some(rtt)) = Rtt::from(
                     core,
                     memory_map,
                     range.start + offset as u32,
                     Some(&mem[offset..]),
-                )? {
+                )
+                .ok()
+                {
                     instances.push(rtt);
 
                     if instances.len() >= 5 {


### PR DESCRIPTION
Currently specifying memory range with --scan-region will always fail to find the control block.