### PR TITLE
add bitbang probe support

### DIFF
--- a/probe-rs/src/probe/bitbang/bitbang_adapter.rs
+++ b/probe-rs/src/probe/bitbang/bitbang_adapter.rs
@@ -1,0 +1,78 @@
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+/// Abstracts the bit bang encoding scheme to generic read/write/quit functions.  The openocd JTAG
+/// documention outlines this protocol: [bitbang](https://github.com/openocd-org/openocd/blob/b6b4f9d46a48aadc1de6bb5152ff4913661c9059/doc/manual/jtag/drivers/remote_bitbang.txt)
+#[derive(Debug)]
+pub struct BitBangAdapter {
+    socket: TcpStream,
+}
+
+impl BitBangAdapter {
+    pub fn new(mut socket: TcpStream) -> io::Result<Self> {
+        // Dump anything that was already in the socket
+        let mut junk = vec![];
+        socket.set_read_timeout(Some(Duration::from_millis(500)))?;
+        socket.set_write_timeout(Some(Duration::from_millis(500)))?;
+        let _ = socket.read_to_end(&mut junk);
+
+        Ok(Self { socket })
+    }
+
+    // TODO: probably want some way of queuing up a longer message, right now each request
+    // (read/write/reset/etc) takes sends 1 tcp packet.
+    /// Send a packet over the socket and check that is was written successfully.
+    fn send_checked_packet(&mut self, packet: &str) -> io::Result<()> {
+        let _written = self.socket.write(packet.as_bytes())?;
+        // TODO: verify all bytes were written
+        Ok(())
+    }
+
+    /// Control the JTAG reset lines
+    pub fn reset(&mut self, trst: bool, srst: bool) -> io::Result<()> {
+        let packet = match (trst, srst) {
+            (false, false) => "r",
+            (false, true) => "s",
+            (true, false) => "t",
+            (true, true) => "u",
+        };
+        self.send_checked_packet(packet)?;
+        Ok(())
+    }
+
+    /// Set the value of TCK, TMS, and TDI
+    pub fn write(&mut self, tck: bool, tms: bool, tdi: bool) -> io::Result<()> {
+        let packet = match (tck, tms, tdi) {
+            (false, false, false) => "0",
+            (false, false, true) => "1",
+            (false, true, false) => "2",
+            (false, true, true) => "3",
+            (true, false, false) => "4",
+            (true, false, true) => "5",
+            (true, true, false) => "6",
+            (true, true, true) => "7",
+        };
+        self.send_checked_packet(packet)?;
+        Ok(())
+    }
+
+    /// read TDO
+    pub fn read(&mut self) -> io::Result<bool> {
+        self.send_checked_packet("R")?;
+        let mut tdo = [1; 1];
+        let n_read = self.socket.read(&mut tdo)?;
+        if n_read != 1 {
+            // TODO proper error
+            panic!("Invalid read...")
+        }
+        // TODO verify n_read is not zero
+        Ok(tdo != "0".as_bytes())
+    }
+
+    /// Tell the bit bang server we are done sending messages
+    pub fn quit(&mut self) -> io::Result<()> {
+        self.send_checked_packet("Q")?;
+        Ok(())
+    }
+}

