### PR TITLE
Allows add_target_from_yaml function to accept multiple sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update MS DAP protocol to v1.60.0. Documentation clarifications only. (#1458)
 - probe-rs-debugger: Cleaned up the timing of caching unwind information, based on new MS DAP protocol docs. (#1458)
+- probe-rs: Allows `add_target_from_yaml` function to accept multiple sources
 
 ### Added
 
@@ -35,10 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added custom sequence support to STM32L0, L1, L4, G0, G4, F0, F3, WB, WL,
   enabling debug clocks during sleep modes #1521
 - Add default sequence 'debug_core_stop', which disables debugging when disconneting from ARM cores by default. (#1525)
-
-### Changed
-
-- probe-rs: Allows `add_target_from_yaml` function to accept multiple sources
 
 ## [0.17.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enabling debug clocks during sleep modes #1521
 - Add default sequence 'debug_core_stop', which disables debugging when disconneting from ARM cores by default. (#1525)
 
+### Changed
+
+- probe-rs: Allows `add_target_from_yaml` function to accept multiple sources
+
 ## [0.17.0]
 
 Released 2023-02-06

--- a/cargo-embed/src/main.rs
+++ b/cargo-embed/src/main.rs
@@ -181,7 +181,8 @@ fn main_try(metadata: Arc<Mutex<Metadata>>, offset: UtcOffset) -> Result<()> {
 
     // Make sure we load the config given in the cli parameters.
     for cdp in &config.general.chip_descriptions {
-        probe_rs::config::add_target_from_yaml(Path::new(cdp))
+        let file = File::open(Path::new(cdp))?;
+        probe_rs::config::add_target_from_yaml(file)
             .with_context(|| format!("failed to load the chip description from {cdp}"))?;
     }
 

--- a/probe-rs-cli-util/src/common_options.rs
+++ b/probe-rs-cli-util/src/common_options.rs
@@ -176,7 +176,8 @@ impl ProbeOptions {
     /// Note: should be called before [FlashOptions::early_exit] and any other functions in [ProbeOptions].
     pub fn maybe_load_chip_desc(&self) -> Result<(), OperationError> {
         if let Some(ref cdp) = self.chip_description_path {
-            probe_rs::config::add_target_from_yaml(Path::new(cdp)).map_err(|error| {
+            let file = File::open(Path::new(cdp))?;
+            probe_rs::config::add_target_from_yaml(file).map_err(|error| {
                 OperationError::FailedChipDescriptionParsing {
                     source: error,
                     path: cdp.clone(),

--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! ## Adding targets at runtime
 //!
-//! To add a target at runtime, the [add_target_from_yaml] file can
+//! To add a target at runtime, the [add_target_from_yaml] function can
 //! be used to read targets from a YAML file.
 //!
 

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -323,6 +323,7 @@ pub(crate) fn get_target_by_chip_info(chip_info: ChipInfo) -> Result<Target, Reg
 /// ## Add targets from a YAML file
 ///
 /// ```no_run
+/// use std::path::Path;
 /// use std::fs::File;
 ///
 /// let file = File::open(Path::new("/path/target.yaml"))?;

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -277,12 +277,9 @@ impl Registry {
         Target::new(family, &chip.name)
     }
 
-    fn add_target_from_yaml<R>(
-        &mut self,
-        yaml_reader: R
-    ) -> Result<(), RegistryError>
+    fn add_target_from_yaml<R>(&mut self, yaml_reader: R) -> Result<(), RegistryError>
     where
-        R: Read
+        R: Read,
     {
         let family: ChipFamily = serde_yaml::from_reader(yaml_reader)?;
 
@@ -320,11 +317,9 @@ pub(crate) fn get_target_by_chip_info(chip_info: ChipInfo) -> Result<Target, Reg
 
 /// Parse a target description and add the contained targets
 /// to the internal target registry.
-pub fn add_target_from_yaml<R>(
-    yaml_reader: R
-) -> Result<(), RegistryError>
+pub fn add_target_from_yaml<R>(yaml_reader: R) -> Result<(), RegistryError>
 where
-    R: Read
+    R: Read,
 {
     REGISTRY.lock().unwrap().add_target_from_yaml(yaml_reader)
 }

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -334,11 +334,9 @@ pub(crate) fn get_target_by_chip_info(chip_info: ChipInfo) -> Result<Target, Reg
 ///
 /// ## Add targets from a embedded YAML file
 ///
-/// ```no_run
+/// ```ignore
 /// const BUILTIN_TARGET_YAML: &[u8] = include_bytes!("/path/target.yaml");
 /// probe_rs::config::add_target_from_yaml(BUILTIN_TARGET_YAML)?;
-///
-/// # Ok::<(), anyhow::Error>(())
 /// ```
 pub fn add_target_from_yaml<R>(yaml_reader: R) -> Result<(), RegistryError>
 where

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -328,6 +328,8 @@ pub(crate) fn get_target_by_chip_info(chip_info: ChipInfo) -> Result<Target, Reg
 ///
 /// let file = File::open(Path::new("/path/target.yaml"))?;
 /// probe_rs::config::add_target_from_yaml(file)?;
+///
+/// # Ok::<(), anyhow::Error>(())
 /// ```
 ///
 /// ## Add targets from a embedded YAML file
@@ -335,6 +337,8 @@ pub(crate) fn get_target_by_chip_info(chip_info: ChipInfo) -> Result<Target, Reg
 /// ```no_run
 /// const BUILTIN_TARGET_YAML: &[u8] = include_bytes!("/path/target.yaml");
 /// probe_rs::config::add_target_from_yaml(BUILTIN_TARGET_YAML)?;
+///
+/// # Ok::<(), anyhow::Error>(())
 /// ```
 pub fn add_target_from_yaml<R>(yaml_reader: R) -> Result<(), RegistryError>
 where

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -317,6 +317,24 @@ pub(crate) fn get_target_by_chip_info(chip_info: ChipInfo) -> Result<Target, Reg
 
 /// Parse a target description and add the contained targets
 /// to the internal target registry.
+///
+/// # Examples
+///
+/// ## Add targets from a YAML file
+///
+/// ```no_run
+/// use std::fs::File;
+///
+/// let file = File::open(Path::new("/path/target.yaml"))?;
+/// probe_rs::config::add_target_from_yaml(file)?;
+/// ```
+///
+/// ## Add targets from a embedded YAML file
+///
+/// ```no_run
+/// const BUILTIN_TARGET_YAML: &[u8] = include_bytes!("/path/target.yaml");
+/// probe_rs::config::add_target_from_yaml(BUILTIN_TARGET_YAML)?;
+/// ```
 pub fn add_target_from_yaml<R>(yaml_reader: R) -> Result<(), RegistryError>
 where
     R: Read,

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::fs::File;
 use std::path::Path;
 use std::rc::Rc;
 use std::time::Instant;
@@ -38,7 +39,8 @@ pub fn cmd_test(
         println!("{error}");
     }
 
-    probe_rs::config::add_target_from_yaml(definition_export_path)?;
+    let file = File::open(Path::new(definition_export_path))?;
+    probe_rs::config::add_target_from_yaml(file)?;
     let mut session =
         probe_rs::Session::auto_attach(ALGORITHM_NAME, Permissions::new().allow_erase_all())?;
 


### PR DESCRIPTION
Currently, the `add_target_from_yaml` function only accepts yaml file with the specified file path and cannot accept yaml file embedded in executable file (use `include_bytes!` macro).
This PR modification allows the `add_target_from_yaml` function to accept arguments that implement the `std::io::Read` trait, which takes a yaml string, a byte stream embedded in an executable, and a file object as arguments.