### PR TITLE
Step over BKPT instruction for Arm  Cortex-M / EBREAK instruction for RISC-V

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - (#350) Flashing and debugging on STM32 chips using WFI instructions should now be stable (fixed in #1177)
+- Fixed rtthost --scan-region to properly support memory range scannig. (#1192)
 - Debug: Improve logic for halt locations used by breakpoints and stepping. (#1156)
 - Debug: Some in-scope variables are excluded from stack_trace. (#1156)
-- Fixed rtthost --scan-region to properly support memory range scannig. (#1192)
 - Debug: Ensure RTT buffer on target is reported to DAP client in 'timely' manner. (#1208)
 - Debug: Provide unique default names on DAP client, when multiple RTT Channels have no configured name. (#1208)
+- Added missing memory regions for ESP32.yaml file, to fix RTT Channel name issue. (#1209)
+- Fix maximum addressable Flash size in ESP32.yaml file, to be 16Mb (was 64Mb). (#1209)
 
 ## [0.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SWV vendor configuration has been refactored into sequences and trace functions have been renamed:
   - `Session::setup_swv` has been renamed to `Session::setup_tracing`
   - `Session::read_swo` has been renamed to `Session::read_trace_data`
+- RTT: When a channel format is `defmt`, automatically set the channel mode to `BlockingIfFull` on attach. (Enhancement request #1161)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SWV vendor configuration has been refactored into sequences and trace functions have been renamed:
   - `Session::setup_swv` has been renamed to `Session::setup_tracing`
   - `Session::read_swo` has been renamed to `Session::read_trace_data`
+- `probe-rs-debugger` RISC-V `ebreak` instruction will enter Debug Mode (#1213)
 - RTT: When a channel format is `defmt`, automatically set the channel mode to `BlockingIfFull` on attach. (Enhancement request #1161)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SWV vendor configuration has been refactored into sequences and trace functions have been renamed:
   - `Session::setup_swv` has been renamed to `Session::setup_tracing`
   - `Session::read_swo` has been renamed to `Session::read_trace_data`
-- `probe-rs-debugger` RISC-V `ebreak` instruction will enter Debug Mode (#1213)
+- `probe-rs-debugger`: RISC-V `ebreak` instruction will enter Debug Mode (#1213)
 - RTT: When a channel format is `defmt`, automatically set the channel mode to `BlockingIfFull` on attach. (Enhancement request #1161)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debug: Provide unique default names on DAP client, when multiple RTT Channels have no configured name. (#1208)
 - Added missing memory regions for ESP32.yaml file, to fix RTT Channel name issue. (#1209)
 - Fix maximum addressable Flash size in ESP32.yaml file, to be 16Mb (was 64Mb). (#1209)
-- Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (# ).
-- Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (#1211).
-- Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (# ).
-- Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (#1211).
+- Debug: Enable stepping or running past a BKPT (Arm Cortex-M) or EBREAK (RISC-V) instruction (#1211).
 
 ## [0.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix maximum addressable Flash size in ESP32.yaml file, to be 16Mb (was 64Mb). (#1209)
 - Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (# ).
 - Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (#1211).
+- Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (# ).
 
 ## [0.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debug: Provide unique default names on DAP client, when multiple RTT Channels have no configured name. (#1208)
 - Added missing memory regions for ESP32.yaml file, to fix RTT Channel name issue. (#1209)
 - Fix maximum addressable Flash size in ESP32.yaml file, to be 16Mb (was 64Mb). (#1209)
+- Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (# ).
 
 ## [0.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (# ).
 - Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (#1211).
 - Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (# ).
+- Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (#1211).
 
 ## [0.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added missing memory regions for ESP32.yaml file, to fix RTT Channel name issue. (#1209)
 - Fix maximum addressable Flash size in ESP32.yaml file, to be 16Mb (was 64Mb). (#1209)
 - Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (# ).
+- Debug: Enable stepping or running past a BKPT (Arm) or EBREAK (Risc-V) instruction (#1211).
 
 ## [0.13.0]
 

--- a/debugger/src/debug_adapter/dap_adapter.rs
+++ b/debugger/src/debug_adapter/dap_adapter.rs
@@ -909,7 +909,10 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                         // Make sure the DAP Client and the DAP Server are in sync with the status of the core.
                         if core_status.is_halted() {
                             if self.halt_after_reset
-                                || core_status == CoreStatus::Halted(HaltReason::Breakpoint)
+                                || matches!(
+                                    core_status,
+                                    CoreStatus::Halted(HaltReason::Breakpoint(_))
+                                )
                             {
                                 let event_body = Some(StoppedEventBody {
                                     reason: core_status.short_long_status().0.to_owned(),
@@ -2226,7 +2229,7 @@ impl DapStatus for CoreStatus {
                 "Core is in LOCKUP status - encountered an unrecoverable exception",
             ),
             CoreStatus::Halted(halt_reason) => match halt_reason {
-                HaltReason::Breakpoint => (
+                HaltReason::Breakpoint(_) => (
                     "breakpoint",
                     "Core halted due to a breakpoint (software or hardware)",
                 ),

--- a/debugger/src/debug_adapter/dap_adapter.rs
+++ b/debugger/src/debug_adapter/dap_adapter.rs
@@ -518,7 +518,10 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             // Use reset_and_halt(), and then resume again afterwards, depending on the reset_after_halt flag.
             match target_core.core.reset_and_halt(Duration::from_millis(500)) {
                 Ok(_) => {
-                    // For RISCV, we need to re-enable any breakpoints that were previously set, because the core reset 'forgets' them.
+                    // Ensure ebreak enters debug mode, this is necessary for soft breakpoints to work on architectures like RISC-V.
+                    target_core.core.debug_on_sw_breakpoint(true)?;
+
+                    // For RISC-V, we need to re-enable any breakpoints that were previously set, because the core reset 'forgets' them.
                     let saved_breakpoints = target_core
                         .core_data
                         .breakpoints
@@ -587,6 +590,9 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             // Otherwise the probe will run past the `main()` before the DAP Client has had a chance to set breakpoints in `main()`.
             match target_core.core.reset_and_halt(Duration::from_millis(500)) {
                 Ok(_) => {
+                    // Ensure ebreak enters debug mode, this is necessary for soft breakpoints to work on architectures like RISC-V.
+                    target_core.core.debug_on_sw_breakpoint(true)?;
+
                     if let Some(request) = request {
                         return self.send_response::<()>(request, Ok(None));
                     }

--- a/debugger/src/debugger/core_data.rs
+++ b/debugger/src/debugger/core_data.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use anyhow::Result;
 use probe_rs::{debug::debug_info::DebugInfo, Core};
-use probe_rs_cli_util::rtt;
+use probe_rs_cli_util::rtt::{self, ChannelMode, DataFormat};
 
 /// [CoreData] is used to cache data needed by the debugger, on a per-core basis.
 pub struct CoreData {
@@ -58,6 +58,10 @@ impl<'p> CoreHandle<'p> {
             Ok(target_rtt) => {
                 for any_channel in target_rtt.active_channels.iter() {
                     if let Some(up_channel) = &any_channel.up_channel {
+                        if any_channel.data_format == DataFormat::Defmt {
+                            // For defmt, we set the channel to be blocking when full.
+                            up_channel.set_mode(&mut self.core, ChannelMode::BlockIfFull)?;
+                        }
                         debugger_rtt_channels.push(debug_rtt::DebuggerRttChannel {
                             channel_number: up_channel.number(),
                             // This value will eventually be set to true by a VSCode client request "rttWindowOpened"

--- a/debugger/src/debugger/debug_entry.rs
+++ b/debugger/src/debugger/debug_entry.rs
@@ -829,7 +829,10 @@ impl Debugger {
                     // Immediately after attaching, halt the core, so that we can finish initalization without bumping into user code.
                     // Depending on supplied `config`, the core will be restarted at the end of initialization in the `configuration_done` request.
                     match halt_core(&mut target_core.core) {
-                        Ok(_) => {}
+                        Ok(_) => {
+                            // Ensure ebreak enters debug mode, this is necessary for soft breakpoints to work on architectures like RISC-V.
+                            target_core.core.debug_on_sw_breakpoint(true)?;
+                        }
                         Err(error) => {
                             debug_adapter.send_error_response(&error)?;
                             return Err(error);

--- a/probe-rs-cli-util/src/rtt.rs
+++ b/probe-rs-cli-util/src/rtt.rs
@@ -4,6 +4,7 @@ use chrono::Local;
 use num_traits::Zero;
 use probe_rs::config::MemoryRegion;
 use probe_rs::Core;
+pub use probe_rs_rtt::ChannelMode;
 use probe_rs_rtt::{DownChannel, Rtt, ScanRegion, UpChannel};
 use serde::Deserialize;
 use std::collections::HashMap;

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -607,7 +607,7 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
             {
                 log::debug!("Encountered a breakpoint instruction @ {}. We need to manually advance the program counter to the next instruction.", pc_after_step);
                 // Advance the program counter by the architecture specific byte size of the BKPT instruction.
-                pc_after_step.add_bytes(2)?;
+                pc_after_step.incremenet_address(2)?;
                 self.write_core_reg(self.registers().program_counter().id, pc_after_step)?;
             }
             self.enable_breakpoints(true)?;

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -569,14 +569,16 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
         // First check if we stopped on a breakpoint, because this requires special handling before we can continue.
-        let was_breakpoint =
-            if self.state.current_state == CoreStatus::Halted(HaltReason::Breakpoint) {
-                log::debug!("Core was halted on breakpoint, disabling breakpoints");
-                self.enable_breakpoints(false)?;
-                true
-            } else {
-                false
-            };
+        let pc_before_step = self.read_core_reg(self.registers().program_counter().id)?;
+        let was_breakpoint = if matches!(
+            self.state.current_state,
+            CoreStatus::Halted(HaltReason::Breakpoint(_))
+        ) {
+            self.enable_breakpoints(false)?;
+            true
+        } else {
+            false
+        };
 
         let mut value = Dhcsr(0);
         // Leave halted state.
@@ -589,18 +591,30 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
 
         self.memory.write_word_32(Dhcsr::ADDRESS, value.into())?;
         self.memory.flush()?;
+
         self.wait_for_core_halted(Duration::from_millis(100))?;
+
+        // Try to read the new program counter.
+        let mut pc_after_step = self.read_core_reg(self.registers().program_counter().id)?;
 
         // Re-enable breakpoints before we continue.
         if was_breakpoint {
+            // If we were stopped on a software breakpoint, then we need to manually advance the PC, or else we will be stuck here forever.
+            if pc_before_step == pc_after_step
+                && !self
+                    .hw_breakpoints()?
+                    .contains(&pc_before_step.try_into().ok())
+            {
+                log::debug!("Encountered a breakpoint instruction @ {}. We need to manually advance the program counter to the next instruction.", pc_after_step);
+                // Advance the program counter by the architecture specific byte size of the BKPT instruction.
+                pc_after_step.add_bytes(2)?;
+                self.write_core_reg(self.registers().program_counter().id, pc_after_step)?;
+            }
             self.enable_breakpoints(true)?;
         }
-        // try to read the program counter
-        let pc_value = self.read_core_reg(PC.id)?;
 
-        // get pc
         Ok(CoreInformation {
-            pc: pc_value.try_into()?,
+            pc: pc_after_step.try_into()?,
         })
     }
 

--- a/probe-rs/src/architecture/arm/core/armv7a_debug_regs.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a_debug_regs.rs
@@ -2,7 +2,7 @@
 use bitfield::bitfield;
 use std::mem::size_of;
 
-use crate::HaltReason;
+use crate::{core::BreakpointCause, HaltReason};
 
 /// A debug register that is accessible to the external debugger
 pub trait Armv7DebugRegister {
@@ -235,11 +235,11 @@ impl Dbgdscr {
                 // Halt request from debugger
                 0b0000 => HaltReason::Request,
                 // Breakpoint debug event
-                0b0001 => HaltReason::Breakpoint,
+                0b0001 => HaltReason::Breakpoint(BreakpointCause::Hardware),
                 // Async watchpoint debug event
                 0b0010 => HaltReason::Watchpoint,
                 // BKPT instruction
-                0b0011 => HaltReason::Breakpoint,
+                0b0011 => HaltReason::Breakpoint(BreakpointCause::Software),
                 // External halt request
                 0b0100 => HaltReason::External,
                 // Vector catch
@@ -247,7 +247,7 @@ impl Dbgdscr {
                 // OS Unlock vector catch
                 0b1000 => HaltReason::Exception,
                 // Sync watchpoint debug event
-                0b1010 => HaltReason::Breakpoint,
+                0b1010 => HaltReason::Watchpoint,
                 // All other values are reserved
                 _ => HaltReason::Unknown,
             }

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -796,7 +796,6 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
         // First check if we stopped on a breakpoint, because this requires special handling before we can continue.
-        let pc_before_step = self.read_core_reg(register::PC.id)?;
         let was_breakpoint =
             if self.state.current_state == CoreStatus::Halted(HaltReason::Breakpoint) {
                 self.enable_breakpoints(false)?;
@@ -827,9 +826,6 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
         self.memory.flush()?;
 
         self.wait_for_core_halted(Duration::from_millis(100))?;
-
-        // Try to read the new program counter.
-        let mut pc_after_step = self.read_core_reg(register::PC.id)?;
 
         // Re-enable breakpoints before we continue.
         if was_breakpoint {

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -843,7 +843,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
             {
                 log::debug!("Encountered a breakpoint instruction @ {}. We need to manually advance the program counter to the next instruction.", pc_after_step);
                 // Advance the program counter by the architecture specific byte size of the BKPT instruction.
-                pc_after_step.add_bytes(2)?;
+                pc_after_step.incremenet_address(2)?;
                 self.write_core_reg(self.registers().program_counter().id, pc_after_step)?;
             }
             self.enable_breakpoints(true)?;

--- a/probe-rs/src/architecture/arm/core/armv8a_debug_regs.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a_debug_regs.rs
@@ -2,7 +2,7 @@
 use bitfield::bitfield;
 use std::mem::size_of;
 
-use crate::HaltReason;
+use crate::{core::BreakpointCause, HaltReason};
 
 /// A debug register that is accessible to the external debugger
 pub trait Armv8DebugRegister {
@@ -135,7 +135,8 @@ impl Edscr {
     pub fn halt_reason(&self) -> HaltReason {
         match self.status() {
             // Breakpoint debug event
-            0b000111 => HaltReason::Breakpoint,
+            // TODO: The DBGDSCR register will contain information about whether this was a Software or Hardware breakpoint.
+            0b000111 => HaltReason::Breakpoint(BreakpointCause::Unknown),
             // External debug request.
             0b010011 => HaltReason::Request,
             // Halting step
@@ -148,8 +149,8 @@ impl Edscr {
             0b100111 => HaltReason::Exception,
             // Watchpoint
             0b101011 => HaltReason::Watchpoint,
-            // HLT instruction.
-            0b101111 => HaltReason::Breakpoint,
+            // HLT instruction - causes entry into Debug state.
+            0b101111 => HaltReason::Breakpoint(BreakpointCause::Software),
             // Software access to debug register.
             0b110011 => HaltReason::Exception,
             // Exception Catch.

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -218,7 +218,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
             {
                 log::debug!("Encountered a breakpoint instruction @ {}. We need to manually advance the program counter to the next instruction.", pc_after_step);
                 // Advance the program counter by the architecture specific byte size of the BKPT instruction.
-                pc_after_step.add_bytes(2)?;
+                pc_after_step.incremenet_address(2)?;
                 self.write_core_reg(self.registers().program_counter().id, pc_after_step)?;
             }
             self.enable_breakpoints(true)?;

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     core::{
-        MemoryMappedRegister, RegisterDataType, RegisterDescription, RegisterFile, RegisterId,
-        RegisterKind, RegisterValue,
+        BreakpointCause, MemoryMappedRegister, RegisterDataType, RegisterDescription, RegisterFile,
+        RegisterId, RegisterKind, RegisterValue,
     },
     CoreStatus, HaltReason,
 };
@@ -930,6 +930,8 @@ impl Dfsr {
         Dfsr(0b11111)
     }
 
+    /// This only returns the correct halt_reason for armv(x)-m variants. The armv(x)-a variants have their own implementation.
+    // TODO: The different implementations between -m and -a can do with cleanup/refactoring.
     fn halt_reason(&self) -> HaltReason {
         if self.0 == 0 {
             // No bit is set
@@ -945,12 +947,12 @@ impl Dfsr {
             // Because of this, we still return breakpoint
             // even if other reasons are possible as well.
             if self.bkpt() {
-                HaltReason::Breakpoint
+                HaltReason::Breakpoint(BreakpointCause::Unknown)
             } else {
                 HaltReason::Multiple
             }
         } else if self.bkpt() {
-            HaltReason::Breakpoint
+            HaltReason::Breakpoint(BreakpointCause::Unknown)
         } else if self.external() {
             HaltReason::External
         } else if self.dwttrap() {

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -247,7 +247,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
             let mut debug_pc = self.read_core_reg(RegisterId(0x7b1))?;
             // Advance the dpc by the size of the EBREAK (c.ebreak) instruction.
             // TODO: The riscv- "c"/compressed variant uses a 2 byte instruction length for c.ebreak. We need to differentiate between different riscv- variants to make this fool proof.
-            debug_pc.add_bytes(2)?;
+            debug_pc.incremenet_address(2)?;
 
             self.write_core_reg(RegisterId(0x7b1), debug_pc)?;
             return Ok(CoreInformation {

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -562,6 +562,16 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
             "Fpu detection not yet implemented"
         )))
     }
+
+    fn debug_on_sw_breakpoint(&mut self, enabled: bool) -> Result<(), crate::error::Error> {
+        let mut dcsr = Dcsr(self.read_core_reg(RegisterId(0x7b0))?.try_into()?);
+
+        dcsr.set_ebreakm(enabled);
+        dcsr.set_ebreaks(enabled);
+        dcsr.set_ebreaku(enabled);
+
+        self.write_csr(0x7b0, dcsr.0).map_err(|e| e.into())
+    }
 }
 
 impl<'probe> MemoryInterface for Riscv32<'probe> {

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -1061,6 +1061,17 @@ impl CoreStatus {
     }
 }
 
+/// When the core halts due to a breakpoint request, some architectures will allow us to distinguish between a software and hardware breakpoint.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum BreakpointCause {
+    /// We encountered a hardware breakpoint.
+    Hardware,
+    /// We encountered a software breakpoint instruction.
+    Software,
+    /// We were not able to distinguish if this was a hardware or software breakpoint.
+    Unknown,
+}
+
 /// The reason why a core was halted.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum HaltReason {
@@ -1070,9 +1081,8 @@ pub enum HaltReason {
     /// step ends up on a breakpoint, after which both breakpoint and step / request
     /// are set.
     Multiple,
-    /// Core halted due to a breakpoint, either
-    /// a *soft* or a *hard* breakpoint.
-    Breakpoint,
+    /// Core halted due to a breakpoint. The cause is `Unknown` if we cannot distinguish between a hardware and software breakpoint.
+    Breakpoint(BreakpointCause),
     /// Core halted due to an exception, e.g. an
     /// an interrupt.
     Exception,

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -132,6 +132,48 @@ pub enum RegisterValue {
 }
 
 impl RegisterValue {
+    /// A helper function to add a fixed number of bytes to a register value.
+    pub fn add_bytes(&mut self, bytes: usize) -> Result<(), Error> {
+        match self {
+            RegisterValue::U32(value) => {
+                if let Some(reg_val) = value.checked_add(bytes as u32) {
+                    *value = reg_val;
+                    Ok(())
+                } else {
+                    Err(Error::Other(anyhow!(
+                        "Overflow error: Attempting to add {} bytes to Register value {}",
+                        bytes,
+                        self
+                    )))
+                }
+            }
+            RegisterValue::U64(value) => {
+                if let Some(reg_val) = value.checked_add(bytes as u64) {
+                    *value = reg_val;
+                    Ok(())
+                } else {
+                    Err(Error::Other(anyhow!(
+                        "Overflow error: Attempting to add {} bytes to Register value {}",
+                        bytes,
+                        self
+                    )))
+                }
+            }
+            RegisterValue::U128(value) => {
+                if let Some(reg_val) = value.checked_add(bytes as u128) {
+                    *value = reg_val;
+                    Ok(())
+                } else {
+                    Err(Error::Other(anyhow!(
+                        "Overflow error: Attempting to add {} bytes to Register value {}",
+                        bytes,
+                        self
+                    )))
+                }
+            }
+        }
+    }
+
     /// A helper function to determine if the contained register value is equal to the maximum value that can be stored in that datatype.
     pub fn is_max_value(&self) -> bool {
         match self {
@@ -199,6 +241,7 @@ impl core::fmt::Display for RegisterValue {
         }
     }
 }
+
 impl From<u32> for RegisterValue {
     fn from(val: u32) -> Self {
         Self::U32(val)

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -493,6 +493,12 @@ pub trait CoreInterface: MemoryInterface {
     /// Returns `true` if hwardware breakpoints are enabled, `false` otherwise.
     fn hw_breakpoints_enabled(&self) -> bool;
 
+    /// Configure the target to ensure software breakpoints will enter Debug Mode.
+    fn debug_on_sw_breakpoint(&mut self, _enabled: bool) -> Result<(), error::Error> {
+        // This default will have override methods for architectures that require special behavior, e.g. RISV-V.
+        Ok(())
+    }
+
     /// Get the `Architecture` of the Core.
     fn architecture(&self) -> Architecture;
 
@@ -848,6 +854,11 @@ impl<'probe> Core<'probe> {
     /// Enables breakpoints on this core. If a breakpoint is set, it will halt as soon as it is hit.
     fn enable_breakpoints(&mut self, state: bool) -> Result<(), error::Error> {
         self.inner.enable_breakpoints(state)
+    }
+
+    /// Configure the debug module to ensure software breakpoints will enter Debug Mode.
+    pub fn debug_on_sw_breakpoint(&mut self, enabled: bool) -> Result<(), error::Error> {
+        self.inner.debug_on_sw_breakpoint(enabled)
     }
 
     /// Returns a list of all the registers of this core.

--- a/probe-rs/src/core/mod.rs
+++ b/probe-rs/src/core/mod.rs
@@ -132,8 +132,8 @@ pub enum RegisterValue {
 }
 
 impl RegisterValue {
-    /// A helper function to add a fixed number of bytes to a register value.
-    pub fn add_bytes(&mut self, bytes: usize) -> Result<(), Error> {
+    /// A helper function to increment an address by a fixed number of bytes.
+    pub fn incremenet_address(&mut self, bytes: usize) -> Result<(), Error> {
         match self {
             RegisterValue::U32(value) => {
                 if let Some(reg_val) = value.checked_add(bytes as u32) {

--- a/probe-rs/src/debug/debug_step.rs
+++ b/probe-rs/src/debug/debug_step.rs
@@ -287,7 +287,7 @@ impl SteppingMode {
                             // We have halted at the address after the current statement, so we can conclude there was no branching calls in this sequence.
                             log::debug!("Stepping into next statement, but no branching calls found. Stepped to next available statement.");
                         } else if new_pc < current_source_statement.instruction_range.end
-                            && matches!(core_status, CoreStatus::Halted(HaltReason::Breakpoint))
+                            && matches!(core_status, CoreStatus::Halted(HaltReason::Breakpoint(_)))
                         {
                             // We have halted at a PC that is within the current statement, so there must be another breakpoint.
                             log::debug!(
@@ -442,7 +442,7 @@ fn step_to_address(
         match core.status()? {
             CoreStatus::Halted(halt_reason) => match halt_reason {
                 HaltReason::Step | HaltReason::Request => continue,
-                HaltReason::Breakpoint => {
+                HaltReason::Breakpoint(_) => {
                     log::debug!(
                         "Encountered a breakpoint before the target address ({:#010x}) was reached.",
                         target_address_range.end()

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -86,9 +86,9 @@ mod session;
 
 pub use crate::config::{CoreType, InstructionSet, Target};
 pub use crate::core::{
-    Architecture, BreakpointId, CommunicationInterface, Core, CoreInformation, CoreInterface,
-    CoreState, CoreStatus, HaltReason, MemoryMappedRegister, RegisterDescription, RegisterFile,
-    RegisterId, RegisterValue, SpecificCoreState,
+    Architecture, BreakpointCause, BreakpointId, CommunicationInterface, Core, CoreInformation,
+    CoreInterface, CoreState, CoreStatus, HaltReason, MemoryMappedRegister, RegisterDescription,
+    RegisterFile, RegisterId, RegisterValue, SpecificCoreState,
 };
 pub use crate::error::Error;
 pub use crate::memory::{Memory, MemoryInterface};

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -576,6 +576,13 @@ impl Drop for Session {
             log::warn!("Could not clear all hardware breakpoints: {:?}", err);
         }
 
+        if let Err(err) = { 0..self.cores.len() }.try_for_each(|i| {
+            self.core(i)
+                .and_then(|mut core| core.debug_on_sw_breakpoint(false))
+        }) {
+            log::warn!("Could not reset software breakpoint behaviour: {:?}", err);
+        }
+
         if let Err(err) = { 0..self.cores.len() }
             .try_for_each(|i| self.core(i).and_then(|mut core| core.on_session_stop()))
         {

--- a/probe-rs/targets/esp32.yaml
+++ b/probe-rs/targets/esp32.yaml
@@ -7,30 +7,43 @@ variants:
     cores:
       - name: main
         type: riscv
-        core_access_options:
-          !Riscv {}
-    memory_map:
+        core_access_options: !Riscv {}
+    memory_map: # From ESP32-C3 Technical Reference Manual, Table 3.2/3.3 Internal/External Memory Address Mapping
       - !Nvm
-          range:
-            start: 0
-            end: 67108864
-          is_boot_memory: true
-          cores:
-            - main
+        range: #16 Mb Max addressable Flash size
+          start: 0x0
+          end: 0x01000000
+        is_boot_memory: true
+        cores:
+          - main
       - !Ram
-          range:
-            start: 1077411840
-            end: 1077805056
-          is_boot_memory: false
-          cores:
-            - main
+        range: # 384 Kb SRAM on Instruction Bus
+          start: 0x40380000
+          end: 0x403e0000
+        is_boot_memory: false
+        cores:
+          - main
       - !Ram
-          range:
-            start: 1070071808
-            end: 1070137344
-          is_boot_memory: false
-          cores:
-            - main
+        range: # 384 Kb SRAM on Data Bus
+          start: 0x3fc80000
+          end: 0x3fc90000
+        is_boot_memory: false
+        cores:
+          - main
+      - !Nvm
+        range: # External Flash on Instruction Bus (Read Only)
+          start: 0x42000000
+          end: 0x42800000
+        is_boot_memory: false
+        cores:
+          - main
+      - !Nvm
+        range: # External Flash on Data Bus (Read Only)
+          start: 0x3c000000
+          end: 0x3c800000
+        is_boot_memory: false
+        cores:
+          - main
     flash_algorithms:
       - esp32c3-flashloader
 flash_algorithms:
@@ -38,7 +51,7 @@ flash_algorithms:
     description: A flash loader for the esp32c3.
     default: true
     instructions: QREGxjcFOUADRQUHGcEBRS2glwDH/+eAoHCBRZcAx//ngIAUlwDH/+eAwBEZ5QFFtwU5QAVGI4jFBrJAQQGCgDGBFwPH/2cAYw4XA8f/ZwBjDRN3NgABxxMFoAqCgK6GsoU2hhcDx/9nAIMMAUWCgAAAAAA=
-    load_address: 1077477376
+    load_address: 0x40390000 # See discussion at https://github.com/probe-rs/probe-rs/pull/1209/#issuecomment-1218430338
     pc_init: 0
     pc_uninit: 108
     pc_program_page: 82
@@ -46,9 +59,9 @@ flash_algorithms:
     pc_erase_all: 74
     data_section_offset: 116
     flash_properties:
-      address_range:
-        start: 0
-        end: 67108864
+      address_range: #16 Mb Max addressable Flash size
+        start: 0x0
+        end: 0x1000000
       page_size: 2048
       erased_byte_value: 255
       program_page_timeout: 1000

--- a/smoke-tester/src/tests/stepping.rs
+++ b/smoke-tester/src/tests/stepping.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use probe_rs::{
-    config::MemoryRegion, Architecture, Core, CoreStatus, DebugProbeError, Error, HaltReason,
-    MemoryInterface,
+    config::MemoryRegion, Architecture, BreakpointCause, Core, CoreStatus, DebugProbeError, Error,
+    HaltReason, MemoryInterface,
 };
 
 const TEST_CODE: &[u8] = include_bytes!("test_arm.bin");
@@ -83,7 +83,11 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
 
     let core_status = core.status()?;
 
-    assert_eq!(core_status, CoreStatus::Halted(HaltReason::Breakpoint));
+    assert!(matches!(
+        core_status,
+        CoreStatus::Halted(HaltReason::Breakpoint(BreakpointCause::Hardware))
+            | CoreStatus::Halted(HaltReason::Breakpoint(BreakpointCause::Unknown))
+    ));
 
     let pc: u64 = core.read_core_reg(registers.program_counter())?;
 
@@ -122,7 +126,11 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
 
     let core_status = core.status()?;
 
-    assert_eq!(core_status, CoreStatus::Halted(HaltReason::Breakpoint));
+    assert!(matches!(
+        core_status,
+        CoreStatus::Halted(HaltReason::Breakpoint(BreakpointCause::Hardware))
+            | CoreStatus::Halted(HaltReason::Breakpoint(BreakpointCause::Unknown))
+    ));
 
     let pc: u64 = core.read_core_reg(registers.program_counter())?;
 


### PR DESCRIPTION
This implements the ability to step over / run past, software breakpoints on the Arm Cortex-M and RISCV architectures.

I do not have any Arm Cortex-A hardware to test changes against, so for now, software breakpoints on Arm Cortex-A will continue to behave as pre- this PR, i.e. you cannot step past them.