### PR TITLE
`probe-rs-debugger` updates related to MS DAP protocol implementation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update MS DAP protocol to v1.60.0. Documentation clarifications only. (#)
+- Update MS DAP protocol to v1.60.0. Documentation clarifications only. (#1458)
+- probe-rs-debugger: Cleaned up the timing of caching unwind information, based on new MS DAP protocol docs. (#1458)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Restart` will now restart the debug session. Currently this is support for ARM targets only.
   - If a newer binary is available, and flashing enabled, then the new binary will be flashed before starting the new debug session.
 
+### Changed
+
+- Update MS DAP protocol to v1.60.0. Documentation clarifications only. (#)
+
 ### Added
 
 - Added LPC55Sxx target #1513

--- a/debugger/src/debug_adapter/debugProtocol.json
+++ b/debugger/src/debug_adapter/debugProtocol.json
@@ -3486,7 +3486,7 @@
 				},
 				"canRestart": {
 					"type": "boolean",
-					"description": "Indicates whether this frame can be restarted with the `restart` request. Clients should only use this if the debug adapter supports the `restart` request and the corresponding capability `supportsRestartRequest` is true."
+					"description": "Indicates whether this frame can be restarted with the `restart` request. Clients should only use this if the debug adapter supports the `restart` request and the corresponding capability `supportsRestartRequest` is true. If a debug adapter has this capability, then `canRestart` defaults to `true` if the property is absent."
 				},
 				"instructionPointerReference": {
 					"type": "string",
@@ -3701,11 +3701,11 @@
 				},
 				"hitCondition": {
 					"type": "string",
-					"description": "The expression that controls how many hits of the breakpoint are ignored.\nThe debug adapter is expected to interpret the expression as needed.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsHitConditionalBreakpoints` is true."
+					"description": "The expression that controls how many hits of the breakpoint are ignored.\nThe debug adapter is expected to interpret the expression as needed.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsHitConditionalBreakpoints` is true.\nIf both this property and `condition` are specified, `hitCondition` should be evaluated only if the `condition` is met, and the debug adapter should stop only if both conditions are met."
 				},
 				"logMessage": {
 					"type": "string",
-					"description": "If this attribute exists and is non-empty, the debug adapter must not 'break' (stop)\nbut log the message instead. Expressions within `{}` are interpolated.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsLogPoints` is true."
+					"description": "If this attribute exists and is non-empty, the debug adapter must not 'break' (stop)\nbut log the message instead. Expressions within `{}` are interpolated.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsLogPoints` is true.\nIf either `hitCondition` or `condition` is specified, then the message should only be logged if those conditions are met."
 				}
 			},
 			"required": [ "line" ]


### PR DESCRIPTION
- Update to 1.60.0 of the MS DAP Specification.

- The timing and lifetime of the `Threads->StackTrace->Scopes->Variables` requests have been clarified in the documentation, and how and when VSCode sends these requests, have also been updated. 
  - In response, this PR moves the 'unwinding' of the probe-rs-debugger stackframes, from 'Threads' request to the 'StackTrace` request, to avoid mismatches in cached data when VSCode refreshes the `Threads` and `Scopes` data, without refreshing the `StackTrace` data.