### PR TITLE
Improve logging in probe-rs-cli-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,6 +2159,7 @@ dependencies = [
  "git-version",
  "goblin",
  "indicatif",
+ "is-terminal",
  "log",
  "num-traits",
  "once_cell",

--- a/cargo-embed/CHANGELOG.md
+++ b/cargo-embed/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Log messages are printed to stderr, not stdout.
+
+### Fixed
+
+- If the output was redirect into a file, some log messages were not printed.
+
 ## [0.16.0]
 
 Released 2023-01-29

--- a/cargo-flash/CHANGELOG.md
+++ b/cargo-flash/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Log messages are printed to stderr, not stdout.
+
+### Fixed
+
+- If the output was redirect into a file, some log messages were not printed.
+
 ## [0.16.0]
 
 Released 2023-01-29

--- a/probe-rs-cli-util/Cargo.toml
+++ b/probe-rs-cli-util/Cargo.toml
@@ -42,3 +42,4 @@ num-traits = "0.2.14"
 defmt-decoder = { version = "0.3.4", features = ["unstable"] }
 git-version = { version = "0.3" }
 time = "0.3"
+is-terminal = "0.4.2"


### PR DESCRIPTION
The logging was done in the format call, which is not the correct place. Also, some logging calls where missing when the output was redirect to a file, since indicatif does not print the messages in that case.

This PR also changes the log output target, the log messages are now sent to stderr, not stdout. This is the default behaviour of the logger. The log target could be changed back to stdout if desired.