### PR TITLE
Add RTT defmt error checking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `probe-rs-debugger`: RISC-V `ebreak` instruction will enter Debug Mode (#1213)
 - RTT: When a channel format is `defmt`, automatically set the channel mode to `BlockingIfFull` on attach. (Enhancement request #1161)
 - RTT: Report data decode errors when channel format is `defmt`. (#1243)
-  - Note: This is a breaking API change for `probe_rs_cli::rtt::RttActiveChannel::get_rtt_data()`.
+  - Note: This is a breaking API change for `probe_rs_cli::rtt::RttActiveChannel::get_rtt_data()`. To mitigate the impact of this change:
+    - `probe_rs_cli::rtt::RttActiveTarget::poll_rtt()` will maintain the original signature and behaviour of ignoring errors from `defmt` until deprecated in 0.14.0.
+    - The new `probe_rs_cli::rtt::RttActiveTarget::poll_rtt_fallible()` will propagate errors from `get_rtt_data()` on any of the active channels.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Session::read_swo` has been renamed to `Session::read_trace_data`
 - `probe-rs-debugger`: RISC-V `ebreak` instruction will enter Debug Mode (#1213)
 - RTT: When a channel format is `defmt`, automatically set the channel mode to `BlockingIfFull` on attach. (Enhancement request #1161)
-- RTT: Report data decode errors when channel format is `defmt`. (#)
+- RTT: Report data decode errors when channel format is `defmt`. (#1243)
   - Note: This is a breaking API change for `probe_rs_cli::rtt::RttActiveChannel::get_rtt_data()`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Session::read_swo` has been renamed to `Session::read_trace_data`
 - `probe-rs-debugger`: RISC-V `ebreak` instruction will enter Debug Mode (#1213)
 - RTT: When a channel format is `defmt`, automatically set the channel mode to `BlockingIfFull` on attach. (Enhancement request #1161)
+- RTT: Report data decode errors when channel format is `defmt`. (#)
+  - Note: This is a breaking API change for `probe_rs_cli::rtt::RttActiveChannel::get_rtt_data()`.
 
 ### Fixed
 

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -63,7 +63,7 @@ pub fn run(
     if let Some(rtta) = &mut rtta {
         let mut stdout = std::io::stdout();
         loop {
-            for (_ch, data) in rtta.poll_rtt(&mut core) {
+            for (_ch, data) in rtta.poll_rtt_fallible(&mut core)? {
                 stdout.write_all(data.as_bytes()).unwrap();
             }
         }

--- a/probe-rs-cli-util/src/rtt.rs
+++ b/probe-rs-cli-util/src/rtt.rs
@@ -430,7 +430,10 @@ impl RttActiveTarget {
 
     /// Polls the RTT target on all channels and returns available data.
     /// Errors on any channel will be ignored and the data (even if incomplete) from the other channels will be returned.
-    // NOTE: Keeping this signature and "ignore errors" behaviour for backwards compatibility.
+    #[deprecated(
+        since = "0.14.0",
+        note = "This function is deprecated and will be removed in a future version. Please use `poll_rtt_fallible` instead."
+    )]
     pub fn poll_rtt(&mut self, core: &mut Core) -> HashMap<String, String> {
         let defmt_state = self.defmt_state.as_ref();
         self.active_channels

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -494,17 +494,13 @@ impl CoresightComponent {
 
     /// Finds the first component with the given peripheral type
     pub fn find_component(&self, peripheral_type: PeripheralType) -> Option<&CoresightComponent> {
-        for component in self.iter() {
-            if component
+        self.iter().find(|&component| {
+            component
                 .component
                 .id()
                 .peripheral_id
                 .is_of_type(peripheral_type)
-            {
-                return Some(component);
-            }
-        }
-        None
+        })
     }
 
     /// Turns this component into a component iterator which iterates all its children recursively.

--- a/probe-rs/src/probe/jlink/arm.rs
+++ b/probe-rs/src/probe/jlink/arm.rs
@@ -774,7 +774,7 @@ fn parse_swd_response(response: &[bool], direction: TransferDirection) -> Result
 
     let read_value_offset = ack_offset + 3;
 
-    let register_val: Vec<bool> = (&response[read_value_offset..read_value_offset + 32]).to_owned();
+    let register_val: Vec<bool> = response[read_value_offset..read_value_offset + 32].to_owned();
 
     let parity_bit = response[read_value_offset + 32];
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -286,8 +286,8 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
             .write(&[commands::GET_TARGET_VOLTAGE], &[], &mut buf, TIMEOUT)
             .and_then(|_| {
                 // The next two unwraps are safe!
-                let a0 = (&buf[0..4]).pread_with::<u32>(0, LE).unwrap();
-                let a1 = (&buf[4..8]).pread_with::<u32>(0, LE).unwrap();
+                let a0 = buf[0..4].pread_with::<u32>(0, LE).unwrap();
+                let a1 = buf[4..8].pread_with::<u32>(0, LE).unwrap();
                 if a0 != 0 {
                     Ok(Some(2. * (a1 as f32) * 1.2 / (a0 as f32)))
                 } else {
@@ -422,7 +422,7 @@ impl<D: StLinkUsb> StLink<D> {
         self.device
             .write(&[commands::GET_VERSION], &[], &mut buf, TIMEOUT)
             .map(|_| {
-                let version: u16 = (&buf[0..2]).pread_with(0, BE).unwrap();
+                let version: u16 = buf[0..2].pread_with(0, BE).unwrap();
                 self.hw_version = (version >> HW_VERSION_SHIFT) as u8 & HW_VERSION_MASK;
                 self.jtag_version = (version >> JTAG_VERSION_SHIFT) as u8 & JTAG_VERSION_MASK;
             })?;
@@ -442,7 +442,7 @@ impl<D: StLinkUsb> StLink<D> {
             self.device
                 .write(&[commands::GET_VERSION_EXT], &[], &mut buf, TIMEOUT)
                 .map(|_| {
-                    let version: u8 = (&buf[2..3]).pread_with(0, LE).unwrap();
+                    let version: u8 = buf[2..3].pread_with(0, LE).unwrap();
                     self.jtag_version = version;
                 })?;
         }
@@ -575,7 +575,7 @@ impl<D: StLinkUsb> StLink<D> {
             TIMEOUT,
         )?;
 
-        let mut values = (&buf)
+        let mut values = buf
             .chunks(4)
             .map(|chunk| chunk.pread_with::<u32>(0, LE).unwrap())
             .collect::<Vec<u32>>();
@@ -774,7 +774,7 @@ impl<D: StLinkUsb> StLink<D> {
         let mut buf = [0; 8];
         self.send_jtag_command(cmd, &[], &mut buf, TIMEOUT)?;
         // Unwrap is ok!
-        Ok((&buf[4..8]).pread_with(0, LE).unwrap())
+        Ok(buf[4..8].pread_with(0, LE).unwrap())
     }
 
     /// Writes a value to the DAP register on the specified port and address.


### PR DESCRIPTION
Report data decode errors when RTT channel format is `defmt`.

Notes: 
- This is a breaking API change for `probe_rs_cli::rtt::RttActiveChannel::get_rtt_data()`.
- To mitigate the impact of this change:
  - `probe_rs_cli::rtt::RttActiveTarget::poll_rtt()` will maintain the original signature and behaviour of ignoring errors from `defmt` until deprecated in 0.14.0.
  - The new `probe_rs_cli::rtt::RttActiveTarget::poll_rtt_fallible()` will propagate errors from `get_rtt_data()` on any of the active channels.
- `probe-rs-debugger` will now report any errors from `get_rtt_data()`.
