### PR TITLE
Propagate running state to probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for the Olimex ARM-USB-TINY-H JTAG device (#1586).
+- Added support for propagating `CoreStatus` to the probe in use (#1588).
 
 ## [0.18.0]
 

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mock.rs
@@ -46,7 +46,9 @@ impl FlushableArmAccess for MockMemoryAp {
         >,
         DebugProbeError,
     > {
-        todo!()
+        Err(DebugProbeError::NotImplemented(
+            "get_arm_communication_interface",
+        ))
     }
 }
 

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -449,7 +449,7 @@ impl<'interface> ArmCommunicationInterface<Initialized> {
         Ok(initialized_interface)
     }
 
-    /// Report the [`CoreStatus`] of the chip attached to the probe (to the probe).
+    /// Inform the probe of the [`CoreStatus`] of the chip attached to the probe.
     pub fn update_core_status(&mut self, state: CoreStatus) {
         self.probe.update_core_status(state).ok();
     }

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -450,8 +450,8 @@ impl<'interface> ArmCommunicationInterface<Initialized> {
     }
 
     /// Inform the probe of the [`CoreStatus`] of the chip attached to the probe.
-    pub fn update_core_status(&mut self, state: CoreStatus) {
-        self.probe.update_core_status(state).ok();
+    pub fn core_status_notification(&mut self, state: CoreStatus) {
+        self.probe.core_status_notification(state).ok();
     }
 
     /// Tries to obtain a memory interface which can be used to read memory from ARM targets.

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -12,7 +12,8 @@ use super::{
     ApAddress, ArmError, DapAccess, DpAddress, PortType, RawDapAccess, SwoAccess, SwoConfig,
 };
 use crate::{
-    architecture::arm::ap::DataSize, DebugProbe, DebugProbeError, Error as ProbeRsError, Probe,
+    architecture::arm::ap::DataSize, CoreStatus, DebugProbe, DebugProbeError,
+    Error as ProbeRsError, Probe,
 };
 use jep106::JEP106Code;
 
@@ -448,9 +449,9 @@ impl<'interface> ArmCommunicationInterface<Initialized> {
         Ok(initialized_interface)
     }
 
-    /// Report the running state to the underlying probe.
-    pub fn set_running(&mut self, running: bool) {
-        self.probe.set_running(running);
+    /// Report the [`CoreStatus`] of the chip attached to the probe (to the probe).
+    pub fn update_core_status(&mut self, state: CoreStatus) {
+        self.probe.update_core_status(state).ok();
     }
 
     /// Tries to obtain a memory interface which can be used to read memory from ARM targets.

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -448,6 +448,11 @@ impl<'interface> ArmCommunicationInterface<Initialized> {
         Ok(initialized_interface)
     }
 
+    /// Report the running state to the underlying probe.
+    pub fn set_running(&mut self, running: bool) {
+        self.probe.set_running(running);
+    }
+
     /// Tries to obtain a memory interface which can be used to read memory from ARM targets.
     pub fn memory_interface(
         &'interface mut self,

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -499,11 +499,8 @@ impl<'probe> Armv6m<'probe> {
         })
     }
 
-    fn set_current_core_status(&mut self, status: CoreStatus) {
-        if status != self.state.current_state {
-            self.memory.update_core_status(status);
-            self.state.current_state = status;
-        }
+    fn set_core_status(&mut self, new_status: CoreStatus) {
+        super::update_core_status(&mut self.memory, &mut self.state.current_state, new_status);
     }
 }
 
@@ -565,8 +562,7 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
         self.memory.flush()?;
 
         // We assume that the core is running now.
-        self.set_current_core_status(CoreStatus::Running);
-
+        self.set_core_status(CoreStatus::Running);
         Ok(())
     }
 
@@ -744,8 +740,7 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
                 "The core is in locked up status as a result of an unrecoverable exception"
             );
 
