### PR TITLE
Add support for the Olimex ARM-USB-TINY-H JTAG adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - probe-rs-debugger: Show errors that happen before VSCode/DAP Client session initializion has completed (#1581).
 
+### Added
+
+- Added support for the Olimex ARM-USB-TINY-H JTAG device (#1586).
+
 ## [0.18.0]
 
 Released 2023-03-31


### PR DESCRIPTION
Thanks for making `probe-rs`, it's very nice!

This PR adds the PID/VID for the [Olimex ARM-USB-TINY-H] JTAG adapter ([datasheet]) as being compatible with FTDI devices.
This device contains an FTDI `FT2232H` chip internally.

Here's the OpenOCD config for reference: [olimex-arm-usb-ocd.cfg](https://github.com/openocd-org/openocd/blob/573a39b36cf133bb7403b12337301a5616112f1a/tcl/interface/ftdi/olimex-arm-usb-ocd.cfg).

I tested this manually and was able to halt, resume, and read the memory of a RISC-V chip running on an FPGA.
Let me know if there's any more thorough testing I can do.

There are other Olimex devices using the `FT2232H/C` chips with PIDs `0x0004`, `0x0003`, and `0x002B` but I don't have any to test with so didn't add them.

[Olimex ARM-USB-TINY-H]: https://www.olimex.com/Products/ARM/JTAG/ARM-USB-TINY-H/
[datasheet]: https://www.olimex.com/Products/ARM/JTAG/_resources/ARM-USB-TINY_and_TINY_H_manual.pdf