### PR TITLE
Add reset catch sequence for Silicon Labs EFM32/EFR32 Series 2 chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Add reset catch sequence for Silicon Labs EFM32/EFR32 Series 2 chips.
+
 - target-gen: Use the correct flash base address when testing flash algorithm (#1542)
 
 - VSCode and probe-rs-debugger is very slow if `rttEnabled: true` and target application has no RTT initialized (#1497).

--- a/probe-rs/src/architecture/arm/sequences/efm32xg2.rs
+++ b/probe-rs/src/architecture/arm/sequences/efm32xg2.rs
@@ -1,0 +1,68 @@
+//! Sequences for Silicon Labs EFM32 Series 2 chips
+
+use std::sync::Arc;
+
+use crate::{
+    architecture::arm::{
+        core::armv7m::{Demcr, Dhcsr},
+        memory::adi_v5_memory_interface::ArmProbe,
+        ArmError,
+    },
+    core::MemoryMappedRegister,
+};
+
+use super::ArmDebugSequence;
+
+/// The sequence handle for the EFM32 Series 2 family.
+///
+/// Uses a breakpoint on the reset vector for the reset catch.
+pub struct EFM32xG2(());
+
+impl EFM32xG2 {
+    /// Create a sequence handle for the EFM32xG2
+    pub fn create() -> Arc<dyn ArmDebugSequence> {
+        Arc::new(Self(()))
+    }
+}
+
+impl ArmDebugSequence for EFM32xG2 {
+    fn reset_catch_set(
+        &self,
+        core: &mut dyn ArmProbe,
+        _core_type: probe_rs_target::CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        let reset_vector = core.read_word_32(0x0000_0004)?;
+
+        if reset_vector != 0xffff_ffff {
+            tracing::info!("Breakpoint on user application reset vector");
+            core.write_word_32(0xE000_2008, reset_vector | 1)?;
+            core.write_word_32(0xE000_2000, 3)?;
+        }
+
+        if reset_vector == 0xffff_ffff {
+            tracing::info!("Enable reset vector catch");
+            let mut demcr = Demcr(core.read_word_32(Demcr::ADDRESS)?);
+            demcr.set_vc_corereset(true);
+            core.write_word_32(Demcr::ADDRESS, demcr.into())?;
+        }
+
+        let _ = core.read_word_32(Dhcsr::ADDRESS)?;
+
+        Ok(())
+    }
+
+    fn reset_catch_clear(
+        &self,
+        core: &mut dyn ArmProbe,
+        _core_type: probe_rs_target::CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        core.write_word_32(0xE000_2008, 0x0)?;
+        core.write_word_32(0xE000_2000, 0x2)?;
+
+        let mut demcr = Demcr(core.read_word_32(Demcr::ADDRESS)?);
+        demcr.set_vc_corereset(false);
+        core.write_word_32(Demcr::ADDRESS, demcr.into())
+    }
+}

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -1,6 +1,7 @@
 //! Debug sequences to operate special requirements ARM targets.
 
 pub mod atsame5x;
+pub mod efm32xg2;
 pub mod infineon;
 mod nrf;
 pub mod nrf52;

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -3,6 +3,7 @@ use probe_rs_target::{Architecture, ChipFamily};
 use super::{Core, MemoryRegion, RawFlashAlgorithm, RegistryError, TargetDescriptionSource};
 use crate::architecture::arm::sequences::{
     atsame5x::AtSAME5x,
+    efm32xg2::EFM32xG2,
     infineon::XMC4000,
     nrf52::Nrf52,
     nrf53::Nrf5340,
@@ -110,6 +111,14 @@ impl Target {
         {
             tracing::warn!("Using custom sequence for LPC55S16/26/28/66/69");
             debug_sequence = DebugSequence::Arm(LPC55Sxx::create());
+        } else if chip.name.starts_with("EFM32PG2")
+            || chip.name.starts_with("EFR32BG2")
+            || chip.name.starts_with("EFR32FG2")
+            || chip.name.starts_with("EFR32MG2")
+            || chip.name.starts_with("EFR32ZG2")
+        {
+            tracing::warn!("Using custom sequence for EFM32 Series 2");
+            debug_sequence = DebugSequence::Arm(EFM32xG2::create());
         } else if chip.name.starts_with("esp32c3") {
             tracing::warn!("Using custom sequence for ESP32C3");
             debug_sequence = DebugSequence::Riscv(ESP32C3::create());


### PR DESCRIPTION
At least my EFR32BG22C224F512IM40 does not obey VC_CORERESET.  The JLink system uses a breakpoint on the reset vector for this chip.