### PR TITLE
Refactor startup code in debugger

### DIFF
--- a/debugger/src/debug_adapter/dap_adapter.rs
+++ b/debugger/src/debug_adapter/dap_adapter.rs
@@ -536,10 +536,8 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         if let Some(request) = request {
             // Use reset_and_halt(), and then resume again afterwards, depending on the reset_after_halt flag.
             if let Err(error) = target_core.core.reset_and_halt(Duration::from_millis(500)) {
-                return self.send_response::<()>(
-                    request,
-                    Err(DebuggerError::Other(anyhow!("{}", error))),
-                );
+                return self
+                    .send_response::<()>(request, Err(DebuggerError::Other(anyhow!("{}", error))));
             }
 
             // Ensure ebreak enters debug mode, this is necessary for soft breakpoints to work on architectures like RISC-V.
@@ -1226,10 +1224,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 });
             };
         }
-        self.send_response(
-            request,
-            Ok(Some(ScopesResponseBody { scopes: dap_scopes })),
-        )
+        self.send_response(request, Ok(Some(ScopesResponseBody { scopes: dap_scopes })))
     }
 
     /// Attempt to extract disassembled source code to supply the instruction_count required.
@@ -1792,10 +1787,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 Ok(())
             }
             Err(error) => {
-                self.send_response::<()>(
-                    request,
-                    Err(DebuggerError::Other(anyhow!("{}", error))),
-                )?;
+                self.send_response::<()>(request, Err(DebuggerError::Other(anyhow!("{}", error))))?;
                 Err(error.into())
             }
         }

--- a/debugger/src/debugger/configuration.rs
+++ b/debugger/src/debugger/configuration.rs
@@ -9,9 +9,6 @@ use std::{env::current_dir, path::PathBuf};
 #[derive(Clone, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionConfig {
-    /// IP port number to listen for incoming DAP connections, e.g. "50000"
-    pub(crate) port: Option<u16>,
-
     /// Level of information to be logged to the debugger console (Error, Info or Debug )
     #[serde(default = "default_console_log")]
     pub(crate) console_log_level: Option<ConsoleLog>,
