### PR TITLE
`prober-rs-debugger`: Improve performance of the `readMemory` request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - VSCode and probe-rs-debugger is very slow if `rttEnabled: true` and target application has no RTT initialized (#1497).
 
+- prober-rs-debugger: Using the readMemory request on RISC-V (ESP32C3 board) is slow (#1275).
+
 ## [0.17.0]
 
 Released 2023-02-06


### PR DESCRIPTION
Fixes #1275

The original issue was more noticeable against the ESP32-C3 RISC-V chip, but the solution will improve performance of this operation for all core types.