### PR TITLE
Fix: Support reading banked DP register on ST-Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- st-link: Support reading banked DP registers if firmware is new enough to support it.
+
 ## [0.16.0]
 
 Released 2023-01-29

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -32,6 +32,8 @@ pub(crate) fn show_info_of_device(common: &ProbeOptions) -> Result<()> {
 
     for protocol in protocols {
         println!("Probing target via {protocol}");
+        println!();
+
         let (new_probe, result) = try_show_info(probe, protocol, common.connect_under_reset);
 
         probe = new_probe;
@@ -41,6 +43,8 @@ pub(crate) fn show_info_of_device(common: &ProbeOptions) -> Result<()> {
         if let Err(e) = result {
             println!("Error identifying target using protocol {protocol}: {e}");
         }
+
+        println!();
     }
 
     Ok(())
@@ -74,7 +78,8 @@ fn try_show_info(
                     Ok(mut interface) => {
                         if let Err(e) = show_arm_info(&mut *interface) {
                             // Log error?
-                            println!("Error showing ARM chip information: {e}");
+                            println!("Error showing ARM chip information:");
+                            println!("{e:?}")
                         }
 
                         probe = interface.close();
@@ -176,7 +181,7 @@ fn show_arm_info(interface: &mut dyn ArmProbeInterface) -> Result<()> {
     let mut tree = Tree::new(dp_node);
 
     let dp = DpAddress::Default;
-    let num_access_ports = interface.num_access_ports(dp).unwrap();
+    let num_access_ports = interface.num_access_ports(dp)?;
 
     for ap_index in 0..num_access_ports {
         let ap = ApAddress {
@@ -185,7 +190,7 @@ fn show_arm_info(interface: &mut dyn ArmProbeInterface) -> Result<()> {
         };
         let access_port = GenericAp::new(ap);
 
-        let ap_information = interface.ap_information(access_port).unwrap();
+        let ap_information = interface.ap_information(access_port)?;
 
         match ap_information {
             ApInformation::MemoryAp(MemoryApInformation {
@@ -235,6 +240,7 @@ fn show_arm_info(interface: &mut dyn ArmProbeInterface) -> Result<()> {
         }
     }
 
+    println!("ARM Chip:");
     println!("{tree}");
 
     Ok(())

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -54,7 +54,7 @@ impl ApAccess for MockMemoryAp {
     /// Mocks the read_register method of a AP.
     ///
     /// Returns an Error if any bad instructions or values are chosen.
-    fn read_ap_register<PORT, R>(&mut self, _port: impl Into<PORT>) -> Result<R, ArmError>
+    fn read_ap_register<PORT, R>(&mut self, _port: PORT) -> Result<R, ArmError>
     where
         PORT: AccessPort,
         R: ApRegister<PORT>,
@@ -227,6 +227,8 @@ impl ApAccess for MockMemoryAp {
         PORT: AccessPort,
         R: ApRegister<PORT>,
     {
+        let port = port.into();
+
         for value in values {
             let register_value: R = self.read_ap_register(port.clone())?;
             *value = register_value.into()

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -97,7 +97,7 @@ pub enum DebugProbeError {
     Usb(#[source] Option<Box<dyn std::error::Error + Send + Sync>>),
     /// The firmware of the probe is outdated. This error is especially prominent with ST-Links.
     /// You can use their official updater utility to update your probe firmware.
-    #[error("The firmware on the probe is outdated")]
+    #[error("The firmware on the probe is outdated, and not supported by probe-rs.")]
     ProbeFirmwareOutdated,
     /// An error which is specific to the debug probe in use occurred.
     #[error("An error specific to a probe type occurred")]

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -297,7 +297,7 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
                     Ok(Some(2. * (a1 as f32) * 1.2 / (a0 as f32)))
                 } else {
                     // Should never happen
-                    Err(StlinkError::VoltageDivisionByZero.into())
+                    Err(StlinkError::VoltageDivisionByZero)
                 }
             })
             .map_err(|e| e.into())
@@ -860,7 +860,7 @@ impl<D: StLinkUsb> StLink<D> {
 
         let addbytes = address.to_le_bytes();
 
-        let value = retry_on_wait(|| {
+        retry_on_wait(|| {
             self.device.write(
                 &[
                     commands::JTAG_COMMAND,
@@ -883,7 +883,7 @@ impl<D: StLinkUsb> StLink<D> {
 
         tracing::debug!("Read ok");
 
-        Ok(value)
+        Ok(())
     }
 
     fn read_mem_8bit(

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -832,6 +832,7 @@ impl<D: StLinkUsb> StLink<D> {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, data, apsel), fields(ap=apsel, length= data.len()))]
     fn read_mem_32bit(
         &mut self,
         address: u32,
@@ -839,12 +840,6 @@ impl<D: StLinkUsb> StLink<D> {
         apsel: u8,
     ) -> Result<(), DebugProbeError> {
         self.select_ap(apsel)?;
-
-        tracing::debug!(
-            "Read mem 32 bit, address={:08x}, length={}",
-            address,
-            data.len()
-        );
 
         // Ensure maximum read length is not exceeded.
         assert!(
@@ -885,6 +880,8 @@ impl<D: StLinkUsb> StLink<D> {
 
             self.get_last_rw_status()
         })?;
+
+        tracing::debug!("Read ok");
 
         Ok(value)
     }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -38,7 +38,7 @@ const STLINK_MAX_WRITE_LEN: usize = 0xFFFC;
 const DP_PORT: u16 = 0xFFFF;
 
 #[derive(Debug)]
-pub struct StLink<D: StLinkUsb> {
+pub(crate) struct StLink<D: StLinkUsb> {
     device: D,
     name: String,
     hw_version: u8,
@@ -138,8 +138,8 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     fn attach(&mut self) -> Result<(), DebugProbeError> {
-        tracing::debug!("attach({:?})", self.protocol);
         self.enter_idle()?;
 
         let param = match self.protocol {
@@ -198,7 +198,8 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
         if self.swo_enabled {
             self.disable_swo().map_err(crate::Error::Arm)?;
         }
-        self.enter_idle().map_err(crate::Error::Probe)
+        self.enter_idle()
+            .map_err(|e| DebugProbeError::from(e).into())
     }
 
     fn target_reset(&mut self) -> Result<(), DebugProbeError> {
@@ -212,7 +213,9 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
             &[],
             &mut buf,
             TIMEOUT,
-        )
+        )?;
+
+        Ok(())
     }
 
     fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
@@ -226,7 +229,9 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
             &[],
             &mut buf,
             TIMEOUT,
-        )
+        )?;
+
+        Ok(())
     }
 
     fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
@@ -240,7 +245,9 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
             &[],
             &mut buf,
             TIMEOUT,
-        )
+        )?;
+
+        Ok(())
     }
 
     fn select_protocol(&mut self, protocol: WireProtocol) -> Result<(), DebugProbeError> {
@@ -293,6 +300,7 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
                     Err(StlinkError::VoltageDivisionByZero.into())
                 }
             })
+            .map_err(|e| e.into())
     }
 }
 
@@ -357,8 +365,14 @@ impl<D: StLinkUsb> StLink<D> {
     /// Firmware version that adds multiple AP support.
     const MIN_JTAG_VERSION_MULTI_AP: u8 = 28;
 
+    /// Firmware version which supports banked DP registers.
+    ///
+    /// This only applies to HW version 2, for version 3 we only support
+    /// FW versions where this is supported.
+    const MIN_JTAG_VERSION_DP_BANK_SEL: u8 = 32;
+
     /// Get the current mode of the ST-Link
-    fn get_current_mode(&mut self) -> Result<Mode, DebugProbeError> {
+    fn get_current_mode(&mut self) -> Result<Mode, StlinkError> {
         tracing::trace!("Getting current mode of device...");
         let mut buf = [0; 2];
         self.device
@@ -371,7 +385,7 @@ impl<D: StLinkUsb> StLink<D> {
             1 => MassStorage,
             2 => Jtag,
             3 => Swim,
-            _ => return Err(StlinkError::UnknownMode.into()),
+            _ => return Err(StlinkError::UnknownMode),
         };
 
         tracing::debug!("Current device mode: {:?}", mode);
@@ -379,9 +393,17 @@ impl<D: StLinkUsb> StLink<D> {
         Ok(mode)
     }
 
+    /// Check if selecting different banks in the DP is supported.
+    ///
+    /// If this is not supported, some DP registers cannot be accessed.
+    fn supports_dp_bank_selection(&self) -> bool {
+        (self.hw_version == 2 && self.jtag_version >= Self::MIN_JTAG_VERSION_DP_BANK_SEL)
+            || self.hw_version == 3
+    }
+
     /// Commands the ST-Link to enter idle mode.
     /// Internal helper.
-    fn enter_idle(&mut self) -> Result<(), DebugProbeError> {
+    fn enter_idle(&mut self) -> Result<(), StlinkError> {
         let mode = self.get_current_mode()?;
 
         match mode {
@@ -464,14 +486,14 @@ impl<D: StLinkUsb> StLink<D> {
 
         if let Err(e) = self.enter_idle() {
             match e {
-                DebugProbeError::Usb(_) => {
+                StlinkError::Usb(_) => {
                     // Reset the device, and try to enter idle mode again
                     self.device.reset()?;
 
                     self.enter_idle()?;
                 }
                 // Other error occurred, return it
-                _ => return Err(e),
+                _ => return Err(e.into()),
             }
         }
 
@@ -504,7 +526,9 @@ impl<D: StLinkUsb> StLink<D> {
             &[],
             &mut buf,
             TIMEOUT,
-        )
+        )?;
+
+        Ok(())
     }
 
     /// Sets the JTAG frequency.
@@ -522,7 +546,9 @@ impl<D: StLinkUsb> StLink<D> {
             &[],
             &mut buf,
             TIMEOUT,
-        )
+        )?;
+
+        Ok(())
     }
 
     /// Sets the communication frequency (V3 only)
@@ -546,7 +572,9 @@ impl<D: StLinkUsb> StLink<D> {
         command.extend_from_slice(&frequency_khz.to_le_bytes());
 
         let mut buf = [0; 8];
-        self.send_jtag_command(&command, &[], &mut buf, TIMEOUT)
+        self.send_jtag_command(&command, &[], &mut buf, TIMEOUT)?;
+
+        Ok(())
     }
 
     /// Returns the current and available communication frequencies (V3 only)
@@ -604,6 +632,8 @@ impl<D: StLinkUsb> StLink<D> {
             tracing::debug!("Opening AP {}", ap);
             self.open_ap(ap)?;
             self.opened_aps.push(ap);
+        } else {
+            tracing::trace!("AP {} already open.", ap);
         }
 
         Ok(())
@@ -628,7 +658,9 @@ impl<D: StLinkUsb> StLink<D> {
                 &mut buf,
                 TIMEOUT,
             )
-        })
+        })?;
+
+        Ok(())
     }
 
     /// Close a specific AP, which was opened with `open_ap`.
@@ -650,7 +682,9 @@ impl<D: StLinkUsb> StLink<D> {
                 &mut buf,
                 TIMEOUT,
             )
-        })
+        })?;
+
+        Ok(())
     }
 
     fn send_jtag_command(
@@ -659,13 +693,13 @@ impl<D: StLinkUsb> StLink<D> {
         write_data: &[u8],
         read_data: &mut [u8],
         timeout: Duration,
-    ) -> Result<(), DebugProbeError> {
+    ) -> Result<(), StlinkError> {
         self.device.write(cmd, write_data, read_data, timeout)?;
         match Status::from(read_data[0]) {
             Status::JtagOk => Ok(()),
             status => {
                 tracing::warn!("send_jtag_command {} failed: {:?}", cmd[0], status);
-                Err(StlinkError::CommandFailed(status).into())
+                Err(StlinkError::CommandFailed(status))
             }
         }
     }
@@ -725,19 +759,24 @@ impl<D: StLinkUsb> StLink<D> {
         Ok(buf)
     }
 
-    fn get_last_rw_status(&mut self) -> Result<(), DebugProbeError> {
+    #[tracing::instrument(skip(self))]
+    fn get_last_rw_status(&mut self) -> Result<(), StlinkError> {
         let mut receive_buffer = [0u8; 12];
+
         self.send_jtag_command(
             &[commands::JTAG_COMMAND, commands::JTAG_GETLASTRWSTATUS2],
             &[],
             &mut receive_buffer,
             TIMEOUT,
-        )
+        )?;
+
+        Ok(())
     }
 
     /// Reads the DAP register on the specified port and address.
     fn read_register(&mut self, port: u16, addr: u8) -> Result<u32, DebugProbeError> {
-        if port == DP_PORT && addr & 0xf0 != 0 {
+        if port == DP_PORT && addr & 0xf0 != 0 && !self.supports_dp_bank_selection() {
+            tracing::warn!("Trying to access DP register at address {addr:#x}, which is not supported on ST-Links.");
             return Err(StlinkError::BanksNotAllowedOnDPRegister.into());
         }
 
@@ -788,7 +827,9 @@ impl<D: StLinkUsb> StLink<D> {
         ];
         let mut buf = [0; 2];
 
-        retry_on_wait(|| self.send_jtag_command(cmd, &[], &mut buf, TIMEOUT))
+        retry_on_wait(|| self.send_jtag_command(cmd, &[], &mut buf, TIMEOUT))?;
+
+        Ok(())
     }
 
     fn read_mem_32bit(
@@ -824,7 +865,7 @@ impl<D: StLinkUsb> StLink<D> {
 
         let addbytes = address.to_le_bytes();
 
-        retry_on_wait(|| {
+        let value = retry_on_wait(|| {
             self.device.write(
                 &[
                     commands::JTAG_COMMAND,
@@ -843,7 +884,9 @@ impl<D: StLinkUsb> StLink<D> {
             )?;
 
             self.get_last_rw_status()
-        })
+        })?;
+
+        Ok(value)
     }
 
     fn read_mem_8bit(
@@ -958,7 +1001,9 @@ impl<D: StLinkUsb> StLink<D> {
             )?;
 
             self.get_last_rw_status()
-        })
+        })?;
+
+        Ok(())
     }
 
     fn write_mem_8bit(
@@ -1005,7 +1050,9 @@ impl<D: StLinkUsb> StLink<D> {
             )?;
 
             self.get_last_rw_status()
-        })
+        })?;
+
+        Ok(())
     }
 
     fn _read_debug_reg(&mut self, address: u32) -> Result<u32, DebugProbeError> {
@@ -1041,7 +1088,9 @@ impl<D: StLinkUsb> StLink<D> {
         cmd.pwrite_with(address, 2, LE).unwrap();
         cmd.pwrite_with(value, 6, LE).unwrap();
 
-        self.send_jtag_command(&cmd, &[], &mut buff, TIMEOUT)
+        self.send_jtag_command(&cmd, &[], &mut buff, TIMEOUT)?;
+
+        Ok(())
     }
 }
 
@@ -1092,6 +1141,8 @@ pub(crate) enum StlinkError {
     MultidropNotSupported,
     #[error("Unaligned")]
     UnalignedAddress,
+    #[error("USB")]
+    Usb(#[from] rusb::Error),
 }
 
 impl From<StlinkError> for DebugProbeError {
@@ -1112,6 +1163,7 @@ struct UninitializedStLink {
 }
 
 impl UninitializedArmProbe for UninitializedStLink {
+    #[tracing::instrument(skip(self, _sequence))]
     fn initialize(
         self: Box<Self>,
         _sequence: Arc<dyn ArmDebugSequence>,
@@ -1186,11 +1238,17 @@ impl StlinkArmDebug {
 }
 
 impl DapAccess for StlinkArmDebug {
+    #[tracing::instrument(skip(self), fields(value))]
     fn read_raw_dp_register(&mut self, dp: DpAddress, address: u8) -> Result<u32, ArmError> {
         if dp != DpAddress::Default {
             return Err(DebugProbeError::from(StlinkError::MultidropNotSupported).into());
         }
         let result = self.probe.read_register(DP_PORT, address)?;
+
+        tracing::Span::current().record("value", result);
+
+        tracing::debug!("Read succesful");
+
         Ok(result)
     }
 
@@ -1247,6 +1305,7 @@ impl ArmProbeInterface for StlinkArmDebug {
         Ok(Box::new(interface) as _)
     }
 
+    #[tracing::instrument(skip(self))]
     fn ap_information(
         &mut self,
         access_port: crate::architecture::arm::ap::GenericAp,
@@ -1587,22 +1646,14 @@ impl ArmProbe for StLinkMemoryInterface<'_> {
     }
 }
 
-fn is_wait_error(e: &DebugProbeError) -> bool {
-    if let DebugProbeError::ProbeSpecific(e) = e {
-        matches!(
-            e.downcast_ref(),
-            Some(StlinkError::CommandFailed(
-                Status::SwdDpWait | Status::SwdApWait
-            ))
-        )
-    } else {
-        false
-    }
+fn is_wait_error(e: &StlinkError) -> bool {
+    matches!(
+        e,
+        StlinkError::CommandFailed(Status::SwdDpWait | Status::SwdApWait)
+    )
 }
 
-fn retry_on_wait<R>(
-    mut f: impl FnMut() -> Result<R, DebugProbeError>,
-) -> Result<R, DebugProbeError> {
+fn retry_on_wait<R>(mut f: impl FnMut() -> Result<R, StlinkError>) -> Result<R, StlinkError> {
     let mut last_err = None;
     for attempt in 0..13 {
         match f() {
@@ -1667,7 +1718,7 @@ mod test {
             _write_data: &[u8],
             read_data: &mut [u8],
             _timeout: std::time::Duration,
-        ) -> Result<(), crate::DebugProbeError> {
+        ) -> Result<(), StlinkError> {
             match cmd[0] {
                 commands::GET_VERSION => {
                     // GET_VERSION response structure:
@@ -1789,9 +1840,6 @@ mod test {
 
     #[test]
     fn test_is_wait_error() {
-        assert!(!is_wait_error(&DebugProbeError::InterfaceNotAvailable(
-            "foo"
-        )));
         assert!(!is_wait_error(
             &StlinkError::BanksNotAllowedOnDPRegister.into()
         ));

--- a/probe-rs/src/probe/stlink/usb_interface.rs
+++ b/probe-rs/src/probe/stlink/usb_interface.rs
@@ -235,8 +235,7 @@ impl StLinkUsb for StLinkUsbDevice {
             return Err(StlinkError::NotEnoughBytesWritten {
                 is: written_bytes,
                 should: CMD_LEN,
-            }
-            .into());
+            });
         }
 
         // Optional data out phase.

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -200,7 +200,9 @@ impl Session {
 
                 {
                     // For each core, setup debugging
-                    for core in &target.cores {
+                    for (id, core) in target.cores.iter().enumerate() {
+                        let core_span = tracing::debug_span!("debug_setup", core_id = id).entered();
+
                         let arm_core_access_options = match &core.core_access_options {
                             probe_rs_target::CoreAccessOptions::Arm(opt) => opt,
                             probe_rs_target::CoreAccessOptions::Riscv(_) => {
@@ -230,6 +232,8 @@ impl Session {
                             arm_core_access_options.cti_base,
                         )?;
                         drop(core_start_sequence);
+
+                        drop(core_span);
                     }
                 }
 


### PR DESCRIPTION
`probe-rs-cli info` was updated to also read the DPIDR register, which led to errors with ST-Link probes.

Newer ST-Link firmware actually supports reading this register, so this PR adds a firmware version check.

This should fix #1349.