### PR TITLE
Show error message when an error occurs in info command

### DIFF
--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -77,13 +77,13 @@ fn try_show_info(
                     Ok(mut interface) => {
                         if let Err(e) = show_arm_info(&mut *interface) {
                             // Log error?
-                            log::warn!("Error showing ARM chip information: {}", e);
+                            println!("Error showing ARM chip information: {}", e);
                         }
 
                         probe = interface.close();
                     }
                     Err((interface, e)) => {
-                        log::warn!("Error showing ARM chip information: {}", e);
+                        println!("Error showing ARM chip information: {}", e);
 
                         probe = interface.close();
                     }
@@ -99,30 +99,34 @@ fn try_show_info(
         );
     }
 
-    if probe.has_riscv_interface() && protocol == WireProtocol::Jtag {
-        match probe.try_into_riscv_interface() {
-            Ok(mut interface) => {
-                if let Err(e) = show_riscv_info(&mut interface) {
-                    log::warn!("Error showing RISCV chip information: {}", e);
+    if protocol == WireProtocol::Jtag {
+        if probe.has_riscv_interface() {
+            match probe.try_into_riscv_interface() {
+                Ok(mut interface) => {
+                    if let Err(e) = show_riscv_info(&mut interface) {
+                        log::warn!("Error showing RISCV chip information: {}", e);
+                    }
+
+                    probe = interface.close();
                 }
+                Err((interface_probe, e)) => {
+                    let mut source = Some(&e as &dyn Error);
 
-                probe = interface.close();
-            }
-            Err((interface_probe, e)) => {
-                let mut source = Some(&e as &dyn Error);
+                    while let Some(parent) = source {
+                        log::error!("Error: {}", parent);
+                        source = parent.source();
+                    }
 
-                while let Some(parent) = source {
-                    log::error!("Error: {}", parent);
-                    source = parent.source();
+                    probe = interface_probe;
                 }
-
-                probe = interface_probe;
             }
+        } else {
+            println!(
+            "Unable to debug RISC-V targets using the current probe. RISC-V specific information cannot be printed."
+        );
         }
     } else {
-        println!(
-            "No JTAG interface was found on the connected probe. Thus, RISC-V info cannot be printed."
-        );
+        tracing::info!("Debugging RISCV-Targets over SWD is not supported.");
     }
 
     (probe, Ok(()))

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -265,7 +265,7 @@ fn main() -> Result<()> {
         .without_time()
         .with_filter(
             EnvFilter::builder()
-                .with_default_directive(LevelFilter::OFF.into())
+                .with_default_directive(LevelFilter::ERROR.into())
                 .from_env_lossy(),
         );
 


### PR DESCRIPTION
See #1349, show the error message if an error occurs, and don't warn about JTAG when SWD is used.