### PR TITLE
fix CMSIS_DAP named probes not recognised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- probe-rs: recognize `CMSIS-DAP` probes with device strings containing `CMSIS_DAP`
 - probe-rs-debugger: Show errors that happen before VSCode/DAP Client session initializion has completed (#1581).
 - probe-rs-cli-util: replace unwanted instance of `println` with `eprintln` (#1595, fixes #1593).
 

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -384,10 +384,9 @@ pub fn open_device_from_selector(
     }
 }
 
-    
-/// We recognise cmis dap interfaces if they have string like "CMSIS-DAP" 
+/// We recognise cmis dap interfaces if they have string like "CMSIS-DAP"
 /// in them. As devices spell CMIS DAP differently we go through known
-/// spellings/patterns looking for a match 
+/// spellings/patterns looking for a match
 fn is_cmsis_dap(id: &str) -> bool {
     id.contains("CMSIS-DAP") || id.contains("CMSIS_DAP")
 }

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -128,7 +128,7 @@ fn get_cmsisdap_hid_info(device: &hidapi::DeviceInfo) -> Option<DebugProbeInfo> 
     let prod_str = device.product_string().unwrap_or("");
     let path = device.path().to_str().unwrap_or("");
     if is_cmsis_dap(prod_str) || is_cmsis_dap(path) {
-        tracing::trace!("CMSIS_DAP device with USB path: {:?}", device.path());
+        tracing::trace!("CMSIS-DAP device with USB path: {:?}", device.path());
         tracing::trace!("                product_string: {:?}", prod_str);
         tracing::trace!(
             "                     interface: {}",


### PR DESCRIPTION
`probe-rs` recognizes _Cmsis Dap devices_ by looking for the string `CMSIS-DAP`. Some of these probes are called `CMSIS_DAP` (note underscore) instead. These are missed.

This commit fixes that by checking for the string `CMSIS-DAP` or `CMSIS_DAP`

#### Context
I ran into this while using `probe-run`, see linked [issue](https://github.com/knurling-rs/probe-run/issues/400).

#### Testing
This PR was tested by building `probe-run` with it applied and flashing an stm32 using my probe that is listed in lsusb as "CMSIS_DAP". I do not have a CMSIS DAP with a dash in the name however given the changes I can not imagine they will stop working.