### PR TITLE
Full support for ATSAM D5x/E5x Devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for in-line (column specific) breakpoints where multiple statements (potential breakpoints) are on the same line of source code. (#1156)
 - Added support for MSP432P4XX targets (#1201)
 - Added support for Microchip SAMDA1
+- Added Probe re-attach handling when needed after `debug_device_unlock`
+- Added Custom ArmDebugSequence for ATSAM D5x/E5x devices
 
 ### Changed
 

--- a/probe-rs/src/architecture/arm/sequences/atsame5x.rs
+++ b/probe-rs/src/architecture/arm/sequences/atsame5x.rs
@@ -10,19 +10,19 @@ use anyhow::Result;
 bitfield! {
     /// Device Service Unit Control Register, DSU - CTRL
     #[derive(Copy, Clone)]
-    struct DsuCtrl(u8);
+    pub struct DsuCtrl(u8);
     impl Debug;
-    // Chip-Erase
-    // Writing a '0' to this bit has no effect.
-    // Writing a '1' to this bit starts the Chip-Erase operation.
+    /// Chip-Erase
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit starts the Chip-Erase operation.
     pub _, set_ce: 4;
-    // Memory Built-In Self-Test
-    // Writing a '0' to this bit has no effect.
-    // Writing a '1' to this bit starts the memory BIST algorithm.
+    /// Memory Built-In Self-Test
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit starts the memory BIST algorithm.
     pub _, set_mbist: 3;
-    // 32-bit Cyclic Redundancy Check
-    // Writing a '0' to this bit has no effect.
-    // Writing a '1' to this bit starts the cyclic redundancy check algorithm.
+    /// 32-bit Cyclic Redundancy Check
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit starts the cyclic redundancy check algorithm.
     pub _, set_crc: 2;
     /// Software Reset
     /// Writing a '0' to this bit has no effect.
@@ -31,7 +31,8 @@ bitfield! {
 }
 
 impl DsuCtrl {
-    const ADDRESS: u64 = 0x4100_2100;
+    /// The DSU CTRL register address
+    pub const ADDRESS: u64 = 0x4100_2100;
 }
 
 impl From<u8> for DsuCtrl {
@@ -49,36 +50,36 @@ impl From<DsuCtrl> for u8 {
 bitfield! {
     /// Device Service Unit Control Register, DSU - CTRL
     #[derive(Copy, Clone)]
-    struct DsuStatusA(u8);
+    pub struct DsuStatusA(u8);
     impl Debug;
-    // Protection Error
-    // Writing a '0' to this bit has no effect.
-    // Writing a '1' to this bit clears the Protection Error bit.
-    // This bit is set when a command that is not allowed in Protected state is issued.
+    /// Protection Error
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit clears the Protection Error bit.
+    /// This bit is set when a command that is not allowed in Protected state is issued.
     pub perr, set_perr: 4;
 
-    // Failure
-    // Writing a '0' to this bit has no effect.
-    // Writing a '1' to this bit clears the Failure bit.
-    // This bit is set when a DSU operation failure is detected.
+    /// Failure
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit clears the Failure bit.
+    /// This bit is set when a DSU operation failure is detected.
     pub fail, set_fail: 3;
 
-    // Bus Error
-    // Writing a '0' to this bit has no effect.
-    // Writing a '1' to this bit clears the Bus Error bit.
-    // This bit is set when a bus error is detected.
+    /// Bus Error
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit clears the Bus Error bit.
+    /// This bit is set when a bus error is detected.
     pub berr, set_berr: 2;
 
-    // CPU Reset Phase Extension
-    // Writing a '0' to this bit has no effect.
-    // Writing a '1' to this bit clears the CPU Reset Phase Extension bit.
-    // This bit is set when a debug adapter Cold-Plugging is detected, which extends the CPU Reset phase.
+    /// CPU Reset Phase Extension
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit clears the CPU Reset Phase Extension bit.
+    /// This bit is set when a debug adapter Cold-Plugging is detected, which extends the CPU Reset phase.
     pub crstext, set_crstext: 1;
 
-    // Done
-    // Writing a '0' to this bit has no effect.
-    // Writing a '1' to this bit clears the Done bit.
-    // This bit is set when a DSU operation is completed.
+    /// Done
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit clears the Done bit.
+    /// This bit is set when a DSU operation is completed.
     pub done, set_done: 0;
 }
 
@@ -95,39 +96,40 @@ impl From<DsuStatusA> for u8 {
 }
 
 impl DsuStatusA {
-    const ADDRESS: u64 = 0x4100_2101;
+    /// The DSU STATUSA register address
+    pub const ADDRESS: u64 = 0x4100_2101;
 }
 
 bitfield! {
     /// Device Service Unit Control Register, DSU - CTRL
     #[derive(Copy, Clone)]
-    struct DsuStatusB(u8);
+    pub struct DsuStatusB(u8);
     impl Debug;
 
-    // Chip Erase Locked
-    // This bit is set when Chip Erase is locked.
-    // This bit is cleared when Chip Erase is unlocked.
+    /// Chip Erase Locked
+    /// This bit is set when Chip Erase is locked.
+    /// This bit is cleared when Chip Erase is unlocked.
     pub celck, _: 5;
-    // Hot-Plugging Enable
-    // This bit is set when Hot-Plugging is enabled.
-    // This bit is cleared when Hot-Plugging is disabled. This is the case when the SWCLK function is changed.
-    // Only a power-reset or a external reset can set it again.
+    /// Hot-Plugging Enable
+    /// This bit is set when Hot-Plugging is enabled.
+    /// This bit is cleared when Hot-Plugging is disabled. This is the case when the SWCLK function is changed.
+    /// Only a power-reset or a external reset can set it again.
     pub hpe, _: 4;
-    // Debug Communication Channel 1 Dirty
-    // This bit is set when DCC is written.
-    // This bit is cleared when DCC is read.
+    /// Debug Communication Channel 1 Dirty
+    /// This bit is set when DCC is written.
+    /// This bit is cleared when DCC is read.
     pub dccd1, _: 3;
-    // Debug Communication Channel 0 Dirty
-    // This bit is set when DCC is written.
-    // This bit is cleared when DCC is read.
+    /// Debug Communication Channel 0 Dirty
+    /// This bit is set when DCC is written.
+    /// This bit is cleared when DCC is read.
     pub dccd0, _: 2;
-    // Debugger Present
-    // This bit is set when a debugger probe is detected.
-    // This bit is never cleared.
+    /// Debugger Present
+    /// This bit is set when a debugger probe is detected.
+    /// This bit is never cleared.
     pub dbgpres, _: 1;
-    // Protected
-    // This bit is set at power-up when the device is protected.
-    // This bit is never cleared.
+    /// Protected
+    /// This bit is set at power-up when the device is protected.
+    /// This bit is never cleared.
     pub prot, _: 0;
 
 }
@@ -145,7 +147,8 @@ impl From<DsuStatusB> for u8 {
 }
 
 impl DsuStatusB {
-    const ADDRESS: u64 = 0x4100_2102;
+    /// The DSU STATUSB register address
+    pub const ADDRESS: u64 = 0x4100_2102;
 }
 
 /// A wrapper for different types that can perform SWD Commands (SWJ_Pins SWJ_Sequence)
@@ -182,12 +185,15 @@ impl AtSAME5x {
 
     /// Perform a Chip-Erase operation
     ///
+    /// Issue a Chip-Erase command to the device provided that `permission` grants `erase-all`.
+    ///
     /// # Errors
     /// This operation can fail due to insufficient permissions, or if Chip-Erase Lock is
     /// enabled (this lock can only be released from within the device firmare).
     /// After a successful Chip-Erase a `DebugProbeError::ReAttachRequired` is returned
     /// to signal that a re-connect is needed for the DSU to start operating in unlocked mode.
     pub fn erase_all(&self, memory: &mut Memory, permissions: &Permissions) -> Result<(), Error> {
+        let dsu_status_a = DsuStatusA::from(memory.read_word_8(DsuStatusA::ADDRESS)?);
         let dsu_status_b = DsuStatusB::from(memory.read_word_8(DsuStatusB::ADDRESS)?);
 
         match (dsu_status_b.celck(), dsu_status_b.prot(), permissions.erase_all()) {
@@ -198,7 +204,7 @@ impl AtSAME5x {
             )),
             (false, true, Err(_)) => Err(Error::MissingPermissions(
                 "Device is locked. A Chip-Erase operation is required to unlock. \
-                            Re-run with '--connect-under-reset --allow-erase-all' to perform Chip-Erase."
+                            Re-run with granting the 'erase-all' permission and connecting under reset"
                     .into(),
             )),
             (false, false, Err(e)) => Err(e),
@@ -217,7 +223,12 @@ impl AtSAME5x {
             let current_dsu_statusa = DsuStatusA::from(memory.read_word_8(DsuStatusA::ADDRESS)?);
             if current_dsu_statusa.done() {
                 log::info!("Chip-Erase complete");
-                self.reset_hardware_with_extension(memory.get_arm_interface()?)?;
+                // If the device was in Reset Extension when we started put it back into Reset Extension
+                if dsu_status_a.crstext() {
+                    self.reset_hardware_with_extension(memory.get_arm_interface()?)?;
+                } else {
+                    self.reset_hardware(memory.get_arm_interface()?)?;
+                }
 
                 // We need to reconnect to target to finalize the unlock.
                 // Signal ReAttachRequired so that the session will try to re-connect

--- a/probe-rs/src/architecture/arm/sequences/atsame5x.rs
+++ b/probe-rs/src/architecture/arm/sequences/atsame5x.rs
@@ -370,7 +370,7 @@ impl ArmDebugSequence for AtSAME5x {
         let dsu_status_b = DsuStatusB::from(memory.read_word_8(DsuStatusB::ADDRESS)?);
 
         if dsu_status_b.prot() {
-            log::warn!("device is locked, unlocking..");
+            log::warn!("The Device is locked, unlocking..");
             self.erase_all(&mut memory, permissions)
         } else {
             Ok(())

--- a/probe-rs/src/architecture/arm/sequences/atsame5x.rs
+++ b/probe-rs/src/architecture/arm/sequences/atsame5x.rs
@@ -1,0 +1,379 @@
+//! Sequences for ATSAM D5x/E5x target families
+
+use super::ArmDebugSequence;
+use crate::{architecture, DebugProbeError, Error, Memory, Permissions};
+use bitfield::bitfield;
+use std::sync::Arc;
+
+use anyhow::Result;
+
+bitfield! {
+    /// Device Service Unit Control Register, DSU - CTRL
+    #[derive(Copy, Clone)]
+    struct DsuCtrl(u8);
+    impl Debug;
+    // Chip-Erase
+    // Writing a '0' to this bit has no effect.
+    // Writing a '1' to this bit starts the Chip-Erase operation.
+    pub _, set_ce: 4;
+    // Memory Built-In Self-Test
+    // Writing a '0' to this bit has no effect.
+    // Writing a '1' to this bit starts the memory BIST algorithm.
+    pub _, set_mbist: 3;
+    // 32-bit Cyclic Redundancy Check
+    // Writing a '0' to this bit has no effect.
+    // Writing a '1' to this bit starts the cyclic redundancy check algorithm.
+    pub _, set_crc: 2;
+    /// Software Reset
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit resets the module.
+    pub _, set_swrst: 0;
+}
+
+impl DsuCtrl {
+    const ADDRESS: u64 = 0x4100_2100;
+}
+
+impl From<u8> for DsuCtrl {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DsuCtrl> for u8 {
+    fn from(value: DsuCtrl) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// Device Service Unit Control Register, DSU - CTRL
+    #[derive(Copy, Clone)]
+    struct DsuStatusA(u8);
+    impl Debug;
+    // Protection Error
+    // Writing a '0' to this bit has no effect.
+    // Writing a '1' to this bit clears the Protection Error bit.
+    // This bit is set when a command that is not allowed in Protected state is issued.
+    pub perr, set_perr: 4;
+
+    // Failure
+    // Writing a '0' to this bit has no effect.
+    // Writing a '1' to this bit clears the Failure bit.
+    // This bit is set when a DSU operation failure is detected.
+    pub fail, set_fail: 3;
+
+    // Bus Error
+    // Writing a '0' to this bit has no effect.
+    // Writing a '1' to this bit clears the Bus Error bit.
+    // This bit is set when a bus error is detected.
+    pub berr, set_berr: 2;
+
+    // CPU Reset Phase Extension
+    // Writing a '0' to this bit has no effect.
+    // Writing a '1' to this bit clears the CPU Reset Phase Extension bit.
+    // This bit is set when a debug adapter Cold-Plugging is detected, which extends the CPU Reset phase.
+    pub crstext, set_crstext: 1;
+
+    // Done
+    // Writing a '0' to this bit has no effect.
+    // Writing a '1' to this bit clears the Done bit.
+    // This bit is set when a DSU operation is completed.
+    pub done, set_done: 0;
+}
+
+impl From<u8> for DsuStatusA {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DsuStatusA> for u8 {
+    fn from(value: DsuStatusA) -> Self {
+        value.0
+    }
+}
+
+impl DsuStatusA {
+    const ADDRESS: u64 = 0x4100_2101;
+}
+
+bitfield! {
+    /// Device Service Unit Control Register, DSU - CTRL
+    #[derive(Copy, Clone)]
+    struct DsuStatusB(u8);
+    impl Debug;
+
+    // Chip Erase Locked
+    // This bit is set when Chip Erase is locked.
+    // This bit is cleared when Chip Erase is unlocked.
+    pub celck, _: 5;
+    // Hot-Plugging Enable
+    // This bit is set when Hot-Plugging is enabled.
+    // This bit is cleared when Hot-Plugging is disabled. This is the case when the SWCLK function is changed.
+    // Only a power-reset or a external reset can set it again.
+    pub hpe, _: 4;
+    // Debug Communication Channel 1 Dirty
+    // This bit is set when DCC is written.
+    // This bit is cleared when DCC is read.
+    pub dccd1, _: 3;
+    // Debug Communication Channel 0 Dirty
+    // This bit is set when DCC is written.
+    // This bit is cleared when DCC is read.
+    pub dccd0, _: 2;
+    // Debugger Present
+    // This bit is set when a debugger probe is detected.
+    // This bit is never cleared.
+    pub dbgpres, _: 1;
+    // Protected
+    // This bit is set at power-up when the device is protected.
+    // This bit is never cleared.
+    pub prot, _: 0;
+
+}
+
+impl From<u8> for DsuStatusB {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DsuStatusB> for u8 {
+    fn from(value: DsuStatusB) -> Self {
+        value.0
+    }
+}
+
+impl DsuStatusB {
+    const ADDRESS: u64 = 0x4100_2102;
+}
+
+/// A wrapper for different types that can perform SWD Commands (SWJ_Pins SWJ_Sequence)
+struct SwdSequenceShim<'a>(&'a mut dyn architecture::arm::communication_interface::DapProbe);
+
+impl<'a> From<&'a mut dyn architecture::arm::communication_interface::DapProbe>
+    for SwdSequenceShim<'a>
+{
+    fn from(p: &'a mut dyn architecture::arm::communication_interface::DapProbe) -> Self {
+        Self(p)
+    }
+}
+
+impl<'a> architecture::arm::communication_interface::SwdSequence for SwdSequenceShim<'a> {
+    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), Error> {
+        self.0.swj_sequence(bit_len, bits).map_err(Error::Probe)
+    }
+
+    fn swj_pins(&mut self, pin_out: u32, pin_select: u32, pin_wait: u32) -> Result<u32, Error> {
+        self.0
+            .swj_pins(pin_out, pin_select, pin_wait)
+            .map_err(Error::Probe)
+    }
+}
+
+/// Marker struct indicating initialization sequencing for ATSAM D5x/E5x family parts.
+pub struct AtSAME5x {}
+
+impl AtSAME5x {
+    /// Create the sequencer for the ATSAM D5x/E5x family of parts.
+    pub fn create() -> Arc<Self> {
+        Arc::new(Self {})
+    }
+
+    /// Perform a Chip-Erase operation
+    ///
+    /// # Errors
+    /// This operation can fail due to insufficient permissions, or if Chip-Erase Lock is
+    /// enabled (this lock can only be released from within the device firmare).
+    /// After a successful Chip-Erase a `DebugProbeError::ReAttachRequired` is returned
+    /// to signal that a re-connect is needed for the DSU to start operating in unlocked mode.
+    pub fn erase_all(&self, memory: &mut Memory, permissions: &Permissions) -> Result<(), Error> {
+        let dsu_status_b = DsuStatusB::from(memory.read_word_8(DsuStatusB::ADDRESS)?);
+
+        match (dsu_status_b.celck(), dsu_status_b.prot(), permissions.erase_all()) {
+            (true, _, _) => Err(Error::MissingPermissions(
+                "Chip-Erase is locked. This can only be unlocked from within the device firmware by performing \
+                a Chip-Erase Unlock (CEULCK) command."
+                    .into(),
+            )),
+            (false, true, Err(_)) => Err(Error::MissingPermissions(
+                "Device is locked. A Chip-Erase operation is required to unlock. \
+                            Re-run with '--connect-under-reset --allow-erase-all' to perform Chip-Erase."
+                    .into(),
+            )),
+            (false, false, Err(e)) => Err(e),
+            (false, _, Ok(())) => Ok(()),
+        }?;
+
+        // Start the chip-erase process
+        let mut dsu_ctrl = DsuCtrl(0);
+        dsu_ctrl.set_ce(true);
+        memory.write_word_8(DsuCtrl::ADDRESS, dsu_ctrl.0)?;
+        log::info!("Chip-Erase started..");
+
+        // Wait for it to finish
+        let start = std::time::Instant::now();
+        while start.elapsed() < std::time::Duration::from_secs(8) {
+            let current_dsu_statusa = DsuStatusA::from(memory.read_word_8(DsuStatusA::ADDRESS)?);
+            if current_dsu_statusa.done() {
+                log::info!("Chip-Erase complete");
+                self.reset_hardware_with_extension(memory.get_arm_interface()?)?;
+
+                // We need to reconnect to target to finalize the unlock.
+                // Signal ReAttachRequired so that the session will try to re-connect
+                return Err(Error::Probe(DebugProbeError::ReAttachRequired));
+            } else if current_dsu_statusa.fail() {
+                return Err(Error::Other(anyhow::anyhow!("Chip-Erase Failed")));
+            }
+            std::thread::sleep(std::time::Duration::from_millis(250));
+        }
+
+        log::error!("Chip-Erase failed to complete within 8 seconds");
+        Err(Error::Probe(DebugProbeError::Timeout))
+    }
+
+    /// Perform a hardware reset in a way that puts the core into CPU Reset Extension
+    ///
+    /// CPU Reset Extension is a vendor specific feature that allows the CPU core to remain
+    /// in reset while the rest of the debugging subsystem can run and initialize itself.
+    ///
+    /// For more details see: 12.6.2 CPU Reset Extension in the SAM D5/E5 Family Data Sheet
+    ///
+    /// # Errors
+    /// Subject to probe communication errors
+    pub fn reset_hardware_with_extension(
+        &self,
+        interface: &mut dyn architecture::arm::communication_interface::SwdSequence,
+    ) -> Result<(), Error> {
+        let mut pins = architecture::arm::Pins(0);
+        pins.set_nreset(true);
+        pins.set_swdio_tms(true);
+        pins.set_swclk_tck(true);
+
+        let mut pin_values = architecture::arm::Pins(0);
+
+        // First set nReset, SWDIO and SWCLK to low.
+        let _ = interface.swj_pins(pin_values.0 as u32, pins.0 as u32, 0)?;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        // Next release nReset, but keep SWDIO and SWCLK low. This should put the device into
+        // reset extension ()
+        pin_values.set_nreset(true);
+        let _ = interface.swj_pins(pin_values.0 as u32, pins.0 as u32, 0)?;
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        Ok(())
+    }
+
+    /// Release the CPU core from Reset Extension
+    ///
+    /// Clear the DSU Reset Extension bit, which releases the core from reset extension.
+    ///
+    /// # Errors
+    /// Subject to probe communication errors
+    pub fn release_reset_extension(&self, memory: &mut Memory) -> Result<(), Error> {
+        // clear the reset extension bit
+        let mut dsu_statusa = DsuStatusA(0);
+        dsu_statusa.set_crstext(true);
+        memory.write_8(DsuStatusA::ADDRESS, &[dsu_statusa.0])?;
+
+        let start = std::time::Instant::now();
+        while start.elapsed() < std::time::Duration::from_millis(100) {
+            let current_dsu_statusa = DsuStatusA::from(memory.read_word_8(DsuStatusA::ADDRESS)?);
+            if !current_dsu_statusa.crstext() {
+                return Ok(());
+            }
+        }
+
+        Err(Error::Probe(DebugProbeError::Timeout))
+    }
+
+    /// Perform a normal hardware reset without triggering a Reset extension
+    ///
+    /// # Errors
+    /// Subject to probe communication errors
+    pub fn reset_hardware(
+        &self,
+        interface: &mut dyn architecture::arm::communication_interface::SwdSequence,
+    ) -> Result<(), Error> {
+        let mut pins = architecture::arm::Pins(0);
+        pins.set_nreset(true);
+        pins.set_swdio_tms(true);
+        pins.set_swclk_tck(true);
+
+        let mut pin_values = pins;
+        pin_values.set_nreset(false);
+
+        let _ = interface.swj_pins(pin_values.0 as u32, pins.0 as u32, 0)?;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        pin_values.set_nreset(true);
+        let _ = interface.swj_pins(pin_values.0 as u32, pins.0 as u32, 0)?;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        Ok(())
+    }
+}
+
+impl ArmDebugSequence for AtSAME5x {
+    /// `reset_hardware_assert` for ATSAM D5x/E5x devices
+    ///
+    /// Instead of keeping `nReset` asserted, the device is instead put into CPU Reset Extension
+    /// which will keep the CPU Core in reset until manually released by the debugger probe.
+    fn reset_hardware_assert(
+        &self,
+        interface: &mut dyn architecture::arm::communication_interface::DapProbe,
+    ) -> Result<(), Error> {
+        let mut shim = SwdSequenceShim::from(interface);
+        self.reset_hardware_with_extension(&mut shim)
+    }
+
+    /// `reset_hardware_deassert` for ATSAM D5x/E5x devices
+    ///
+    /// Instead of de-asserting `nReset` here (this was already done during the CPU Reset Extension process),
+    /// the device is released from Reset Extension.
+    fn reset_hardware_deassert(&self, memory: &mut Memory) -> Result<(), Error> {
+        let interface = memory.get_arm_probe();
+
+        let mut pins = architecture::arm::Pins(0);
+        pins.set_nreset(true);
+
+        let current_pins =
+            architecture::arm::Pins(interface.swj_pins(pins.0 as u32, pins.0 as u32, 0)? as u8);
+        if !current_pins.nreset() {
+            return Err(Error::Probe(DebugProbeError::Other(anyhow::anyhow!(
+                "Expected nReset to already be de-asserted"
+            ))));
+        }
+
+        self.release_reset_extension(memory)
+    }
+
+    /// `debug_device_unlock` for ATSAM D5x/E5x devices
+    ///
+    /// First check the device lock status by querying its Device Service Unit (DSU).
+    /// If the device is already unlocked then return `Ok` directly.
+    /// If the device is locked the following happens:
+    /// * If the `erase_all` permission is missing return the appropriate error
+    /// * If the Chip-Erase command is also locked then return an error since Chip-Erase Unlock can only be
+    ///   done from within the device firmware.
+    /// * Perform a Chip-Erase to unlock the device and if successful return a `DebugProbeError::ReAttachRequired`
+    ///   to signal that a probe re-attach is required before the new `unlocked` status takes effect.
+    fn debug_device_unlock(
+        &self,
+        interface: &mut Box<dyn architecture::arm::ArmProbeInterface>,
+        default_ap: architecture::arm::ap::MemoryAp,
+        permissions: &Permissions,
+    ) -> Result<(), Error> {
+        // First check if the device is locked
+        let mut memory = interface.memory_interface(default_ap)?;
+        let dsu_status_b = DsuStatusB::from(memory.read_word_8(DsuStatusB::ADDRESS)?);
+
+        if dsu_status_b.prot() {
+            log::warn!("device is locked, unlocking..");
+            self.erase_all(&mut memory, permissions)
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -1,5 +1,6 @@
 //! Debug sequences to operate special requirements ARM targets.
 
+pub mod atsame5x;
 mod nrf;
 pub mod nrf52;
 pub mod nrf53;

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -2,6 +2,7 @@ use probe_rs_target::{Architecture, ChipFamily};
 
 use super::{Core, MemoryRegion, RawFlashAlgorithm, RegistryError, TargetDescriptionSource};
 use crate::architecture::arm::sequences::{
+    atsame5x::AtSAME5x,
     nrf52::Nrf52,
     nrf53::Nrf5340,
     nrf91::Nrf9160,
@@ -122,6 +123,9 @@ impl Target {
         {
             log::warn!("Using custom sequence for STM32F2/4/7");
             debug_sequence = DebugSequence::Arm(Stm32fSeries::create());
+        } else if chip.name.starts_with("ATSAMD5") || chip.name.starts_with("ATSAME5") {
+            log::warn!("Using custom sequence for {}", chip.name);
+            debug_sequence = DebugSequence::Arm(AtSAME5x::create());
         }
 
         Ok(Target {

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -145,6 +145,10 @@ pub enum DebugProbeError {
     /// Check the wiring before continuing.
     #[error("Failed to find the target or attach to the target")]
     TargetNotFound,
+    /// Performing certain operations (e.g device unlock or Chip-Erase) can leave the device in a state
+    /// that requires a probe re-attach to resolve.
+    #[error("Probe and device internal state mismatch. A probe re-attach is required")]
+    ReAttachRequired,
     /// The variant of the function you called is not yet implemented.
     /// This can happen if some debug probe has some unimplemented functionality for a specific protocol or architecture.
     #[error("Some functionality was not implemented yet: {0}")]

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -186,7 +186,7 @@ impl Session {
                     Ok(()) => (),
                     // In case this happens after unlock. Try to re-attach the probe once.
                     Err(crate::Error::Probe(crate::DebugProbeError::ReAttachRequired)) => {
-                        log::debug!("Re-attaching Probe");
+                        log::debug!("Re-attaching to the Probe");
                         let mut probe = interface.close();
                         probe.detach()?;
                         probe.attach_to_unspecified()?;
@@ -195,7 +195,7 @@ impl Session {
                             probe.try_into_arm_interface().map_err(|(_, err)| err)?;
                         interface = arm_interface.initialize(sequence_handle.clone())?;
 
-                        log::debug!("Probe re-attached");
+                        log::debug!("The probe was re-attached");
                     }
                     Err(e) => return Err(e),
                 }


### PR DESCRIPTION
This change implements full support for the ATSAMD5x and ATSAME5x families by providing a custom `ArmDebugSequence` implementation for these devices which utilizes the vendor specific "CPU Reset Extension" and "Chip-Erase" features of these devices.

This implementation may work out-of-the-box (or used as a base) for other ATSAM families of devices but since I do not have any of those devices at hand, I could not test them.

With this change `--connect-under-reset` performs the Debugger Cold-Plugging which required to connect to locked devices or devices where the SWD pins have been remapped in firmware.

`--connect-under-reset --allow-erase-all` will unlock a locked device by issuing a Chip-Erase followed by a re-attach of the debug probe.

Tested on HS-Probe with ATSAME51N20A and on EDBG with ATSAME54P20A (SAME54 Xplained PRO). Although ATSAMD5x is not explicitly tested, the ATSAME5x is essentially the same silicon with extra CAN peripherals, so it should be safe to claim ATSAMD5x support as well.

Note: one outstanding issue that I am not sure how best to solve, is that this provided Chip-Erase method is not used during flashing (even with `--chip-erase`) as there seems to be no way of selecting custom Chip-Erase implementations during flashing (it only uses data from the target description files which in this case don't claim chip-erase support). 
