### PR TITLE
Fix: Show errors that happen before the VSCode startup has completed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- probe-rs-debugger: Show errors that happen before VSCode/DAP Client session initializion has completed (#).
+- probe-rs-debugger: Show errors that happen before VSCode/DAP Client session initializion has completed (#1581).
 
 ## [0.18.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- probe-rs-debugger: Show errors that happen before VSCode/DAP Client session initializion has completed (#).
+
 ## [0.18.0]
 
 Released 2023-03-31

--- a/debugger/src/debug_adapter/dap/adapter.rs
+++ b/debugger/src/debug_adapter/dap/adapter.rs
@@ -642,7 +642,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                         Err(DebuggerError::Other(anyhow!("{}", error))),
                     );
                 } else {
-                    return self.send_error_response(&DebuggerError::Other(anyhow!("{}", error)));
+                    return self.show_error_message(&DebuggerError::Other(anyhow!("{}", error)));
                 }
             }
         }
@@ -722,7 +722,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             let core_info = match target_core.core.reset_and_halt(Duration::from_millis(500)) {
                 Ok(core_info) => core_info,
                 Err(error) => {
-                    return self.send_error_response(&DebuggerError::Other(anyhow!("{}", error)));
+                    return self.show_error_message(&DebuggerError::Other(anyhow!("{}", error)));
                 }
             };
 
@@ -1707,7 +1707,8 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         self.adapter.send_response(request, response)
     }
 
