### PR TITLE
Debug: Gracefully handle stack unwind when CFA rule references a FP with value of zero.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix maximum addressable Flash size in ESP32.yaml file, to be 16Mb (was 64Mb). (#1209)
 - Debug: Enable stepping or running past a BKPT (Arm Cortex-M) or EBREAK (RISC-V) instruction (#1211).
 - (#1058) Non-successful DAP Transfer requests no longer require response data to be present.
+- Debug: Gracefully handle stack unwind when CFA rule references a FP with value of zero. (#1226)
 
 ## [0.13.0]
 


### PR DESCRIPTION
This fixes an error where stack unwinding would give an error, 
```
UNWIND: Failed to read from address 0xfffffffffffffff8 (4 bytes): A core architecture specific error occurred [2022-09-16T14:08:52Z ERROR probe_rs::debug::debug_info] UNWIND: Rule: Offset -16 from address 0x00000008
```
The correct behaviour is to detect the case where the CFA register rule references a FP with a zero value, and gracefully end the  unwind process. The error was only reproduce-able on NRF chips, and the same code would unwind successfully on ST, PICO and ESP32-C3 tests.