### PR TITLE
Prevent `probe-rs-debugger` from crashing when error messages are excessively long.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debugger: Improve core status checking during launch.(#1228)
 - Debugger: Prevent stack overflows when expanding "static" section in probe-rs-debugger. (#1231)
 - RTT: Prevent panicking in `probe-rs-cli-util/src/rtt/rs` when defmt stream decoding provides invalid frame index. (#1236)
+- Debug: Fix `probe-rs-debugger` crashes when variable unwind fails with excessively long error messages. (#1252)
 
 ## [0.13.0]
 

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -514,9 +514,9 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                     }
                     other_attribute => {
                         child_variable.set_value(VariableValue::Error(format!(
-                            "Unimplemented: Variable Attribute {:?} : {:?}, with children = {}",
-                            other_attribute.static_string(),
-                            tree_node.entry().attr_value(other_attribute),
+                            "Unimplemented: Variable Attribute {:.100} : {:.100}, with children = {}",
+                            format!("{:?}", other_attribute.static_string()),
+                            format!("{:?}", tree_node.entry().attr_value(other_attribute)),
                             tree_node.entry().has_children()
                         )));
                     }
@@ -818,7 +818,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                     VariantRole::Variant(const_value as u64)
                                 }
                                 other_attribute_value => {
-                                    variable.set_value(VariableValue::Error(format!("Unimplemented: Attribute Value for DW_AT_discr_value: {:?}", other_attribute_value)));
+                                    variable.set_value(VariableValue::Error(format!("Unimplemented: Attribute Value for DW_AT_discr_value: {:.100}", format!("{:?}", other_attribute_value))));
                                     VariantRole::Variant(u64::MAX)
                                 }
                             }
@@ -950,8 +950,8 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                         other_attribute_value => {
                                             child_variable.set_value(VariableValue::Error(
                                                 format!(
-                                            "Unimplemented: Attribute Value for DW_AT_type {:?}",
-                                            other_attribute_value
+                                            "Unimplemented: Attribute Value for DW_AT_type {:.100}",
+                                            format!("{:?}", other_attribute_value)
                                         ),
                                             ));
                                         }
@@ -1198,9 +1198,9 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                         other_attribute_value => {
                                             child_variable.set_value(VariableValue::Error(
                                                 format!(
-                                            "Unimplemented: Attribute Value for DW_AT_type {:?}",
-                                            other_attribute_value
-                                        ),
+                                                    "Unimplemented: Attribute Value for DW_AT_type {:?}",
+                                                    other_attribute_value
+                                                ),
                                             ));
                                         }
                                     }
@@ -1294,8 +1294,8 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                     }
                                     other_attribute_value => {
                                         child_variable.set_value(VariableValue::Error(format!(
-                                            "Unimplemented: Attribute Value for DW_AT_type {:?}",
-                                            other_attribute_value
+                                            "Unimplemented: Attribute Value for DW_AT_type {:.100}",
+                                            format!("{:?}", other_attribute_value)
                                         )));
                                     }
                                 },
@@ -1431,7 +1431,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                     }
                     other_attribute_value => {
                         return Ok(ExpressionResult::Location(VariableLocation::Unsupported(
-                            format!( "Unimplemented: extract_location() Could not extract location from: {:?}", other_attribute_value))))
+                            format!( "Unimplemented: extract_location() Could not extract location from: {:.100}", format!("{:?}", other_attribute_value)))))
                     }
                 },
                 gimli::DW_AT_address_class => {
@@ -1447,8 +1447,8 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                         }
                         other_attribute_value => {
                             return Ok(ExpressionResult::Location(VariableLocation::Unsupported(format!(
-                                "Unimplemented: extract_location() found invalid DW_AT_address_class: {:?}",
-                                other_attribute_value
+                                "Unimplemented: extract_location() found invalid DW_AT_address_class: {:.100}",
+                                format!("{:?}", other_attribute_value)
                             ))))
                         }
                     }
@@ -1558,8 +1558,8 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 }
                 l => Ok(ExpressionResult::Location(VariableLocation::Error(
                     format!(
-                        "Unimplemented: extract_location() found a location type: {:?}",
-                        l
+                        "Unimplemented: extract_location() found a location type: {:.100}",
+                        format!("{:?}", l)
                     ),
                 ))),
             }

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -1388,7 +1388,6 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                     .get_program_counter()
                                     .and_then(|reg| reg.value)
                                 {
-                                    // let program_counter: u64 = pc.try_into()?;
                                     let mut expression: Option<gimli::Expression<GimliReader>> =
                                         None;
                                     while let Some(location) = match locations.next() {

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -513,6 +513,8 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                         // Processed by `extract_type()`
                     }
                     other_attribute => {
+                        #[allow(clippy::format_in_format_args)]
+                        // This follows the examples of the "format!" documenation as the way to limit string length of a {:?} parameter.
                         child_variable.set_value(VariableValue::Error(format!(
                             "Unimplemented: Variable Attribute {:.100} : {:.100}, with children = {}",
                             format!("{:?}", other_attribute.static_string()),


### PR DESCRIPTION
Fixes #1252 

The problem is caused when a variable unwind generates an error message with excessively long strings. In this case, those strings contained irrelevant data, so this fix truncates those error messages after 100 characters.  

The new error message is now 
```
<variable not found "< Unimplemented: extract_location() found a location type: Bytes { value: EndianReader { range: SubRange { bytes: [255, 255, 255, 255, 240, 1, 0, 16, 0, 0, 0,  >">
``` 

Note. This fixes the reported crash, but makes no attempt at implementing the unimplemented functionality. New PR's are welcome :)