### PR TITLE
Debugger: Slightly relax the RISC-V restriction when handling of `restart` request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - probe-rs-debugger: Remove `restart-after-flashing` option, and make it the default behaviour. (#1550)
 
+- probe-rs-debugger: Slightly relax the RISC-V restriction when handling `restart` request. Allows restart, but does not re-flash. (#)
+
 ### Added
 
 - Added EFM32TG11B family targets #1420
@@ -55,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add default sequence 'debug_core_stop', which disables debugging when disconneting from ARM cores by default. (#1525)
 
 - probe-rs-debugger: Initial support for 'gdb-like' commands to be typed into VSCode Debug Console REPL. (#1552)
+
   - The `help` command will list available commands, and arguments.
   - Command completions are supported for the individual commands, but not for the arguments.
   - Additional commands can be added in the future, as required, but will benefit from some refactoring to share code with functionality that is already implementated in `dap_adapter.rs` for MS DAP requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - probe-rs-debugger: Remove `restart-after-flashing` option, and make it the default behaviour. (#1550)
 
-- probe-rs-debugger: Slightly relax the RISC-V restriction when handling `restart` request. Allows restart, but does not re-flash. (#)
+- probe-rs-debugger: Slightly relax the RISC-V restriction when handling `restart` request. Allows restart, but does not re-flash. (#1569)
 
 ### Added
 


### PR DESCRIPTION
With this PR, we now allow restart, but will not re-flash, so that we avoid the issue #1519, while still allowing users to restart their target during debugging.

cc: @MabezDev please confirm that this is what you requested :)