### PR TITLE
fix: Determine local time as early as possible

### DIFF
--- a/cargo-embed/CHANGELOG.md
+++ b/cargo-embed/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Ensure offset between local time and UTC gets determined as early as possible.
+
+  Determining the local time fails in multi-threaded programs, so it needs to be
+  done as early as possible. Otherwise the program will quit with an error saying that the local time could not have been determined.
+
 ## [0.15.0]
 
 Released 2023-01-28

--- a/cargo-embed/src/rttui/app.rs
+++ b/cargo-embed/src/rttui/app.rs
@@ -480,9 +480,13 @@ impl App {
     /// # Errors
     /// If getting the current time or formatting a timestamp fails,
     /// this function will abort and return a [`time::Error`].
-    pub fn poll_rtt(&mut self, core: &mut Core) -> Result<(), time::Error> {
+    pub fn poll_rtt(
+        &mut self,
+        core: &mut Core,
+        offset: time::UtcOffset,
+    ) -> Result<(), time::Error> {
         for channel in self.tabs.iter_mut() {
-            channel.poll_rtt(core)?;
+            channel.poll_rtt(core, offset)?;
         }
 
         Ok(())

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,10 +4,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Ensure offset between local time and UTC gets determined as early as possible.
+
+  Determining the local time fails in multi-threaded programs, so it needs to be
+  done as early as possible. Otherwise the program will quit with an error saying that the local time could not have been determined.
 
 ## [0.15.0]
 
 Released 2023-01-28
+
+
 
 ## [0.14.2]
 

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -7,12 +7,14 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 use std::time::Duration;
+use time::UtcOffset;
 
 pub fn run(
     common: ProbeOptions,
     path: &str,
     chip_erase: bool,
     disable_double_buffering: bool,
+    timestamp_offset: UtcOffset,
 ) -> Result<()> {
     let mut session = common.simple_attach()?;
 
@@ -52,7 +54,13 @@ pub fn run(
     let mut core = session.core(0)?;
     core.reset()?;
 
-    let mut rtta = match rtt::attach_to_rtt(&mut core, &memory_map, Path::new(path), &rtt_config) {
+    let mut rtta = match rtt::attach_to_rtt(
+        &mut core,
+        &memory_map,
+        Path::new(path),
+        &rtt_config,
+        timestamp_offset,
+    ) {
         Ok(target_rtt) => Some(target_rtt),
         Err(error) => {
             log::error!("{:?} Continuing without RTT... ", error);

--- a/debugger/src/debugger/core_data.rs
+++ b/debugger/src/debugger/core_data.rs
@@ -12,6 +12,7 @@ use crate::{
 use anyhow::{anyhow, Result};
 use probe_rs::{debug::debug_info::DebugInfo, Core, CoreStatus, Error};
 use probe_rs_cli_util::rtt::{self, ChannelMode, DataFormat};
+use time::UtcOffset;
 
 /// [CoreData] is used to cache data needed by the debugger, on a per-core basis.
 pub struct CoreData {
@@ -154,6 +155,7 @@ impl<'p> CoreHandle<'p> {
         target_memory_map: &[probe_rs::config::MemoryRegion],
         program_binary: &std::path::Path,
         rtt_config: &rtt::RttConfig,
+        timestamp_offset: UtcOffset,
     ) -> Result<()> {
         let mut debugger_rtt_channels: Vec<debug_rtt::DebuggerRttChannel> = vec![];
         match rtt::attach_to_rtt(
@@ -161,6 +163,7 @@ impl<'p> CoreHandle<'p> {
             target_memory_map,
             program_binary,
             rtt_config,
+            timestamp_offset,
         ) {
             Ok(target_rtt) => {
                 for any_channel in target_rtt.active_channels.iter() {


### PR DESCRIPTION
The offset between local time and UTC can only be determined when
only a single thread is running. If it's done with multiple threads,
it will fail.

This PR changes all tools to determine the offset once at the beginning,
and then store it.
