### PR TITLE
Handle RISC-V compressed instruction sets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated gdb-server to use gdbstub internally (#1125)
 - gdb-server now uses all cores on a target (#1125)
 - gdb-server now supports floating point registers (#1133)
-- Debug: Correctly handle compressed vs non-compressed instructions sets for RISC-V. (#)
+- Debug: Correctly handle compressed vs non-compressed instructions sets for RISC-V. (#1224)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated gdb-server to use gdbstub internally (#1125)
 - gdb-server now uses all cores on a target (#1125)
 - gdb-server now supports floating point registers (#1133)
+- Debug: Correctly handle compressed vs non-compressed instructions sets for RISC-V. (#)
 
 ### Fixed
 

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -94,6 +94,14 @@ impl DebugCli {
                         .mode(riscvArchMode::RiscV32)
                         .endian(Endian::Little)
                         .build(),
+                    InstructionSet::RV32C => Capstone::new()
+                        .riscv()
+                        .mode(riscvArchMode::RiscV32)
+                        .endian(Endian::Little)
+                        .extra_mode(std::iter::once(
+                            capstone::arch::riscv::ArchExtraMode::RiscVC,
+                        ))
+                        .build(),
                 }
                 .map_err(|err| anyhow!("Error creating capstone: {:?}", err))?;
 

--- a/debugger/src/debug_adapter/dap_adapter.rs
+++ b/debugger/src/debug_adapter/dap_adapter.rs
@@ -1312,6 +1312,11 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 .riscv()
                 .mode(riscvArchMode::RiscV32)
                 .endian(Endian::Little)
+                .build(),
+            InstructionSet::RV32C => Capstone::new()
+                .riscv()
+                .mode(riscvArchMode::RiscV32)
+                .endian(Endian::Little)
                 .extra_mode(std::iter::once(
                     capstone::arch::riscv::ArchExtraMode::RiscVC,
                 ))
@@ -1322,7 +1327,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
         // Adjust instruction offset as required for variable length instruction sets.
         let instruction_offset_as_bytes = match target_instruction_set {
-            InstructionSet::Thumb2 | InstructionSet::RV32 => {
+            InstructionSet::Thumb2 | InstructionSet::RV32C => {
                 // Since we cannot guarantee the size of individual instructions, let's assume we will read the 120% of the requested number of 16-bit instructions.
                 (instruction_offset
                     * target_core
@@ -1332,7 +1337,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     / 4
                     * 5
             }
-            InstructionSet::A32 | InstructionSet::A64 => {
+            InstructionSet::A32 | InstructionSet::A64 | InstructionSet::RV32 => {
                 instruction_offset
                     * target_core
                         .core

--- a/probe-rs-target/src/chip_family.rs
+++ b/probe-rs-target/src/chip_family.rs
@@ -82,8 +82,10 @@ pub enum InstructionSet {
     A32,
     /// ARM A64 (aarch64) instruction set
     A64,
-    /// RISC-V 32-bit instruction set
+    /// RISC-V 32-bit uncompressed instruction sets (RV32) - covers all ISA variants that use 32-bit instructions.
     RV32,
+    /// RISC-V 32-bit compressed instruction sets (RV32C) - covers all ISA variants that allow compressed 16-bit instructions.
+    RV32C,
 }
 
 impl InstructionSet {
@@ -96,21 +98,13 @@ impl InstructionSet {
             }
             InstructionSet::A32 => 4,
             InstructionSet::A64 => 4,
-            InstructionSet::RV32 => {
-                // Assume that we are using the RV32C (compressed) instruction set.
-                // TODO: Need an impl of RV32 and RV32C to properly differentiate this, then we don't need to assume.
-                2
-            }
+            InstructionSet::RV32 => 4,
+            InstructionSet::RV32C => 2,
         }
     }
-    /// Get the maximum instruction size in bytes.
+    /// Get the maximum instruction size in bytes. All supported architectures have a maximum instruction size of 4 bytes.
     pub fn get_maximum_instruction_size(&self) -> u8 {
-        match self {
-            InstructionSet::Thumb2 => 4,
-            InstructionSet::A32 => 4,
-            InstructionSet::A64 => 4,
-            InstructionSet::RV32 => 4,
-        }
+        4
     }
 }
 


### PR DESCRIPTION
The current implementation of RISC-V assumed that the instruction set architecture (isa) was always compressed. 

WIth this change, we read the `misa` register to determine the actual value of compressed vs non-compressed, and use the value to define behavior for things like stepping and disassembly.

PS. I believe this is the last outstanding 'known' issue in #877 