### PR TITLE
Prevent panicking in probe-rs-cli-util.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debug: Gracefully handle stack unwind when CFA rule references a FP with value of zero. (#1226)
 - Debugger: Improve core status checking during launch.(#1228)
 - Debugger: Prevent stack overflows when expanding "static" section in probe-rs-debugger. (#1231)
+- RTT: Prevent panicking in `probe-rs-cli-util/src/rtt/rs` when defmt stream decoding provides invalid frame index. (#1236)
 
 ## [0.13.0]
 


### PR DESCRIPTION
Fixes #1236

The current code panics when `defmt-decoder` reports an invalid frame index for the source location of the string.

This update intercepts (and reports) that condition, rather than panicking.

The user's test case only prints a single string, and for that string, the frame index is `8`, but every so often, `defmt_decoder` reports a frame index of `2`, which used to panic when trying to lookup the source location using that index. 

The updated code will now report the error as part of the output, e.g.
```
Set 24.0 min 0 reached true step 1
└─ src/main.rs:225
Set 24.0 min 0 reached true step 1
└─ src/main.rs:225
1
└─ <invalid location: defmt frame-index: 2>
```