-            self.set_current_core_status(CoreStatus::LockedUp);
-
+            self.set_core_status(CoreStatus::LockedUp);
             return Ok(CoreStatus::LockedUp);
         }
 
@@ -755,8 +750,7 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
                 tracing::warn!("Expected core to be halted, but core is running");
             }
 
-            self.set_current_core_status(CoreStatus::Sleeping);
-
+            self.set_core_status(CoreStatus::Sleeping);
             return Ok(CoreStatus::Sleeping);
         }
 
@@ -789,7 +783,7 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
                 );
             }
 
-            self.set_current_core_status(CoreStatus::Halted(reason));
+            self.set_core_status(CoreStatus::Halted(reason));
 
             return Ok(CoreStatus::Halted(reason));
         }
@@ -799,7 +793,7 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
             tracing::warn!("Core is running, but we expected it to be halted");
         }
 
-        self.set_current_core_status(CoreStatus::Running);
+        self.set_core_status(CoreStatus::Running);
 
         Ok(CoreStatus::Running)
     }

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -501,11 +501,7 @@ impl<'probe> Armv6m<'probe> {
 
     fn set_current_core_status(&mut self, status: CoreStatus) {
         if status != self.state.current_state {
-            if status == CoreStatus::Running {
-                self.memory.set_running(true);
-            } else {
-                self.memory.set_running(false);
-            }
+            self.memory.update_core_status(status);
             self.state.current_state = status;
         }
     }

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -1060,7 +1060,9 @@ mod test {
             >,
             DebugProbeError,
         > {
-            todo!()
+            Err(DebugProbeError::NotImplemented(
+                "get_arm_communication_interface",
+            ))
         }
 
         fn read_64(&mut self, _address: u64, _data: &mut [u64]) -> Result<(), ArmError> {

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -293,11 +293,7 @@ impl<'probe> Armv7a<'probe> {
 
     fn set_current_core_status(&mut self, status: CoreStatus) {
         if status != self.state.current_state {
-            if status == CoreStatus::Running {
-                self.memory.set_running(true);
-            } else {
-                self.memory.set_running(false);
-            }
+            self.memory.update_core_status(status);
             self.state.current_state = status;
         }
     }
@@ -717,7 +713,6 @@ impl<'probe> CoreInterface for Armv7a<'probe> {
             let reason = dbgdscr.halt_reason();
 
             self.set_current_core_status(CoreStatus::Halted(reason));
-            self.memory.set_running(false);
 
             self.read_fp_reg_count()?;
 
@@ -961,7 +956,7 @@ mod test {
     }
 
     impl ArmProbe for MockProbe {
-        fn set_running(&mut self, _running: bool) {}
+        fn update_core_status(&mut self, _: CoreStatus) {}
 
         fn read_8(&mut self, _address: u64, _data: &mut [u8]) -> Result<(), ArmError> {
             todo!()

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -291,11 +291,8 @@ impl<'probe> Armv7a<'probe> {
         self.execute_instruction_with_input(instruction, value)
     }
 
-    fn set_current_core_status(&mut self, status: CoreStatus) {
-        if status != self.state.current_state {
-            self.memory.update_core_status(status);
-            self.state.current_state = status;
-        }
+    fn set_core_status(&mut self, new_status: CoreStatus) {
+        super::update_core_status(&mut self.memory, &mut self.state.current_state, new_status);
     }
 }
 
@@ -373,7 +370,7 @@ impl<'probe> CoreInterface for Armv7a<'probe> {
         }
 
         // Recompute / verify current state
-        self.set_current_core_status(CoreStatus::Running);
+        self.set_core_status(CoreStatus::Running);
         let _ = self.status()?;
 
         Ok(())
@@ -712,7 +709,7 @@ impl<'probe> CoreInterface for Armv7a<'probe> {
         if dbgdscr.halted() {
             let reason = dbgdscr.halt_reason();
 
-            self.set_current_core_status(CoreStatus::Halted(reason));
+            self.set_core_status(CoreStatus::Halted(reason));
 
             self.read_fp_reg_count()?;
 
@@ -723,7 +720,7 @@ impl<'probe> CoreInterface for Armv7a<'probe> {
             tracing::warn!("Core is running, but we expected it to be halted");
         }
 
-        self.set_current_core_status(CoreStatus::Running);
+        self.set_core_status(CoreStatus::Running);
 
         Ok(CoreStatus::Running)
     }

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -640,11 +640,7 @@ impl<'probe> Armv7m<'probe> {
 
     fn set_current_core_status(&mut self, status: CoreStatus) {
         if status != self.state.current_state {
-            if status == CoreStatus::Running {
-                self.memory.set_running(true);
-            } else {
-                self.memory.set_running(false);
-            }
+            self.memory.update_core_status(status);
             self.state.current_state = status;
         }
     }

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -638,11 +638,8 @@ impl<'probe> Armv7m<'probe> {
         })
     }
 
-    fn set_current_core_status(&mut self, status: CoreStatus) {
-        if status != self.state.current_state {
-            self.memory.update_core_status(status);
-            self.state.current_state = status;
-        }
+    fn set_core_status(&mut self, new_status: CoreStatus) {
+        super::update_core_status(&mut self.memory, &mut self.state.current_state, new_status);
     }
 }
 
@@ -674,7 +671,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
                 "The core is in locked up status as a result of an unrecoverable exception"
             );
 
-            self.set_current_core_status(CoreStatus::LockedUp);
+            self.set_core_status(CoreStatus::LockedUp);
 
             return Ok(CoreStatus::LockedUp);
         }
@@ -685,7 +682,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
                 tracing::warn!("Expected core to be halted, but core is running");
             }
 
-            self.set_current_core_status(CoreStatus::Sleeping);
+            self.set_core_status(CoreStatus::Sleeping);
 
             return Ok(CoreStatus::Sleeping);
         }
@@ -717,7 +714,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
                 );
             }
 
-            self.set_current_core_status(CoreStatus::Halted(reason));
+            self.set_core_status(CoreStatus::Halted(reason));
 
             return Ok(CoreStatus::Halted(reason));
         }
