### PR TITLE
Revert recent broken FTDI changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `log` crate, with `tracing` in `probe-rs-debugger` executable, and in the `rtt` library. (#1297)
 - Replace FTDI probe command creation with `ftdi-mpsse` library functions/enums (#1302)
 - Improved formatting of `probe-rs-cli info` output. (#1305)
-- Refactor FTDI probe impl to use all JtagCommand logic (#1307)
 - Refactor VSCode handling of logging and user messaging - see [VSCode PR #37](https://github.com/probe-rs/vscode/pull/37) (#1334)
 - Refactor error handling, split `crate::Error::ArchitectureSpecific` into two separate variants for RISC-V and ARM, and create a new `ArmError` enum for ARM specific errors. (#1344)
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `probe_rs_target::chip::Chip` has a new field `pack_file_release` which is populated by `target-gen`.(#1259)
 - Benchmarking code moved from an example to `probe-rs-cli` subcommand (#1296).
 - Replace `log` crate, with `tracing` in `probe-rs-debugger` executable, and in the `rtt` library. (#1297)
-- Replace FTDI probe command creation with `ftdi-mpsse` library functions/enums (#1302)
 - Improved formatting of `probe-rs-cli info` output. (#1305)
 - Refactor VSCode handling of logging and user messaging - see [VSCode PR #37](https://github.com/probe-rs/vscode/pull/37) (#1334)
 - Refactor error handling, split `crate::Error::ArchitectureSpecific` into two separate variants for RISC-V and ARM, and create a new `ArmError` enum for ARM specific errors. (#1344)

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -23,12 +23,8 @@ vendored-libusb = ["rusb/vendored"]
 # Enable all built in targets.
 builtin-targets = []
 
-ftdi = ["libftdi1-sys", "ftdi-mpsse"]
-ftdi-vendored = [
-    "libftdi1-sys/vendored",
-    "libftdi1-sys/libusb1-sys",
-    "ftdi-mpsse",
-]
+ftdi = ["libftdi1-sys"]
+ftdi-vendored = ["libftdi1-sys/vendored", "libftdi1-sys/libusb1-sys"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -67,7 +63,6 @@ tracing = { version = "0.1.37", features = ["log"] }
 # optional
 hexdump = { version = "0.1.0", optional = true }
 libftdi1-sys = { version = "1.1.2", optional = true }
-ftdi-mpsse = { version = "0.1.1", optional = true }
 
 # path
 probe-rs-target = { workspace = true }

--- a/probe-rs/src/probe/ftdi/commands.rs
+++ b/probe-rs/src/probe/ftdi/commands.rs
@@ -1,7 +1,6 @@
 use std::io;
 
 use bitvec::{order::Lsb0, prelude::BitVec, slice::BitSlice};
-use ftdi_mpsse::*;
 
 use crate::{probe::CommandResult, DebugProbeError};
 
@@ -248,31 +247,24 @@ impl ShiftTmsCommand {
 
 impl JtagCommand for ShiftTmsCommand {
     fn add_bytes(&mut self, buffer: &mut Vec<u8>) {
-        let mut command = MpsseCmdBuilder::new();
+        let mut command = vec![];
 
-        // Clock Data to TMS pin, no read.
-        //
-        // Can only clock 7 TMS bits at a time, as 8th bit reserved for TDI output.
-        // However, this is never called where we transfer TDI data at same time,
-        // so TDI arg always false in clock_tms_out()
-        //
-        // See https://www.ftdichip.com/Support/Documents/AppNotes/AN_108_Command_Processor_for_MPSSE_and_MCU_Host_Bus_Emulation_Modes.pdf
-        // section 3.5
         let mut bits = self.bits;
         let mut data: &[u8] = &self.data;
         while bits > 0 {
             if bits >= 8 {
-                command = command.clock_tms_out(ClockTMSOut::NegEdge, data[0], false, 7);
+                // 0x4b = Clock Data to TMS pin (no read)
+                // see https://www.ftdichip.com/Support/Documents/AppNotes/AN_108_Command_Processor_for_MPSSE_and_MCU_Host_Bus_Emulation_Modes.pdf
+                command.extend_from_slice(&[0x4b, 0x07, data[0]]);
                 data = &data[1..];
                 bits -= 8;
             } else {
-                command =
-                    command.clock_tms_out(ClockTMSOut::NegEdge, data[0], false, (bits - 1) as u8);
+                command.extend_from_slice(&[0x4b, (bits - 1) as u8, data[0]]);
                 bits = 0;
             }
         }
 
-        buffer.extend_from_slice(command.as_slice());
+        buffer.extend_from_slice(&command);
     }
 
     fn bytes_to_read(&self) -> usize {
@@ -301,7 +293,7 @@ impl JtagCommand for ShiftTdiCommand {
         assert!(self.bits > 0);
         assert!((self.bits + 7) / 8 <= self.data.len());
 
-        let mut command = MpsseCmdBuilder::new();
+        let mut command = vec![];
         let mut bits = self.bits;
         let mut data: &[u8] = &self.data;
 
@@ -309,29 +301,29 @@ impl JtagCommand for ShiftTdiCommand {
         if full_bytes > 0 {
             assert!(full_bytes <= 65536);
 
-            command = command.clock_data_out(ClockDataOut::LsbNeg, &data[..full_bytes]);
+            command.extend_from_slice(&[0x19]);
+            let n: u16 = (full_bytes - 1) as u16;
+            command.extend_from_slice(&n.to_le_bytes());
+            command.extend_from_slice(&data[..full_bytes]);
 
             bits -= full_bytes * 8;
             data = &data[full_bytes..];
         }
         assert!(bits <= 8);
 
-        // Leftover data less than full byte
         if bits > 0 {
             let byte = data[0];
             if bits > 1 {
                 let n = (bits - 2) as u8;
-                command = command.clock_bits_out(ClockBitsOut::LsbNeg, byte, n);
+                command.extend_from_slice(&[0x1b, n, byte]);
             }
 
-            // Use TMS command to clock out last bit of TDI, does not clock any TMS out (length is 0)
-            // In contrast to ClockTMSBitsOut commands, ClockTMS also reads TDO
             let last_bit = (byte >> (bits - 1)) & 0x01;
-            let tms_byte = 0x01 | (last_bit << 7); // Not sure why we or w/ 0x01 (only set bit in TMS component) if length is 0?
-            command = command.clock_tms_out(ClockTMSOut::NegEdge, tms_byte, true, 0);
+            let tms_byte = 0x01 | (last_bit << 7);
+            command.extend_from_slice(&[0x4b, 0x00, tms_byte]);
         }
 
-        buffer.extend_from_slice(command.as_slice());
+        buffer.extend_from_slice(&command);
     }
 
     fn bytes_to_read(&self) -> usize {
@@ -366,7 +358,7 @@ impl JtagCommand for TransferTdiCommand {
         assert!(self.bits > 0);
         assert!((self.bits + 7) / 8 <= self.data.len());
 
-        let mut command = MpsseCmdBuilder::new();
+        let mut command = vec![];
 
         let mut bits = self.bits;
         let mut data: &[u8] = &self.data;
@@ -375,7 +367,10 @@ impl JtagCommand for TransferTdiCommand {
         if full_bytes > 0 {
             assert!(full_bytes <= 65536);
 
-            command = command.clock_data(ClockData::LsbPosIn, &data[..full_bytes]);
+            command.extend_from_slice(&[0x39]);
+            let n: u16 = (full_bytes - 1) as u16;
+            command.extend_from_slice(&n.to_le_bytes());
+            command.extend_from_slice(&data[..full_bytes]);
 
             bits -= full_bytes * 8;
             data = &data[full_bytes..];
@@ -385,16 +380,14 @@ impl JtagCommand for TransferTdiCommand {
         let byte = data[0];
         if bits > 1 {
             let n = (bits - 2) as u8;
-            command = command.clock_bits(ClockBits::LsbPosIn, byte, n);
+            command.extend_from_slice(&[0x3b, n, byte]);
         }
 
-        // Use TMS command to clock out last bit of TDI, does not clock any TMS out (length is 0)
-        // In contrast to ClockTMSBitsOut commands, ClockTMS also reads TDO
         let last_bit = (byte >> (bits - 1)) & 0x01;
-        let tms_byte = 0x01 | (last_bit << 7); // Not sure why we or w/ 0x01 (only set bit in TMS component) if length is 0?
-        command = command.clock_tms(ClockTMS::NegTMSPosTDO, tms_byte, true, 0);
+        let tms_byte = 0x01 | (last_bit << 7);
+        command.extend_from_slice(&[0x6b, 0x00, tms_byte]);
 
-        buffer.extend_from_slice(command.as_slice());
+        buffer.extend_from_slice(&command);
 
         let mut expect_bytes = full_bytes + 1;
         if bits > 1 {

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -8,7 +8,6 @@ use crate::{
     DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType, WireProtocol,
 };
 use bitvec::{order::Lsb0, slice::BitSlice, vec::BitVec};
-use ftdi_mpsse::*;
 use rusb::UsbContext;
 use std::convert::TryInto;
 use std::io::{self, Read, Write};
@@ -68,13 +67,13 @@ impl JtagAdapter {
         // Minimal values, may not work with all probes
         let output: u16 = 0x0008;
         let direction: u16 = 0x000b;
+        self.device
+            .write_all(&[0x80, output as u8, direction as u8])?;
+        self.device
+            .write_all(&[0x82, (output >> 8) as u8, (direction >> 8) as u8])?;
 
-        let command = MpsseCmdBuilder::new()
-            .set_gpio_lower(output as u8, direction as u8)
-            .set_gpio_upper((output >> 8) as u8, (direction >> 8) as u8)
-            .disable_loopback();
-
-        self.device.write_all(command.as_slice())?;
+        // Disable loopback
+        self.device.write_all(&[0x85])?;
 
         Ok(())
     }
@@ -106,36 +105,35 @@ impl JtagAdapter {
         assert!(bits > 0);
         assert!((bits + 7) / 8 <= data.len());
 
-        let mut command = MpsseCmdBuilder::new();
+        let mut command = vec![];
 
-        // Never called where we transfer TDI data at same time,
-        // so TDI arg always false in clock_tms_out()
         while bits > 0 {
             if bits >= 8 {
-                command = command.clock_tms_out(ClockTMSOut::NegEdge, data[0], false, 0x07);
+                command.extend_from_slice(&[0x4b, 0x07, data[0]]);
                 data = &data[1..];
                 bits -= 8;
             } else {
-                command =
-                    command.clock_tms_out(ClockTMSOut::NegEdge, data[0], false, (bits - 1) as u8);
+                command.extend_from_slice(&[0x4b, (bits - 1) as u8, data[0]]);
                 bits = 0;
             }
         }
-
-        self.device.write_all(command.as_slice())
+        self.device.write_all(&command)
     }
 
     fn shift_tdi(&mut self, mut data: &[u8], mut bits: usize) -> io::Result<()> {
         assert!(bits > 0);
         assert!((bits + 7) / 8 <= data.len());
 
-        let mut command = MpsseCmdBuilder::new();
+        let mut command = vec![];
 
         let full_bytes = (bits - 1) / 8;
         if full_bytes > 0 {
             assert!(full_bytes <= 65536);
 
-            command = command.clock_data_out(ClockDataOut::LsbNeg, &data[..full_bytes]);
+            command.extend_from_slice(&[0x19]);
+            let n: u16 = (full_bytes - 1) as u16;
+            command.extend_from_slice(&n.to_le_bytes());
+            command.extend_from_slice(&data[..full_bytes]);
 
             bits -= full_bytes * 8;
             data = &data[full_bytes..];
@@ -146,53 +144,49 @@ impl JtagAdapter {
             let byte = data[0];
             if bits > 1 {
                 let n = (bits - 2) as u8;
-                command = command.clock_bits_out(ClockBitsOut::LsbNeg, byte, n);
+                command.extend_from_slice(&[0x1b, n, byte]);
             }
 
-            // Use TMS command to clock out last bit of TDI, does not clock any TMS out (length is 0)
-            // In contrast to ClockTMSBitsOut commands, ClockTMS also reads TDO
             let last_bit = (byte >> (bits - 1)) & 0x01;
-            let tms_byte = 0x01 | (last_bit << 7); // Not sure why we or w/ 0x01 (last bit of TMS) if length is 0?
-            command = command.clock_tms_out(ClockTMSOut::NegEdge, tms_byte, true, 0);
+            let tms_byte = 0x01 | (last_bit << 7);
+            command.extend_from_slice(&[0x4b, 0x00, tms_byte]);
         }
 
-        self.device.write_all(command.as_slice())
+        self.device.write_all(&command)
     }
 
-    fn transfer_tdi(&mut self, mut data: &[u8], mut bits: usize) -> io::Result<Vec<u8>> {
+    fn tranfer_tdi(&mut self, mut data: &[u8], mut bits: usize) -> io::Result<Vec<u8>> {
         assert!(bits > 0);
         assert!((bits + 7) / 8 <= data.len());
 
-        // Write data out
-        let mut command = MpsseCmdBuilder::new();
+        let mut command = vec![];
 
         let full_bytes = (bits - 1) / 8;
         if full_bytes > 0 {
             assert!(full_bytes <= 65536);
 
-            command = command.clock_data(ClockData::LsbPosIn, &data[..full_bytes]);
+            command.extend_from_slice(&[0x39]);
+            let n: u16 = (full_bytes - 1) as u16;
+            command.extend_from_slice(&n.to_le_bytes());
+            command.extend_from_slice(&data[..full_bytes]);
 
             bits -= full_bytes * 8;
             data = &data[full_bytes..];
         }
         assert!(0 < bits && bits <= 8);
 
-        // Leftover data less than full byte
         let byte = data[0];
         if bits > 1 {
             let n = (bits - 2) as u8;
-            command = command.clock_bits(ClockBits::LsbPosIn, byte, n);
+            command.extend_from_slice(&[0x3b, n, byte]);
         }
 
-        // Use TMS command to clock out last bit of TDI, does not clock any TMS out (length is 0)
-        // In contrast to ClockTMSBitsOut commands, ClockTMS also reads TDO
         let last_bit = (byte >> (bits - 1)) & 0x01;
-        let tms_byte = 0x01 | (last_bit << 7); // Not sure why we or w/ 0x01 (last bit of TMS) if length is 0?
-        command = command.clock_tms(ClockTMS::NegTMSPosTDO, tms_byte, true, 0);
+        let tms_byte = 0x01 | (last_bit << 7);
+        command.extend_from_slice(&[0x6b, 0x00, tms_byte]);
 
-        self.device.write_all(command.as_slice())?;
+        self.device.write_all(&command)?;
 
-        // Read data back
         let mut expect_bytes = full_bytes + 1;
         if bits > 1 {
             expect_bytes += 1;
@@ -237,7 +231,7 @@ impl JtagAdapter {
     /// Shift to IR and return to IDLE
     pub fn transfer_ir(&mut self, data: &[u8], bits: usize) -> io::Result<Vec<u8>> {
         self.shift_tms(&[0b0011], 4)?;
-        let r = self.transfer_tdi(data, bits)?;
+        let r = self.tranfer_tdi(data, bits)?;
         self.shift_tms(&[0b01], 2)?;
         Ok(r)
     }
@@ -245,7 +239,7 @@ impl JtagAdapter {
     /// Shift to DR and return to IDLE
     pub fn transfer_dr(&mut self, data: &[u8], bits: usize) -> io::Result<Vec<u8>> {
         self.shift_tms(&[0b001], 3)?;
-        let r = self.transfer_tdi(data, bits)?;
+        let r = self.tranfer_tdi(data, bits)?;
         self.shift_tms(&[0b01], 2)?;
         Ok(r)
     }
@@ -385,7 +379,6 @@ impl JtagAdapter {
         }
 
         // Write IR register
-        // Do we always have to write the IR reg? JLink impl checks cached value before attempting
         let irbits = params.irpre + params.irlen + params.irpost;
         assert!(irbits <= 32);
         let mut ir: u32 = (1 << params.irpre) - 1;
@@ -393,7 +386,6 @@ impl JtagAdapter {
         ir |= ((1 << params.irpost) - 1) << (params.irpre + params.irlen);
         self.shift_ir(&ir.to_le_bytes(), irbits)?;
 
-        // Write/read DR register
         let drbits = params.drpre + len_bits + params.drpost;
         let request = if let Some(data_slice) = data {
             let data = BitSlice::<u8, Lsb0>::from_slice(data_slice);
@@ -665,7 +657,7 @@ impl JTAGAccess for FtdiProbe {
             // Send Immediate: This will make the FTDI chip flush its buffer back to the PC.
             // See https://www.ftdichip.com/Support/Documents/AppNotes/AN_108_Command_Processor_for_MPSSE_and_MCU_Host_Bus_Emulation_Modes.pdf
             // section 5.1
-            out_buffer.push(MpsseCmd::DisableLoopback as u8);
+            out_buffer.push(0x87);
 
             let write_res = self.adapter.device.write_all(&out_buffer);
             match write_res {


### PR DESCRIPTION
As discussed in the matrix chat, recent commits I have authored break the FTDI probe implementation (thank you @9names for testing). These are commits #1303 and #1308 (tracking issues #1302 and #1307). This commit reverts both commits (but not the merge commits), so I can work on and test these changes out of tree without blocking the upcoming release. I apologize for any headache this may have caused and will ensure proper testing and better communication on my part in the future.

To verify this revert, I have side-by-side reviewed the reverted commits and flashed my test RISCV board using an FTDI probe. Applying relevant patches to get my FTDI probe and RISCV testing target working  (change interface, different GPIO pin direction/output for FTDI probe and custom reset sequence for RISCV board), probe-rs performs target flash erase and programming as expected. However, the example blinky program I am using (from [longan-nano hal](https://github.com/riscv-rust/longan-nano) examples) does not start correctly, which I suspect is an unrelated bug specific to my target.

As I only have access to a Longan Nano RISCV board (which has its own issues), I cannot assure that the FTDI probe behavior will work as expected for other boards. I would appreciate if others can test these changes while I purchase another target board to test in the future (sorry to bother @9names, but do you mind?)