### PR TITLE
Update Rust version in CI, try to fix release CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,4 +1,3 @@
-
 name: Install toolchain
 description: Install toolchain
 inputs:
@@ -11,8 +10,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@1.67.0
-        with:
-          targets: ${{ inputs.targets }}
-          components: ${{ inputs.components }}
+    - name: Install toolchain
+      uses: dtolnay/rust-toolchain@1.68.2
+      with:
+        targets: ${{ inputs.targets }}
+        components: ${{ inputs.components }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ permissions:
 on:
   push:
     tags:
-      - '*-?v[0-9]+*'
+      - "*-?v[0-9]+*"
 
 jobs:
   # Create the Github Release™ so the packages have something to be uploaded to
@@ -52,25 +52,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
-        run: rustup update 1.67.1 --no-self-update && rustup default 1.67.1
-
-      # Manual addition of build deps
-
-      - name: Install libusb, libudev (linux)
-        run: |
-          sudo apt update
-          sudo apt install -y libusb-1.0-0-dev libudev-dev
-        # Only install on Ubuntu
-        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'ubuntu-20.04')
-
+        run: rustup update 1.68.2 --no-self-update && rustup default 1.68.2
       - name: Install cargo-dist
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.4/cargo-dist-v0.0.4-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.5/cargo-dist-v0.0.5-installer.sh | sh
       - id: create-release
         run: |
           cargo dist manifest --tag=${{ github.ref_name }} --artifacts=all --no-local-paths --output-format=json > dist-manifest.json
           echo "dist manifest ran successfully"
           cat dist-manifest.json
-        
+
           # Create the Github Release™ based on what cargo-dist thinks it should be
           ANNOUNCEMENT_TITLE=$(cat dist-manifest.json | jq --raw-output ".announcement_title")
           IS_PRERELEASE=$(cat dist-manifest.json | jq --raw-output ".announcement_is_prerelease")
@@ -95,15 +85,15 @@ jobs:
       matrix:
         # For these target platforms
         include:
-        - os: macos-11
-          dist-args: --artifacts=local --target=aarch64-apple-darwin --target=x86_64-apple-darwin
-          install-dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.4/cargo-dist-v0.0.4-installer.sh | sh
-        - os: ubuntu-20.04
-          dist-args: --artifacts=local --target=x86_64-unknown-linux-gnu
-          install-dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.4/cargo-dist-v0.0.4-installer.sh | sh
-        - os: windows-2019
-          dist-args: --artifacts=local --target=x86_64-pc-windows-msvc
-          install-dist: irm  https://github.com/axodotdev/cargo-dist/releases/download/v0.0.4/cargo-dist-v0.0.4-installer.ps1 | iex
+          - os: macos-11
+            dist-args: --artifacts=local --target=aarch64-apple-darwin --target=x86_64-apple-darwin
+            install-dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.5/cargo-dist-v0.0.5-installer.sh | sh
+          - os: ubuntu-20.04
+            dist-args: --artifacts=local --target=x86_64-unknown-linux-gnu
+            install-dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.5/cargo-dist-v0.0.5-installer.sh | sh
+          - os: windows-2019
+            dist-args: --artifacts=local --target=x86_64-pc-windows-msvc
+            install-dist: irm  https://github.com/axodotdev/cargo-dist/releases/download/v0.0.5/cargo-dist-v0.0.5-installer.ps1 | iex
 
     runs-on: ${{ matrix.os }}
     env:
@@ -111,7 +101,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
-        run: rustup update 1.67.1 --no-self-update && rustup default 1.67.1
+        run: rustup update 1.68.2 --no-self-update && rustup default 1.68.2
+      # Manual addition of build deps
+      - name: Install libusb, libudev (linux)
+        run: |
+          sudo apt update
+          sudo apt install -y libusb-1.0-0-dev libudev-dev
+        # Only install on Ubuntu
+        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'ubuntu-20.04')
       - name: Install cargo-dist
         run: ${{ matrix.install-dist }}
       - name: Run cargo-dist

--- a/.github/workflows/release_crates.yml
+++ b/.github/workflows/release_crates.yml
@@ -16,11 +16,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release'))
 
     steps:
-
       - name: Checkout sources
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # This is a workaround for cargo-release, see https://github.com/crate-ci/cargo-release/issues/625
+          fetch-depth: 0 # This is a workaround for cargo-release, see https://github.com/crate-ci/cargo-release/issues/625
 
       - name: Install libusb and libftdi (linux)
         run: |
@@ -31,7 +30,7 @@ jobs:
 
       - name: install cargo-release
         run: |
-          curl -LsSf https://github.com/crate-ci/cargo-release/releases/download/v0.24.0/cargo-release-v0.24.0-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ${CARGO_HOME:-~/.cargo}/bin
+          curl -LsSf https://github.com/crate-ci/cargo-release/releases/download/v0.24.8/cargo-release-v0.24.8-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Install SSH
         run: |
@@ -61,6 +60,8 @@ jobs:
         run: |
           git checkout master
           cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          cargo release --no-confirm --execute --sign ${{ steps.crate_version.outputs.version }}
+          cargo publish --no-confirm --execute
+          cargo tag --no-confirm --execute --sign-tag
+          cargo push --no-confirm --execute
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ anyhow = "1.0.70"
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.0.4"
+cargo-dist-version = "0.0.5"
 # The preferred Rust toolchain to use in CI (rustup toolchain syntax)
-rust-toolchain-version = "1.67.1"
+rust-toolchain-version = "1.68.2"
 # CI backends to support (see 'cargo dist generate-ci')
 ci = ["github"]
 # Target platforms to build apps for (Rust target-triple syntax)


### PR DESCRIPTION
This updates the Rust version in CI to 1.68.2, and installs the build dependencies for the binary creation in the correct step.

It also splits `cargo release` into multiple steps, to avoid the issue seen in the [latest CI run](https://github.com/probe-rs/probe-rs/actions/runs/4576125486/jobs/8079840403#step:9:1344), where pushin the commit failed due to branch protection.

Tip: Hiding the whitespace changes makes the diff much clearer.