### PR TITLE
Feat: Add default debug_core_stop sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added LPC55Sxx target #1513
 - Added custom sequence support to STM32L0, L1, L4, G0, G4, F0, F3, WB, WL,
   enabling debug clocks during sleep modes #1521
-- Add default sequence 'debug_core_stop', which disables debugging when disconneting from ARM cores by default.
+- Add default sequence 'debug_core_stop', which disables debugging when disconneting from ARM cores by default. (#1525)
 
 ## [0.17.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added LPC55Sxx target #1513
 - Added custom sequence support to STM32L0, L1, L4, G0, G4, F0, F3, WB, WL,
   enabling debug clocks during sleep modes #1521
+- Add default sequence 'debug_core_stop', which disables debugging when disconneting from ARM cores by default.
 
 ## [0.17.0]
 

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -25,8 +25,10 @@ use crate::{architecture::arm::ArmProbeInterface, core::MemoryMappedRegister, De
 
 use super::{
     ap::{AccessPortError, MemoryAp},
+    armv6m::Demcr,
     communication_interface::{DapProbe, Initialized},
     component::{TraceFunnel, TraceSink},
+    core::cortex_m::Dhcsr,
     dp::{Abort, Ctrl, DebugPortError, DpAccess, Select, DPIDR},
     memory::{
         adi_v5_memory_interface::ArmProbe,
@@ -569,17 +571,20 @@ pub trait ArmDebugSequence: Send + Sync {
     #[doc(alias = "DebugCoreStart")]
     fn debug_core_start(
         &self,
-        core: &mut dyn ArmProbe,
+        interface: &mut dyn ArmProbeInterface,
+        core_ap: MemoryAp,
         core_type: CoreType,
         debug_base: Option<u64>,
         cti_base: Option<u64>,
     ) -> Result<(), ArmError> {
+        let mut core = interface.memory_interface(core_ap)?;
+
         // Dispatch based on core type (Cortex-A vs M)
         match core_type {
-            CoreType::Armv7a => armv7a_core_start(core, debug_base),
-            CoreType::Armv8a => armv8a_core_start(core, debug_base, cti_base),
+            CoreType::Armv7a => armv7a_core_start(&mut *core, debug_base),
+            CoreType::Armv8a => armv8a_core_start(&mut *core, debug_base, cti_base),
             CoreType::Armv6m | CoreType::Armv7m | CoreType::Armv7em | CoreType::Armv8m => {
-                cortex_m_core_start(core)
+                cortex_m_core_start(&mut *core)
             }
             _ => panic!("Logic inconsistency bug - non ARM core type passed {core_type:?}"),
         }
@@ -716,8 +721,26 @@ pub trait ArmDebugSequence: Send + Sync {
     ///
     /// [ARM SVD Debug Description]: http://www.keil.com/pack/doc/cmsis/Pack/html/debug_description.html#recoverSupportStart
     #[doc(alias = "DebugCoreStop")]
-    fn debug_core_stop(&self, _interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
-        // Empty by default
+    fn debug_core_stop(
+        &self,
+        interface: &mut dyn ArmProbeInterface,
+        core_ap: MemoryAp,
+        core_type: CoreType,
+    ) -> Result<(), ArmError> {
+        if core_type.is_cortex_m() {
+            let mut memory_interface = interface.memory_interface(core_ap)?;
+
+            // System Control Space (SCS) offset as defined in Armv6-M/Armv7-M.
+            // Disable Core Debug via DHCSR
+            let mut dhcsr = Dhcsr(0);
+            dhcsr.enable_write();
+            memory_interface.write_word_32(Dhcsr::ADDRESS, dhcsr.0)?;
+
+            // Disable DWT and ITM blocks, DebugMonitor handler,
+            // halting debug traps, and Reset Vector Catch.
+            memory_interface.write_word_32(Demcr::ADDRESS, 0x0)?;
+        }
+
         Ok(())
     }
 

--- a/probe-rs/src/architecture/arm/sequences/stm32_armv6.rs
+++ b/probe-rs/src/architecture/arm/sequences/stm32_armv6.rs
@@ -4,8 +4,10 @@
 
 use std::sync::Arc;
 
+use probe_rs_target::CoreType;
+
 use super::ArmDebugSequence;
-use crate::architecture::arm::{ap::MemoryAp, ApAddress, ArmError, ArmProbeInterface, DpAddress};
+use crate::architecture::arm::{ap::MemoryAp, ArmError, ArmProbeInterface};
 
 /// Supported families for custom sequences on ARMv6 STM32 devices.
 pub enum Stm32Armv6Family {
@@ -137,14 +139,13 @@ impl ArmDebugSequence for Stm32Armv6 {
         Ok(())
     }
 
-    fn debug_core_stop(&self, interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
-        // Power down the debug components
-        let ap = MemoryAp::new(ApAddress {
-            dp: DpAddress::Default,
-            ap: 0,
-        });
-
-        let mut memory = interface.memory_interface(ap)?;
+    fn debug_core_stop(
+        &self,
+        interface: &mut dyn ArmProbeInterface,
+        core_ap: MemoryAp,
+        _core_type: CoreType,
+    ) -> Result<(), ArmError> {
+        let mut memory = interface.memory_interface(core_ap)?;
 
         match self.family {
             Stm32Armv6Family::F0 => {

--- a/probe-rs/src/architecture/arm/sequences/stm32_armv7.rs
+++ b/probe-rs/src/architecture/arm/sequences/stm32_armv7.rs
@@ -10,10 +10,11 @@
 
 use std::sync::Arc;
 
+use probe_rs_target::CoreType;
+
 use super::ArmDebugSequence;
 use crate::architecture::arm::{
-    ap::MemoryAp, component::TraceSink, memory::CoresightComponent, ApAddress, ArmError,
-    ArmProbeInterface, DpAddress,
+    ap::MemoryAp, component::TraceSink, memory::CoresightComponent, ArmError, ArmProbeInterface,
 };
 
 /// Marker structure for most ARMv7 STM32 devices.
@@ -81,14 +82,13 @@ impl ArmDebugSequence for Stm32Armv7 {
         Ok(())
     }
 
-    fn debug_core_stop(&self, interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
-        // Power down the debug components
-        let ap = MemoryAp::new(ApAddress {
-            dp: DpAddress::Default,
-            ap: 0,
-        });
-
-        let mut memory = interface.memory_interface(ap)?;
+    fn debug_core_stop(
+        &self,
+        interface: &mut dyn ArmProbeInterface,
+        core_ap: MemoryAp,
+        _core_type: CoreType,
+    ) -> Result<(), ArmError> {
+        let mut memory = interface.memory_interface(core_ap)?;
 
         let mut cr = dbgmcu::Control::read(&mut *memory)?;
         cr.enable_standby_debug(false);

--- a/probe-rs/src/architecture/arm/sequences/stm32h7.rs
+++ b/probe-rs/src/architecture/arm/sequences/stm32h7.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 
+use probe_rs_target::CoreType;
+
 use super::ArmDebugSequence;
 use crate::architecture::arm::{
     ap::MemoryAp,
@@ -45,7 +47,7 @@ impl Stm32h7 {
     /// Configure all debug components on the chip.
     pub fn enable_debug_components(
         &self,
-        memory: &mut (impl ArmProbe + ?Sized),
+        memory: &mut dyn ArmProbe,
         enable: bool,
     ) -> Result<(), ArmError> {
         if enable {
@@ -149,7 +151,7 @@ impl ArmDebugSequence for Stm32h7 {
         _default_ap: MemoryAp,
         _permissions: &crate::Permissions,
     ) -> Result<(), ArmError> {
-        // Power up the debug components through AP2, which is the defualt AP debug port.
+        // Power up the debug components through AP2, which is the default AP debug port.
         let ap = MemoryAp::new(ApAddress {
             dp: DpAddress::Default,
             ap: 2,
@@ -161,14 +163,21 @@ impl ArmDebugSequence for Stm32h7 {
         Ok(())
     }
 
-    fn debug_core_stop(&self, interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
-        // Power up the debug components through AP2, which is the defualt AP debug port.
-        let ap = MemoryAp::new(ApAddress {
+    fn debug_core_stop(
+        &self,
+        interface: &mut dyn ArmProbeInterface,
+        _core_ap: MemoryAp,
+        _core_type: CoreType,
+    ) -> Result<(), ArmError> {
+        // Power up the debug components through AP2, which is the default AP debug port.
+
+        let debug_ap = MemoryAp::new(ApAddress {
             dp: DpAddress::Default,
             ap: 2,
         });
 
-        let mut memory = interface.memory_interface(ap)?;
+        let mut memory = interface.memory_interface(debug_ap)?;
+
         self.enable_debug_components(&mut *memory, false)?;
 
         Ok(())

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -1,3 +1,5 @@
+use probe_rs_target::CoreAccessOptions;
+
 use crate::architecture::arm::component::get_arm_components;
 use crate::architecture::arm::sequences::{ArmDebugSequence, DefaultArmSequence};
 use crate::architecture::arm::{ApAddress, ArmError, DpAddress};
@@ -220,13 +222,12 @@ impl Session {
                             ap: arm_core_access_options.ap,
                         });
 
-                        let mut memory_interface = interface.memory_interface(mem_ap)?;
-
                         let core_start_sequence =
                             tracing::debug_span!("debug_core_start").entered();
                         // Enable debug mode
                         sequence_handle.debug_core_start(
-                            &mut *memory_interface,
+                            &mut *interface,
+                            mem_ap,
                             config.core_type,
                             arm_core_access_options.debug_base,
                             arm_core_access_options.cti_base,
@@ -551,11 +552,10 @@ impl Session {
                                     ap: arm_core_access_options.ap,
                                 });
 
-                                let mut memory_interface = interface.memory_interface(mem_ap)?;
-
                                 // Enable debug mode
                                 debug_sequence.debug_core_start(
-                                    &mut *memory_interface,
+                                    &mut **interface,
+                                    mem_ap,
                                     config.core_type,
                                     arm_core_access_options.debug_base,
                                     arm_core_access_options.cti_base,
@@ -724,15 +724,34 @@ impl Drop for Session {
         if let DebugSequence::Arm(sequence) = &self.target.debug_sequence {
             let sequence = sequence.clone();
 
-            // Note(unwrap): We already verified we're using an arm debug sequence, so we should
-            // always be able to access the arm probe interface.
-            let interface = self.get_arm_interface().unwrap();
+            if let Err(err) = { 0..self.cores.len() }.try_for_each(|i| {
+                // Note(unwrap): We already verified we're using an arm debug sequence, so we should
+                // always be able to access the arm probe interface.
 
-            let stop_span = tracing::debug_span!("debug_core_stop").entered();
-            if sequence.debug_core_stop(interface).is_err() {
-                tracing::warn!("Failed to deconfigure device during shutdown");
+                let core_type = self.target.cores[i].core_type;
+
+                let core_information = match &self.target.cores[i].core_access_options {
+                    CoreAccessOptions::Arm(arm) => arm,
+                    CoreAccessOptions::Riscv(_) => panic!(),
+                };
+
+                let ap = core_information.ap;
+                let dp = match core_information.psel {
+                    0 => DpAddress::Default,
+                    x => DpAddress::Multidrop(x),
+                };
+
+                let interface = self.get_arm_interface().unwrap();
+                let core_ap = MemoryAp::new(ApAddress { dp, ap });
+
+                let stop_span = tracing::debug_span!("debug_core_stop", core_id = i).entered();
+                sequence.debug_core_stop(interface, core_ap, core_type)?;
+                drop(stop_span);
+
+                Ok::<(), ArmError>(())
+            }) {
+                tracing::warn!("Failed to deconfigure device during shutdown: {err:?}");
             }
-            drop(stop_span);
         }
     }
 }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -725,14 +725,11 @@ impl Drop for Session {
             let sequence = sequence.clone();
 
             if let Err(err) = { 0..self.cores.len() }.try_for_each(|i| {
-                // Note(unwrap): We already verified we're using an arm debug sequence, so we should
-                // always be able to access the arm probe interface.
-
                 let core_type = self.target.cores[i].core_type;
 
                 let core_information = match &self.target.cores[i].core_access_options {
                     CoreAccessOptions::Arm(arm) => arm,
-                    CoreAccessOptions::Riscv(_) => panic!(),
+                    CoreAccessOptions::Riscv(_) => unreachable!(),
                 };
 
                 let ap = core_information.ap;
@@ -741,7 +738,10 @@ impl Drop for Session {
                     x => DpAddress::Multidrop(x),
                 };
 
+                // Note(unwrap): We already verified we're using an arm debug sequence, so we should
+                // always be able to access the arm probe interface.
                 let interface = self.get_arm_interface().unwrap();
+
                 let core_ap = MemoryAp::new(ApAddress { dp, ap });
 
                 let stop_span = tracing::debug_span!("debug_core_stop", core_id = i).entered();

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -37,7 +37,10 @@ reqwest = { version = "0.11.14", features = ["json", "blocking"] }
 serde = { version = "1", features = ["derive"] }
 futures = "0.3.26"
 tokio = { version = "1.25.0", features = ["macros", "rt", "rt-multi-thread"] }
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.16", features = [
+    "env-filter",
+    "tracing-log",
+] }
 xshell = { version = "0.2", default-features = false }
 cargo_metadata = { version = "0.15", default-features = false }
 indicatif = { version = "0.17", default-features = false }


### PR DESCRIPTION
Add the default implementation for `debug_core_stop`, taken from https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/debug_description.html#debugCoreStop.