### PR TITLE
Debug Erase Sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for MAX32660 target (#1249)
 - Added support for W7500 target
 - Added an optional `stack_size` configuration to flash algorithms to control the stack size (#1260)
+- Added Support for Debug Erase Sequences that (if available) are used instead of the normal chip-erase logic
 
 ### Changed
 

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -732,4 +732,27 @@ pub trait ArmDebugSequence: Send + Sync {
         // Empty by default
         Ok(())
     }
+
+    /// Return the Debug Erase Sequence implementation if it exists
+    fn debug_erase_sequence(&self) -> Option<Arc<dyn DebugEraseSequence>> {
+        None
+    }
+}
+
+/// Chip-Erase Handling via the Device's Debug Interface
+pub trait DebugEraseSequence: Send + Sync {
+    /// Perform Chip-Erase by vendor specific means.
+    ///
+    /// Some devices provide custom methods for mass erasing the entire flash area and even reset
+    /// other non-volatile chip state to its default setting.
+    ///
+    /// # Errors
+    /// May fail if the device is e.g. permanently locked or due to communication issues with the device.
+    /// Some devices require the probe to be disconnected and re-attached after a successful chip-erase in
+    /// which case it will return `Error::Probe(DebugProbeError::ReAttachRequired)`
+    fn erase_all(&self, _interface: &mut Box<dyn ArmProbeInterface>) -> Result<(), crate::Error> {
+        Err(crate::Error::Probe(DebugProbeError::NotImplemented(
+            "Debug erase sequence is not available on this device",
+        )))
+    }
 }

--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -49,7 +49,7 @@ pub fn erase_all(session: &mut Session) -> Result<(), FlashError> {
 
         if flasher.is_chip_erase_supported() {
             tracing::debug!("     -- chip erase supported, doing it.");
-            flasher.run_erase(|active| active.erase_all())?;
+            flasher.run_erase_all()?;
         } else {
             tracing::debug!("     -- chip erase not supported, erasing by sector.");
 

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -315,7 +315,7 @@ impl FlashLoader {
 
             if do_chip_erase {
                 tracing::debug!("    Doing chip erase...");
-                flasher.run_erase(|active| active.erase_all())?;
+                flasher.run_erase_all()?;
 
                 if let Some(progress) = options.progress {
                     progress.finished_erasing();


### PR DESCRIPTION
An experimental way of enabling Custom Erase Sequences during erasing and flashing

I thought I'd try to implement the idea of Custom Erase Sequences as per our Matrix discussion. 

This PR is tested to work fine on ATSAM D5x/E5x that have this custom Chip-Erase procedure but I'm not expecting it to be merged as is but rather as a discussion on whether its at all a feasible way forward.  If you think its in the right direction, I'll be happy to finalize it. Likewise, if there are better ways to do it I'm open for that too.

