### PR TITLE
Use the correct flash base address when testing flash algorithm with target-gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- target-gen: Use the correct flash base address when testing flash algorithm (#1542)
+
 - VSCode and probe-rs-debugger is very slow if `rttEnabled: true` and target application has no RTT initialized (#1497).
 
 - prober-rs-debugger: Using the readMemory request on RISC-V (ESP32C3 board) is slow (#1275).

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -95,7 +95,9 @@ pub fn cmd_test(
     // TODO: The sector used here is not necessarily the sector the flash algorithm targets.
     // Make this configurable.
     let mut readback = vec![0; flash_properties.sectors[0].size as usize];
-    session.core(0)?.read_8(0x0, &mut readback)?;
+    session
+        .core(0)?
+        .read_8(flash_properties.address_range.start, &mut readback)?;
     assert!(
         !readback.iter().any(|v| *v != erased_state),
         "Not all sectors were erased"
@@ -106,10 +108,12 @@ pub fn cmd_test(
         .into_iter()
         .map(|n| (n % 256) as u8)
         .collect::<Vec<_>>();
-    loader.add_data(0x1, &data)?;
+    loader.add_data(flash_properties.address_range.start + 1, &data)?;
     run_flash_download(&mut session, loader, progress.clone(), true)?;
     let mut readback = vec![0; data_size as usize];
-    session.core(0)?.read_8(0x1, &mut readback)?;
+    session
+        .core(0)?
+        .read_8(flash_properties.address_range.start + 1, &mut readback)?;
     assert_eq!(readback, data);
 
     println!("{test}: Erasing the entire chip and writing two pages ...");
@@ -117,7 +121,9 @@ pub fn cmd_test(
     // TODO: The sector used here is not necessarily the sector the flash algorithm targets.
     // Make this configurable.
     let mut readback = vec![0; flash_properties.sectors[0].size as usize];
-    session.core(0)?.read_8(0x0, &mut readback)?;
+    session
+        .core(0)?
+        .read_8(flash_properties.address_range.start, &mut readback)?;
     assert!(
         !readback.iter().any(|v| *v != erased_state),
         "Not all sectors were erased"
@@ -128,10 +134,12 @@ pub fn cmd_test(
         .into_iter()
         .map(|n| (n % 256) as u8)
         .collect::<Vec<_>>();
-    loader.add_data(0x1, &data)?;
+    loader.add_data(flash_properties.address_range.start + 1, &data)?;
     run_flash_download(&mut session, loader, progress.clone(), true)?;
     let mut readback = vec![0; data_size as usize];
-    session.core(0)?.read_8(0x1, &mut readback)?;
+    session
+        .core(0)?
+        .read_8(flash_properties.address_range.start + 1, &mut readback)?;
     assert_eq!(readback, data);
 
     println!("{test}: Erasing sectorwise and writing two pages double buffered ...");
@@ -139,7 +147,9 @@ pub fn cmd_test(
     // TODO: The sector used here is not necessarily the sector the flash algorithm targets.
     // Make this configurable.
     let mut readback = vec![0; flash_properties.sectors[0].size as usize];
-    session.core(0)?.read_8(0x0, &mut readback)?;
+    session
+        .core(0)?
+        .read_8(flash_properties.address_range.start, &mut readback)?;
     assert!(
         !readback.iter().any(|v| *v != erased_state),
         "Not all sectors were erased"
@@ -150,10 +160,12 @@ pub fn cmd_test(
         .into_iter()
         .map(|n| (n % 256) as u8)
         .collect::<Vec<_>>();
-    loader.add_data(0x1, &data)?;
+    loader.add_data(flash_properties.address_range.start + 1, &data)?;
     run_flash_download(&mut session, loader, progress, false)?;
     let mut readback = vec![0; data_size as usize];
-    session.core(0)?.read_8(0x1, &mut readback)?;
+    session
+        .core(0)?
+        .read_8(flash_properties.address_range.start + 1, &mut readback)?;
     assert_eq!(readback, data);
 
     Ok(())


### PR DESCRIPTION
Hi all,

This PR is an attempt to fix this issue: https://github.com/probe-rs/flash-algorithm-template/issues/4

I've tested it on STM32WLE5JC with my DIY flash algorithm and it works fine.

Regards,
Jackson