### PR TITLE
Replace deprecated `base64::encode/decode`

### DIFF
--- a/debugger/src/debug_adapter/dap_adapter.rs
+++ b/debugger/src/debug_adapter/dap_adapter.rs
@@ -8,6 +8,7 @@ use crate::{
     DebuggerError,
 };
 use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose, Engine as _};
 use capstone::{
     arch::arm::ArchMode as armArchMode, arch::arm64::ArchMode as aarch64ArchMode,
     arch::riscv::ArchMode as riscvArchMode, prelude::*, Capstone, Endian,
@@ -143,7 +144,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             }
         }
         if !buff.is_empty() || num_bytes_unread == 0 {
-            let response = base64::encode(&buff);
+            let response = general_purpose::STANDARD.encode(&buff);
             self.send_response(
                 request,
                 Ok(Some(ReadMemoryResponseBody {
@@ -193,7 +194,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 ))),
             );
         };
-        let data_bytes = match base64::decode(&arguments.data) {
+        let data_bytes = match general_purpose::STANDARD.decode(&arguments.data) {
             Ok(decoded_bytes) => decoded_bytes,
             Err(error) => {
                 return self.send_response::<()>(

--- a/debugger/src/debug_adapter/dap_adapter.rs
+++ b/debugger/src/debug_adapter/dap_adapter.rs
@@ -8,7 +8,7 @@ use crate::{
     DebuggerError,
 };
 use anyhow::{anyhow, Result};
-use base64::{engine::general_purpose, Engine as _};
+use base64::{engine::general_purpose as base64_engine, Engine as _};
 use capstone::{
     arch::arm::ArchMode as armArchMode, arch::arm64::ArchMode as aarch64ArchMode,
     arch::riscv::ArchMode as riscvArchMode, prelude::*, Capstone, Endian,
@@ -144,7 +144,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             }
         }
         if !buff.is_empty() || num_bytes_unread == 0 {
-            let response = general_purpose::STANDARD.encode(&buff);
+            let response = base64_engine::STANDARD.encode(&buff);
             self.send_response(
                 request,
                 Ok(Some(ReadMemoryResponseBody {
@@ -194,7 +194,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 ))),
             );
         };
-        let data_bytes = match general_purpose::STANDARD.decode(&arguments.data) {
+        let data_bytes = match base64_engine::STANDARD.decode(&arguments.data) {
             Ok(decoded_bytes) => decoded_bytes,
             Err(error) => {
                 return self.send_response::<()>(

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -1,6 +1,6 @@
 use super::flash_properties::FlashProperties;
 use crate::serialize::{hex_option, hex_u_int};
-use base64::{engine::general_purpose, Engine as _};
+use base64::{engine::general_purpose as base64_engine, Engine as _};
 use serde::{Deserialize, Serialize};
 
 /// The raw flash algorithm is the description of a flash algorithm,
@@ -60,7 +60,7 @@ pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    serializer.serialize_str(general_purpose::STANDARD.encode(bytes).as_str())
+    serializer.serialize_str(base64_engine::STANDARD.encode(bytes).as_str())
 }
 
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
@@ -80,7 +80,7 @@ where
         where
             E: serde::de::Error,
         {
-            general_purpose::STANDARD
+            base64_engine::STANDARD
                 .decode(v)
                 .map_err(serde::de::Error::custom)
         }

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -1,5 +1,6 @@
 use super::flash_properties::FlashProperties;
 use crate::serialize::{hex_option, hex_u_int};
+use base64::{engine::general_purpose, Engine as _};
 use serde::{Deserialize, Serialize};
 
 /// The raw flash algorithm is the description of a flash algorithm,
@@ -59,7 +60,7 @@ pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    serializer.serialize_str(&base64::encode(bytes))
+    serializer.serialize_str(general_purpose::STANDARD.encode(bytes).as_str())
 }
 
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
@@ -79,7 +80,9 @@ where
         where
             E: serde::de::Error,
         {
-            base64::decode(v).map_err(serde::de::Error::custom)
+            general_purpose::STANDARD
+                .decode(v)
+                .map_err(serde::de::Error::custom)
         }
     }
 


### PR DESCRIPTION
#1355 Introduced new deprecation warnings for `base64::encode/decode`.

As per [their deprecation note in docs](https://docs.rs/base64/latest/base64/) I replaced those calls and used the `STANDARD` engine.

They do have a `BIN_HEX` specific alphabet, but using that fails the build script when trying to encode existing target flash algorithms, and as such I've not tried to implement `BIN_HEX`.