### PR TITLE
Use sequence for STM32F1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix: Timeout during flashing when using connect under reset - regression from #1259. (#1286)
 - Fix: Validate RiscV CSR addresses to avoid unnecessary panics. (#1291)
 - Debugger: Fix unpredictable behaviour when breaking on, or stepping over macros. (#1230)
+- Fix: Extend fix for WFI instructions (#1177) to STM32F1
 
 ## [0.13.0]
 

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -119,11 +119,12 @@ impl Target {
         } else if chip.name.starts_with("STM32H7") {
             tracing::warn!("Using custom sequence for STM32H7");
             debug_sequence = DebugSequence::Arm(Stm32h7::create());
-        } else if chip.name.starts_with("STM32F2")
+        } else if chip.name.starts_with("STM32F1")
+            || chip.name.starts_with("STM32F2")
             || chip.name.starts_with("STM32F4")
             || chip.name.starts_with("STM32F7")
         {
-            tracing::warn!("Using custom sequence for STM32F2/4/7");
+            tracing::warn!("Using custom sequence for STM32F1/2/4/7");
             debug_sequence = DebugSequence::Arm(Stm32fSeries::create());
         } else if chip.name.starts_with("ATSAMD5") || chip.name.starts_with("ATSAME5") {
             tracing::warn!("Using custom sequence for {}", chip.name);


### PR DESCRIPTION
The STM32F1 also needs the sequence to function correctly when wfi is used (see #350).

The lowest 8 bits of the DBGMCU_CR register (which are used in the [stm32f sequence](https://github.com/probe-rs/probe-rs/blob/7243f5afe17bea45610a10f829aabd635d4f3b47/probe-rs/src/architecture/arm/sequences/stm32f_series.rs#L34-L38)) are the same as with the STM32F4 so the sequence should be applicable for the STM32F1 as well.

Unfortunately this still doesn't work correctly when the device is first connected to the st-link. ("Command failed with status SwdDpWait") But at least all subsequent flashes after the first flash (done with `--connect-under-reset` and manual resetting) work now with this patch.