### PR TITLE
Improve cli info output

### DIFF
--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -226,6 +226,10 @@ impl ApInformation {
 
             tracing::debug!("HNONSEC supported: {}", supports_hnonsec);
 
+            let device_enabled = csw.DeviceEn == 1;
+
+            tracing::debug!("Device enabled: {}", device_enabled);
+
             let cfg: CFG = probe.read_ap_register(access_port)?;
 
             let has_large_address_extension = cfg.LA == 1;
@@ -238,6 +242,7 @@ impl ApInformation {
                 supports_hnonsec,
                 has_large_address_extension,
                 has_large_data_extension,
+                device_enabled,
             }))
         } else {
             Ok(ApInformation::Other {
@@ -277,6 +282,10 @@ pub struct MemoryApInformation {
 
     /// This AP has the large data extension present, supporting 64-bit data access
     pub has_large_data_extension: bool,
+
+    /// Memory transaction can be issued through this AP. If this bit is not set,
+    /// no transactions can be issued.
+    pub device_enabled: bool,
 }
 
 /// An implementation of the communication protocol between probe and target.

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -283,7 +283,7 @@ pub struct MemoryApInformation {
     /// This AP has the large data extension present, supporting 64-bit data access
     pub has_large_data_extension: bool,
 
-    /// Memory transaction can be issued through this AP. If this bit is not set,
+    /// Memory transactions can be issued through this AP. If this bit is not set,
     /// no transactions can be issued.
     pub device_enabled: bool,
 }

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -993,6 +993,7 @@ mod tests {
                 debug_base_address: 0xf000_0000,
                 has_large_address_extension: false,
                 has_large_data_extension: false,
+                device_enabled: true,
             };
 
             Self::new(mock, &ap_information).unwrap()

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -654,6 +654,14 @@ impl PeripheralID {
         self.PART
     }
 
+    pub fn arch_id(&self) -> u16 {
+        self.arch_id
+    }
+
+    pub fn dev_type(&self) -> u8 {
+        self.dev_type
+    }
+
     /// Uses the available data to match it againts a table of known components.
     /// If the component is known, some info about it is returned.
     /// If it is not known, None is returned.
@@ -710,7 +718,8 @@ impl PeripheralID {
             ("ARM Ltd", 0xD21, 0x00, 0x1A03) => Some(PartInfo::new("Cortex-M33 BPU", PeripheralType::Bpu)),
             ("ARM Ltd", 0xD21, 0x13, 0x4A13) => Some(PartInfo::new("Cortex-M33 ETM", PeripheralType::Etm)),
             ("ARM Ltd", 0xD21, 0x11, 0x0000) => Some(PartInfo::new("Cortex-M33 TPIU", PeripheralType::Tpiu)),
-            ("ARM Ltd", 0x9a3, 0x13, 0x0000) => Some(PartInfo::new("Cortex-M0 MTB", PeripheralType::Mtb)),
+            ("ARM Ltd", 0xD21, 0x14, 0x1A14) => Some(PartInfo::new("Cortex-M33 CTI", PeripheralType::Cti)),
+            ("ARM Ltd", 0x9A3, 0x13, 0x0000) => Some(PartInfo::new("Cortex-M0 MTB", PeripheralType::Mtb)),
             _ => None,
         }
     }
@@ -785,6 +794,8 @@ pub enum PeripheralType {
     Tmc,
     /// Micro Trace Buffer
     Mtb,
+    /// Cross Trigger Interface
+    Cti,
 }
 
 impl std::fmt::Display for PeripheralType {
@@ -805,6 +816,7 @@ impl std::fmt::Display for PeripheralType {
             PeripheralType::Tsgen => write!(f, "Tsgen (Time Stamp Generator)"),
             PeripheralType::Tmc => write!(f, "Tmc (Trace Memory Controller)"),
             PeripheralType::Mtb => write!(f, "MTB (Micro Trace Buffer)"),
+            PeripheralType::Cti => write!(f, "CTI (Cross Trigger Interface)"),
         }
     }
 }

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -285,6 +285,7 @@ impl ArmProbeInterface for FakeArmInterface<Initialized> {
             supports_hnonsec: false,
             has_large_data_extension: false,
             has_large_address_extension: false,
+            device_enabled: true,
         };
 
         let memory = ADIMemoryInterface::new(&mut self.memory_ap, &ap_information)?;


### PR DESCRIPTION
- Detect when Memory-AP is not enabled, and show in output.
- Show TARGETID register in output when available.
- Fix endless recursion in J-Link register access.