### PR TITLE
probe-rs-debugger: Fix "Launch/Attach" behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Restart` will now restart the debug session. Currently this is support for ARM targets only.
   - If a newer binary is available, and flashing enabled, then the new binary will be flashed before starting the new debug session.
 
-- probe-rs-debugger: Ensure VSCode will halt on early `main()`, irrespective of flashing config. (#1529)
+- probe-rs-debugger: Ensure VSCode will halt on all configured breakpoints`, irrespective of flashing config. (#1529)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Terminate` request is not supported, and DAP configuration is such that it won't be requested by the client.
 
 - probe-rs-debugger: Improve handling of `restart` request. With support in DAP Client/VSCode for: (#1507)
+
   - `Restart` will now restart the debug session. Currently this is support for ARM targets only.
   - If a newer binary is available, and flashing enabled, then the new binary will be flashed before starting the new debug session.
 
 ### Changed
 
 - Update MS DAP protocol to v1.60.0. Documentation clarifications only. (#1458)
+
 - probe-rs-debugger: Cleaned up the timing of caching unwind information, based on new MS DAP protocol docs. (#1458)
+
+- probe-rs-debugger: Remove `restart-after-flashing` option, and make it the default behaviour. (#)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Restart` will now restart the debug session. Currently this is support for ARM targets only.
   - If a newer binary is available, and flashing enabled, then the new binary will be flashed before starting the new debug session.
 
+- probe-rs-debugger: Ensure VSCode will halt on early `main()`, irrespective of flashing config. (#1529)
+
 ### Changed
 
 - Update MS DAP protocol to v1.60.0. Documentation clarifications only. (#1458)
 
 - probe-rs-debugger: Cleaned up the timing of caching unwind information, based on new MS DAP protocol docs. (#1458)
 
-- probe-rs-debugger: Remove `restart-after-flashing` option, and make it the default behaviour. (#)
+- probe-rs-debugger: Remove `restart-after-flashing` option, and make it the default behaviour. (#1550)
 
 ### Added
 

--- a/debugger/src/debugger/configuration.rs
+++ b/debugger/src/debugger/configuration.rs
@@ -156,10 +156,6 @@ pub struct FlashingConfig {
     #[serde(default)]
     pub(crate) flashing_enabled: bool,
 
-    /// Reset the target after flashing
-    #[serde(default)]
-    pub(crate) reset_after_flashing: bool,
-
     /// Halt the target after reset
     #[serde(default)]
     pub(crate) halt_after_reset: bool,

--- a/debugger/src/debugger/debug_entry.rs
+++ b/debugger/src/debugger/debug_entry.rs
@@ -493,9 +493,6 @@ impl Debugger {
             return Err(error);
         }
 
-        // Ensure ebreak enters debug mode, this is necessary for soft breakpoints to work on architectures like RISC-V.
-        target_core.core.debug_on_sw_breakpoint(true)?;
-
         // Before we complete, load the (optional) CMSIS-SVD file and its variable cache.
         // Configure the [CorePeripherals].
         if let Some(svd_file) = &target_core_config.svd_file {
@@ -513,10 +510,15 @@ impl Debugger {
             };
         }
 
-        if self.config.flashing_config.flashing_enabled {
+        if requested_target_session_type == TargetSessionType::LaunchRequest {
+            // This will effectively do a `reset` and `halt` of the core, which is what we want until after the `configuration_done` request.
             debug_adapter
                 .restart(&mut target_core, None)
                 .context("Failed to restart core")?;
+        } else {
+            // Ensure ebreak enters debug mode, this is necessary for soft breakpoints to work on architectures like RISC-V.
+            // For LaunchRequest, this is done in the `restart` above.
+            target_core.core.debug_on_sw_breakpoint(true)?;
         }
 
         drop(target_core);
@@ -572,21 +574,16 @@ impl Debugger {
                 Err(error)
             })?;
 
-        // Immediately after attaching, halt the core, so that we can finish initalization without bumping into user code.
-        // Depending on supplied `config`, the core will be restarted at the end of initialization in the `configuration_done` request.
+        // Immediately after attaching, halt the core, so that we can finish restart logic without bumping into user code.
         if let Err(error) = halt_core(&mut target_core.core) {
             debug_adapter.send_error_response(&error)?;
             return Err(error);
         }
 
-        // Ensure ebreak enters debug mode, this is necessary for soft breakpoints to work on architectures like RISC-V.
-        target_core.core.debug_on_sw_breakpoint(true)?;
-
-        if self.config.flashing_config.flashing_enabled {
-            debug_adapter
-                .restart(&mut target_core, Some(request))
-                .context("Failed to restart core")?;
-        }
+        // After completing optional flashing and other config, we can run the debug adapter's restart logic.
+        debug_adapter
+            .restart(&mut target_core, Some(request))
+            .context("Failed to restart core")?;
 
         Ok(debug_adapter)
     }

--- a/debugger/src/debugger/debug_entry.rs
+++ b/debugger/src/debugger/debug_entry.rs
@@ -415,7 +415,6 @@ impl Debugger {
         if requested_target_session_type == TargetSessionType::AttachRequest {
             // Since VSCode doesn't do field validation checks for relationships in launch.json request types, check it here.
             if self.config.flashing_config.flashing_enabled
-                || self.config.flashing_config.reset_after_flashing
                 || self.config.flashing_config.halt_after_reset
                 || self.config.flashing_config.full_chip_erase
                 || self.config.flashing_config.restore_unwritten_bytes
@@ -514,9 +513,7 @@ impl Debugger {
             };
         }
 
-        if self.config.flashing_config.flashing_enabled
-            && self.config.flashing_config.reset_after_flashing
-        {
+        if self.config.flashing_config.flashing_enabled {
             debug_adapter
                 .restart(&mut target_core, None)
                 .context("Failed to restart core")?;
@@ -585,9 +582,7 @@ impl Debugger {
         // Ensure ebreak enters debug mode, this is necessary for soft breakpoints to work on architectures like RISC-V.
         target_core.core.debug_on_sw_breakpoint(true)?;
 
-        if self.config.flashing_config.flashing_enabled
-            && self.config.flashing_config.reset_after_flashing
-        {
+        if self.config.flashing_config.flashing_enabled {
             debug_adapter
                 .restart(&mut target_core, Some(request))
                 .context("Failed to restart core")?;


### PR DESCRIPTION
- Remove `reset_after_flashing` option.
  - The debugger will silently ignore this option if requested from the VSCode configuration.
  - Future VSCode extension updates will remove this option.
- Fix Issue #1529

The new behaviour is that the target connect sequence will be as follows.
- During `Launch/Attach` request processing
  - Halt the target.
  - For `Launch` requests optionally flash the target.
  - For `Launch` requests, reset the target and halt the target.
- After completion of `ConfigurationDone` from VSCode
  - For `Launch` requests, optionally resume the target.
  - For `Attach` requests, resume the target.