### PR TITLE
Mention troubleshooting page in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ fn main() -> Result<(), probe_rs::Error> {
 
 Don't hesitate to [file an issue](https://github.com/probe-rs/probe-rs/issues/new), ask questions on [Matrix](https://matrix.to/#/#probe-rs:matrix.org), or contact [@Yatekii](https://github.com/Yatekii) via e-mail.
 
+There is also a [trouble-shooting section](https://probe.rs/docs/knowledge-base/troubleshooting/) on the [project page](https://probe.rs/).
+
 ### How can I help?
 
 Please have a look at the issues or open one if you feel that something is needed.


### PR DESCRIPTION
This depends on https://github.com/probe-rs/webpage/pull/78 to actually add the trouble-shooting page.