### PR TITLE
Fix extraneous MSDAP "StoppedEvent" being sent from `probe-rs-debugger`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,196 +1,166 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Launch smoke tester",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--package=smoke_tester"
-                ]
-            },
-            "program": "${cargo:program}",
-            "args": [
-                "--dut-definitions=../dut-definitions/"
-            ]
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "DAP-Server probe-rs-debugger", // Use this to test the dap server .
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=probe-rs-debugger",
-                    "--package=probe-rs-debugger"
-                ],
-                "filter": {
-                    "name": "probe-rs-debugger",
-                    "kind": "bin"
-                }
-            },
-            "args": [
-                "debug",
-                "--port",
-                "50001"
-            ],
-            "env": {
-                "RUST_LOG": "error",
-                "DEFMT_LOG": "info"
-            },
-            "cwd": "${workspaceFolder}/debugger"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "list supported chips",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=probe-rs-debugger",
-                    "--package=probe-rs-debugger"
-                ],
-                "filter": {
-                    "name": "probe-rs-debugger",
-                    "kind": "bin"
-                }
-            },
-            "args": [
-                "list-chips",
-            ],
-            "cwd": "${workspaceFolder}/debugger"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "list attached probes",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=probe-rs-debugger",
-                    "--package=probe-rs-debugger"
-                ],
-                "filter": {
-                    "name": "probe-rs-debugger",
-                    "kind": "bin"
-                }
-            },
-            "args": [
-                "list",
-            ],
-            "cwd": "${workspaceFolder}/debugger"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "display help text",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=probe-rs-debugger",
-                    "--package=probe-rs-debugger"
-                ],
-                "filter": {
-                    "name": "probe-rs-debugger",
-                    "kind": "bin"
-                }
-            },
-            "args": [
-                "help",
-            ],
-            "cwd": "${workspaceFolder}/debugger"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "display debug subcommand help text",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=probe-rs-debugger",
-                    "--package=probe-rs-debugger"
-                ],
-                "filter": {
-                    "name": "probe-rs-debugger",
-                    "kind": "bin"
-                }
-            },
-            "args": [
-                "help",
-                "debug",
-            ],
-            "cwd": "${workspaceFolder}/debugger"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "target-gen Download and Update supported ARM target definitions",
-            "cwd": "${workspaceFolder}/target-gen",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=target-gen",
-                    "--package=target-gen"
-                ],
-                "filter": {
-                    "name": "target-gen",
-                    "kind": "bin"
-                }
-            },
-            "args": [
-                "arm",
-                // "--list", // Use this to list the available targets before filtering by chipFamily.
-                "--filter",
-                "${input:chipFamily}",
-                "${input:yamlFile}"
-            ],
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "target-gen Generate target yaml from single ARM CMSIS Pack file",
-            "cwd": "${workspaceFolder}/target-gen",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=target-gen",
-                    "--package=target-gen"
-                ],
-                "filter": {
-                    "name": "target-gen",
-                    "kind": "bin"
-                }
-            },
-            "args": [
-                "pack",
-                "${input:packFile}",
-                "${input:yamlFile}"
-            ],
-        },
-    ],
-    "inputs": [
-        {
-            "id": "packFile",
-            "type": "promptString",
-            "description": "Please enter the path to Pack file or the unzipped Pack directory.",
-            "default": "${workspaceFolder}/../pack_files/NXP.LPC55S69_DFP.15.0.0.pack"
-        },
-        {
-            "id": "yamlFile",
-            "type": "promptString",
-            "description": "Please enter the path to the output directory for yaml files.",
-            "default": "${workspaceFolder}/probe-rs/targets"
-        },
-        {
-            "id": "chipFamily",
-            "type": "promptString",
-            "description": "Please enter the name or part of a name to filter the list of chips to be generated.",
-            "default": "STM32H7xx_DFP"
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Launch smoke tester",
+      "cargo": {
+        "args": ["build", "--package=smoke_tester"]
+      },
+      "program": "${cargo:program}",
+      "args": ["--dut-definitions=../dut-definitions/"]
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "DAP-Server probe-rs-debugger", // Use this to test the dap server .
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=probe-rs-debugger",
+          "--package=probe-rs-debugger"
+        ],
+        "filter": {
+          "name": "probe-rs-debugger",
+          "kind": "bin"
         }
-    ]
+      },
+      "args": ["debug", "--port", "50001"],
+      // "env": {
+      //     "RUST_LOG": "error",
+      //     "DEFMT_LOG": "info"
+      // },
+      "cwd": "${workspaceFolder}/debugger"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "list supported chips",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=probe-rs-debugger",
+          "--package=probe-rs-debugger"
+        ],
+        "filter": {
+          "name": "probe-rs-debugger",
+          "kind": "bin"
+        }
+      },
+      "args": ["list-chips"],
+      "cwd": "${workspaceFolder}/debugger"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "list attached probes",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=probe-rs-debugger",
+          "--package=probe-rs-debugger"
+        ],
+        "filter": {
+          "name": "probe-rs-debugger",
+          "kind": "bin"
+        }
+      },
+      "args": ["list"],
+      "cwd": "${workspaceFolder}/debugger"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "display help text",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=probe-rs-debugger",
+          "--package=probe-rs-debugger"
+        ],
+        "filter": {
+          "name": "probe-rs-debugger",
+          "kind": "bin"
+        }
+      },
+      "args": ["help"],
+      "cwd": "${workspaceFolder}/debugger"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "display debug subcommand help text",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=probe-rs-debugger",
+          "--package=probe-rs-debugger"
+        ],
+        "filter": {
+          "name": "probe-rs-debugger",
+          "kind": "bin"
+        }
+      },
+      "args": ["help", "debug"],
+      "cwd": "${workspaceFolder}/debugger"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "target-gen Download and Update supported ARM target definitions",
+      "cwd": "${workspaceFolder}/target-gen",
+      "cargo": {
+        "args": ["build", "--bin=target-gen", "--package=target-gen"],
+        "filter": {
+          "name": "target-gen",
+          "kind": "bin"
+        }
+      },
+      "args": [
+        "arm",
+        // "--list", // Use this to list the available targets before filtering by chipFamily.
+        "--filter",
+        "${input:chipFamily}",
+        "${input:yamlFile}"
+      ]
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "target-gen Generate target yaml from single ARM CMSIS Pack file",
+      "cwd": "${workspaceFolder}/target-gen",
+      "cargo": {
+        "args": ["build", "--bin=target-gen", "--package=target-gen"],
+        "filter": {
+          "name": "target-gen",
+          "kind": "bin"
+        }
+      },
+      "args": ["pack", "${input:packFile}", "${input:yamlFile}"]
+    }
+  ],
+  "inputs": [
+    {
+      "id": "packFile",
+      "type": "promptString",
+      "description": "Please enter the path to Pack file or the unzipped Pack directory.",
+      "default": "${workspaceFolder}/../pack_files/NXP.LPC55S69_DFP.15.0.0.pack"
+    },
+    {
+      "id": "yamlFile",
+      "type": "promptString",
+      "description": "Please enter the path to the output directory for yaml files.",
+      "default": "${workspaceFolder}/probe-rs/targets"
+    },
+    {
+      "id": "chipFamily",
+      "type": "promptString",
+      "description": "Please enter the name or part of a name to filter the list of chips to be generated.",
+      "default": "STM32H7xx_DFP"
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add flashing and debugging support for the ESP32C6 (#1476)
 
+- VSCode: Avoid sending extraneous `StoppedEvent` from probe-rs-debugger (#1485).
+
 ## [0.16.0]
 
 Released 2023-01-29
 
 probe-rs library is unchanged, version number is increased to keep in sync with other
 probe-rs packages.
-
 
 ## [0.15.0]
 

--- a/debugger/src/debugger/core_data.rs
+++ b/debugger/src/debugger/core_data.rs
@@ -83,7 +83,8 @@ impl<'p> CoreHandle<'p> {
                                 // HaltReason::Step is a special case, where we have to send a custome event to the client that the core halted.
                                 // In this case, we don't re-send the "stopped" event, but further down, we will
                                 // update the `last_known_status` to the actual HaltReason returned by the core.
-                                if self.core_data.last_known_status != CoreStatus::Halted(HaltReason::Step)
+                                if self.core_data.last_known_status
+                                    != CoreStatus::Halted(HaltReason::Step)
                                 {
                                     let program_counter = self
                                         .core

--- a/debugger/src/debugger/core_data.rs
+++ b/debugger/src/debugger/core_data.rs
@@ -83,7 +83,7 @@ impl<'p> CoreHandle<'p> {
                                 // HaltReason::Step is a special case, where we have to send a custome event to the client that the core halted.
                                 // In this case, we don't re-send the "stopped" event, but further down, we will
                                 // update the `last_known_status` to the actual HaltReason returned by the core.
-                                if !matches!(self.core_data.last_known_status, CoreStatus::Halted(halt_reason) if halt_reason == HaltReason::Step)
+                                if self.core_data.last_known_status != CoreStatus::Halted(HaltReason::Step)
                                 {
                                     let program_counter = self
                                         .core


### PR DESCRIPTION
During the 'step' processing, the debugger would send a `StoppedEvent` with reason `step`, and immediately after, the regular polling operation would send another `StoppedEvent` with reason `breakpoint`. The result of this was that the client would duplicate the identical sequence of  `Threads->Stacktrace->Scopes->Variables` requests. This caused duplicated processing in `probe-rs-debugger`.