--- a/probe-rs/src/probe/bitbang/bitbang_engine.rs
+++ b/probe-rs/src/probe/bitbang/bitbang_engine.rs
@@ -1,0 +1,170 @@
+use std::io;
+use std::net::TcpStream;
+
+use super::bitbang_adapter::BitBangAdapter;
+
+/// Uses a `BitBangAdapter` to provide generic JTAG functions
+#[derive(Debug)]
+pub struct BitBangEngine {
+    pub adapter: BitBangAdapter,
+}
+
+impl BitBangEngine {
+    pub fn new(socket: TcpStream) -> io::Result<Self> {
+        let adapter = BitBangAdapter::new(socket)?;
+        Ok(Self { adapter })
+    }
+
+    /// Clocks out tms, tdi and clock in tdo. Starts on a falling edge.  TDI will be sampled on the
+    /// rising edge, TDO is sampled after the falling edge
+    fn clock(&mut self, tms: bool, tdi: bool) -> io::Result<bool> {
+        // drop TCK and write our TDI
+        self.adapter.write(false, tms, tdi)?;
+        // TODO read TDO
+        let tdo = self.adapter.read()?;
+        // Now clock high again to finish the cycle
+        self.adapter.write(true, tms, tdi)?;
+
+        Ok(tdo)
+    }
+
+    /// clock out the provided tms bits
+    fn write_tms(&mut self, tmss: &[bool]) -> io::Result<()> {
+        for tms in tmss {
+            self.clock(*tms, false)?;
+        }
+        Ok(())
+    }
+
+    /// Called after entering the shift-ir/dr state.  This function will write the tdi into the
+    /// register, and transition to the exit state
+    fn shift_reg(&mut self, tdis: &[bool]) -> io::Result<Vec<bool>> {
+        let mut tdos = vec![];
+
+        // Nothing to write...
+        if tdis.len() == 0 {
+            return Ok(tdos);
+        }
+
+        // We skip the last bit as it will be clocked in when we transition tms
+        for tdi in &tdis[..tdis.len() - 1] {
+            // TMS will always be low
+            let tdo = self.clock(false, *tdi)?;
+            tdos.push(tdo)
+        }
+
+        // this will transition to the exit state and clock in our last TDI bit
+        let tdo = self.clock(true, tdis[tdis.len() - 1])?;
+        tdos.push(tdo);
+
+        Ok(tdos)
+    }
+
+    /// idle for given number of clock cycles
+    pub fn idle(&mut self, clock_cycles: usize) -> io::Result<()> {
+        // should already be in the idle state
+        for _ in 0..clock_cycles {
+            self.clock(false, false)?;
+        }
+        Ok(())
+    }
+
+    /// perform a reset of the tap controller and/or the system, the return to the RunTestIdle
+    /// state
+    pub fn reset(&mut self, tap_reset: bool, system_reset: bool) -> io::Result<()> {
+        self.adapter.reset(tap_reset, system_reset)?;
+
+        // incase trst is not supported, also use the state transitions to get there
+        // 5 tms '1's are guarenteed to hit the TestLogicReset state
+        self.write_tms(&[true, true, true, true, true])?;
+        // transition to RunTestIdleState
+        self.write_tms(&[false])?;
+        Ok(())
+    }
+
+    /// Write data into IR and transiton back to the idle state.  Jtag tap controller must already
+    /// be in the RunTestIdle state.
+    pub fn write_ir(&mut self, data: &[bool]) -> io::Result<()> {
+        // transition to Shift-IR
+        self.write_tms(&[true, true, false, false])?;
+        // this will leave us in the exit state
+        self.shift_reg(data)?;
+
+        // transiton to Update-IR, then RunTestIdle
+        self.write_tms(&[true, false])?;
+        Ok(())
+    }
+
+    /// Write data into DR and transiton back to the idle state.  Jtag tap controller must already
+    /// be in the RunTestIdle state.
+    pub fn write_read_dr(&mut self, data: &[bool]) -> io::Result<Vec<bool>> {
+        // transition to Shift-DR
+        self.write_tms(&[true, false, false])?;
+        // this will leave us in the exit state
+        let read_data = self.shift_reg(data)?;
+
+        // transiton to Update-DR, then RunTestIdle
+        self.write_tms(&[true, false])?;
+
+        Ok(read_data)
+    }
+
+    /// Write the data into register and return back the data that was shifted out
+    pub fn write_read_register(
+        &mut self,
+        address: u32,
+        ir_len: u32,
+        data: &[bool],
+    ) -> io::Result<Vec<bool>> {
+        // convert address to slice of bool
+        let mut ir_bools = vec![];
+        // the address is still only u32 so it will just be padded up with zeros
+        for i in 0..ir_len {
+            if i < 32 {
+                ir_bools.push((address & (1 << i)) != 0);
+            } else {
+                ir_bools.push(false);
+            }
+        }
+        self.write_ir(&ir_bools)?;
+
+        self.write_read_dr(data)
+    }
+
+    /// Tells the bitbang interface we are done
+    pub fn quit(&mut self) -> io::Result<()> {
+        self.adapter.quit()?;
+        Ok(())
+    }
+}
+
+// Probably optional...
+impl Drop for BitBangEngine {
+    fn drop(&mut self) {
+        // We are dropping the object, don't care if the socket connection failed
+        let _ = self.adapter.quit();
+    }
+}
+
+/// convert the bool slice to a u8 slice, with each bool being one bit
+pub fn bool_slice_to_u8_slice(r: &[bool], len: usize) -> Vec<u8> {
+    // split into 8 bit chunks
+    // let r = r.chunks(8);
+
+    let mut read_data = vec![];
+    // first populate with all zeros
+    for _ in 0..len / 8 {
+        read_data.push(0u8);
+    }
+    if len % 8 != 0 {
+        read_data.push(0u8);
+    }
+    // now fill in the actual data
+    for i in 0..len {
+        let bit = r[i] as u8;
+        let bit = bit << (i % 8);
+        read_data[i / 8] |= bit;
+    }
+
+    read_data
+}

