### PR TITLE
Add Support for W7500 from Wiznet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `FlashLoader::data` method (#1254)
 - Added Support for STM32H735 family. (#913)
 - Added support for MAX32660 target (#1249)
+- Added support for W7500 target
 
 ### Changed
 

--- a/probe-rs/targets/W7500.yaml
+++ b/probe-rs/targets/W7500.yaml
@@ -1,0 +1,51 @@
+name: W7500
+variants:
+- name: W7500
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Nvm
+    name: FLASH
+    range:
+      start: 0x0
+      end: 0x20000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  flash_algorithms:
+  - w7500_128
+flash_algorithms:
+- name: w7500_128
+  description: W7500 128KB FLASH
+  default: true
+  instructions: MLQRTKRGMLxgRwAgcEcAIHBHACMQtRpGGUYUIP/38P8AIBC9ELUAIwFGGkYSIP/35/8AIBC9C0YQtQFGIiD/99//ACAQvQAAARD/HwAAAAA=
+  pc_init: 0xb
+  pc_uninit: 0xf
+  pc_program_page: 0x37
+  pc_erase_sector: 0x25
+  pc_erase_all: 0x13
+  data_section_offset: 0x4c
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x20000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 100
+    erase_sector_timeout: 3000
+    sectors:
+    - size: 0x100
+      address: 0x0
+  cores:
+  - main


### PR DESCRIPTION
This pull request adds a target descriptor for the W7500 device from Wiznet.

The descriptor has been generated using target-gen, using this [FLM (ELF)](https://docs.wiznet.io/img/products/w7500/overview/w7500_128_flm.zip) file as input.

Some correction has been done in the memory_map section according to supplier [memory map](https://docs.wiznet.io/Product/iMCU/W7500/system-and-memory#memory-map) documentation (both !Nvm and !Ram ranges were wrong and is_boot_memory was wrongly applyed to !Ram instead of !Nvm).

Smoke_tester was successfully run with a J-Link EDU probe on real target :

```bash
georges@Goten:~/Dev/Rust/probe-rs (master)$ ./target/debug/smoke_tester --chip W7500 --probe 1366:0105
[1/1](W7500) - Starting Test
[1/1](W7500) - Probe: "J-Link"
[1/1](W7500) - Chip:  "W7500"
[1/1](W7500) - Core 0: Armv6m
[1/1](W7500) - Halting core..
[1/1](W7500) - Test [1/0] - Testing register access...
[1/1](W7500) - Test [1/0] - Test passed.
[1/1](W7500) - Test [2/0] - Test - RAM Start 32
[1/1](W7500) - Test [2/0] - Test - RAM End 32
[1/1](W7500) - Test [2/0] - Test - RAM Start 8
[1/1](W7500) - Test [2/0] - Test - RAM 8 Unaligned
[1/1](W7500) - Test [2/0] - Test - RAM End 8
[1/1](W7500) - Test [2/0] - Test passed.
[1/1](W7500) - Test [3/0] - Testing HW breakpoints
[1/1](W7500) - Test [3/0] - 4 breakpoints supported
[1/1](W7500) - Test [3/0] - Test passed.
Testing stepping...
R0 value ok!
Core halted at 0x20000002, now trying to run...
Core halted again!
Core halted at 0x20000006, now trying to run...
Run core again, with pc = 0x20000008
[1/1](W7500) - Test [4/0] - Test passed.
[1/1](W7500) - Tests Passed
[DONE] - All DUTs passed.
```