### PR TITLE
Added support for finding targets externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for the Infineon XMC4000 family
 - Added support for the Infineon XMC4000 family (#1301)
 - Added debug support for viewing function arguments (#1333)
+- Added support for finding targets externally (#1338)
 
 ### Changed
 

--- a/probe-rs/build.rs
+++ b/probe-rs/build.rs
@@ -22,7 +22,7 @@ fn main() {
     visit_dirs(Path::new("targets"), &mut files).unwrap();
 
     // Check if there are any additional targets to generate for
-    match env::var("PROBE_RS_ADDITIONAL_TARGETS_DIR") {
+    match env::var("PROBE_RS_TARGETS_DIR") {
         Ok(additional_target_dir) => {
             visit_dirs(Path::new(&additional_target_dir), &mut files).unwrap();
         }

--- a/probe-rs/build.rs
+++ b/probe-rs/build.rs
@@ -20,6 +20,17 @@ fn main() {
 
     let mut files = vec![];
     visit_dirs(Path::new("targets"), &mut files).unwrap();
+
+    // Check if there are any additional targets to generate for
+    match env::var("PROBE_RS_ADDITIONAL_TARGETS_DIR") {
+        Ok(additional_target_dir) => {
+            visit_dirs(Path::new(&additional_target_dir), &mut files).unwrap();
+        }
+        Err(_err) => {
+            // Do nothing as you dont have to add any other targets
+        }
+    }
+
     for file in files {
         let string = read_to_string(&file).expect(
             "Algorithm definition file could not be read. This is a bug. Please report it.",


### PR DESCRIPTION
Not sure if it makes sense to add tests when the only change is made to `build.rs`.