### PR TITLE
stlink: fix retries on DP/AP WAIT errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- stlink: fix retries on DP/AP WAIT errors. (#1406)
+
 ## [0.14.1]
 
 Released 2023-01-14


### PR DESCRIPTION
Memory accesses send the command, then get the result with `get_last_rw_status()`. We were retrying only getting the status. We have to retry the command as well.

This fixes SwdDpWait errors when flashing stm32c0 chips.