@@ -727,7 +724,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
             tracing::warn!("Core is running, but we expected it to be halted");
         }
 
-        self.set_current_core_status(CoreStatus::Running);
+        self.set_core_status(CoreStatus::Running);
 
         Ok(CoreStatus::Running)
     }
@@ -793,7 +790,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
         self.memory.flush()?;
 
         // We assume that the core is running now
-        self.set_current_core_status(CoreStatus::Running);
+        self.set_core_status(CoreStatus::Running);
 
         Ok(())
     }

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -714,6 +714,17 @@ impl<'probe> Armv8a<'probe> {
 
         Ok(())
     }
+
+    fn set_current_core_status(&mut self, status: CoreStatus) {
+        if status != self.state.current_state {
+            if status == CoreStatus::Running {
+                self.memory.set_running(true);
+            } else {
+                self.memory.set_running(false);
+            }
+            self.state.current_state = status;
+        }
+    }
 }
 
 impl<'probe> CoreInterface for Armv8a<'probe> {
@@ -816,7 +827,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
         }
 
         // Recompute / verify current state
-        self.state.current_state = CoreStatus::Running;
+        self.set_current_core_status(CoreStatus::Running);
         let _ = self.status()?;
 
         // Gate restart channel
@@ -1041,7 +1052,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
         if edscr.halted() {
             let reason = edscr.halt_reason();
 
-            self.state.current_state = CoreStatus::Halted(reason);
+            self.set_current_core_status(CoreStatus::Halted(reason));
             self.state.is_64_bit = edscr.currently_64_bit();
 
             return Ok(CoreStatus::Halted(reason));
@@ -1051,7 +1062,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
             tracing::warn!("Core is running, but we expected it to be halted");
         }
 
