### PR TITLE
Feat: Better multicore connection

### DIFF
--- a/cargo-flash/src/main.rs
+++ b/cargo-flash/src/main.rs
@@ -168,7 +168,9 @@ fn main_try(metadata: Arc<Mutex<Metadata>>) -> Result<(), OperationError> {
     }
 
     // Create a new session
-    let mut session = opt.probe_options.attach_session(probe, target_selector)?;
+    let mut session = opt
+        .probe_options
+        .attach_session(probe, target_selector, None)?;
 
     // Flash the binary
     let flashloader = opt.probe_options.build_flashloader(&mut session, &path)?;

--- a/cli/src/benchmark.rs
+++ b/cli/src/benchmark.rs
@@ -45,7 +45,7 @@ pub fn benchmark(common_options: ProbeOptions, options: BenchmarkOptions) -> any
 
     let target = common_options.get_target_selector()?;
     let probe_name = probe.get_name();
-    let mut session = common_options.attach_session(probe, target)?;
+    let mut session = common_options.attach_session(probe, target, None)?;
 
     let target_name = session.target().name.clone();
 

--- a/cli/src/gdb.rs
+++ b/cli/src/gdb.rs
@@ -8,7 +8,7 @@ pub fn run_gdb_server(
     connection_string: Option<&str>,
     reset_halt: bool,
 ) -> anyhow::Result<()> {
-    let mut session = common.simple_attach()?;
+    let mut session = common.simple_attach(None)?;
 
     if reset_halt {
         session

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -16,7 +16,7 @@ pub fn run(
     disable_double_buffering: bool,
     timestamp_offset: UtcOffset,
 ) -> Result<()> {
-    let mut session = common.simple_attach()?;
+    let mut session = common.simple_attach(None)?;
 
     let mut file = match File::open(path) {
         Ok(file) => file,

--- a/cli/src/trace.rs
+++ b/cli/src/trace.rs
@@ -2,6 +2,7 @@
 
 use super::{CoreOptions, ProbeOptions};
 use probe_rs::architecture::arm::component::TraceSink;
+use probe_rs_cli_util::common_options::CoreIdentifier;
 
 /// Trace the application using ITM.
 ///
@@ -17,9 +18,19 @@ pub(crate) fn itm_trace(
     sink: TraceSink,
     duration: std::time::Duration,
 ) -> anyhow::Result<()> {
-    let mut session = common.simple_attach()?;
+    let mut session = common.simple_attach(shared_options.core.clone())?;
+    let core_index = match shared_options
+        .core
+        .as_ref()
+        .unwrap_or(&CoreIdentifier::Index(0))
+    {
+        CoreIdentifier::Index(i) => *i,
+        CoreIdentifier::Name(_name) => {
+            todo!()
+        }
+    };
 
-    session.setup_tracing(shared_options.core, sink)?;
+    session.setup_tracing(core_index, sink)?;
 
     let decoder = itm::Decoder::new(
         session.swo_reader()?,

--- a/cli/src/trace.rs
+++ b/cli/src/trace.rs
@@ -1,8 +1,7 @@
 //! Provides ITM tracing capabilities.
 
 use super::{CoreOptions, ProbeOptions};
-use probe_rs::architecture::arm::component::TraceSink;
-use probe_rs_cli_util::common_options::CoreIdentifier;
+use probe_rs::{architecture::arm::component::TraceSink, CoreSelector};
 
 /// Trace the application using ITM.
 ///
@@ -22,10 +21,10 @@ pub(crate) fn itm_trace(
     let core_index = match shared_options
         .core
         .as_ref()
-        .unwrap_or(&CoreIdentifier::Index(0))
+        .unwrap_or(&CoreSelector::Index(0))
     {
-        CoreIdentifier::Index(i) => *i,
-        CoreIdentifier::Name(_name) => {
+        CoreSelector::Index(i) => *i,
+        CoreSelector::Name(_name) => {
             todo!()
         }
     };

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -73,11 +73,14 @@ pub enum CoreAccessOptions {
 }
 
 impl CoreAccessOptions {
+    /// Get ARM access options
+    ///
+    /// This funciton will panic if self is `CoreAccessOptions::Riscv`.
     #[track_caller]
     pub fn expect_arm(&self) -> &ArmCoreAccessOptions {
         match self {
             CoreAccessOptions::Arm(opts) => opts,
-            other => panic!("{self:?} is not an ARM core."),
+            other => panic!("{other:?} is not an ARM core."),
         }
     }
 }

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -72,6 +72,16 @@ pub enum CoreAccessOptions {
     Riscv(RiscvCoreAccessOptions),
 }
 
+impl CoreAccessOptions {
+    #[track_caller]
+    pub fn expect_arm(&self) -> &ArmCoreAccessOptions {
+        match self {
+            CoreAccessOptions::Arm(opts) => opts,
+            other => panic!("{self:?} is not an ARM core."),
+        }
+    }
+}
+
 /// The data required to access an ARM core
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ArmCoreAccessOptions {

--- a/probe-rs/src/architecture/arm/sequences/atsame5x.rs
+++ b/probe-rs/src/architecture/arm/sequences/atsame5x.rs
@@ -392,6 +392,7 @@ impl ArmDebugSequence for AtSAME5x {
         interface: &mut dyn ArmProbeInterface,
         default_ap: architecture::arm::ap::MemoryAp,
         permissions: &Permissions,
+        _core_index: usize,
     ) -> Result<(), ArmError> {
         // First check if the device is locked
         let mut memory = interface.memory_interface(default_ap)?;

--- a/probe-rs/src/architecture/arm/sequences/atsame5x.rs
+++ b/probe-rs/src/architecture/arm/sequences/atsame5x.rs
@@ -9,7 +9,7 @@ use crate::{
             ArmProbeInterface, DpAddress,
         },
     },
-    session::MissingPermissions,
+    session::permissions::MissingPermissions,
     DebugProbeError, Permissions,
 };
 use bitfield::bitfield;

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -422,18 +422,22 @@ pub trait ArmDebugSequence: Send + Sync {
     ///
     /// [ARM SVD Debug Description]: http://www.keil.com/pack/doc/cmsis/Pack/html/debug_description.html#resetHardwareDeassert
     #[doc(alias = "ResetHardwareDeassert")]
-    fn reset_hardware_deassert(&self, memory: &mut dyn ArmProbe) -> Result<(), ArmError> {
+    fn reset_hardware_deassert(
+        &self,
+        probe: &mut dyn ArmProbeInterface,
+        _default_ap: MemoryAp,
+    ) -> Result<(), ArmError> {
         let mut n_reset = Pins(0);
         n_reset.set_nreset(true);
         let n_reset = n_reset.0 as u32;
 
-        let can_read_pins = memory.swj_pins(n_reset, n_reset, 0)? != 0xffff_ffff;
+        let can_read_pins = probe.swj_pins(n_reset, n_reset, 0)? != 0xffff_ffff;
 
         if can_read_pins {
             let start = Instant::now();
 
             while start.elapsed() < Duration::from_secs(1) {
-                if Pins(memory.swj_pins(n_reset, n_reset, 0)? as u8).nreset() {
+                if Pins(probe.swj_pins(n_reset, n_reset, 0)? as u8).nreset() {
                     return Ok(());
                 }
 

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -694,6 +694,7 @@ pub trait ArmDebugSequence: Send + Sync {
         _interface: &mut dyn ArmProbeInterface,
         _default_ap: MemoryAp,
         _permissions: &crate::Permissions,
+        _core_index: usize,
     ) -> Result<(), ArmError> {
         tracing::debug!("debug_device_unlock - empty by default");
         Ok(())

--- a/probe-rs/src/architecture/arm/sequences/nrf52.rs
+++ b/probe-rs/src/architecture/arm/sequences/nrf52.rs
@@ -86,7 +86,7 @@ impl ArmDebugSequence for Nrf52 {
         iface: &mut dyn ArmProbeInterface,
         _default_ap: MemoryAp,
         permissions: &crate::Permissions,
-        core_index: usize,
+        _core_index: usize,
     ) -> Result<(), ArmError> {
         let ctrl_ap = ApAddress {
             ap: 1,

--- a/probe-rs/src/architecture/arm/sequences/nrf52.rs
+++ b/probe-rs/src/architecture/arm/sequences/nrf52.rs
@@ -86,6 +86,7 @@ impl ArmDebugSequence for Nrf52 {
         iface: &mut dyn ArmProbeInterface,
         _default_ap: MemoryAp,
         permissions: &crate::Permissions,
+        core_index: usize,
     ) -> Result<(), ArmError> {
         let ctrl_ap = ApAddress {
             ap: 1,

--- a/probe-rs/src/architecture/arm/sequences/nrf52.rs
+++ b/probe-rs/src/architecture/arm/sequences/nrf52.rs
@@ -7,7 +7,7 @@ use crate::architecture::arm::{
     ap::MemoryAp, component::TraceSink, memory::CoresightComponent, ApAddress, ArmError,
     ArmProbeInterface, DpAddress,
 };
-use crate::session::MissingPermissions;
+use crate::session::permissions::MissingPermissions;
 
 /// An error when operating a core ROM table component occurred.
 #[derive(thiserror::Error, Debug)]

--- a/probe-rs/src/architecture/arm/sequences/nrf53.rs
+++ b/probe-rs/src/architecture/arm/sequences/nrf53.rs
@@ -52,6 +52,7 @@ impl Nrf for Nrf5340 {
         let csw: CSW = arm_interface
             .read_raw_ap_register(ahb_ap_address, 0x00)?
             .try_into()?;
+        tracing::info!("CSW = {:#010x}", u32::from(csw));
         Ok(csw.DeviceEn != 0)
     }
 

--- a/probe-rs/src/architecture/arm/sequences/stm32f_series.rs
+++ b/probe-rs/src/architecture/arm/sequences/stm32f_series.rs
@@ -61,6 +61,7 @@ impl ArmDebugSequence for Stm32fSeries {
         interface: &mut dyn ArmProbeInterface,
         default_ap: MemoryAp,
         _permissions: &crate::Permissions,
+        core_index: usize,
     ) -> Result<(), ArmError> {
         let mut memory = interface.memory_interface(default_ap)?;
 

--- a/probe-rs/src/architecture/arm/sequences/stm32f_series.rs
+++ b/probe-rs/src/architecture/arm/sequences/stm32f_series.rs
@@ -61,7 +61,7 @@ impl ArmDebugSequence for Stm32fSeries {
         interface: &mut dyn ArmProbeInterface,
         default_ap: MemoryAp,
         _permissions: &crate::Permissions,
-        core_index: usize,
+        _core_index: usize,
     ) -> Result<(), ArmError> {
         let mut memory = interface.memory_interface(default_ap)?;
 

--- a/probe-rs/src/architecture/arm/sequences/stm32h7.rs
+++ b/probe-rs/src/architecture/arm/sequences/stm32h7.rs
@@ -148,6 +148,7 @@ impl ArmDebugSequence for Stm32h7 {
         interface: &mut dyn ArmProbeInterface,
         _default_ap: MemoryAp,
         _permissions: &crate::Permissions,
+        core_index: usize,
     ) -> Result<(), ArmError> {
         // Power up the debug components through AP2, which is the defualt AP debug port.
         let ap = MemoryAp::new(ApAddress {

--- a/probe-rs/src/architecture/arm/sequences/stm32h7.rs
+++ b/probe-rs/src/architecture/arm/sequences/stm32h7.rs
@@ -148,9 +148,9 @@ impl ArmDebugSequence for Stm32h7 {
         interface: &mut dyn ArmProbeInterface,
         _default_ap: MemoryAp,
         _permissions: &crate::Permissions,
-        core_index: usize,
+        _core_index: usize,
     ) -> Result<(), ArmError> {
-        // Power up the debug components through AP2, which is the defualt AP debug port.
+        // Power up the debug components through AP2, which is the default AP debug port.
         let ap = MemoryAp::new(ApAddress {
             dp: DpAddress::Default,
             ap: 2,
@@ -163,7 +163,7 @@ impl ArmDebugSequence for Stm32h7 {
     }
 
     fn debug_core_stop(&self, interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
-        // Power up the debug components through AP2, which is the defualt AP debug port.
+        // Power up the debug components through AP2, which is the default AP debug port.
         let ap = MemoryAp::new(ApAddress {
             dp: DpAddress::Default,
             ap: 2,

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -100,7 +100,7 @@ pub use crate::probe::{
     Probe, ProbeCreationError, WireProtocol,
 };
 pub use crate::session::permissions::Permissions;
-pub use crate::session::{Config, CoreSelection, Session};
+pub use crate::session::{Config, CoreSelection, Session, CoreSelector};
 
 // TODO: Hide behind feature
 pub use crate::probe::fake_probe::FakeProbe;

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -99,7 +99,8 @@ pub use crate::probe::{
     AttachMethod, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType,
     Probe, ProbeCreationError, WireProtocol,
 };
-pub use crate::session::{Permissions, Session};
+pub use crate::session::permissions::Permissions;
+pub use crate::session::{Config, CoreSelection, Session};
 
 // TODO: Hide behind feature
 pub use crate::probe::fake_probe::FakeProbe;

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -340,6 +340,7 @@ impl Probe {
         Ok(())
     }
 
+    /// Attach with the given config
     pub fn attach_with_config(
         mut self,
         target: impl Into<TargetSelector>,
@@ -347,7 +348,6 @@ impl Probe {
     ) -> Result<Session, Error> {
         self.attached = true;
 
-        // The session will de-assert reset after connecting to the debug interface.
         Session::new(self, target.into(), config)
     }
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1843,16 +1843,16 @@ mod test {
     #[test]
     fn test_is_wait_error() {
         assert!(!is_wait_error(
-            &StlinkError::BanksNotAllowedOnDPRegister.into()
+            &StlinkError::BanksNotAllowedOnDPRegister
         ));
         assert!(!is_wait_error(
-            &StlinkError::CommandFailed(Status::JtagFreqNotSupported).into()
+            &StlinkError::CommandFailed(Status::JtagFreqNotSupported)
         ));
         assert!(is_wait_error(
-            &StlinkError::CommandFailed(Status::SwdDpWait).into()
+            &StlinkError::CommandFailed(Status::SwdDpWait)
         ));
         assert!(is_wait_error(
-            &StlinkError::CommandFailed(Status::SwdApWait).into()
+            &StlinkError::CommandFailed(Status::SwdApWait)
         ));
     }
 }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -251,7 +251,7 @@ impl Session {
             // Enable debug mode
             let unlock_res = sequence_handle.debug_device_unlock(
                 &mut *interface,
-                memory_ap.clone(),
+                *memory_ap,
                 &config.permissions,
                 *id,
             );

--- a/probe-rs/src/session/permissions.rs
+++ b/probe-rs/src/session/permissions.rs
@@ -1,0 +1,48 @@
+/// The `Permissions` struct represents what a [Session] is allowed to do with a target.
+/// Some operations can be irreversable, so need to be explicitly allowed by the user.
+///
+/// # Example
+///
+/// ```
+/// use probe_rs::Permissions;
+///
+/// let permissions = Permissions::new().allow_erase_all();
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone, Default)]
+pub struct Permissions {
+    /// When set to true, all memory of the chip may be erased or reset to factory default
+    erase_all: bool,
+}
+
+impl Permissions {
+    /// Constructs a new permissions object with the default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allow the session to erase all memory of the chip or reset it to factory default.
+    ///
+    /// # Warning
+    /// This may irreversibly remove otherwise read-protected data from the device like security keys and 3rd party firmware.
+    /// What happens exactly may differ per device and per probe-rs version.
+    #[must_use]
+    pub fn allow_erase_all(self) -> Self {
+        Self {
+            erase_all: true,
+            ..self
+        }
+    }
+
+    pub(crate) fn erase_all(&self) -> Result<(), MissingPermissions> {
+        if self.erase_all {
+            Ok(())
+        } else {
+            Err(MissingPermissions("erase_all".into()))
+        }
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("An operation could not be performed because it lacked the permission to do so: {0}")]
+pub struct MissingPermissions(pub String);


### PR DESCRIPTION
This is not yet final, just for feedback.

This adds a new `Configuration` struct, which can be used to select the cores for a `Session`. This is helpful for chips where one of the cores could be locked, or otherwise not accessible for debugging, so that it's still possible to work with the other core(s).