### PR TITLE
probe-rs: Replace log with tracing

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,3 +38,4 @@ num-traits = "0.2.14"
 bitfield = "0.14.0"
 jep106 = "0.2.6"
 itm-decode = { version = "0.6", default-features = false }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,6 +24,7 @@ use probe_rs_cli_util::{
 use rustyline::Editor;
 
 use anyhow::{Context, Result};
+use tracing_subscriber::EnvFilter;
 
 use std::{fs::File, path::PathBuf};
 use std::{io, time::Instant};
@@ -226,8 +227,11 @@ pub(crate) enum ItmSource {
 }
 
 fn main() -> Result<()> {
-    // Initialize the logging backend.
-    pretty_env_logger::init();
+    tracing_subscriber::fmt::fmt()
+        .compact()
+        .without_time()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
 
     let matches = Cli::parse();
 

--- a/doc/attach_flow_arm.md
+++ b/doc/attach_flow_arm.md
@@ -1,0 +1,24 @@
+# Target attachment flow
+
+Overview over the steps which happen when
+attaching to an ARM target.
+
+```mermaid
+flowchart TD
+    st((start))
+    st --> att{Attach under\n Reset?}
+    att -- yes --> reset_assert(Assert hardware reset)
+    dp_setup(Setup Debug Port)
+    att -- no --> dp_setup
+    reset_assert --> dp_setup
+    dp_setup --> device_unlock(Unlock debug device)
+    device_unlock --> debug_core_start(Debug core Start)
+    debug_core_start --> attach_decision_after{Attach under\n Reset?}
+    attach_decision_after -- yes --> reset_catch_set(Set Reset Catch)
+    reset_catch_set --> reset_deassert(Deassert hardware reset)
+    reset_deassert --> wait_core_halted(Wait for core to be halted)
+    wait_core_halted --> reset_catch_clear(Clear Reset Catch)
+    reset_catch_clear --> attach_done_core_halted((Attach done \n Core halted))
+    attach_decision_after -- no --> attach_done_core_unknown((Attach done, \n Core state unknown))
+```
+

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -45,7 +45,6 @@ ihex = "3.0.0"
 jaylink = "0.3.0"
 jep106 = "0.2.6"
 once_cell = "1.7.2"
-log = { workspace = true }
 num-traits = "0.2.11"
 object = { version = "0.30.0", default-features = false, features = [
     "elf",
@@ -59,6 +58,7 @@ serde_yaml = "0.9"
 static_assertions = "1.1.0"
 svg = "0.12.0"
 thiserror = { workspace = true }
+tracing = { version = "0.1.37", features = ["log"] }
 
 # optional
 hexdump = { version = "0.1.0", optional = true }
@@ -66,6 +66,7 @@ libftdi1-sys = { version = "1.1.2", optional = true }
 
 # path
 probe-rs-target = { workspace = true }
+
 
 [build-dependencies]
 bincode = "1.3.2"

--- a/probe-rs/examples/tcp_itm.rs
+++ b/probe-rs/examples/tcp_itm.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Error> {
         while let Ok(Some(packet)) = decoder.pull() {
             match packet {
                 TracePacket::LocalTimestamp1 { ts, data_relation } => {
-                    log::debug!(
+                    tracing::debug!(
                         "Timestamp packet: data_relation={:?} ts={}",
                         data_relation,
                         ts
@@ -56,11 +56,11 @@ fn main() -> Result<(), Error> {
                     timestamp += time_delta;
                 }
                 // TracePacket::DwtData { id, payload } => {
-                //     log::warn!("Dwt: id={} payload={:?}", id, payload);
+                //     tracing::warn!("Dwt: id={} payload={:?}", id, payload);
 
                 //     if id == 17 {
                 //         let value: i32 = payload.pread(0).unwrap();
-                //         log::trace!("VAL={}", value);
+                //         tracing::trace!("VAL={}", value);
                 //         // client.send_sample("a", timestamp, value as f64).unwrap();
                 //     }
                 // }
@@ -93,10 +93,10 @@ fn main() -> Result<(), Error> {
                     }
                 }
                 _ => {
-                    log::warn!("Trace packet: {:?}", packet);
+                    tracing::warn!("Trace packet: {:?}", packet);
                 }
             }
-            log::debug!("{}", timestamp);
+            tracing::debug!("{}", timestamp);
         }
     }
 }
@@ -124,7 +124,7 @@ impl TcpPublisher {
                     if err.kind() == std::io::ErrorKind::WouldBlock {
                     } else {
                         to_remove.push(i);
-                        log::error!("Writing to a tcp socket experienced an error: {:?}", err)
+                        tracing::error!("Writing to a tcp socket experienced an error: {:?}", err)
                     }
                 }
             }
@@ -197,7 +197,7 @@ impl SwoPublisher<Box<dyn Any + Send>> for TcpPublisher {
         let (_outbound, tx) = channel::<O>();
         let (halt_tx, halt_rx) = channel::<()>();
 
-        log::info!("Opening websocket on '{}'", self.connection_string);
+        tracing::info!("Opening websocket on '{}'", self.connection_string);
         let server = TcpListener::bind(&self.connection_string).unwrap();
         server.set_nonblocking(true).unwrap();
 
@@ -219,20 +219,20 @@ impl SwoPublisher<Box<dyn Any + Send>> for TcpPublisher {
                             // Make sure we operate in nonblocking mode.
                             // Is is required so read does not block forever.
                             stream.set_nonblocking(true).unwrap();
-                            log::info!("Accepted a new websocket connection from {}", addr);
+                            tracing::info!("Accepted a new websocket connection from {}", addr);
                             sockets.push((stream, addr));
                         }
                         Some(Err(err)) => {
                             if err.kind() == std::io::ErrorKind::WouldBlock {
                             } else {
-                                log::error!(
+                                tracing::error!(
                                     "Connecting to a websocket experienced an error: {:?}",
                                     err
                                 )
                             }
                         }
                         None => {
-                            log::error!("The TCP listener iterator was exhausted. Shutting down websocket listener.");
+                            tracing::error!("The TCP listener iterator was exhausted. Shutting down websocket listener.");
                             return;
                         }
                     }
@@ -266,7 +266,7 @@ impl SwoPublisher<Box<dyn Any + Send>> for TcpPublisher {
             h.0.join()
         }) {
             Some(Err(err)) => {
-                log::error!("An error occurred during thread execution: {:?}", err);
+                tracing::error!("An error occurred during thread execution: {:?}", err);
                 Err(err)
             }
             _ => Ok(()),

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -133,7 +133,7 @@ impl ApAccess for MockMemoryAp {
         PORT: AccessPort,
         R: ApRegister<PORT>,
     {
-        log::debug!("Mock: Write to register {:x?}", &register);
+        tracing::debug!("Mock: Write to register {:x?}", &register);
 
         let value: u32 = register.into();
         self.store.insert(R::ADDRESS, value);

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -151,10 +151,10 @@ impl<T: DapAccess> ApAccess for T {
         PORT: AccessPort,
         R: ApRegister<PORT>,
     {
-        log::debug!("Reading register {}", R::NAME);
+        tracing::debug!("Reading register {}", R::NAME);
         let raw_value = self.read_raw_ap_register(port.into().ap_address(), R::ADDRESS)?;
 
-        log::debug!("Read register    {}, value=0x{:x?}", R::NAME, raw_value);
+        tracing::debug!("Read register    {}, value=0x{:x?}", R::NAME, raw_value);
 
         Ok(raw_value.into())
     }
@@ -168,7 +168,7 @@ impl<T: DapAccess> ApAccess for T {
         PORT: AccessPort,
         R: ApRegister<PORT>,
     {
-        log::debug!("Writing register {}, value={:x?}", R::NAME, register);
+        tracing::debug!("Writing register {}, value={:x?}", R::NAME, register);
         self.write_raw_ap_register(port.into().ap_address(), R::ADDRESS, register.into())
     }
 
@@ -182,7 +182,7 @@ impl<T: DapAccess> ApAccess for T {
         PORT: AccessPort,
         R: ApRegister<PORT>,
     {
-        log::debug!(
+        tracing::debug!(
             "Writing register {}, block with len={} words",
             R::NAME,
             values.len(),
@@ -200,7 +200,7 @@ impl<T: DapAccess> ApAccess for T {
         PORT: AccessPort,
         R: ApRegister<PORT>,
     {
-        log::debug!(
+        tracing::debug!(
             "Reading register {}, block with len={} words",
             R::NAME,
             values.len(),

--- a/probe-rs/src/architecture/arm/component/dwt.rs
+++ b/probe-rs/src/architecture/arm/component/dwt.rs
@@ -35,12 +35,12 @@ impl<'a> Dwt<'a> {
     pub fn info(&mut self) -> Result<(), Error> {
         let ctrl = Ctrl::load(self.component, self.interface)?;
 
-        log::info!("DWT info:");
-        log::info!("  number of comparators available: {}", ctrl.numcomp());
-        log::info!("  trace sampling support: {}", !ctrl.notrcpkt());
-        log::info!("  compare match support: {}", !ctrl.noexttrig());
-        log::info!("  cyccnt support: {}", !ctrl.nocyccnt());
-        log::info!("  performance counter support: {}", !ctrl.noprfcnt());
+        tracing::info!("DWT info:");
+        tracing::info!("  number of comparators available: {}", ctrl.numcomp());
+        tracing::info!("  trace sampling support: {}", !ctrl.notrcpkt());
+        tracing::info!("  compare match support: {}", !ctrl.noexttrig());
+        tracing::info!("  cyccnt support: {}", !ctrl.nocyccnt());
+        tracing::info!("  performance counter support: {}", !ctrl.noprfcnt());
 
         Ok(())
     }

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -279,7 +279,7 @@ pub(crate) fn read_trace_memory(
                 // ITM ATID, see Itm::tx_enable()
                 13 => itm_trace.push(data),
                 0 => (),
-                id => log::warn!("Unexpected trace source ATID {id}: {data}, ignoring"),
+                id => tracing::warn!("Unexpected trace source ATID {id}: {data}, ignoring"),
             }
         }
         id = frame.id();

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -69,12 +69,12 @@ impl<'probe> Armv7a<'probe> {
             let address = Dbgdscr::get_mmio_address(base_address);
             let dbgdscr = Dbgdscr(memory.read_word_32(address)?);
 
-            log::debug!("State when connecting: {:x?}", dbgdscr);
+            tracing::debug!("State when connecting: {:x?}", dbgdscr);
 
             let core_state = if dbgdscr.halted() {
                 let reason = dbgdscr.halt_reason();
 
-                log::debug!("Core was halted when connecting, reason: {:?}", reason);
+                tracing::debug!("Core was halted when connecting, reason: {:?}", reason);
 
                 CoreStatus::Halted(reason)
             } else {
@@ -711,7 +711,7 @@ impl<'probe> CoreInterface for Armv7a<'probe> {
         }
         // Core is neither halted nor sleeping, so we assume it is running.
         if self.state.current_state.is_halted() {
-            log::warn!("Core is running, but we expected it to be halted");
+            tracing::warn!("Core is running, but we expected it to be halted");
         }
 
         self.state.current_state = CoreStatus::Running;

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -75,12 +75,12 @@ impl<'probe> Armv8a<'probe> {
             let address = Edscr::get_mmio_address(base_address);
             let edscr = Edscr(memory.read_word_32(address)?);
 
-            log::debug!("State when connecting: {:x?}", edscr);
+            tracing::debug!("State when connecting: {:x?}", edscr);
 
             let core_state = if edscr.halted() {
                 let reason = edscr.halt_reason();
 
-                log::debug!("Core was halted when connecting, reason: {:?}", reason);
+                tracing::debug!("Core was halted when connecting, reason: {:?}", reason);
 
                 CoreStatus::Halted(reason)
             } else {
@@ -1047,7 +1047,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
         }
         // Core is neither halted nor sleeping, so we assume it is running.
         if self.state.current_state.is_halted() {
-            log::warn!("Core is running, but we expected it to be halted");
+            tracing::warn!("Core is running, but we expected it to be halted");
         }
 
         self.state.current_state = CoreStatus::Running;

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -41,7 +41,7 @@ impl<'probe> Armv8m<'probe> {
             // determine current state
             let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
 
-            log::debug!("State when connecting: {:x?}", dhcsr);
+            tracing::debug!("State when connecting: {:x?}", dhcsr);
 
             let core_state = if dhcsr.s_sleep() {
                 CoreStatus::Sleeping
@@ -50,7 +50,7 @@ impl<'probe> Armv8m<'probe> {
 
                 let reason = dfsr.halt_reason();
 
-                log::debug!("Core was halted when connecting, reason: {:?}", reason);
+                tracing::debug!("Core was halted when connecting, reason: {:?}", reason);
 
                 CoreStatus::Halted(reason)
             } else {
@@ -210,7 +210,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
                     .hw_breakpoints()?
                     .contains(&pc_before_step.try_into().ok())
             {
-                log::debug!("Encountered a breakpoint instruction @ {}. We need to manually advance the program counter to the next instruction.", pc_after_step);
+                tracing::debug!("Encountered a breakpoint instruction @ {}. We need to manually advance the program counter to the next instruction.", pc_after_step);
                 // Advance the program counter by the architecture specific byte size of the BKPT instruction.
                 pc_after_step.incremenet_address(2)?;
                 self.write_core_reg(self.registers().program_counter().id, pc_after_step)?;
@@ -320,7 +320,9 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         let dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::ADDRESS)?);
 
         if dhcsr.s_lockup() {
-            log::warn!("The core is in locked up status as a result of an unrecoverable exception");
+            tracing::warn!(
+                "The core is in locked up status as a result of an unrecoverable exception"
+            );
 
             self.state.current_state = CoreStatus::LockedUp;
 
@@ -330,7 +332,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         if dhcsr.s_sleep() {
             // Check if we assumed the core to be halted
             if self.state.current_state.is_halted() {
-                log::warn!("Expected core to be halted, but core is running");
+                tracing::warn!("Expected core to be halted, but core is running");
             }
 
             self.state.current_state = CoreStatus::Sleeping;
@@ -356,11 +358,11 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
                 // that the reason for the halt has changed. No bits set
                 // means that we have an unkown HaltReason.
                 if reason == HaltReason::Unknown {
-                    log::debug!("Cached halt reason: {:?}", self.state.current_state);
+                    tracing::debug!("Cached halt reason: {:?}", self.state.current_state);
                     return Ok(self.state.current_state);
                 }
 
-                log::debug!(
+                tracing::debug!(
                     "Reason for halt has changed, old reason was {:?}, new reason is {:?}",
                     &self.state.current_state,
                     &reason
@@ -374,7 +376,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
 
         // Core is neither halted nor sleeping, so we assume it is running.
         if self.state.current_state.is_halted() {
-            log::warn!("Core is running, but we expected it to be halted");
+            tracing::warn!("Core is running, but we expected it to be halted");
         }
 
         self.state.current_state = CoreStatus::Running;

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -937,7 +937,7 @@ impl Dfsr {
             // No bit is set
             HaltReason::Unknown
         } else if self.0.count_ones() > 1 {
-            log::debug!("DFSR: {:?}", self);
+            tracing::debug!("DFSR: {:?}", self);
 
             // We cannot identify why the chip halted,
             // it could be for multiple reasons.

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -47,9 +47,9 @@ pub trait DpAccess {
 
 impl<T: DapAccess> DpAccess for T {
     fn read_dp_register<R: DpRegister>(&mut self, dp: DpAddress) -> Result<R, DebugPortError> {
-        log::debug!("Reading DP register {}", R::NAME);
+        tracing::debug!("Reading DP register {}", R::NAME);
         let result = self.read_raw_dp_register(dp, R::ADDRESS)?;
-        log::debug!("Read    DP register {}, value=0x{:08x}", R::NAME, result);
+        tracing::debug!("Read    DP register {}, value=0x{:08x}", R::NAME, result);
         Ok(result.into())
     }
 
@@ -59,7 +59,7 @@ impl<T: DapAccess> DpAccess for T {
         register: R,
     ) -> Result<(), DebugPortError> {
         let value = register.into();
-        log::debug!("Writing DP register {}, value=0x{:08x}", R::NAME, value);
+        tracing::debug!("Writing DP register {}, value=0x{:08x}", R::NAME, value);
         self.write_raw_dp_register(dp, R::ADDRESS, value)?;
         Ok(())
     }

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -341,7 +341,7 @@ where
 
         let mut data_offset = 0;
 
-        log::debug!(
+        tracing::debug!(
             "Read first block with len {} at address {:#08x}",
             first_chunk_size_bytes,
             address
@@ -368,7 +368,7 @@ where
 
             let next_chunk_size_bytes = std::cmp::min(max_chunk_size_bytes, remaining_data_len * 4);
 
-            log::debug!(
+            tracing::debug!(
                 "Reading chunk with len {} at address {:#08x}",
                 next_chunk_size_bytes,
                 address
@@ -387,7 +387,7 @@ where
             data_offset += next_chunk_size_words;
         }
 
-        log::debug!("Finished reading block");
+        tracing::debug!("Finished reading block");
 
         Ok(())
     }
@@ -535,7 +535,7 @@ where
             return Err(AccessPortError::alignment_error(start_address, 4));
         }
 
-        log::debug!(
+        tracing::debug!(
             "Write block with total size {} bytes to address {:#08x}",
             data.len() * 4,
             start_address
@@ -564,7 +564,7 @@ where
 
         let mut data_offset = 0;
 
-        log::debug!(
+        tracing::debug!(
             "Write first block with len {} at address {:#08x}",
             first_chunk_size_bytes,
             address
@@ -589,7 +589,7 @@ where
 
             let next_chunk_size_bytes = std::cmp::min(max_chunk_size_bytes, remaining_data_len * 4);
 
-            log::debug!(
+            tracing::debug!(
                 "Writing chunk with len {} at address {:#08x}",
                 next_chunk_size_bytes,
                 address
@@ -608,7 +608,7 @@ where
             data_offset += next_chunk_size_words;
         }
 
-        log::debug!("Finished writing block");
+        tracing::debug!("Finished writing block");
 
         Ok(())
     }

--- a/probe-rs/src/architecture/arm/memory/mod.rs
+++ b/probe-rs/src/architecture/arm/memory/mod.rs
@@ -4,4 +4,4 @@ pub(crate) mod adi_v5_memory_interface;
 pub(crate) mod romtable;
 
 use super::ap::AccessPortError;
-pub use romtable::{Component, CoresightComponent, PeripheralType};
+pub use romtable::{Component, ComponentId, CoresightComponent, PeripheralType};

--- a/probe-rs/src/architecture/arm/sequences/atsame5x.rs
+++ b/probe-rs/src/architecture/arm/sequences/atsame5x.rs
@@ -215,14 +215,14 @@ impl AtSAME5x {
         let mut dsu_ctrl = DsuCtrl(0);
         dsu_ctrl.set_ce(true);
         memory.write_word_8(DsuCtrl::ADDRESS, dsu_ctrl.0)?;
-        log::info!("Chip-Erase started..");
+        tracing::info!("Chip-Erase started..");
 
         // Wait for it to finish
         let start = std::time::Instant::now();
         while start.elapsed() < std::time::Duration::from_secs(8) {
             let current_dsu_statusa = DsuStatusA::from(memory.read_word_8(DsuStatusA::ADDRESS)?);
             if current_dsu_statusa.done() {
-                log::info!("Chip-Erase complete");
+                tracing::info!("Chip-Erase complete");
                 // If the device was in Reset Extension when we started put it back into Reset Extension
                 if dsu_status_a.crstext() {
                     self.reset_hardware_with_extension(memory.get_arm_interface()?)?;
@@ -239,7 +239,7 @@ impl AtSAME5x {
             std::thread::sleep(std::time::Duration::from_millis(250));
         }
 
-        log::error!("Chip-Erase failed to complete within 8 seconds");
+        tracing::error!("Chip-Erase failed to complete within 8 seconds");
         Err(Error::Probe(DebugProbeError::Timeout))
     }
 
@@ -381,7 +381,7 @@ impl ArmDebugSequence for AtSAME5x {
         let dsu_status_b = DsuStatusB::from(memory.read_word_8(DsuStatusB::ADDRESS)?);
 
         if dsu_status_b.prot() {
-            log::warn!("The Device is locked, unlocking..");
+            tracing::warn!("The Device is locked, unlocking..");
             self.erase_all(&mut memory, permissions)
         } else {
             Ok(())

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -134,7 +134,7 @@ fn armv7a_core_start(core: &mut Memory, debug_base: Option<u64>) -> Result<(), c
     let debug_base = debug_base.ok_or_else(|| {
         crate::Error::architecture_specific(ArmDebugSequenceError::DebugBaseNotSpecified)
     })?;
-    log::debug!(
+    tracing::debug!(
         "Starting debug for ARMv7-A core with registers at {:#X}",
         debug_base
     );
@@ -156,7 +156,7 @@ fn armv7a_core_start(core: &mut Memory, debug_base: Option<u64>) -> Result<(), c
     let mut dbgdscr = Dbgdscr(core.read_word_32(address)?);
 
     if dbgdscr.hdbgen() {
-        log::debug!("Core is already in debug mode, no need to enable it again");
+        tracing::debug!("Core is already in debug mode, no need to enable it again");
         return Ok(());
     }
 
@@ -253,7 +253,7 @@ fn armv8a_core_start(
         crate::Error::architecture_specific(ArmDebugSequenceError::CtiBaseNotSpecified)
     })?;
 
-    log::debug!(
+    tracing::debug!(
         "Starting debug for ARMv8-A core with registers at {:#X}",
         debug_base
     );
@@ -293,7 +293,7 @@ fn armv8a_core_start(
     let mut edscr = Edscr(core.read_word_32(address)?);
 
     if edscr.hde() {
-        log::debug!("Core is already in debug mode, no need to enable it again");
+        tracing::debug!("Core is already in debug mode, no need to enable it again");
         return Ok(());
     }
 
@@ -311,7 +311,7 @@ fn cortex_m_core_start(core: &mut Memory) -> Result<(), crate::Error> {
 
     // Note: Manual addition for debugging, not part of the original DebugCoreStart function
     if current_dhcsr.c_debugen() {
-        log::debug!("Core is already in debug mode, no need to enable it again");
+        tracing::debug!("Core is already in debug mode, no need to enable it again");
         return Ok(());
     }
     // -- End addition
@@ -432,6 +432,8 @@ pub trait ArmDebugSequence: Send + Sync {
                 if Pins(interface.swj_pins(n_reset, n_reset, 0)? as u8).nreset() {
                     return Ok(());
                 }
+
+                thread::sleep(Duration::from_millis(100));
             }
 
             Err(DebugProbeError::Timeout.into())
@@ -546,7 +548,7 @@ pub trait ArmDebugSequence: Send + Sync {
 
             let ctrl_reg: Ctrl = interface.read_dp_register(dp)?;
             if !(ctrl_reg.csyspwrupack() && ctrl_reg.cdbgpwrupack()) {
-                log::error!("Debug power request failed");
+                tracing::error!("Debug power request failed");
                 return Err(DapError::TargetPowerUpFailed.into());
             }
 
@@ -703,7 +705,7 @@ pub trait ArmDebugSequence: Send + Sync {
         _default_ap: MemoryAp,
         _permissions: &crate::Permissions,
     ) -> Result<(), crate::Error> {
-        // Empty by default
+        tracing::debug!("debug_device_unlock - empty by default");
         Ok(())
     }
 

--- a/probe-rs/src/architecture/arm/sequences/nrf.rs
+++ b/probe-rs/src/architecture/arm/sequences/nrf.rs
@@ -69,17 +69,17 @@ impl<T: Nrf> ArmDebugSequence for T {
         for (core_index, (core_ahb_ap_address, core_ctrl_ap_address)) in
             self.core_aps(&mut interface).iter().copied().enumerate()
         {
-            log::info!("Checking if core {} is unlocked", core_index);
+            tracing::info!("Checking if core {} is unlocked", core_index);
             if self.is_core_unlocked(
                 interface.get_arm_interface()?,
                 core_ahb_ap_address,
                 core_ctrl_ap_address,
             )? {
-                log::info!("Core {} is already unlocked", core_index);
+                tracing::info!("Core {} is already unlocked", core_index);
                 continue;
             }
 
-            log::warn!(
+            tracing::warn!(
                 "Core {} is locked. Erase procedure will be started to unlock it.",
                 core_index
             );

--- a/probe-rs/src/architecture/arm/sequences/nrf52.rs
+++ b/probe-rs/src/architecture/arm/sequences/nrf52.rs
@@ -74,7 +74,7 @@ impl ArmDebugSequence for Nrf52 {
     ) -> Result<(), crate::Error> {
         let tpiu_clock = match sink {
             TraceSink::TraceMemory => {
-                log::error!("nRF52 does not have a trace buffer");
+                tracing::error!("nRF52 does not have a trace buffer");
                 return Err(Error::architecture_specific(
                     ComponentError::NordicNoTraceMem,
                 ));
@@ -91,7 +91,7 @@ impl ArmDebugSequence for Nrf52 {
             32_000_000 => 0,
             tpiu_clk => {
                 let e = ComponentError::NordicUnsupportedTPUICLKValue(tpiu_clk);
-                log::error!("{:?}", e);
+                tracing::error!("{:?}", e);
                 return Err(Error::architecture_specific(e));
             }
         };

--- a/probe-rs/src/architecture/arm/sequences/stm32h7.rs
+++ b/probe-rs/src/architecture/arm/sequences/stm32h7.rs
@@ -49,9 +49,9 @@ impl Stm32h7 {
         enable: bool,
     ) -> Result<(), crate::Error> {
         if enable {
-            log::info!("Enabling STM32H7 debug components");
+            tracing::info!("Enabling STM32H7 debug components");
         } else {
-            log::info!("Disabling STM32H7 debug components");
+            tracing::info!("Disabling STM32H7 debug components");
         }
 
         let mut control = dbgmcu::Control::read(memory)?;
@@ -183,7 +183,7 @@ impl ArmDebugSequence for Stm32h7 {
         components: &[CoresightComponent],
         sink: &TraceSink,
     ) -> Result<(), crate::Error> {
-        log::warn!("Enabling tracing for STM32H7");
+        tracing::warn!("Enabling tracing for STM32H7");
 
         // Configure the two trace funnels in the H7 debug system to route trace data to the
         // appropriate destination. The CSTF feeds the TPIU and ETF peripherals.

--- a/probe-rs/src/architecture/riscv/dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm.rs
@@ -40,7 +40,7 @@ impl Dtm {
 
         let dtmcs = Dtmcs(u32::from_le_bytes((&dtmcs_raw[..]).try_into().unwrap()));
 
-        log::debug!("Dtmcs: {:?}", dtmcs);
+        tracing::debug!("Dtmcs: {:?}", dtmcs);
 
         let abits = dtmcs.abits();
         let idle_cycles = dtmcs.idle();

--- a/probe-rs/src/architecture/riscv/sequences/esp32c3.rs
+++ b/probe-rs/src/architecture/riscv/sequences/esp32c3.rs
@@ -20,7 +20,7 @@ impl RiscvDebugSequence for ESP32C3 {
         &self,
         interface: &mut crate::architecture::riscv::communication_interface::RiscvCommunicationInterface,
     ) -> Result<(), crate::Error> {
-        log::info!("Disabling esp32c3 watchdogs...");
+        tracing::info!("Disabling esp32c3 watchdogs...");
         // disable super wdt
         interface.write_word_32(0x600080B0, 0x8F1D312Au32)?; // write protection off
         let current = interface.read_word_32(0x600080AC)?;

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -160,7 +160,7 @@ impl Registry {
     fn get_target_by_name(&self, name: impl AsRef<str>) -> Result<Target, RegistryError> {
         let name = name.as_ref();
 
-        log::debug!("Searching registry for chip with name {}", name);
+        tracing::debug!("Searching registry for chip with name {}", name);
 
         let (family, chip) = {
             // Try get the corresponding chip.
@@ -171,10 +171,10 @@ impl Registry {
                 for variant in family.variants.iter() {
                     if match_name_prefix(&variant.name, name) {
                         if variant.name.len() == name.len() {
-                            log::debug!("Exact match for chip name: {}", variant.name);
+                            tracing::debug!("Exact match for chip name: {}", variant.name);
                             exact_matches += 1;
                         } else {
-                            log::debug!("Partial match for chip name: {}", variant.name);
+                            tracing::debug!("Partial match for chip name: {}", variant.name);
                             partial_matches += 1;
                             if exact_matches > 0 {
                                 continue;
@@ -185,7 +185,7 @@ impl Registry {
                 }
             }
             if exact_matches > 1 || (exact_matches == 0 && partial_matches > 1) {
-                log::warn!(
+                tracing::warn!(
                     "Ignoring ambiguous matches for specified chip name {}",
                     name,
                 );
@@ -194,14 +194,14 @@ impl Registry {
             let (family, chip) = selected_family_and_chip
                 .ok_or_else(|| RegistryError::ChipNotFound(name.to_owned()))?;
             if exact_matches == 0 && partial_matches == 1 {
-                log::warn!(
+                tracing::warn!(
                     "Found chip {} which matches given partial name {}. Consider specifying its full name.",
                     chip.name,
                     name,
                 );
             }
             if chip.name.to_ascii_lowercase() != name.to_ascii_lowercase() {
-                log::warn!(
+                tracing::warn!(
                     "Matching {} based on wildcard. Consider specifying the chip as {} instead.",
                     name,
                     chip.name,
@@ -215,7 +215,7 @@ impl Registry {
     }
 
     fn search_chips(&self, name: &str) -> Vec<String> {
-        log::debug!("Searching registry for chip with name {}", name);
+        tracing::debug!("Searching registry for chip with name {}", name);
 
         let mut targets = Vec::new();
 
@@ -249,7 +249,7 @@ impl Registry {
                     let mut identified_chips = Vec::new();
 
                     for family in families {
-                        log::debug!("Checking family {}", family.name);
+                        tracing::debug!("Checking family {}", family.name);
 
                         let chips = family
                             .variants()
@@ -263,7 +263,7 @@ impl Registry {
                     if identified_chips.len() == 1 {
                         identified_chips.pop().unwrap()
                     } else {
-                        log::debug!(
+                        tracing::debug!(
                         "Found {} matching chips for information {:?}, unable to determine chip",
                         identified_chips.len(),
                         chip_info

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -95,34 +95,34 @@ impl Target {
         };
 
         if chip.name.starts_with("MIMXRT10") {
-            log::warn!("Using custom sequence for MIMXRT10xx");
+            tracing::warn!("Using custom sequence for MIMXRT10xx");
             debug_sequence = DebugSequence::Arm(MIMXRT10xx::create());
         } else if chip.name.starts_with("LPC55S16") || chip.name.starts_with("LPC55S69") {
-            log::warn!("Using custom sequence for LPC55S16/LPC55S69");
+            tracing::warn!("Using custom sequence for LPC55S16/LPC55S69");
             debug_sequence = DebugSequence::Arm(LPC55S69::create());
         } else if chip.name.starts_with("esp32c3") {
-            log::warn!("Using custom sequence for ESP32c3");
+            tracing::warn!("Using custom sequence for ESP32c3");
             debug_sequence = DebugSequence::Riscv(ESP32C3::create());
         } else if chip.name.starts_with("nRF5340") {
-            log::warn!("Using custom sequence for nRF5340");
+            tracing::warn!("Using custom sequence for nRF5340");
             debug_sequence = DebugSequence::Arm(Nrf5340::create());
         } else if chip.name.starts_with("nRF52") {
-            log::warn!("Using custom sequence for nRF52");
+            tracing::warn!("Using custom sequence for nRF52");
             debug_sequence = DebugSequence::Arm(Nrf52::create());
         } else if chip.name.starts_with("nRF9160") {
-            log::warn!("Using custom sequence for nRF9160");
+            tracing::warn!("Using custom sequence for nRF9160");
             debug_sequence = DebugSequence::Arm(Nrf9160::create());
         } else if chip.name.starts_with("STM32H7") {
-            log::warn!("Using custom sequence for STM32H7");
+            tracing::warn!("Using custom sequence for STM32H7");
             debug_sequence = DebugSequence::Arm(Stm32h7::create());
         } else if chip.name.starts_with("STM32F2")
             || chip.name.starts_with("STM32F4")
             || chip.name.starts_with("STM32F7")
         {
-            log::warn!("Using custom sequence for STM32F2/4/7");
+            tracing::warn!("Using custom sequence for STM32F2/4/7");
             debug_sequence = DebugSequence::Arm(Stm32fSeries::create());
         } else if chip.name.starts_with("ATSAMD5") || chip.name.starts_with("ATSAME5") {
-            log::warn!("Using custom sequence for {}", chip.name);
+            tracing::warn!("Using custom sequence for {}", chip.name);
             debug_sequence = DebugSequence::Arm(AtSAME5x::create());
         }
 

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -165,7 +165,7 @@ impl DebugInfo {
                                                                     &unit, header, file_entry,
                                                                 )
                                                             {
-                                                                log::debug!(
+                                                                tracing::debug!(
                                                                     "{} - {:?}",
                                                                     address,
                                                                     previous_row.isa()
@@ -200,7 +200,7 @@ impl DebugInfo {
                                                                 &unit, header, file_entry,
                                                             )
                                                         {
-                                                            log::debug!(
+                                                            tracing::debug!(
                                                                 "{} - {:?}",
                                                                 address,
                                                                 row.isa()
@@ -229,7 +229,7 @@ impl DebugInfo {
                                     }
                                 }
                                 Err(error) => {
-                                    log::warn!(
+                                    tracing::warn!(
                                         "No valid source code ranges found for address {}: {:?}",
                                         address,
                                         error
@@ -240,7 +240,7 @@ impl DebugInfo {
                     }
                 }
                 Err(error) => {
-                    log::warn!(
+                    tracing::warn!(
                         "No valid source code ranges found for address {}: {:?}",
                         address,
                         error
@@ -381,7 +381,7 @@ impl DebugInfo {
                                         VariableLocation::Address(memory_location as u64)
                                     }
                                     Err(error) => {
-                                        log::error!("Failed to read referenced variable address from memory location {} : {}.", parent_variable.memory_location , error);
+                                        tracing::error!("Failed to read referenced variable address from memory location {} : {}.", parent_variable.memory_location , error);
                                         VariableLocation::Error(format!("Failed to read referenced variable address from memory location {} : {}.", parent_variable.memory_location, error))
                                     }
                                 };
@@ -545,7 +545,7 @@ impl DebugInfo {
                     .function_name()
                     .unwrap_or_else(|| unknown_function.clone());
 
-                log::debug!("UNWIND: Function name: {}", function_name);
+                tracing::debug!("UNWIND: Function name: {}", function_name);
 
                 let next_function = &functions[index + 1];
 
@@ -558,7 +558,7 @@ impl DebugInfo {
                     // The first instruction of the inlined function is used as the call site
                     inlined_call_site = Some(RegisterValue::from(next_function.low_pc));
 
-                    log::debug!(
+                    tracing::debug!(
                         "UNWIND: Callsite for inlined function {:?}",
                         next_function.function_name()
                     );
@@ -567,9 +567,9 @@ impl DebugInfo {
                 }
 
                 if let Some(inlined_call_site) = inlined_call_site {
-                    log::debug!("UNWIND: Call site: {:?}", inlined_caller_source_location);
+                    tracing::debug!("UNWIND: Call site: {:?}", inlined_caller_source_location);
 
-                    log::trace!("UNWIND: Function name: {}", function_name);
+                    tracing::trace!("UNWIND: Function name: {}", function_name);
 
                     // Now that we have the function_name and function_source_location, we can create the appropriate variable caches for this stack frame.
                     // Resolve the statics that belong to the compilation unit that this function is in.
@@ -577,7 +577,7 @@ impl DebugInfo {
                         .create_static_scope_cache(core, &unit_info)
                         .map_or_else(
                             |error| {
-                                log::error!(
+                                tracing::error!(
                                     "Could not resolve static variables. {}. Continuing...",
                                     error
                                 );
@@ -591,7 +591,7 @@ impl DebugInfo {
                         .create_function_scope_cache(core, function_die, &unit_info)
                         .map_or_else(
                             |error| {
-                                log::error!(
+                                tracing::error!(
                                     "Could not resolve function variables. {}. Continuing...",
                                     error
                                 );
@@ -613,7 +613,7 @@ impl DebugInfo {
                         local_variables,
                     });
                 } else {
-                    log::warn!(
+                    tracing::warn!(
                         "UNWIND: Unknown call site for inlined function {}.",
                         function_name
                     );
@@ -637,7 +637,7 @@ impl DebugInfo {
                 .create_static_scope_cache(core, &unit_info)
                 .map_or_else(
                     |error| {
-                        log::error!(
+                        tracing::error!(
                             "Could not resolve static variables. {}. Continuing...",
                             error
                         );
@@ -651,7 +651,7 @@ impl DebugInfo {
                 .create_function_scope_cache(core, last_function, &unit_info)
                 .map_or_else(
                     |error| {
-                        log::error!(
+                        tracing::error!(
                             "Could not resolve function variables. {}. Continuing...",
                             error
                         );
@@ -737,7 +737,7 @@ impl DebugInfo {
             let frame_pc = frame_pc_register_value
                 .try_into()
                 .map_err(|error| crate::Error::Other(anyhow::anyhow!("Cannot convert register value for program counter to a 64-bit integeer value: {:?}", error)))?;
-            log::trace!(
+            tracing::trace!(
                 "UNWIND: Will generate `StackFrame` for function at address (PC) {}",
                 frame_pc,
             );
@@ -750,7 +750,7 @@ impl DebugInfo {
                         // If we encountered INLINED functions (all `StackFrames`s in this Vec, except for the last one, which is the containing NON-INLINED function), these are simply added to the list of stack_frames we return.
                         #[allow(clippy::unwrap_used)]
                         let inlined_frame = cached_stack_frames.pop().unwrap(); // unwrap is safe while .len() > 1
-                        log::trace!(
+                        tracing::trace!(
                             "UNWIND: Found inlined function - name={}, pc={}",
                             inlined_frame.function_name,
                             inlined_frame.pc
@@ -763,13 +763,13 @@ impl DebugInfo {
                         cached_stack_frames.pop().unwrap() // unwrap is safe for .len==1
                     } else {
                         // Obviously something has gone wrong and zero stackframes were returned in the vector.
-                        log::error!("UNWIND: No `StackFrame` information: available");
+                        tracing::error!("UNWIND: No `StackFrame` information: available");
                         // There is no point in continuing with the unwind, so let's get out of here.
                         break;
                     }
                 }
                 Err(e) => {
-                    log::error!("UNWIND: Unable to complete `StackFrame` information: {}", e);
+                    tracing::error!("UNWIND: Unable to complete `StackFrame` information: {}", e);
                     // There is no point in continuing with the unwind, so let's get out of here.
                     break;
                 }
@@ -781,18 +781,18 @@ impl DebugInfo {
                 if check_return_address.is_max_value() || check_return_address.is_zero() {
                     // When we encounter the starting (after reset) return address, we've reached the bottom of the stack, so no more unwinding after this.
                     stack_frames.push(return_frame);
-                    log::trace!("UNWIND: Stack unwind complete - Reached the 'Reset' value of the LR register.");
+                    tracing::trace!("UNWIND: Stack unwind complete - Reached the 'Reset' value of the LR register.");
                     break;
                 }
             } else {
                 // If the debug info rules result in a None return address, we cannot continue unwinding.
                 stack_frames.push(return_frame);
-                log::trace!("UNWIND: Stack unwind complete - LR register value is 'None.");
+                tracing::trace!("UNWIND: Stack unwind complete - LR register value is 'None.");
                 break;
             }
 
             // PART 2: Setup the registers for the next iteration (a.k.a. unwind previous frame, a.k.a. "callee", in the call stack).
-            log::trace!(
+            tracing::trace!(
                 "UNWIND - Preparing `StackFrameIterator` to unwind NON-INLINED function {:?} at {:?}",
                 return_frame.function_name,
                 return_frame.source_location
@@ -814,11 +814,11 @@ impl DebugInfo {
                                         // If we encounter this rule for CFA, it implies the scenario depends on a FP/frame pointer to continue successfully.
                                         // Therefore, if reg_val is zero (i.e. FP is zero), then we do not have enough information to determine the CFA by rule.
                                         stack_frames.push(return_frame);
-                                        log::trace!("UNWIND: Stack unwind complete - The FP register value unwound to a value of zero.");
+                                        tracing::trace!("UNWIND: Stack unwind complete - The FP register value unwound to a value of zero.");
                                         break;
                                     }
                                     let unwind_cfa = add_to_address(reg_val.try_into()?, *offset);
-                                    log::trace!(
+                                    tracing::trace!(
                                         "UNWIND - CFA : {:#010x}\tRule: {:?}",
                                         unwind_cfa,
                                         unwind_info.cfa()
@@ -826,7 +826,7 @@ impl DebugInfo {
                                     Some(unwind_cfa)
                                 }
                                 None => {
-                                    log::error!("UNWIND: `StackFrameIterator` unable to determine the unwind CFA: Missing value of register {}",register.0);
+                                    tracing::error!("UNWIND: `StackFrameIterator` unable to determine the unwind CFA: Missing value of register {}",register.0);
                                     stack_frames.push(return_frame);
                                     break;
                                 }
@@ -897,7 +897,7 @@ impl DebugInfo {
                         }
                     } else {
                         stack_frames.push(return_frame);
-                        log::trace!("UNWIND: Stack unwind complete. No available debug info for program counter {}: {}", frame_pc, error);
+                        tracing::trace!("UNWIND: Stack unwind complete. No available debug info for program counter {}: {}", frame_pc, error);
                         break;
                     }
                 }
@@ -916,7 +916,7 @@ impl DebugInfo {
         line: u64,
         column: Option<u64>,
     ) -> Result<(Option<u64>, Option<SourceLocation>), DebugError> {
-        log::debug!(
+        tracing::debug!(
             "Looking for breakpoint location for {}:{}:{}",
             path.display(),
             line,
@@ -1212,7 +1212,7 @@ fn unwind_register(
                     register_rule_string = "PC=(unwound LR) (dwarf Undefined)".to_string();
                     unwound_return_address.and_then(|return_address| {
                         if return_address.is_max_value() || return_address.is_zero() {
-                            log::warn!("No reliable return address is available, so we cannot determine the program counter to unwind the previous frame.");
+                            tracing::warn!("No reliable return address is available, so we cannot determine the program counter to unwind the previous frame.");
                             None
                         } else {
                             match return_address {
@@ -1229,7 +1229,7 @@ fn unwind_register(
                                     Some(RegisterValue::U64(return_address))
                                 },
                                 RegisterValue::U128(_) => {
-                                    log::warn!("128 bit address space not supported");
+                                    tracing::warn!("128 bit address space not supported");
                                     None
                                 }
                             }
@@ -1263,7 +1263,7 @@ fn unwind_register(
                             .map(|_| RegisterValue::U64(u64::from_le_bytes(buff)))
                     }
                     _ => {
-                        log::error!(
+                        tracing::error!(
                             "UNWIND: Address size {} not supported.  Please report this as a bug.",
                             address_size
                         );
@@ -1280,14 +1280,14 @@ fn unwind_register(
                         Some(register_value)
                     }
                     Err(error) => {
-                        log::error!(
+                        tracing::error!(
                             "UNWIND: Failed to read value for register {} from address {} ({} bytes): {}",
                             debug_register.name,
                             RegisterValue::from(previous_frame_register_address),
                             4,
                             error
                         );
-                        log::error!(
+                        tracing::error!(
                             "UNWIND: Rule: Offset {} from address {:#010x}",
                             address_offset,
                             unwind_cfa
@@ -1296,7 +1296,7 @@ fn unwind_register(
                     }
                 }
             } else {
-                log::error!("UNWIND: Tried to unwind `RegisterRule` at CFA = None. Please report this as a bug.");
+                tracing::error!("UNWIND: Tried to unwind `RegisterRule` at CFA = None. Please report this as a bug.");
                 return ControlFlow::Break(());
             }
         }
@@ -1305,7 +1305,7 @@ fn unwind_register(
     };
     debug_register.value = new_value;
 
-    log::trace!(
+    tracing::trace!(
         "UNWIND - {:>10}: Caller: {}\tCallee: {}\tRule: {}",
         debug_register.get_register_name(),
         debug_register.value.unwrap_or_default(),

--- a/probe-rs/src/debug/debug_step.rs
+++ b/probe-rs/src/debug/debug_step.rs
@@ -88,7 +88,7 @@ impl SteppingMode {
                         pc_at_error,
                     } => {
                         // Step on target instruction, and then try again.
-                        log::trace!(
+                        tracing::trace!(
                             "Incomplete stepping information @{:#010X}: {}",
                             pc_at_error,
                             message
@@ -100,7 +100,7 @@ impl SteppingMode {
                     other_error => {
                         core_status = core.status()?;
                         program_counter = core.read_core_reg(core.registers().program_counter())?;
-                        log::error!("Error during step ({:?}): {}", self, other_error);
+                        tracing::error!("Error during step ({:?}): {}", self, other_error);
                         return Ok((core_status, program_counter));
                     }
                 },
@@ -109,7 +109,7 @@ impl SteppingMode {
 
         (core_status, program_counter) = match target_address {
             Some(target_address) => {
-                log::debug!(
+                tracing::debug!(
                     "Preparing to step ({:20?}): \n\tfrom: {:?} @ {:#010X} \n\t  to: {:?} @ {:#010X}",
                     self,
                     debug_info
@@ -181,7 +181,7 @@ impl SteppingMode {
                     if let Some(halt_address) =
                         source_statement.get_first_halt_address(program_counter)
                     {
-                        log::debug!(
+                        tracing::debug!(
                             "Found first breakpoint {:#010x} for address: {:#010x}",
                             halt_address,
                             program_counter
@@ -285,17 +285,17 @@ impl SteppingMode {
                         let (core_status, new_pc) = step_to_address(inclusive_range, core)?;
                         if new_pc == current_source_statement.instruction_range.end {
                             // We have halted at the address after the current statement, so we can conclude there was no branching calls in this sequence.
-                            log::debug!("Stepping into next statement, but no branching calls found. Stepped to next available statement.");
+                            tracing::debug!("Stepping into next statement, but no branching calls found. Stepped to next available statement.");
                         } else if new_pc < current_source_statement.instruction_range.end
                             && matches!(core_status, CoreStatus::Halted(HaltReason::Breakpoint(_)))
                         {
                             // We have halted at a PC that is within the current statement, so there must be another breakpoint.
-                            log::debug!(
+                            tracing::debug!(
                                 "Stepping into next statement, but encountered a breakpoint."
                             );
                         } else {
                             // We have reached a location that is not in the current statement range (branch instruction or breakpoint in an interrupt handler).
-                            log::debug!(
+                            tracing::debug!(
                                 "Stepping into next statement at address: {:#010x}.",
                                 new_pc
                             );
@@ -312,7 +312,7 @@ impl SteppingMode {
                 {
                     // We want the first qualifying (PC is in range) function from the back of this list, to access the 'innermost' functions first.
                     if let Some(function) = function_dies.iter().rev().next() {
-                        log::trace!(
+                        tracing::trace!(
                             "Step Out target: Evaluating function {:?}, low_pc={:?}, high_pc={:?}",
                             function.function_name(),
                             function.low_pc,
@@ -338,7 +338,7 @@ impl SteppingMode {
                                         None,
                                     );
                                 } else if let Some(return_address) = return_address {
-                                    log::debug!(
+                                    tracing::debug!(
                                         "Step Out target: non-inline function, stepping over return address: {:#010x}",
                                             return_address
                                     );
@@ -443,7 +443,7 @@ fn step_to_address(
             CoreStatus::Halted(halt_reason) => match halt_reason {
                 HaltReason::Step | HaltReason::Request => continue,
                 HaltReason::Breakpoint(_) => {
-                    log::debug!(
+                    tracing::debug!(
                         "Encountered a breakpoint before the target address ({:#010x}) was reached.",
                         target_address_range.end()
                     );

--- a/probe-rs/src/debug/function_die.rs
+++ b/probe-rs/src/debug/function_die.rs
@@ -42,7 +42,7 @@ impl<'debugunit, 'abbrev, 'unit: 'debugunit, 'unit_info, 'debug_info>
                 frame_base: None,
             }),
             other_tag => {
-                log::error!("FunctionDie has to has to have Tag DW_TAG_subprogram, but tag is {:?}. This is a bug, please report it.", other_tag.static_string());
+                tracing::error!("FunctionDie has to has to have Tag DW_TAG_subprogram, but tag is {:?}. This is a bug, please report it.", other_tag.static_string());
                 None
             }
         }
@@ -65,7 +65,7 @@ impl<'debugunit, 'abbrev, 'unit: 'debugunit, 'unit_info, 'debug_info>
                 frame_base: None,
             }),
             other_tag => {
-                log::error!("FunctionDie has to has to have Tag DW_TAG_inlined_subroutine, but tag is {:?}. This is a bug, please report it.", other_tag.static_string());
+                tracing::error!("FunctionDie has to has to have Tag DW_TAG_inlined_subroutine, but tag is {:?}. This is a bug, please report it.", other_tag.static_string());
                 None
             }
         }
@@ -82,19 +82,19 @@ impl<'debugunit, 'abbrev, 'unit: 'debugunit, 'unit_info, 'debug_info>
                     match self.unit_info.debug_info.dwarf.string(fn_name_ref) {
                         Ok(fn_name_raw) => Some(String::from_utf8_lossy(&fn_name_raw).to_string()),
                         Err(error) => {
-                            log::debug!("No value for DW_AT_name: {:?}: error", error);
+                            tracing::debug!("No value for DW_AT_name: {:?}: error", error);
 
                             None
                         }
                     }
                 }
                 value => {
-                    log::debug!("Unexpected attribute value for DW_AT_name: {:?}", value);
+                    tracing::debug!("Unexpected attribute value for DW_AT_name: {:?}", value);
                     None
                 }
             }
         } else {
-            log::debug!("DW_AT_name attribute not found, unable to retrieve function name");
+            tracing::debug!("DW_AT_name attribute not found, unable to retrieve function name");
             None
         }
     }

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -138,16 +138,16 @@ fn extract_file(
                 {
                     Some((path, file))
                 } else {
-                    log::warn!("Unable to extract file or path from {:?}.", attribute_value);
+                    tracing::warn!("Unable to extract file or path from {:?}.", attribute_value);
                     None
                 }
             } else {
-                log::warn!("Unable to extract file entry for {:?}.", attribute_value);
+                tracing::warn!("Unable to extract file entry for {:?}.", attribute_value);
                 None
             }
         }),
         other => {
-            log::warn!(
+            tracing::warn!(
                 "Unable to extract file information from attribute value {:?}: Not implemented.",
                 other
             );
@@ -166,14 +166,14 @@ fn extract_byte_size(
             Some(byte_size_attr) => match byte_size_attr.value() {
                 gimli::AttributeValue::Udata(byte_size) => byte_size,
                 other => {
-                    log::warn!("Unimplemented: DW_AT_byte_size value: {:?} ", other);
+                    tracing::warn!("Unimplemented: DW_AT_byte_size value: {:?} ", other);
                     0
                 }
             },
             None => 0,
         },
         Err(error) => {
-            log::warn!(
+            tracing::warn!(
                 "Failed to extract byte_size: {:?} for debug_entry {:?}",
                 error,
                 di_entry.tag().static_string()
@@ -267,7 +267,7 @@ pub(crate) fn _print_all_attributes(
                                         .unwrap()
                                 }
                                 x => {
-                                    log::error!(
+                                    tracing::error!(
                                         "Requested memory with size {}, which is not supported yet.",
                                         x
                                     );

--- a/probe-rs/src/debug/registers.rs
+++ b/probe-rs/src/debug/registers.rs
@@ -136,7 +136,7 @@ impl DebugRegisters {
                             value: match core.read_core_reg(platform_register.id) {
                                 Ok::<RegisterValue, Error>(register_value) => Some(register_value),
                                 Err(e) => {
-                                    log::warn!(
+                                    tracing::warn!(
                                         "Failed to read value for register {:?}: {}",
                                         platform_register,
                                         e
@@ -147,7 +147,7 @@ impl DebugRegisters {
                         });
                     }
                 } else {
-                    log::warn!(
+                    tracing::warn!(
                         "Unsupported platform register type or size for register: {:?}",
                         platform_register
                     );

--- a/probe-rs/src/debug/source_statement.rs
+++ b/probe-rs/src/debug/source_statement.rs
@@ -106,7 +106,7 @@ impl SourceStatements {
                 pc_at_error: program_counter,
             })
         } else {
-            log::trace!(
+            tracing::trace!(
                 "Source statements for pc={:#010x}\n{:?}",
                 program_counter,
                 source_statements
@@ -263,7 +263,7 @@ fn log_row_eval(
     row: &gimli::LineRow,
     status: &str,
 ) {
-    log::trace!("Sequence row {:#010X}<={:#010X}<{:#010X}: addr={:#010X} stmt={:5}  ep={:5}  es={:5}  line={:04}  col={:05}  f={:02} : {}",
+    tracing::trace!("Sequence row {:#010X}<={:#010X}<{:#010X}: addr={:#010X} stmt={:5}  ep={:5}  es={:5}  line={:04}  col={:05}  f={:02} : {}",
         active_sequence.start,
         pc,
         active_sequence.end,

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -33,7 +33,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
         stackframe_registers: Option<&DebugRegisters>,
         find_inlined: bool,
     ) -> Result<Vec<FunctionDie>, DebugError> {
-        log::trace!("Searching Function DIE for address {}", address);
+        tracing::trace!("Searching Function DIE for address {}", address);
 
         let mut entries_cursor = self.unit.entries();
         while let Ok(Some((_depth, current))) = entries_cursor.next_dfs() {
@@ -61,7 +61,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                     die.frame_base = Some(address);
                                 }
                             } else {
-                                log::trace!(
+                                tracing::trace!(
                                 "No stackframe registers provided, skipping frame_base calculation for function DIE."
                             );
                             }
@@ -70,7 +70,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                             let mut functions = vec![die];
 
                             if find_inlined {
-                                log::debug!(
+                                tracing::debug!(
                                     "Found DIE, now checking for inlined functions: name={:?}",
                                     functions[0].function_name()
                                 );
@@ -82,9 +82,9 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                 )?;
 
                                 if inlined_functions.is_empty() {
-                                    log::debug!("No inlined function found!");
+                                    tracing::debug!("No inlined function found!");
                                 } else {
-                                    log::debug!(
+                                    tracing::debug!(
                                         "{} inlined functions for address {}",
                                         inlined_functions.len(),
                                         address
@@ -94,7 +94,10 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
 
                                 return Ok(functions);
                             } else {
-                                log::debug!("Found DIE: name={:?}", functions[0].function_name());
+                                tracing::debug!(
+                                    "Found DIE: name={:?}",
+                                    functions[0].function_name()
+                                );
                             }
                             return Ok(functions);
                         }
@@ -159,13 +162,15 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                             }
                                         }
                                     }
-                                    other_value => log::warn!(
+                                    other_value => tracing::warn!(
                                         "Unsupported DW_AT_abstract_origin value: {:?}",
                                         other_value
                                     ),
                                 }
                             } else {
-                                log::warn!("No abstract origin for inlined function, skipping.");
+                                tracing::warn!(
+                                    "No abstract origin for inlined function, skipping."
+                                );
                                 return Ok(vec![]);
                             }
                         }
@@ -276,7 +281,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
             },
             Err(debug_error) => {
                 // An Err() result indicates something happened that we have not accounted for, and therefore will propogate upwards to terminate the process in an ungraceful manner. This should be treated as a bug.
-                log::error!("Encounted an unexpected error while resolving the location for variable {:?}. Please report this as a bug", child_variable.name);
+                tracing::error!("Encounted an unexpected error while resolving the location for variable {:?}. Please report this as a bug", child_variable.name);
                 return Err(debug_error);
             }
         }
@@ -555,7 +560,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 )));
             };
 
-            log::trace!("process_tree for parent {}", parent_variable.variable_key);
+            tracing::trace!("process_tree for parent {}", parent_variable.variable_key);
 
             let mut child_nodes = parent_node.children();
             while let Some(mut child_node) = child_nodes.next()? {

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -581,7 +581,7 @@ impl Variable {
             return;
         }
 
-        log::trace!(
+        tracing::trace!(
             "Extracting value for {:?}, type={:?}",
             self.name,
             self.type_name
@@ -1050,7 +1050,7 @@ impl Value for String {
                     // TODO: If implemented, the variable should not be fetched automatically,
                     // but only when requested by the user. This workaround can then be removed.
                     if string_length > 200 {
-                        log::warn!(
+                        tracing::warn!(
                             "Very long string ({} bytes), truncating to 200 bytes.",
                             string_length
                         );

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -54,7 +54,7 @@ impl VariableCache {
             // The caller is telling us this is definitely a new `Variable`
             variable_to_add.variable_key = get_sequential_key();
 
-            log::trace!(
+            tracing::trace!(
                 "VariableCache: Add Variable: key={}, parent={:?}, name={:?}",
                 variable_to_add.variable_key,
                 variable_to_add.parent_key,
@@ -71,7 +71,7 @@ impl VariableCache {
             new_entry_key
         } else {
             // Attempt to update an existing `Variable` in the cache
-            log::trace!(
+            tracing::trace!(
                 "VariableCache: Update Variable, key={}, name={:?}",
                 variable_to_add.variable_key,
                 &variable_to_add.name
@@ -83,8 +83,8 @@ impl VariableCache {
                 .get_mut(&variable_to_add.variable_key)
             {
                 if &variable_to_add != prev_entry {
-                    log::trace!("Updated:  {:?}", variable_to_add);
-                    log::trace!("Previous: {:?}", prev_entry);
+                    tracing::trace!("Updated:  {:?}", variable_to_add);
+                    tracing::trace!("Previous: {:?}", prev_entry);
                 }
 
                 *prev_entry = variable_to_add
@@ -129,7 +129,7 @@ impl VariableCache {
     }
 
     /// Retrieve a clone of a specific `Variable`, using the `name` and `parent_key`.
-    /// If there is more than one, it will be logged (log::error!), and only the last will be returned.
+    /// If there is more than one, it will be logged (tracing::error!), and only the last will be returned.
     pub fn get_variable_by_name_and_parent(
         &self,
         variable_name: &VariableName,
@@ -147,14 +147,14 @@ impl VariableCache {
             0 => None,
             1 => child_variables.first().cloned(),
             child_count => {
-                log::error!("Found {} variables with parent_key={:?} and name={}. Please report this as a bug.", child_count, parent_key, variable_name);
+                tracing::error!("Found {} variables with parent_key={:?} and name={}. Please report this as a bug.", child_count, parent_key, variable_name);
                 child_variables.last().cloned()
             }
         }
     }
 
     /// Retrieve a clone of a specific `Variable`, using the `name`.
-    /// If there is more than one, it will be logged (log::warn!), and only the first will be returned.
+    /// If there is more than one, it will be logged (tracing::warn!), and only the first will be returned.
     /// It is possible for a hierarchy of variables in a cache to have duplicate names under different parents.
     pub fn get_variable_by_name(&self, variable_name: &VariableName) -> Option<Variable> {
         let child_variables = self
@@ -167,7 +167,7 @@ impl VariableCache {
             0 => None,
             1 => child_variables.first().cloned(),
             child_count => {
-                log::warn!(
+                tracing::warn!(
                     "Found {} variables with name={}. Please report this as a bug.",
                     child_count,
                     variable_name

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -225,7 +225,7 @@ pub(super) fn extract_from_elf<'data>(
         let mut elf_section = Vec::new();
 
         if !segment_data.is_empty() && segment.p_type(endian) == PT_LOAD {
-            log::info!(
+            tracing::info!(
                 "Found loadable segment, physical address: {:#010x}, virtual address: {:#010x}, flags: {:#x}",
                 p_paddr,
                 p_vaddr,
@@ -243,15 +243,19 @@ pub(super) fn extract_from_elf<'data>(
                 };
 
                 if sector.contains_range(&(section_offset..section_offset + section_filesize)) {
-                    log::info!("Matching section: {:?}", section.name()?);
+                    tracing::info!("Matching section: {:?}", section.name()?);
 
                     #[cfg(feature = "hexdump")]
                     for line in hexdump::hexdump_iter(section.data()?) {
-                        log::trace!("{}", line);
+                        tracing::trace!("{}", line);
                     }
 
                     for (offset, relocation) in section.relocations() {
-                        log::info!("Relocation: offset={}, relocation={:?}", offset, relocation);
+                        tracing::info!(
+                            "Relocation: offset={}, relocation={:?}",
+                            offset,
+                            relocation
+                        );
                     }
 
                     elf_section.push(section.name()?.to_owned());
@@ -259,7 +263,7 @@ pub(super) fn extract_from_elf<'data>(
             }
 
             if elf_section.is_empty() {
-                log::info!("Not adding segment, no matching sections found.");
+                tracing::info!("Not adding segment, no matching sections found.");
             } else {
                 let section_data =
                     &elf_data[segment_offset as usize..][..segment_filesize as usize];

--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -7,13 +7,13 @@ use crate::Session;
 
 /// Mass-erase all nonvolatile memory.
 pub fn erase_all(session: &mut Session) -> Result<(), FlashError> {
-    log::debug!("Erasing all...");
+    tracing::debug!("Erasing all...");
 
     let mut algos: HashMap<(String, String), Vec<NvmRegion>> = HashMap::new();
-    log::debug!("Regions:");
+    tracing::debug!("Regions:");
     for region in &session.target().memory_map {
         if let MemoryRegion::Nvm(region) = region {
-            log::debug!(
+            tracing::debug!(
                 "    region: {:08x}-{:08x} ({} bytes)",
                 region.range.start,
                 region.range.end,
@@ -33,12 +33,12 @@ pub fn erase_all(session: &mut Session) -> Result<(), FlashError> {
                 .or_default();
             entry.push(region.clone());
 
-            log::debug!("     -- using algorithm: {}", algo.name);
+            tracing::debug!("     -- using algorithm: {}", algo.name);
         }
     }
 
     for ((algo_name, core_name), regions) in algos {
-        log::debug!("Erasing with algorithm: {}", algo_name);
+        tracing::debug!("Erasing with algorithm: {}", algo_name);
 
         // This can't fail, algo_name comes from the target.
         let algo = session.target().flash_algorithm_by_name(&algo_name);
@@ -48,10 +48,10 @@ pub fn erase_all(session: &mut Session) -> Result<(), FlashError> {
         let mut flasher = Flasher::new(session, core_index, &algo)?;
 
         if flasher.is_chip_erase_supported() {
-            log::debug!("     -- chip erase supported, doing it.");
+            tracing::debug!("     -- chip erase supported, doing it.");
             flasher.run_erase(|active| active.erase_all())?;
         } else {
-            log::debug!("     -- chip erase not supported, erasing by sector.");
+            tracing::debug!("     -- chip erase not supported, erasing by sector.");
 
             // loop over all sectors erasing them individually instead.
 
@@ -66,7 +66,7 @@ pub fn erase_all(session: &mut Session) -> Result<(), FlashError> {
 
             flasher.run_erase(|active| {
                 for info in sectors {
-                    log::debug!(
+                    tracing::debug!(
                         "    sector: {:08x}-{:08x} ({} bytes)",
                         info.base_address,
                         info.base_address + info.size,

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -55,7 +55,7 @@ impl FlashAlgorithm {
     /// be returned.
     pub fn sector_info(&self, address: u64) -> Option<SectorInfo> {
         if !self.flash_properties.address_range.contains(&address) {
-            log::trace!("Address {:08x} not contained in this flash device", address);
+            tracing::trace!("Address {:08x} not contained in this flash device", address);
             return None;
         }
 

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -130,7 +130,7 @@ impl<'session> Flasher<'session> {
         core.write_32(algo.load_address as u64, algo.instructions.as_slice())
             .map_err(FlashError::Core)?;
 
-        let _span = span.exit();
+        drop(span);
 
         let mut data = vec![0; algo.instructions.len()];
         core.read_32(algo.load_address as u64, &mut data)

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -78,7 +78,7 @@ impl<'session> Flasher<'session> {
                 name: session.target().name.clone(),
             })?;
 
-        log::info!("chosen RAM to run the algo: {:x?}", ram);
+        tracing::info!("Chosen RAM to run the algo: {:x?}", ram);
 
         let flash_algorithm = FlashAlgorithm::assemble_from_raw(raw_flash_algorithm, ram, target)?;
 
@@ -102,7 +102,7 @@ impl<'session> Flasher<'session> {
     }
 
     fn load(&mut self) -> Result<(), FlashError> {
-        log::debug!("Initializing the flash algorithm.");
+        tracing::debug!("Initializing the flash algorithm.");
         let algo = &mut self.flash_algorithm;
 
         // Attach to memory and core.
@@ -112,25 +112,25 @@ impl<'session> Flasher<'session> {
             .map_err(FlashError::Core)?;
 
         // TODO: Halt & reset target.
-        log::debug!("Halting core {}", self.core_index);
+        tracing::debug!("Halting core {}", self.core_index);
         let cpu_info = core
             .halt(Duration::from_millis(100))
             .map_err(FlashError::Core)?;
-        log::debug!("PC = 0x{:08x}", cpu_info.pc);
-        log::debug!("Reset and halt");
+        tracing::debug!("PC = 0x{:08x}", cpu_info.pc);
+        tracing::debug!("Reset and halt");
         core.reset_and_halt(Duration::from_millis(500))
             .map_err(FlashError::Core)?;
 
         // TODO: Possible special preparation of the target such as enabling faster clocks for the flash e.g.
 
         // Load flash algorithm code into target RAM.
-        log::debug!(
-            "Loading algorithm into RAM at address 0x{:08x}",
-            algo.load_address
-        );
+        let span = tracing::debug_span!("Loading algorithm into RAM", address = algo.load_address)
+            .entered();
 
         core.write_32(algo.load_address as u64, algo.instructions.as_slice())
             .map_err(FlashError::Core)?;
+
+        let _span = span.exit();
 
         let mut data = vec![0; algo.instructions.len()];
         core.read_32(algo.load_address as u64, &mut data)
@@ -139,21 +139,21 @@ impl<'session> Flasher<'session> {
         for (offset, (original, read_back)) in algo.instructions.iter().zip(data.iter()).enumerate()
         {
             if original != read_back {
-                log::error!(
+                tracing::error!(
                     "Failed to verify flash algorithm. Data mismatch at address {:#08x}",
                     algo.load_address + (4 * offset) as u64
                 );
-                log::error!("Original instruction: {:#08x}", original);
-                log::error!("Readback instruction: {:#08x}", read_back);
+                tracing::error!("Original instruction: {:#08x}", original);
+                tracing::error!("Readback instruction: {:#08x}", read_back);
 
-                log::error!("Original: {:x?}", &algo.instructions);
-                log::error!("Readback: {:x?}", &data);
+                tracing::error!("Original: {:x?}", &algo.instructions);
+                tracing::error!("Readback: {:x?}", &data);
 
                 return Err(FlashError::FlashAlgorithmNotLoaded);
             }
         }
 
-        log::debug!("RAM contents match flashing algo blob.");
+        tracing::debug!("RAM contents match flashing algo blob.");
 
         Ok(())
     }
@@ -168,7 +168,7 @@ impl<'session> Flasher<'session> {
             .core(self.core_index)
             .map_err(FlashError::Core)?;
 
-        log::debug!("Preparing Flasher for operation {}", O::operation_name());
+        tracing::debug!("Preparing Flasher for operation {}", O::operation_name());
         let mut flasher = ActiveFlasher::<O> {
             core,
             flash_algorithm: self.flash_algorithm.clone(),
@@ -231,7 +231,7 @@ impl<'session> Flasher<'session> {
         skip_erasing: bool,
         progress: &FlashProgress,
     ) -> Result<(), FlashError> {
-        log::debug!("Starting program procedure.");
+        tracing::debug!("Starting program procedure.");
         // Convert the list of flash operations into flash sectors and pages.
         let mut flash_layout = flash_builder.build_sectors_and_pages(
             region,
@@ -241,8 +241,8 @@ impl<'session> Flasher<'session> {
 
         progress.initialized(flash_layout.clone());
 
-        log::debug!("Double Buffering enabled: {:?}", enable_double_buffering);
-        log::debug!(
+        tracing::debug!("Double Buffering enabled: {:?}", enable_double_buffering);
+        tracing::debug!(
             "Restoring unwritten bytes enabled: {:?}",
             restore_unwritten_bytes
         );
@@ -494,9 +494,9 @@ pub(super) struct ActiveFlasher<'probe, O: Operation> {
 }
 
 impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
+    #[tracing::instrument(name = "Call to flash algorithm init", skip(self, clock))]
     pub(super) fn init(&mut self, clock: Option<u32>) -> Result<(), FlashError> {
         let algo = &self.flash_algorithm;
-        log::debug!("Running init routine.");
 
         let address = self.flash_algorithm.flash_properties.address_range.start;
 
@@ -532,7 +532,7 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
     // }
 
     pub(super) fn uninit(&mut self) -> Result<(), FlashError> {
-        log::debug!("Running uninit routine.");
+        tracing::debug!("Running uninit routine.");
         let algo = &self.flash_algorithm;
 
         if let Some(pc_uninit) = algo.pc_uninit {
@@ -571,7 +571,7 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
     }
 
     fn call_function(&mut self, registers: &Registers, init: bool) -> Result<(), crate::Error> {
-        log::debug!("Calling routine {:?}, init={})", &registers, init);
+        tracing::debug!("Calling routine {:?}, init={})", &registers, init);
 
         let algo = &self.flash_algorithm;
         let regs: &'static RegisterFile = self.core.registers();
@@ -613,7 +613,7 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
         for (description, value) in &registers {
             if let Some(v) = value {
                 self.core.write_core_reg(description.id, *v)?;
-                log::debug!(
+                tracing::debug!(
                     "content of {} {:#x}: 0x{:08x} should be: 0x{:08x}",
                     description.name,
                     description.id.0,
@@ -635,8 +635,9 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     pub(super) fn wait_for_completion(&mut self, timeout: Duration) -> Result<u32, crate::Error> {
-        log::debug!("Waiting for routine call completion.");
+        tracing::debug!("Waiting for routine call completion.");
         let regs = self.core.registers();
 
         self.core.wait_for_core_halted(timeout)?;
@@ -648,7 +649,7 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
 
 impl<'probe> ActiveFlasher<'probe, Erase> {
     pub(super) fn erase_all(&mut self) -> Result<(), FlashError> {
-        log::debug!("Erasing entire chip.");
+        tracing::debug!("Erasing entire chip.");
         let flasher = self;
         let algo = &flasher.flash_algorithm;
 
@@ -685,7 +686,7 @@ impl<'probe> ActiveFlasher<'probe, Erase> {
     }
 
     pub(super) fn erase_sector(&mut self, address: u64) -> Result<(), FlashError> {
-        log::info!("Erasing sector at address 0x{:08x}", address);
+        tracing::info!("Erasing sector at address 0x{:08x}", address);
         let t1 = std::time::Instant::now();
 
         let result = self
@@ -706,7 +707,7 @@ impl<'probe> ActiveFlasher<'probe, Erase> {
                 sector_address: address,
                 source: Box::new(error),
             })?;
-        log::info!(
+        tracing::info!(
             "Done erasing sector. Result is {}. This took {:?}",
             result,
             t1.elapsed()
@@ -727,7 +728,7 @@ impl<'p> ActiveFlasher<'p, Program> {
     pub(super) fn program_page(&mut self, address: u64, bytes: &[u8]) -> Result<(), FlashError> {
         let t1 = std::time::Instant::now();
 
-        log::info!(
+        tracing::info!(
             "Flashing page at address {:#08x} with size: {}",
             address,
             bytes.len()
@@ -756,7 +757,7 @@ impl<'p> ActiveFlasher<'p, Program> {
                 page_address: address,
                 source: Box::new(error),
             })?;
-        log::info!("Flashing took: {:?}", t1.elapsed());
+        tracing::info!("Flashing took: {:?}", t1.elapsed());
 
         if result != 0 {
             Err(FlashError::PageWrite {
@@ -832,7 +833,7 @@ impl<'p> ActiveFlasher<'p, Program> {
             .write_32(algo.page_buffers[buffer_number], &words)
             .map_err(FlashError::Core)?;
 
-        log::info!(
+        tracing::info!(
             "Took {:?} to download {} byte page into ram",
             t1.elapsed(),
             bytes.len()

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -64,7 +64,7 @@ impl FlashLoader {
     ///
     /// The chunk can cross flash boundaries as long as one flash region connects to another flash region.
     pub fn add_data(&mut self, address: u64, data: &[u8]) -> Result<(), FlashError> {
-        log::trace!(
+        tracing::trace!(
             "Adding data at address {:#010x} with size {} bytes",
             address,
             data.len()
@@ -158,11 +158,11 @@ impl FlashLoader {
         let num_sections = extract_from_elf(&mut extracted_data, &elf_buffer)?;
 
         if num_sections == 0 {
-            log::warn!("No loadable segments were found in the ELF file.");
+            tracing::warn!("No loadable segments were found in the ELF file.");
             return Err(FileDownloadError::NoLoadableSegments);
         }
 
-        log::info!("Found {} loadable sections:", num_sections);
+        tracing::info!("Found {} loadable sections:", num_sections);
 
         for section in &extracted_data {
             let source = if section.section_names.is_empty() {
@@ -173,7 +173,7 @@ impl FlashLoader {
                 "Multiple sections".to_owned()
             };
 
-            log::info!(
+            tracing::info!(
                 "    {} at {:08X?} ({} byte{})",
                 source,
                 section.address,
@@ -199,11 +199,11 @@ impl FlashLoader {
         session: &mut Session,
         options: DownloadOptions<'_>,
     ) -> Result<(), FlashError> {
-        log::debug!("committing FlashLoader!");
+        tracing::debug!("committing FlashLoader!");
 
-        log::debug!("Contents of builder:");
+        tracing::debug!("Contents of builder:");
         for (&address, data) in &self.builder.data {
-            log::debug!(
+            tracing::debug!(
                 "    data: {:08x}-{:08x} ({} bytes)",
                 address,
                 address + data.len() as u64,
@@ -211,11 +211,11 @@ impl FlashLoader {
             );
         }
 
-        log::debug!("Flash algorithms:");
+        tracing::debug!("Flash algorithms:");
         for algorithm in &session.target().flash_algorithms {
             let Range { start, end } = algorithm.flash_properties.address_range;
 
-            log::debug!(
+            tracing::debug!(
                 "    algo {}: {:08x}-{:08x} ({} bytes)",
                 algorithm.name,
                 start,
@@ -227,7 +227,7 @@ impl FlashLoader {
         // Iterate over all memory regions, and program their data.
 
         if self.memory_map != session.target().memory_map {
-            log::warn!("Memory map of flash loader does not match memory map of target!");
+            tracing::warn!("Memory map of flash loader does not match memory map of target!");
         }
 
         let mut algos: HashMap<(String, String), Vec<NvmRegion>> = HashMap::new();
@@ -241,10 +241,10 @@ impl FlashLoader {
         // using a given algorithm erases all regions controlled by it. Therefore, we must do
         // chip erase once per algorithm, not once per region. Otherwise subsequent chip erases will
         // erase previous regions' flashed contents.
-        log::debug!("Regions:");
+        tracing::debug!("Regions:");
         for region in &self.memory_map {
             if let MemoryRegion::Nvm(region) = region {
-                log::debug!(
+                tracing::debug!(
                     "    region: {:08x}-{:08x} ({} bytes)",
                     region.range.start,
                     region.range.end,
@@ -254,7 +254,7 @@ impl FlashLoader {
                 // If we have no data in this region, ignore it.
                 // This avoids uselessly initializing and deinitializing its flash algorithm.
                 if !self.builder.has_data_in_range(&region.range) {
-                    log::debug!("     -- empty, ignoring!");
+                    tracing::debug!("     -- empty, ignoring!");
                     continue;
                 }
 
@@ -272,12 +272,12 @@ impl FlashLoader {
                     .or_default();
                 entry.push(region.clone());
 
-                log::debug!("     -- using algorithm: {}", algo.name);
+                tracing::debug!("     -- using algorithm: {}", algo.name);
             }
         }
 
         if options.dry_run {
-            log::info!("Skipping programming, dry run!");
+            tracing::info!("Skipping programming, dry run!");
 
             if let Some(progress) = options.progress {
                 progress.failed_filling();
@@ -290,7 +290,7 @@ impl FlashLoader {
 
         // Iterate all flash algorithms we need to use.
         for ((algo_name, core_name), regions) in algos {
-            log::debug!("Flashing ranges for algo: {}", algo_name);
+            tracing::debug!("Flashing ranges for algo: {}", algo_name);
 
             // This can't fail, algo_name comes from the target.
             let algo = session.target().flash_algorithm_by_name(&algo_name);
@@ -309,12 +309,12 @@ impl FlashLoader {
             // If the flash algo doesn't support erase all, disable chip erase.
             if do_chip_erase && !flasher.is_chip_erase_supported() {
                 do_chip_erase = false;
-                log::warn!("Chip erase was the selected method to erase the sectors but this chip does not support chip erases (yet).");
-                log::warn!("A manual sector erase will be performed.");
+                tracing::warn!("Chip erase was the selected method to erase the sectors but this chip does not support chip erases (yet).");
+                tracing::warn!("A manual sector erase will be performed.");
             }
 
             if do_chip_erase {
-                log::debug!("    Doing chip erase...");
+                tracing::debug!("    Doing chip erase...");
                 flasher.run_erase(|active| active.erase_all())?;
 
                 if let Some(progress) = options.progress {
@@ -324,12 +324,12 @@ impl FlashLoader {
 
             let mut do_use_double_buffering = flasher.double_buffering_supported();
             if do_use_double_buffering && options.disable_double_buffering {
-                log::info!("Disabled double-buffering support for loader via passed option, though target supports it.");
+                tracing::info!("Disabled double-buffering support for loader via passed option, though target supports it.");
                 do_use_double_buffering = false;
             }
 
             for region in regions {
-                log::debug!(
+                tracing::debug!(
                     "    programming region: {:08x}-{:08x} ({} bytes)",
                     region.range.start,
                     region.range.end,
@@ -348,12 +348,12 @@ impl FlashLoader {
             }
         }
 
-        log::debug!("committing RAM!");
+        tracing::debug!("committing RAM!");
 
         // Commit RAM last, because NVM flashing overwrites RAM
         for region in &self.memory_map {
             if let MemoryRegion::Ram(region) = region {
-                log::debug!(
+                tracing::debug!(
                     "    region: {:08x}-{:08x} ({} bytes)",
                     region.range.start,
                     region.range.end,
@@ -375,7 +375,7 @@ impl FlashLoader {
                 let mut some = false;
                 for (address, data) in self.builder.data_in_range(&region.range) {
                     some = true;
-                    log::debug!(
+                    tracing::debug!(
                         "     -- writing: {:08x}-{:08x} ({} bytes)",
                         address,
                         address + data.len() as u64,
@@ -387,15 +387,15 @@ impl FlashLoader {
                 }
 
                 if !some {
-                    log::debug!("     -- empty.")
+                    tracing::debug!("     -- empty.")
                 }
             }
         }
 
         if options.verify {
-            log::debug!("Verifying!");
+            tracing::debug!("Verifying!");
             for (&address, data) in &self.builder.data {
-                log::debug!(
+                tracing::debug!(
                     "    data: {:08x}-{:08x} ({} bytes)",
                     address,
                     address + data.len() as u64,

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -333,11 +333,11 @@ impl Probe {
         if let Some(dap_probe) = self.try_as_dap_probe() {
             DefaultArmSequence(()).reset_hardware_assert(dap_probe)?;
         } else {
-            log::info!(
+            tracing::info!(
                 "Custom reset sequences are not supported on {}.",
                 self.get_name()
             );
-            log::info!("Falling back to standard probe reset.");
+            tracing::info!("Falling back to standard probe reset.");
             self.target_reset_assert()?;
         }
 
@@ -397,7 +397,7 @@ impl Probe {
     ///
     /// This is not supported on all probes.
     pub fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
-        log::debug!("Asserting target reset");
+        tracing::debug!("Asserting target reset");
         self.inner.target_reset_assert()
     }
 
@@ -406,7 +406,7 @@ impl Probe {
     ///
     /// This is not supported on all probes.
     pub fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
-        log::debug!("Deasserting target reset");
+        tracing::debug!("Deasserting target reset");
         self.inner.target_reset_deassert()
     }
 

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
@@ -178,7 +178,7 @@ impl Request for TransferRequest {
         }
         let transfer_count = buffer[0];
         if transfer_count as usize > self.transfers.len() {
-            log::error!("Transfer count larger than requested number of transfers");
+            tracing::error!("Transfer count larger than requested number of transfers");
             return Err(SendError::UnexpectedAnswer);
         }
 
@@ -305,7 +305,7 @@ impl Request for TransferBlockRequest {
 
         let num_transfers = (buffer.len() - 3) / 4;
 
-        log::debug!(
+        tracing::debug!(
             "Expected {} responses, got {} responses with data..",
             transfer_count,
             num_transfers

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -43,7 +43,7 @@ impl EspUsbJtag {
     }
 
     fn read_dr(&mut self, register_bits: usize) -> Result<Vec<u8>, DebugProbeError> {
-        log::debug!("Read {} bits from DR", register_bits);
+        tracing::debug!("Read {} bits from DR", register_bits);
 
         let tms_enter_shift = [true, false, false];
 
@@ -65,7 +65,7 @@ impl EspUsbJtag {
 
         let mut response = self.protocol.jtag_io(tms, tdi, true)?;
 
-        log::trace!("Response: {:?}", response);
+        tracing::trace!("Response: {:?}", response);
 
         let _remainder = response.split_off(tms_enter_shift.len());
 
@@ -84,7 +84,7 @@ impl EspUsbJtag {
             result.push(bits_to_byte(response.split_off(remaining_bits)) as u8);
         }
 
-        log::debug!("Read from DR: {:?}", result);
+        tracing::debug!("Read from DR: {:?}", result);
 
         Ok(result)
     }
@@ -94,7 +94,7 @@ impl EspUsbJtag {
     /// will be truncated to `len` bits. If data has less
     /// than `len` bits, an error will be returned.
     fn write_ir(&mut self, data: &[u8], len: usize) -> Result<(), DebugProbeError> {
-        log::debug!("Write IR: {:?}, len={}", data, len);
+        tracing::debug!("Write IR: {:?}, len={}", data, len);
 
         // Check the bit length, enough data has to be
         // available
@@ -157,12 +157,12 @@ impl EspUsbJtag {
 
         tdi.extend_from_slice(&tdi_enter_idle);
 
-        log::trace!("tms: {:?}", tms);
-        log::trace!("tdi: {:?}", tdi);
+        tracing::trace!("tms: {:?}", tms);
+        tracing::trace!("tdi: {:?}", tdi);
 
         let response = self.protocol.jtag_io(tms, tdi, true)?;
 
-        log::trace!("Response: {:?}", response);
+        tracing::trace!("Response: {:?}", response);
 
         if len >= 8 {
             return Err(DebugProbeError::NotImplemented(
@@ -179,7 +179,7 @@ impl EspUsbJtag {
     }
 
     fn write_dr(&mut self, data: &[u8], register_bits: usize) -> Result<Vec<u8>, DebugProbeError> {
-        log::debug!("Write DR: {:?}, len={}", data, register_bits);
+        tracing::debug!("Write DR: {:?}, len={}", data, register_bits);
 
         let tms_enter_shift = [true, false, false];
 
@@ -235,7 +235,7 @@ impl EspUsbJtag {
 
         let mut response = self.protocol.jtag_io(tms, tdi, true)?;
 
-        log::trace!("Response: {:?}", response);
+        tracing::trace!("Response: {:?}", response);
 
         let _remainder = response.split_off(tms_enter_shift.len());
 
@@ -254,7 +254,7 @@ impl EspUsbJtag {
             result.push(bits_to_byte(response.split_off(remaining_bits)) as u8);
         }
 
-        log::trace!("result: {:?}", result);
+        tracing::trace!("result: {:?}", result);
 
         Ok(result)
     }
@@ -362,17 +362,17 @@ impl DebugProbe for EspUsbJtag {
     }
 
     fn attach(&mut self) -> Result<(), super::DebugProbeError> {
-        log::debug!("Attaching to ESP USB JTAG");
+        tracing::debug!("Attaching to ESP USB JTAG");
 
         // TODO: Maybe can be left in protocol altogether.
 
         // try some JTAG stuff
 
-        log::debug!("Resetting JTAG chain using trst");
+        tracing::debug!("Resetting JTAG chain using trst");
         self.protocol.set_reset(true, true)?;
         self.protocol.set_reset(false, false)?;
 
-        log::debug!("Resetting JTAG chain by setting tms high for 5 bits");
+        tracing::debug!("Resetting JTAG chain by setting tms high for 5 bits");
 
         // Reset JTAG chain (5 times TMS high), and enter idle state afterwards
         let tms = vec![true, true, true, true, true, false];
@@ -380,7 +380,7 @@ impl DebugProbe for EspUsbJtag {
 
         let response: Vec<_> = self.protocol.jtag_io(tms, tdi, false)?.collect();
 
-        log::debug!("Response to reset: {:?}", response);
+        tracing::debug!("Response to reset: {:?}", response);
 
         // try to read the idcode until we have some non-zero bytes
         let start = Instant::now();
@@ -393,7 +393,7 @@ impl DebugProbe for EspUsbJtag {
             }
         };
 
-        log::info!("JTAG IDCODE: {:#010x}", idcode);
+        tracing::info!("JTAG IDCODE: {:#010x}", idcode);
 
         Ok(())
     }
@@ -407,13 +407,13 @@ impl DebugProbe for EspUsbJtag {
     }
 
     fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
-        log::info!("reset_assert!");
+        tracing::info!("reset_assert!");
         self.protocol.set_reset(false, false)?;
         Ok(())
     }
 
     fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
-        log::info!("reset_deassert!");
+        tracing::info!("reset_deassert!");
         self.protocol.set_reset(true, true)?;
         Ok(())
     }

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -33,13 +33,13 @@ pub fn list_stlink_devices() -> Vec<DebugProbeInfo> {
                             // Reading the serial number can fail, e.g. if the driver for the probe
                             // is not installed. In this case we can still list the probe,
                             // just without serial number.
-                            log::debug!(
+                            tracing::debug!(
                                 "Failed to read serial number of device {:04x}:{:04x} : {}",
                                 descriptor.vendor_id(),
                                 descriptor.product_id(),
                                 e
                             );
-                            log::debug!("This might be happening because of a missing driver.");
+                            tracing::debug!("This might be happening because of a missing driver.");
                             None
                         }
                     };

--- a/probe-rs/src/probe/stlink/usb_interface.rs
+++ b/probe-rs/src/probe/stlink/usb_interface.rs
@@ -106,7 +106,7 @@ impl StLinkUsbDevice {
 
         let context = Context::new()?;
 
-        log::debug!("Acquired libusb context.");
+        tracing::debug!("Acquired libusb context.");
 
         let device = context
             .devices()?
@@ -138,21 +138,21 @@ impl StLinkUsbDevice {
 
         let mut device_handle = device.open()?;
 
-        log::debug!("Aquired handle for probe");
+        tracing::debug!("Aquired handle for probe");
 
         let config = device.active_config_descriptor()?;
 
-        log::debug!("Active config descriptor: {:?}", &config);
+        tracing::debug!("Active config descriptor: {:?}", &config);
 
         let descriptor = device.device_descriptor()?;
 
-        log::debug!("Device descriptor: {:?}", &descriptor);
+        tracing::debug!("Device descriptor: {:?}", &descriptor);
 
         let info = USB_PID_EP_MAP[&descriptor.product_id()].clone();
 
         device_handle.claim_interface(0)?;
 
-        log::debug!("Claimed interface 0 of USB device.");
+        tracing::debug!("Claimed interface 0 of USB device.");
 
         let mut endpoint_out = false;
         let mut endpoint_in = false;
@@ -189,7 +189,7 @@ impl StLinkUsbDevice {
             info,
         };
 
-        log::debug!("Succesfully attached to STLink.");
+        tracing::debug!("Succesfully attached to STLink.");
 
         Ok(usb_stlink)
     }
@@ -213,7 +213,7 @@ impl StLinkUsb for StLinkUsbDevice {
         read_data: &mut [u8],
         timeout: Duration,
     ) -> Result<(), DebugProbeError> {
-        log::trace!(
+        tracing::trace!(
             "Sending command {:x?} to STLink, timeout: {:?}",
             cmd,
             timeout
@@ -255,14 +255,14 @@ impl StLinkUsb for StLinkUsbDevice {
                 remaining_bytes -= written_bytes;
                 write_index += written_bytes;
 
-                log::trace!(
+                tracing::trace!(
                     "Wrote {} bytes, {} bytes remaining",
                     written_bytes,
                     remaining_bytes
                 );
             }
 
-            log::trace!("USB write done!");
+            tracing::trace!("USB write done!");
         }
 
         // Optional data in phase.
@@ -279,7 +279,7 @@ impl StLinkUsb for StLinkUsbDevice {
                 read_index += read_bytes;
                 remaining_bytes -= read_bytes;
 
-                log::trace!(
+                tracing::trace!(
                     "Read {} bytes, {} bytes remaining",
                     read_bytes,
                     remaining_bytes
@@ -294,7 +294,7 @@ impl StLinkUsb for StLinkUsbDevice {
         read_data: &mut [u8],
         timeout: Duration,
     ) -> Result<usize, DebugProbeError> {
-        log::trace!(
+        tracing::trace!(
             "Reading {:?} SWO bytes to STLink, timeout: {:?}",
             read_data.len(),
             timeout
@@ -314,7 +314,7 @@ impl StLinkUsb for StLinkUsbDevice {
     /// Reset the USB device. This can be used to recover when the
     /// STLink does not respond to USB requests.
     fn reset(&mut self) -> Result<(), DebugProbeError> {
-        log::debug!("Resetting USB device of STLink");
+        tracing::debug!("Resetting USB device of STLink");
         self.device_handle
             .reset()
             .map_err(|e| DebugProbeError::Usb(Some(Box::new(e))))


### PR DESCRIPTION
Replace `log` with `tracing`.

With this PR this improves the logging output in `probe-rs-cli`.