-        self.state.current_state = CoreStatus::Running;
+        self.set_current_core_status(CoreStatus::Running);
 
         Ok(CoreStatus::Running)
     }
@@ -1279,6 +1290,8 @@ mod test {
     }
 
     impl ArmProbe for MockProbe {
+        fn set_running(&mut self, _running: bool) {}
+
         fn read_8(&mut self, _address: u64, _data: &mut [u8]) -> Result<(), ArmError> {
             todo!()
         }

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -1377,7 +1377,9 @@ mod test {
             >,
             DebugProbeError,
         > {
-            todo!()
+            Err(DebugProbeError::NotImplemented(
+                "get_arm_communication_interface",
+            ))
         }
 
         fn read_64(&mut self, _address: u64, _data: &mut [u64]) -> Result<(), ArmError> {

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -717,11 +717,7 @@ impl<'probe> Armv8a<'probe> {
 
     fn set_current_core_status(&mut self, status: CoreStatus) {
         if status != self.state.current_state {
-            if status == CoreStatus::Running {
-                self.memory.set_running(true);
-            } else {
-                self.memory.set_running(false);
-            }
+            self.memory.update_core_status(status);
             self.state.current_state = status;
         }
     }
@@ -1290,7 +1286,7 @@ mod test {
     }
 
     impl ArmProbe for MockProbe {
-        fn set_running(&mut self, _running: bool) {}
+        fn update_core_status(&mut self, _: CoreStatus) {}
 
         fn read_8(&mut self, _address: u64, _data: &mut [u8]) -> Result<(), ArmError> {
             todo!()

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -715,11 +715,8 @@ impl<'probe> Armv8a<'probe> {
         Ok(())
     }
 
-    fn set_current_core_status(&mut self, status: CoreStatus) {
-        if status != self.state.current_state {
-            self.memory.update_core_status(status);
-            self.state.current_state = status;
-        }
+    fn set_core_status(&mut self, new_status: CoreStatus) {
+        super::update_core_status(&mut self.memory, &mut self.state.current_state, new_status);
     }
 }
 
@@ -823,7 +820,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
         }
 
         // Recompute / verify current state
-        self.set_current_core_status(CoreStatus::Running);
+        self.set_core_status(CoreStatus::Running);
         let _ = self.status()?;
 
         // Gate restart channel
@@ -1048,7 +1045,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
         if edscr.halted() {
             let reason = edscr.halt_reason();
 
-            self.set_current_core_status(CoreStatus::Halted(reason));
+            self.set_core_status(CoreStatus::Halted(reason));
             self.state.is_64_bit = edscr.currently_64_bit();
 
             return Ok(CoreStatus::Halted(reason));
@@ -1058,7 +1055,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
             tracing::warn!("Core is running, but we expected it to be halted");
         }
 
-        self.set_current_core_status(CoreStatus::Running);
+        self.set_core_status(CoreStatus::Running);
 
         Ok(CoreStatus::Running)
     }

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -78,11 +78,7 @@ impl<'probe> Armv8m<'probe> {
 
     fn set_current_core_status(&mut self, status: CoreStatus) {
         if status != self.state.current_state {
-            if status == CoreStatus::Running {
-                self.memory.set_running(true);
-            } else {
-                self.memory.set_running(false);
-            }
+            self.memory.update_core_status(status);
             self.state.current_state = status;
         }
     }

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -76,11 +76,8 @@ impl<'probe> Armv8m<'probe> {
         })
     }
 
-    fn set_current_core_status(&mut self, status: CoreStatus) {
-        if status != self.state.current_state {
-            self.memory.update_core_status(status);
-            self.state.current_state = status;
-        }
+    fn set_core_status(&mut self, new_status: CoreStatus) {
+        super::update_core_status(&mut self.memory, &mut self.state.current_state, new_status);
     }
 }
 
@@ -139,7 +136,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         self.memory.flush()?;
 
         // We assume that the core is running now
-        self.set_current_core_status(CoreStatus::Running);
+        self.set_core_status(CoreStatus::Running);
 
         Ok(())
     }
@@ -332,7 +329,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
                 "The core is in locked up status as a result of an unrecoverable exception"
             );
 
-            self.set_current_core_status(CoreStatus::LockedUp);
+            self.set_core_status(CoreStatus::LockedUp);
 
             return Ok(CoreStatus::LockedUp);
         }
