### PR TITLE
Debugger: Fix RTT data from target is not polled/reported in a timely manner - during stepping, and after breakpoint halting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix: Timeout during flashing when using connect under reset - regression from #1259. (#1286)
 - Fix: Validate RiscV CSR addresses to avoid unnecessary panics. (#1291)
 - Debugger: Fix unpredictable behaviour when breaking on, or stepping over macros. (#1230)
+- Debugger: Fix RTT data from target is not polled/reported in a timely manner - during stepping, and after breakpoint halting. (#)
 
 ## [0.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix: Validate RiscV CSR addresses to avoid unnecessary panics. (#1291)
 - Debugger: Fix unpredictable behaviour when breaking on, or stepping over macros. (#1230)
 - Fix: Extend fix for WFI instructions (#1177) to STM32F1
-- Debugger: Fix RTT data from target is not polled/reported in a timely manner - during stepping, and after breakpoint halting. (#1341)
+- Debugger: RTT data from target is now polled/reported in a timely manner, during stepping, and after breakpoint halting. (#1341)
 
 ## [0.13.0]
 

--- a/debugger/src/debug_adapter/dap_adapter.rs
+++ b/debugger/src/debug_adapter/dap_adapter.rs
@@ -38,7 +38,7 @@ pub struct DebugAdapter<P: ProtocolAdapter> {
     /// - `configuration_done` will ignore target status, and simply notify VSCode when it is done.
     /// - `threads` will check for [DebugAdapter::configuration_done] and ...
     ///   - If it is `false`, it will ...
-    ///     - send back a threads response, with `all_threds_stopped=Some(false)`, and set [DebugAdapter::configuration_done] to `true`.
+    ///     - send back a threads response, with `all_threads_stopped=Some(false)`, and set [DebugAdapter::configuration_done] to `true`.
     ///   - If it is `true`, it will respond with thread information as expected.
     pub(crate) configuration_done: bool,
     /// Flag to indicate if all cores of the target are halted. This is used to accurately report the `all_threads_stopped` field in the DAP `StoppedEvent`, as well as to prevent unnecessary polling of core status.

--- a/debugger/src/debugger/core_data.rs
+++ b/debugger/src/debugger/core_data.rs
@@ -22,7 +22,7 @@ pub struct CoreData {
     ///   For instance, when the client sets the core running, and the core halts because of a breakpoint, we need to notify the client.
     /// 2. Some requests, like [`DebugAdapter::next()`], has an implicit action of setting the core running, before it waits for it to halt at the next statement.
     ///   To ensure the [`CoreData::poll_core()`] behaves correctly, it will set the `last_known_status` to [`CoreStatus::Running`],
-    ///   and execute the request normally, with the expectation that the core will be halted, and that #1 above will detect this new status.
+    ///   and execute the request normally, with the expectation that the core will be halted, and that 1. above will detect this new status.
     ///   These 'implicit' updates of `last_known_status` will not(and should not) result in a notification to the client.
     pub(crate) last_known_status: CoreStatus,
     pub(crate) target_name: String,

--- a/debugger/src/debugger/core_data.rs
+++ b/debugger/src/debugger/core_data.rs
@@ -73,7 +73,7 @@ impl<'p> CoreHandle<'p> {
                                     thread_id: self.core.id() as i64,
                                 });
                                 debug_adapter.send_event("continued", event_body)?;
-                                tracing::debug!(
+                                tracing::trace!(
                                     "Notified DAP client that the core continued: {:?}",
                                     status
                                 );
@@ -93,7 +93,7 @@ impl<'p> CoreHandle<'p> {
                                     hit_breakpoint_ids: None,
                                 });
                                 debug_adapter.send_event("stopped", event_body)?;
-                                tracing::debug!(
+                                tracing::trace!(
                                     "Notified DAP client that the core halted: {:?}",
                                     status
                                 );
@@ -127,7 +127,7 @@ impl<'p> CoreHandle<'p> {
                 }
             }
         } else {
-            tracing::debug!(
+            tracing::trace!(
                 "Ignored last_known_status: {:?} during `configuration_done=false`, and reset it to {:?}.",
                 self.core_data.last_known_status,
                 CoreStatus::Unknown

--- a/debugger/src/debugger/core_data.rs
+++ b/debugger/src/debugger/core_data.rs
@@ -61,7 +61,7 @@ impl<'p> CoreHandle<'p> {
         &mut self,
         debug_adapter: &mut DebugAdapter<P>,
     ) -> Result<CoreStatus, Error> {
-        if debug_adapter.configuration_done {
+        if debug_adapter.configuration_is_done() {
             match self.core.status() {
                 Ok(status) => {
                     let has_changed_state = status != self.core_data.last_known_status;

--- a/debugger/src/debugger/core_data.rs
+++ b/debugger/src/debugger/core_data.rs
@@ -21,7 +21,7 @@ pub struct CoreData {
     /// 1. By polling the core status periodically (in [`Debugger::process_next_request()`]).
     ///   For instance, when the client sets the core running, and the core halts because of a breakpoint, we need to notify the client.
     /// 2. Some requests, like [`DebugAdapter::next()`], has an implicit action of setting the core running, before it waits for it to halt at the next statement.
-    ///   To ensure the [`CoreData::poll_core()`] behaves correctly, it will the `last_known_status` to [`CoreStatus::Running`],
+    ///   To ensure the [`CoreData::poll_core()`] behaves correctly, it will set the `last_known_status` to [`CoreStatus::Running`],
     ///   and execute the request normally, with the expectation that the core will be halted, and that #1 above will detect this new status.
     ///   These 'implicit' updates of `last_known_status` will not(and should not) result in a notification to the client.
     pub(crate) last_known_status: CoreStatus,

--- a/debugger/src/debugger/debug_entry.rs
+++ b/debugger/src/debugger/debug_entry.rs
@@ -96,7 +96,7 @@ impl Debugger {
                     let (_, suggest_delay_required) =
                         session_data.poll_cores(&self.config, debug_adapter)?;
                     // If there are no requests from the DAP Client, and there was no RTT data in the last poll, then we can sleep for a short period of time to reduce CPU usage.
-                    if debug_adapter.configuration_done && suggest_delay_required {
+                    if debug_adapter.configuration_is_done() && suggest_delay_required {
                         tracing::trace!(
                             "Sleeping (core is running) for 50ms to reduce polling overheads."
                         );
@@ -291,7 +291,7 @@ impl Debugger {
                         }
                         Err(e) => Err(DebuggerError::Other(e.context("Error executing request."))),
                     }
-                } else if debug_adapter.configuration_done {
+                } else if debug_adapter.configuration_is_done() {
                     // We've passed `configuration_done` and still do not have at least one core configured.
                     Err(DebuggerError::Other(anyhow!(
                         "Cannot continue unless one target core configuration is defined."

--- a/debugger/src/debugger/debug_entry.rs
+++ b/debugger/src/debugger/debug_entry.rs
@@ -72,306 +72,237 @@ impl Debugger {
     }
 
     /// The logic of this function is as follows:
-    /// - While we are waiting for DAP-Client (TCP or STDIO), we have to continuously check in on the status of the probe.
-    /// - Initally, while `LAST_KNOWN_STATUS` probe-rs::CoreStatus::Unknown, we do nothing. Wait until latter part of `debug_session` sets it to something known.
-    /// - If the `LAST_KNOWN_STATUS` is `Halted`, then we stop polling the Probe until the next DAP-Client request attempts an action
-    /// - If the `new_status` is an Err, then the probe is no longer available, and we  end the debugging session
-    /// - If the `new_status` is different from the `LAST_KNOWN_STATUS`, then we have to tell the DAP-Client by way of an `Event`
-    /// - If the `new_status` is `Running`, then we have to poll on a regular basis, until the Probe stops for good reasons like breakpoints, or bad reasons like panics. Then tell the DAP-Client.
+    /// - While we are waiting for DAP-Client, we have to continuously check in on the status of the probe.
+    /// - Initally, while [`DebugAdapter::configuration_done`] = `false`, we do nothing.
+    /// - Once [`DebugAdapter::configuration_done`] = `true`, we can start polling the probe for status, as follows:
+    ///   - If the [`CoreData::last_known_status`] is `Halted(_)`, then we stop polling the Probe until the next DAP-Client request attempts an action
+    ///   - If the `new_status` is an Err, then the probe is no longer available, and we  end the debugging session
+    ///   - If the `new_status` is `Running`, then we have to poll on a regular basis, until the Probe stops for good reasons like breakpoints, or bad reasons like panics.
     pub(crate) fn process_next_request<P: ProtocolAdapter>(
         &mut self,
         session_data: &mut session_data::SessionData,
         debug_adapter: &mut DebugAdapter<P>,
     ) -> Result<DebuggerStatus, DebuggerError> {
-        let request = debug_adapter.listen_for_request()?;
-        match request {
-            None => {
-                // If there are no requests, we poll target cores for status, which includes handling RTT data.
-                // TODO: Currently, debug_adapter.last_known_status only applies to the first core. Needs multi-core implementation.
-                match debug_adapter.last_known_status {
-                    CoreStatus::Unknown => {
-                        // Don't do anything until we know VSCode's startup sequence is complete, and changes this to either Halted or Running.
-                        Ok(DebuggerStatus::ContinueSession)
-                    }
-                    CoreStatus::Halted(_) => {
-                        // If the probe is known to be halted, then we don't need to poll it.
-                        // Small delay to reduce fast looping costs.
-                        thread::sleep(Duration::from_millis(50));
-                        Ok(DebuggerStatus::ContinueSession)
-                    }
-                    _other => {
-                        if let (core_id, Some(new_status)) = (
-                            0_usize,
-                            session_data
-                                .poll_cores(&self.config, debug_adapter)?
-                                .first()
-                                .cloned(),
-                        ) {
-                            if new_status == debug_adapter.last_known_status {
-                                return Ok(DebuggerStatus::ContinueSession);
-                            } else {
-                                debug_adapter.last_known_status = new_status;
-                                match new_status {
-                                    CoreStatus::Running | CoreStatus::Sleeping => {
-                                        let event_body = Some(ContinuedEventBody {
-                                            all_threads_continued: Some(true),
-                                            thread_id: core_id as i64,
-                                        });
-                                        debug_adapter.send_event("continued", event_body)?;
-                                    }
-                                    CoreStatus::Halted(_) => {
-                                        let event_body = Some(StoppedEventBody {
-                                            reason: new_status.short_long_status().0.to_owned(),
-                                            description: Some(
-                                                new_status.short_long_status().1.to_owned(),
-                                            ),
-                                            thread_id: Some(core_id as i64),
-                                            preserve_focus_hint: Some(false),
-                                            text: None,
-                                            all_threads_stopped: Some(true),
-                                            hit_breakpoint_ids: None,
-                                        });
-                                        debug_adapter.send_event("stopped", event_body)?;
-                                    }
-                                    CoreStatus::LockedUp => {
-                                        debug_adapter.show_message(
-                                            MessageSeverity::Error,
-                                            new_status.short_long_status().1.to_owned(),
-                                        );
-                                        return Err(DebuggerError::Other(anyhow!(new_status
-                                            .short_long_status()
-                                            .1
-                                            .to_owned())));
-                                    }
-                                    CoreStatus::Unknown => {
-                                        debug_adapter.send_error_response(
-                                            &DebuggerError::Other(anyhow!(
-                                                "Unknown Device status reveived from Probe-rs"
-                                            )),
-                                        )?;
+        // First, we poll ALL target cores for status, which includes synching status with the DAP client, and handling RTT data.
+        let (core_statuses, suggest_delay_required) =
+            session_data.poll_cores(&self.config, debug_adapter)?;
 
-                                        return Err(DebuggerError::Other(anyhow!(
-                                            "Unknown Device status reveived from Probe-rs"
-                                        )));
-                                    }
-                                };
-                            };
+        // TODO: Currently, we only use `poll_cores()` results from the first core and need to expand to a multi-core implementation that understands which MS DAP requests are core specific.
+        if let (core_id, Some(new_status)) = (0_usize, core_statuses.first().cloned()) {
+            match debug_adapter.listen_for_request()? {
+                None => {
+                    // If there are no requests from the DAP Client, and there was no RTT data in the last poll, then we can sleep for a short period of time to reduce CPU usage.
+                    if debug_adapter.configuration_done && suggest_delay_required {
+                        if new_status.is_halted() {
+                            // TODO: In an ideal world, we would stop calling 'poll_cores()' above while the core is halted, but we need to figure out how to handle RTT data in that case.
+                            tracing::debug!(
+                                "Sleeping (core is halted) for 250ms to reduce polling costs."
+                            );
+                            thread::sleep(Duration::from_millis(250)); // Medium delay to reduce fast looping costs.
+                        } else {
+                            tracing::debug!(
+                                "Sleeping (core is running) for 50ms to reduce polling costs."
+                            );
+                            thread::sleep(Duration::from_millis(50)); // Small delay to reduce fast looping costs.
                         }
-                        Ok(DebuggerStatus::ContinueSession)
-                    }
-                }
-            }
-            Some(request) => {
-                // Always poll the core first, so that we know what its status is, and can read RTT data, etc. before handling the next requeest.
-                if debug_adapter.last_known_status != CoreStatus::Unknown {
-                    if let Some(new_status) = session_data
-                        .poll_cores(&self.config, debug_adapter)?
-                        .first()
-                        .cloned()
-                    {
-                        debug_adapter.last_known_status = new_status;
-                    }
-                }
+                    } else {
+                        tracing::debug!("Retrieving data from the core, no delay required between iterations of polling the core.");
+                    };
 
-                // Attach to the core. so that we have the handle available for processing the request.
-                // TODO: This only works for a single core, so until it can be redesigned, will use the first one configured.
-                let mut target_core = if let Some(target_core_config) =
-                    self.config.core_configs.first_mut()
-                {
-                    if let Ok(core_handle) = session_data.attach_core(target_core_config.core_index)
+                    Ok(DebuggerStatus::ContinueSession)
+                }
+                Some(request) => {
+                    // Attach to the core. so that we have the handle available for processing the request.
+                    let mut target_core = if let Some(target_core_config) =
+                        self.config.core_configs.get_mut(core_id)
                     {
-                        core_handle
+                        if let Ok(core_handle) =
+                            session_data.attach_core(target_core_config.core_index)
+                        {
+                            core_handle
+                        } else {
+                            return Err(DebuggerError::Other(anyhow!(
+                                "Unable to connect to target core"
+                            )));
+                        }
                     } else {
                         return Err(DebuggerError::Other(anyhow!(
-                            "Unable to connect to target core"
+                            "No core configuration found for core id {}",
+                            core_id
                         )));
-                    }
-                } else {
-                    return Err(DebuggerError::Other(anyhow!(
-                        "Cannot continue unless one target core configuration is defined."
-                    )));
-                };
+                    };
 
-                // For some operations, we need to make sure the core isn't sleeping, by calling `Core::halt()`.
-                // When we do this, we need to flag it (`unhalt_me = true`), and later call `Core::run()` again.
-                // NOTE: The target will exit sleep mode as a result of this command.
-                let mut unhalt_me = false;
-                match request.command.as_ref() {
-                    "configurationDone"
-                    | "setBreakpoint"
-                    | "setBreakpoints"
-                    | "setInstructionBreakpoints"
-                    | "clearBreakpoint"
-                    | "stackTrace"
-                    | "threads"
-                    | "scopes"
-                    | "variables"
-                    | "readMemory"
-                    | "writeMemory"
-                    | "disassemble" => {
-                        match target_core.core.status() {
-                            Ok(current_status) => {
-                                if current_status == CoreStatus::Sleeping {
-                                    match target_core.core.halt(Duration::from_millis(100)) {
-                                        Ok(_) => {
-                                            debug_adapter.last_known_status =
-                                                CoreStatus::Halted(probe_rs::HaltReason::Request);
-                                            unhalt_me = true;
-                                        }
-                                        Err(error) => {
-                                            debug_adapter.send_response::<()>(
-                                                request,
-                                                Err(DebuggerError::Other(anyhow!("{}", error))),
-                                            )?;
-                                            return Err(error.into());
-                                        }
+                    // For some operations, we need to make sure the core isn't sleeping, by calling `Core::halt()`.
+                    // When we do this, we need to flag it (`unhalt_me = true`), and later call `Core::run()` again.
+                    // NOTE: The target will exit sleep mode as a result of this command.
+                    let mut unhalt_me = false;
+                    match request.command.as_ref() {
+                        "configurationDone"
+                        | "setBreakpoint"
+                        | "setBreakpoints"
+                        | "setInstructionBreakpoints"
+                        | "clearBreakpoint"
+                        | "stackTrace"
+                        | "threads"
+                        | "scopes"
+                        | "variables"
+                        | "readMemory"
+                        | "writeMemory"
+                        | "disassemble" => {
+                            if new_status == CoreStatus::Sleeping {
+                                match target_core.core.halt(Duration::from_millis(100)) {
+                                    Ok(_) => {
+                                        unhalt_me = true;
+                                    }
+                                    Err(error) => {
+                                        debug_adapter.send_response::<()>(
+                                            request,
+                                            Err(DebuggerError::Other(anyhow!("{}", error))),
+                                        )?;
+                                        return Err(error.into());
                                     }
                                 }
                             }
-                            Err(error) => {
-                                let failed_command = request.command.clone();
-                                let wrapped_err = DebuggerError::ProbeRs(error);
-                                debug_adapter.send_response::<()>(request, Err(wrapped_err))?;
-
-                                // TODO: Nicer response here
-                                return Err(DebuggerError::Other(anyhow!(
-                                    "Failed to get core status. Could not complete command: {:?}",
-                                    failed_command
-                                )));
-                            }
                         }
+                        _ => {}
                     }
-                    _ => {}
-                }
 
-                // Now we are ready to execute supported commands, or return an error if it isn't supported.
-                match match request.command.clone().as_ref() {
-                    "rttWindowOpened" => {
-                        if let Some(debugger_rtt_target) =
-                            target_core.core_data.rtt_connection.as_mut()
-                        {
-                            match get_arguments::<RttWindowOpenedArguments>(&request) {
-                                Ok(arguments) => {
-                                    debugger_rtt_target
-                                        .debugger_rtt_channels
-                                        .iter_mut()
-                                        .find(|debugger_rtt_channel| {
-                                            debugger_rtt_channel.channel_number
-                                                == arguments.channel_number
-                                        })
-                                        .map_or(false, |rtt_channel| {
-                                            rtt_channel.has_client_window =
-                                                arguments.window_is_open;
-                                            arguments.window_is_open
-                                        });
-                                    debug_adapter.send_response::<()>(request, Ok(None))?;
-                                }
-                                Err(error) => {
-                                    debug_adapter.send_response::<()>(
-                                        request,
-                                        Err(DebuggerError::Other(anyhow!(
+                    // Now we are ready to execute supported commands, or return an error if it isn't supported.
+                    match match request.command.clone().as_ref() {
+                        "rttWindowOpened" => {
+                            if let Some(debugger_rtt_target) =
+                                target_core.core_data.rtt_connection.as_mut()
+                            {
+                                match get_arguments::<RttWindowOpenedArguments>(&request) {
+                                    Ok(arguments) => {
+                                        debugger_rtt_target
+                                            .debugger_rtt_channels
+                                            .iter_mut()
+                                            .find(|debugger_rtt_channel| {
+                                                debugger_rtt_channel.channel_number
+                                                    == arguments.channel_number
+                                            })
+                                            .map_or(false, |rtt_channel| {
+                                                rtt_channel.has_client_window =
+                                                    arguments.window_is_open;
+                                                arguments.window_is_open
+                                            });
+                                        debug_adapter.send_response::<()>(request, Ok(None))?;
+                                    }
+                                    Err(error) => {
+                                        debug_adapter.send_response::<()>(
+                                            request,
+                                            Err(DebuggerError::Other(anyhow!(
                                     "Could not deserialize arguments for RttWindowOpened : {:?}.",
                                     error
                                 ))),
-                                    )?;
+                                        )?;
+                                    }
                                 }
                             }
+                            Ok(DebuggerStatus::ContinueSession)
                         }
-                        Ok(DebuggerStatus::ContinueSession)
-                    }
-                    "disconnect" => debug_adapter
-                        .send_response::<()>(request, Ok(None))
-                        .and(Ok(DebuggerStatus::TerminateSession)),
-                    "terminate" => debug_adapter
-                        .pause(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::TerminateSession)),
-                    "status" => debug_adapter
-                        .status(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "next" => debug_adapter
-                        .next(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "stepIn" => debug_adapter
-                        .step_in(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "stepOut" => debug_adapter
-                        .step_out(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "pause" => debug_adapter
-                        .pause(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "readMemory" => debug_adapter
-                        .read_memory(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "writeMemory" => debug_adapter
-                        .write_memory(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "setVariable" => debug_adapter
-                        .set_variable(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "configurationDone" => debug_adapter
-                        .configuration_done(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "threads" => debug_adapter
-                        .threads(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "restart" => {
-                        // Reset RTT so that the link can be re-established
-                        target_core.core_data.rtt_connection = None;
-                        debug_adapter
-                            .restart(&mut target_core, Some(request))
-                            .and(Ok(DebuggerStatus::ContinueSession))
-                    }
-                    "setBreakpoints" => debug_adapter
-                        .set_breakpoints(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "setInstructionBreakpoints" => debug_adapter
-                        .set_instruction_breakpoints(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "stackTrace" => debug_adapter
-                        .stack_trace(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "scopes" => debug_adapter
-                        .scopes(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "disassemble" => debug_adapter
-                        .disassemble(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "variables" => debug_adapter
-                        .variables(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "continue" => debug_adapter
-                        .r#continue(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    "evaluate" => debug_adapter
-                        .evaluate(&mut target_core, request)
-                        .and(Ok(DebuggerStatus::ContinueSession)),
-                    other_command => {
-                        // Unimplemented command.
-                        debug_adapter.send_response::<()>(
+                        "disconnect" => debug_adapter
+                            .send_response::<()>(request, Ok(None))
+                            .and(Ok(DebuggerStatus::TerminateSession)),
+                        "terminate" => debug_adapter
+                            .pause(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::TerminateSession)),
+                        "next" => debug_adapter
+                            .next(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "stepIn" => debug_adapter
+                            .step_in(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "stepOut" => debug_adapter
+                            .step_out(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "pause" => debug_adapter
+                            .pause(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "readMemory" => debug_adapter
+                            .read_memory(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "writeMemory" => debug_adapter
+                            .write_memory(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "setVariable" => debug_adapter
+                            .set_variable(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "configurationDone" => debug_adapter
+                            .configuration_done(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "threads" => debug_adapter
+                            .threads(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "restart" => {
+                            // Reset RTT so that the link can be re-established
+                            target_core.core_data.rtt_connection = None;
+                            debug_adapter
+                                .restart(&mut target_core, Some(request))
+                                .and(Ok(DebuggerStatus::ContinueSession))
+                        }
+                        "setBreakpoints" => debug_adapter
+                            .set_breakpoints(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "setInstructionBreakpoints" => debug_adapter
+                            .set_instruction_breakpoints(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "stackTrace" => debug_adapter
+                            .stack_trace(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "scopes" => debug_adapter
+                            .scopes(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "disassemble" => debug_adapter
+                            .disassemble(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "variables" => debug_adapter
+                            .variables(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "continue" => debug_adapter
+                            .r#continue(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        "evaluate" => debug_adapter
+                            .evaluate(&mut target_core, request)
+                            .and(Ok(DebuggerStatus::ContinueSession)),
+                        other_command => {
+                            // Unimplemented command.
+                            debug_adapter.send_response::<()>(
                             request,
                             Err(DebuggerError::Other(anyhow!("Received request '{}', which is not supported or not implemented yet", other_command))),)
                             .and(Ok(DebuggerStatus::ContinueSession))
-                    }
-                } {
-                    Ok(debugger_status) => {
-                        if unhalt_me {
-                            match target_core.core.run() {
-                                Ok(_) => debug_adapter.last_known_status = CoreStatus::Running,
-                                Err(error) => {
-                                    debug_adapter.send_error_response(&DebuggerError::Other(
-                                        anyhow!("{}", error),
-                                    ))?;
-                                    return Err(error.into());
+                        }
+                    } {
+                        Ok(debugger_status) => {
+                            if unhalt_me {
+                                match target_core.core.run() {
+                                    Ok(_) => {}
+                                    Err(error) => {
+                                        debug_adapter.send_error_response(
+                                            &DebuggerError::Other(anyhow!("{}", error)),
+                                        )?;
+                                        return Err(error.into());
+                                    }
                                 }
                             }
+                            Ok(debugger_status)
                         }
-                        Ok(debugger_status)
+                        Err(e) => Err(DebuggerError::Other(e.context("Error executing request."))),
                     }
-                    Err(e) => Err(DebuggerError::Other(e.context("Error executing request."))),
                 }
             }
+        } else if debug_adapter.configuration_done {
+            // We've passed `configuration_done` and still do not have at least one core configured.
+            Err(DebuggerError::Other(anyhow!(
+                "Cannot continue unless one target core configuration is defined."
+            )))
+        } else {
+            // Do nothing until we've passed `configuration_done` and have a valid `target_core`.
+            Ok(DebuggerStatus::ContinueSession)
         }
+
+        // Now we can process the next (if any) DAP request.
     }
 
     /// `debug_session` is where the primary _debug processing_ for the DAP (Debug Adapter Protocol) adapter happens.

--- a/debugger/src/debugger/session_data.rs
+++ b/debugger/src/debugger/session_data.rs
@@ -239,7 +239,7 @@ impl SessionData {
                                 if core_rtt.process_rtt_data(debug_adapter, &mut target_core.core) {
                                     suggest_delay_required = false;
                                 }
-                            } else if debug_adapter.configuration_done {
+                            } else if debug_adapter.configuration_is_done() {
                                 // We have not yet reached the point in the target application where the RTT buffers are initialized,
                                 // so, provided we have processed the MSDAP request for "configurationDone" , we should check again.
                                 {

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -75,6 +75,14 @@ pub enum DebugError {
         /// The value of the program counter for which a halt was requested.
         pc_at_error: u64,
     },
+    /// Non-terminal Errors encountered while unwinding the stack, e.g. Could not resolve the value of a variable in the stack.
+    /// These are distinct from other errors because they do not interrupt processing.
+    /// Instead, the cause of incomplete results are reported back/explained to the user, and the stack continues to unwind.
+    #[error("{message}")]
+    UnwindIncompleteResults {
+        /// A message that can be displayed to the user to help them understand the reason for the incomplete results.
+        message: String,
+    },
     /// Some other error occurred.
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -554,9 +554,10 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
             {
                 program_counter.try_into()?
             } else {
-                return Err(DebugError::Other(anyhow::anyhow!(
-                    "Cannot unwind `Variable` without a valid PC (program_counter)"
-                )));
+                return Err(DebugError::UnwindIncompleteResults {
+                    message: "Cannot unwind `Variable` without a valid PC (program_counter)"
+                        .to_string(),
+                });
             };
 
             tracing::trace!("process_tree for parent {}", parent_variable.variable_key);
@@ -599,7 +600,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                             VariableName::Namespace(name) => {
                                             VariableName::Namespace(format!("{}::{}", name, extract_name(self.debug_info, attr.value())))
                                             }
-                                            other => return Err(DebugError::Other(anyhow::anyhow!("Unable to construct namespace variable, unexpected parent name: {:?}", other)))
+                                            other => return Err(DebugError::UnwindIncompleteResults {message: format!("Unable to construct namespace variable, unexpected parent name: {:?}", other)})
                                         }
 
                                     } else { VariableName::AnonymousNamespace};
@@ -888,9 +889,10 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                 );
 
                                 if has_overflowed {
-                                    return Err(DebugError::Other(anyhow::anyhow!(
-                                        "Overflow calculating variable address"
-                                    )));
+                                    return Err(DebugError::UnwindIncompleteResults {
+                                        message: "Overflow calculating variable address"
+                                            .to_string(),
+                                    });
                                 } else {
                                     child_variable.memory_location =
                                         VariableLocation::Address(location);
@@ -989,9 +991,10 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                 );
 
                                 if has_overflowed {
-                                    return Err(DebugError::Other(anyhow::anyhow!(
-                                        "Overflow calculating variable address"
-                                    )));
+                                    return Err(DebugError::UnwindIncompleteResults {
+                                        message: "Overflow calculating variable address"
+                                            .to_string(),
+                                    });
                                 } else {
                                     child_variable.memory_location =
                                         VariableLocation::Address(location);
@@ -1237,9 +1240,10 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                 );
 
                                 if has_overflowed {
-                                    return Err(DebugError::Other(anyhow::anyhow!(
-                                        "Overflow calculating variable address"
-                                    )));
+                                    return Err(DebugError::UnwindIncompleteResults {
+                                        message: "Overflow calculating variable address"
+                                            .to_string(),
+                                    });
                                 } else {
                                     child_variable.memory_location =
                                         VariableLocation::Address(location);
@@ -1372,7 +1376,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                         return match self.evaluate_expression(core, expression, stack_frame_registers, frame_base) {
                             Ok(result) => Ok(result),
                             Err(error) => {
-                                if matches!(error, DebugError::Other(_)) {
+                                if matches!(error, DebugError::UnwindIncompleteResults { message: _ }) {
                                     Ok(ExpressionResult::Location(VariableLocation::Unavailable))
                                 } else {
                                     Err(error)
@@ -1429,7 +1433,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                         ) {
                                             Ok(result) => Ok(result),
                                             Err(error) => {
-                                                if matches!(error, DebugError::Other(_)) {
+                                                if matches!(error, DebugError::UnwindIncompleteResults { message: _ }) {
                                                     Ok(ExpressionResult::Location(VariableLocation::Unavailable))
                                                 } else {
                                                     Err(error)
@@ -1610,7 +1614,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                     let mut buff = vec![0u8; size as usize];
                     if let Some(core) = core.as_mut() {
                         core.read(address, &mut buff).map_err(|_| {
-                        DebugError::Other(anyhow::anyhow!("Unexpected error while reading debug expressions from target memory. Please report this as a bug."))
+                        DebugError::UnwindIncompleteResults {message: "Unexpected error while reading debug expressions from target memory. Please report this as a bug.".to_string()}
                     })?;
                         match size {
                             1 => evaluation.resume_with_memory(gimli::Value::U8(buff[0]))?,
@@ -1626,32 +1630,34 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                 evaluation.resume_with_memory(gimli::Value::U32(val))?
                             }
                             x => {
-                                todo!(
-                                    "Requested memory with size {}, which is not supported yet.",
+                                return Err(DebugError::UnwindIncompleteResults {
+                            message: format!("Unimplemented: Requested memory with size {}, which is not supported yet.",
                                     x
-                                );
+                                )});
                             }
                         }
                     } else {
-                        return Err(DebugError::Other(anyhow::anyhow!(
-                            "Cannot unwind `Variable` location without a valid reference to the core."
-                        )));
+                        return Err(DebugError::UnwindIncompleteResults {
+                            message: "Cannot unwind `Variable` location without a valid reference to the core.".to_string()
+                    });
                     }
                 }
                 RequiresFrameBase => {
                     let frame_base = if let Some(frame_base) = frame_base {
                         frame_base
                     } else {
-                        return Err(DebugError::Other(anyhow::anyhow!("Cannot unwind `Variable` location without a valid frame base address.)")));
+                        return Err(DebugError::UnwindIncompleteResults {message: "Cannot unwind `Variable` location without a valid frame base address.)".to_string()});
                     };
 
                     match evaluation.resume_with_frame_base(frame_base) {
                         Ok(evaluation_result) => evaluation_result,
                         Err(error) => {
-                            return Err(DebugError::Other(anyhow::anyhow!(
-                                "Error while calculating `Variable::memory_location`:{}.",
-                                error
-                            )))
+                            return Err(DebugError::UnwindIncompleteResults {
+                                message: format!(
+                                    "Error while calculating `Variable::memory_location`:{}.",
+                                    error
+                                ),
+                            })
                         }
                     }
                 }
@@ -1665,18 +1671,18 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                     {
                         Some(raw_value) => {
                             if base_type != gimli::UnitOffset(0) {
-                                return Err(DebugError::Other(anyhow::anyhow!(
-                                    "Unimplemented: Support for type {:?} in `RequiresRegister` request is not yet implemented.",
+                                return Err(DebugError::UnwindIncompleteResults {
+                                    message: format!("Unimplemented: Support for type {:?} in `RequiresRegister` request is not yet implemented.",
                                     base_type
-                                )));
+                                )});
                             }
                             raw_value
                         }
                         None => {
-                            return Err(DebugError::Other(anyhow::anyhow!(
-                                    "Error while calculating `Variable::memory_location`. No value for register #:{}.",
+                            return Err(DebugError::UnwindIncompleteResults {
+                                    message: format!("Error while calculating `Variable::memory_location`. No value for register #:{}.",
                                     register.0
-                                )));
+                                )});
                         }
                     };
 
@@ -1687,10 +1693,10 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                     evaluation.resume_with_relocated_address(address_index)?
                 }
                 unimplemented_expression => {
-                    return Err(DebugError::Other(anyhow::anyhow!(
-                        "Unimplemented: Expressions that include {:?} are not currently supported.",
+                    return Err(DebugError::UnwindIncompleteResults {
+                        message: format!("Unimplemented: Expressions that include {:?} are not currently supported.",
                         unimplemented_expression
-                    )));
+                    )});
                 }
             }
         }

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -1369,16 +1369,16 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                 | gimli::DW_AT_data_member_location
                 | gimli::DW_AT_frame_base => match attr.value() {
                     gimli::AttributeValue::Exprloc(expression) => {
-                        match self.evaluate_expression(core, expression, stack_frame_registers, frame_base) {
-                            Ok(result) => return Ok(result),
+                        return match self.evaluate_expression(core, expression, stack_frame_registers, frame_base) {
+                            Ok(result) => Ok(result),
                             Err(error) => {
                                 if matches!(error, DebugError::Other(_)) {
-                                    return Ok(ExpressionResult::Location(VariableLocation::Unavailable));
+                                    Ok(ExpressionResult::Location(VariableLocation::Unavailable))
                                 } else {
-                                    return Err(error);
+                                    Err(error)
                                 }
                             },
-                        }
+                        };
                     }
                     gimli::AttributeValue::Udata(offset_from_parent) => match parent_location {
                         VariableLocation::Address(address) => {
@@ -1421,21 +1421,21 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
                                         }
                                     }
                                     if let Some(valid_expression) = expression {
-                                        match self.evaluate_expression(
+                                        return match self.evaluate_expression(
                                             core,
                                             valid_expression,
                                             stack_frame_registers,
                                             frame_base,
                                         ) {
-                                            Ok(result) => return Ok(result),
+                                            Ok(result) => Ok(result),
                                             Err(error) => {
                                                 if matches!(error, DebugError::Other(_)) {
-                                                    return Ok(ExpressionResult::Location(VariableLocation::Unavailable));
+                                                    Ok(ExpressionResult::Location(VariableLocation::Unavailable))
                                                 } else {
-                                                    return Err(error);
+                                                    Err(error)
                                                 }
                                             },
-                                        }
+                                        };
                                     } else {
                                         return Ok(ExpressionResult::Location(
                                             VariableLocation::Unavailable,

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -964,7 +964,9 @@ impl Value for bool {
                 }
             })? as u8,
         )
-        .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+        .map_err(|error| DebugError::UnwindIncompleteResults {
+            message: format!("{:?}", error),
+        })
     }
 }
 impl Value for char {
@@ -989,14 +991,17 @@ impl Value for char {
         core.write_word_32(
             variable.memory_location.memory_address()?,
             <char as FromStr>::from_str(new_value).map_err(|error| {
-                DebugError::UnwindIncompleteResults { message: format!(
-                    "Invalid data conversion from value: {:?}. {:?}",
-                    new_value,
-                    error
-                )}
+                DebugError::UnwindIncompleteResults {
+                    message: format!(
+                        "Invalid data conversion from value: {:?}. {:?}",
+                        new_value, error
+                    ),
+                }
             })? as u32,
         )
-        .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+        .map_err(|error| DebugError::UnwindIncompleteResults {
+            message: format!("{:?}", error),
+        })
     }
 }
 impl Value for String {
@@ -1074,8 +1079,7 @@ impl Value for String {
         _core: &mut Core<'_>,
         _new_value: &str,
     ) -> Result<(), DebugError> {
-        Err(DebugError::UnwindIncompleteResults { message: 
-            "Unsupported datatype: \"String\". Please only update variables with a base data type.".to_string()})
+        Err(DebugError::UnwindIncompleteResults { message:"Unsupported datatype: \"String\". Please only update variables with a base data type.".to_string()})
     }
 }
 impl Value for i8 {
@@ -1098,14 +1102,17 @@ impl Value for i8 {
         core.write_word_8(
             variable.memory_location.memory_address()?,
             <i8 as FromStr>::from_str(new_value).map_err(|error| {
-                DebugError::UnwindIncompleteResults { message: format!(
-                    "Invalid data conversion from value: {:?}. {:?}",
-                    new_value,
-                    error
-                )}
+                DebugError::UnwindIncompleteResults {
+                    message: format!(
+                        "Invalid data conversion from value: {:?}. {:?}",
+                        new_value, error
+                    ),
+                }
             })? as u8,
         )
-        .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+        .map_err(|error| DebugError::UnwindIncompleteResults {
+            message: format!("{:?}", error),
+        })
     }
 }
 impl Value for i16 {
@@ -1126,14 +1133,17 @@ impl Value for i16 {
         new_value: &str,
     ) -> Result<(), DebugError> {
         let buff = i16::to_le_bytes(<i16 as FromStr>::from_str(new_value).map_err(|error| {
-            DebugError::UnwindIncompleteResults { message: format!(
-                "Invalid data conversion from value: {:?}. {:?}",
-                new_value,
-                error
-            )}
+            DebugError::UnwindIncompleteResults {
+                message: format!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value, error
+                ),
+            }
         })?);
         core.write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+            .map_err(|error| DebugError::UnwindIncompleteResults {
+                message: format!("{:?}", error),
+            })
     }
 }
 impl Value for i32 {
@@ -1154,14 +1164,17 @@ impl Value for i32 {
         new_value: &str,
     ) -> Result<(), DebugError> {
         let buff = i32::to_le_bytes(<i32 as FromStr>::from_str(new_value).map_err(|error| {
-            DebugError::UnwindIncompleteResults { message: format!(
-                "Invalid data conversion from value: {:?}. {:?}",
-                new_value,
-                error
-            )}
+            DebugError::UnwindIncompleteResults {
+                message: format!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value, error
+                ),
+            }
         })?);
         core.write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+            .map_err(|error| DebugError::UnwindIncompleteResults {
+                message: format!("{:?}", error),
+            })
     }
 }
 impl Value for i64 {
@@ -1182,14 +1195,17 @@ impl Value for i64 {
         new_value: &str,
     ) -> Result<(), DebugError> {
         let buff = i64::to_le_bytes(<i64 as FromStr>::from_str(new_value).map_err(|error| {
-            DebugError::UnwindIncompleteResults { message: format!(
-                "Invalid data conversion from value: {:?}. {:?}",
-                new_value,
-                error
-            )}
+            DebugError::UnwindIncompleteResults {
+                message: format!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value, error
+                ),
+            }
         })?);
         core.write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+            .map_err(|error| DebugError::UnwindIncompleteResults {
+                message: format!("{:?}", error),
+            })
     }
 }
 impl Value for i128 {
@@ -1210,14 +1226,17 @@ impl Value for i128 {
         new_value: &str,
     ) -> Result<(), DebugError> {
         let buff = i128::to_le_bytes(<i128 as FromStr>::from_str(new_value).map_err(|error| {
-            DebugError::UnwindIncompleteResults { message: format!(
-                "Invalid data conversion from value: {:?}. {:?}",
-                new_value,
-                error
-            )}
+            DebugError::UnwindIncompleteResults {
+                message: format!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value, error
+                ),
+            }
         })?);
         core.write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+            .map_err(|error| DebugError::UnwindIncompleteResults {
+                message: format!("{:?}", error),
+            })
     }
 }
 impl Value for isize {
@@ -1240,14 +1259,17 @@ impl Value for isize {
     ) -> Result<(), DebugError> {
         let buff =
             isize::to_le_bytes(<isize as FromStr>::from_str(new_value).map_err(|error| {
-                DebugError::UnwindIncompleteResults { message: format!(
-                    "Invalid data conversion from value: {:?}. {:?}",
-                    new_value,
-                    error
-                )}
+                DebugError::UnwindIncompleteResults {
+                    message: format!(
+                        "Invalid data conversion from value: {:?}. {:?}",
+                        new_value, error
+                    ),
+                }
             })?);
         core.write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+            .map_err(|error| DebugError::UnwindIncompleteResults {
+                message: format!("{:?}", error),
+            })
     }
 }
 impl Value for u8 {
@@ -1270,14 +1292,17 @@ impl Value for u8 {
         core.write_word_8(
             variable.memory_location.memory_address()?,
             <u8 as FromStr>::from_str(new_value).map_err(|error| {
-                DebugError::UnwindIncompleteResults { message: format!(
-                    "Invalid data conversion from value: {:?}. {:?}",
-                    new_value,
-                    error
-                )}
+                DebugError::UnwindIncompleteResults {
+                    message: format!(
+                        "Invalid data conversion from value: {:?}. {:?}",
+                        new_value, error
+                    ),
+                }
             })?,
         )
-        .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+        .map_err(|error| DebugError::UnwindIncompleteResults {
+            message: format!("{:?}", error),
+        })
     }
 }
 impl Value for u16 {
@@ -1298,14 +1323,17 @@ impl Value for u16 {
         new_value: &str,
     ) -> Result<(), DebugError> {
         let buff = u16::to_le_bytes(<u16 as FromStr>::from_str(new_value).map_err(|error| {
-            DebugError::UnwindIncompleteResults { message: format!(
-                "Invalid data conversion from value: {:?}. {:?}",
-                new_value,
-                error
-            )}
+            DebugError::UnwindIncompleteResults {
+                message: format!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value, error
+                ),
+            }
         })?);
         core.write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+            .map_err(|error| DebugError::UnwindIncompleteResults {
+                message: format!("{:?}", error),
+            })
     }
 }
 impl Value for u32 {
@@ -1326,14 +1354,17 @@ impl Value for u32 {
         new_value: &str,
     ) -> Result<(), DebugError> {
         let buff = u32::to_le_bytes(<u32 as FromStr>::from_str(new_value).map_err(|error| {
-            DebugError::UnwindIncompleteResults { message: format!(
-                "Invalid data conversion from value: {:?}. {:?}",
-                new_value,
-                error
-            )}
+            DebugError::UnwindIncompleteResults {
+                message: format!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value, error
+                ),
+            }
         })?);
         core.write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+            .map_err(|error| DebugError::UnwindIncompleteResults {
+                message: format!("{:?}", error),
+            })
     }
 }
 impl Value for u64 {
@@ -1354,14 +1385,17 @@ impl Value for u64 {
         new_value: &str,
     ) -> Result<(), DebugError> {
         let buff = u64::to_le_bytes(<u64 as FromStr>::from_str(new_value).map_err(|error| {
-            DebugError::UnwindIncompleteResults { message: format!(
-                "Invalid data conversion from value: {:?}. {:?}",
-                new_value,
-                error
-            )}
+            DebugError::UnwindIncompleteResults {
+                message: format!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value, error
+                ),
+            }
         })?);
         core.write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+            .map_err(|error| DebugError::UnwindIncompleteResults {
+                message: format!("{:?}", error),
+            })
     }
 }
 impl Value for u128 {
@@ -1382,14 +1416,17 @@ impl Value for u128 {
         new_value: &str,
     ) -> Result<(), DebugError> {
         let buff = u128::to_le_bytes(<u128 as FromStr>::from_str(new_value).map_err(|error| {
-            DebugError::UnwindIncompleteResults { message: format!(
-                "Invalid data conversion from value: {:?}. {:?}",
-                new_value,
-                error
-            )}
+            DebugError::UnwindIncompleteResults {
+                message: format!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value, error
+                ),
+            }
         })?);
         core.write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+            .map_err(|error| DebugError::UnwindIncompleteResults {
+                message: format!("{:?}", error),
+            })
     }
 }
 impl Value for usize {
@@ -1412,14 +1449,17 @@ impl Value for usize {
     ) -> Result<(), DebugError> {
         let buff =
             usize::to_le_bytes(<usize as FromStr>::from_str(new_value).map_err(|error| {
-                DebugError::UnwindIncompleteResults { message: format!(
-                    "Invalid data conversion from value: {:?}. {:?}",
-                    new_value,
-                    error
-                )}
+                DebugError::UnwindIncompleteResults {
+                    message: format!(
+                        "Invalid data conversion from value: {:?}. {:?}",
+                        new_value, error
+                    ),
+                }
             })?);
         core.write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+            .map_err(|error| DebugError::UnwindIncompleteResults {
+                message: format!("{:?}", error),
+            })
     }
 }
 impl Value for f32 {
@@ -1440,14 +1480,17 @@ impl Value for f32 {
         new_value: &str,
     ) -> Result<(), DebugError> {
         let buff = f32::to_le_bytes(<f32 as FromStr>::from_str(new_value).map_err(|error| {
-            DebugError::UnwindIncompleteResults { message: format!(
-                "Invalid data conversion from value: {:?}. {:?}",
-                new_value,
-                error
-            )}
+            DebugError::UnwindIncompleteResults {
+                message: format!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value, error
+                ),
+            }
         })?);
         core.write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+            .map_err(|error| DebugError::UnwindIncompleteResults {
+                message: format!("{:?}", error),
+            })
     }
 }
 impl Value for f64 {
@@ -1468,13 +1511,16 @@ impl Value for f64 {
         new_value: &str,
     ) -> Result<(), DebugError> {
         let buff = f64::to_le_bytes(<f64 as FromStr>::from_str(new_value).map_err(|error| {
-            DebugError::UnwindIncompleteResults { message: format!(
-                "Invalid data conversion from value: {:?}. {:?}",
-                new_value,
-                error
-            )}
+            DebugError::UnwindIncompleteResults {
+                message: format!(
+                    "Invalid data conversion from value: {:?}. {:?}",
+                    new_value, error
+                ),
+            }
         })?);
         core.write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults { message: format!("{:?}", error)})
+            .map_err(|error| DebugError::UnwindIncompleteResults {
+                message: format!("{:?}", error),
+            })
     }
 }


### PR DESCRIPTION
When the debugger is stepping or halting at breakpoints, it fails to retrieve (and display) all RTT data from the target.

The root cause of this is related to how the debugger queried and cached the core status from the target. Over various iterations of development, the status handling spread through various parts of the code and the 'last_known_status' was not always in synch between the DAP Client (VSCode), the DAP server (probe-rs-debugger) and the target itself.

This PR is a refactor of the status handling, and centralizes code that checks target status, as well as code that notifies the DAP Client of the status of the target.

Hint: For testing, you can install this branch with `cargo install --force --git https://github.com/probe-rs/probe-rs --branch debugger_rtt_fix probe-rs-debugger`