### PR TITLE
jlink: correctly return WAIT status for AP reads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   As an example, this makes flashing the Teensy 4.1 (which has an i.MX RT1062) reliable.
 
+- probe-rs: jlink: fix WAIT retries on AP reads. Fixes flashing on nrf91. (#1489)
+
 - Add flashing and debugging support for the ESP32C6 (#1476)
 
 - VSCode: Avoid sending extraneous `StoppedEvent` from probe-rs-debugger (#1485).


### PR DESCRIPTION
Fixes flashing the nrf91 with the onboard jlink. 

Chip erase still fails though. I think it has never worked, even in past versions where flashing did work.

related: #1223 