@@ -19,7 +16,7 @@ pub struct SessionConfig {
     /// Path to the requested working directory for the debugger
     pub(crate) cwd: Option<PathBuf>,
 
-    /// The number associated with the debug probe to use. Use 'list' command to see available probes
+    /// The debug probe selector associated with the debug probe to use. Use 'list' command to see available probes
     #[serde(alias = "probe")]
     pub(crate) probe_selector: Option<DebugProbeSelector>,
 

--- a/debugger/src/debugger/debug_entry.rs
+++ b/debugger/src/debugger/debug_entry.rs
@@ -70,9 +70,6 @@ pub struct Debugger {
 
 impl Debugger {
     /// Create a new debugger instance
-    ///
-    /// If `port` is `None`, the debugger will communicate over stdin and stdout,
-    /// otherwise it will listen for messages on the given port.
     pub fn new(timestamp_offset: UtcOffset) -> Self {
         Self {
             config: configuration::SessionConfig::default(),
@@ -414,7 +411,7 @@ impl Debugger {
                 Err(DebuggerError::Other(anyhow!(error_message.clone()))),
             )?;
 
-            return Err(DebuggerError::Other(anyhow!(error_message)));
+            Err(DebuggerError::Other(anyhow!(error_message)))
         })?;
 
         self.config = configuration::SessionConfig { ..arguments };
@@ -486,7 +483,7 @@ impl Debugger {
             .attach_core(target_core_config.core_index)
             .or_else(|error| {
                 debug_adapter.send_error_response(&error)?;
-                return Err(error);
+                Err(error)
             })?;
 
         // Immediately after attaching, halt the core, so that we can finish initalization without bumping into user code.

--- a/debugger/src/debugger/debug_entry.rs
+++ b/debugger/src/debugger/debug_entry.rs
@@ -462,27 +462,6 @@ impl Debugger {
                     return Err(err);
                 };
 
-            debug_adapter = self.flash(
-                &path_to_elf,
-                debug_adapter,
-                launch_attach_request.seq,
-                &mut session_data,
-            )?;
-        }
-
-        if self.config.flashing_config.flashing_enabled {
-            let target_core_config = self.config.core_configs.first_mut().ok_or_else(|| {
-                DebuggerError::Other(anyhow!(
-                    "Cannot continue unless one target core configuration is defined."
-                ))
-            })?;
-            let Some(path_to_elf) = target_core_config.program_binary.clone() else {
-                    let err =  DebuggerError::Other(anyhow!("Please specify use the `program-binary` option in `launch.json` to specify an executable"));
-
-                    debug_adapter.send_error_response(&err)?;
-                    return Err(err);
-                };
-
             // Store timestamp of flashed binary
             self.binary_timestamp = get_file_timestamp(&path_to_elf);
 

--- a/debugger/src/debugger/debug_entry.rs
+++ b/debugger/src/debugger/debug_entry.rs
@@ -360,7 +360,7 @@ impl Debugger {
             match debug_session_status {
                 DebugSessionStatus::Continue => {
                     // All is good. We can process the next request.
-                    ()
+                    
                 }
                 DebugSessionStatus::Restart(request) => {
                     debug_adapter = self.restart(debug_adapter, &mut session_data, &request)?;

--- a/debugger/src/debugger/debug_entry.rs
+++ b/debugger/src/debugger/debug_entry.rs
@@ -524,6 +524,8 @@ impl Debugger {
 
         drop(target_core);
 
+        debug_adapter.send_response::<()>(&launch_attach_request, Ok(None))?;
+
         Ok((debug_adapter, session_data))
     }
 

--- a/debugger/src/debugger/debug_entry.rs
+++ b/debugger/src/debugger/debug_entry.rs
@@ -360,7 +360,6 @@ impl Debugger {
             match debug_session_status {
                 DebugSessionStatus::Continue => {
                     // All is good. We can process the next request.
-                    
                 }
                 DebugSessionStatus::Restart(request) => {
                     debug_adapter = self.restart(debug_adapter, &mut session_data, &request)?;

--- a/debugger/src/debugger/session_data.rs
+++ b/debugger/src/debugger/session_data.rs
@@ -249,10 +249,10 @@ impl SessionData {
             };
 
             // We need to poll the core to determine its status.
-            let current_core_status = target_core.poll_core(debug_adapter).or_else(|error| {
+            let current_core_status = target_core.poll_core(debug_adapter).map_err(|error| {
                 let error = DebuggerError::ProbeRs(error);
                 let _ = debug_adapter.send_error_response(&error);
-                return Err(error);
+                error
             })?;
 
             // If appropriate, check for RTT data.

--- a/debugger/src/debugger/session_data.rs
+++ b/debugger/src/debugger/session_data.rs
@@ -209,7 +209,7 @@ impl SessionData {
         }
     }
 
-    /// The target has no way of notifying the debug adapater when things changes, so we have to constantly poll it to determine:
+    /// The target has no way of notifying the debug adapter when things changes, so we have to constantly poll it to determine:
     /// - Whether the target cores are running, and what their actual status is.
     /// - Whether the target cores have data in their RTT buffers that we need to read and pass to the client.
     ///
@@ -240,61 +240,59 @@ impl SessionData {
         // Always set `all_cores_halted` to true, until one core is found to be running.
         debug_adapter.all_cores_halted = true;
         for core_config in session_config.core_configs.iter() {
-            if let Ok(mut target_core) = self.attach_core(core_config.core_index) {
-                // We need to poll the core to determine its status.
-                match target_core.poll_core(debug_adapter) {
-                    Ok(current_core_status) => {
-                        // If appropriate, check for RTT data.
-                        if core_config.rtt_config.enabled {
-                            if let Some(core_rtt) = &mut target_core.core_data.rtt_connection {
-                                // We should poll the target for rtt data, and if any RTT data was processed, we clear the flag.
-                                if core_rtt.process_rtt_data(debug_adapter, &mut target_core.core) {
-                                    suggest_delay_required = false;
-                                }
-                            } else if debug_adapter.configuration_is_done() {
-                                // We have not yet reached the point in the target application where the RTT buffers are initialized,
-                                // so, provided we have processed the MSDAP request for "configurationDone" , we should check again.
-                                {
-                                    #[allow(clippy::unwrap_used)]
-                                    match target_core.attach_to_rtt(
-                                        debug_adapter,
-                                        target_memory_map,
-                                        core_config.program_binary.as_ref().unwrap(),
-                                        &core_config.rtt_config,
-                                        timestamp_offset,
-                                    ) {
-                                        Ok(_) => {
-                                            // Nothing else to do.
-                                        }
-                                        Err(error) => {
-                                            debug_adapter
-                                                .send_error_response(&DebuggerError::Other(error))
-                                                .ok();
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        // If the core is running, we set the flag to indicate that at least one core is not halted.
-                        // By setting it here, we ensure that RTT will be checked at least once after the core has halted.
-                        if !current_core_status.is_halted() {
-                            debug_adapter.all_cores_halted = false;
-                        }
-                        status_of_cores.push(current_core_status);
-                    }
-                    Err(error) => {
-                        let error = DebuggerError::ProbeRs(error);
-                        let _ = debug_adapter.send_error_response(&error);
-                        return Err(error);
-                    }
-                }
-            } else {
+            let Ok(mut target_core) = self.attach_core(core_config.core_index) else {
                 tracing::debug!(
                     "Failed to attach to target core #{}. Cannot poll for RTT data.",
                     core_config.core_index
                 );
+                continue;
+            };
+
+            // We need to poll the core to determine its status.
+            let current_core_status = target_core.poll_core(debug_adapter).or_else(|error| {
+                let error = DebuggerError::ProbeRs(error);
+                let _ = debug_adapter.send_error_response(&error);
+                return Err(error);
+            })?;
+
+            // If appropriate, check for RTT data.
+            if core_config.rtt_config.enabled {
+                if let Some(core_rtt) = &mut target_core.core_data.rtt_connection {
+                    // We should poll the target for rtt data, and if any RTT data was processed, we clear the flag.
+                    if core_rtt.process_rtt_data(debug_adapter, &mut target_core.core) {
+                        suggest_delay_required = false;
+                    }
+                } else if debug_adapter.configuration_is_done() {
+                    // We have not yet reached the point in the target application where the RTT buffers are initialized,
+                    // so, provided we have processed the MSDAP request for "configurationDone" , we should check again.
+                    {
+                        #[allow(clippy::unwrap_used)]
+                        match target_core.attach_to_rtt(
+                            debug_adapter,
+                            target_memory_map,
+                            core_config.program_binary.as_ref().unwrap(),
+                            &core_config.rtt_config,
+                            timestamp_offset,
+                        ) {
+                            Ok(_) => {
+                                // Nothing else to do.
+                            }
+                            Err(error) => {
+                                debug_adapter
+                                    .send_error_response(&DebuggerError::Other(error))
+                                    .ok();
+                            }
+                        }
+                    }
+                }
             }
+
+            // If the core is running, we set the flag to indicate that at least one core is not halted.
+            // By setting it here, we ensure that RTT will be checked at least once after the core has halted.
+            if !current_core_status.is_halted() {
+                debug_adapter.all_cores_halted = false;
+            }
+            status_of_cores.push(current_core_status);
         }
         Ok((status_of_cores, suggest_delay_required))
     }

--- a/debugger/src/main.rs
+++ b/debugger/src/main.rs
@@ -81,7 +81,7 @@ enum CliCommands {
     Debug {
         /// IP port number to listen for incoming DAP connections, e.g. "50000"
         #[clap(long)]
-        port: Option<u16>,
+        port: u16,
 
         /// The debug adapter processed was launched by VSCode, and should terminate itself at the end of every debug session (when receiving `Disconnect` or `Terminate` Request from VSCode). The "false"(default) state of this option implies that the process was launched (and will be managed) by the user.
         #[clap(long, hide = true)]

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -182,12 +182,10 @@ impl RegisterValue {
 
     /// A helper function to determine if the contained register value is zero.
     pub fn is_zero(&self) -> bool {
-        match self {
-            RegisterValue::U32(0) => true,
-            RegisterValue::U64(0) => true,
-            RegisterValue::U128(0) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            RegisterValue::U32(0) | RegisterValue::U64(0) | RegisterValue::U128(0)
+        )
     }
 }
 

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -1,7 +1,6 @@
 use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
 use crate::architecture::riscv::RiscVState;
 use crate::{CoreType, InstructionSet};
-use num_traits::Zero;
 pub use probe_rs_target::{Architecture, CoreAccessOptions};
 
 use crate::architecture::{
@@ -184,9 +183,10 @@ impl RegisterValue {
     /// A helper function to determine if the contained register value is zero.
     pub fn is_zero(&self) -> bool {
         match self {
-            RegisterValue::U32(register_value) => register_value.is_zero(),
-            RegisterValue::U64(register_value) => register_value.is_zero(),
-            RegisterValue::U128(register_value) => register_value.is_zero(),
+            RegisterValue::U32(0) => true,
+            RegisterValue::U64(0) => true,
+            RegisterValue::U128(0) => true,
+            _ => false,
         }
     }
 }

--- a/probe-rs/src/debug/source_statement.rs
+++ b/probe-rs/src/debug/source_statement.rs
@@ -1,6 +1,5 @@
 use super::{unit_info::UnitInfo, DebugError, DebugInfo};
 use gimli::{ColumnType, LineSequence};
-use num_traits::Zero;
 use std::{
     fmt::{Debug, Formatter},
     num::NonZeroU64,
@@ -100,7 +99,7 @@ impl SourceStatements {
             }
         }
 
-        if source_statements.len().is_zero() {
+        if source_statements.len() == 0 {
             Err(DebugError::NoValidHaltLocation{
                 message: "Could not find valid source statements for this address. Consider using instruction level stepping.".to_string(),
                 pc_at_error: program_counter,

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -1,7 +1,6 @@
 use super::*;
 use anyhow::anyhow;
 use gimli::{DebugInfoOffset, UnitOffset};
-use num_traits::Zero;
 use std::str::FromStr;
 
 /// Define the role that a variable plays in a Variant relationship. See section '5.7.10 Variant Entries' of the DWARF 5 specification
@@ -706,7 +705,7 @@ impl Variable {
         indentation: usize,
         show_name: bool,
     ) -> String {
-        let line_feed = if indentation.is_zero() { "" } else { "\n" }.to_string();
+        let line_feed = if indentation == 0 { "" } else { "\n" }.to_string();
         // Allow for chained `if let` without complaining
         #[allow(clippy::if_same_then_else)]
         if !self.value.is_empty() {
@@ -1023,7 +1022,7 @@ impl Value for String {
                     }
                     None => 0_u64,
                 };
-                if string_location.is_zero() {
+                if string_location == 0 {
                     str_value = "Error: Failed to determine &str memory location".to_string();
                 } else {
                     // Limit string length to work around buggy information, otherwise the debugger
@@ -1039,7 +1038,7 @@ impl Value for String {
                         string_length = 200;
                     }
 
-                    if string_length.is_zero() {
+                    if string_length == 0 {
                         // A string with length 0 doesn't need to be read from memory.
                     } else {
                         let mut buff = vec![0u8; string_length];

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1842,17 +1842,15 @@ mod test {
 
     #[test]
     fn test_is_wait_error() {
-        assert!(!is_wait_error(
-            &StlinkError::BanksNotAllowedOnDPRegister
-        ));
-        assert!(!is_wait_error(
-            &StlinkError::CommandFailed(Status::JtagFreqNotSupported)
-        ));
-        assert!(is_wait_error(
-            &StlinkError::CommandFailed(Status::SwdDpWait)
-        ));
-        assert!(is_wait_error(
-            &StlinkError::CommandFailed(Status::SwdApWait)
-        ));
+        assert!(!is_wait_error(&StlinkError::BanksNotAllowedOnDPRegister));
+        assert!(!is_wait_error(&StlinkError::CommandFailed(
+            Status::JtagFreqNotSupported
+        )));
+        assert!(is_wait_error(&StlinkError::CommandFailed(
+            Status::SwdDpWait
+        )));
+        assert!(is_wait_error(&StlinkError::CommandFailed(
+            Status::SwdApWait
+        )));
     }
 }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1843,16 +1843,16 @@ mod test {
     #[test]
     fn test_is_wait_error() {
         assert!(!is_wait_error(
-            &StlinkError::BanksNotAllowedOnDPRegister.into()
+            &StlinkError::BanksNotAllowedOnDPRegister
         ));
         assert!(!is_wait_error(
-            &StlinkError::CommandFailed(Status::JtagFreqNotSupported).into()
+            &StlinkError::CommandFailed(Status::JtagFreqNotSupported)
         ));
         assert!(is_wait_error(
-            &StlinkError::CommandFailed(Status::SwdDpWait).into()
+            &StlinkError::CommandFailed(Status::SwdDpWait)
         ));
         assert!(is_wait_error(
-            &StlinkError::CommandFailed(Status::SwdApWait).into()
+            &StlinkError::CommandFailed(Status::SwdApWait)
         ));
     }
 }


### PR DESCRIPTION
I've tried to refactor the "startup" code of the debugger to make it a bit easier to read, the actual functionality should be unchanged.

It's mostly splitting up the `debug_session` function into different functions, so it's easier to see what's going on, and trying to reduce the nesting level, by returning early.

@noppej This probably conflicts with #1506, I'm happy to wait until that one gets merged and will then update this PR.