### PR TITLE
Add custom sequence support for STM32 F0, F3, G0, G4, WB, WL, L0, L1, L4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added LPC55Sxx target #1513
+- Added custom sequence support to STM32L0, L1, L4, G0, G4, F0, F3, WB, WL,
+  enabling debug clocks during sleep modes #1521
 
 ## [0.17.0]
 

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -7,7 +7,8 @@ pub mod nrf52;
 pub mod nrf53;
 pub mod nrf91;
 pub mod nxp;
-pub mod stm32f_series;
+pub mod stm32_armv6;
+pub mod stm32_armv7;
 pub mod stm32h7;
 
 use std::{

--- a/probe-rs/src/architecture/arm/sequences/stm32_armv6.rs
+++ b/probe-rs/src/architecture/arm/sequences/stm32_armv6.rs
@@ -1,0 +1,211 @@
+//! Sequences for ARMv6 STM32s: STM32F0, STM32G0, STM32L0.
+//!
+//! This covers devices where DBGMCU is at 0x40015800 and has the DBG_STANDBY and DBG_STOP bits.
+
+use std::sync::Arc;
+
+use super::ArmDebugSequence;
+use crate::architecture::arm::{ap::MemoryAp, ApAddress, ArmError, ArmProbeInterface, DpAddress};
+
+/// Supported families for custom sequences on ARMv6 STM32 devices.
+pub enum Stm32Armv6Family {
+    /// STM32F0 family
+    F0,
+
+    /// STM32L0 family
+    L0,
+
+    /// STM32G0 family
+    G0,
+}
+
+/// Marker structure for ARMv6 STM32 devices.
+pub struct Stm32Armv6 {
+    family: Stm32Armv6Family,
+}
+
+impl Stm32Armv6 {
+    /// Create the sequencer for ARMv6 STM32 devices.
+    pub fn create(family: Stm32Armv6Family) -> Arc<Self> {
+        Arc::new(Self { family })
+    }
+}
+
+mod rcc {
+    use crate::architecture::arm::{memory::adi_v5_memory_interface::ArmProbe, ArmError};
+    use bitfield::bitfield;
+
+    /// The base address of the RCC peripheral
+    const RCC: u64 = 0x40021000;
+
+    bitfield! {
+        pub struct EnrF0(u32);
+        impl Debug;
+
+        pub u8, dbgen, enable_dbg: 22;
+    }
+
+    bitfield! {
+        pub struct EnrL0(u32);
+        impl Debug;
+
+        pub u8, dbgen, enable_dbg: 22;
+    }
+
+    bitfield! {
+        pub struct EnrG0(u32);
+        impl Debug;
+
+        pub u8, dbgen, enable_dbg: 27;
+    }
+
+    impl EnrF0 {
+        const ADDRESS: u64 = 0x18;
+
+        /// Read the enable register from memory.
+        pub fn read(memory: &mut dyn ArmProbe) -> Result<Self, ArmError> {
+            let contents = memory.read_word_32(RCC + Self::ADDRESS)?;
+            Ok(Self(contents))
+        }
+
+        /// Write the enable register to memory.
+        pub fn write(&mut self, memory: &mut dyn ArmProbe) -> Result<(), ArmError> {
+            memory.write_word_32(RCC + Self::ADDRESS, self.0)
+        }
+    }
+
+    impl EnrL0 {
+        const ADDRESS: u64 = 0x34;
+
+        /// Read the enable register from memory.
+        pub fn read(memory: &mut dyn ArmProbe) -> Result<Self, ArmError> {
+            let contents = memory.read_word_32(RCC + Self::ADDRESS)?;
+            Ok(Self(contents))
+        }
+
+        /// Write the enable register to memory.
+        pub fn write(&mut self, memory: &mut dyn ArmProbe) -> Result<(), ArmError> {
+            memory.write_word_32(RCC + Self::ADDRESS, self.0)
+        }
+    }
+
+    impl EnrG0 {
+        const ADDRESS: u64 = 0x3c;
+
+        /// Read the enable register from memory.
+        pub fn read(memory: &mut dyn ArmProbe) -> Result<Self, ArmError> {
+            let contents = memory.read_word_32(RCC + Self::ADDRESS)?;
+            Ok(Self(contents))
+        }
+
+        /// Write the enable register to memory.
+        pub fn write(&mut self, memory: &mut dyn ArmProbe) -> Result<(), ArmError> {
+            memory.write_word_32(RCC + Self::ADDRESS, self.0)
+        }
+    }
+}
+
+mod dbgmcu {
+    use crate::architecture::arm::{memory::adi_v5_memory_interface::ArmProbe, ArmError};
+    use bitfield::bitfield;
+
+    /// The base address of the DBGMCU component
+    const DBGMCU: u64 = 0x40015800;
+
+    bitfield! {
+        /// The control register (CR) of the DBGMCU. This register is described in "RM0360: STM32F0
+        /// family reference manual" section 26.9.3.
+        pub struct Control(u32);
+        impl Debug;
+
+        pub u8, dbg_standby, enable_standby_debug: 2;
+        pub u8, dbg_stop, enable_stop_debug: 1;
+    }
+
+    impl Control {
+        /// The offset of the Control register in the DBGMCU block.
+        const ADDRESS: u64 = 0x04;
+
+        /// Read the control register from memory.
+        pub fn read(memory: &mut dyn ArmProbe) -> Result<Self, ArmError> {
+            let contents = memory.read_word_32(DBGMCU + Self::ADDRESS)?;
+            Ok(Self(contents))
+        }
+
+        /// Write the control register to memory.
+        pub fn write(&mut self, memory: &mut dyn ArmProbe) -> Result<(), ArmError> {
+            memory.write_word_32(DBGMCU + Self::ADDRESS, self.0)
+        }
+    }
+}
+
+impl ArmDebugSequence for Stm32Armv6 {
+    fn debug_device_unlock(
+        &self,
+        interface: &mut dyn ArmProbeInterface,
+        default_ap: MemoryAp,
+        _permissions: &crate::Permissions,
+    ) -> Result<(), ArmError> {
+        let mut memory = interface.memory_interface(default_ap)?;
+
+        match self.family {
+            Stm32Armv6Family::F0 => {
+                let mut enr = rcc::EnrF0::read(&mut *memory)?;
+                enr.enable_dbg(true);
+                enr.write(&mut *memory)?;
+            }
+            Stm32Armv6Family::L0 => {
+                let mut enr = rcc::EnrL0::read(&mut *memory)?;
+                enr.enable_dbg(true);
+                enr.write(&mut *memory)?;
+            }
+            Stm32Armv6Family::G0 => {
+                let mut enr = rcc::EnrG0::read(&mut *memory)?;
+                enr.enable_dbg(true);
+                enr.write(&mut *memory)?;
+            }
+        }
+
+        let mut cr = dbgmcu::Control::read(&mut *memory)?;
+        cr.enable_standby_debug(true);
+        cr.enable_stop_debug(true);
+        cr.write(&mut *memory)?;
+
+        Ok(())
+    }
+
+    fn debug_core_stop(&self, interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
+        // Power down the debug components
+        let ap = MemoryAp::new(ApAddress {
+            dp: DpAddress::Default,
+            ap: 0,
+        });
+
+        let mut memory = interface.memory_interface(ap)?;
+
+        match self.family {
+            Stm32Armv6Family::F0 => {
+                let mut enr = rcc::EnrF0::read(&mut *memory)?;
+                enr.enable_dbg(false);
+                enr.write(&mut *memory)?;
+            }
+            Stm32Armv6Family::L0 => {
+                let mut enr = rcc::EnrL0::read(&mut *memory)?;
+                enr.enable_dbg(false);
+                enr.write(&mut *memory)?;
+            }
+            Stm32Armv6Family::G0 => {
+                let mut enr = rcc::EnrG0::read(&mut *memory)?;
+                enr.enable_dbg(false);
+                enr.write(&mut *memory)?;
+            }
+        }
+
+        let mut cr = dbgmcu::Control::read(&mut *memory)?;
+        cr.enable_standby_debug(false);
+        cr.enable_stop_debug(false);
+        cr.write(&mut *memory)?;
+
+        Ok(())
+    }
+}

--- a/probe-rs/src/architecture/arm/sequences/stm32_armv6.rs
+++ b/probe-rs/src/architecture/arm/sequences/stm32_armv6.rs
@@ -38,71 +38,34 @@ mod rcc {
     /// The base address of the RCC peripheral
     const RCC: u64 = 0x40021000;
 
-    bitfield! {
-        pub struct EnrF0(u32);
-        impl Debug;
+    macro_rules! enable_reg {
+        ($name:ident, $offset:literal, $bit:literal) => {
+            bitfield! {
+                pub struct $name(u32);
+                impl Debug;
+                pub u8, dbgen, enable_dbg: $bit;
+            }
+            impl $name {
+                const ADDRESS: u64 = $offset;
+                /// Read the enable register from memory.
+                pub fn read(memory: &mut dyn ArmProbe) -> Result<Self, ArmError> {
+                    let contents = memory.read_word_32(RCC + Self::ADDRESS)?;
+                    Ok(Self(contents))
+                }
 
-        pub u8, dbgen, enable_dbg: 22;
+                /// Write the enable register to memory.
+                pub fn write(&mut self, memory: &mut dyn ArmProbe) -> Result<(), ArmError> {
+                    memory.write_word_32(RCC + Self::ADDRESS, self.0)
+                }
+            }
+        };
     }
 
-    bitfield! {
-        pub struct EnrL0(u32);
-        impl Debug;
-
-        pub u8, dbgen, enable_dbg: 22;
-    }
-
-    bitfield! {
-        pub struct EnrG0(u32);
-        impl Debug;
-
-        pub u8, dbgen, enable_dbg: 27;
-    }
-
-    impl EnrF0 {
-        const ADDRESS: u64 = 0x18;
-
-        /// Read the enable register from memory.
-        pub fn read(memory: &mut dyn ArmProbe) -> Result<Self, ArmError> {
-            let contents = memory.read_word_32(RCC + Self::ADDRESS)?;
-            Ok(Self(contents))
-        }
-
-        /// Write the enable register to memory.
-        pub fn write(&mut self, memory: &mut dyn ArmProbe) -> Result<(), ArmError> {
-            memory.write_word_32(RCC + Self::ADDRESS, self.0)
-        }
-    }
-
-    impl EnrL0 {
-        const ADDRESS: u64 = 0x34;
-
-        /// Read the enable register from memory.
-        pub fn read(memory: &mut dyn ArmProbe) -> Result<Self, ArmError> {
-            let contents = memory.read_word_32(RCC + Self::ADDRESS)?;
-            Ok(Self(contents))
-        }
-
-        /// Write the enable register to memory.
-        pub fn write(&mut self, memory: &mut dyn ArmProbe) -> Result<(), ArmError> {
-            memory.write_word_32(RCC + Self::ADDRESS, self.0)
-        }
-    }
-
-    impl EnrG0 {
-        const ADDRESS: u64 = 0x3c;
-
-        /// Read the enable register from memory.
-        pub fn read(memory: &mut dyn ArmProbe) -> Result<Self, ArmError> {
-            let contents = memory.read_word_32(RCC + Self::ADDRESS)?;
-            Ok(Self(contents))
-        }
-
-        /// Write the enable register to memory.
-        pub fn write(&mut self, memory: &mut dyn ArmProbe) -> Result<(), ArmError> {
-            memory.write_word_32(RCC + Self::ADDRESS, self.0)
-        }
-    }
+    // Create enable registers for each device family.
+    // On F0 and L0 this is bit 22 in APB2ENR, while on G0 it's bit 27 in APBENR1.
+    enable_reg!(EnrF0, 0x18, 22);
+    enable_reg!(EnrL0, 0x34, 22);
+    enable_reg!(EnrG0, 0x3c, 27);
 }
 
 mod dbgmcu {

--- a/probe-rs/src/architecture/arm/sequences/stm32_armv7.rs
+++ b/probe-rs/src/architecture/arm/sequences/stm32_armv7.rs
@@ -1,4 +1,12 @@
-//! Sequences for STM32F-series devices
+//! Sequences for most ARMv7 STM32s: STM32F1/2/3/4/7, STM32G4, STM32L1/4, STM32WB and STM32WL.
+//!
+//! This covers devices where DBGMCU is at 0xE0042000 and has the TRACE_MODE, TRACE_IOEN,
+//! DBG_STANDBY, DBG_STOP, and DBG_SLEEP bits, which is most STM32 devices with ARMv7 CPUs.
+//!
+//! It does _not_ include STM32F0, STM32G0, STM32L0, which are ARMv6 and have a simpler DBGMCU
+//! component at a different address which requires clock gating, or the STM32L5 or STM32U5 which
+//! are ARMv8, or the STM32H7 which is ARMv7 but has a more complicated DBGMCU at a different
+//! address.
 
 use std::sync::Arc;
 
@@ -8,11 +16,11 @@ use crate::architecture::arm::{
     ArmProbeInterface, DpAddress,
 };
 
-/// Marker structure for STM32F-series devices.
-pub struct Stm32fSeries {}
+/// Marker structure for most ARMv7 STM32 devices.
+pub struct Stm32Armv7 {}
 
-impl Stm32fSeries {
-    /// Create the sequencer for the F-series family of parts.
+impl Stm32Armv7 {
+    /// Create the sequencer for most ARMv7 STM32 families.
     pub fn create() -> Arc<Self> {
         Arc::new(Self {})
     }
@@ -55,7 +63,7 @@ mod dbgmcu {
     }
 }
 
-impl ArmDebugSequence for Stm32fSeries {
+impl ArmDebugSequence for Stm32Armv7 {
     fn debug_device_unlock(
         &self,
         interface: &mut dyn ArmProbeInterface,

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -8,7 +8,8 @@ use crate::architecture::arm::sequences::{
     nrf53::Nrf5340,
     nrf91::Nrf9160,
     nxp::{LPC55Sxx, MIMXRT10xx, MIMXRT11xx},
-    stm32f_series::Stm32fSeries,
+    stm32_armv6::{Stm32Armv6, Stm32Armv6Family},
+    stm32_armv7::Stm32Armv7,
     stm32h7::Stm32h7,
     ArmDebugSequence,
 };
@@ -124,16 +125,31 @@ impl Target {
         } else if chip.name.starts_with("nRF9160") {
             tracing::warn!("Using custom sequence for nRF9160");
             debug_sequence = DebugSequence::Arm(Nrf9160::create());
+        } else if chip.name.starts_with("STM32F0") {
+            tracing::warn!("Using custom sequence for ARMv6 {}", chip.name);
+            debug_sequence = DebugSequence::Arm(Stm32Armv6::create(Stm32Armv6Family::F0));
+        } else if chip.name.starts_with("STM32L0") {
+            tracing::warn!("Using custom sequence for ARMv6 {}", chip.name);
+            debug_sequence = DebugSequence::Arm(Stm32Armv6::create(Stm32Armv6Family::L0));
+        } else if chip.name.starts_with("STM32G0") {
+            tracing::warn!("Using custom sequence for ARMv6 {}", chip.name);
+            debug_sequence = DebugSequence::Arm(Stm32Armv6::create(Stm32Armv6Family::G0));
+        } else if chip.name.starts_with("STM32F1")
+            || chip.name.starts_with("STM32F2")
+            || chip.name.starts_with("STM32F3")
+            || chip.name.starts_with("STM32F4")
+            || chip.name.starts_with("STM32F7")
+            || chip.name.starts_with("STM32G4")
+            || chip.name.starts_with("STM32L1")
+            || chip.name.starts_with("STM32L4")
+            || chip.name.starts_with("STM32WB")
+            || chip.name.starts_with("STM32WL")
+        {
+            tracing::warn!("Using custom sequence for ARMv7 {}", chip.name);
+            debug_sequence = DebugSequence::Arm(Stm32Armv7::create());
         } else if chip.name.starts_with("STM32H7") {
             tracing::warn!("Using custom sequence for STM32H7");
             debug_sequence = DebugSequence::Arm(Stm32h7::create());
-        } else if chip.name.starts_with("STM32F1")
-            || chip.name.starts_with("STM32F2")
-            || chip.name.starts_with("STM32F4")
-            || chip.name.starts_with("STM32F7")
-        {
-            tracing::warn!("Using custom sequence for STM32F1/2/4/7");
-            debug_sequence = DebugSequence::Arm(Stm32fSeries::create());
         } else if chip.name.starts_with("ATSAMD5") || chip.name.starts_with("ATSAME5") {
             tracing::warn!("Using custom sequence for {}", chip.name);
             debug_sequence = DebugSequence::Arm(AtSAME5x::create());


### PR DESCRIPTION
Currently probe-rs supports custom sequences on STM32F1/2/4/7 and H7. I've checked the reference manuals and F3, G4, WB, WL, L1, and L4 all have the same DBGMCU_CR register in the same location with the same bits as the F1/2/4/7 we already support, so this PR renames the "stm32f_series" to "stm32_armv7" and includes all those families. STM32H7 remains a separate case.

The STM32s with Cortex-M0/M0+ CPUs (ie ARMv6) have a very different DBGMCU which is on the APB bus, has its own clock enable bit in RCC, and only supports DBG_STOP and DBG_STANDBY. On these CPUs, going to normal sleep does not disable the debug interface (unlike the ARMv7 ones). This PR adds support for these CPUs, enabling the DBG clock in RCC and setting those DBG_STOP/DBG_STANDBY bits. I think this is probably worth having but it could be removed and for most users I expect the default behaviour is already enough.

Finally the ARMv8 STM32s (U5, L5) are still unsupported, they have a slightly different DBGMCU again and I haven't looked into it.

I've only tested this on G4 hardware so far, where it works as expected.