### PR TITLE
Add support for Star-MC1 core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - st-link: Support reading banked DP registers if firmware is new enough to support it.
 
+- target-gen: Add support for STAR-MC1 by Arm China
+
 ### Fixed
 
 - probe-rs: Emit chip erase started and finished/failed events correctly (#1470)

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -181,6 +181,7 @@ fn core_to_probe_core(value: &Core) -> Result<CoreType, Error> {
         Core::CortexM23 => CoreType::Armv8m,
         Core::CortexM33 => CoreType::Armv8m,
         Core::CortexM7 => CoreType::Armv7em,
+        Core::StarMC1 => CoreType::Armv8m,
         c => {
             bail!("Core '{:?}' is not yet supported for target generation.", c);
         }


### PR DESCRIPTION
STAR-MC1 is a variant of Armv8-M with TrustZone designed by Arm China.

See-also: https://github.com/pyocd/cmsis-pack-manager/pull/204