--- a/probe-rs/src/probe/bitbang/commands.rs
+++ b/probe-rs/src/probe/bitbang/commands.rs
@@ -1,0 +1,449 @@
+use std::io;
+
+use bitvec::{order::Lsb0, prelude::BitVec, slice::BitSlice};
+
+use crate::{probe::CommandResult, DebugProbeError};
+
+use super::ChainParams;
+
+pub trait JtagCommand: std::fmt::Debug + Send {
+    fn add_bytes(&mut self, buffer: &mut Vec<u8>);
+
+    fn bytes_to_read(&self) -> usize;
+
+    fn process_output(&self, data: &[u8]) -> Result<CommandResult, DebugProbeError>;
+}
+
+#[derive(Debug)]
+pub struct WriteRegisterCommand {
+    subcommands: [Box<dyn JtagCommand>; 2],
+}
+
+impl WriteRegisterCommand {
+    pub(super) fn new(
+        address: u32,
+        data: Vec<u8>,
+        len: usize,
+        idle_cycles: usize,
+        chain_params: ChainParams,
+    ) -> io::Result<WriteRegisterCommand> {
+        let target_transfer = TargetTransferCommand::new(address, data, len, chain_params)?;
+        let idle = IdleCommand::new(idle_cycles);
+
+        Ok(WriteRegisterCommand {
+            subcommands: [Box::new(target_transfer), Box::new(idle)],
+        })
+    }
+}
+
+impl JtagCommand for WriteRegisterCommand {
+    fn add_bytes(&mut self, buffer: &mut Vec<u8>) {
+        for subcommand in &mut self.subcommands {
+            subcommand.add_bytes(buffer);
+        }
+    }
+
+    fn bytes_to_read(&self) -> usize {
+        self.subcommands.iter().map(|e| e.bytes_to_read()).sum()
+    }
+
+    fn process_output(&self, data: &[u8]) -> Result<CommandResult, DebugProbeError> {
+        let r = self.subcommands[0].process_output(&data[0..(self.subcommands[0].bytes_to_read())]);
+        self.subcommands[1].process_output(&data[self.subcommands[0].bytes_to_read()..])?;
+        r
+    }
+}
+
+#[derive(Debug)]
+struct TargetTransferCommand {
+    len: usize,
+    chain_params: ChainParams,
+    shift_ir_cmd: ShiftIrCommand,
+    transfer_dr_cmd: TransferDrCommand,
+}
+
+impl TargetTransferCommand {
+    pub fn new(
+        address: u32,
+        data: Vec<u8>,
+        len: usize,
+        chain_params: ChainParams,
+    ) -> io::Result<TargetTransferCommand> {
+        let params = &chain_params;
+        let max_address = (1 << params.irlen) - 1;
+        assert!(address <= max_address);
+
+        // Write IR register
+        let irbits = params.irpre + params.irlen + params.irpost;
+        assert!(irbits <= 32);
+        let mut ir: u32 = (1 << params.irpre) - 1;
+        ir |= address << params.irpre;
+        ir |= ((1 << params.irpost) - 1) << (params.irpre + params.irlen);
+
+        let shift_ir_cmd = ShiftIrCommand::new(ir.to_le_bytes().to_vec(), irbits);
+
+        let drbits = params.drpre + len + params.drpost;
+        let request = {
+            let data = BitSlice::<u8, Lsb0>::from_slice(&data);
+            let mut data = BitVec::<u8, Lsb0>::from_bitslice(data);
+            data.truncate(len);
+
+            let mut buf = BitVec::<u8, Lsb0>::new();
+            buf.resize(params.drpre, false);
+            buf.append(&mut data);
+            buf.resize(buf.len() + params.drpost, false);
+
+            buf.into_vec()
+        };
+
+        let transfer_dr = TransferDrCommand::new(request.to_vec(), drbits);
+
+        Ok(TargetTransferCommand {
+            len,
+            chain_params,
+            shift_ir_cmd,
+            transfer_dr_cmd: transfer_dr,
+        })
+    }
+}
+
+impl JtagCommand for TargetTransferCommand {
+    fn add_bytes(&mut self, buffer: &mut Vec<u8>) {
+        self.shift_ir_cmd.add_bytes(buffer);
+        self.transfer_dr_cmd.add_bytes(buffer);
+    }
+
+    fn bytes_to_read(&self) -> usize {
+        self.shift_ir_cmd.bytes_to_read() + self.transfer_dr_cmd.bytes_to_read()
+    }
+
+    fn process_output(&self, data: &[u8]) -> Result<CommandResult, DebugProbeError> {
+        let params = self.chain_params;
+        let reply = self.transfer_dr_cmd.process_output(data);
+
+        let reply = if let Ok(CommandResult::VecU8(reply)) = reply {
+            reply
+        } else {
+            return Err(DebugProbeError::ProbeSpecific(Box::new(
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "Unexpected data received"),
+            )));
+        };
+
+        // Process the reply
+        let mut reply = BitVec::<u8, Lsb0>::from_vec(reply);
+        if params.drpre > 0 {
+            reply = reply.split_off(params.drpre);
+        }
+        reply.truncate(self.len);
+        let reply = reply.into_vec();
+
+        Ok(CommandResult::VecU8(reply))
+    }
+}
+
+#[derive(Debug)]
+struct ShiftIrCommand {
+    subcommands: [Box<dyn JtagCommand>; 3],
+}
+impl ShiftIrCommand {
+    pub fn new(data: Vec<u8>, bits: usize) -> ShiftIrCommand {
+        ShiftIrCommand {
+            subcommands: [
+                Box::new(ShiftTmsCommand::new(vec![0b0011], 4)),
+                Box::new(ShiftTdiCommand::new(data, bits)),
+                Box::new(ShiftTmsCommand::new(vec![0b01], 2)),
+            ],
+        }
+    }
+}
+
+impl JtagCommand for ShiftIrCommand {
+    fn add_bytes(&mut self, buffer: &mut Vec<u8>) {
+        for subcommand in &mut self.subcommands {
+            subcommand.add_bytes(buffer);
+        }
+    }
+
+    fn bytes_to_read(&self) -> usize {
+        self.subcommands.iter().map(|e| e.bytes_to_read()).sum()
+    }
+
+    fn process_output(&self, data: &[u8]) -> Result<CommandResult, DebugProbeError> {
+        let mut start = 0usize;
+        for subcommand in &self.subcommands {
+            let end = start + subcommand.bytes_to_read();
+            let cmd_data = data[start..end].to_vec();
+            let _ = subcommand.process_output(&cmd_data); // TODO check if ok
+            start += subcommand.bytes_to_read();
+        }
+
+        Ok(CommandResult::None)
+    }
+}
+
+#[derive(Debug)]
+struct TransferDrCommand {
+    subcommands: Vec<Box<dyn JtagCommand>>,
+}
+
+impl TransferDrCommand {
+    pub fn new(data: Vec<u8>, bits: usize) -> TransferDrCommand {
+        TransferDrCommand {
+            subcommands: vec![
+                Box::new(ShiftTmsCommand::new(vec![0b001], 3)),
+                Box::new(TransferTdiCommand::new(data, bits)),
+                Box::new(ShiftTmsCommand::new(vec![0b01], 2)),
+            ],
+        }
+    }
+}
+
+impl JtagCommand for TransferDrCommand {
+    fn add_bytes(&mut self, buffer: &mut Vec<u8>) {
+        for subcommand in &mut self.subcommands {
+            subcommand.add_bytes(buffer);
+        }
+    }
+
+    fn bytes_to_read(&self) -> usize {
+        self.subcommands.iter().map(|e| e.bytes_to_read()).sum()
+    }
+
+    fn process_output(&self, data: &[u8]) -> Result<CommandResult, DebugProbeError> {
+        let mut start = 0usize;
+
+        let end = start + self.subcommands[0].bytes_to_read();
+        let cmd_data = data[start..end].to_vec();
+        self.subcommands[0].process_output(&cmd_data)?;
+        start += self.subcommands[0].bytes_to_read();
+
+        let end = start + self.subcommands[1].bytes_to_read();
+        let cmd_data = data[start..end].to_vec();
+        let reply = self.subcommands[1].process_output(&cmd_data);
+        start += self.subcommands[1].bytes_to_read();
+
+        let end = start + self.subcommands[2].bytes_to_read();
+        let cmd_data = data[start..end].to_vec();
+        self.subcommands[2].process_output(&cmd_data)?;
+
+        reply
+    }
+}
+
+#[derive(Debug)]
+struct ShiftTmsCommand {
+    data: Vec<u8>,
+    bits: usize,
+}
+
+impl ShiftTmsCommand {
+    pub fn new(data: Vec<u8>, bits: usize) -> ShiftTmsCommand {
+        assert!(bits > 0);
+        assert!((bits + 7) / 8 <= data.len());
+
+        ShiftTmsCommand { data, bits }
+    }
+}
+
+impl JtagCommand for ShiftTmsCommand {
+    fn add_bytes(&mut self, buffer: &mut Vec<u8>) {
+        let mut command = vec![];
+
+        let mut bits = self.bits;
+        let mut data: &[u8] = &self.data;
+        while bits > 0 {
+            if bits >= 8 {
+                // 0x4b = Clock Data to TMS pin (no read)
+                // see https://www.ftdichip.com/Support/Documents/AppNotes/AN_108_Command_Processor_for_MPSSE_and_MCU_Host_Bus_Emulation_Modes.pdf
+                command.extend_from_slice(&[0x4b, 0x07, data[0]]);
+                data = &data[1..];
+                bits -= 8;
+            } else {
+                command.extend_from_slice(&[0x4b, (bits - 1) as u8, data[0]]);
+                bits = 0;
+            }
+        }
+
+        buffer.extend_from_slice(&command);
+    }
+
+    fn bytes_to_read(&self) -> usize {
+        0
+    }
+
+    fn process_output(&self, _data: &[u8]) -> Result<CommandResult, DebugProbeError> {
+        Ok(CommandResult::None)
+    }
+}
+
+#[derive(Debug)]
+struct ShiftTdiCommand {
+    data: Vec<u8>,
+    bits: usize,
+}
+
+impl ShiftTdiCommand {
+    pub fn new(data: Vec<u8>, bits: usize) -> ShiftTdiCommand {
+        ShiftTdiCommand { data, bits }
+    }
+}
+
+impl JtagCommand for ShiftTdiCommand {
+    fn add_bytes(&mut self, buffer: &mut Vec<u8>) {
+        assert!(self.bits > 0);
+        assert!((self.bits + 7) / 8 <= self.data.len());
+
+        let mut command = vec![];
+        let mut bits = self.bits;
+        let mut data: &[u8] = &self.data;
+
+        let full_bytes = (bits - 1) / 8;
+        if full_bytes > 0 {
+            assert!(full_bytes <= 65536);
+
+            command.extend_from_slice(&[0x19]);
+            let n: u16 = (full_bytes - 1) as u16;
+            command.extend_from_slice(&n.to_le_bytes());
+            command.extend_from_slice(&data[..full_bytes]);
+
+            bits -= full_bytes * 8;
+            data = &data[full_bytes..];
+        }
+        assert!(bits <= 8);
+
+        if bits > 0 {
+            let byte = data[0];
+            if bits > 1 {
+                let n = (bits - 2) as u8;
+                command.extend_from_slice(&[0x1b, n, byte]);
+            }
+
+            let last_bit = (byte >> (bits - 1)) & 0x01;
+            let tms_byte = 0x01 | (last_bit << 7);
+            command.extend_from_slice(&[0x4b, 0x00, tms_byte]);
+        }
+
+        buffer.extend_from_slice(&command);
+    }
+
+    fn bytes_to_read(&self) -> usize {
+        0
+    }
+
+    fn process_output(&self, _data: &[u8]) -> Result<CommandResult, DebugProbeError> {
+        Ok(CommandResult::None)
+    }
+}
+
+#[derive(Debug)]
+struct TransferTdiCommand {
+    data: Vec<u8>,
+    bits: usize,
+
+    response_bytes: usize,
+}
+
+impl TransferTdiCommand {
+    pub fn new(data: Vec<u8>, bits: usize) -> TransferTdiCommand {
+        TransferTdiCommand {
+            data,
+            bits,
+            response_bytes: 0,
+        }
+    }
+}
+
+impl JtagCommand for TransferTdiCommand {
+    fn add_bytes(&mut self, buffer: &mut Vec<u8>) {
+        assert!(self.bits > 0);
+        assert!((self.bits + 7) / 8 <= self.data.len());
+
+        let mut command = vec![];
+
+        let mut bits = self.bits;
+        let mut data: &[u8] = &self.data;
+
+        let full_bytes = (bits - 1) / 8;
+        if full_bytes > 0 {
+            assert!(full_bytes <= 65536);
+
+            command.extend_from_slice(&[0x39]);
+            let n: u16 = (full_bytes - 1) as u16;
+            command.extend_from_slice(&n.to_le_bytes());
+            command.extend_from_slice(&data[..full_bytes]);
+
+            bits -= full_bytes * 8;
+            data = &data[full_bytes..];
+        }
+        assert!(0 < bits && bits <= 8);
+
+        let byte = data[0];
+        if bits > 1 {
+            let n = (bits - 2) as u8;
+            command.extend_from_slice(&[0x3b, n, byte]);
+        }
+
+        let last_bit = (byte >> (bits - 1)) & 0x01;
+        let tms_byte = 0x01 | (last_bit << 7);
+        command.extend_from_slice(&[0x6b, 0x00, tms_byte]);
+
+        buffer.extend_from_slice(&command);
+
+        let mut expect_bytes = full_bytes + 1;
+        if bits > 1 {
+            expect_bytes += 1;
+        }
+
+        self.bits = bits;
+        self.response_bytes = expect_bytes;
+    }
+
+    fn bytes_to_read(&self) -> usize {
+        self.response_bytes
+    }
+
+    fn process_output(&self, data: &[u8]) -> Result<CommandResult, DebugProbeError> {
+        let mut last_byte = data[data.len() - 1] >> 7;
+        if self.bits > 1 {
+            let byte = data[data.len() - 2] >> (8 - (self.bits - 1));
+            last_byte = byte | (last_byte << (self.bits - 1));
+        }
+
+        let mut reply = Vec::<u8>::new();
+        reply.extend_from_slice(data);
+        reply.push(last_byte);
+        Ok(CommandResult::VecU8(reply))
+    }
+}
+
+/// Execute RUN-TEST/IDLE for a number of cycles
+#[derive(Debug)]
+struct IdleCommand {
+    cycles: usize,
+}
+
+impl IdleCommand {
+    pub fn new(cycles: usize) -> IdleCommand {
+        IdleCommand { cycles }
+    }
+}
+
+impl JtagCommand for IdleCommand {
+    fn add_bytes(&mut self, buffer: &mut Vec<u8>) {
+        if self.cycles == 0 {
+            return;
+        }
+        let mut buf = vec![];
+        buf.resize((self.cycles + 7) / 8, 0);
+
+        ShiftTmsCommand::new(buf, self.cycles).add_bytes(buffer);
+    }
+
+    fn bytes_to_read(&self) -> usize {
+        0
+    }
+
+    fn process_output(&self, _data: &[u8]) -> Result<CommandResult, DebugProbeError> {
+        Ok(CommandResult::None)
+    }
+}

