### PR TITLE
ci: Reduce dependabot frequency to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10


### PR DESCRIPTION
With the checked in lockfile, I find the daily dependabot PRs a bit too frequent.
Weekly updates are still enough to not become too outdated.