@@ -343,7 +340,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
                 tracing::warn!("Expected core to be halted, but core is running");
             }
 
-            self.set_current_core_status(CoreStatus::Sleeping);
+            self.set_core_status(CoreStatus::Sleeping);
 
             return Ok(CoreStatus::Sleeping);
         }
@@ -377,7 +374,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
                 );
             }
 
-            self.set_current_core_status(CoreStatus::Halted(reason));
+            self.set_core_status(CoreStatus::Halted(reason));
 
             return Ok(CoreStatus::Halted(reason));
         }
@@ -387,7 +384,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
             tracing::warn!("Core is running, but we expected it to be halted");
         }
 
-        self.set_current_core_status(CoreStatus::Running);
+        self.set_core_status(CoreStatus::Running);
 
         Ok(CoreStatus::Running)
     }

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -1052,3 +1052,23 @@ impl CortexAState {
         self.initialized
     }
 }
+
+/// Core implementations should call this function when they
+/// wish to update the [`CoreStatus`] of their core.
+///
+/// It will reflect the core status to the probe/memory interface if
+/// the status has changed, and will replace `current_status` with
+/// `new_status`.
+pub fn update_core_status<
+    P: super::memory::adi_v5_memory_interface::ArmProbe + ?Sized,
+    T: core::ops::DerefMut<Target = P>,
+>(
+    probe: &mut T,
+    current_status: &mut CoreStatus,
+    new_status: CoreStatus,
+) {
+    if *current_status != new_status {
+        probe.deref_mut().update_core_status(new_status);
+    }
+    *current_status = new_status;
+}

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -139,7 +139,8 @@ pub trait ArmProbe: SwdSequence {
 
     /// Report the CoreStatus of the chip attached to the probe (to the probe).
     //
-    // NOTE: this function is designed to be infallible.
+    // NOTE: this function is designed to be infallible as it is usually only
+    // a visual indication.
     fn update_core_status(&mut self, state: CoreStatus);
 
     fn get_arm_communication_interface(

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -12,6 +12,8 @@ use std::convert::TryInto;
 use std::ops::Range;
 
 pub trait ArmProbe: SwdSequence {
+    fn set_running(&mut self, _running: bool) {}
+
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), ArmError>;
 
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), ArmError>;
@@ -880,6 +882,13 @@ impl<AP> ArmProbe for ADIMemoryInterface<'_, AP>
 where
     AP: FlushableArmAccess + ApAccess + DpAccess,
 {
+    fn set_running(&mut self, running: bool) {
+        self.interface
+            .get_arm_communication_interface()
+            .map(|i| i.set_running(running))
+            .ok();
+    }
+
     fn supports_native_64bit_access(&mut self) -> bool {
         self.ap_information.has_large_data_extension
     }

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -148,7 +148,7 @@ pub trait ArmProbe: SwdSequence {
     // a visual indication.
     fn update_core_status(&mut self, state: CoreStatus) {
         self.get_arm_communication_interface()
-            .map(|iface| iface.update_core_status(state))
+            .map(|iface| iface.core_status_notification(state))
             .ok();
     }
 }

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -150,7 +150,7 @@ pub trait RawDapAccess {
     fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe>;
 
     /// Inform the probe of the [`CoreStatus`] of the chip attached to the probe.
-    fn update_core_status(&mut self, state: CoreStatus) -> Result<(), DebugProbeError>;
+    fn core_status_notification(&mut self, state: CoreStatus) -> Result<(), DebugProbeError>;
 }
 
 /// High-level DAP register access.

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -1,4 +1,4 @@
-use crate::{DebugProbe, DebugProbeError};
+use crate::{CoreStatus, DebugProbe, DebugProbeError};
 
 use super::ArmError;
 
@@ -149,9 +149,8 @@ pub trait RawDapAccess {
     /// Cast this interface into a generic [`DebugProbe`].
     fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe>;
 
-    /// Report the running state of the chip attached to our probe
-    /// to the probe.
-    fn set_running(&mut self, _running: bool) {}
+    /// Report the [`CoreStatus`] of the chip attached to the probe (to the probe).
+    fn update_core_status(&mut self, state: CoreStatus) -> Result<(), DebugProbeError>;
 }
 
 /// High-level DAP register access.

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -149,7 +149,7 @@ pub trait RawDapAccess {
     /// Cast this interface into a generic [`DebugProbe`].
     fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe>;
 
-    /// Report the [`CoreStatus`] of the chip attached to the probe (to the probe).
+    /// Inform the probe of the [`CoreStatus`] of the chip attached to the probe.
     fn update_core_status(&mut self, state: CoreStatus) -> Result<(), DebugProbeError>;
 }
 

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -148,6 +148,10 @@ pub trait RawDapAccess {
 
     /// Cast this interface into a generic [`DebugProbe`].
     fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe>;
+
+    /// Report the running state of the chip attached to our probe
+    /// to the probe.
+    fn set_running(&mut self, _running: bool) {}
 }
 
 /// High-level DAP register access.

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -1089,6 +1089,11 @@ impl CoreStatus {
     pub fn is_halted(&self) -> bool {
         matches!(self, CoreStatus::Halted(_))
     }
+
+    /// Returns `true` if the core is currently running.
+    pub fn is_running(&self) -> bool {
+        self == &Self::Running
+    }
 }
 
 /// When the core halts due to a breakpoint request, some architectures will allow us to distinguish between a software and hardware breakpoint.

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         },
         BatchCommand,
     },
