### PR TITLE
ESP32C6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The finished/failed event would only be emitted when a sectorwise erase would be
 Now the events are correctly emitted.
 probe-rs: Emit chip erase started and finished/failed events correctly (#1470)
 
+- Add flashing and debugging support for the ESP32C6 (#1476)
+
 ## [0.16.0]
 
 Released 2023-01-29

--- a/probe-rs/src/architecture/riscv/sequences/esp32c6.rs
+++ b/probe-rs/src/architecture/riscv/sequences/esp32c6.rs
@@ -1,0 +1,47 @@
+//! Sequences for the ESP32C6.
+
+use std::sync::Arc;
+
+use super::RiscvDebugSequence;
+use crate::MemoryInterface;
+
+/// The debug sequence implementation for the ESP32C6.
+pub struct ESP32C6(());
+
+impl ESP32C6 {
+    /// Creates a new debug sequence handle for the ESP32C6.
+    pub fn create() -> Arc<dyn RiscvDebugSequence> {
+        Arc::new(Self(()))
+    }
+}
+
+impl RiscvDebugSequence for ESP32C6 {
+    fn on_connect(
+        &self,
+        interface: &mut crate::architecture::riscv::communication_interface::RiscvCommunicationInterface,
+    ) -> Result<(), crate::Error> {
+        tracing::info!("Disabling esp32c6 watchdogs...");
+        // disable super wdt
+        interface.write_word_32(0x600B1C20, 0x50D83AA1u32)?; // write protection off
+        let current = interface.read_word_32(0x600B_1C1C)?;
+        interface.write_word_32(0x600B_1C1C, current | 1 << 18)?; // set RTC_CNTL_SWD_AUTO_FEED_EN
+        interface.write_word_32(0x600B1C20, 0x0)?; // write protection on
+
+        // tg0 wdg
+        interface.write_word_32(0x6000_8064, 0x50D83AA1u32)?; // write protection off
+        interface.write_word_32(0x6000_8048, 0x0)?;
+        interface.write_word_32(0x6000_8064, 0x0)?; // write protection on
+
+        // tg1 wdg
+        interface.write_word_32(0x6000_9064, 0x50D83AA1u32)?; // write protection off
+        interface.write_word_32(0x6000_9048, 0x0)?;
+        interface.write_word_32(0x6000_9064, 0x0)?; // write protection on
+
+        // rtc wdg
+        interface.write_word_32(0x600B_1C18, 0x50D83AA1u32)?; // write protection off
+        interface.write_word_32(0x600B_1C00, 0x0)?;
+        interface.write_word_32(0x600B_1C18, 0x0)?; // write protection on
+
+        Ok(())
+    }
+}

--- a/probe-rs/src/architecture/riscv/sequences/mod.rs
+++ b/probe-rs/src/architecture/riscv/sequences/mod.rs
@@ -4,6 +4,7 @@ use super::communication_interface::RiscvCommunicationInterface;
 use std::sync::Arc;
 
 pub mod esp32c3;
+pub mod esp32c6;
 
 /// A interface to operate debug sequences for RISC-V targets.
 ///

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -12,7 +12,7 @@ use crate::architecture::arm::sequences::{
     stm32h7::Stm32h7,
     ArmDebugSequence,
 };
-use crate::architecture::riscv::sequences::esp32c3::ESP32C3;
+use crate::architecture::riscv::sequences::{esp32c3::ESP32C3, esp32c6::ESP32C6};
 use crate::architecture::riscv::sequences::{DefaultRiscvSequence, RiscvDebugSequence};
 use crate::flashing::FlashLoader;
 use std::sync::Arc;
@@ -105,8 +105,11 @@ impl Target {
             tracing::warn!("Using custom sequence for LPC55S16/LPC55S69");
             debug_sequence = DebugSequence::Arm(LPC55S69::create());
         } else if chip.name.starts_with("esp32c3") {
-            tracing::warn!("Using custom sequence for ESP32c3");
+            tracing::warn!("Using custom sequence for ESP32C3");
             debug_sequence = DebugSequence::Riscv(ESP32C3::create());
+        } else if chip.name.starts_with("esp32c6") {
+            tracing::warn!("Using custom sequence for ESP32C6");
+            debug_sequence = DebugSequence::Riscv(ESP32C6::create());
         } else if chip.name.starts_with("nRF5340") {
             tracing::warn!("Using custom sequence for nRF5340");
             debug_sequence = DebugSequence::Arm(Nrf5340::create());

--- a/probe-rs/targets/esp32c3.yaml
+++ b/probe-rs/targets/esp32c3.yaml
@@ -1,5 +1,5 @@
 ---
-name: esp32
+name: esp32c3
 manufacturer: ~
 variants:
   - name: esp32c3

--- a/probe-rs/targets/esp32c6.yaml
+++ b/probe-rs/targets/esp32c6.yaml
@@ -1,0 +1,59 @@
+---
+name: esp32c6
+manufacturer: null
+variants:
+  - name: esp32c6
+    part: null
+    cores:
+      - name: main
+        type: riscv
+        core_access_options: !Riscv {}
+    memory_map:
+      - !Nvm
+        range: #16 Mb Max addressable Flash size
+          start: 0x0
+          end: 0x01000000
+        is_boot_memory: true
+        cores:
+          - main
+      - !Nvm
+        range: # External Flash on Instruction/Data Bus
+          start: 0x42000000
+          end: 0x42FFFFFF
+        is_boot_memory: false
+        cores:
+          - main
+      - !Ram
+        range:
+          start: 0x40800000
+          end: 0x4087FFFF
+        is_boot_memory: false
+        cores:
+          - main
+    flash_algorithms:
+      - esp32c6-flashloader
+flash_algorithms:
+  - name: esp32c6-flashloader
+    description: A flasher loader for the esp32c6.
+    default: true
+    cores:
+      - main
+    instructions: QREGxjcFgUCDRUUGAUWF4QFFlwB//+eAoByXAH//54CgExHltwWBQAVGI4LFBrJAQQGCgDGBFwN//2cA4xAXA3//ZwBjDhN3NgABxxMFoAqCgK6GsoU2hhcDf/9nAEMPAUWCgAAAAAA=
+    load_address: 0x40810000
+    pc_init: 0x0
+    pc_uninit: 0x60
+    pc_program_page: 0x46
+    pc_erase_sector: 0x34
+    pc_erase_all: 0x3e
+    data_section_offset: 0x40810068
+    flash_properties:
+      address_range:
+        start: 0x0
+        end: 0x4000000
+      page_size: 0x800
+      erased_byte_value: 0xff
+      program_page_timeout: 1000
+      erase_sector_timeout: 2000
+      sectors:
+        - size: 0x1000
+          address: 0x0


### PR DESCRIPTION
- Adds a flash loader algo generated from https://github.com/esp-rs/esp-flash-loader/pull/2
- Adds a reset sequence which disables watchdogs

As with the ESP32C3, this only supports flashing [direct-boot](https://github.com/espressif/esp32c3-direct-boot-example#esp32-c3-direct-boot-example) format elf files.

There is an experimental branch adding ESP32C6 support to esp-hal [here](https://github.com/JurajSadel/esp-hal/commits/esp32c6), which you can use to test this algo. `cargo build --example $NAME --features direct-boot` and flash with probe-rs-cli, or `cargo flash --protocol jtag --speed 1000 --chip esp32c6 --example hello_world --features direct-boot`