### PR TITLE
Error message in case of usb device access issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- (#1269) Error message in case of FTDI device access issues.
 - (#350) Flashing and debugging on STM32 chips using WFI instructions should now be stable (fixed in #1177)
 - Fixed rtthost --scan-region to properly support memory range scannig. (#1192)
 - Debug: Improve logic for halt locations used by breakpoints and stepping. (#1156)

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -751,11 +751,11 @@ fn get_device_info(device: &rusb::Device<rusb::Context>) -> Option<DebugProbeInf
 
     let handle = match device.open() {
         Err(rusb::Error::Access) => {
-            log::Warn("Access denied: probe device {:#?}", device);
+            log::warn!("Access denied: probe device {:#?}", device);
             return None;
         }
         Err(e) => {
-            log::Warn("Can't open probe device {:#?} -- Error: {:#?}", device, e);
+            log::warn!("Can't open probe device {:#?} -- Error: {:#?}", device, e);
             return None;
         }
         Ok(v) => v,

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -749,7 +749,18 @@ fn get_device_info(device: &rusb::Device<rusb::Context>) -> Option<DebugProbeInf
         return None;
     }
 
-    let handle = device.open().ok()?;
+    let handle = match device.open() {
+        Err(rusb::Error::Access) => {
+            eprintln!("Access denied: probe device {:#?}", device);
+            eprintln!("(Hint: check udev-Rules!)");
+            return None;
+        }
+        Err(e) => {
+            eprint!("Can't open probe device {:#?} -- Error: {:#?}", device, e);
+            return None;
+        }
+        Ok(v) => v,
+    };
 
     let prod_str = handle.read_product_string_ascii(&d_desc).ok()?;
     let sn_str = handle.read_serial_number_string_ascii(&d_desc).ok();

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -751,12 +751,11 @@ fn get_device_info(device: &rusb::Device<rusb::Context>) -> Option<DebugProbeInf
 
     let handle = match device.open() {
         Err(rusb::Error::Access) => {
-            eprintln!("Access denied: probe device {:#?}", device);
-            eprintln!("(Hint: check udev-Rules!)");
+            log::Warn("Access denied: probe device {:#?}", device);
             return None;
         }
         Err(e) => {
-            eprint!("Can't open probe device {:#?} -- Error: {:#?}", device, e);
+            log::Warn("Can't open probe device {:#?} -- Error: {:#?}", device, e);
             return None;
         }
         Ok(v) => v,


### PR DESCRIPTION
Report more verbose error message in case of insufficient access privileges to open connected/found probe devices.

This is usually caused by missing udev rules specifying unprivileged access.