### PR TITLE
Stack overflow when expanding "static" section in probe-rs-debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (#1058) Non-successful DAP Transfer requests no longer require response data to be present.
 - Debug: Gracefully handle stack unwind when CFA rule references a FP with value of zero. (#1226)
 - Debugger: Improve core status checking during launch.(#1228)
+- Debugger: Stack overflow when expanding "static" section in probe-rs-debugger. (#1231)
 
 ## [0.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (#1058) Non-successful DAP Transfer requests no longer require response data to be present.
 - Debug: Gracefully handle stack unwind when CFA rule references a FP with value of zero. (#1226)
 - Debugger: Improve core status checking during launch.(#1228)
-- Debugger: Stack overflow when expanding "static" section in probe-rs-debugger. (#1231)
+- Debugger: Prevent stack overflows when expanding "static" section in probe-rs-debugger. (#1231)
 
 ## [0.13.0]
 

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
 };
 use crate::{core::Core, MemoryInterface};
 use gimli::DebuggingInformationEntry;
-use num_traits::Zero;
+
 use std::{
     io,
     path::PathBuf,

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -296,15 +296,10 @@ pub(crate) fn _print_all_attributes(
                                 .unwrap()
                         }
                         RequiresRelocatedAddress(address_index) => {
-                            if address_index.is_zero() {
-                                // This is a rust-lang bug for statics ... https://github.com/rust-lang/rust/issues/32574;
-                                evaluation.resume_with_relocated_address(u64::MAX).unwrap()
-                            } else {
-                                // Use the address_index as an offset from 0, so just pass it into the next step.
-                                evaluation
-                                    .resume_with_relocated_address(address_index)
-                                    .unwrap()
-                            }
+                            // Use the address_index as an offset from 0, so just pass it into the next step.
+                            evaluation
+                                .resume_with_relocated_address(address_index)
+                                .unwrap()
                         }
                         x => {
                             println!("print_all_attributes {:?}", x);


### PR DESCRIPTION
There was an error in the logic that prevented cetain variable types from being loaded in a deferred/lazy way. This resulted in situations where recursively referenced types (as in a linked list) would loop forever trying to resolve all children of a structured variable.

Fixes #1231

Additional fixes: 
- This also fixes a new issue (exposed by testing of this PR). Recent changes in RUST have removed the intermediate `DW_AT_name` attribute for the `DW_AT_type` of the `data_ptr` child of `&str` variables, resulting in a failure to resolve those variable values during debug.
- A [RUST compiler issue](https://github.com/rust-lang/rust/issues/32574) resulted in a reference to a variable being left behind in the debug info, even though the value has been optimized out. This PR updated the error message to be a bit more user friendly.


