### PR TITLE
`probe-rs-debugger` README update

### DIFF
--- a/debugger/README.md
+++ b/debugger/README.md
@@ -1,38 +1,10 @@
 # probe-rs-debugger
 
-A debugger that uses the [probe-rs](https://github.com/probe-rs/probe-rs) library to provide an interactive debugging experience.
-
-## Installation
-
-```
-cargo install --git https://github.com/probe-rs/probe-rs probe-rs-debugger
-```
+A debugger that uses the [probe-rs](https://github.com/probe-rs/probe-rs) library to provide an interactive debugging experience with [DAP](https://microsoft.github.io/debug-adapter-protocol/) capable clients, such as Microsoft VSCode.
 
 ## Usage
 
-Assuming that `CARGO_HOME` is in your path, you can try any of the following:
-
-1. For full list of command line options
-
-```
-probe-rs-debugger --help
-``` 
-
-2. An fully qualified example of a CLI based debug session
-
-```
-probe-rs-debugger debug --chip STM32H745ZITx --speed 24000 --probe PID:VID --program-binary ./target/thumbv7em-none-eabihf/debug/debug_example --protocol swd --connect-under-reset  --core-index 0 --flashing-enabled --reset-after-flashing --halt-after-reset
-```
-
-3. Starting a DAP server on a specific port, to allow a DAP Client like VSCode to connect 
-
-```
-probe-rs-debugger debug --dap --port 50001
-```
-
-## Additional information
-
-**Please refer to [probe-rs/vscode](https://github.com/probe-rs/vscode) for additional instructions, as well as up to date information on supported functionality and ongoing improvements.**
+Please refer to the [official documentation](https://probe.rs/docs/tools/vscode/) for up to date Installation, Usage, and Configuration, instructions, as well as information about supported capabilities and known limitations.
 
 ## Acknowledgements
 
@@ -42,14 +14,13 @@ This debugger is an extension of, and builds on the prior work of the [probe-rs]
 
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-   http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   http://opensource.org/licenses/MIT) at your option.
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  http://opensource.org/licenses/MIT) at your option.
 
 ## Contributing
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall
 be dual licensed as above, without any additional terms or conditions.
-


### PR DESCRIPTION
The README was out of date and included outdated instructions for CLI mode, which is no longer relevant.