### PR TITLE
Print "Finished" message to stderr instead of stdout when flashing with `probe-rs-cli run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - probe-rs-debugger: Show errors that happen before VSCode/DAP Client session initializion has completed (#1581).
+- probe-rs-cli-util: replace unwanted instance of `println` with `eprintln` (#1595, fixes #1593).
 
 ### Added
 

--- a/cargo-flash/CHANGELOG.md
+++ b/cargo-flash/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+### Fixed
+
+- Replace unwanted instance of `println` with `eprintln` (#1595).
+
 ## [0.18.0]
 
 Released 2023-03-31

--- a/cargo-flash/src/main.rs
+++ b/cargo-flash/src/main.rs
@@ -136,7 +136,7 @@ fn main_try(metadata: Arc<Mutex<Metadata>>) -> Result<(), OperationError> {
             .into()
     };
 
-    logging::println(format!(
+    logging::eprintln(format!(
         "    {} {}",
         "Flashing".green().bold(),
         path.display()

--- a/probe-rs-cli-util/src/flash.rs
+++ b/probe-rs-cli-util/src/flash.rs
@@ -160,7 +160,7 @@ pub fn run_flash_download(
 
     // Stop timer.
     let elapsed = instant.elapsed();
-    logging::println(format!(
+    logging::eprintln(format!(
         "    {} in {}s",
         "Finished".green().bold(),
         elapsed.as_millis() as f32 / 1000.0,


### PR DESCRIPTION
Fixes #1593 

Should [this println](https://github.com/probe-rs/probe-rs/blob/master/cargo-flash/src/main.rs#L139) also be an `eprintln`?