### PR TITLE
Update STM32G0_Series.yaml, to include latest variants (STM32G0B1 and STM32G0C1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix: Dual core devices had incorrect 'core' names in `STM32H7_Series.yaml`, causing panic during flashing. (#1023)
 - Fix: Include all RAM regions in `STM32H7_Series.yaml` (#429)
 - Fix: Include all new STM32H7 variants from the latest CMSIS pack file (#913)
+- Fix: Update STM32G0_Series.yaml to include latest variants (STM32G050, STM32G051, STM32G061, STM32G0B0, STM32G0B1, STM32G0C1) (#1266)
 
 ## [0.13.0]
 

--- a/probe-rs/targets/STM32G0_Series.yaml
+++ b/probe-rs/targets/STM32G0_Series.yaml
@@ -1,2351 +1,5508 @@
 name: STM32G0 Series
+generated_from_pack: true
+pack_file_release: 1.4.0
 variants:
-  - name: STM32G030C6Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x0_opt
-  - name: STM32G030C8Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x0_opt
-  - name: STM32G030F6Px
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x0_opt
-  - name: STM32G030J6Mx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x0_opt
-  - name: STM32G030K6Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x0_opt
-  - name: STM32G030K8Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x0_opt
-  - name: STM32G031C4Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8004000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_16
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031C4Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8004000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_16
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031C6Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031C6Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031C8Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031C8Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031F4Px
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8004000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_16
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031F6Px
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031F8Px
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031G4Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8004000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_16
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031G6Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031G8Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031J4Mx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8004000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_16
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031J6Mx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031K4Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8004000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_16
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031K4Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8004000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_16
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031K6Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031K6Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031K8Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031K8Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G031Y8Yx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041C6Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041C6Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041C8Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041C8Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041F6Px
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041F8Px
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041G6Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041G8Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041J6Mx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041K6Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041K6Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041K8Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041K8Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G041Y8Yx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20002000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G070CBTx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x0_opt
-  - name: STM32G070KBTx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x0_opt
-  - name: STM32G070RBTx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x0_opt
-  - name: STM32G071C6Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071C6Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071C8Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071C8Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071CBTx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071CBUx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071EBYx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071G6Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071G8Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071G8UxN
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071GBUx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071GBUxN
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071K6Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071K6Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071K8Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071K8TxN
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071K8Ux
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071K8UxN
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071KBTx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071KBTxN
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071KBUx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071KBUxN
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071R6Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8008000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_32
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071R8Tx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8010000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_64
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071RBIx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G071RBTx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G081CBTx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G081CBUx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G081EBYx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G081GBUx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G081GBUxN
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G081KBTx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G081KBTxN
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G081KBUx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G081KBUxN
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G081RBIx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
-  - name: STM32G081RBTx
-    cores:
-      - name: main
-        type: armv6m
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20009000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x8000000
-            end: 0x8020000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - stm32g0xx_128
-      - stm32g0xx_otp
-      - stm32g0x1_opt
+- name: STM32G030C6Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G030C8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G030F6Px
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G030J6Mx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G030K6Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G030K8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031C4Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_16
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031C4Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_16
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031C6Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031C6Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031C8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031C8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031F4Px
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_16
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031F6Px
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031F8Px
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031G4Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_16
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031G6Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031G8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031J4Mx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_16
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031J6Mx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031K4Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_16
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031K4Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_16
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031K6Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031K6Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031K8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031K8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G031Y8Yx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041C6Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041C6Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041C8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041C8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041F6Px
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041F8Px
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041G6Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041G8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041J6Mx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041K6Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041K6Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041K8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041K8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G041Y8Yx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G050C6Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G050C8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G050F6Px
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G050K6Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G050K8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051C6Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051C6Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051C8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051C8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051F6Px
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051F8Px
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051F8Yx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051G6Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051G8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051K6Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051K6Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051K8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G051K8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061C6Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061C6Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061C8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061C8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061F6Px
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061F8Px
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061F8Yx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061G6Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061G8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061K6Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061K6Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_32
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061K8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G061K8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004800
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G070CBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G070KBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G070RBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071C8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071C8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071CBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071CBUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071EBYx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071G8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071G8UxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071GBUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071GBUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071K8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071K8TxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071K8Ux
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071K8UxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071KBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071KBTxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071KBUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071KBUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071R8Tx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_64
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071RBIx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G071RBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G081CBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G081CBUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G081EBYx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G081GBUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G081GBUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G081KBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G081KBTxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G081KBUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G081KBUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G081RBIx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G081RBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20009000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B0CETx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B0KETx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B0RETx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B0VETx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x0_sb_opt
+  - stm32g0x0_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1CBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1CBTxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1CBUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1CBUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1CCTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1CCTxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1CCUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1CCUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1CETx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1CETxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1CEUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1CEUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1KBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1KBTxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1KBUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1KBUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1KCTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1KCTxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1KCUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1KCUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1KETx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1KETxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1KEUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1KEUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1MBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1MCTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1METx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1NEYx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1RBIxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1RBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1RBTxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1RCIxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1RCTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1RCTxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1REIxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1RETx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1RETxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1VBIx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1VBTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0xx_128
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1VCIx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1VCTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1VEIx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0B1VETx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1CCTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1CCTxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1CCUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1CCUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1CETx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1CETxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1CEUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1CEUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1KCTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1KCTxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1KCUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1KCUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1KETx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1KETxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1KEUx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1KEUxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1MCTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1METx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1NEYx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1RCIxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1RCTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1RCTxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1REIxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1RETx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1RETxN
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1VCIx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1VCTx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_256
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1VEIx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
+- name: STM32G0C1VETx
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20024000
+    cores:
+    - main
+  - !Nvm
+    name: Main_Flash
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - stm32g0bx_512
+  - stm32g0xx_otp
+  - stm32g0x1_sb_opt
+  - stm32g0x1_db_opt
+  supports_connect_under_reset: true
 flash_algorithms:
-  - name: stm32g0xx_otp
-    description: STM32G0xx Flash OTP
-    cores:
-      - main
-    default: false
-    instructions: v/NPj3BHG0gZSYFgGkmBYBpJAWEAIHBHASAWScAHSGEAIHBHASBwRwAgcEfwtckdEEzJCBFNyQAlYQEmACcT4GZhE2gDYFNoQ2C/80+PI2nbA/zUZ2EjaStCAtAlYQEg8L0IMAg5CDIAKenRACDwvSMBZ0UAIAJAq4nvzfrDAAAAAAAA
-    pc_init: 0x7
-    pc_uninit: 0x19
-    pc_program_page: 0x2d
-    pc_erase_sector: 0x29
-    pc_erase_all: null
-    data_section_offset: 0x80
-    flash_properties:
-      address_range:
-        start: 0x1fff7000
-        end: 0x1fff7400
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0xbb8
-      erase_sector_timeout: 0xbb8
-      sectors:
-        - size: 0x400
-          address: 0x0
-  - name: stm32g0xx_16
-    description: STM32G0xx 16 KB Flash
-    cores:
-      - main
-    default: true
-    instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
-    pc_init: 0xd
-    pc_uninit: 0x1f
-    pc_program_page: 0x9d
-    pc_erase_sector: 0x65
-    pc_erase_all: 0x2f
-    data_section_offset: 0xf0
-    flash_properties:
-      address_range:
-        start: 0x8000000
-        end: 0x8004000
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0x190
-      erase_sector_timeout: 0x190
-      sectors:
-        - size: 0x800
-          address: 0x0
-  - name: stm32g0x1_opt
-    description: STM32G0x1 Flash Options
-    cores:
-      - main
-    default: false
-    instructions: v/NPj3BHPEg6SYFgO0mBYDtJwWA7ScFgO0kBYQAgcEcBITVIyQdBYUEEQWEAIHBHASBwRzBINEsDYTRJAWI/IcFiAWP/IUFiACKCYkFjgmMpSYAxCmABIUkEQWG/80+PAWnJA/zUQmEBaRlCBNABaRlDAWEBIHBHACBwRwAgcEfwtRd7Fn28Rhd+FWi+RlRok2gRaRhI0mkbTwdhHE89QAViHE0sQMRiK0ADY2dG+7JDYhlLGUCBYvGyQWN3RvmygWMWSQpADEmAMQpgmQtBYb/zT48BackD/NQCaQpJCkIE0AJpCkMCYQEg8L0AIPC9QBhwRyMBZ0UAIAJAq4nvzTsqGQh/bl1M+sMAAKr+Tzj//08/PwA/AP8AAID/AAEAAAAAAA==
-    pc_init: 0x7
-    pc_uninit: 0x21
-    pc_program_page: 0x81
-    pc_erase_sector: 0x7d
-    pc_erase_all: 0x35
-    data_section_offset: 0x120
-    flash_properties:
-      address_range:
-        start: 0x1fff7800
-        end: 0x1fff7820
-      page_size: 0x20
-      erased_byte_value: 0xff
-      program_page_timeout: 0xbb8
-      erase_sector_timeout: 0xbb8
-      sectors:
-        - size: 0x20
-          address: 0x0
-  - name: stm32g0xx_64
-    description: STM32G0xx 64 KB Flash
-    cores:
-      - main
-    default: true
-    instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
-    pc_init: 0xd
-    pc_uninit: 0x1f
-    pc_program_page: 0x9d
-    pc_erase_sector: 0x65
-    pc_erase_all: 0x2f
-    data_section_offset: 0xf0
-    flash_properties:
-      address_range:
-        start: 0x8000000
-        end: 0x8010000
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0x190
-      erase_sector_timeout: 0x190
-      sectors:
-        - size: 0x800
-          address: 0x0
-  - name: stm32g0xx_128
-    description: STM32G0xx 128 KB Flash
-    cores:
-      - main
-    default: true
-    instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
-    pc_init: 0xd
-    pc_uninit: 0x1f
-    pc_program_page: 0x9d
-    pc_erase_sector: 0x65
-    pc_erase_all: 0x2f
-    data_section_offset: 0xf0
-    flash_properties:
-      address_range:
-        start: 0x8000000
-        end: 0x8020000
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0x190
-      erase_sector_timeout: 0x190
-      sectors:
-        - size: 0x800
-          address: 0x0
-  - name: stm32g0x0_opt
-    description: STM32G0x0 Flash Options
-    cores:
-      - main
-    default: false
-    instructions: v/NPj3BHLUgrSYFgLEmBYCxJwWAsScFgLEkBYQAgcEcBISZIyQdBYUEEQWEAIHBHASBwRyFIJUoCYSVJAWI/IcFiAWMBIUkEQWG/80+PAWnJA/zUACFBYQFpEUIE0AFpEUMBYQEgcEcAIHBHACBwRzC1lGgTaFFoEEgUSgJhFU0rQANiFEsZQMFiHEAEYwEhSQRBYb/zT48BackD/NQBaRFCBNABaRFDAWEBIDC9ACAwvUAYcEcAACMBZ0UAIAJAq4nvzTsqGQh/bl1M+sMAAKr+Tzj//08/PwA/AAAAAAA=
-    pc_init: 0x7
-    pc_uninit: 0x21
-    pc_program_page: 0x71
-    pc_erase_sector: 0x6d
-    pc_erase_all: 0x35
-    data_section_offset: 0xdc
-    flash_properties:
-      address_range:
-        start: 0x1fff7800
-        end: 0x1fff780c
-      page_size: 0xc
-      erased_byte_value: 0xff
-      program_page_timeout: 0xbb8
-      erase_sector_timeout: 0xbb8
-      sectors:
-        - size: 0xc
-          address: 0x0
-  - name: stm32g0xx_32
-    description: STM32G0xx 32 KB Flash
-    cores:
-      - main
-    default: true
-    instructions: v/NPj3BHwAOADnBHNUg0SYFgNUmBYDVJAWEAIHBHASAwScAHSGEAIHBHASBwRy1ILkoCYQQhQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCBNABaRFDAWEBIHBHACBwR8ADgQ4eSCBKAmHJAIkcQWFBaQEjGwQZQ0Fhv/NPjwFpyQP81AAhQWEBaRFCAtACYQEgcEcAIHBH8LXJHRBMyQgRTckAJWEBJgAnE+BmYRNoA2BTaENgv/NPjyNp2wP81GdhI2krQgLQJWEBIPC9CDAIOQgyACnp0QAg8L0jAWdFACACQKuJ7836wwAAAAAAAA==
-    pc_init: 0xd
-    pc_uninit: 0x1f
-    pc_program_page: 0x9d
-    pc_erase_sector: 0x65
-    pc_erase_all: 0x2f
-    data_section_offset: 0xf0
-    flash_properties:
-      address_range:
-        start: 0x8000000
-        end: 0x8008000
-      page_size: 0x400
-      erased_byte_value: 0xff
-      program_page_timeout: 0x190
-      erase_sector_timeout: 0x190
-      sectors:
-        - size: 0x800
-          address: 0x0
+- name: stm32g0xx_32
+  description: STM32G0xx 32 KB Flash
+  default: true
+  instructions: crZqSmpJimBqSopgAOAAvwppkgOSD/rRZ0pKRFBgZ0gAjAAEgAmQYEAI0GBkSABoAwVkSBsNGBgf0AooHdAQKBvQASAQYAhqgALADxBhCGrAAwjUXUhcSgJgUhACYAYiQmBbSoJgCGoAAwTUWkhZSUFgfyEBYAAgcEcAIOLnTkhIREBoAWhKSEkcBNABaAEiEgSRQwFgQWkBItIHEUNBYb/zT48AIHBHASBwR0BIS0oCYcETQWFBaQEjGwQZQ0Fhv/NPjwDgAL8BaYkDiQ/60QFpEUIC0AJhASBwRwAgcEcwtTVLASRLRBpo5AQBKgzRGWkBKQLQmWihQgbR3WhZaE0ZhUIB2AEhAOAAIQEqAdCaaAbgGmkBKgLQmmiiQgDR2mguS1IeEEAhSsAKE2HAAEkDgBwIQ1BhUGkBIQkECENQYb/zT48A4AC/EGmAA4AP+tEQaRhAAdATYQEgML0wtckdE0vJCB1NyQAdYQEkXGEU4BRoBGBUaERgv/NPjwDgAL8caaQDpA/60RxpLEIC0B1hASAwvQgwCDkIMgAp6NFYaUAIQABYYQAgML0jAWdFACACQKuJ780EAAAAwHX/HwBYAUCq+///qqoAAAAwAED/DwAA/wEAAAAsAED6wwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x7f
+  pc_program_page: 0x15f
+  pc_erase_sector: 0xe1
+  pc_erase_all: 0xad
+  data_section_offset: 0x1e0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8008000
+    page_size: 0x400
+    erased_byte_value: 0xff
+    program_page_timeout: 400
+    erase_sector_timeout: 400
+    sectors:
+    - size: 0x800
+      address: 0x0
+- name: stm32g0xx_otp
+  description: STM32G0xx Flash OTP
+  instructions: v/NPj3BHG0gZSYFgGkmBYBpJAWEAIHBHASAWScAHSGEAIHBHASBwRwAgcEfwtckdEEzJCBFNyQAlYQEmACcT4GZhE2gDYFNoQ2C/80+PI2nbA/zUZ2EjaStCAtAlYQEg8L0IMAg5CDIAKenRACDwvSMBZ0UAIAJAq4nvzfrDAAAAAAAA
+  pc_init: 0x7
+  pc_uninit: 0x19
+  pc_program_page: 0x2d
+  pc_erase_sector: 0x29
+  data_section_offset: 0x80
+  flash_properties:
+    address_range:
+      start: 0x1fff7000
+      end: 0x1fff7400
+    page_size: 0x400
+    erased_byte_value: 0xff
+    program_page_timeout: 3000
+    erase_sector_timeout: 3000
+    sectors:
+    - size: 0x400
+      address: 0x0
+- name: stm32g0x0_sb_opt
+  description: STM32G0x0 SB Flash Options
+  instructions: v/NPj3BHLUgrSYFgLEmBYCxJwWAsScFgLEkBYQAgcEcBISZIyQdBYUEEQWEAIHBHASBwRyFIJUoCYSVJAWJ/IcFiAWMBIUkEQWG/80+PAWnJA/zUACFBYQFpEUIE0AFpEUMBYQEgcEcAIHBHACBwRzC1lGgTaFFoEEgUSgJhFU0rQANiFEsZQMFiHEAEYwEhSQRBYb/zT48BackD/NQBaRFCBNABaRFDAWEBIDC9ACAwvUAYcEcAACMBZ0UAIAJAq4nvzTsqGQh/bl1M+sMAAKr+/////38/fwB/AAAAAAA=
+  pc_init: 0x7
+  pc_uninit: 0x21
+  pc_program_page: 0x71
+  pc_erase_sector: 0x6d
+  pc_erase_all: 0x35
+  data_section_offset: 0xdc
+  flash_properties:
+    address_range:
+      start: 0x1fff7800
+      end: 0x1fff780c
+    page_size: 0xc
+    erased_byte_value: 0xff
+    program_page_timeout: 3000
+    erase_sector_timeout: 3000
+    sectors:
+    - size: 0xc
+      address: 0x0
+- name: stm32g0x0_db_opt
+  description: STM32G0x0 DB Flash Options
+  instructions: v/NPj3BHM0gxSYFgMkmBYDJJwWAyScFgMkkBYQAgcEcBISxIyQdBYUEEQWEAIHBHASBwRydIK0oCYStJAWJ/IcFiAWMjS0Az2WAZYQEhSQRBYb/zT48BackD/NQAIUFhAWkRQgTQAWkRQwFhASBwRwAgcEcAIHBH8LUVaFRok2jRaBRIEmkXTwdhGE41QAViF00sQMRiK0ADYw5LKUBAM9lgKkAaYQEhSQRBYb/zT48BackD/NQBaTlCBNABaTlDAWEBIPC9ACDwvUAYcEcAACMBZ0UAIAJAq4nvzTsqGQh/bl1M+sMAAKr+/////38/fwB/AAAAAAA=
+  pc_init: 0x7
+  pc_uninit: 0x21
+  pc_program_page: 0x79
+  pc_erase_sector: 0x75
+  pc_erase_all: 0x35
+  data_section_offset: 0xf4
+  flash_properties:
+    address_range:
+      start: 0x1fff7800
+      end: 0x1fff7814
+    page_size: 0x14
+    erased_byte_value: 0xff
+    program_page_timeout: 3000
+    erase_sector_timeout: 3000
+    sectors:
+    - size: 0x14
+      address: 0x0
+- name: stm32g0xx_64
+  description: STM32G0xx 64 KB Flash
+  default: true
+  instructions: crZqSmpJimBqSopgAOAAvwppkgOSD/rRZ0pKRFBgZ0gAjAAEgAmQYEAI0GBkSABoAwVkSBsNGBgf0AooHdAQKBvQASAQYAhqgALADxBhCGrAAwjUXUhcSgJgUhACYAYiQmBbSoJgCGoAAwTUWkhZSUFgfyEBYAAgcEcAIOLnTkhIREBoAWhKSEkcBNABaAEiEgSRQwFgQWkBItIHEUNBYb/zT48AIHBHASBwR0BIS0oCYcETQWFBaQEjGwQZQ0Fhv/NPjwDgAL8BaYkDiQ/60QFpEUIC0AJhASBwRwAgcEcwtTVLASRLRBpo5AQBKgzRGWkBKQLQmWihQgbR3WhZaE0ZhUIB2AEhAOAAIQEqAdCaaAbgGmkBKgLQmmiiQgDR2mguS1IeEEAhSsAKE2HAAEkDgBwIQ1BhUGkBIQkECENQYb/zT48A4AC/EGmAA4AP+tEQaRhAAdATYQEgML0wtckdE0vJCB1NyQAdYQEkXGEU4BRoBGBUaERgv/NPjwDgAL8caaQDpA/60RxpLEIC0B1hASAwvQgwCDkIMgAp6NFYaUAIQABYYQAgML0jAWdFACACQKuJ780EAAAAwHX/HwBYAUCq+///qqoAAAAwAED/DwAA/wEAAAAsAED6wwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x7f
+  pc_program_page: 0x15f
+  pc_erase_sector: 0xe1
+  pc_erase_all: 0xad
+  data_section_offset: 0x1e0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8010000
+    page_size: 0x400
+    erased_byte_value: 0xff
+    program_page_timeout: 400
+    erase_sector_timeout: 400
+    sectors:
+    - size: 0x800
+      address: 0x0
+- name: stm32g0xx_16
+  description: STM32G0xx 16 KB Flash
+  default: true
+  instructions: crZqSmpJimBqSopgAOAAvwppkgOSD/rRZ0pKRFBgZ0gAjAAEgAmQYEAI0GBkSABoAwVkSBsNGBgf0AooHdAQKBvQASAQYAhqgALADxBhCGrAAwjUXUhcSgJgUhACYAYiQmBbSoJgCGoAAwTUWkhZSUFgfyEBYAAgcEcAIOLnTkhIREBoAWhKSEkcBNABaAEiEgSRQwFgQWkBItIHEUNBYb/zT48AIHBHASBwR0BIS0oCYcETQWFBaQEjGwQZQ0Fhv/NPjwDgAL8BaYkDiQ/60QFpEUIC0AJhASBwRwAgcEcwtTVLASRLRBpo5AQBKgzRGWkBKQLQmWihQgbR3WhZaE0ZhUIB2AEhAOAAIQEqAdCaaAbgGmkBKgLQmmiiQgDR2mguS1IeEEAhSsAKE2HAAEkDgBwIQ1BhUGkBIQkECENQYb/zT48A4AC/EGmAA4AP+tEQaRhAAdATYQEgML0wtckdE0vJCB1NyQAdYQEkXGEU4BRoBGBUaERgv/NPjwDgAL8caaQDpA/60RxpLEIC0B1hASAwvQgwCDkIMgAp6NFYaUAIQABYYQAgML0jAWdFACACQKuJ780EAAAAwHX/HwBYAUCq+///qqoAAAAwAED/DwAA/wEAAAAsAED6wwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x7f
+  pc_program_page: 0x15f
+  pc_erase_sector: 0xe1
+  pc_erase_all: 0xad
+  data_section_offset: 0x1e0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8004000
+    page_size: 0x400
+    erased_byte_value: 0xff
+    program_page_timeout: 400
+    erase_sector_timeout: 400
+    sectors:
+    - size: 0x800
+      address: 0x0
+- name: stm32g0x1_sb_opt
+  description: STM32G0x1 SB Flash Options
+  instructions: v/NPj3BHPkg8SYFgPUmBYD1JwWA9ScFgPUkBYQAgcEcBITdIyQdBYUEEQWEAIHBHASBwRzJINksDYTZJAWL/IcFiAWM0SUFiACKCYkFjgmMrSYAxCmABIUkEQWG/80+PAWnJA/zUQmEBaRlCBNABaRlDAWEBIHBHACBwRwAgcEfwtZeJloq8RheLFWi+RlRok2gRaRpI0mkdTwdhH089QAViH00sQMRiK0ADY2dG+wXbDUNiG0sZQIFi8QXJDUFjd0b5BckNgWMXSQpADEmAMQpgmQtBYb/zT48BackD/NQCaQtJCkIE0AJpCkMCYQEg8L0AIPC9QBhwRwAAIwFnRQAgAkCrie/NOyoZCH9uXUz6wwAAqv7///8BAAD//38/fwB/AP8BAID/APEPAAAAAA==
+  pc_init: 0x7
+  pc_uninit: 0x21
+  pc_program_page: 0x81
+  pc_erase_sector: 0x7d
+  pc_erase_all: 0x35
+  data_section_offset: 0x12c
+  flash_properties:
+    address_range:
+      start: 0x1fff7800
+      end: 0x1fff7820
+    page_size: 0x20
+    erased_byte_value: 0xff
+    program_page_timeout: 3000
+    erase_sector_timeout: 3000
+    sectors:
+    - size: 0x20
+      address: 0x0
+- name: stm32g0x1_db_opt
+  description: STM32G0x1 DB Flash Options
+  instructions: v/NPj3BHVUhTSYFgVEmBYFRJwWBUScFgVEkBYQAgcEcBIU5IyQdBYUEEQWEAIHBHASBwRzC1SUhMTQVhTEkBYv8kxGIEY8sNQ2IAIoJiQ2OCY0JJgDEKYEBJQDHMYAxhS2CKYEthimEBIUkEQWG/80+PAWnJA/zUQmEBaSlCBNABaSlDAWEBIDC9ACAwvQAgcEfwtYawF2hWaJBoBZCQiQSQEGmERpCKA5AQiwKQEI3VaRRqU2oBkBCO0WqGRpKOAJImSClKAmEqShdAB2IqShZAxmIFnhZABmMEnvYF9g1GYiZPZkY+QIZiA572BfYNRmMCnvYF9g2GYyFONUAXToA2NWAVTRRAQDXsYBNAK2EBmtIF0g1qYDlAqWBxRskFyQ1pYQCa0QXJDalhuQtBYb/zT48BackD/NQBaQtKEUIF0AFpEUMBYQEgBrDwvQAg++dAGHBHAAAjAWdFACACQKuJ7807KhkIf25dTPrDAACq/v////9/P38AfwD/AQCA/wDxDwAAAAA=
+  pc_init: 0x7
+  pc_uninit: 0x21
+  pc_program_page: 0x93
+  pc_erase_sector: 0x8f
+  pc_erase_all: 0x35
+  data_section_offset: 0x184
+  flash_properties:
+    address_range:
+      start: 0x1fff7800
+      end: 0x1fff7838
+    page_size: 0x38
+    erased_byte_value: 0xff
+    program_page_timeout: 3000
+    erase_sector_timeout: 3000
+    sectors:
+    - size: 0x38
+      address: 0x0
+- name: stm32g0xx_128
+  description: STM32G0xx 128 KB Flash
+  default: true
+  instructions: crZqSmpJimBqSopgAOAAvwppkgOSD/rRZ0pKRFBgZ0gAjAAEgAmQYEAI0GBkSABoAwVkSBsNGBgf0AooHdAQKBvQASAQYAhqgALADxBhCGrAAwjUXUhcSgJgUhACYAYiQmBbSoJgCGoAAwTUWkhZSUFgfyEBYAAgcEcAIOLnTkhIREBoAWhKSEkcBNABaAEiEgSRQwFgQWkBItIHEUNBYb/zT48AIHBHASBwR0BIS0oCYcETQWFBaQEjGwQZQ0Fhv/NPjwDgAL8BaYkDiQ/60QFpEUIC0AJhASBwRwAgcEcwtTVLASRLRBpo5AQBKgzRGWkBKQLQmWihQgbR3WhZaE0ZhUIB2AEhAOAAIQEqAdCaaAbgGmkBKgLQmmiiQgDR2mguS1IeEEAhSsAKE2HAAEkDgBwIQ1BhUGkBIQkECENQYb/zT48A4AC/EGmAA4AP+tEQaRhAAdATYQEgML0wtckdE0vJCB1NyQAdYQEkXGEU4BRoBGBUaERgv/NPjwDgAL8caaQDpA/60RxpLEIC0B1hASAwvQgwCDkIMgAp6NFYaUAIQABYYQAgML0jAWdFACACQKuJ780EAAAAwHX/HwBYAUCq+///qqoAAAAwAED/DwAA/wEAAAAsAED6wwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x7f
+  pc_program_page: 0x15f
+  pc_erase_sector: 0xe1
+  pc_erase_all: 0xad
+  data_section_offset: 0x1e0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8020000
+    page_size: 0x400
+    erased_byte_value: 0xff
+    program_page_timeout: 400
+    erase_sector_timeout: 400
+    sectors:
+    - size: 0x800
+      address: 0x0
+- name: stm32g0bx_512
+  description: STM32G0Bx_512
+  default: true
+  instructions: crZqSmpJimBqSopgAOAAvwppkgOSD/rRZ0pKRFBgZ0gAjAAEgAmQYEAI0GBkSABoAwVkSBsNGBgf0AooHdAQKBvQASAQYAhqgALADxBhCGrAAwjUXUhcSgJgUhACYAYiQmBbSoJgCGoAAwTUWkhZSUFgfyEBYAAgcEcAIOLnTkhIREBoAWhKSEkcBNABaAEiEgSRQwFgQWkBItIHEUNBYb/zT48AIHBHASBwR0BIS0oCYcETQWFBaQEjGwQZQ0Fhv/NPjwDgAL8BaYkDiQ/60QFpEUIC0AJhASBwRwAgcEcwtTVLASRLRBpo5AQBKgzRGWkBKQLQmWihQgbR3WhZaE0ZhUIB2AEhAOAAIQEqAdCaaAbgGmkBKgLQmmiiQgDR2mguS1IeEEAhSsAKE2HAAEkDgBwIQ1BhUGkBIQkECENQYb/zT48A4AC/EGmAA4AP+tEQaRhAAdATYQEgML0wtckdE0vJCB1NyQAdYQEkXGEU4BRoBGBUaERgv/NPjwDgAL8caaQDpA/60RxpLEIC0B1hASAwvQgwCDkIMgAp6NFYaUAIQABYYQAgML0jAWdFACACQKuJ780EAAAAwHX/HwBYAUCq+///qqoAAAAwAED/DwAA/wEAAAAsAED6wwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x7f
+  pc_program_page: 0x15f
+  pc_erase_sector: 0xe1
+  pc_erase_all: 0xad
+  data_section_offset: 0x1e0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8080000
+    page_size: 0x400
+    erased_byte_value: 0xff
+    program_page_timeout: 400
+    erase_sector_timeout: 400
+    sectors:
+    - size: 0x800
+      address: 0x0
+- name: stm32g0bx_256
+  description: STM32G0Bx_256
+  default: true
+  instructions: crZqSmpJimBqSopgAOAAvwppkgOSD/rRZ0pKRFBgZ0gAjAAEgAmQYEAI0GBkSABoAwVkSBsNGBgf0AooHdAQKBvQASAQYAhqgALADxBhCGrAAwjUXUhcSgJgUhACYAYiQmBbSoJgCGoAAwTUWkhZSUFgfyEBYAAgcEcAIOLnTkhIREBoAWhKSEkcBNABaAEiEgSRQwFgQWkBItIHEUNBYb/zT48AIHBHASBwR0BIS0oCYcETQWFBaQEjGwQZQ0Fhv/NPjwDgAL8BaYkDiQ/60QFpEUIC0AJhASBwRwAgcEcwtTVLASRLRBpo5AQBKgzRGWkBKQLQmWihQgbR3WhZaE0ZhUIB2AEhAOAAIQEqAdCaaAbgGmkBKgLQmmiiQgDR2mguS1IeEEAhSsAKE2HAAEkDgBwIQ1BhUGkBIQkECENQYb/zT48A4AC/EGmAA4AP+tEQaRhAAdATYQEgML0wtckdE0vJCB1NyQAdYQEkXGEU4BRoBGBUaERgv/NPjwDgAL8caaQDpA/60RxpLEIC0B1hASAwvQgwCDkIMgAp6NFYaUAIQABYYQAgML0jAWdFACACQKuJ780EAAAAwHX/HwBYAUCq+///qqoAAAAwAED/DwAA/wEAAAAsAED6wwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x7f
+  pc_program_page: 0x15f
+  pc_erase_sector: 0xe1
+  pc_erase_all: 0xad
+  data_section_offset: 0x1e0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8040000
+    page_size: 0x400
+    erased_byte_value: 0xff
+    program_page_timeout: 400
+    erase_sector_timeout: 400
+    sectors:
+    - size: 0x800
+      address: 0x0


### PR DESCRIPTION
Updated the file based on the procedure outlined to me in the matrix chat by dirbaio. The diff looks a little messy, is there some formatting script I should be using? or would it be ok if I reformatted it manually?
I also have no clue how to test this. I tried replacing the probe-rs dependencies in `cargo-embed`, but it seems like there are a lot of errors, i think from previous changes to probe-rs the v0.13 release.