### PR TITLE
Fix: VSCode using probe-rs debugger is very slow if `rttEnabled: true` and target application has no RTT.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- VSCode and probe-rs-debugger is very slow if `rttEnabled: true` and target application has no RTT initialized (#1497).
+
 ## [0.17.0]
 
 Released 2023-02-06
@@ -31,6 +35,7 @@ Released 2023-02-06
 - Add flashing and debugging support for the ESP32C6 (#1476)
 
 - Debug: Fixed a number of known issues, which included some code refactoring to avoid code duplication (#1484).
+
   - Unwind of variables that are in inlined subroutines now resolve correctly under all known conditions.
   - Unwind of nested arrays now resolve, irrespective of the levels of nesting (#1404).
   - Gracefully handle the unwind of arrays that are empty.


### PR DESCRIPTION
Fixes #1497

The long delay is caused when RTT attach attempts to scan the target memory for the RTT control block. Since there is none, this retries and has no hope of ever succeeding.

The change now scans the binary file for the RTT control block, and will not fall back to scanning the target memory.

This makes the user experience much better, but ultimately the overhead can be completely avoided by deleting, or setting `rttEnabled: false` in the launch.json, if the target application does not use RTT.