### PR TITLE
Better info output in probe-rs-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `probe_rs_target::chip::Chip` has a new field `pack_file_release` which is populated by `target-gen`.(#1259)
 - Benchmarking code moved from an example to `probe-rs-cli` subcommand (#1296).
 - Replace `log` crate, with `tracing` in `probe-rs-debugger` executable, and in the `rtt` library. (#1297)
+- Improved formatting of `probe-rs-cli info` output. (#1305)
 
 ### Fixed
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,3 +43,4 @@ rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["blocking", "json"] }
 chrono = "0.4.23"
 serde = { version = "1.0.147", features = ["derive"] }
+termtree = "0.4.0"

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -1,13 +1,15 @@
 use std::error::Error;
+use std::fmt::Write;
 
 use probe_rs::{
     architecture::{
         arm::{
             ap::{GenericAp, MemoryAp},
             armv6m::Demcr,
+            dp::DPIDR,
             memory::Component,
             sequences::DefaultArmSequence,
-            ApAddress, ApInformation, ArmProbeInterface, DpAddress, MemoryApInformation,
+            ApAddress, ApInformation, ArmProbeInterface, DpAddress, MemoryApInformation, Register,
         },
         riscv::communication_interface::RiscvCommunicationInterface,
     },
@@ -16,6 +18,7 @@ use probe_rs::{
 
 use anyhow::Result;
 use probe_rs_cli_util::common_options::ProbeOptions;
+use termtree::Tree;
 
 pub(crate) fn show_info_of_device(common: &ProbeOptions) -> Result<()> {
     let mut probe = common.attach_probe()?;
@@ -69,9 +72,7 @@ fn try_show_info(
     if probe.has_arm_interface() {
         match probe.try_into_arm_interface() {
             Ok(interface) => {
-                let mut interface = interface
-                    .initialize(DefaultArmSequence::create())
-                    .expect("This should not be an unwrap...");
+                let mut interface = interface.initialize(DefaultArmSequence::create()).unwrap();
 
                 if let Err(e) = show_arm_info(&mut interface) {
                     // Log error?
@@ -116,7 +117,26 @@ fn try_show_info(
 }
 
 fn show_arm_info(interface: &mut Box<dyn ArmProbeInterface>) -> Result<()> {
-    println!("\nAvailable Access Ports:");
+    let dp_info = interface.read_raw_dp_register(DpAddress::Default, DPIDR::ADDRESS)?;
+    let dp_info = DPIDR(dp_info);
+
+    let mut dp_node = String::new();
+
+    write!(dp_node, "Debug Port: Version {}", dp_info.version())?;
+
+    if dp_info.min() {
+        write!(dp_node, ", MINDP")?;
+    }
+
+    let jep_code = jep106::JEP106Code::new(dp_info.jep_cc(), dp_info.jep_id());
+
+    write!(
+        dp_node,
+        ", Designer: {}",
+        jep_code.get().unwrap_or("<unknown>")
+    )?;
+
+    let mut tree = Tree::new(dp_node);
 
     let dp = DpAddress::Default;
     let num_access_ports = interface.num_access_ports(dp).unwrap();
@@ -132,8 +152,12 @@ fn show_arm_info(interface: &mut Box<dyn ArmProbeInterface>) -> Result<()> {
 
         match ap_information {
             ApInformation::MemoryAp(MemoryApInformation {
-                debug_base_address, ..
+                debug_base_address,
+                address,
+                ..
             }) => {
+                let mut ap_nodes = Tree::new(format!("{} MemoryAP", address.ap));
+
                 let access_port: MemoryAp = access_port.into();
 
                 let base_address = *debug_base_address;
@@ -149,25 +173,99 @@ fn show_arm_info(interface: &mut Box<dyn ArmProbeInterface>) -> Result<()> {
                 demcr.set_dwtena(true);
                 memory.write_word_32(Demcr::ADDRESS, demcr.into())?;
 
-                let component_table = Component::try_parse(&mut memory, base_address);
+                let component = Component::try_parse(&mut memory, base_address)?;
 
-                component_table
-                    .iter()
-                    .for_each(|entry| println!("{:#08x?}", entry));
+                let component_tree = coresight_component_tree(&component)?;
 
-                // let mut reader = crate::memory::romtable::RomTableReader::new(&link_ref, baseaddr as u64);
+                ap_nodes.push(component_tree);
 
-                // for e in reader.entries() {
-                //     if let Ok(e) = e {
-                //         println!("ROM Table Entry: Component @ 0x{:08x}", e.component_addr());
-                //     }
-                // }
+                tree.push(ap_nodes);
             }
-            ApInformation::Other { .. } => println!("Unknown Type of access port"),
+
+            ApInformation::Other { address, idr } => {
+                let designer = idr.DESIGNER;
+
+                let cc = (designer >> 7) as u8;
+                let id = (designer & 0x7f) as u8;
+
+                let jep = jep106::JEP106Code::new(cc, id);
+
+                let ap_type = if designer == 0x43b {
+                    format!("{:?}", idr.TYPE)
+                } else {
+                    format!("{:#x}", idr.TYPE as u8)
+                };
+
+                tree.push(format!(
+                    "{} Unknown AP (Designer: {}, Class: {:?}, Type: {}, Variant: {:#x}, Revision: {:#x})",
+                    address.ap,
+                    jep.get().unwrap_or("unknown"),
+                    idr.CLASS,
+                    ap_type,
+                    idr.VARIANT,
+                    idr.REVISION
+                ));
+            }
         }
     }
 
+    println!("{}", tree);
+
     Ok(())
+}
+
+fn coresight_component_tree(component: &Component) -> Result<Tree<String>> {
+    let tree = match component {
+        Component::GenericVerificationComponent(_) => Tree::new("Generic".to_string()),
+        Component::Class1RomTable(_, table) => {
+            let mut rom_table = Tree::new("ROM Table (Class 1)".to_string());
+
+            for entry in table.entries() {
+                let component = entry.component();
+
+                rom_table.push(coresight_component_tree(component)?);
+            }
+
+            rom_table
+        }
+        Component::CoresightComponent(id) => {
+            let peripheral_id = id.peripheral_id();
+
+            let component_description = if let Some(part_info) = peripheral_id.determine_part() {
+                format!("{}  (Coresight Component)", part_info.name())
+            } else {
+                format!(
+                    "Coresight Component, Part: {:#06x}, Designer: {}",
+                    peripheral_id.part(),
+                    peripheral_id
+                        .jep106()
+                        .and_then(|j| j.get())
+                        .unwrap_or("<unknown>"),
+                )
+            };
+
+            Tree::new(component_description)
+        }
+
+        Component::PeripheralTestBlock(_) => Tree::new("Peripheral test block".to_string()),
+        Component::GenericIPComponent(id) => {
+            let peripheral_id = id.peripheral_id();
+
+            let desc = if let Some(part_desc) = peripheral_id.determine_part() {
+                format!("{} (Generic IP component)", part_desc.name())
+            } else {
+                "Generic IP component".to_string()
+            };
+
+            Tree::new(desc)
+        }
+
+        Component::CoreLinkOrPrimeCellOrSystemComponent(_) => {
+            Tree::new("Core Link / Prime Cell / System component".to_string())
+        }
+    };
+
+    Ok(tree)
 }
 
 fn show_riscv_info(interface: &mut RiscvCommunicationInterface) -> Result<()> {

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -183,7 +183,7 @@ fn show_arm_info(interface: &mut Box<dyn ArmProbeInterface>) -> Result<()> {
                 tree.push(format!(
                     "{} Unknown AP (Designer: {}, Class: {:?}, Type: {}, Variant: {:#x}, Revision: {:#x})",
                     address.ap,
-                    jep.get().unwrap_or("unknown"),
+                    jep.get().unwrap_or("<unknown>"),
                     idr.CLASS,
                     ap_type,
                     idr.VARIANT,

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -103,9 +103,6 @@ pub trait UninitializedArmProbe: SwdSequence {
     fn initialize_unspecified(self: Box<Self>) -> Result<Box<dyn ArmProbeInterface>, ProbeRsError> {
         self.initialize(DefaultArmSequence::create())
     }
-
-    /// Read DPDIR Register
-    fn read_dpidr(&mut self) -> Result<u32, ProbeRsError>;
 }
 
 pub trait ArmDebugState {}
@@ -361,12 +358,6 @@ impl ArmCommunicationInterface<Uninitialized> {
 }
 
 impl UninitializedArmProbe for ArmCommunicationInterface<Uninitialized> {
-    fn read_dpidr(&mut self) -> Result<u32, ProbeRsError> {
-        let result = self.probe.raw_read_register(PortType::DebugPort, 0)?;
-
-        Ok(result)
-    }
-
     fn initialize(
         mut self: Box<Self>,
         sequence: Arc<dyn ArmDebugSequence>,

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -263,12 +263,6 @@ impl<S: ArmDebugState> SwdSequence for FakeArmInterface<S> {
 }
 
 impl UninitializedArmProbe for FakeArmInterface<Uninitialized> {
-    fn read_dpidr(&mut self) -> Result<u32, Error> {
-        let result = self.probe.raw_read_register(PortType::DebugPort, 0)?;
-
-        Ok(result)
-    }
-
     fn initialize(
         self: Box<Self>,
         sequence: Arc<dyn ArmDebugSequence>,

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -9,9 +9,8 @@ use crate::{
     architecture::arm::{
         ap::{valid_access_ports, AccessPort, ApAccess, ApClass, MemoryAp, IDR},
         communication_interface::{
-            ArmProbeInterface, Initialized, Register, SwdSequence, UninitializedArmProbe,
+            ArmProbeInterface, Initialized, SwdSequence, UninitializedArmProbe,
         },
-        dp::DPIDR,
         memory::{adi_v5_memory_interface::ArmProbe, Component},
         sequences::ArmDebugSequence,
         ApAddress, ApInformation, ArmChipInfo, DapAccess, DpAddress, Pins, SwoAccess, SwoConfig,
@@ -1118,16 +1117,6 @@ struct UninitializedStLink {
 }
 
 impl UninitializedArmProbe for UninitializedStLink {
-    // Todo: Is this possible with an uninitialized ST Link?
-    fn read_dpidr(&mut self) -> Result<u32, ProbeRsError> {
-        let result = self
-            .probe
-            .read_register(DP_PORT, DPIDR::ADDRESS)
-            .map_err(|e| ProbeRsError::Other(e.into()))?;
-
-        Ok(result)
-    }
-
     fn initialize(
         self: Box<Self>,
         _sequence: Arc<dyn ArmDebugSequence>,


### PR DESCRIPTION
Nicer info output, in tree structure:

```
Debug Port: Version 2, Designer: ARM Ltd
├── 0 MemoryAP
│   └── ROM Table (Class 1)
│       ├── ROM Table (Class 1)
│       │   ├── Cortex-M33 SCS  (Coresight Component)
│       │   ├── Cortex-M33 DWT  (Coresight Component)
│       │   ├── Cortex-M33 BPU  (Coresight Component)
│       │   └── Cortex-M33 ITM  (Coresight Component)
│       └── Cortex-M33 TPIU  (Coresight Component)
├── 1 MemoryAP
│   └── Error during access: A core architecture specific error occurred
└── 2 Unknown AP (Designer: NXP (Philips), Class: Undefined, Type: 0x0, Variant: 0x0, Revision: 0x0)
```