### PR TITLE
Add experimental WCH-Link probe(RV mode) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Released 2023-10-12
 ### Added
 
  - rtthost: Add --version
- - Added experimental support for WCH-Link probe (#1437)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Released 2023-10-12
 ### Added
 
  - rtthost: Add --version
+ - Added experimental support for WCH-Link probe (#1437)
 
 ### Changed
 

--- a/changelog/added-support-for-wch-link.md
+++ b/changelog/added-support-for-wch-link.md
@@ -1,0 +1,1 @@
+Added experimental support for WCH-Link probe in RV mode.

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -55,7 +55,7 @@ fn get_cmsisdap_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
     let timeout = Duration::from_millis(100);
     let d_desc = device.device_descriptor().ok()?;
     let handle = device.open().ok()?;
-    let language = handle.read_languages(timeout).ok()?.get(0).cloned()?;
+    let language = handle.read_languages(timeout).ok()?.first().cloned()?;
     let prod_str = handle
         .read_product_string(language, &d_desc, timeout)
         .ok()?;
@@ -64,7 +64,7 @@ fn get_cmsisdap_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
         .ok();
 
     // Most CMSIS-DAP probes say something like "CMSIS-DAP"
-    let cmsis_dap_product = is_cmsis_dap(&prod_str);
+    let cmsis_dap_product = is_cmsis_dap(&prod_str) || is_known_cmsis_dap_dev(&d_desc);
 
     // Iterate all interfaces, looking for:
     // 1. Any with CMSIS-DAP in their interface string
@@ -157,7 +157,7 @@ pub fn open_v2_device(device: Device<rusb::Context>) -> Option<CmsisDapDevice> {
     let vid = d_desc.vendor_id();
     let pid = d_desc.product_id();
     let mut handle = device.open().ok()?;
-    let language = handle.read_languages(timeout).ok()?.get(0).cloned()?;
+    let language = handle.read_languages(timeout).ok()?.first().cloned()?;
 
     // Go through interfaces to try and find a v2 interface.
     // The CMSIS-DAPv2 spec says that v2 interfaces should use a specific
@@ -294,7 +294,7 @@ pub fn open_device_from_selector(
 
             let timeout = Duration::from_millis(100);
             let sn_str = match handle.read_languages(timeout) {
-                Ok(langs) => langs.get(0).and_then(|lang| {
+                Ok(langs) => langs.first().and_then(|lang| {
                     handle
                         .read_serial_number_string(*lang, &d_desc, timeout)
                         .ok()
@@ -389,5 +389,17 @@ pub fn open_device_from_selector(
 /// in them. As devices spell CMIS DAP differently we go through known
 /// spellings/patterns looking for a match
 fn is_cmsis_dap(id: &str) -> bool {
-    id.contains("CMSIS-DAP") || id.contains("CMSIS_DAP") || id.contains("WCH-Link")
+    id.contains("CMSIS-DAP") || id.contains("CMSIS_DAP")
+}
+
+/// Some devices don't have a CMSIS-DAP interface string, but are still
+/// CMSIS-DAP probes. We hardcode a list of known VID/PID pairs here.
+fn is_known_cmsis_dap_dev(device_descriptor: &DeviceDescriptor) -> bool {
+    // - 1a86:8012 WCH-Link in DAP mode, This shares the same description string as the
+    //   WCH-Link in RV mode, so we have to check by vendor ID and product ID.
+    const KNOWN_DAPS: &[(u16, u16)] = &[(0x1a86, 0x8012)];
+
+    KNOWN_DAPS.iter().any(|&(vid, pid)| {
+        device_descriptor.vendor_id() == vid && device_descriptor.product_id() == pid
+    })
 }

--- a/probe-rs/src/probe/wlink/commands.rs
+++ b/probe-rs/src/probe/wlink/commands.rs
@@ -1,0 +1,307 @@
+//! WCH-LinkRV commands
+
+use super::{RiscvChip, WchLinkError, WchLinkVariant, DMI_OP_NOP, DMI_OP_READ, DMI_OP_WRITE};
+
+/// Only part of commands are implemented
+#[repr(u8)]
+pub enum CommandId {
+    /// Probe control
+    Control = 0x0D,
+    /// Config chip, flash protection, etc
+    ConfigChip = 0x01,
+    /// Chip reset
+    Reset = 0x0b,
+    /// Set chip type and connection speed
+    SetSpeed = 0x0c,
+    /// DMI operations
+    DmiOp = 0x08,
+}
+
+pub(crate) trait WchLinkCommand {
+    const COMMAND_ID: CommandId;
+    type Response: WchLinkCommandResponse;
+
+    fn payload(&self) -> Vec<u8>;
+
+    /// Convert the request to bytes, which can be sent to the probe.
+    /// Returns the amount of bytes written to the buffer.
+    fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, super::WchLinkError> {
+        let payload = self.payload();
+        let payload_len = payload.len();
+
+        buffer[0] = 0x81;
+        buffer[1] = Self::COMMAND_ID as u8;
+        buffer[2] = payload_len as u8;
+        buffer[3..payload_len + 3].copy_from_slice(&payload);
+        Ok(payload_len + 3)
+    }
+
+    /// Parse the response to this request from received bytes.
+    fn parse_response(&self, buffer: &[u8]) -> Result<Self::Response, super::WchLinkError> {
+        Self::Response::from_raw(buffer)
+    }
+}
+
+pub(crate) trait WchLinkCommandResponse {
+    /// parse from the PAYLOAD part only
+    fn from_payload(bytes: &[u8]) -> Result<Self, WchLinkError>
+    where
+        Self: Sized;
+
+    /// default implementation for parsing [0x82 CMD LEN PAYLOAD] style response
+    fn from_raw(resp: &[u8]) -> Result<Self, WchLinkError>
+    where
+        Self: Sized,
+    {
+        if resp[0] == 0x81 {
+            let reason = resp[1];
+            let len = resp[2] as usize;
+            if len != resp[3..].len() {
+                return Err(WchLinkError::InvalidPayload);
+            }
+            if reason == 0x55 {
+                return Err(WchLinkError::Protocol(reason, resp.to_vec()));
+            }
+            Err(WchLinkError::Protocol(reason, resp.to_vec()))
+        } else if resp[0] == 0x82 {
+            let len = resp[2] as usize;
+            if len != resp[3..].len() {
+                return Err(WchLinkError::InvalidPayload);
+            }
+            let payload = resp[3..3 + len].to_vec();
+            Self::from_payload(&payload)
+        } else {
+            Err(WchLinkError::InvalidPayload)
+        }
+    }
+}
+
+impl WchLinkCommandResponse for () {
+    fn from_payload(_bytes: &[u8]) -> Result<Self, WchLinkError> {
+        Ok(())
+    }
+}
+impl WchLinkCommandResponse for u8 {
+    fn from_payload(bytes: &[u8]) -> Result<Self, WchLinkError> {
+        if bytes.len() != 1 {
+            Err(WchLinkError::InvalidPayload)
+        } else {
+            Ok(bytes[0])
+        }
+    }
+}
+
+/// Get current probe info, version, etc
+#[derive(Debug)]
+pub struct GetProbeInfo;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetProbeInfoResponse {
+    pub major_version: u8,
+    pub minor_version: u8,
+    pub variant: WchLinkVariant,
+}
+
+impl WchLinkCommandResponse for GetProbeInfoResponse {
+    fn from_payload(bytes: &[u8]) -> Result<Self, WchLinkError> {
+        if bytes.len() < 3 {
+            return Err(WchLinkError::InvalidPayload);
+        }
+
+        Ok(GetProbeInfoResponse {
+            major_version: bytes[0],
+            minor_version: bytes[1],
+            variant: WchLinkVariant::try_from_u8(bytes[2])?,
+        })
+    }
+}
+
+impl WchLinkCommand for GetProbeInfo {
+    const COMMAND_ID: CommandId = CommandId::Control;
+    type Response = GetProbeInfoResponse;
+
+    fn payload(&self) -> Vec<u8> {
+        vec![0x01]
+    }
+}
+
+/// Attach to the target chip
+#[derive(Debug)]
+pub struct AttachChip;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AttachChipResponse {
+    pub chip_family: RiscvChip,
+    pub riscvchip: u8,
+    pub chip_id: u32,
+}
+
+impl WchLinkCommandResponse for AttachChipResponse {
+    fn from_payload(bytes: &[u8]) -> Result<Self, WchLinkError> {
+        if bytes.len() != 5 {
+            return Err(WchLinkError::InvalidPayload);
+        }
+        Ok(Self {
+            chip_family: RiscvChip::try_from_u8(bytes[0])
+                .ok_or(WchLinkError::UnknownChip(bytes[0]))?,
+            riscvchip: bytes[0],
+            chip_id: u32::from_be_bytes(bytes[1..5].try_into().unwrap()),
+        })
+    }
+}
+
+impl WchLinkCommand for AttachChip {
+    const COMMAND_ID: CommandId = CommandId::Control;
+    type Response = AttachChipResponse;
+
+    fn payload(&self) -> Vec<u8> {
+        vec![0x02]
+    }
+}
+
+/// Detach from the target chip, aka. `OptEnd`
+#[derive(Debug)]
+pub struct DetachChip;
+
+impl WchLinkCommand for DetachChip {
+    const COMMAND_ID: CommandId = CommandId::Control;
+    type Response = ();
+
+    fn payload(&self) -> Vec<u8> {
+        vec![0xff]
+    }
+}
+
+/// Set speed
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum Speed {
+    /// 400kHz
+    Low = 0x03,
+    /// 4000kHz
+    Medium = 0x02,
+    /// 6000kHz
+    High = 0x01,
+}
+
+impl Default for Speed {
+    fn default() -> Self {
+        Speed::High
+    }
+}
+
+impl Speed {
+    pub fn to_khz(&self) -> u32 {
+        match self {
+            Speed::Low => 400,
+            Speed::Medium => 4000,
+            Speed::High => 6000,
+        }
+    }
+
+    pub fn from_khz(khz: u32) -> Option<Self> {
+        if khz >= 6000 {
+            Some(Speed::High)
+        } else if khz >= 4000 {
+            Some(Speed::Medium)
+        } else if khz >= 400 {
+            Some(Speed::Low)
+        } else {
+            None
+        }
+    }
+}
+
+/// Set chip family and speed
+#[derive(Debug)]
+pub struct SetSpeed(pub super::RiscvChip, pub Speed);
+
+impl WchLinkCommand for SetSpeed {
+    const COMMAND_ID: CommandId = CommandId::SetSpeed;
+    type Response = u8;
+
+    fn payload(&self) -> Vec<u8> {
+        vec![self.0 as u8, self.1 as u8]
+    }
+}
+
+/// RISC-V DMI operations
+#[derive(Debug)]
+pub enum DmiOp {
+    DmiNop,
+    DmiRead { addr: u8 },
+    DmiWrite { addr: u8, data: u32 },
+}
+
+impl DmiOp {
+    pub fn nop() -> Self {
+        Self::DmiNop
+    }
+    pub fn read(addr: u8) -> Self {
+        Self::DmiRead { addr }
+    }
+    pub fn write(addr: u8, data: u32) -> Self {
+        Self::DmiWrite { addr, data }
+    }
+}
+
+#[derive(Debug)]
+pub struct DmiOpResponse {
+    pub addr: u8,
+    pub data: u32,
+    pub op: u8,
+}
+
+impl WchLinkCommandResponse for DmiOpResponse {
+    fn from_payload(bytes: &[u8]) -> Result<Self, WchLinkError> {
+        if bytes.len() != 6 {
+            return Err(WchLinkError::InvalidPayload);
+        }
+        let addr = bytes[0];
+        let op = bytes[5];
+        let data = u32::from_be_bytes([bytes[1], bytes[2], bytes[3], bytes[4]]);
+        Ok(DmiOpResponse { addr, data, op })
+    }
+}
+
+impl WchLinkCommand for DmiOp {
+    const COMMAND_ID: CommandId = CommandId::DmiOp;
+    type Response = DmiOpResponse;
+
+    fn payload(&self) -> Vec<u8> {
+        let mut bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        match self {
+            DmiOp::DmiNop => {
+                bytes[5] = DMI_OP_NOP;
+            }
+            DmiOp::DmiRead { addr } => {
+                bytes[0] = *addr;
+                bytes[5] = DMI_OP_READ;
+            }
+            DmiOp::DmiWrite { addr, data } => {
+                bytes[0] = *addr;
+                bytes[5] = DMI_OP_WRITE;
+                bytes[1..5].copy_from_slice(&data.to_be_bytes());
+            }
+        }
+        bytes
+    }
+}
+
+/// Reset the chip
+#[derive(Debug)]
+pub struct ResetTarget;
+
+impl WchLinkCommand for ResetTarget {
+    const COMMAND_ID: CommandId = CommandId::Reset;
+    type Response = ();
+    fn payload(&self) -> Vec<u8> {
+        vec![0x01]
+    }
+}
+
+pub struct GetCodeFlashProtection;
+
+pub struct SetCodeFlashProtection {
+    protected: bool,
+}

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -1,0 +1,641 @@
+//! WCH-LinkRV probe support.
+//!
+//! The protocl is mostly undocumented, and is changing between firmware versions.
+//! For more details see: <https://github.com/ch32-rs/wlink/blob/main/protocol.md>
+
+use core::fmt;
+use std::{thread::sleep, time::Duration};
+
+use rusb::{Device, UsbContext};
+
+use crate::{
+    architecture::riscv::communication_interface::{RiscvCommunicationInterface, RiscvError},
+    DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType,
+    ProbeCreationError, WireProtocol,
+};
+
+use self::usb_interface::WchLinkUsbDevice;
+use super::JTAGAccess;
+
+mod usb_interface;
+
+const VENDOR_ID: u16 = 0x1a86;
+const PRODUCT_ID: u16 = 0x8010;
+
+// See: RISC-V Debug Specification, 6.1 JTAG DTM Registers
+const DMI_VALUE_BIT_OFFSET: u32 = 2;
+const DMI_ADDRESS_BIT_OFFSET: u32 = 34;
+const DMI_OP_MASK: u128 = 0b11; // 2 bits
+
+const DMI_OP_NOP: u8 = 0;
+const DMI_OP_READ: u8 = 1;
+const DMI_OP_WRITE: u8 = 2;
+
+const REG_BYPASS_ADDRESS: u8 = 0x1f;
+const REG_IDCODE_ADDRESS: u8 = 0x01;
+const REG_DTMCS_ADDRESS: u8 = 0x10;
+const REG_DMI_ADDRESS: u8 = 0x11;
+
+const DTMCS_DMIRESET_MASK: u32 = 1 << 16;
+const DTMCS_DMIHARDRESET_MASK: u32 = 1 << 17;
+
+/// All WCH-Link probe variants, see-also: http://www.wch-ic.com/products/WCH-Link.html
+#[derive(Clone, Copy, Debug)]
+#[repr(u8)]
+pub enum WchLinkVariant {
+    /// WCH-Link-CH549, does not support CH32V00X
+    Ch549 = 1,
+    /// WCH-LinkE-CH32V305
+    ECh32v305 = 2,
+    /// WCH-LinkS-CH32V203
+    SCh32v203 = 3,
+    /// WCH-LinkB,
+    B = 4,
+}
+
+impl fmt::Display for WchLinkVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WchLinkVariant::Ch549 => write!(f, "WCH-Link-CH549"),
+            WchLinkVariant::ECh32v305 => write!(f, "WCH-LinkE-CH32V305"),
+            WchLinkVariant::SCh32v203 => write!(f, "WCH-LinkS-CH32V203"),
+            WchLinkVariant::B => write!(f, "WCH-LinkB"),
+        }
+    }
+}
+
+/// Currently supported RISC-V chip series
+#[derive(Clone, Copy, Debug)]
+#[repr(u8)]
+pub enum RiscvChip {
+    /// CH32V103 RISC-V3A series
+    CH32V103 = 0x01,
+    /// CH571/CH573 RISC-V3A BLE 4.2 series
+    CH57x = 0x02,
+    /// CH569/CH565 RISC-V3A series
+    CH56x = 0x03,
+    /// CH32V20x RISC-V4B/V4C series
+    CH32V20x = 0x05,
+    /// CH32V30x RISC-V4C/V4F series
+    CH32V30x = 0x06,
+    /// CH581/CH582/CH583 RISC-V4A BLE 5.3 series
+    CH58x = 0x07,
+    /// CH32V003 RISC-V2A series
+    CH32V003 = 0x09,
+}
+
+impl RiscvChip {
+    fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0x01 => Some(RiscvChip::CH32V103),
+            0x02 => Some(RiscvChip::CH57x),
+            0x03 => Some(RiscvChip::CH56x),
+            0x05 => Some(RiscvChip::CH32V20x),
+            0x06 => Some(RiscvChip::CH32V30x),
+            0x07 => Some(RiscvChip::CH58x),
+            0x09 => Some(RiscvChip::CH32V003),
+            _ => None,
+        }
+    }
+}
+
+/// WCH-Link device (mod:RV)
+#[derive(Debug)]
+pub(crate) struct WchLink {
+    device: WchLinkUsbDevice,
+    name: String,
+    variant: WchLinkVariant,
+    v_major: u8,
+    v_minor: u8,
+    riscvchip: u8,
+    chip_type: u32,
+    // Hack to support NOP after READ
+    last_dmi_read: Option<(u8, u32, u8)>,
+}
+
+impl WchLink {
+    fn get_version(&mut self) -> Result<(), DebugProbeError> {
+        tracing::debug!("Getting version of WCH-Link...");
+
+        let rxbuf = self
+            .device
+            .write_command(&[0x81, 0x0d, 0x01, 0x01], Duration::from_millis(300))?;
+
+        if rxbuf[0] != 0x82 {
+            return Err(WchLinkError::CommandFailed.into());
+        }
+
+        match rxbuf.len() {
+            // 2.3
+            5 => {
+                self.variant = WchLinkVariant::Ch549;
+                self.v_major = rxbuf[3];
+                self.v_minor = rxbuf[4];
+                tracing::warn!(
+                    "WCH-Link {} {}.{} is outdated, please update the firmware.",
+                    self.variant,
+                    self.v_major,
+                    self.v_minor
+                );
+            }
+            // 2.7, 2.8
+            7 => {
+                self.v_major = rxbuf[3];
+                self.v_minor = rxbuf[4];
+
+                match rxbuf[5] {
+                    1 => self.variant = WchLinkVariant::Ch549,
+                    2 => self.variant = WchLinkVariant::ECh32v305,
+                    3 => self.variant = WchLinkVariant::SCh32v203,
+                    4 => self.variant = WchLinkVariant::B,
+                    _ => return Err(WchLinkError::UnknownDevice.into()),
+                }
+            }
+            _ => return Err(WchLinkError::UnsupportedFirmwareVersion.into()),
+        }
+
+        Ok(())
+    }
+
+    fn init(&mut self) -> Result<(), DebugProbeError> {
+        // first stage of wlink_init
+        tracing::debug!("Initializing WCH-Link...");
+
+        self.get_version()?;
+
+        tracing::info!(
+            "WCH-Link variant: {}, firmware version: {}.{}",
+            self.variant,
+            self.v_major,
+            self.v_minor
+        );
+
+        if self.v_major != 0x02 && self.v_minor > 7 {
+            return Err(WchLinkError::UnsupportedFirmwareVersion.into());
+        }
+        self.name = format!("{} v{}.{}", self.variant, self.v_major, self.v_minor);
+
+        Ok(())
+    }
+
+    fn reset(&mut self) -> Result<(), DebugProbeError> {
+        self.dmi_op_write(0x10, 0x80000001)?;
+        sleep(Duration::from_millis(1));
+        self.dmi_op_read(0x11)?;
+        sleep(Duration::from_millis(1));
+
+        let mut txbuf = [0x81, 0x0d, 0x01, 0x03];
+        if self.riscvchip == 0x02 {
+            txbuf[3] = 0x02;
+        }
+        self.device
+            .write(&txbuf, &mut [0u8; 4], Duration::from_millis(300))?;
+
+        self.dmi_op_write(0x10, 0x80000001)?;
+        sleep(Duration::from_millis(1));
+        self.dmi_op_read(0x11)?;
+        Ok(())
+    }
+
+    fn dmi_op_read(&mut self, addr: u8) -> Result<(u8, u32, u8), DebugProbeError> {
+        let mut rxbuf = [0u8; 9];
+        self.device.write(
+            &[0x81, 0x08, 0x06, addr, 0, 0, 0, 0, DMI_OP_READ],
+            &mut rxbuf,
+            Duration::from_millis(300),
+        )?;
+
+        if rxbuf[0] == 0x82 {
+            let data_out = u32::from_be_bytes([rxbuf[4], rxbuf[5], rxbuf[6], rxbuf[7]]);
+            Ok((rxbuf[3], data_out, rxbuf[8]))
+        } else {
+            Err(WchLinkError::CommandFailed.into())
+        }
+    }
+
+    fn dmi_op_write(&mut self, addr: u8, data: u32) -> Result<(u8, u32, u8), DebugProbeError> {
+        let mut rxbuf = [0u8; 9];
+        let raw_data = data.to_be_bytes();
+        self.device.write(
+            &[
+                0x81,
+                0x08,
+                0x06,
+                addr,
+                raw_data[0],
+                raw_data[1],
+                raw_data[2],
+                raw_data[3],
+                DMI_OP_WRITE,
+            ],
+            &mut rxbuf,
+            Duration::from_millis(300),
+        )?;
+
+        if rxbuf[0] == 0x82 {
+            let data_out = u32::from_be_bytes([rxbuf[4], rxbuf[5], rxbuf[6], rxbuf[7]]);
+            Ok((rxbuf[3], data_out, rxbuf[8]))
+        } else {
+            Err(WchLinkError::CommandFailed.into())
+        }
+    }
+
+    fn dmi_op_nop(&mut self, addr: u8, data: u32) -> Result<(u8, u32, u8), DebugProbeError> {
+        let mut rxbuf = [0u8; 9];
+        let raw_data = data.to_be_bytes();
+        self.device.write(
+            &[
+                0x81,
+                0x08,
+                0x06,
+                addr,
+                raw_data[0],
+                raw_data[1],
+                raw_data[2],
+                raw_data[3],
+                DMI_OP_NOP,
+            ],
+            &mut rxbuf,
+            Duration::from_millis(300),
+        )?;
+
+        let data_out = u32::from_be_bytes([rxbuf[4], rxbuf[5], rxbuf[6], rxbuf[7]]);
+        if rxbuf[0] == 0x82 {
+            Ok((rxbuf[3], data_out, rxbuf[8]))
+        } else {
+            Err(WchLinkError::CommandFailed.into())
+        }
+    }
+
+    pub fn assert_unprotected(&mut self) -> Result<(), DebugProbeError> {
+        let rxbuf = self
+            .device
+            .write_command(&[0x81, 0x06, 0x01, 0x01], Duration::from_millis(300))?;
+
+        if rxbuf[0] == 0x82 {
+            if rxbuf[3] == 0x02 {
+                Ok(())
+            } else if rxbuf[3] == 0x01 {
+                Err(WchLinkError::ReadProtected.into())
+            } else {
+                unreachable!()
+            }
+        } else {
+            Err(WchLinkError::CommandFailed.into())
+        }
+    }
+}
+
+impl DebugProbe for WchLink {
+    fn new_from_selector(
+        selector: impl Into<DebugProbeSelector>,
+    ) -> Result<Box<Self>, DebugProbeError>
+    where
+        Self: Sized,
+    {
+        let device = WchLinkUsbDevice::new_from_selector(selector)?;
+        let mut wlink = Self {
+            device,
+            name: "WCH-Link".into(),
+            variant: WchLinkVariant::Ch549,
+            v_major: 0,
+            v_minor: 0,
+            chip_type: 0,
+            riscvchip: 0,
+            last_dmi_read: None,
+        };
+
+        wlink.init()?;
+
+        Ok(Box::new(wlink))
+    }
+
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    fn speed_khz(&self) -> u32 {
+        todo!()
+    }
+
+    fn set_speed(&mut self, _speed_khz: u32) -> Result<u32, DebugProbeError> {
+        Err(DebugProbeError::NotImplemented("set_speed"))
+    }
+
+    fn attach(&mut self) -> Result<(), DebugProbeError> {
+        // second stage of wlink_init
+        tracing::trace!("attach to target chip");
+        let mut rxbuf = self
+            .device
+            .write_command(&[0x81, 0x0d, 0x01, 0x02], Duration::from_millis(300))?;
+        if rxbuf[0] != 0x82 {
+            return Err(WchLinkError::CommandFailed.into());
+        }
+
+        self.riscvchip = rxbuf[3];
+        tracing::info!(
+            "attach riscvchip 0x{:02x} {:?}",
+            self.riscvchip,
+            RiscvChip::from_u8(self.riscvchip)
+        );
+
+        if rxbuf.len() > 7 {
+            let chip_type =
+                u32::from_be_bytes([rxbuf[4], rxbuf[5], rxbuf[6], rxbuf[7]]) & 0xffffff0f;
+            tracing::info!("attach chip_type 0x{:08x}", chip_type);
+            self.chip_type = chip_type;
+        } else {
+            tracing::warn!("Using old firmware, chip_type not available")
+        }
+
+        match self.riscvchip {
+            0x01 => {
+                // CH32V103
+                self.device.write(
+                    &[0x81, 0x0d, 0x01, 0x03],
+                    &mut rxbuf[0..4],
+                    Duration::from_millis(300),
+                )?;
+                self.assert_unprotected()?;
+                self.reset()?;
+            }
+            0x02 => {
+                // CH57x
+            }
+            0x03 => {
+                // CH569
+                let rxbuf = self
+                    .device
+                    .write_command(&[0x81, 0x0d, 0x01, 0x04], Duration::from_millis(300))?;
+                println!("rxbuf: {rxbuf:?}");
+            }
+            0x05 => {
+                // CH32V20x
+                self.device.write(
+                    &[0x81, 0x0d, 0x01, 0x03],
+                    &mut rxbuf[0..4],
+                    Duration::from_millis(300),
+                )?;
+                self.assert_unprotected()?;
+            }
+            0x06 => {
+                // CH32V30x
+                self.device.write(
+                    &[0x81, 0x0d, 0x01, 0x03],
+                    &mut rxbuf[0..4],
+                    Duration::from_millis(300),
+                )?;
+                self.assert_unprotected()?;
+            }
+            0x07 => {
+                // CH58x
+            }
+            0x09 => {
+                // CH32V003
+                unimplemented!("CH32V003 (rv32ec) is not supported yet");
+            }
+            _ => unimplemented!("riscvchip 0x{:02}", self.riscvchip),
+        }
+
+        Ok(())
+    }
+
+    fn detach(&mut self) -> Result<(), crate::Error> {
+        // wlink_disabledebug
+        if self.riscvchip == 0x02 || self.riscvchip == 0x03 {
+            self.device.write(
+                &[0x81, 0x0e, 0x01, 0x00],
+                &mut [0u8; 3],
+                Duration::from_millis(300),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn target_reset(&mut self) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::NotImplemented("target_reset"))
+    }
+
+    fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
+        tracing::info!("target reset assert");
+        Err(DebugProbeError::NotImplemented("target_reset_assert"))
+    }
+
+    fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
+        tracing::info!("target reset deassert");
+        Ok(())
+    }
+
+    fn select_protocol(&mut self, protocol: WireProtocol) -> Result<(), DebugProbeError> {
+        // Assume Jtag, as it is the only supported protocol for riscv
+        match protocol {
+            WireProtocol::Jtag => Ok(()),
+            _ => Err(DebugProbeError::UnsupportedProtocol(protocol)),
+        }
+    }
+
+    fn active_protocol(&self) -> Option<WireProtocol> {
+        Some(WireProtocol::Jtag)
+    }
+
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
+    }
+
+    fn has_riscv_interface(&self) -> bool {
+        true
+    }
+
+    fn try_get_riscv_interface(
+        self: Box<Self>,
+    ) -> Result<RiscvCommunicationInterface, (Box<dyn DebugProbe>, RiscvError)> {
+        RiscvCommunicationInterface::new(self).map_err(|(probe, err)| (probe.into_probe(), err))
+    }
+}
+
+impl JTAGAccess for WchLink {
+    fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {
+        tracing::debug!("read register 0x{:08x}", address);
+        assert_eq!(len, 32);
+
+        match address as u8 {
+            REG_IDCODE_ADDRESS => {
+                tracing::debug!("using hard coded idcode 0x00000001");
+                Ok(0x1_u32.to_le_bytes().to_vec())
+            }
+            REG_DTMCS_ADDRESS => {
+                // See: RISC-V Debug Specification, 6.1.4
+                // 0x71: abits=7, version=1(1.0)
+                Ok(0x71_u32.to_le_bytes().to_vec())
+            }
+            REG_BYPASS_ADDRESS => Ok(vec![0; 4]),
+            _ => panic!("unknown read register address {address:08x}"),
+        }
+    }
+
+    fn set_idle_cycles(&mut self, idle_cycles: u8) {
+        tracing::debug!("set idle scycles {}, nop", idle_cycles);
+    }
+
+    fn get_idle_cycles(&self) -> u8 {
+        todo!()
+    }
+
+    fn set_ir_len(&mut self, len: u32) {
+        tracing::debug!("set ir len {}, nop", len);
+    }
+
+    fn write_register(
+        &mut self,
+        address: u32,
+        data: &[u8],
+        len: u32,
+    ) -> Result<Vec<u8>, DebugProbeError> {
+        match address as u8 {
+            REG_DTMCS_ADDRESS => {
+                let val = u32::from_le_bytes(data.try_into().unwrap());
+                if val & DTMCS_DMIRESET_MASK != 0 {
+                    tracing::warn!("TODO reset dmi");
+                } else if val & DTMCS_DMIHARDRESET_MASK != 0 {
+                    tracing::warn!("TODO hard reset dmi");
+                }
+
+                Ok(0x71_u32.to_le_bytes().to_vec())
+            }
+            REG_DMI_ADDRESS => {
+                assert_eq!(
+                    len, 41,
+                    "should be 41 bits: 8 bits abits + 32 bits data + 2 bits op"
+                );
+                let register_value: u128 = u128::from_le_bytes(data.try_into().unwrap());
+
+                let dmi_addr = ((register_value >> DMI_ADDRESS_BIT_OFFSET) & 0x3f) as u8;
+                let dmi_value = ((register_value >> DMI_VALUE_BIT_OFFSET) & 0xffffffff) as u32;
+                let dmi_op = (register_value & DMI_OP_MASK) as u8;
+
+                tracing::trace!(
+                    "dmi op={} addr 0x{:02x} data 0x{:08x}",
+                    dmi_op,
+                    dmi_addr,
+                    dmi_value,
+                );
+
+                match dmi_op {
+                    DMI_OP_READ => {
+                        let (addr, data, op) = self.dmi_op_read(dmi_addr)?;
+                        let ret = (addr as u128) << DMI_ADDRESS_BIT_OFFSET
+                            | (data as u128) << DMI_VALUE_BIT_OFFSET
+                            | (op as u128);
+                        tracing::debug!("dmi read 0x{:02x} 0x{:08x} op={}", addr, data, op);
+                        self.last_dmi_read = Some((addr, data, op));
+                        Ok(ret.to_le_bytes().to_vec())
+                    }
+                    DMI_OP_NOP => {
+                        // No idea why NOP with zero addr should return the last read value.
+                        let (addr, data, op) = if dmi_addr == 0 && dmi_value == 0 {
+                            self.dmi_op_nop(dmi_addr, dmi_value)?;
+                            self.last_dmi_read.unwrap()
+                        } else {
+                            self.dmi_op_nop(dmi_addr, dmi_value)?
+                        };
+
+                        let ret = (addr as u128) << DMI_ADDRESS_BIT_OFFSET
+                            | (data as u128) << DMI_VALUE_BIT_OFFSET
+                            | (op as u128);
+                        tracing::debug!("dmi nop 0x{:02x} 0x{:08x} op={}", addr, data, op);
+                        Ok(ret.to_le_bytes().to_vec())
+                    }
+                    DMI_OP_WRITE => {
+                        let (addr, data, op) = self.dmi_op_write(dmi_addr, dmi_value)?;
+                        let ret = (addr as u128) << DMI_ADDRESS_BIT_OFFSET
+                            | (data as u128) << DMI_VALUE_BIT_OFFSET
+                            | (op as u128);
+                        tracing::debug!("dmi write 0x{:02x} 0x{:08x} op={}", addr, data, op);
+                        Ok(ret.to_le_bytes().to_vec())
+                    }
+                    _ => unreachable!("unknown dmi_op {dmi_op}"),
+                }
+            }
+            _ => unreachable!("unknown register address 0x{:08x}", address),
+        }
+    }
+}
+
+fn get_wlink_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
+    let timeout = Duration::from_millis(100);
+
+    let d_desc = device.device_descriptor().ok()?;
+    let handle = device.open().ok()?;
+    let language = handle.read_languages(timeout).ok()?.get(0).cloned()?;
+
+    let prod_str = handle
+        .read_product_string(language, &d_desc, timeout)
+        .ok()?;
+    let sn_str = handle
+        .read_serial_number_string(language, &d_desc, timeout)
+        .ok();
+
+    if prod_str == "WCH-Link" {
+        Some(DebugProbeInfo {
+            identifier: "WCH-Link".into(),
+            vendor_id: VENDOR_ID,
+            product_id: PRODUCT_ID,
+            serial_number: sn_str,
+            probe_type: DebugProbeType::WchLink,
+            hid_interface: None,
+        })
+    } else {
+        None
+    }
+}
+
+#[tracing::instrument(skip_all)]
+pub fn list_wlink_devices() -> Vec<DebugProbeInfo> {
+    tracing::debug!("Searching for WCH-Link probes using libusb");
+    let probes = match rusb::Context::new().and_then(|ctx| ctx.devices()) {
+        Ok(devices) => devices
+            .iter()
+            .filter(|device| {
+                device
+                    .device_descriptor()
+                    .map(|desc| desc.vendor_id() == VENDOR_ID && desc.product_id() == PRODUCT_ID)
+                    .unwrap_or(false)
+            })
+            .filter_map(|device| get_wlink_info(&device))
+            .collect(),
+        Err(_) => vec![],
+    };
+
+    tracing::debug!("Found {} WCH-Link probes total", probes.len());
+    probes
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum WchLinkError {
+    #[error("Device's read-protect status is enabled")]
+    ReadProtected,
+    #[error("Unknown WCH-Link device(new variant?)")]
+    UnknownDevice,
+    #[error("Firmware version is not supported.")]
+    UnsupportedFirmwareVersion,
+    #[error("Not enough bytes written.")]
+    NotEnoughBytesWritten { is: usize, should: usize },
+    #[error("Not enough bytes read.")]
+    NotEnoughBytesRead { is: usize, should: usize },
+    #[error("Usb endpoint not found.")]
+    EndpointNotFound,
+    #[error("Command failed from the device.")]
+    CommandFailed,
+}
+
+impl From<WchLinkError> for DebugProbeError {
+    fn from(e: WchLinkError) -> Self {
+        DebugProbeError::ProbeSpecific(Box::new(e))
+    }
+}
+
+impl From<WchLinkError> for ProbeCreationError {
+    fn from(e: WchLinkError) -> Self {
+        ProbeCreationError::ProbeSpecific(Box::new(e))
+    }
+}

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -4,7 +4,7 @@
 //! For more details see: <https://github.com/ch32-rs/wlink>
 
 use core::fmt;
-use std::{thread::sleep, time::Duration};
+use std::time::Duration;
 
 use probe_rs_target::ScanChainElement;
 use rusb::{Device, UsbContext};
@@ -15,11 +15,11 @@ use crate::{
     ProbeCreationError, WireProtocol,
 };
 
-use self::usb_interface::WchLinkUsbDevice;
+use self::{commands::Speed, usb_interface::WchLinkUsbDevice};
 use super::JTAGAccess;
 
-mod usb_interface;
 mod commands;
+mod usb_interface;
 
 const VENDOR_ID: u16 = 0x1a86;
 const PRODUCT_ID: u16 = 0x8010;
@@ -41,18 +41,18 @@ const REG_DMI_ADDRESS: u8 = 0x11;
 const DTMCS_DMIRESET_MASK: u32 = 1 << 16;
 const DTMCS_DMIHARDRESET_MASK: u32 = 1 << 17;
 
-/// All WCH-Link probe variants, see-also: http://www.wch-ic.com/products/WCH-Link.html
-#[derive(Clone, Copy, Debug)]
+/// All WCH-Link probe variants, see-also: <http://www.wch-ic.com/products/WCH-Link.html>
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum WchLinkVariant {
-    /// WCH-Link-CH549, does not support CH32V00X
+    /// WCH-Link-CH549, does not support RV32EC
     Ch549 = 1,
-    /// WCH-LinkE-CH32V305
+    /// WCH-LinkE-CH32V305, the full featured version
     ECh32v305 = 2,
     /// WCH-LinkS-CH32V203
     SCh32v203 = 3,
-    /// WCH-LinkB,
-    B = 4,
+    /// WCH-LinkW-CH32V208, a wirelessed version
+    WCh32v208 = 5,
 }
 
 impl fmt::Display for WchLinkVariant {
@@ -61,41 +61,73 @@ impl fmt::Display for WchLinkVariant {
             WchLinkVariant::Ch549 => write!(f, "WCH-Link-CH549"),
             WchLinkVariant::ECh32v305 => write!(f, "WCH-LinkE-CH32V305"),
             WchLinkVariant::SCh32v203 => write!(f, "WCH-LinkS-CH32V203"),
-            WchLinkVariant::B => write!(f, "WCH-LinkB"),
+            WchLinkVariant::WCh32v208 => write!(f, "WCH-LinkW-CH32V208"),
         }
     }
 }
 
-/// Currently supported RISC-V chip series
-#[derive(Clone, Copy, Debug)]
+impl WchLinkVariant {
+    pub fn try_from_u8(value: u8) -> Result<Self, WchLinkError> {
+        match value {
+            1 => Ok(Self::Ch549),
+            2 => Ok(Self::ECh32v305),
+            3 => Ok(Self::SCh32v203),
+            5 => Ok(Self::WCh32v208),
+            0x12 => Ok(Self::ECh32v305), // ??
+            _ => Err(WchLinkError::UnknownDevice),
+        }
+    }
+}
+
+/// Currently supported RISC-V chip series/families. The IP core name is "Qingke".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum RiscvChip {
-    /// CH32V103 RISC-V3A series
+    /// CH32V103 Qingke-V3A series
     CH32V103 = 0x01,
-    /// CH571/CH573 RISC-V3A BLE 4.2 series
-    CH57x = 0x02,
-    /// CH569/CH565 RISC-V3A series
-    CH56x = 0x03,
-    /// CH32V20x RISC-V4B/V4C series
-    CH32V20x = 0x05,
-    /// CH32V30x RISC-V4C/V4F series
-    CH32V30x = 0x06,
-    /// CH581/CH582/CH583 RISC-V4A BLE 5.3 series
-    CH58x = 0x07,
-    /// CH32V003 RISC-V2A series
+    /// CH571/CH573 Qingke-V3A BLE 4.2 series
+    CH57X = 0x02,
+    /// CH565/CH569 Qingke-V3A series
+    CH56X = 0x03,
+    /// CH32V20X Qingke-V4B/V4C series
+    CH32V20X = 0x05,
+    /// CH32V30X Qingke-V4C/V4F series, the same as CH32V20X
+    CH32V30X = 0x06,
+    /// CH58x Qingke-V4A BLE 5.3 series
+    CH58X = 0x07,
+    /// CH32V003 Qingke-V2A series
     CH32V003 = 0x09,
+    // The only reference I can find is <https://www.wch.cn/news/606.html>.
+    /// RISC-V EC controller, undocumented.
+    CH8571 = 0x0A, // 10,
+    /// CH59x Qingke-V4C BLE 5.4 series, fallback as CH58X
+    CH59X = 0x0B, // 11
+    /// CH643 Qingke-V4C series, RGB Display Driver MCU
+    CH643 = 0x0C, // 12
+    /// CH32X035 Qingke-V4C USB-PD series, fallbak as CH643
+    CH32X035 = 0x0D, // 13
+    /// CH32L103 Qingke-V4C low power series, USB-PD
+    CH32L103 = 0x0E, // 14
+    /// CH641 Qingke-V2A series, USB-PD, fallback as CH32V003
+    CH641 = 0x49,
 }
 
 impl RiscvChip {
-    fn from_u8(value: u8) -> Option<Self> {
+    fn try_from_u8(value: u8) -> Option<Self> {
         match value {
             0x01 => Some(RiscvChip::CH32V103),
-            0x02 => Some(RiscvChip::CH57x),
-            0x03 => Some(RiscvChip::CH56x),
-            0x05 => Some(RiscvChip::CH32V20x),
-            0x06 => Some(RiscvChip::CH32V30x),
-            0x07 => Some(RiscvChip::CH58x),
+            0x02 => Some(RiscvChip::CH57X),
+            0x03 => Some(RiscvChip::CH56X),
+            0x05 => Some(RiscvChip::CH32V20X),
+            0x06 => Some(RiscvChip::CH32V30X),
+            0x07 => Some(RiscvChip::CH58X),
             0x09 => Some(RiscvChip::CH32V003),
+            0x0A => Some(RiscvChip::CH8571),
+            0x0B => Some(RiscvChip::CH59X),
+            0x0C => Some(RiscvChip::CH643),
+            0x0D => Some(RiscvChip::CH32X035),
+            0x0E => Some(RiscvChip::CH32L103),
+            0x49 => Some(RiscvChip::CH641),
             _ => None,
         }
     }
@@ -109,52 +141,28 @@ pub(crate) struct WchLink {
     variant: WchLinkVariant,
     v_major: u8,
     v_minor: u8,
-    riscvchip: u8,
-    chip_type: u32,
+    /// Chip family
+    chip_family: RiscvChip,
+    /// Chip id to identify the target chip variant
+    chip_id: u32,
     // Hack to support NOP after READ
     last_dmi_read: Option<(u8, u32, u8)>,
+    speed: commands::Speed,
 }
 
 impl WchLink {
-    fn get_version(&mut self) -> Result<(), DebugProbeError> {
+    fn get_probe_info(&mut self) -> Result<(), DebugProbeError> {
         tracing::debug!("Getting version of WCH-Link...");
 
-        let rxbuf = self
-            .device
-            .write_command(&[0x81, 0x0d, 0x01, 0x01], Duration::from_millis(300))?;
+        let probe_info = self.device.send_command(commands::GetProbeInfo)?;
+        self.v_major = probe_info.major_version;
+        self.v_minor = probe_info.minor_version;
 
-        if rxbuf[0] != 0x82 {
-            return Err(WchLinkError::CommandFailed.into());
+        if self.v_major != 0x02 && self.v_minor < 0x07 {
+            return Err(DebugProbeError::ProbeFirmwareOutdated);
         }
 
-        match rxbuf.len() {
-            // 2.3
-            5 => {
-                self.variant = WchLinkVariant::Ch549;
-                self.v_major = rxbuf[3];
-                self.v_minor = rxbuf[4];
-                tracing::warn!(
-                    "WCH-Link {} {}.{} is outdated, please update the firmware.",
-                    self.variant,
-                    self.v_major,
-                    self.v_minor
-                );
-            }
-            // 2.7, 2.8
-            7 => {
-                self.v_major = rxbuf[3];
-                self.v_minor = rxbuf[4];
-
-                match rxbuf[5] {
-                    1 => self.variant = WchLinkVariant::Ch549,
-                    2 => self.variant = WchLinkVariant::ECh32v305,
-                    3 => self.variant = WchLinkVariant::SCh32v203,
-                    4 => self.variant = WchLinkVariant::B,
-                    _ => return Err(WchLinkError::UnknownDevice.into()),
-                }
-            }
-            _ => return Err(WchLinkError::UnsupportedFirmwareVersion.into()),
-        }
+        self.variant = probe_info.variant;
 
         Ok(())
     }
@@ -163,7 +171,7 @@ impl WchLink {
         // first stage of wlink_init
         tracing::debug!("Initializing WCH-Link...");
 
-        self.get_version()?;
+        self.get_probe_info()?;
 
         tracing::info!(
             "WCH-Link variant: {}, firmware version: {}.{}",
@@ -180,111 +188,24 @@ impl WchLink {
         Ok(())
     }
 
-    fn reset(&mut self) -> Result<(), DebugProbeError> {
-        self.dmi_op_write(0x10, 0x80000001)?;
-        sleep(Duration::from_millis(1));
-        self.dmi_op_read(0x11)?;
-        sleep(Duration::from_millis(1));
-
-        let mut txbuf = [0x81, 0x0d, 0x01, 0x03];
-        if self.riscvchip == 0x02 {
-            txbuf[3] = 0x02;
-        }
-        self.device
-            .write(&txbuf, &mut [0u8; 4], Duration::from_millis(300))?;
-
-        self.dmi_op_write(0x10, 0x80000001)?;
-        sleep(Duration::from_millis(1));
-        self.dmi_op_read(0x11)?;
-        Ok(())
-    }
-
     fn dmi_op_read(&mut self, addr: u8) -> Result<(u8, u32, u8), DebugProbeError> {
-        let mut rxbuf = [0u8; 9];
-        self.device.write(
-            &[0x81, 0x08, 0x06, addr, 0, 0, 0, 0, DMI_OP_READ],
-            &mut rxbuf,
-            Duration::from_millis(300),
-        )?;
+        let resp = self.device.send_command(commands::DmiOp::read(addr))?;
 
-        if rxbuf[0] == 0x82 {
-            let data_out = u32::from_be_bytes([rxbuf[4], rxbuf[5], rxbuf[6], rxbuf[7]]);
-            Ok((rxbuf[3], data_out, rxbuf[8]))
-        } else {
-            Err(WchLinkError::CommandFailed.into())
-        }
+        Ok((resp.addr, resp.data, resp.op))
     }
 
     fn dmi_op_write(&mut self, addr: u8, data: u32) -> Result<(u8, u32, u8), DebugProbeError> {
-        let mut rxbuf = [0u8; 9];
-        let raw_data = data.to_be_bytes();
-        self.device.write(
-            &[
-                0x81,
-                0x08,
-                0x06,
-                addr,
-                raw_data[0],
-                raw_data[1],
-                raw_data[2],
-                raw_data[3],
-                DMI_OP_WRITE,
-            ],
-            &mut rxbuf,
-            Duration::from_millis(300),
-        )?;
-
-        if rxbuf[0] == 0x82 {
-            let data_out = u32::from_be_bytes([rxbuf[4], rxbuf[5], rxbuf[6], rxbuf[7]]);
-            Ok((rxbuf[3], data_out, rxbuf[8]))
-        } else {
-            Err(WchLinkError::CommandFailed.into())
-        }
-    }
-
-    fn dmi_op_nop(&mut self, addr: u8, data: u32) -> Result<(u8, u32, u8), DebugProbeError> {
-        let mut rxbuf = [0u8; 9];
-        let raw_data = data.to_be_bytes();
-        self.device.write(
-            &[
-                0x81,
-                0x08,
-                0x06,
-                addr,
-                raw_data[0],
-                raw_data[1],
-                raw_data[2],
-                raw_data[3],
-                DMI_OP_NOP,
-            ],
-            &mut rxbuf,
-            Duration::from_millis(300),
-        )?;
-
-        let data_out = u32::from_be_bytes([rxbuf[4], rxbuf[5], rxbuf[6], rxbuf[7]]);
-        if rxbuf[0] == 0x82 {
-            Ok((rxbuf[3], data_out, rxbuf[8]))
-        } else {
-            Err(WchLinkError::CommandFailed.into())
-        }
-    }
-
-    pub fn assert_unprotected(&mut self) -> Result<(), DebugProbeError> {
-        let rxbuf = self
+        let resp = self
             .device
-            .write_command(&[0x81, 0x06, 0x01, 0x01], Duration::from_millis(300))?;
+            .send_command(commands::DmiOp::write(addr, data))?;
 
-        if rxbuf[0] == 0x82 {
-            if rxbuf[3] == 0x02 {
-                Ok(())
-            } else if rxbuf[3] == 0x01 {
-                Err(WchLinkError::ReadProtected.into())
-            } else {
-                unreachable!()
-            }
-        } else {
-            Err(WchLinkError::CommandFailed.into())
-        }
+        Ok((resp.addr, resp.data, resp.op))
+    }
+
+    fn dmi_op_nop(&mut self) -> Result<(u8, u32, u8), DebugProbeError> {
+        let resp = self.device.send_command(commands::DmiOp::nop())?;
+
+        Ok((resp.addr, resp.data, resp.op))
     }
 }
 
@@ -302,9 +223,10 @@ impl DebugProbe for WchLink {
             variant: WchLinkVariant::Ch549,
             v_major: 0,
             v_minor: 0,
-            chip_type: 0,
-            riscvchip: 0,
+            chip_id: 0,
+            chip_family: RiscvChip::CH32V103,
             last_dmi_read: None,
+            speed: Speed::default(),
         };
 
         wlink.init()?;
@@ -317,105 +239,45 @@ impl DebugProbe for WchLink {
     }
 
     fn speed_khz(&self) -> u32 {
-        todo!()
+        self.speed.to_khz()
     }
 
-    fn set_speed(&mut self, _speed_khz: u32) -> Result<u32, DebugProbeError> {
-        Err(DebugProbeError::NotImplemented("set_speed"))
+    fn set_speed(&mut self, speed_khz: u32) -> Result<u32, DebugProbeError> {
+        let speed =
+            Speed::from_khz(speed_khz).ok_or(DebugProbeError::UnsupportedSpeed(speed_khz))?;
+        self.device
+            .send_command(commands::SetSpeed(self.chip_family, speed))?;
+        Ok(speed.to_khz())
     }
 
+    /// Attach chip
     fn attach(&mut self) -> Result<(), DebugProbeError> {
         // second stage of wlink_init
         tracing::trace!("attach to target chip");
-        let mut rxbuf = self
-            .device
-            .write_command(&[0x81, 0x0d, 0x01, 0x02], Duration::from_millis(300))?;
-        if rxbuf[0] != 0x82 {
-            return Err(WchLinkError::CommandFailed.into());
-        }
 
-        self.riscvchip = rxbuf[3];
-        tracing::info!(
-            "attach riscvchip 0x{:02x} {:?}",
-            self.riscvchip,
-            RiscvChip::from_u8(self.riscvchip)
-        );
+        let resp = self.device.send_command(commands::AttachChip)?;
 
-        if rxbuf.len() > 7 {
-            let chip_type =
-                u32::from_be_bytes([rxbuf[4], rxbuf[5], rxbuf[6], rxbuf[7]]) & 0xffffff0f;
-            tracing::info!("attach chip_type 0x{:08x}", chip_type);
-            self.chip_type = chip_type;
-        } else {
-            tracing::warn!("Using old firmware, chip_type not available")
-        }
+        self.chip_family = resp.chip_family;
 
-        match self.riscvchip {
-            0x01 => {
-                // CH32V103
-                self.device.write(
-                    &[0x81, 0x0d, 0x01, 0x03],
-                    &mut rxbuf[0..4],
-                    Duration::from_millis(300),
-                )?;
-                self.assert_unprotected()?;
-                self.reset()?;
-            }
-            0x02 => {
-                // CH57x
-            }
-            0x03 => {
-                // CH569
-                let rxbuf = self
-                    .device
-                    .write_command(&[0x81, 0x0d, 0x01, 0x04], Duration::from_millis(300))?;
-                println!("rxbuf: {rxbuf:?}");
-            }
-            0x05 => {
-                // CH32V20x
-                self.device.write(
-                    &[0x81, 0x0d, 0x01, 0x03],
-                    &mut rxbuf[0..4],
-                    Duration::from_millis(300),
-                )?;
-                self.assert_unprotected()?;
-            }
-            0x06 => {
-                // CH32V30x
-                self.device.write(
-                    &[0x81, 0x0d, 0x01, 0x03],
-                    &mut rxbuf[0..4],
-                    Duration::from_millis(300),
-                )?;
-                self.assert_unprotected()?;
-            }
-            0x07 => {
-                // CH58x
-            }
-            0x09 => {
-                // CH32V003
-                unimplemented!("CH32V003 (rv32ec) is not supported yet");
-            }
-            _ => unimplemented!("riscvchip 0x{:02}", self.riscvchip),
-        }
+        tracing::info!("attached riscvchip {:?}", self.chip_family);
+
+        let chip_type = resp.chip_id;
+
+        self.chip_id = chip_type;
 
         Ok(())
     }
 
     fn detach(&mut self) -> Result<(), crate::Error> {
-        // wlink_disabledebug
-        if self.riscvchip == 0x02 || self.riscvchip == 0x03 {
-            self.device.write(
-                &[0x81, 0x0e, 0x01, 0x00],
-                &mut [0u8; 3],
-                Duration::from_millis(300),
-            )?;
-        }
+        tracing::trace!("Detach chip");
+        self.device.send_command(commands::DetachChip)?;
+
         Ok(())
     }
 
     fn target_reset(&mut self) -> Result<(), DebugProbeError> {
-        Err(DebugProbeError::NotImplemented("target_reset"))
+        self.device.send_command(commands::ResetTarget)?;
+        Ok(())
     }
 
     fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
@@ -472,7 +334,7 @@ impl JTAGAccess for WchLink {
 
         match address as u8 {
             REG_IDCODE_ADDRESS => {
-                // using hard coded idcode 0x00000001, the same as WCH's official appro
+                // using hard coded idcode 0x00000001, the same as WCH's openocd fork
                 tracing::debug!("using hard coded idcode 0x00000001");
                 Ok(0x1_u32.to_le_bytes().to_vec())
             }
@@ -494,9 +356,7 @@ impl JTAGAccess for WchLink {
         todo!()
     }
 
-    fn set_ir_len(&mut self, len: u32) {
-        tracing::debug!("set ir len {}, nop", len);
-    }
+    fn set_ir_len(&mut self, _len: u32) {}
 
     fn write_register(
         &mut self,
@@ -508,9 +368,13 @@ impl JTAGAccess for WchLink {
             REG_DTMCS_ADDRESS => {
                 let val = u32::from_le_bytes(data.try_into().unwrap());
                 if val & DTMCS_DMIRESET_MASK != 0 {
-                    tracing::warn!("TODO reset dmi");
+                    tracing::warn!("dmi reset");
+                    self.dmi_op_write(0x10, 0x00000000)?;
+                    self.dmi_op_write(0x10, 0x00000001)?;
+                    // dmcontrol.dmactive is checked later
                 } else if val & DTMCS_DMIHARDRESET_MASK != 0 {
-                    tracing::warn!("TODO hard reset dmi");
+                    tracing::warn!("dmi hard reset");
+                    // TODO
                 }
 
                 Ok(0x71_u32.to_le_bytes().to_vec())
@@ -546,10 +410,10 @@ impl JTAGAccess for WchLink {
                     DMI_OP_NOP => {
                         // No idea why NOP with zero addr should return the last read value.
                         let (addr, data, op) = if dmi_addr == 0 && dmi_value == 0 {
-                            self.dmi_op_nop(dmi_addr, dmi_value)?;
+                            self.dmi_op_nop()?;
                             self.last_dmi_read.unwrap()
                         } else {
-                            self.dmi_op_nop(dmi_addr, dmi_value)?
+                            self.dmi_op_nop()?
                         };
 
                         let ret = (addr as u128) << DMI_ADDRESS_BIT_OFFSET
@@ -604,7 +468,7 @@ fn get_wlink_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
 
 #[tracing::instrument(skip_all)]
 pub fn list_wlink_devices() -> Vec<DebugProbeInfo> {
-    tracing::debug!("Searching for WCH-Link probes using libusb");
+    tracing::debug!("Searching for WCH-Link(RV) probes using libusb");
     let probes = match rusb::Context::new().and_then(|ctx| ctx.devices()) {
         Ok(devices) => devices
             .iter()
@@ -639,11 +503,20 @@ pub(crate) enum WchLinkError {
     EndpointNotFound,
     #[error("Command failed from the device.")]
     CommandFailed,
+    #[error("Invalid payload.")]
+    InvalidPayload,
+    #[error("Protocl error.")]
+    Protocol(u8, Vec<u8>),
+    #[error("Unknown chip 0x{0:02x}")]
+    UnknownChip(u8),
 }
 
 impl From<WchLinkError> for DebugProbeError {
     fn from(e: WchLinkError) -> Self {
-        DebugProbeError::ProbeSpecific(Box::new(e))
+        match e {
+            WchLinkError::UnsupportedFirmwareVersion => DebugProbeError::ProbeFirmwareOutdated,
+            _ => DebugProbeError::ProbeSpecific(Box::new(e)),
+        }
     }
 }
 

--- a/probe-rs/src/probe/wlink/usb_interface.rs
+++ b/probe-rs/src/probe/wlink/usb_interface.rs
@@ -1,0 +1,206 @@
+use std::time::Duration;
+
+use rusb::{DeviceHandle, UsbContext};
+
+use crate::{DebugProbeError, DebugProbeSelector, ProbeCreationError};
+
+use super::{get_wlink_info, WchLinkError};
+
+const ENDPOINT_OUT: u8 = 0x01;
+const ENDPOINT_IN: u8 = 0x81;
+
+// const RAW_ENDPOINT_OUT: u8 = 0x02;
+// const RAW_ENDPOINT_IN: u8 = 0x82;
+
+#[derive(Debug)]
+pub struct WchLinkUsbDevice {
+    device_handle: DeviceHandle<rusb::Context>,
+}
+
+impl WchLinkUsbDevice {
+    pub fn new_from_selector(
+        selector: impl Into<DebugProbeSelector>,
+    ) -> Result<Self, ProbeCreationError> {
+        let selector = selector.into();
+
+        let context = rusb::Context::new()?;
+
+        tracing::debug!("Acquired libusb context.");
+        let device = context
+            .devices()?
+            .iter()
+            .filter(|device| {
+                device
+                    .device_descriptor()
+                    .map(|desc| {
+                        desc.vendor_id() == selector.vendor_id
+                            && desc.product_id() == selector.product_id
+                    })
+                    .unwrap_or(false)
+            })
+            .find(|device| get_wlink_info(device).is_some())
+            .map_or(Err(ProbeCreationError::NotFound), Ok)?;
+
+        let mut device_handle = device.open()?;
+
+        tracing::debug!("Aquired handle for probe");
+
+        let config = device.active_config_descriptor()?;
+
+        tracing::debug!("Active config descriptor: {:?}", &config);
+
+        let descriptor = device.device_descriptor()?;
+
+        tracing::debug!("Device descriptor: {:?}", &descriptor);
+
+        device_handle.claim_interface(0)?;
+
+        tracing::debug!("Claimed interface 0 of USB device.");
+
+        let mut endpoint_out = false;
+        let mut endpoint_in = false;
+
+        if let Some(interface) = config.interfaces().next() {
+            if let Some(descriptor) = interface.descriptors().next() {
+                for endpoint in descriptor.endpoint_descriptors() {
+                    if endpoint.address() == ENDPOINT_OUT {
+                        endpoint_out = true;
+                    } else if endpoint.address() == ENDPOINT_IN {
+                        endpoint_in = true;
+                    }
+                }
+            }
+        }
+
+        if !endpoint_out {
+            return Err(WchLinkError::EndpointNotFound.into());
+        }
+
+        if !endpoint_in {
+            return Err(WchLinkError::EndpointNotFound.into());
+        }
+
+        let usb_wlink = Self { device_handle };
+
+        tracing::debug!("Succesfully attached to WCH-Link.");
+
+        Ok(usb_wlink)
+    }
+
+    fn close(&mut self) -> Result<(), rusb::Error> {
+        self.device_handle.release_interface(0)
+    }
+
+    pub(crate) fn write_command(
+        &mut self,
+        cmd: &[u8],
+        timeout: Duration,
+    ) -> Result<Vec<u8>, DebugProbeError> {
+        tracing::trace!(
+            "Sending command {:02x?} to WCH-Link, timeout: {:?}",
+            cmd,
+            timeout
+        );
+
+        // Command phase.
+        let written_bytes = self
+            .device_handle
+            .write_bulk(ENDPOINT_OUT, cmd, timeout)
+            .map_err(|e| DebugProbeError::Usb(Some(Box::new(e))))?;
+
+        if written_bytes != cmd.len() {
+            return Err(WchLinkError::NotEnoughBytesWritten {
+                is: written_bytes,
+                should: cmd.len(),
+            }
+            .into());
+        }
+
+        // data in phase.
+        let mut rxbuf = [0u8; 64];
+        let read_bytes = self
+            .device_handle
+            .read_bulk(ENDPOINT_IN, &mut rxbuf[..], timeout)
+            .map_err(|e| DebugProbeError::Usb(Some(Box::new(e))))?;
+
+        if read_bytes < 3 {
+            return Err(WchLinkError::NotEnoughBytesRead {
+                is: read_bytes,
+                should: 3,
+            }
+            .into());
+        }
+        if read_bytes != rxbuf[2] as usize + 3 {
+            return Err(WchLinkError::NotEnoughBytesRead {
+                is: read_bytes,
+                should: 3 + (rxbuf[2] as usize),
+            }
+            .into());
+        }
+
+        tracing::trace!(
+            "Receive response {:02x?} from WCH-Link",
+            &rxbuf[..read_bytes]
+        );
+        Ok(rxbuf[..read_bytes].to_vec())
+    }
+
+    pub(crate) fn write(
+        &mut self,
+        cmd: &[u8],
+        read_data: &mut [u8],
+        timeout: Duration,
+    ) -> Result<(), DebugProbeError> {
+        tracing::trace!(
+            "Sending command {:02x?} to WCH-Link, timeout: {:?}",
+            cmd,
+            timeout
+        );
+
+        // Command phase.
+        let written_bytes = self
+            .device_handle
+            .write_bulk(ENDPOINT_OUT, cmd, timeout)
+            .map_err(|e| DebugProbeError::Usb(Some(Box::new(e))))?;
+
+        if written_bytes != cmd.len() {
+            return Err(WchLinkError::NotEnoughBytesWritten {
+                is: written_bytes,
+                should: cmd.len(),
+            }
+            .into());
+        }
+
+        // data in phase.
+        let mut remaining_bytes = read_data.len();
+        let mut read_index = 0;
+
+        while remaining_bytes > 0 {
+            let read_bytes = self
+                .device_handle
+                .read_bulk(ENDPOINT_IN, &mut read_data[read_index..], timeout)
+                .map_err(|e| DebugProbeError::Usb(Some(Box::new(e))))?;
+
+            read_index += read_bytes;
+            remaining_bytes -= read_bytes;
+
+            if remaining_bytes > 0 {
+                tracing::trace!(
+                    "Read {} bytes, {} bytes remaining, buf {:02x?}",
+                    read_bytes,
+                    remaining_bytes,
+                    &read_data[..read_index]
+                );
+            }
+        }
+        tracing::trace!("Receive response {:02x?} from WCH-Link", read_data);
+        Ok(())
+    }
+}
+
+impl Drop for WchLinkUsbDevice {
+    fn drop(&mut self) {
+        // We ignore the error case as we can't do much about it anyways.
+        let _ = self.close();
+    }
+}


### PR DESCRIPTION
NOTE: This PR tries to add WCH-Link(RV mode) support. Not for CMSIS-DAP mode(ARM mode).

```console
>  cargo run -p probe-rs-cli -- list
The following devices were found:
[0]: WCH-Link (VID: 1a86, PID: 8010, Serial: 0001A0000000, WchLink)

> RUST_LOG=info cargo run -p probe-rs-cli -- info
 INFO open: probe_rs::probe::wlink: WCH-Link variant: WCH-LinkE-CH32V307, firmware version: 2.7
Probing target via JTAG
 INFO probe_rs::probe::wlink: attach riscvchip 0x05 Some(CH32V20x)
 INFO probe_rs::probe::wlink: attach chip_type 0x20360500
No DAP interface was found on the connected probe. Thus, ARM info cannot be printed.
 WARN probe_rs::probe::wlink: patch dtmcs(0x10) to be 0x00000071, read: 0x80000001
RISCV Chip:
        IDCODE: 0000000001
         Version:      0
         Part:         0
         Manufacturer: 0 (Unknown Manufacturer Code)
Probing target via SWD
Error identifying target using protocol SWD: Probe does not support SWD

> # read flash size and chip UID
> cargo run -p probe-rs-cli -- dump 0x1FFFF7E0 4 --chip riscv
...
DEBUG probe_rs::architecture::riscv: Before requesting halt, the Dmcontrol register value was: Dmcontrol { .0: 1, hartreset: false, hasel: false, hartsello: 0, hartselhi: 0, ndmreset: false, dmactive: true }
Addr 0x1ffff7e0: 0xffff0020
Addr 0x1ffff7e4: 0xffffffff
Addr 0x1ffff7e8: 0xaeb4abcd
Addr 0x1ffff7ec: 0x16c6bc45
Read 4 words in 14.032084ms
```

Status:
- `dump`, `info` subcommands tested for CH32V203 / CH32V307
- CH32V103 loops forever at "Determine the number of harts" (2^20 times actually). It seems that the chip has some bug in `Dmstatus.anynonexistent`. By adding a hard limit to `num_harts`, it works too
- Tested WCH-Link v2.7 firmware, WCH-LinkE variant
- Use `wlink` for variable name or file name, use `WCH-Link or WchLink` for type name or display name
- It is still at a very early stage, but this might be a start to full support for WCH-Link.

Implementation Details:
- WCH-Link supports `DMI_OP` by a standalone command
- Most details are from wch-OpenOCD, there're WCH-Link's RV-specific codes at wlink.c riscv.c riscv-013.c
- This PR wraps WCH-Link's `DMI_OP` USB command as JTAGAccess

Ref: https://github.com/Seneral/riscv-openocd-wch (and many others)