### PR TITLE
Release release/0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.14.0
+
+Released 2023-01-13
+
 ### Added
 
 - Added PartialEq Trait to the struct DebugProbeInfo. (#1173)
@@ -676,7 +680,8 @@ Initial release on crates.io
 - Working basic flash downloader with nRF51.
 - Introduce cargo-flash which can automatically build & flash the target elf file.
 
-[unreleased]: https://github.com/probe-rs/probe-rs/compare/v0.13.0...master
+[unreleased]: https://github.com/probe-rs/probe-rs/compare/v0.14.0...master
+[v0.14.0]: https://github.com/probe-rs/probe-rs/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/probe-rs/probe-rs/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/probe-rs/probe-rs/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/probe-rs/probe-rs/compare/v0.10.1...v0.11.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 
 documentation = "https://docs.rs/probe-rs/"
@@ -27,11 +27,11 @@ members = [
 ]
 
 [workspace.dependencies]
-probe-rs = { path = "probe-rs", version = "0.13.0" }
-probe-rs-cli-util = { path = "probe-rs-cli-util", version = "0.13.0" }
-probe-rs-rtt = { path = "rtt", version = "0.13.0" }
-probe-rs-target = { path = "probe-rs-target", version = "0.13.0" }
-gdb-server = { path = "gdb-server", version = "0.13.0" }
+probe-rs = { path = "probe-rs", version = "0.14.0" }
+probe-rs-cli-util = { path = "probe-rs-cli-util", version = "0.14.0" }
+probe-rs-rtt = { path = "rtt", version = "0.14.0" }
+probe-rs-target = { path = "probe-rs-target", version = "0.14.0" }
+gdb-server = { path = "gdb-server", version = "0.14.0" }
 
 log = "0.4.6"
 pretty_env_logger = "0.4.0"

--- a/cargo-embed/CHANGELOG.md
+++ b/cargo-embed/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.14.0
+
+Released 2023-01-13
+
 ### Added
 
 ### Changed
@@ -177,7 +181,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[unreleased]: https://github.com/probe-rs/cargo-embed/compare/v0.13.0...master
+[unreleased]: https://github.com/probe-rs/cargo-embed/compare/v0.14.0...master
+[v0.14.0]: https://github.com/probe-rs/cargo-embed/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/probe-rs/cargo-embed/releases/tag/v0.12.0..v0.13.0
 [0.12.0]: https://github.com/probe-rs/cargo-embed/releases/tag/v0.11.0..v0.12.0
 [0.11.0]: https://github.com/probe-rs/cargo-embed/releases/tag/v0.10.1..v0.11.0

--- a/cargo-flash/CHANGELOG.md
+++ b/cargo-flash/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.14.0
+
+Released 2023-01-13
+
 ### Added
 
 ### Changed
@@ -165,7 +169,8 @@ Improved flashing for `cargo-flash` considering speed and useability.
 
 - Introduce cargo-flash which can automatically build & flash the target elf file.
 
-[unreleased]: https://github.com/probe-rs/cargo-flash/compare/v0.13.0...master
+[unreleased]: https://github.com/probe-rs/cargo-flash/compare/v0.14.0...master
+[v0.14.0]: https://github.com/probe-rs/cargo-flash/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/probe-rs/cargo-flash/releases/tag/v0.12.1..v0.13.0
 [0.12.1]: https://github.com/probe-rs/cargo-flash/releases/tag/v0.12.0..v0.12.1
 [0.12.0]: https://github.com/probe-rs/cargo-flash/releases/tag/v0.11.0..v0.12.0

--- a/rtt/Cargo.toml
+++ b/rtt/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 tracing = { version = "0.1.37", features = ["log"] }
-probe-rs = { version = "0.13.0", path = "../probe-rs" }
+probe-rs = { version = "0.14.0", path = "../probe-rs" }
 scroll = "0.10.1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1.0.11"

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -15,8 +15,8 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-probe-rs = { path = "../probe-rs", version = "0.13.0", default-features = true }
-probe-rs-target = { path = "../probe-rs-target", version = "0.13.0", default-features = false }
+probe-rs = { path = "../probe-rs", version = "0.14.0", default-features = true }
+probe-rs-target = { path = "../probe-rs-target", version = "0.14.0", default-features = false }
 cmsis-pack = { version = "0.6", git = "https://github.com/pyocd/cmsis-pack-manager" }
 goblin = "0.6.0"
 scroll = "0.11.0"


### PR DESCRIPTION
This is the release PR for **0.14.0**.
---
It releases:

- probe-rs
- probe-rs-target
- probe-rs-rtt
- probe-rs-cli-util
- probe-rs-cli
- probe-rs-debugger
- gdb-server
- target-gen
- rtthost
- cargo-embed
---
Use `bors r+` to merge.