--- a/probe-rs/src/probe/bitbang/mod.rs
+++ b/probe-rs/src/probe/bitbang/mod.rs
@@ -1,0 +1,231 @@
+use crate::architecture::riscv::communication_interface::{
+    RiscvCommunicationInterface, RiscvError,
+};
+use crate::probe::JTAGAccess;
+use crate::{
+    DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType,
+    ProbeCreationError, WireProtocol,
+};
+use std::net::TcpStream;
+
+mod bitbang_adapter;
+mod bitbang_engine;
+
+use bitbang_engine::{bool_slice_to_u8_slice, BitBangEngine};
+
+#[derive(Debug)]
+pub struct BitBangProbe {
+    engine: BitBangEngine,
+    speed_khz: u32,
+    idle_cycles: u8,
+    ir_len: u32,
+}
+
+impl DebugProbe for BitBangProbe {
+    fn new_from_selector(
+        _selector: impl Into<DebugProbeSelector>,
+    ) -> Result<Box<Self>, DebugProbeError>
+    where
+        Self: Sized,
+    {
+        /*
+        // TODO match on the selector some how...
+        let selector = selector.into();
+
+        // Only open FTDI probes
+        if selector.vendor_id != 0xFFFF {
+            return Err(DebugProbeError::ProbeCouldNotBeCreated(
+                ProbeCreationError::NotFound,
+            ));
+        }
+
+        // let adapter = JtagAdapter::open(selector.vendor_id, selector.product_id)
+        */
+
+        let socket = TcpStream::connect("127.0.0.1:44853")
+            .map_err(|_e| DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::NotFound))?;
+        let engine =
+            BitBangEngine::new(socket).map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+
+        let probe = BitBangProbe {
+            engine,
+            speed_khz: 0,
+            idle_cycles: 0,
+            ir_len: 32,
+        };
+        tracing::debug!("opened probe: {:?}", probe);
+        Ok(Box::new(probe))
+    }
+
+    fn get_name(&self) -> &str {
+        "BitBang"
+    }
+
+    // TODO some way of regulating speed/reporting it as not supported?
+    fn speed_khz(&self) -> u32 {
+        self.speed_khz
+    }
+
+    // TODO some way of regulating speed/reporting it as not supported?
+    fn set_speed(&mut self, speed_khz: u32) -> Result<u32, DebugProbeError> {
+        self.speed_khz = speed_khz;
+        Ok(speed_khz)
+    }
+
+    fn attach(&mut self) -> Result<(), DebugProbeError> {
+        tracing::debug!("attaching...");
+
+        // Do a quick tap reset
+        // TODO proper error mapping?
+        self.engine
+            .reset(true, false)
+            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+
+        // We will use this to map the DebugProbeSelector, maybe?
+        /*
+        let idcode = self.engine.write_read_dr(&[false;32]).map_err(|_e| DebugProbeError::TargetNotFound)?;
+        let idcode = bool_slice_to_u8_slice(&idcode, 32);
+        tracing::debug!("found idcode {:x?}", idcode);
+        */
+
+        Ok(())
+    }
+
+    fn detach(&mut self) -> Result<(), crate::Error> {
+        // TODO proper error mapping
+        self.engine.quit().unwrap();
+        Ok(())
+    }
+
+    fn target_reset(&mut self) -> Result<(), DebugProbeError> {
+        tracing::trace!("BitBang target_reset");
+        unimplemented!()
+    }
+
+    fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
+        self.engine.adapter.reset(true, true).unwrap();
+        tracing::trace!("BitBang target_reset_assert");
+        Ok(())
+    }
+
+    fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
+        self.engine.adapter.reset(false, false).unwrap();
+        tracing::trace!("BitBang target_reset_deassert");
+        Ok(())
+    }
+
+    fn select_protocol(&mut self, protocol: WireProtocol) -> Result<(), DebugProbeError> {
+        if protocol != WireProtocol::Jtag {
+            Err(DebugProbeError::UnsupportedProtocol(protocol))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn active_protocol(&self) -> Option<WireProtocol> {
+        // Only supports JTAG
+        Some(WireProtocol::Jtag)
+    }
+
+    fn try_get_riscv_interface(
+        self: Box<Self>,
+    ) -> Result<RiscvCommunicationInterface, (Box<dyn DebugProbe>, RiscvError)> {
+        match RiscvCommunicationInterface::new(self) {
+            Ok(interface) => Ok(interface),
+            Err((probe, err)) => Err((probe.into_probe(), err)),
+        }
+    }
+
+    fn has_riscv_interface(&self) -> bool {
+        true
+    }
+
+    fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
+        self
+    }
+}
+
+impl JTAGAccess for BitBangProbe {
+    fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {
+        tracing::trace!("read_register({:#x}, {})", address, len);
+        // convert data u8 slice into bool slice
+        let mut bool_data = vec![];
+        for _ in 0..len {
+            bool_data.push(false)
+        }
+        let data = self
+            .engine
+            .write_read_register(address, self.ir_len, &bool_data)
+            .map_err(|e| {
+                tracing::error!("target_transfer error: {:?}", e);
+                DebugProbeError::ProbeSpecific(Box::new(e))
+            })?;
+
+        let read_data = bool_slice_to_u8_slice(&data, len as usize);
+
+        self.engine
+            .idle(self.idle_cycles as usize)
+            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+        tracing::trace!("read_register result: {:#x?})", read_data);
+        Ok(read_data)
+    }
+
+    fn set_idle_cycles(&mut self, idle_cycles: u8) {
+        tracing::trace!("set_idle_cycles({})", idle_cycles);
+        self.idle_cycles = idle_cycles;
+    }
+
+    fn write_register(
+        &mut self,
+        address: u32,
+        data: &[u8],
+        len: u32,
+    ) -> Result<Vec<u8>, DebugProbeError> {
+        tracing::trace!("write_register({:#x}, {:#x?}, {})", address, data, len);
+
+        // convert data u8 slice into bool slice
+        let mut bool_data = vec![];
+        for i in 0..len {
+            bool_data.push((data[i as usize / 8] & (1 << (i % 8))) != 0)
+        }
+
+        let r = self
+            .engine
+            .write_read_register(address, self.ir_len, &bool_data)
+            .map_err(|e| {
+                tracing::error!("target_transfer error: {:?}", e);
+                DebugProbeError::ProbeSpecific(Box::new(e))
+            })?;
+
+        let read_data = bool_slice_to_u8_slice(&r, len as usize);
+
+        self.engine
+            .idle(self.idle_cycles as usize)
+            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+        tracing::trace!("write_register result: {:#x?})", read_data);
+        Ok(read_data)
+    }
+
+    fn get_idle_cycles(&self) -> u8 {
+        self.idle_cycles
+    }
+
+    fn set_ir_len(&mut self, len: u32) {
+        self.ir_len = len;
+    }
+}
+
+#[tracing::instrument(skip_all)]
+pub(crate) fn list_bitbang_devices() -> Vec<DebugProbeInfo> {
+    let mut devs = vec![];
+    devs.push(DebugProbeInfo {
+        identifier: "BitBang Interface".to_owned(),
+        vendor_id: 0,
+        product_id: 0,
+        serial_number: None,
+        probe_type: DebugProbeType::BitBang,
+        hid_interface: None,
+    });
+
+    devs
+}


### PR DESCRIPTION
This provides support for a network socket JTAG bitbang interface.  I think the best resource for this is the [openocd doc](https://github.com/openocd-org/openocd/blob/master/doc/manual/jtag/drivers/remote_bitbang.txt).    This probe is a little different from the other implementations as it is not connected to a physical usb device, which raises some issues:

1. `DebugProbeSelector` does not support non usb devices as it just encodes VID:PID.
2. No way to list the bitbang socket under `list_devices`, since it could be on any port.

To address (1), we could convert `DebugProbeSelector` to an enum, with both `Usb` and `Net` variants.  With some strict implementations of `TryFrom` it should not be hard to distinguish network urls from vid/pids.  Does anyone have strong opinions about this/alternative solutions?   I plan to proceed with the above unless anyone objects.

This PR is still WIP, but all of the underlying functionality should be there. (as long as only 1 TAP controller...).  It still needs a way to map a `DebugProbeSelector` to a tcp socket, and some general cleanup.