### PR TITLE
WIP Refactor FTDI impl to use all JtagCommand logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `log` crate, with `tracing` in `probe-rs-debugger` executable, and in the `rtt` library. (#1297)
 - Replace FTDI probe command creation with `ftdi-mpsse` library functions/enums (#1302)
 - Improved formatting of `probe-rs-cli info` output. (#1305)
+- Refactor FTDI probe impl to use all JtagCommand logic (#1307)
 
 
 ### Fixed

--- a/probe-rs/src/probe/ftdi/commands.rs
+++ b/probe-rs/src/probe/ftdi/commands.rs
@@ -15,6 +15,48 @@ pub trait JtagCommand: std::fmt::Debug + Send {
     fn process_output(&self, data: &[u8]) -> Result<CommandResult, DebugProbeError>;
 }
 
+// ReadRegisterCommand and WriteRegisterCommand have same structure
+// save that ReadRegisterCommand passes None for data and WriteRegisterCommand
+// passes Some(Vec<u8>) in creating the TargetTransferCommand
+#[derive(Debug)]
+pub struct ReadRegisterCommand {
+    subcommands: [Box<dyn JtagCommand>; 2],
+}
+
+impl ReadRegisterCommand {
+    pub(super) fn new(
+        address: u32,
+        len: usize,
+        idle_cycles: usize,
+        chain_params: ChainParams,
+    ) -> io::Result<ReadRegisterCommand> {
+        let target_transfer = TargetTransferCommand::new(address, None, len, chain_params)?;
+        let idle = IdleCommand::new(idle_cycles);
+
+        Ok(ReadRegisterCommand {
+            subcommands: [Box::new(target_transfer), Box::new(idle)],
+        })
+    }
+}
+
+impl JtagCommand for ReadRegisterCommand {
+    fn add_bytes(&mut self, buffer: &mut Vec<u8>) {
+        for subcommand in &mut self.subcommands {
+            subcommand.add_bytes(buffer);
+        }
+    }
+
+    fn bytes_to_read(&self) -> usize {
+        self.subcommands.iter().map(|e| e.bytes_to_read()).sum()
+    }
+
+    fn process_output(&self, data: &[u8]) -> Result<CommandResult, DebugProbeError> {
+        let r = self.subcommands[0].process_output(&data[0..(self.subcommands[0].bytes_to_read())]);
+        self.subcommands[1].process_output(&data[self.subcommands[0].bytes_to_read()..])?;
+        r
+    }
+}
+
 #[derive(Debug)]
 pub struct WriteRegisterCommand {
     subcommands: [Box<dyn JtagCommand>; 2],
@@ -28,7 +70,7 @@ impl WriteRegisterCommand {
         idle_cycles: usize,
         chain_params: ChainParams,
     ) -> io::Result<WriteRegisterCommand> {
-        let target_transfer = TargetTransferCommand::new(address, data, len, chain_params)?;
+        let target_transfer = TargetTransferCommand::new(address, Some(data), len, chain_params)?;
         let idle = IdleCommand::new(idle_cycles);
 
         Ok(WriteRegisterCommand {
@@ -66,7 +108,7 @@ struct TargetTransferCommand {
 impl TargetTransferCommand {
     pub fn new(
         address: u32,
-        data: Vec<u8>,
+        data: Option<Vec<u8>>,
         len: usize,
         chain_params: ChainParams,
     ) -> io::Result<TargetTransferCommand> {
@@ -84,8 +126,9 @@ impl TargetTransferCommand {
         let shift_ir_cmd = ShiftIrCommand::new(ir.to_le_bytes().to_vec(), irbits);
 
         let drbits = params.drpre + len + params.drpost;
-        let request = {
-            let data = BitSlice::<u8, Lsb0>::from_slice(&data);
+        let request = if let Some(data_slice) = data {
+            // Write
+            let data = BitSlice::<u8, Lsb0>::from_slice(&data_slice);
             let mut data = BitVec::<u8, Lsb0>::from_bitslice(data);
             data.truncate(len);
 
@@ -95,6 +138,9 @@ impl TargetTransferCommand {
             buf.resize(buf.len() + params.drpost, false);
 
             buf.into_vec()
+        } else {
+            // Read
+            vec![0; (drbits + 7) / 8]
         };
 
         let transfer_dr = TransferDrCommand::new(request.to_vec(), drbits);
@@ -183,7 +229,7 @@ impl JtagCommand for ShiftIrCommand {
 }
 
 #[derive(Debug)]
-struct TransferDrCommand {
+pub(super) struct TransferDrCommand {
     subcommands: Vec<Box<dyn JtagCommand>>,
 }
 
@@ -200,6 +246,55 @@ impl TransferDrCommand {
 }
 
 impl JtagCommand for TransferDrCommand {
+    fn add_bytes(&mut self, buffer: &mut Vec<u8>) {
+        for subcommand in &mut self.subcommands {
+            subcommand.add_bytes(buffer);
+        }
+    }
+
+    fn bytes_to_read(&self) -> usize {
+        self.subcommands.iter().map(|e| e.bytes_to_read()).sum()
+    }
+
+    fn process_output(&self, data: &[u8]) -> Result<CommandResult, DebugProbeError> {
+        let mut start = 0usize;
+
+        let end = start + self.subcommands[0].bytes_to_read();
+        let cmd_data = data[start..end].to_vec();
+        self.subcommands[0].process_output(&cmd_data)?;
+        start += self.subcommands[0].bytes_to_read();
+
+        let end = start + self.subcommands[1].bytes_to_read();
+        let cmd_data = data[start..end].to_vec();
+        let reply = self.subcommands[1].process_output(&cmd_data);
+        start += self.subcommands[1].bytes_to_read();
+
+        let end = start + self.subcommands[2].bytes_to_read();
+        let cmd_data = data[start..end].to_vec();
+        self.subcommands[2].process_output(&cmd_data)?;
+
+        reply
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct TransferIrCommand {
+    subcommands: Vec<Box<dyn JtagCommand>>,
+}
+
+impl TransferIrCommand {
+    pub fn new(data: Vec<u8>, bits: usize) -> TransferIrCommand {
+        TransferIrCommand {
+            subcommands: vec![
+                Box::new(ShiftTmsCommand::new(vec![0b0011], 4)),
+                Box::new(TransferTdiCommand::new(data, bits)),
+                Box::new(ShiftTmsCommand::new(vec![0b01], 2)),
+            ],
+        }
+    }
+}
+
+impl JtagCommand for TransferIrCommand {
     fn add_bytes(&mut self, buffer: &mut Vec<u8>) {
         for subcommand in &mut self.subcommands {
             subcommand.add_bytes(buffer);

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -6,7 +6,6 @@ use crate::probe::{JTAGAccess, ProbeCreationError};
 use crate::{
     DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType, WireProtocol,
 };
-use bitvec::{order::Lsb0, slice::BitSlice, vec::BitVec};
 use ftdi_mpsse::*;
 use rusb::UsbContext;
 use std::convert::TryInto;
@@ -18,7 +17,9 @@ use ftdi_impl as ftdi;
 
 mod commands;
 
-use self::commands::{JtagCommand, WriteRegisterCommand};
+use self::commands::{
+    JtagCommand, ReadRegisterCommand, TransferDrCommand, TransferIrCommand, WriteRegisterCommand,
+};
 
 use super::{BatchExecutionError, CommandResult};
 
@@ -41,6 +42,10 @@ pub(super) struct ChainParams {
 pub struct JtagAdapter {
     device: ftdi::Device,
     chain_params: Option<ChainParams>,
+
+    /// Idle cycles necessary between consecutive
+    /// accesses to the DMI register (RISC-V specific)
+    jtag_idle_cycles: u8,
 }
 
 impl JtagAdapter {
@@ -52,6 +57,7 @@ impl JtagAdapter {
         Ok(Self {
             device,
             chain_params: None,
+            jtag_idle_cycles: 0,
         })
     }
 
@@ -78,186 +84,100 @@ impl JtagAdapter {
         Ok(())
     }
 
-    fn read_response(&mut self, size: usize) -> io::Result<Vec<u8>> {
+    fn read_response(&mut self, size: usize) -> Result<Vec<u8>, DebugProbeError> {
         let timeout = Duration::from_millis(10);
         let mut result = Vec::new();
 
         let t0 = std::time::Instant::now();
         while result.len() < size {
             if t0.elapsed() > timeout {
-                return Err(io::Error::from(io::ErrorKind::TimedOut));
+                return Err(DebugProbeError::Timeout);
             }
 
-            self.device.read_to_end(&mut result)?;
+            self.device
+                .read_to_end(&mut result)
+                .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
         }
 
         if result.len() > size {
-            return Err(io::Error::new(
+            return Err(DebugProbeError::ProbeSpecific(Box::new(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Read more data than expected",
-            ));
+            ))));
         }
 
         Ok(result)
     }
 
-    fn shift_tms(&mut self, mut data: &[u8], mut bits: usize) -> io::Result<()> {
-        assert!(bits > 0);
-        assert!((bits + 7) / 8 <= data.len());
-
-        let mut command = MpsseCmdBuilder::new();
-
-        // Never called where we transfer TDI data at same time,
-        // so TDI arg always false in clock_tms_out()
-        while bits > 0 {
-            if bits >= 8 {
-                command = command.clock_tms_out(ClockTMSOut::NegEdge, data[0], false, 0x07);
-                data = &data[1..];
-                bits -= 8;
-            } else {
-                command =
-                    command.clock_tms_out(ClockTMSOut::NegEdge, data[0], false, (bits - 1) as u8);
-                bits = 0;
-            }
-        }
-
-        self.device.write_all(command.as_slice())
-    }
-
-    fn shift_tdi(&mut self, mut data: &[u8], mut bits: usize) -> io::Result<()> {
-        assert!(bits > 0);
-        assert!((bits + 7) / 8 <= data.len());
-
-        let mut command = MpsseCmdBuilder::new();
-
-        let full_bytes = (bits - 1) / 8;
-        if full_bytes > 0 {
-            assert!(full_bytes <= 65536);
-
-            command = command.clock_data_out(ClockDataOut::LsbNeg, &data[..full_bytes]);
-
-            bits -= full_bytes * 8;
-            data = &data[full_bytes..];
-        }
-        assert!(bits <= 8);
-
-        if bits > 0 {
-            let byte = data[0];
-            if bits > 1 {
-                let n = (bits - 2) as u8;
-                command = command.clock_bits_out(ClockBitsOut::LsbNeg, byte, n);
-            }
-
-            // Use TMS command to clock out last bit of TDI, does not clock any TMS out (length is 0)
-            // In contrast to ClockTMSBitsOut commands, ClockTMS also reads TDO
-            let last_bit = (byte >> (bits - 1)) & 0x01;
-            let tms_byte = 0x01 | (last_bit << 7); // Not sure why we or w/ 0x01 (last bit of TMS) if length is 0?
-            command = command.clock_tms_out(ClockTMSOut::NegEdge, tms_byte, true, 0);
-        }
-
-        self.device.write_all(command.as_slice())
-    }
-
-    fn transfer_tdi(&mut self, mut data: &[u8], mut bits: usize) -> io::Result<Vec<u8>> {
-        assert!(bits > 0);
-        assert!((bits + 7) / 8 <= data.len());
-
-        // Write data out
-        let mut command = MpsseCmdBuilder::new();
-
-        let full_bytes = (bits - 1) / 8;
-        if full_bytes > 0 {
-            assert!(full_bytes <= 65536);
-
-            command = command.clock_data(ClockData::LsbPosIn, &data[..full_bytes]);
-
-            bits -= full_bytes * 8;
-            data = &data[full_bytes..];
-        }
-        assert!(0 < bits && bits <= 8);
-
-        // Leftover data less than full byte
-        let byte = data[0];
-        if bits > 1 {
-            let n = (bits - 2) as u8;
-            command = command.clock_bits(ClockBits::LsbPosIn, byte, n);
-        }
-
-        // Use TMS command to clock out last bit of TDI, does not clock any TMS out (length is 0)
-        // In contrast to ClockTMSBitsOut commands, ClockTMS also reads TDO
-        let last_bit = (byte >> (bits - 1)) & 0x01;
-        let tms_byte = 0x01 | (last_bit << 7); // Not sure why we or w/ 0x01 (last bit of TMS) if length is 0?
-        command = command.clock_tms(ClockTMS::NegTMSPosTDO, tms_byte, true, 0);
-
-        self.device.write_all(command.as_slice())?;
-
-        // Read data back
-        let mut expect_bytes = full_bytes + 1;
-        if bits > 1 {
-            expect_bytes += 1;
-        }
-
-        let mut reply = self.read_response(expect_bytes)?;
-
-        let mut last_byte = reply[reply.len() - 1] >> 7;
-        if bits > 1 {
-            let byte = reply[reply.len() - 2] >> (8 - (bits - 1));
-            last_byte = byte | (last_byte << (bits - 1));
-        }
-        reply[full_bytes] = last_byte;
-        reply.truncate(full_bytes + 1);
-
-        Ok(reply)
-    }
-
     /// Reset and go to RUN-TEST/IDLE
-    pub fn reset(&mut self) -> io::Result<()> {
-        self.shift_tms(&[0xff, 0xff, 0xff, 0xff, 0x7f], 40)
-    }
-
-    /// Execute RUN-TEST/IDLE for a number of cycles
-    pub fn idle(&mut self, cycles: usize) -> io::Result<()> {
-        if cycles == 0 {
-            return Ok(());
-        }
-        let mut buf = vec![];
-        buf.resize((cycles + 7) / 8, 0);
-        self.shift_tms(&buf, cycles)
+    pub fn reset(&mut self) -> Result<Vec<u8>, DebugProbeError> {
+        self.run_jtag_cmd(TransferIrCommand::new(
+            [0xff, 0xff, 0xff, 0xff, 0x7f].to_vec(),
+            40,
+        ))
     }
 
     /// Shift to IR and return to IDLE
-    pub fn shift_ir(&mut self, data: &[u8], bits: usize) -> io::Result<()> {
-        self.shift_tms(&[0b0011], 4)?;
-        self.shift_tdi(data, bits)?;
-        self.shift_tms(&[0b01], 2)?;
-        Ok(())
-    }
-
-    /// Shift to IR and return to IDLE
-    pub fn transfer_ir(&mut self, data: &[u8], bits: usize) -> io::Result<Vec<u8>> {
-        self.shift_tms(&[0b0011], 4)?;
-        let r = self.transfer_tdi(data, bits)?;
-        self.shift_tms(&[0b01], 2)?;
-        Ok(r)
+    pub fn transfer_ir(&mut self, data: Vec<u8>, bits: usize) -> Result<Vec<u8>, DebugProbeError> {
+        self.run_jtag_cmd(TransferIrCommand::new(data, bits))
     }
 
     /// Shift to DR and return to IDLE
-    pub fn transfer_dr(&mut self, data: &[u8], bits: usize) -> io::Result<Vec<u8>> {
-        self.shift_tms(&[0b001], 3)?;
-        let r = self.transfer_tdi(data, bits)?;
-        self.shift_tms(&[0b01], 2)?;
-        Ok(r)
+    pub fn transfer_dr(&mut self, data: Vec<u8>, bits: usize) -> Result<Vec<u8>, DebugProbeError> {
+        self.run_jtag_cmd(TransferDrCommand::new(data, bits))
     }
 
-    fn scan(&mut self) -> io::Result<Vec<JtagChainItem>> {
-        let max_device_count = 8;
+    fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {
+        let chain_params = self
+            .get_chain_params()
+            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+
+        // Generate Read register command
+        let cmd = ReadRegisterCommand::new(
+            address,
+            len as usize,
+            self.jtag_idle_cycles as usize,
+            chain_params,
+        )
+        .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+
+        self.run_jtag_cmd(cmd)
+    }
+
+    fn write_register(
+        &mut self,
+        address: u32,
+        data: &[u8],
+        len: u32,
+    ) -> Result<Vec<u8>, DebugProbeError> {
+        let chain_params = self
+            .get_chain_params()
+            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+
+        // Generate write register command
+        let cmd = WriteRegisterCommand::new(
+            address,
+            data.to_vec(),
+            len as usize,
+            self.jtag_idle_cycles as usize,
+            chain_params,
+        )
+        .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+
+        self.run_jtag_cmd(cmd)
+    }
+
+    fn scan(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
+        const MAX_DEVICE_COUNT: usize = 8;
 
         self.reset()?;
 
-        let cmd = vec![0xff; max_device_count * 4];
-        let r = self.transfer_dr(&cmd, cmd.len() * 8)?;
+        // TODO: Go back to using vec![] and fix borrow
+        let cmd: [u8; MAX_DEVICE_COUNT * 4] = [0xff; MAX_DEVICE_COUNT * 4];
+        let r = self.transfer_dr(cmd.to_vec(), (cmd.len() * 8) as usize)?;
+
         let mut targets = vec![];
-        for i in 0..max_device_count {
+        for i in 0..MAX_DEVICE_COUNT {
             let idcode = u32::from_le_bytes(r[i * 4..(i + 1) * 4].try_into().unwrap());
             if idcode != 0xffffffff {
                 tracing::debug!("tap found: {:08x}", idcode);
@@ -287,14 +207,16 @@ impl JtagAdapter {
         // Then we shift in lots of `0` bytes. The output will be something like `0b00000111`, and the
         // number of ones is the IR length.
         if targets.len() == 1 {
-            let r = self.transfer_ir(&[0xFF, 0x00], 16)?;
+            let cmd: Vec<u8> = vec![0xFF, 0x00];
+            let r = self.transfer_ir(cmd, 16)?;
 
             let irlen = r[1].count_ones() as usize;
             targets[0].irlen = irlen;
             tracing::debug!("tap irlen: {}", irlen);
         } else {
-            let cmd = vec![0xff; max_device_count];
-            let mut r = self.transfer_ir(&cmd, cmd.len() * 8)?;
+            // TODO: Go back to using vec![] and fix borrow
+            let cmd: [u8; MAX_DEVICE_COUNT] = [0xFF; MAX_DEVICE_COUNT];
+            let mut r = self.transfer_ir(cmd.to_vec(), (cmd.len() * 8) as usize)?;
 
             let mut ir = 0;
             let mut irbits = 0;
@@ -314,10 +236,10 @@ impl JtagAdapter {
                     target.irlen = irlen as usize;
                 } else {
                     tracing::debug!("invalid irlen for tap {}", i);
-                    return Err(io::Error::new(
+                    return Err(DebugProbeError::ProbeSpecific(Box::new(io::Error::new(
                         io::ErrorKind::InvalidData,
                         "Invalid IR sequence during the chain scan",
-                    ));
+                    ))));
                 }
             }
         }
@@ -325,7 +247,26 @@ impl JtagAdapter {
         Ok(targets)
     }
 
-    pub fn select_target(&mut self, idcode: u32) -> io::Result<()> {
+    fn run_jtag_cmd(&mut self, mut cmd: impl JtagCommand) -> Result<Vec<u8>, DebugProbeError> {
+        // Copy generated command bytes into vec and write to device
+        let mut out_buffer = Vec::<u8>::new();
+        cmd.add_bytes(&mut out_buffer);
+
+        self.device
+            .write_all(&out_buffer)
+            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+
+        // Read back response, ensure received correct amt of data
+        let resp = self.read_response(cmd.bytes_to_read())?;
+
+        let read_res = match cmd.process_output(&resp)? {
+            CommandResult::VecU8(data) => data,
+            _ => panic!("Internal error occurred. Only expect VecU8 for FTDI data"),
+        };
+        Ok(read_res)
+    }
+
+    pub fn select_target(&mut self, idcode: u32) -> Result<(), DebugProbeError> {
         let taps = self.scan()?;
 
         let mut found = false;
@@ -354,7 +295,10 @@ impl JtagAdapter {
             self.chain_params = Some(params);
             Ok(())
         } else {
-            Err(io::Error::new(io::ErrorKind::NotFound, "target not found"))
+            Err(DebugProbeError::ProbeSpecific(Box::new(io::Error::new(
+                io::ErrorKind::NotFound,
+                "target not found",
+            ))))
         }
     }
 
@@ -366,59 +310,6 @@ impl JtagAdapter {
                 "target is not selected",
             )),
         }
-    }
-
-    fn target_transfer(
-        &mut self,
-        address: u32,
-        data: Option<&[u8]>,
-        len_bits: usize,
-    ) -> io::Result<Vec<u8>> {
-        let params = self.get_chain_params()?;
-        let max_address = (1 << params.irlen) - 1;
-        if address > max_address {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "invalid register address",
-            ));
-        }
-
-        // Write IR register
-        // Do we always have to write the IR reg? JLink impl checks cached value before attempting
-        let irbits = params.irpre + params.irlen + params.irpost;
-        assert!(irbits <= 32);
-        let mut ir: u32 = (1 << params.irpre) - 1;
-        ir |= address << params.irpre;
-        ir |= ((1 << params.irpost) - 1) << (params.irpre + params.irlen);
-        self.shift_ir(&ir.to_le_bytes(), irbits)?;
-
-        // Write/read DR register
-        let drbits = params.drpre + len_bits + params.drpost;
-        let request = if let Some(data_slice) = data {
-            let data = BitSlice::<u8, Lsb0>::from_slice(data_slice);
-            let mut data = BitVec::<u8, Lsb0>::from_bitslice(data);
-            data.truncate(len_bits);
-
-            let mut buf = BitVec::<u8, Lsb0>::new();
-            buf.resize(params.drpre, false);
-            buf.append(&mut data);
-            buf.resize(buf.len() + params.drpost, false);
-
-            buf.into_vec()
-        } else {
-            vec![0; (drbits + 7) / 8]
-        };
-        let reply = self.transfer_dr(&request, drbits)?;
-
-        // Process the reply
-        let mut reply = BitVec::<u8, Lsb0>::from_vec(reply);
-        if params.drpre > 0 {
-            reply = reply.split_off(params.drpre);
-        }
-        reply.truncate(len_bits);
-        let reply = reply.into_vec();
-
-        Ok(reply)
     }
 }
 
@@ -478,18 +369,13 @@ impl DebugProbe for FtdiProbe {
             .attach()
             .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
 
-        let taps = self
-            .adapter
-            .scan()
-            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+        let taps = self.adapter.scan()?;
         if taps.is_empty() {
             tracing::warn!("no JTAG taps detected");
             return Err(DebugProbeError::TargetNotFound);
         }
         if taps.len() == 1 {
-            self.adapter
-                .select_target(taps[0].idcode)
-                .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+            self.adapter.select_target(taps[0].idcode)?;
         } else {
             let known_idcodes = [
                 0x1000563d, // GD32VF103
@@ -499,9 +385,7 @@ impl DebugProbe for FtdiProbe {
                 .map(|tap| tap.idcode)
                 .find(|idcode| known_idcodes.iter().any(|v| v == idcode));
             if let Some(idcode) = idcode {
-                self.adapter
-                    .select_target(idcode)
-                    .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+                self.adapter.select_target(idcode)?
             } else {
                 return Err(DebugProbeError::TargetNotFound);
             }
@@ -569,18 +453,9 @@ impl DebugProbe for FtdiProbe {
 impl JTAGAccess for FtdiProbe {
     fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {
         tracing::debug!("read_register({:#x}, {})", address, len);
-        let r = self
-            .adapter
-            .target_transfer(address, None, len as usize)
-            .map_err(|e| {
-                tracing::debug!("target_transfer error: {:?}", e);
-                DebugProbeError::ProbeSpecific(Box::new(e))
-            })?;
-        self.adapter
-            .idle(self.idle_cycles as usize)
-            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
-        tracing::debug!("read_register result: {:?})", r);
-        Ok(r)
+        let read_res = self.adapter.read_register(address, len)?;
+        tracing::debug!("read_register result: {:?})", read_res);
+        Ok(read_res)
     }
 
     fn set_idle_cycles(&mut self, idle_cycles: u8) {
@@ -595,18 +470,9 @@ impl JTAGAccess for FtdiProbe {
         len: u32,
     ) -> Result<Vec<u8>, DebugProbeError> {
         tracing::debug!("write_register({:#x}, {:?}, {})", address, data, len);
-        let r = self
-            .adapter
-            .target_transfer(address, Some(data), len as usize)
-            .map_err(|e| {
-                tracing::debug!("target_transfer error: {:?}", e);
-                DebugProbeError::ProbeSpecific(Box::new(e))
-            })?;
-        self.adapter
-            .idle(self.idle_cycles as usize)
-            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
-        tracing::debug!("write_register result: {:?})", r);
-        Ok(r)
+        let read_res = self.adapter.write_register(address, data, len)?;
+        tracing::debug!("write_register result: {:?})", read_res);
+        Ok(read_res)
     }
 
     fn get_idle_cycles(&self) -> u8 {


### PR DESCRIPTION
- Refactors `read_register()`, `write_register()`, `transfer_ir()`, `transfer_dr()`, and `reset()` to use `JtagCommand`s                                                     
- Changes several function returns to use `Result` instead of `io::Result`
- Creates new JtagCommands `ReadRegisterCommand` and `TransferIrCommand`
- Changes `TransferDrCommand`'s impl to be `pub(super)`, matching `WriteRegisterCommand`
- Removes individual transfer JtagAdapter functions `shift_tms()`, `shift_tdi()`, `transfer_tdi()`

Fixes #1307.