### PR TITLE
Add target support for LPC55Sxx chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - prober-rs-debugger: Using the readMemory request on RISC-V (ESP32C3 board) is slow (#1275).
 
+### Added
+
+- Added LPC55Sxx target #1513
+
 ## [0.17.0]
 
 Released 2023-02-06

--- a/probe-rs/src/architecture/arm/sequences/nxp.rs
+++ b/probe-rs/src/architecture/arm/sequences/nxp.rs
@@ -87,17 +87,17 @@ fn debug_port_start(
     Ok(powered_down)
 }
 
-/// The sequence handle for the LPC55S69.
-pub struct LPC55S69(());
+/// The sequence handle for the LPC55Sxx family.
+pub struct LPC55Sxx(());
 
-impl LPC55S69 {
-    /// Create a sequence handle for the LPC55S69.
+impl LPC55Sxx {
+    /// Create a sequence handle for the LPC55Sxx.
     pub fn create() -> Arc<dyn ArmDebugSequence> {
         Arc::new(Self(()))
     }
 }
 
-impl ArmDebugSequence for LPC55S69 {
+impl ArmDebugSequence for LPC55Sxx {
     fn debug_port_start(
         &self,
         interface: &mut ArmCommunicationInterface<Initialized>,

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -7,7 +7,7 @@ use crate::architecture::arm::sequences::{
     nrf52::Nrf52,
     nrf53::Nrf5340,
     nrf91::Nrf9160,
-    nxp::{MIMXRT10xx, MIMXRT11xx, LPC55S69},
+    nxp::{LPC55Sxx, MIMXRT10xx, MIMXRT11xx},
     stm32f_series::Stm32fSeries,
     stm32h7::Stm32h7,
     ArmDebugSequence,
@@ -101,9 +101,14 @@ impl Target {
         } else if chip.name.starts_with("MIMXRT11") {
             tracing::warn!("Using custom sequence for MIMXRT11xx");
             debug_sequence = DebugSequence::Arm(MIMXRT11xx::create());
-        } else if chip.name.starts_with("LPC55S16") || chip.name.starts_with("LPC55S69") {
-            tracing::warn!("Using custom sequence for LPC55S16/LPC55S69");
-            debug_sequence = DebugSequence::Arm(LPC55S69::create());
+        } else if chip.name.starts_with("LPC55S16")
+            || chip.name.starts_with("LPC55S26")
+            || chip.name.starts_with("LPC55S28")
+            || chip.name.starts_with("LPC55S66")
+            || chip.name.starts_with("LPC55S69")
+        {
+            tracing::warn!("Using custom sequence for LPC55S16/26/28/66/69");
+            debug_sequence = DebugSequence::Arm(LPC55Sxx::create());
         } else if chip.name.starts_with("esp32c3") {
             tracing::warn!("Using custom sequence for ESP32C3");
             debug_sequence = DebugSequence::Riscv(ESP32C3::create());


### PR DESCRIPTION
Adding support for LPC55Sxx chips besides the LPC55S69, which was already supported.

Tested with cargo flash and cargo embed, working for both on LPC55S28