### PR TITLE
Release release/0.14.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
       - name: release to crates.io
         run: |
           git config user.name "releasebot"
-          git config user.email "actions@users.noreply.github.com"
+          git config user.email "release@probe.rs"
           git checkout master
           cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          cargo release --no-confirm $( echo '${{ github.head_ref }}' | sed 's?release/all/??' )
+          cargo release --no-confirm $( echo '${{ github.head_ref }}' | sed 's?release/??' )
 
       - name: Generate Release Notes
         id: notes
@@ -48,8 +48,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.head_ref }}
-          release_name: ${{ github.head_ref }}
+          tag_name: $( echo '${{ github.head_ref }}' | sed 's?release/??' )
+          release_name: $( echo '${{ github.head_ref }}' | sed 's?release/??' )
           body: ${{ steps.notes.outputs.notes }}
           draft: false
           prerelease: false

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -14,17 +14,66 @@ jobs:
       pull-requests: write
       contents: write
     runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: release/${{ inputs.version }}
     steps:
       - uses: actions/checkout@v3
       - uses: chainguard-dev/actions/setup-gitsign@main
       - name: install cargo-release
         run: |
           curl -LsSf https://github.com/crate-ci/cargo-release/releases/download/v0.24.0/cargo-release-v0.24.0-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ${CARGO_HOME:-~/.cargo}/bin
+      # - name: Install semver checks
+      #   run: |
+      #     cargo install cargo-semver-checks --locked
+      - name: Install libusb, libudev (linux)
+        run: |
+          sudo apt update
+          sudo apt install -y libusb-1.0-0-dev libudev-dev
 
-      - uses: cargo-bins/release-pr@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: ${{ inputs.version }}
-          crate-release-all: true
-          check-semver: true
-          pr-label: "release"
+      - name: Git setup
+        run: |
+          git config user.name "releasebot"
+          git config user.email "release@probe.rs"
+          git fetch --unshallow
+          git fetch --tags
+
+      - name: Create branch
+        run: |
+          git checkout -b ${BRANCH_NAME}
+
+      - name: Bump versions
+        run: |
+          cargo release version ${{ inputs.version }} --execute --verbose --no-confirm --allow-branch ${BRANCH_NAME}
+          cargo release replace --execute --verbose --no-confirm
+          cargo release hook --execute --verbose --no-confirm
+          cargo release commit --execute --verbose --no-confirm
+
+      # - name: Check semver compliance
+      #   run: |
+      #     cargo semver-checks check-release -p probe-rs -p probe-rs-target -p probe-rs-rtt -p probe-rs-cli-util
+
+      - name: Push branch
+        run: |
+          git push origin ${BRANCH_NAME}
+
+      - name: create pull request
+        run: |
+          gh pr create -B master -H "${BRANCH_NAME}"\
+            --title "Release ${BRANCH_NAME}"\
+            --body "This is the release PR for ${{ inputs.version }}.
+
+            It releases crates:
+
+              - probe-rs
+              - probe-rs-target
+              - probe-rs-rtt
+              - probe-rs-cli-util
+              - probe-rs-cli
+              - probe-rs-debugger
+              - gdb-server
+              - target-gen
+              - rtthost
+            
+            Use `bors r+` to merge."
+        env:
+            GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.14.0
+
+Released 2022-12-11
+
 ### Added
 
 - Added PartialEq Trait to the struct DebugProbeInfo. (#1173)
@@ -666,7 +670,8 @@ Initial release on crates.io
 - Working basic flash downloader with nRF51.
 - Introduce cargo-flash which can automatically build & flash the target elf file.
 
-[unreleased]: https://github.com/probe-rs/probe-rs/compare/v0.13.0...master
+[unreleased]: https://github.com/probe-rs/probe-rs/compare/v0.14.0...master
+[v0.14.0]: https://github.com/probe-rs/probe-rs/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/probe-rs/probe-rs/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/probe-rs/probe-rs/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/probe-rs/probe-rs/compare/v0.10.1...v0.11.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 
 documentation = "https://docs.rs/probe-rs/"
@@ -25,11 +25,11 @@ members = [
 ]
 
 [workspace.dependencies]
-probe-rs = { path = "probe-rs", version = "0.13.0" }
-probe-rs-cli-util = { path = "probe-rs-cli-util", version = "0.13.0" }
-probe-rs-rtt = { path = "rtt", version = "0.13.0" }
-probe-rs-target = { path = "probe-rs-target", version = "0.13.0" }
-gdb-server = { path = "gdb-server", version = "0.13.0" }
+probe-rs = { path = "probe-rs", version = "0.14.0" }
+probe-rs-cli-util = { path = "probe-rs-cli-util", version = "0.14.0" }
+probe-rs-rtt = { path = "rtt", version = "0.14.0" }
+probe-rs-target = { path = "probe-rs-target", version = "0.14.0" }
+gdb-server = { path = "gdb-server", version = "0.14.0" }
 
 log = "0.4.6"
 pretty_env_logger = "0.4.0"

--- a/rtt/Cargo.toml
+++ b/rtt/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 tracing = { version = "0.1.37", features = ["log"] }
-probe-rs = { version = "0.13.0", path = "../probe-rs" }
+probe-rs = { version = "0.14.0", path = "../probe-rs" }
 scroll = "0.10.1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1.0.11"

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -15,8 +15,8 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-probe-rs = { path = "../probe-rs", version = "0.13.0", default-features = true }
-probe-rs-target = { path = "../probe-rs-target", version = "0.13.0", default-features = false }
+probe-rs = { path = "../probe-rs", version = "0.14.0", default-features = true }
+probe-rs-target = { path = "../probe-rs-target", version = "0.14.0", default-features = false }
 cmsis-pack = { version = "0.6", git = "https://github.com/pyocd/cmsis-pack-manager" }
 goblin = "0.6.0"
 scroll = "0.11.0"


### PR DESCRIPTION
This is the release PR for 0.14.0.

  It releases crates:

    - probe-rs
    - probe-rs-target
    - probe-rs-rtt
    - probe-rs-cli-util
    - probe-rs-cli
    - probe-rs-debugger
    - gdb-server
    - target-gen
    - rtthost
  
  Use  to merge.