### PR TITLE
Fixing erase progress event emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- probe-rs: Emit chip erase started and finished/failed events correctly (#1470)
+- probe-rs: Emit chip erase started and finished/failed events correctly (#1470) (#1496)
 
   The finished/failed event would only be emitted when a sectorwise erase would be performed.
   Now the events are correctly emitted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- probe-rs: Emit chip erase started and finished/failed events correctly (#1470) (#1496)
+- probe-rs: Emit chip erase started and finished/failed events correctly (#1470, #1496)
 
   The finished/failed event would only be emitted when a sectorwise erase would be performed.
   Now the events are correctly emitted.

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -193,9 +193,8 @@ impl<'session> Flasher<'session> {
     }
 
     pub(super) fn run_erase_all(&mut self) -> Result<(), FlashError> {
-        if self.session.has_sequence_erase_all() {
-            self.progress.started_erasing();
-
+        self.progress.started_erasing();
+        let result = if self.session.has_sequence_erase_all() {
             fn run(flasher: &mut Flasher) -> Result<(), FlashError> {
                 flasher
                     .session
@@ -208,18 +207,18 @@ impl<'session> Flasher<'session> {
                 flasher.load()
             }
 
-            let result = run(self);
-
-            if result.is_ok() {
-                self.progress.finished_erasing();
-            } else {
-                self.progress.failed_erasing();
-            }
-
-            result
+            run(self)
         } else {
             self.run_erase(|active| active.erase_all())
+        };
+
+        if result.is_ok() {
+            self.progress.finished_erasing();
+        } else {
+            self.progress.failed_erasing();
         }
+
+        result
     }
 
     pub(super) fn run_erase<T, F>(&mut self, f: F) -> Result<T, FlashError>


### PR DESCRIPTION
This PR fixes #1469 ( again) by updating emission of the flash erase start/stop events to not depend on the presence of the erase debug sequence.

CC @Yatekii 