### PR TITLE
Add public get_data method to FlashLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for Microchip SAMDA1
 - Added Probe re-attach handling when needed after `debug_device_unlock`
 - Added Custom ArmDebugSequence for ATSAM D5x/E5x devices
+- Added FlashLoader::data method
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for Microchip SAMDA1
 - Added Probe re-attach handling when needed after `debug_device_unlock`
 - Added Custom ArmDebugSequence for ATSAM D5x/E5x devices
-- Added FlashLoader::data method
+- Added a `FlashLoader::data` method (#1254)
 
 ### Changed
 

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -473,4 +473,12 @@ impl FlashLoader {
             }
         }
     }
+
+    /// Return data chunks stored in the `FlashLoader` as pairs of address and bytes.
+    pub fn data(&self) -> impl Iterator<Item = (u64, &[u8])> {
+        self.builder
+            .data
+            .iter()
+            .map(|(address, data)| (*address, data.as_slice()))
+    }
 }


### PR DESCRIPTION
This adds:
```rust
impl FlashLoader {
    pub fn data(&self) -> impl Iterator<Item = (u64, &[u8])>;
}

```

This allows users to inspect the binary data that will be flashed.

I needed this for analyzing a bug in `cargo objcopy`.

Usage:
```rust
let target = probe_rs::config::get_target_by_name(chip).unwrap();
let mut loader = probe_rs::flashing::FlashLoader::new(target.memory_map.to_vec(), target.source().clone());
loader.load_elf_data(&mut file).unwrap();
let data: Vec<(u64, &[u8])> = loader.data().collect();
```

If there's anything I should change or add, let me know 😄 