-    pub fn send_error_response(&mut self, response: &DebuggerError) -> Result<()> {
+    /// Displays an error message to the user.
+    pub fn show_error_message(&mut self, response: &DebuggerError) -> Result<()> {
         let expanded_error = {
             let mut response_message = response.to_string();
             let mut offset_iterations = 0;

--- a/debugger/src/debug_adapter/protocol.rs
+++ b/debugger/src/debug_adapter/protocol.rs
@@ -1,7 +1,7 @@
 use crate::{
     debug_adapter::dap::dap_types::{
-        Event, MessageSeverity, OutputEventBody, ProtocolMessage, Request, Response,
-        ShowMessageEventBody,
+        ErrorResponse, ErrorResponseBody, Event, Message, MessageSeverity, OutputEventBody,
+        ProtocolMessage, Request, Response, ShowMessageEventBody,
     },
     server::configuration::ConsoleLog,
     DebuggerError,
@@ -9,7 +9,7 @@ use crate::{
 use anyhow::anyhow;
 use serde::Serialize;
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     io::{BufRead, BufReader, Read, Write},
     str,
     string::ToString,
@@ -311,61 +311,82 @@ impl<R: Read, W: Write> ProtocolAdapter for DapAdapter<R, W> {
         request: &Request,
         response: Result<Option<S>, DebuggerError>,
     ) -> anyhow::Result<()> {
-        let mut resp = Response {
-            command: request.command.clone(),
-            request_seq: request.seq,
-            seq: request.seq,
-            success: false,
-            body: None,
-            type_: "response".to_owned(),
-            message: None,
-        };
-
-        match response {
+        // The encoded response will be constructed from dap::Response for Ok, and dap::ErrorResponse for Err, to ensure VSCode doesn't lose the details of the error.
+        let encoded_resp = match response.as_ref() {
             Ok(value) => {
-                let body_value = match value {
-                    Some(value) => Some(serde_json::to_value(value)?),
-                    None => None,
+                let resp = Response {
+                    command: request.command.clone(),
+                    request_seq: request.seq,
+                    seq: request.seq,
+                    success: true,
+                    type_: "response".to_owned(),
+                    message: None,
+                    body: Some(serde_json::to_value(value)?),
                 };
-                resp.success = true;
-                resp.body = body_value;
+                tracing::debug!("send_response: {:?}", resp);
+                serde_json::to_vec(&resp)?
             }
             Err(debugger_error) => {
-                resp.success = false;
-                resp.message = Some("cancelled".to_string());
-                resp.body = {
-                    let mut response_message = debugger_error.to_string();
-                    let mut offset_iterations = 0;
-                    let mut child_error: Option<&dyn std::error::Error> =
-                        std::error::Error::source(&debugger_error);
-                    while let Some(source_error) = child_error {
-                        offset_iterations += 1;
-                        response_message = format!("{response_message}\n",);
-                        for _offset_counter in 0..offset_iterations {
-                            response_message = format!("{response_message}\t");
-                        }
-                        response_message = format!(
-                            "{}{:?}",
-                            response_message,
-                            <dyn std::error::Error>::to_string(source_error)
-                        );
-                        child_error = std::error::Error::source(source_error);
+                let mut response_message = debugger_error.to_string();
+                let mut offset_iterations = 0;
+                let mut child_error: Option<&dyn std::error::Error> =
+                    std::error::Error::source(&debugger_error);
+                while let Some(source_error) = child_error {
+                    offset_iterations += 1;
+                    response_message = format!("{response_message}\n",);
+                    for _offset_counter in 0..offset_iterations {
+                        response_message = format!("{response_message}\t");
                     }
-                    Some(serde_json::to_value(response_message)?)
+                    response_message = format!(
+                        "{}{:?}",
+                        response_message,
+                        <dyn std::error::Error>::to_string(source_error)
+                    );
+                    child_error = std::error::Error::source(source_error);
+                }
+                // We have to send log messages on error conditions to the DAP Client now, because
+                // if this error happens during the 'launch' or 'attach' request, the DAP Client
+                // will not initiate a session, and will not be listening for 'output' events.
+                self.log_to_console(&response_message);
+                self.show_message(MessageSeverity::Error, &response_message);
+
+                let error_resp = ErrorResponse {
+                    command: request.command.clone(),
+                    request_seq: request.seq,
+                    seq: request.seq,
+                    success: false,
+                    type_: "error_response".to_owned(),
+                    message: Some("cancelled".to_string()), // Predefined value in the MSDAP spec.
+                    body: ErrorResponseBody {
+                        error: Some(Message {
+                            format: "{response_message}".to_string(),
+                            variables: Some(BTreeMap::from([(
+                                "response_message".to_string(),
+                                response_message,
+                            )])),
+                            // TODO: Implement unique error codes, that can index into the documentation for more information and suggested actions.
+                            id: 0,
+                            send_telemetry: Some(false),
+                            show_user: Some(true),
+                            url_label: Some("Documentation".to_string()),
+                            url: Some("https://probe.rs/docs/tools/vscode/".to_string()),
+                        }),
+                    },
                 };
+                tracing::debug!("send_response: {:?}", error_resp);
+                serde_json::to_vec(&error_resp)?
             }
         };
 
-        tracing::debug!("send_response: {:?}", resp);
-
         // Check if we got a request for this response
-        if let Some(request_command) = self.pending_requests.remove(&resp.request_seq) {
-            assert_eq!(request_command, resp.command);
+        if let Some(request_command) = self.pending_requests.remove(&request.seq) {
+            assert_eq!(request_command, request.command);
         } else {
-            tracing::error!("Trying to send a response to non-existing request! Response {:?} has no pending request", resp);
+            tracing::error!(
+                "Trying to send a response to non-existing request! {:?} has no pending request",
+                serde_json::to_value(&encoded_resp)?
+            );
         }
-
-        let encoded_resp = serde_json::to_vec(&resp)?;
 
         match self.send_data(&encoded_resp) {
             Ok(_) => {}
@@ -377,30 +398,20 @@ impl<R: Read, W: Write> ProtocolAdapter for DapAdapter<R, W> {
             }
         }
 
-        if !resp.success {
-            self.log_to_console(
-                &resp
-                    .clone()
-                    .message
-                    .unwrap_or_else(|| "<empty message>".to_string()),
-            );
-            self.show_message(
-                MessageSeverity::Error,
-                &resp
-                    .message
-                    .unwrap_or_else(|| "<empty message>".to_string()),
-            );
-        } else {
+        if response.is_ok() {
             match self.console_log_level {
                 ConsoleLog::Console => {}
                 ConsoleLog::Info => {
                     self.log_to_console(format!(
                         "   Sent DAP Response sequence #{} : {}",
-                        resp.seq, resp.command
+                        request.seq, request.command
                     ));
                 }
                 ConsoleLog::Debug => {
-                    self.log_to_console(format!("\nSent DAP Response: {resp:#?}"));
+                    self.log_to_console(format!(
+                        "\nSent DAP Response: {:#?}",
+                        serde_json::to_value(encoded_resp)?
+                    ));
                 }
             }
         }

--- a/debugger/src/server/core_data.rs
+++ b/debugger/src/server/core_data.rs
@@ -130,7 +130,7 @@ impl<'p> CoreHandle<'p> {
                                 )));
                             }
                             CoreStatus::Unknown => {
-                                debug_adapter.send_error_response(&DebuggerError::Other(
+                                debug_adapter.show_error_message(&DebuggerError::Other(
                                     anyhow!("Unknown Device status reveived from Probe-rs"),
                                 ))?;
 

--- a/debugger/src/server/debug_rtt.rs
+++ b/debugger/src/server/debug_rtt.rs
@@ -62,7 +62,7 @@ impl DebuggerRttChannel {
                         Ok(data_result) => data_result,
                         Err(rtt_error) => {
                             debug_adapter
-                                .send_error_response(&DebuggerError::Other(rtt_error))
+                                .show_error_message(&DebuggerError::Other(rtt_error))
                                 .ok();
                             None
                         }

--- a/debugger/src/server/debugger.rs
+++ b/debugger/src/server/debugger.rs
@@ -273,7 +273,7 @@ impl Debugger {
                     Ok(()) => {
                         if unhalt_me {
                             if let Err(error) = target_core.core.run() {
-                                debug_adapter.send_error_response(&DebuggerError::Other(
+                                debug_adapter.show_error_message(&DebuggerError::Other(
                                     anyhow!("{}", error),
                                 ))?;
                                 return Err(error.into());
@@ -332,7 +332,7 @@ impl Debugger {
             let error =
                 DebuggerError::Other(anyhow!("Failed sending 'initialized' event to DAP Client"));
 
-            debug_adapter.send_error_response(&error)?;
+            debug_adapter.show_error_message(&error)?;
 
             return Err(error);
         }
@@ -430,7 +430,7 @@ impl Debugger {
 
         let mut session_data =
             SessionData::new(&mut self.config, self.timestamp_offset).or_else(|error| {
-                debug_adapter.send_error_response(&error)?;
+                debug_adapter.show_error_message(&error)?;
                 Err(error)
             })?;
 
@@ -445,7 +445,7 @@ impl Debugger {
             let Some(path_to_elf) = target_core_config.program_binary.clone() else {
                     let err =  DebuggerError::Other(anyhow!("Please specify use the `program-binary` option in `launch.json` to specify an executable"));
 
-                    debug_adapter.send_error_response(&err)?;
+                    debug_adapter.show_error_message(&err)?;
                     return Err(err);
                 };
 
@@ -470,14 +470,14 @@ impl Debugger {
         let mut target_core = session_data
             .attach_core(target_core_config.core_index)
             .or_else(|error| {
-                debug_adapter.send_error_response(&error)?;
+                debug_adapter.show_error_message(&error)?;
                 Err(error)
             })?;
 
         // Immediately after attaching, halt the core, so that we can finish initalization without bumping into user code.
         // Depending on supplied `config`, the core will be restarted at the end of initialization in the `configuration_done` request.
         if let Err(error) = halt_core(&mut target_core.core) {
-            debug_adapter.send_error_response(&error)?;
+            debug_adapter.show_error_message(&error)?;
             return Err(error);
         }
 
@@ -531,7 +531,7 @@ impl Debugger {
             let Some(path_to_elf) = target_core_config.program_binary.clone() else {
                     let err =  DebuggerError::Other(anyhow!("Please specify use the `program-binary` option in `launch.json` to specify an executable"));
 
-                    debug_adapter.send_error_response(&err)?;
+                    debug_adapter.show_error_message(&err)?;
                     return Err(err);
                 };
 
@@ -558,13 +558,13 @@ impl Debugger {
         let mut target_core = session_data
             .attach_core(target_core_config.core_index)
             .or_else(|error| {
-                debug_adapter.send_error_response(&error)?;
+                debug_adapter.show_error_message(&error)?;
                 Err(error)
             })?;
 
         // Immediately after attaching, halt the core, so that we can finish restart logic without bumping into user code.
         if let Err(error) = halt_core(&mut target_core.core) {
-            debug_adapter.send_error_response(&error)?;
+            debug_adapter.show_error_message(&error)?;
             return Err(error);
         }
 
@@ -759,7 +759,7 @@ impl Debugger {
             }
             Err(error) => {
                 let error = DebuggerError::FileDownload(error);
-                debug_adapter.send_error_response(&error)?;
+                debug_adapter.show_error_message(&error)?;
                 Err(error)
             }
         }

--- a/debugger/src/server/session_data.rs
+++ b/debugger/src/server/session_data.rs
@@ -265,7 +265,7 @@ impl SessionData {
             // We need to poll the core to determine its status.
             let current_core_status = target_core.poll_core(debug_adapter).map_err(|error| {
                 let error = DebuggerError::ProbeRs(error);
-                let _ = debug_adapter.send_error_response(&error);
+                let _ = debug_adapter.show_error_message(&error);
                 error
             })?;
 
@@ -293,7 +293,7 @@ impl SessionData {
                             }
                             Err(error) => {
                                 debug_adapter
-                                    .send_error_response(&DebuggerError::Other(error))
+                                    .show_error_message(&DebuggerError::Other(error))
                                     .ok();
                             }
                         }


### PR DESCRIPTION
When errors happen in MS DAP requests `initialize`, `launch` or `attach`, requests, the VSCode client terminates the session, and any late arriving error messages from 'probe-rs-debugger' are ignored.

This PR ensures that error messages are logged/displayed to the client, before sending the error response to these requests.
- This fixes errors such as reported in https://github.com/probe-rs/vscode/issues/57.

In addition to changing the timing of the user facing messages, this PR also updated the following related to error handling:
- Updates the `Request` handling to follow the MS DAP guideline more strictly, and makes use of the `ErrorResponse` struct, rather than just reporting the error message in the `Response` struct.
- Renamed `DebugAdapter::send_error_response()` to `DebugAdapter::show_error_message()`, in order to avoid confusion with the handling of the MS DAP `ErrorResponse`. The names were too similar and the behaviour is very distinct.