### PR TITLE
probe-rs-cli: Reduce RTT polling frequency in run command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - probe-rs: Avoid nested calls to tracing macros, otherwise filtering doesn't work properly. (#1415)
 
+- probe-rs-cli: Reduce RTT polling frequency in run command to avoid USB instability issues.
+
 
 ## [0.14.2]
 

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -6,6 +6,7 @@ use probe_rs_cli_util::rtt;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
+use std::time::Duration;
 
 pub fn run(
     common: ProbeOptions,
@@ -63,8 +64,14 @@ pub fn run(
         let mut stdout = std::io::stdout();
         loop {
             for (_ch, data) in rtta.poll_rtt_fallible(&mut core)? {
-                stdout.write_all(data.as_bytes()).unwrap();
+                stdout.write_all(data.as_bytes())?;
             }
+
+            // Poll RTT with a frequency of 10 Hz
+            //
+            // If the polling frequency is too high,
+            // the USB connection to the probe can become unstable.
+            std::thread::sleep(Duration::from_millis(100));
         }
     }
 


### PR DESCRIPTION
A very high polling frequency can lead to USB connection instability,
so we should sleep between polling.
