### PR TITLE
Fix: Debugger: Improve core status checking during launch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debug: Enable stepping or running past a BKPT (Arm Cortex-M) or EBREAK (RISC-V) instruction (#1211).
 - (#1058) Non-successful DAP Transfer requests no longer require response data to be present.
 - Debug: Gracefully handle stack unwind when CFA rule references a FP with value of zero. (#1226)
+- Debugger: Improve core status checking during launch.(#1228)
 
 ## [0.13.0]
 

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::inconsistent_digit_grouping)]
 
 use crate::core::{Architecture, BreakpointCause};
-use crate::{CoreInterface, CoreType, InstructionSet};
+use crate::{CoreInterface, CoreType, DebugProbeError, InstructionSet};
 use anyhow::{anyhow, Result};
 use communication_interface::{
     AbstractCommandErrorKind, DebugRegister, RiscvCommunicationInterface, RiscvError,
@@ -109,7 +109,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
             }
         }
 
-        Err(RiscvError::Timeout.into())
+        Err(Error::Probe(DebugProbeError::Timeout))
     }
 
     fn core_halted(&mut self) -> Result<bool, crate::Error> {


### PR DESCRIPTION
In rare cases the debugger and core would be out of synch immediately after launch. The known cases where this could be reproduced involved a situation where the core would halt on a breakpoint shortly after the debugger read a `CoreStatus::Running` from the core.

The fix also includes a change to RISC-V `wait_for_core_halted()` which returned a different timeout error than the one returned by other architectures.