### PR TITLE
wip: rp2040: add sequence to reset both cores in system_reset.

### DIFF
--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -449,6 +449,19 @@ impl<'interface> ArmCommunicationInterface<Initialized> {
         Ok(initialized_interface)
     }
 
+    /// Reset the cached state of the debug port.
+    ///
+    /// probe-rs caches which DP/AP is currently selected, to avoid having to
+    /// select it multiple times when performing multiple operations on the same
+    /// DP/AP. This function clears this cache.
+    ///
+    /// This can be needed with some kinds of target reset, as the state of the
+    /// DP/AP might have been reset.
+    pub fn clear_state(&mut self) {
+        self.state.current_dp = None;
+        self.state.dps.clear();
+    }
+
     /// Inform the probe of the [`CoreStatus`] of the chip attached to the probe.
     pub fn core_status_notification(&mut self, state: CoreStatus) {
         self.probe.core_status_notification(state).ok();

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -8,6 +8,7 @@ pub mod nrf52;
 pub mod nrf53;
 pub mod nrf91;
 pub mod nxp;
+pub mod rp2040;
 pub mod stm32_armv6;
 pub mod stm32_armv7;
 pub mod stm32h7;

--- a/probe-rs/src/architecture/arm/sequences/rp2040.rs
+++ b/probe-rs/src/architecture/arm/sequences/rp2040.rs
@@ -1,0 +1,57 @@
+//! Sequences for Nrf52 devices
+
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use super::ArmDebugSequence;
+use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
+use crate::architecture::arm::ArmError;
+
+/// Marker struct indicating initialization sequencing for RP2040 family parts.
+pub struct Rp2040 {}
+
+impl Rp2040 {
+    /// Create the sequencer for the RP2040 family of parts.
+    pub fn create() -> Arc<Self> {
+        Arc::new(Self {})
+    }
+}
+
+const PSM_FRCE_ON: u64 = 0x40010000;
+const PSM_FRCE_OFF: u64 = 0x40010004;
+const PSM_WDSEL: u64 = 0x40010008;
+
+const PSM_SEL_SIO: u32 = 1 << 14;
+const PSM_SEL_PROC0: u32 = 1 << 15;
+const PSM_SEL_PROC1: u32 = 1 << 16;
+
+const WATCHDOG_CTRL: u64 = 0x40058000;
+const WATCHDOG_CTRL_TRIGGER: u32 = 1 << 31;
+const WATCHDOG_CTRL_ENABLE: u32 = 1 << 30;
+
+impl ArmDebugSequence for Rp2040 {
+    fn reset_system(
+        &self,
+        interface: &mut dyn ArmProbe,
+        _core_type: probe_rs_target::CoreType,
+        _debug_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        tracing::debug!("rp2040: resetting SIO and processors");
+        interface.write_word_32(PSM_WDSEL, PSM_SEL_SIO | PSM_SEL_PROC0 | PSM_SEL_PROC1)?;
+        interface.write_word_32(WATCHDOG_CTRL, WATCHDOG_CTRL_ENABLE)?;
+        interface.write_word_32(WATCHDOG_CTRL, WATCHDOG_CTRL_ENABLE | WATCHDOG_CTRL_TRIGGER)?;
+
+        // random sleep. No idea if this is needed.
+        thread::sleep(Duration::from_millis(100));
+
+        tracing::debug!("rp2040: reset done");
+
+        interface
+            .get_arm_communication_interface()
+            .unwrap()
+            .clear_state();
+
+        Ok(())
+    }
+}

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -9,6 +9,7 @@ use crate::architecture::arm::sequences::{
     nrf53::Nrf5340,
     nrf91::Nrf9160,
     nxp::{LPC55Sxx, MIMXRT10xx, MIMXRT11xx},
+    rp2040::Rp2040,
     stm32_armv6::{Stm32Armv6, Stm32Armv6Family},
     stm32_armv7::Stm32Armv7,
     stm32h7::Stm32h7,
@@ -165,6 +166,12 @@ impl Target {
         } else if chip.name.starts_with("XMC4") {
             tracing::warn!("Using custom sequence for XMC4000");
             debug_sequence = DebugSequence::Arm(XMC4000::create());
+        } else if chip.name == "RP2040" {
+            // exact match to not include RP2040_SELFDEBUG
+            // since in that case we really want to reset core0 only,
+            // not both (which is what the sequence does).
+            tracing::warn!("Using custom sequence for RP2040");
+            debug_sequence = DebugSequence::Arm(Rp2040::create());
         }
 
         Ok(Target {


### PR DESCRIPTION
in RP2040, SCB SYS_RESET only resets the current core. We need it to reset both cores and SIO, otherwise we can run into funny issues like https://github.com/rp-rs/rp-hal/issues/292.

The way to do it is through the watchdog. The sequence to do this is working, the issue is that it completely resets the SWD state, so afterwards we need to do a complete "reattach". `clear_state` is a lazy attempt at this, but it doesn't cause reattach for the memory interface currently opened...

I'm not sure what's the best way to proceed.