### PR TITLE
Fix probe-rs-cli-util dependency

### DIFF
--- a/cargo-embed/Cargo.toml
+++ b/cargo-embed/Cargo.toml
@@ -20,9 +20,7 @@ sentry = ["probe-rs-cli-util/sentry"]
 [dependencies]
 probe-rs = { workspace = true }
 gdb-server = { workspace = true }
-probe-rs-cli-util = { workspace = true, default-features = false, features = [
-    "anyhow",
-] }
+probe-rs-cli-util = { workspace = true }
 git-version = "0.3.5"
 env_logger = "0.10.0"
 log = { version = "0.4.17", features = ["serde"] }

--- a/cargo-flash/Cargo.toml
+++ b/cargo-flash/Cargo.toml
@@ -24,9 +24,7 @@ sentry = ["probe-rs-cli-util/sentry"]
 env_logger = "0.10"
 colored = "2"
 probe-rs = { workspace = true }
-probe-rs-cli-util = { workspace = true, default-features = false, features = [
-    "anyhow",
-] }
+probe-rs-cli-util = { workspace = true }
 anyhow = "1"
 bytesize = "1"
 thiserror = "1"


### PR DESCRIPTION
Cargo was complaining because of the combination of `default-features = false` and workspace dependencies.