### PR TITLE
nxp: fix reset sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- probe-rs: Fixed a race condition when reseting NXP chips under JTAG (#1482)
+
+  As an example, this makes flashing the Teensy 4.1 (which has an i.MX RT1062) reliable.
+
 ## [0.15.0]
 
 Released 2023-01-28


### PR DESCRIPTION
This fixes a race condition between the debugger and the MCU during reset.

Prior to this change, flashing would often fail.

After this change, I can reliably flash my Teensy 4.1 (which uses an NXP i.MX RT1062) using JTAG.

For reference, my original observations were captured here: https://github.com/probe-rs/probe-rs/pull/1174#issuecomment-1275568493

/cc @mciantyre 