### PR TITLE
Support target-specific flash algo stack size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Support for STM32H735 family. (#913)
 - Added support for MAX32660 target (#1249)
 - Added support for W7500 target
+- Added an optional `stack_size` configuration to flash algorithms to control the stack size (#1260)
 
 ### Changed
 

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -47,6 +47,12 @@ pub struct RawFlashAlgorithm {
     /// List of cores that can use this algorithm
     #[serde(default)]
     pub cores: Vec<String>,
+    /// The flash algorithm's stack size, in bytes.
+    ///
+    /// If not set, probe-rs selects a default value.
+    /// Increase this value if you're concerned about stack
+    /// overruns during flashing.
+    pub stack_size: Option<u32>,
 }
 
 pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
This proposes one of the ideas described in #1251. If accepted, I'll immediately use this feature in #1250.

Flash algorithms support a new field, `stack_size`, to configure the flash algorithm's stack size. probe-rs prefers the flash algorithm's stack size, but defaults to 512 bytes if the stack size isn't specified.

With this commit, I could configure my MIMXRT1170EVK target's flash algorithm with a 4K stack size, and program it. I could also program an MIMXRT1010EVK, which doesn't specify any stack size.