### PR TITLE
Automatically detect Infineon XMC4xxx devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an optional `stack_size` configuration to flash algorithms to control the stack size (#1260)
 - Added Support for Debug Erase Sequences that (if available) are used instead of the normal chip-erase logic
 - Added Support for GD32E50x targets (#1304)
-- Added support for the Infineon XMC4000 family
 - Added support for the Infineon XMC4000 family (#1301)
+- Added target autodetection the Infineon XMC4000 family (#1312)
 
 ### Changed
 

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -238,8 +238,12 @@ impl Registry {
         let (family, chip) = {
             match chip_info {
                 ChipInfo::Arm(chip_info) => {
-                    // Try get the corresponding chip.
+                    if let Some(target) = chip_info.target_name {
+                        // Already identified
+                        return self.get_target_by_name(target);
+                    }
 
+                    // Try get the corresponding chip.
                     let families = self.families.iter().filter(|f| {
                         f.manufacturer
                             .map(|m| m == chip_info.manufacturer)

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1274,10 +1274,11 @@ impl ArmProbeInterface for StlinkArmDebug {
 
                 if let Component::Class1RomTable(component_id, _) = component {
                     if let Some(jep106) = component_id.peripheral_id().jep106() {
-                        return Ok(Some(ArmChipInfo {
-                            manufacturer: jep106,
-                            part: component_id.peripheral_id().part(),
-                        }));
+                        return Ok(Some(ArmChipInfo::autodetect(
+                            jep106,
+                            component_id.peripheral_id().part(),
+                            &mut memory,
+                        )?));
                     }
                 }
             }


### PR DESCRIPTION
This changeset adds a target autodetection facility to `ArmChipInfo` and uses it to autodetect Infineon XMC4xxx targets.

`ArmChipInfo`  contains a `manufacturer` and `part` number and is documented with the caveat that these values are often insufficient to identify a particular target. These values are however read from the target device's ROM table, which means whatever context constructs `ArmChipInfo` has a functional `probe_rs::Memory` which could be used in a `manufaucturer`- and `part`-specific way to identify a specific target.

This PR extends `ArmChipInfo` with a `pub target_name: Option<&'static str>` field. A new function `ArmChipInfo::autodetect(manufacturer, part, memory)` attempts to populate `target_name` by dispatching to a `manufacturer`-specific autodetection sequence, if available.

`probe_rs::architecture::arm::sequences::infineon` now provides a `pub(crate)` `MANUFACTURER` constant and a `pub(crate)` `autodetect()` function for use above. `autodetect()` can positively identify `XMC4…` given the `part` value, at which point it begins an XMC4-specific sequence.

XMC4 autodetection has three steps:

1. All XMC4s have a System Control Unit peripheral at a specific address which can identify itself and the die revision. This gives us a second digit, i.e. XMC44 or `XMC48`.
2. All XMC4s have flash controllers at a specific address, which unfortunately don't report their own capacity. They do however have flash memory mapped to a specific address, and flash memory size can be probed by reading `Memory`. This gives us the last part of the product, i.e. `-X2048`.
3. This leaves the last two digits of the part number (XMC4500 vs 4504 vs 4508) and the package unknown – but as best I can tell these details are not observable from the SoC. That sounds like bad news, but it's actually good news, because given family and flash size, all the remaining targets are identical from `probe-rs`'s perspective. Pick one.