-    DebugProbe, DebugProbeError, DebugProbeSelector, WireProtocol,
+    CoreStatus, DebugProbe, DebugProbeError, DebugProbeSelector, WireProtocol,
 };
 
 use commands::{
@@ -628,9 +628,15 @@ impl DebugProbe for CmsisDap {
 }
 
 impl RawDapAccess for CmsisDap {
-    fn set_running(&mut self, running: bool) {
-        let _: Result<HostStatusResponse, _> =
-            commands::send_command(&mut self.device, HostStatusRequest::running(running));
+    fn update_core_status(&mut self, status: CoreStatus) -> Result<(), DebugProbeError> {
+        let running = if status == CoreStatus::Running {
+            true
+        } else {
+            false
+        };
+
+        commands::send_command(&mut self.device, HostStatusRequest::running(running))?;
+        Ok(())
     }
 
     fn select_dp(&mut self, dp: DpAddress) -> Result<(), ArmError> {

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -628,7 +628,7 @@ impl DebugProbe for CmsisDap {
 }
 
 impl RawDapAccess for CmsisDap {
-    fn update_core_status(&mut self, status: CoreStatus) -> Result<(), DebugProbeError> {
+    fn core_status_notification(&mut self, status: CoreStatus) -> Result<(), DebugProbeError> {
         let running = status.is_running();
         commands::send_command(&mut self.device, HostStatusRequest::running(running))?;
         Ok(())

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -629,8 +629,7 @@ impl DebugProbe for CmsisDap {
 
 impl RawDapAccess for CmsisDap {
     fn update_core_status(&mut self, status: CoreStatus) -> Result<(), DebugProbeError> {
-        let running = status == CoreStatus::Running;
-
+        let running = status.is_running();
         commands::send_command(&mut self.device, HostStatusRequest::running(running))?;
         Ok(())
     }

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -628,6 +628,11 @@ impl DebugProbe for CmsisDap {
 }
 
 impl RawDapAccess for CmsisDap {
+    fn set_running(&mut self, running: bool) {
+        let _: Result<HostStatusResponse, _> =
+            commands::send_command(&mut self.device, HostStatusRequest::running(running));
+    }
+
     fn select_dp(&mut self, dp: DpAddress) -> Result<(), ArmError> {
         match dp {
             DpAddress::Default => Ok(()), // nop

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -629,11 +629,7 @@ impl DebugProbe for CmsisDap {
 
 impl RawDapAccess for CmsisDap {
     fn update_core_status(&mut self, status: CoreStatus) -> Result<(), DebugProbeError> {
-        let running = if status == CoreStatus::Running {
-            true
-        } else {
-            false
-        };
+        let running = status == CoreStatus::Running;
 
         commands::send_command(&mut self.device, HostStatusRequest::running(running))?;
         Ok(())

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -190,7 +190,7 @@ impl RawDapAccess for FakeProbe {
         self
     }
 
-    fn update_core_status(&mut self, _: crate::CoreStatus) -> Result<(), DebugProbeError> {
+    fn core_status_notification(&mut self, _: crate::CoreStatus) -> Result<(), DebugProbeError> {
         Ok(())
     }
 }

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -189,6 +189,10 @@ impl RawDapAccess for FakeProbe {
     fn into_probe(self: Box<Self>) -> Box<dyn DebugProbe> {
         self
     }
+
+    fn update_core_status(&mut self, _: crate::CoreStatus) -> Result<(), DebugProbeError> {
+        Ok(())
+    }
 }
 
 #[derive(Debug)]

--- a/probe-rs/src/probe/jlink/arm.rs
+++ b/probe-rs/src/probe/jlink/arm.rs
@@ -1386,6 +1386,10 @@ impl<Probe: DebugProbe + RawProtocolIo + JTAGAccess + 'static> RawDapAccess for 
 
         Ok(())
     }
+
+    fn update_core_status(&mut self, _: crate::CoreStatus) -> Result<(), DebugProbeError> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/probe-rs/src/probe/jlink/arm.rs
+++ b/probe-rs/src/probe/jlink/arm.rs
@@ -1387,7 +1387,7 @@ impl<Probe: DebugProbe + RawProtocolIo + JTAGAccess + 'static> RawDapAccess for 
         Ok(())
     }
 
-    fn update_core_status(&mut self, _: crate::CoreStatus) -> Result<(), DebugProbeError> {
+    fn core_status_notification(&mut self, _: crate::CoreStatus) -> Result<(), DebugProbeError> {
         Ok(())
     }
 }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1646,6 +1646,8 @@ impl ArmProbe for StLinkMemoryInterface<'_> {
     fn ap(&mut self) -> MemoryAp {
         self.current_ap
     }
+
+    fn update_core_status(&mut self, _: crate::CoreStatus) {}
 }
 
 fn is_wait_error(e: &StlinkError) -> bool {

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1646,8 +1646,6 @@ impl ArmProbe for StLinkMemoryInterface<'_> {
     fn ap(&mut self) -> MemoryAp {
         self.current_ap
     }
-
-    fn update_core_status(&mut self, _: crate::CoreStatus) {}
 }
 
 fn is_wait_error(e: &StlinkError) -> bool {


### PR DESCRIPTION
Add `set_running` functionality to all ARM related traits to propagate running state to probes.

This is mostly to actually use `HostStatus::Running`, which some probes support (including the rusty probe),  working.

I have basically taken a shortcut and just added the method to all relevant traits in the tree, and propagated it on from there. Feedback is welcome and refusal would be understandable, though I think it'd be quite nice to get this functionality implemented.