### PR TITLE
riscv: validate csr address in read/write_csr_progbuf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix: Update STM32G0_Series.yaml to include latest variants (STM32G050, STM32G051, STM32G061, STM32G0B0, STM32G0B1, STM32G0C1) (#1266)
 - Fix: Correct flash algorithm values in LPC55S69.yaml. (#1220)
 - Fix: Timeout during flashing when using connect under reset - regression from #1259. (#1286)
+- Fix: Validate RiscV CSR addresses to avoid unnecessary panics. (#1291)
 
 ## [0.13.0]
 


### PR DESCRIPTION
Previously, a call to `Riscv32::read_core_reg` could panic when passed an invalid CSR number.  The panic originated in `i_type_instruction` call as it asserts `imm <= 0xFFF`.  
Snippet of a backtrace:
```
   2: core::panicking::panic
             at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/panicking.rs:48:5
   3: probe_rs::architecture::riscv::assembly::i_type_instruction
             at /home/fawaz/.cargo/git/checkouts/probe-rs-c1a8b38a079f9523/6ff8fae/probe-rs/src/architecture/riscv/assembly.rs:69:5
   4: probe_rs::architecture::riscv::assembly::csrrs
             at /home/fawaz/.cargo/git/checkouts/probe-rs-c1a8b38a079f9523/6ff8fae/probe-rs/src/architecture/riscv/assembly.rs:43:5
   5: probe_rs::architecture::riscv::assembly::csrr
             at /home/fawaz/.cargo/git/checkouts/probe-rs-c1a8b38a079f9523/6ff8fae/probe-rs/src/architecture/riscv/assembly.rs:36:5
   6: probe_rs::architecture::riscv::communication_interface::RiscvCommunicationInterface::read_csr_progbuf
             at /home/fawaz/.cargo/git/checkouts/probe-rs-c1a8b38a079f9523/6ff8fae/probe-rs/src/architecture/riscv/communication_interface.rs:1110:24
   7: probe_rs::architecture::riscv::Riscv32::read_csr
             at /home/fawaz/.cargo/git/checkouts/probe-rs-c1a8b38a079f9523/6ff8fae/probe-rs/src/architecture/riscv/mod.rs:49:17
   8: <probe_rs::architecture::riscv::Riscv32 as probe_rs::core::CoreInterface>::read_core_reg
             at /home/fawaz/.cargo/git/checkouts/probe-rs-c1a8b38a079f9523/6ff8fae/probe-rs/src/architecture/riscv/mod.rs:293:9
```

The `read_core_reg` function returns a `Result` and I would expect an error to to returned on invalid input, not a panic.  I added a CSR address check to `read_csr_progbuf`, and a new `RiscvError` variant.