### PR TITLE
Add Infineon XMC4000 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Support for Debug Erase Sequences that (if available) are used instead of the normal chip-erase logic
 - Added Support for GD32E50x targets (#1304)
 - Added support for the Infineon XMC4000 family
+- Added support for the Infineon XMC4000 family (#1301)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an optional `stack_size` configuration to flash algorithms to control the stack size (#1260)
 - Added Support for Debug Erase Sequences that (if available) are used instead of the normal chip-erase logic
 - Added Support for GD32E50x targets (#1304)
+- Added support for the Infineon XMC4000 family
 
 ### Changed
 

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -502,7 +502,7 @@ impl FpRev1CompX {
     /// Get the correct register configuration which enables
     /// a hardware breakpoint at the given address.
     /// NOTE: Does not support a `replace` value of '11'
-    fn breakpoint_configuration(address: u32) -> Result<Self, Error> {
+    pub(crate) fn breakpoint_configuration(address: u32) -> Result<Self, Error> {
         let mut reg = FpRev1CompX::from(0);
 
         // The highest 3 bits of the address have to be zero, otherwise the breakpoint cannot
@@ -569,7 +569,7 @@ impl From<FpRev2CompX> for u32 {
 impl FpRev2CompX {
     /// Get the correct register configuration which enables
     /// a hardware breakpoint at the given address.
-    fn breakpoint_configuration(address: u32) -> Self {
+    pub(crate) fn breakpoint_configuration(address: u32) -> Self {
         let mut reg = FpRev2CompX::from(0);
 
         reg.set_bpaddr(address >> 1);

--- a/probe-rs/src/architecture/arm/sequences/infineon.rs
+++ b/probe-rs/src/architecture/arm/sequences/infineon.rs
@@ -1,0 +1,249 @@
+//! Sequences for Infineon target families
+
+use crate::architecture::arm::armv7m::{Aircr, Dhcsr, FpCtrl, FpRev1CompX, FpRev2CompX};
+use anyhow::anyhow;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use crate::Error;
+use crate::Memory;
+use crate::{DebugProbeError, MemoryMappedRegister};
+
+use super::ArmDebugSequence;
+
+/// An Infineon XMC4xxx MCU.
+pub struct XMC4000 {
+    halt_after_reset_state: Mutex<Option<(bool, u32)>>,
+}
+
+impl XMC4000 {
+    /// Create the sequencer for an Infineon XMC4000.
+    pub fn create() -> Arc<dyn ArmDebugSequence> {
+        Arc::new(Self {
+            halt_after_reset_state: Mutex::new(None),
+        })
+    }
+}
+
+impl ArmDebugSequence for XMC4000 {
+    // We have a weird halt-after-reset sequence. It's described only in prose, not in a CMSIS pack
+    // sequence. Per XMC4700/XMC4800 reference manual v1.3 § 28-8:
+    //
+    // > A Halt after system reset (Warm Reset) can be achieved by programming a break point at the
+    // > first instruction of the application code. Before a Warm Reset the CTRL/STAT.CDBGPWRUPREQ
+    // > and the DHCSR.C_DEBUGEN setting has to be ensured. After a system reset, the HAR situation
+    // > is not considered, as the reset is not coming from "Power-on Reset".
+    // >
+    // > Note: The CTRL/STAT.CDBGPWRUPREQ and DHCSR.C_DEBUGEN does not have to be set after a
+    // > system reset, if they have already been set before.
+    // >
+    // > A tool hot plug condition allows to debug the system starting with a tool registration
+    // > (setting CTRL/STAT.CDBGPWRUPREQ register) and a debug system enable (setting the
+    // > DHCSR.C_DEBUGEN register). Afterwards break points can be set or the CPU can directly by
+    // > HALTED by an enable of C_HALT.
+    //
+    // So:
+    // * ResetCatchSet must determine the first user instruction and set a breakpoint there.
+    // * ResetCatchClear must restore the clobbered breakpoint, if any.
+
+    fn reset_catch_set(
+        &self,
+        core: &mut Memory,
+        _core_type: probe_rs_target::CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), Error> {
+        tracing::trace!("performing XMC4000 ResetCatchSet");
+
+        // We need to find the "first instruction of the application code". The XMC4xxx system
+        // software ("SSW") has a vector table at the start of boot ROM. XMC4700/XMC4800 reference
+        // manual v1.3 § 2-31:
+        //
+        // > On system reset, the vector table is fixed at address 0x00000000.
+        //
+        // That reset vector runs first, but it doesn't qualify as "application code". § 27.2:
+        //
+        // > This section describes the startup sequence of the XMC4[78]00 as a process taking place
+        // > before user application software takes control of the system.
+        //
+        // So: where does the application begin? That depends on the boot mode! The boot mode
+        // depends on the System Control Unit (SCU) Startup Control (STCON) register, which includes
+        // both a software-settable field and a power-on-resettable field. We want a normal boot,
+        // because normal boots are sane and reasonable.
+        let stcon = core.read_word_32(0x50004010)?;
+        if stcon & 0x3 != 0 {
+            // HWCON is nonzero, preventing a normal boot, and HWCON is latched at power-on reset
+            //
+            // In principle we can fix this because a) HWCON is connected to the debugger pins and
+            // b) the DEBUG_CM.002 erratum lets us perform power-on resets without disrupting
+            // debugger state (!), but... that's complicated.
+            //
+            // Settle for detecting this condition and producing an error.
+            tracing::error!(
+                "normal boots are impossible without a power on reset: SCU STCON = {:08x}",
+                stcon
+            );
+            return Err(Error::Other(anyhow!(
+                "SCU STCON HWCON must be zero to perform a normal boot"
+            )));
+        }
+        if stcon != 0 {
+            // Ask for a normal boot
+            core.write_word_32(0x50004010, 0)?;
+        }
+
+        // § 27.3.1 describes the normal boot mode, which happens after firmware initialization:
+        //
+        // > Firmware essentially reprograms the Cortex M4’s SCB.VTOR register with the start
+        // > address of flash (0C000000H) and passes control to user application by programing
+        // > register R15 (Program Counter) with reset vector contents. The reset vector contents
+        // > point to a routine that could be in either the cached or the uncached address space of
+        // > the flash.
+        //
+        // Therefore, "the first instruction of the application code" for normal boot mode is the
+        // instruction pointed to by the reset vector at the start of flash, i.e. 0x0C000004.
+        //
+        // This is also why we have to use a breakpoint instead of trapping the reset vector. The
+        // application's entrypoint is a normal jump from the firmware, not an exception dispatched
+        // to the reset vector.
+        let application_entry = core.read_word_32(0x0C000004)? + 1;
+
+        // Read FPCTRL
+        let fp_ctrl = FpCtrl(core.read_word_32(FpCtrl::ADDRESS)?);
+        let enabled = fp_ctrl.enable();
+
+        // Read FPCOMP0 so we can restore it later
+        let value = core.read_word_32(FpRev1CompX::ADDRESS)?;
+        self.halt_after_reset_state
+            .lock()
+            .map(|mut m| m.replace((enabled, value)))
+            .unwrap();
+
+        // Enable FP
+        let mut fp_ctrl = FpCtrl(0);
+        fp_ctrl.set_enable(true);
+        fp_ctrl.set_key(true);
+        core.write_word_32(FpCtrl::ADDRESS, fp_ctrl.into())?;
+
+        // Set a breakpoint at application_entry
+        let val = if fp_ctrl.rev() == 0 {
+            FpRev1CompX::breakpoint_configuration(application_entry)?.into()
+        } else if fp_ctrl.rev() == 1 {
+            FpRev2CompX::breakpoint_configuration(application_entry).into()
+        } else {
+            return Err(Error::Other(anyhow!(
+                "xmc4000: unexpected fp_ctrl.rev = {}",
+                fp_ctrl.rev()
+            )));
+        };
+        core.write_word_32(FpRev1CompX::ADDRESS, val)?;
+        tracing::debug!("Set a breakpoint at {:08x}", application_entry);
+
+        core.flush()?;
+
+        Ok(())
+    }
+
+    fn reset_catch_clear(
+        &self,
+        core: &mut Memory,
+        _core_type: probe_rs_target::CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), Error> {
+        tracing::trace!("performing XMC4000 ResetCatchClear");
+
+        // Grab the prior breakpoint state
+        let (enabled, previous_breakpoint) = self
+            .halt_after_reset_state
+            .lock()
+            .map(|mut m| m.take().unwrap_or((false, 0)))
+            .unwrap();
+
+        // Put FPCTRL back
+        let mut fpctrl = FpCtrl::from(0);
+        fpctrl.set_key(true);
+        fpctrl.set_enable(enabled);
+        core.write_word_32(FpCtrl::ADDRESS, fpctrl.into())?;
+
+        // Put FPCOMP0 back
+        core.write_word_32(FpRev1CompX::ADDRESS, previous_breakpoint)?;
+
+        Ok(())
+    }
+
+    fn reset_system(
+        &self,
+        core: &mut Memory,
+        _core_type: probe_rs_target::CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), Error> {
+        // XMC4700/XMC4800 reference manual v1.3 § 27.2.2.2:
+        // > Since the Reset Status Information in register SCU.RSTSTAT is the accumulated reset
+        // > type, it is necessary to clean the bitfield using the SCU register RSTCLR.RSCLR before
+        // > issuing a System Reset, else SSW will enter the boot mode reflected in STCON.HWCON.
+        //
+        // ARM KB https://developer.arm.com/documentation/ka002435:
+        // > After the user program has handled the the reset sources itself, it needs to clear them
+        // > by executing:
+        // >
+        // >    SCU_RESET->RSTCLR = SCU_RESET_RSTCLR_RSCLR_Msk ;
+        // >
+        // > before the next reset. This will clear also the PORST bit. And if the next reset is no
+        // > Power On Reset, the SSW will also not do HAR.
+        //
+        // This is normally handled by the runtime, but let's be defensive.
+        //
+        // SCU_RESET->RSTCLR is at 0x5000_4408, and RSCLR is the low bit.
+        core.write_word_32(0x5000_4408, 1)?;
+        tracing::debug!("Cleared SCU_RESET->RSTSTAT");
+
+        let mut aircr = Aircr(0);
+        aircr.vectkey();
+        aircr.set_sysresetreq(true);
+        core.write_word_32(Aircr::ADDRESS, aircr.into())?;
+        tracing::debug!("Resetting via AIRCR.SYSRESETREQ");
+
+        // Do not drive the debug pins for a short while
+        // We do not want to clobber the boot mode
+        std::thread::sleep(Duration::from_millis(100));
+
+        let start = Instant::now();
+        loop {
+            let dhcsr = Dhcsr(core.read_word_32(Dhcsr::ADDRESS)?);
+
+            // Wait until the S_RESET_ST bit is cleared on a read
+            if !dhcsr.s_reset_st() {
+                tracing::debug!("Detected reset via S_RESET_ST");
+                break;
+            } else if start.elapsed() > Duration::from_millis(500) {
+                tracing::error!("XMC4000 did not reset as commanded");
+                return Err(crate::Error::Probe(DebugProbeError::Timeout));
+            }
+        }
+
+        if self
+            .halt_after_reset_state
+            .lock()
+            .map(|v| v.is_some())
+            .unwrap()
+        {
+            tracing::debug!("Waiting for XMC4000 to halt after reset");
+            // We're doing a halt-after-reset
+            // Wait for the core to halt
+            loop {
+                let dhcsr = Dhcsr(core.read_word_32(Dhcsr::ADDRESS)?);
+                if dhcsr.s_halt() {
+                    tracing::debug!("Halted after reset");
+                    break;
+                } else if start.elapsed() > Duration::from_millis(1000) {
+                    tracing::error!("XMC4000 did not halt after reset");
+                    return Err(crate::Error::Probe(DebugProbeError::Timeout));
+                }
+            }
+        } else {
+            tracing::debug!("not performing a halt-after-reset");
+        }
+
+        Ok(())
+    }
+}

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -1,6 +1,7 @@
 //! Debug sequences to operate special requirements ARM targets.
 
 pub mod atsame5x;
+pub mod infineon;
 mod nrf;
 pub mod nrf52;
 pub mod nrf53;

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -3,6 +3,7 @@ use probe_rs_target::{Architecture, ChipFamily};
 use super::{Core, MemoryRegion, RawFlashAlgorithm, RegistryError, TargetDescriptionSource};
 use crate::architecture::arm::sequences::{
     atsame5x::AtSAME5x,
+    infineon::XMC4000,
     nrf52::Nrf52,
     nrf53::Nrf5340,
     nrf91::Nrf9160,
@@ -124,6 +125,9 @@ impl Target {
         } else if chip.name.starts_with("ATSAMD5") || chip.name.starts_with("ATSAME5") {
             tracing::warn!("Using custom sequence for {}", chip.name);
             debug_sequence = DebugSequence::Arm(AtSAME5x::create());
+        } else if chip.name.starts_with("XMC4") {
+            tracing::warn!("Using custom sequence for XMC4000");
+            debug_sequence = DebugSequence::Arm(XMC4000::create());
         }
 
         Ok(Target {

--- a/probe-rs/targets/XMC4000.yaml
+++ b/probe-rs/targets/XMC4000.yaml
@@ -1,0 +1,1953 @@
+name: XMC4000
+generated_from_pack: true
+pack_file_release: 2.12.0
+variants:
+- name: XMC4100-F64x128
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffe000
+      end: 0x20002fc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc020000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4200_4100_128
+  - xmc4200_4100c_128
+- name: XMC4100-Q48x128
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffe000
+      end: 0x20002fc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc020000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4200_4100_128
+  - xmc4200_4100c_128
+- name: XMC4104-F64x128
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffe000
+      end: 0x20002fc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc020000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4200_4100_128
+  - xmc4200_4100c_128
+- name: XMC4104-F64x64
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffe000
+      end: 0x20002fc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc010000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4200_4100_64
+  - xmc4200_4100c_64
+- name: XMC4104-Q48x128
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffe000
+      end: 0x20002fc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc020000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4200_4100_128
+  - xmc4200_4100c_128
+- name: XMC4104-Q48x64
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffe000
+      end: 0x20002fc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc010000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4200_4100_64
+  - xmc4200_4100c_64
+- name: XMC4108-F64x64
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffe000
+      end: 0x20002fc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc010000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4200_4100_64
+  - xmc4200_4100c_64
+- name: XMC4108-Q48x64
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffe000
+      end: 0x20002fc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc010000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4200_4100_64
+  - xmc4200_4100c_64
+- name: XMC4200-F64x256
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffc000
+      end: 0x20005fc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc040000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4200_4100_256
+  - xmc4200_4100c_256
+- name: XMC4200-Q48x256
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffc000
+      end: 0x20005fc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc040000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4200_4100_256
+  - xmc4200_4100c_256
+- name: XMC4300-F100x256
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fff0000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc040000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4300_256
+  - xmc4300c_256
+- name: XMC4400-F100x256
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffc000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc040000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4400_256
+  - xmc4400c_256
+- name: XMC4400-F100x512
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffc000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc080000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4400_512
+  - xmc4400c_512
+- name: XMC4400-F64x256
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffc000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc040000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4400_256
+  - xmc4400c_256
+- name: XMC4400-F64x512
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffc000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc080000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4400_512
+  - xmc4400c_512
+- name: XMC4402-F100x256
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffc000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc040000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4400_256
+  - xmc4400c_256
+- name: XMC4402-F64x256
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1fffc000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8040000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc040000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4400_256
+  - xmc4400c_256
+- name: XMC4500-E144x1024
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc100000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4500_1024
+  - xmc4500c_1024
+- name: XMC4500-F100x1024
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc100000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4500_1024
+  - xmc4500c_1024
+- name: XMC4500-F100x768
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x80c0000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc0c0000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4500_768
+  - xmc4500c_768
+- name: XMC4500-F144x1024
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc100000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4500_1024
+  - xmc4500c_1024
+- name: XMC4500-F144x768
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x80c0000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc0c0000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4500_768
+  - xmc4500c_768
+- name: XMC4502-F100x768
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x80c0000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc0c0000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4500_768
+  - xmc4500c_768
+- name: XMC4504-F100x512
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc080000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4500_512
+  - xmc4500c_512
+- name: XMC4504-F144x512
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2
+    range:
+      start: 0x10000000
+      end: 0x10010000
+    cores:
+    - main
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x2000ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8080000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc080000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4500_512
+  - xmc4500c_512
+- name: XMC4700-E196x1536
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffe8000
+      end: 0x2002cfc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8180000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc180000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_1536
+  - xmc4800c_1536
+- name: XMC4700-E196x2048
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffe8000
+      end: 0x2003ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8200000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc200000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_2048
+  - xmc4800c_2048
+- name: XMC4700-F100x1536
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffe8000
+      end: 0x2002cfc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8180000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc180000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_1536
+  - xmc4800c_1536
+- name: XMC4700-F100x2048
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffe8000
+      end: 0x2003ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8200000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc200000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_2048
+  - xmc4800c_2048
+- name: XMC4700-F144x1536
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffe8000
+      end: 0x2002cfc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8180000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc180000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_1536
+  - xmc4800c_1536
+- name: XMC4700-F144x2048
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffe8000
+      end: 0x2003ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8200000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc200000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_2048
+  - xmc4800c_2048
+- name: XMC4800-E196x1024
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffee000
+      end: 0x2001ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc100000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_1024
+  - xmc4800c_1024
+- name: XMC4800-E196x1536
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffe8000
+      end: 0x2002cfc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8180000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc180000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_1536
+  - xmc4800c_1536
+- name: XMC4800-E196x2048
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffe8000
+      end: 0x2003ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8200000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc200000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_2048
+  - xmc4800c_2048
+- name: XMC4800-F100x1024
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffee000
+      end: 0x2001ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc100000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_1024
+  - xmc4800c_1024
+- name: XMC4800-F100x1536
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffe8000
+      end: 0x2002cfc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8180000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc180000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_1536
+  - xmc4800c_1536
+- name: XMC4800-F100x2048
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffe8000
+      end: 0x2003ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8200000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc200000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_2048
+  - xmc4800c_2048
+- name: XMC4800-F144x1024
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffee000
+      end: 0x2001ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8100000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc100000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_1024
+  - xmc4800c_1024
+- name: XMC4800-F144x1536
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffe8000
+      end: 0x2002cfc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8180000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc180000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_1536
+  - xmc4800c_1536
+- name: XMC4800-F144x2048
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM2 + IRAM1
+    range:
+      start: 0x1ffe8000
+      end: 0x2003ffc0
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8200000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IROM2
+    range:
+      start: 0xc000000
+      end: 0xc200000
+    cores:
+    - main
+  flash_algorithms:
+  - xmc4800_2048
+  - xmc4800c_2048
+flash_algorithms:
+- name: xmc4200_4100_128
+  description: XMC4200/4100 128kB Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1N0n1IkphqiRMYTVLVSKaYoAlTWFMYZpiMCHqBBBDAWAxSAFpyQf80QBpL0kIQADQASAwvfC1AySkBgEmLE8sTbYDIEb/99v/rEIB0qQZBOC8QgLSASBABCQYrELx0wAg8L33tQVGI0wAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33RxI/yEBMUhEAPCV+BlIOkZIRAKZAPAw+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAABAwAAAIMCAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3P//4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xa5
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x200
+  flash_properties:
+    address_range:
+      start: 0xc000000
+      end: 0xc020000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+- name: xmc4200_4100c_128
+  description: XMC4200/4100 128kB cached Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1N0n1IkphqiRMYTVLVSKaYoAlTWFMYZpiMCHqBBBDAWAxSAFpyQf80QBpL0kIQADQASAwvfC1AySkBgEmLE8sTbYDIEb/99v/rEIB0qQZBOC8QgLSASBABCQYrELx0wAg8L33tQVGI0wAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33RxI/yEBMUhEAPCV+BlIOkZIRAKZAPAw+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAABAwAAAIMCAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3P//4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xa5
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x200
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8020000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+- name: xmc4200_4100_64
+  description: XMC4200/4100 64kB Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AySkBi9OAScvTb8DIEb/99v/tEIB0uQZCuAsSIRCAtIBIEAEA+CsQgLSASCABCQYrELr0wAg8L33tQVGJEwAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33R1I/yEBMUhEAPCX+BpIOkZIRAKZAPAy+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAEMAAAEDAgAAAD4tQQqLNODBxLQC3hJHANwQBxSHoMHC9ALeEkcA3BAHFIegwcE0At4SRwDcEAcUh6LB5sPBdDJGt8AICPeGwjJCuD/9zf/+L0dRgjJ/UAcRrRALEMQwBIfBCr10vMIyRpSHvDUC3hJHANwQBxSHurUC3hJHANwQBwBKuTUCXgBcPi9AeAEwAkfBCn70osHAdUCgIAcyQcA0AJwcEcAKQvQwwcC0AJwQBxJHgIpBNODBwLVAoCAHIke4+cAIu7nACLf5wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb1
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x210
+  flash_properties:
+    address_range:
+      start: 0xc000000
+      end: 0xc010000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+- name: xmc4200_4100c_64
+  description: XMC4200/4100 64kB cached Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AySkBi9OAScvTb8DIEb/99v/tEIB0uQZCuAsSIRCAtIBIEAEA+CsQgLSASCABCQYrELr0wAg8L33tQVGJEwAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33R1I/yEBMUhEAPCX+BpIOkZIRAKZAPAy+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAEMAAAEDAgAAAD4tQQqLNODBxLQC3hJHANwQBxSHoMHC9ALeEkcA3BAHFIegwcE0At4SRwDcEAcUh6LB5sPBdDJGt8AICPeGwjJCuD/9zf/+L0dRgjJ/UAcRrRALEMQwBIfBCr10vMIyRpSHvDUC3hJHANwQBxSHurUC3hJHANwQBwBKuTUCXgBcPi9AeAEwAkfBCn70osHAdUCgIAcyQcA0AJwcEcAKQvQwwcC0AJwQBxJHgIpBNODBwLVAoCAHIke4+cAIu7nACLf5wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb1
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x210
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8010000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+- name: xmc4200_4100_256
+  description: XMC4200/4100 256kB Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1N0n1IkphqiRMYTVLVSKaYoAlTWFMYZpiMCHqBBBDAWAxSAFpyQf80QBpL0kIQADQASAwvfC1AySkBixOAScsTb8DIEb/99v/tEIB0uQZBOCsQgLSASBABCQYrELx0wAg8L33tQVGI0wAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33RxI/yEBMUhEAPCV+BlIOkZIRAKZAPAw+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAQMCAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3P//4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xa5
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x200
+  flash_properties:
+    address_range:
+      start: 0xc000000
+      end: 0xc040000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+- name: xmc4200_4100c_256
+  description: XMC4200/4100 256kB cached Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1N0n1IkphqiRMYTVLVSKaYoAlTWFMYZpiMCHqBBBDAWAxSAFpyQf80QBpL0kIQADQASAwvfC1AySkBixOAScsTb8DIEb/99v/tEIB0uQZBOCsQgLSASBABCQYrELx0wAg8L33tQVGI0wAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33RxI/yEBMUhEAPCV+BlIOkZIRAKZAPAw+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAQMCAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3P//4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xa5
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x200
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8040000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+- name: xmc4300_256
+  description: XMC4300 256kB Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1N0n1IkphqiRMYTVLVSKaYoAlTWFMYZpiMCHqBBBDAWAxSAFpyQf80QBpL0kIQADQASAwvfC1AySkBixOAScsTb8DIEb/99v/tEIB0uQZBOCsQgLSASBABCQYrELx0wAg8L33tQVGI0wAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33RxI/yEBMUhEAPCV+BlIOkZIRAKZAPAw+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAQMCAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3P//4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xa5
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x200
+  flash_properties:
+    address_range:
+      start: 0xc000000
+      end: 0xc040000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+- name: xmc4300c_256
+  description: XMC4300 256kB cached Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1N0n1IkphqiRMYTVLVSKaYoAlTWFMYZpiMCHqBBBDAWAxSAFpyQf80QBpL0kIQADQASAwvfC1AySkBixOAScsTb8DIEb/99v/tEIB0uQZBOCsQgLSASBABCQYrELx0wAg8L33tQVGI0wAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33RxI/yEBMUhEAPCV+BlIOkZIRAKZAPAw+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAQMCAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3P//4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xa5
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x200
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8040000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+- name: xmc4400_256
+  description: XMC4400 256kB Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1N0n1IkphqiRMYTVLVSKaYoAlTWFMYZpiMCHqBBBDAWAxSAFpyQf80QBpL0kIQADQASAwvfC1AySkBixOAScsTb8DIEb/99v/tEIB0uQZBOCsQgLSASBABCQYrELx0wAg8L33tQVGI0wAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33RxI/yEBMUhEAPCV+BlIOkZIRAKZAPAw+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAQMCAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3P//4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xa5
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x200
+  flash_properties:
+    address_range:
+      start: 0xc000000
+      end: 0xc040000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+- name: xmc4400c_256
+  description: XMC4400 256kB cached Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1N0n1IkphqiRMYTVLVSKaYoAlTWFMYZpiMCHqBBBDAWAxSAFpyQf80QBpL0kIQADQASAwvfC1AySkBixOAScsTb8DIEb/99v/tEIB0uQZBOCsQgLSASBABCQYrELx0wAg8L33tQVGI0wAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33RxI/yEBMUhEAPCV+BlIOkZIRAKZAPAw+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAQMCAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3P//4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xa5
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x200
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8040000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+- name: xmc4400_512
+  description: XMC4400 512kB Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AySkBi9OAScvTb8DIEb/99v/tEIB0uQZCuAsSIRCAtIBIEAEA+CsQgLSASCABCQYrELr0wAg8L33tQVGJEwAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33R1I/yEBMUhEAPCX+BpIOkZIRAKZAPAy+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAgMAAAEDAgAAAD4tQQqLNODBxLQC3hJHANwQBxSHoMHC9ALeEkcA3BAHFIegwcE0At4SRwDcEAcUh6LB5sPBdDJGt8AICPeGwjJCuD/9zf/+L0dRgjJ/UAcRrRALEMQwBIfBCr10vMIyRpSHvDUC3hJHANwQBxSHurUC3hJHANwQBwBKuTUCXgBcPi9AeAEwAkfBCn70osHAdUCgIAcyQcA0AJwcEcAKQvQwwcC0AJwQBxJHgIpBNODBwLVAoCAHIke4+cAIu7nACLf5wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb1
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x210
+  flash_properties:
+    address_range:
+      start: 0xc000000
+      end: 0xc080000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4400c_512
+  description: XMC4400 512kB cached Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AySkBi9OAScvTb8DIEb/99v/tEIB0uQZCuAsSIRCAtIBIEAEA+CsQgLSASCABCQYrELr0wAg8L33tQVGJEwAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33R1I/yEBMUhEAPCX+BpIOkZIRAKZAPAy+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAgMAAAEDAgAAAD4tQQqLNODBxLQC3hJHANwQBxSHoMHC9ALeEkcA3BAHFIegwcE0At4SRwDcEAcUh6LB5sPBdDJGt8AICPeGwjJCuD/9zf/+L0dRgjJ/UAcRrRALEMQwBIfBCr10vMIyRpSHvDUC3hJHANwQBxSHurUC3hJHANwQBwBKuTUCXgBcPi9AeAEwAkfBCn70osHAdUCgIAcyQcA0AJwcEcAKQvQwwcC0AJwQBxJHgIpBNODBwLVAoCAHIke4+cAIu7nACLf5wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb1
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x210
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8080000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4500_1024
+  description: XMC4500 1024kB Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AyQBJ6QGL06/A8ElLQUgRv/32v+0QgHS5BkK4CpIhEIC0gEgQAQD4KxCAtIBIIAEJBisQuvTACDwvfe1BUYjTAAgASYPRkxEtgYpGDFDCXgAKS3RQBz/KPfdHEj/IQExSEQA8JT4GUg6RkhEApkA8C/4EE/1IHhhUCB4YQ1IACGAMAzMAmNDYwgx/yn53aogeGEJSlUhkWKgIXlhNUMoYAZIAWnJB/zRAGkFSQhAANABIP69QFUADICqAAwAIABYAAgAgAAAAgwAAAQMBAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3Of/4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb3
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x20c
+  flash_properties:
+    address_range:
+      start: 0xc000000
+      end: 0xc100000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4500c_1024
+  description: XMC4500 1024kB cached Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AyQBJ6QGL06/A8ElLQUgRv/32v+0QgHS5BkK4CpIhEIC0gEgQAQD4KxCAtIBIIAEJBisQuvTACDwvfe1BUYjTAAgASYPRkxEtgYpGDFDCXgAKS3RQBz/KPfdHEj/IQExSEQA8JT4GUg6RkhEApkA8C/4EE/1IHhhUCB4YQ1IACGAMAzMAmNDYwgx/yn53aogeGEJSlUhkWKgIXlhNUMoYAZIAWnJB/zRAGkFSQhAANABIP69QFUADICqAAwAIABYAAgAgAAAAgwAAAQMBAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3Of/4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb3
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x20c
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8100000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4500_768
+  description: XMC4500 768kB Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AySkBi9OAScvTb8DIEb/99v/tEIB0uQZCuAsSIRCAtIBIEAEA+CsQgLSASCABCQYrELr0wAg8L33tQVGJEwAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33R1I/yEBMUhEAPCX+BpIOkZIRAKZAPAy+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAwMAAAEDAgAAAD4tQQqLNODBxLQC3hJHANwQBxSHoMHC9ALeEkcA3BAHFIegwcE0At4SRwDcEAcUh6LB5sPBdDJGt8AICPeGwjJCuD/9zf/+L0dRgjJ/UAcRrRALEMQwBIfBCr10vMIyRpSHvDUC3hJHANwQBxSHurUC3hJHANwQBwBKuTUCXgBcPi9AeAEwAkfBCn70osHAdUCgIAcyQcA0AJwcEcAKQvQwwcC0AJwQBxJHgIpBNODBwLVAoCAHIke4+cAIu7nACLf5wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb1
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x210
+  flash_properties:
+    address_range:
+      start: 0xc000000
+      end: 0xc0c0000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4500c_768
+  description: XMC4500 768kB cached Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AySkBi9OAScvTb8DIEb/99v/tEIB0uQZCuAsSIRCAtIBIEAEA+CsQgLSASCABCQYrELr0wAg8L33tQVGJEwAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33R1I/yEBMUhEAPCX+BpIOkZIRAKZAPAy+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAwMAAAEDAgAAAD4tQQqLNODBxLQC3hJHANwQBxSHoMHC9ALeEkcA3BAHFIegwcE0At4SRwDcEAcUh6LB5sPBdDJGt8AICPeGwjJCuD/9zf/+L0dRgjJ/UAcRrRALEMQwBIfBCr10vMIyRpSHvDUC3hJHANwQBxSHurUC3hJHANwQBwBKuTUCXgBcPi9AeAEwAkfBCn70osHAdUCgIAcyQcA0AJwcEcAKQvQwwcC0AJwQBxJHgIpBNODBwLVAoCAHIke4+cAIu7nACLf5wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb1
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x210
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x80c0000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4500_512
+  description: XMC4500 512kB Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AySkBi9OAScvTb8DIEb/99v/tEIB0uQZCuAsSIRCAtIBIEAEA+CsQgLSASCABCQYrELr0wAg8L33tQVGJEwAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33R1I/yEBMUhEAPCX+BpIOkZIRAKZAPAy+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAgMAAAEDAgAAAD4tQQqLNODBxLQC3hJHANwQBxSHoMHC9ALeEkcA3BAHFIegwcE0At4SRwDcEAcUh6LB5sPBdDJGt8AICPeGwjJCuD/9zf/+L0dRgjJ/UAcRrRALEMQwBIfBCr10vMIyRpSHvDUC3hJHANwQBxSHurUC3hJHANwQBwBKuTUCXgBcPi9AeAEwAkfBCn70osHAdUCgIAcyQcA0AJwcEcAKQvQwwcC0AJwQBxJHgIpBNODBwLVAoCAHIke4+cAIu7nACLf5wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb1
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x210
+  flash_properties:
+    address_range:
+      start: 0xc000000
+      end: 0xc080000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4500c_512
+  description: XMC4500 512kB cached Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AySkBi9OAScvTb8DIEb/99v/tEIB0uQZCuAsSIRCAtIBIEAEA+CsQgLSASCABCQYrELr0wAg8L33tQVGJEwAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33R1I/yEBMUhEAPCX+BpIOkZIRAKZAPAy+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAAAgMAAAEDAgAAAD4tQQqLNODBxLQC3hJHANwQBxSHoMHC9ALeEkcA3BAHFIegwcE0At4SRwDcEAcUh6LB5sPBdDJGt8AICPeGwjJCuD/9zf/+L0dRgjJ/UAcRrRALEMQwBIfBCr10vMIyRpSHvDUC3hJHANwQBxSHurUC3hJHANwQBwBKuTUCXgBcPi9AeAEwAkfBCn70osHAdUCgIAcyQcA0AJwcEcAKQvQwwcC0AJwQBxJHgIpBNODBwLVAoCAHIke4+cAIu7nACLf5wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb1
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x210
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8080000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4800_1536
+  description: XMC4800 1536kB Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AySkBi9OAScvTb8DIEb/99v/tEIB0uQZCuAsSIRCAtIBIEAEA+CsQgLSASCABCQYrELr0wAg8L33tQVGJEwAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33R1I/yEBMUhEAPCX+BpIOkZIRAKZAPAy+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAABgMAAAEDAgAAAD4tQQqLNODBxLQC3hJHANwQBxSHoMHC9ALeEkcA3BAHFIegwcE0At4SRwDcEAcUh6LB5sPBdDJGt8AICPeGwjJCuD/9zf/+L0dRgjJ/UAcRrRALEMQwBIfBCr10vMIyRpSHvDUC3hJHANwQBxSHurUC3hJHANwQBwBKuTUCXgBcPi9AeAEwAkfBCn70osHAdUCgIAcyQcA0AJwcEcAKQvQwwcC0AJwQBxJHgIpBNODBwLVAoCAHIke4+cAIu7nACLf5wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb1
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x210
+  flash_properties:
+    address_range:
+      start: 0xc000000
+      end: 0xc180000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4800c_1536
+  description: XMC4500 512kB cached Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AySkBi9OAScvTb8DIEb/99v/tEIB0uQZCuAsSIRCAtIBIEAEA+CsQgLSASCABCQYrELr0wAg8L33tQVGJEwAIAEmD0ZMRLYGKRgxQwl4ACkt0UAc/yj33R1I/yEBMUhEAPCX+BpIOkZIRAKZAPAy+BBP9SB4YVAgeGEOSAAhgDAMzAJjQ2MIMf8p+d2qIHhhCUpVIZFioCF5YTVDKGAHSAFpyQf80QBpBUkIQADQASD+vQAAQFUADICqAAwAIABYAAgAgAAAAgwAABgMAAAEDAgAAAD4tQQqLNODBxLQC3hJHANwQBxSHoMHC9ALeEkcA3BAHFIegwcE0At4SRwDcEAcUh6LB5sPBdDJGt8AICPeGwjJCuD/9zf/+L0dRgjJ/UAcRrRALEMQwBIfBCr10vMIyRpSHvDUC3hJHANwQBxSHurUC3hJHANwQBwBKuTUCXgBcPi9AeAEwAkfBCn70osHAdUCgIAcyQcA0AJwcEcAKQvQwwcC0AJwQBxJHgIpBNODBwLVAoCAHIke4+cAIu7nACLf5wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb1
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x210
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8180000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4800_2048
+  description: XMC4800 2048kB Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AyQBJ6QGL06/A2ElbQUgRv/32v+0QgHS5BkK4CpIhEIC0gEgQAQD4KxCAtIBIIAEJBisQuvTACDwvfe1BUYjTAAgASYPRkxEtgYpGDFDCXgAKS3RQBz/KPfdHEj/IQExSEQA8JT4GUg6RkhEApkA8C/4EE/1IHhhUCB4YQ1IACGAMAzMAmNDYwgx/yn53aogeGEJSlUhkWKgIXlhNUMoYAZIAWnJB/zRAGkFSQhAANABIP69QFUADICqAAwAIABYAAgAgAAAAgwAAAQMBAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3Of/4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb3
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x20c
+  flash_properties:
+    address_range:
+      start: 0xc000000
+      end: 0xc200000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4800c_2048
+  description: XMC4800 2048kB cached Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AyQBJ6QGL06/A2ElbQUgRv/32v+0QgHS5BkK4CpIhEIC0gEgQAQD4KxCAtIBIIAEJBisQuvTACDwvfe1BUYjTAAgASYPRkxEtgYpGDFDCXgAKS3RQBz/KPfdHEj/IQExSEQA8JT4GUg6RkhEApkA8C/4EE/1IHhhUCB4YQ1IACGAMAzMAmNDYwgx/yn53aogeGEJSlUhkWKgIXlhNUMoYAZIAWnJB/zRAGkFSQhAANABIP69QFUADICqAAwAIABYAAgAgAAAAgwAAAQMBAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3Of/4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb3
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x20c
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8200000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4800_1024
+  description: XMC4800 1024kB Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AyQBJ6QGL06/A8ElLQUgRv/32v+0QgHS5BkK4CpIhEIC0gEgQAQD4KxCAtIBIIAEJBisQuvTACDwvfe1BUYjTAAgASYPRkxEtgYpGDFDCXgAKS3RQBz/KPfdHEj/IQExSEQA8JT4GUg6RkhEApkA8C/4EE/1IHhhUCB4YQ1IACGAMAzMAmNDYwgx/yn53aogeGEJSlUhkWKgIXlhNUMoYAZIAWnJB/zRAGkFSQhAANABIP69QFUADICqAAwAIABYAAgAgAAAAgwAAAQMBAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3Of/4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb3
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x20c
+  flash_properties:
+    address_range:
+      start: 0xc000000
+      end: 0xc100000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000
+- name: xmc4800c_1024
+  description: XMC4800 1024kB cached Flash
+  default: true
+  instructions: cLUFRgxGFkYC4A/MD8UQPhAu+tIILgLTA8wDxQg+BC4H0wHMAcU2HwPgIXgpcGQcbRx2HvnScL0AIHBHACBwRzC1Okn1IkphqiRMYThLVSKaYoAlTWFMYZpiMCHqBBBDAWA0SAFpyQf80QBpMkkIQADQASAwvfC1AyQBJ6QGL06/A8ElLQUgRv/32v+0QgHS5BkK4CpIhEIC0gEgQAQD4KxCAtIBIIAEJBisQuvTACDwvfe1BUYjTAAgASYPRkxEtgYpGDFDCXgAKS3RQBz/KPfdHEj/IQExSEQA8JT4GUg6RkhEApkA8C/4EE/1IHhhUCB4YQ1IACGAMAzMAmNDYwgx/yn53aogeGEJSlUhkWKgIXlhNUMoYAZIAWnJB/zRAGkFSQhAANABIP69QFUADICqAAwAIABYAAgAgAAAAgwAAAQMBAAAAPi1BCos04MHEtALeEkcA3BAHFIegwcL0At4SRwDcEAcUh6DBwTQC3hJHANwQBxSHosHmw8F0Mka3wAgI94bCMkK4P/3Of/4vR1GCMn9QBxGtEAsQxDAEh8EKvXS8wjJGlIe8NQLeEkcA3BAHFIe6tQLeEkcA3BAHAEq5NQJeAFw+L0B4ATACR8EKfvSiwcB1QKAgBzJBwDQAnBwRwApC9DDBwLQAnBAHEkeAikE04MHAtUCgIAciR7j5wAi7ucAIt/nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  pc_init: 0x39
+  pc_uninit: 0x3d
+  pc_program_page: 0xb3
+  pc_erase_sector: 0x41
+  pc_erase_all: 0x77
+  data_section_offset: 0x20c
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8100000
+    page_size: 0x100
+    erased_byte_value: 0x0
+    program_page_timeout: 100
+    erase_sector_timeout: 20000
+    sectors:
+    - size: 0x4000
+      address: 0x0
+    - size: 0x20000
+      address: 0x20000
+    - size: 0x40000
+      address: 0x40000


### PR DESCRIPTION
This PR adds [Infineon XMC4000](https://www.infineon.com/cms/en/product/microcontroller/32-bit-industrial-microcontroller-based-on-arm-cortex-m/32-bit-xmc4000-industrial-microcontroller-arm-cortex-m4/) support, fixing #1134.

I intend to test this PR again with all my XMC4xxx boards before marking it as ready for review. I'm opening it as a draft for discussion.

### `probe-rs/src/architecture/arm/sequences/infineon.rs`

This product family requires a series of nonstandard debug sequences. This module adds them.

CMSIS provides a means for Infineon to describe these sequences in a machine-readable way. Infineon chose not to do so, instead directing everyone to use SEGGER J-Link instead. I developed my own understanding of the requirements from the reference materials, implemented it, and documented my implementation here.

In my view, the main complexity at work is Infineon's "system software". Typical Arm processors begin executing user code after hardware initialization. Infineon XMC4xxx processors begin executing an invisible boot ROM containing "system software" ("SSW") which does _waves hands_ system stuff before ultimately jumping to user code. A naïve reset-and-halt sequence does indeed reset and halt, but it halts at the entrypoint of that system software, prior to that _waves hands_ system stuff being complete, which leaves the processor in a nonfunctional state. A proper reset-and-halt requires resetting, executing the system software, and halting at the jump to user code.

#### `HWCON`

The system software [supports multiple boot modes](https://www.infineon.com/dgdl/Infineon-Tooling+-+XMC4000+boot+mode+options-TR-v01_00-EN.pdf?fileId=5546d4625696ed7601569d06286314d8). Boot modes are controlled in part by `HWCON[1:0]` hardware straps, i.e. pullup/pulldowns on two pins. `HWCON` is latched at powerup.

The `HWCON` pins are in fact TMS+TCK, allowing the debug interface to override the board configuration. `ResetHardwareAssert` and `ResetHardwareDeassert` normally drive nRST low and then high to command a PORESET. Hardware resets are extended here to also drive TMS+TCK to command a normal boot.

### `probe-rs/src/architecture/arm/core/armv7m.rs`

The custom debug sequences require manipulating a FlashPatch comparator register. I opted to make the needed bits `pub(crate)` rather than re-implementing.

### `probe-rs/src/config/target.rs`

Chips whose name start with `XMC4` now use the new XMC4xxx sequences.

### `probe-rs/targets/XMC4000.yaml`

This is `target-gen`'d from `Infineon.XMC4000_DFP.2.12.0.pack`.

One thing I don't like about this is how the cached and uncached memory regions for each device share a bunch of properties. These could be manually consolidated using YAML anchors `&` and overrides `<<: *` to something like:

```yaml
- &xmc4800_1024
  name: xmc4800_1024
  description: XMC4800 1024kB Flash
  default: true
  instructions: cLUFRgxGFkYC4A/MD8U # <snip>
  pc_init: 0x39
  # <snip>
  flash_properties: &xmc4800_1024_fp
    address_range:
      start: 0xc000000
      end: 0xc100000
    page_size: 0x100
    # <snip>
- <<: *xmc4800_1024
  name: xmc4800c_1024
  description: XMC4800 1024kB cached Flash
  flash_properties:
    <<: *xmc4800_1024_fp
    address_range:
      start: 0x8000000
      end: 0x8100000
```

This would parse to an equivalent document but would be less repetitive on disk. On the other hand, since this file can be readily regenerated, I did not manually deduplicate it.