### PR TITLE
Code refactoring related to handling of memory mapped registers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pbkdf2"
@@ -2201,6 +2201,7 @@ dependencies = [
  "num-traits",
  "object 0.31.0",
  "once_cell",
+ "paste",
  "pretty_env_logger",
  "probe-rs-target",
  "rand",

--- a/cargo-embed/Cargo.toml
+++ b/cargo-embed/Cargo.toml
@@ -20,9 +20,7 @@ sentry = ["probe-rs-cli-util/sentry"]
 [dependencies]
 probe-rs = { workspace = true }
 gdb-server = { workspace = true }
-probe-rs-cli-util = { workspace = true, default-features = false, features = [
-    "anyhow",
-] }
+probe-rs-cli-util = { workspace = true, features = ["anyhow"] }
 git-version = "0.3.5"
 env_logger = "0.10.0"
 log = { version = "0.4.17", features = ["serde"] }

--- a/cargo-flash/Cargo.toml
+++ b/cargo-flash/Cargo.toml
@@ -24,9 +24,7 @@ sentry = ["probe-rs-cli-util/sentry"]
 env_logger = "0.10"
 colored = "2"
 probe-rs = { workspace = true }
-probe-rs-cli-util = { workspace = true, default-features = false, features = [
-    "anyhow",
-] }
+probe-rs-cli-util = { workspace = true, features = ["anyhow"] }
 anyhow = "1"
 bytesize = "1"
 thiserror = "1"

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -253,9 +253,9 @@ fn handle_memory_ap(
 ) -> Result<Tree<String>, anyhow::Error> {
     let component = {
         let mut memory = interface.memory_interface(access_port)?;
-        let mut demcr = Demcr(memory.read_word_32(Demcr::get_mmio_address(None))?);
+        let mut demcr = Demcr(memory.read_word_32(Demcr::get_mmio_address())?);
         demcr.set_dwtena(true);
-        memory.write_word_32(Demcr::get_mmio_address(None), demcr.into())?;
+        memory.write_word_32(Demcr::get_mmio_address(), demcr.into())?;
         Component::try_parse(&mut *memory, base_address)?
     };
     let component_tree = coresight_component_tree(interface, component, access_port)?;

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -253,9 +253,9 @@ fn handle_memory_ap(
 ) -> Result<Tree<String>, anyhow::Error> {
     let component = {
         let mut memory = interface.memory_interface(access_port)?;
-        let mut demcr = Demcr(memory.read_word_32(Demcr::ADDRESS)?);
+        let mut demcr = Demcr(memory.read_word_32(Demcr::get_mmio_address(None))?);
         demcr.set_dwtena(true);
-        memory.write_word_32(Demcr::ADDRESS, demcr.into())?;
+        memory.write_word_32(Demcr::get_mmio_address(None), demcr.into())?;
         Component::try_parse(&mut *memory, base_address)?
     };
     let component_tree = coresight_component_tree(interface, component, access_port)?;

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -54,6 +54,7 @@ object = { version = "0.31.0", default-features = false, features = [
     "read_core",
     "std",
 ] }
+paste = "1.0.12"
 rusb = "0.9.2"
 scroll = "0.11.0"
 serde = { version = "1", features = ["derive"] }

--- a/probe-rs/src/architecture/arm/component/dwt.rs
+++ b/probe-rs/src/architecture/arm/component/dwt.rs
@@ -6,12 +6,10 @@
 //! See ARMv7-M architecture reference manual C1.8 for some additional
 //! info about this stuff.
 
-use bitfield::bitfield;
-
 use super::super::memory::romtable::CoresightComponent;
-use super::DebugRegister;
+use super::DebugComponentInterface;
 use crate::architecture::arm::{ArmError, ArmProbeInterface};
-use crate::Error;
+use crate::{memory_mapped_bitfield_register, Error};
 
 /// A struct representing a DWT unit on target.
 pub struct Dwt<'a> {
@@ -95,10 +93,10 @@ impl<'a> Dwt<'a> {
     }
 }
 
-bitfield! {
-    #[derive(Clone, Default)]
+memory_mapped_bitfield_register! {
     pub struct Ctrl(u32);
-    impl Debug;
+    0x00, "DWT/CTRL",
+    impl From;
     pub u8, numcomp, _: 31, 28;
     pub notrcpkt, _: 27;
     pub noexttrig, _: 26;
@@ -124,144 +122,48 @@ bitfield! {
 
 }
 
-impl From<u32> for Ctrl {
-    fn from(raw: u32) -> Self {
-        Ctrl(raw)
-    }
-}
+impl DebugComponentInterface for Ctrl {}
 
-impl From<Ctrl> for u32 {
-    fn from(raw: Ctrl) -> Self {
-        raw.0
-    }
-}
-
-impl DebugRegister for Ctrl {
-    const ADDRESS: u32 = 0x00;
-    const NAME: &'static str = "DWT/CTRL";
-}
-
-bitfield! {
-    #[derive(Clone, Default)]
+memory_mapped_bitfield_register! {
     pub struct Cyccnt(u32);
-    impl Debug;
+    0x04, "DWT/CYCCNT",
+    impl From;
 }
 
-impl From<u32> for Cyccnt {
-    fn from(raw: u32) -> Self {
-        Cyccnt(raw)
-    }
-}
-
-impl From<Cyccnt> for u32 {
-    fn from(raw: Cyccnt) -> Self {
-        raw.0
-    }
-}
-
-impl DebugRegister for Cyccnt {
-    const ADDRESS: u32 = 0x04;
-    const NAME: &'static str = "DWT/CYCCNT";
-}
-
-bitfield! {
-    #[derive(Clone, Default)]
+memory_mapped_bitfield_register! {
     pub struct Cpicnt(u32);
-    impl Debug;
+    0x08, "DWT/CPICNT",
+    impl From;
 }
 
-impl From<u32> for Cpicnt {
-    fn from(raw: u32) -> Self {
-        Cpicnt(raw)
-    }
-}
-
-impl From<Cpicnt> for u32 {
-    fn from(raw: Cpicnt) -> Self {
-        raw.0
-    }
-}
-
-impl DebugRegister for Cpicnt {
-    const ADDRESS: u32 = 0x08;
-    const NAME: &'static str = "DWT/CPICNT";
-}
-
-bitfield! {
-    #[derive(Clone, Default)]
+memory_mapped_bitfield_register! {
     pub struct Exccnt(u32);
-    impl Debug;
+    0x0C, "DWT/EXCCNT",
+    impl From;
 }
 
-impl From<u32> for Exccnt {
-    fn from(raw: u32) -> Self {
-        Exccnt(raw)
-    }
-}
-
-impl From<Exccnt> for u32 {
-    fn from(raw: Exccnt) -> Self {
-        raw.0
-    }
-}
-
-impl DebugRegister for Exccnt {
-    const ADDRESS: u32 = 0x0C;
-    const NAME: &'static str = "DWT/EXCCNT";
-}
-
-bitfield! {
-    #[derive(Clone, Default)]
+memory_mapped_bitfield_register! {
     pub struct Comp(u32);
-    impl Debug;
+    0x20, "DWT/COMP",
+    impl From;
     pub u32, comp, set_comp: 31, 0;
 }
 
-impl From<u32> for Comp {
-    fn from(raw: u32) -> Self {
-        Comp(raw)
-    }
-}
+impl DebugComponentInterface for Comp {}
 
-impl From<Comp> for u32 {
-    fn from(raw: Comp) -> Self {
-        raw.0
-    }
-}
-
-impl DebugRegister for Comp {
-    const ADDRESS: u32 = 0x20;
-    const NAME: &'static str = "DWT/COMP";
-}
-
-bitfield! {
-    #[derive(Clone, Default)]
+memory_mapped_bitfield_register! {
     pub struct Mask(u32);
-    impl Debug;
+    0x24, "DWT/MASK",
+    impl From;
     pub u32, mask, set_mask: 4, 0;
 }
 
-impl From<u32> for Mask {
-    fn from(raw: u32) -> Self {
-        Mask(raw)
-    }
-}
+impl DebugComponentInterface for Mask {}
 
-impl From<Mask> for u32 {
-    fn from(raw: Mask) -> Self {
-        raw.0
-    }
-}
-
-impl DebugRegister for Mask {
-    const ADDRESS: u32 = 0x24;
-    const NAME: &'static str = "DWT/MASK";
-}
-
-bitfield! {
-    #[derive(Clone, Default)]
+memory_mapped_bitfield_register! {
     pub struct Function(u32);
-    impl Debug;
+    0x28, "DWT/FUNCTION",
+    impl From;
     pub matched, _: 24;
     pub u8, datavaddr1, set_datavaddr1: 19, 16;
     pub u8, datavaddr0, set_datavaddr0: 15, 12;
@@ -276,19 +178,4 @@ bitfield! {
     pub function, set_function: 3, 0;
 }
 
-impl From<u32> for Function {
-    fn from(raw: u32) -> Self {
-        Function(raw)
-    }
-}
-
-impl From<Function> for u32 {
-    fn from(raw: Function) -> Self {
-        raw.0
-    }
-}
-
-impl DebugRegister for Function {
-    const ADDRESS: u32 = 0x28;
-    const NAME: &'static str = "DWT/FUNCTION";
-}
+impl DebugComponentInterface for Function {}

--- a/probe-rs/src/architecture/arm/component/itm.rs
+++ b/probe-rs/src/architecture/arm/component/itm.rs
@@ -3,9 +3,8 @@
 //! ITM = Instrumentation Trace Macrocell
 
 use super::super::memory::romtable::CoresightComponent;
-use super::DebugRegister;
 use crate::architecture::arm::ArmProbeInterface;
-use crate::Error;
+use crate::{Error, MemoryMappedRegister};
 
 pub const _ITM_PID: [u8; 8] = [0x1, 0xB0, 0x3b, 0x0, 0x4, 0x0, 0x0, 0x0];
 
@@ -77,7 +76,7 @@ impl<'a> Itm<'a> {
         // Enable all 32 channels.
         self.component.write_reg(
             self.interface,
-            register::ITM_TER::ADDRESS,
+            register::ITM_TER::ADDRESS_OFFSET as u32,
             register::ITM_TER::enable_all().into(),
         )?;
 
@@ -86,13 +85,14 @@ impl<'a> Itm<'a> {
 }
 
 mod register {
-    use super::super::DebugRegister;
+    use crate::memory_mapped_bitfield_register;
 
-    bitfield::bitfield! {
+    memory_mapped_bitfield_register! {
         #[allow(non_camel_case_types)]
-        #[derive(Copy, Clone)]
         pub struct ITM_TER(u32);
-        impl Debug;
+        0xE00,"ITM_TER",
+        impl From;
+        impl tpiu_continuous_formatting;
         pub stim31, set_stim31: 31;
         pub stim30, set_stim30: 30;
         pub stim29, set_stim29: 29;
@@ -135,22 +135,5 @@ mod register {
         pub fn disable_all() -> Self {
             Self(0x0000_0000)
         }
-    }
-
-    impl From<u32> for ITM_TER {
-        fn from(value: u32) -> Self {
-            Self(value)
-        }
-    }
-
-    impl From<ITM_TER> for u32 {
-        fn from(value: ITM_TER) -> Self {
-            value.0
-        }
-    }
-
-    impl DebugRegister for ITM_TER {
-        const ADDRESS: u32 = 0xE00;
-        const NAME: &'static str = "ITM_TER";
     }
 }

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -375,16 +375,16 @@ pub fn remove_swv_data_trace(
 
 /// Sets TRCENA in DEMCR to begin trace generation.
 pub fn enable_tracing(core: &mut Core) -> Result<(), Error> {
-    let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address(None))?);
+    let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address())?);
     demcr.set_dwtena(true);
-    core.write_word_32(Demcr::get_mmio_address(None), demcr.into())?;
+    core.write_word_32(Demcr::get_mmio_address(), demcr.into())?;
     Ok(())
 }
 
 /// Disables TRCENA in DEMCR to disable trace generation.
 pub fn disable_swv(core: &mut Core) -> Result<(), Error> {
-    let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address(None))?);
+    let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address())?);
     demcr.set_dwtena(false);
-    core.write_word_32(Demcr::get_mmio_address(None), demcr.into())?;
+    core.write_word_32(Demcr::get_mmio_address(), demcr.into())?;
     Ok(())
 }

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -49,19 +49,18 @@ pub enum ComponentError {
     NordicUnsupportedTPUICLKValue(u32),
 }
 
-/// A trait to be implemented on debug register types for debug component interfaces.
-pub trait DebugRegister: Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug {
-    /// The address of the register.
-    const ADDRESS: u32;
-    /// The name of the register.
-    const NAME: &'static str;
-
+/// A trait to be implemented on memory mapped register types for debug component interfaces.
+pub trait DebugComponentInterface:
+    MemoryMappedRegister<u32> + Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug
+{
     /// Loads the register value from the given debug component via the given core.
     fn load(
         component: &CoresightComponent,
         interface: &mut dyn ArmProbeInterface,
     ) -> Result<Self, ArmError> {
-        Ok(Self::from(component.read_reg(interface, Self::ADDRESS)?))
+        Ok(Self::from(
+            component.read_reg(interface, Self::ADDRESS_OFFSET as u32)?,
+        ))
     }
 
     /// Loads the register value from the given component in given unit via the given core.
@@ -70,9 +69,10 @@ pub trait DebugRegister: Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug
         interface: &mut dyn ArmProbeInterface,
         unit: usize,
     ) -> Result<Self, ArmError> {
-        Ok(Self::from(
-            component.read_reg(interface, Self::ADDRESS + 16 * unit as u32)?,
-        ))
+        Ok(Self::from(component.read_reg(
+            interface,
+            Self::ADDRESS_OFFSET as u32 + 16 * unit as u32,
+        )?))
     }
 
     /// Stores the register value to the given debug component via the given core.
@@ -81,7 +81,7 @@ pub trait DebugRegister: Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug
         component: &CoresightComponent,
         interface: &mut dyn ArmProbeInterface,
     ) -> Result<(), ArmError> {
-        component.write_reg(interface, Self::ADDRESS, self.clone().into())
+        component.write_reg(interface, Self::ADDRESS_OFFSET as u32, self.clone().into())
     }
 
     /// Stores the register value to the given component in given unit via the given core.
@@ -93,7 +93,7 @@ pub trait DebugRegister: Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug
     ) -> Result<(), ArmError> {
         component.write_reg(
             interface,
-            Self::ADDRESS + 16 * unit as u32,
+            Self::ADDRESS_OFFSET as u32 + 16 * unit as u32,
             self.clone().into(),
         )
     }

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -375,16 +375,16 @@ pub fn remove_swv_data_trace(
 
 /// Sets TRCENA in DEMCR to begin trace generation.
 pub fn enable_tracing(core: &mut Core) -> Result<(), Error> {
-    let mut demcr = Demcr(core.read_word_32(Demcr::ADDRESS)?);
+    let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address(None))?);
     demcr.set_dwtena(true);
-    core.write_word_32(Demcr::ADDRESS, demcr.into())?;
+    core.write_word_32(Demcr::get_mmio_address(None), demcr.into())?;
     Ok(())
 }
 
 /// Disables TRCENA in DEMCR to disable trace generation.
 pub fn disable_swv(core: &mut Core) -> Result<(), Error> {
-    let mut demcr = Demcr(core.read_word_32(Demcr::ADDRESS)?);
+    let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address(None))?);
     demcr.set_dwtena(false);
-    core.write_word_32(Demcr::ADDRESS, demcr.into())?;
+    core.write_word_32(Demcr::get_mmio_address(None), demcr.into())?;
     Ok(())
 }

--- a/probe-rs/src/architecture/arm/component/scs.rs
+++ b/probe-rs/src/architecture/arm/component/scs.rs
@@ -5,8 +5,10 @@
 use self::register::CPUID;
 
 use super::super::memory::romtable::CoresightComponent;
-use super::DebugRegister;
-use crate::architecture::arm::{ArmError, ArmProbeInterface};
+use crate::{
+    architecture::arm::{ArmError, ArmProbeInterface},
+    MemoryMappedRegister,
+};
 
 /// An interface to control the SCS (System Control Space) of a MCU.
 pub struct Scs<'a> {
@@ -29,40 +31,23 @@ impl<'a> Scs<'a> {
     /// B3.2.3 CPUID Base Register
     pub fn cpuid(&mut self) -> Result<CPUID, ArmError> {
         self.component
-            .read_reg(self.interface, CPUID::ADDRESS)
+            .read_reg(self.interface, CPUID::ADDRESS_OFFSET as u32)
             .map(CPUID)
     }
 }
 
 mod register {
-    use super::super::DebugRegister;
+    use crate::memory_mapped_bitfield_register;
 
-    bitfield::bitfield! {
+    memory_mapped_bitfield_register! {
         /// B3.2.3 CPUID Base Register
         #[allow(non_camel_case_types)]
-        #[derive(Copy, Clone)]
         pub struct CPUID(u32);
-        impl Debug;
+        0xD00, "CPUID",
+        impl From;
         pub implementer, _: 31, 24;
         pub variant, _: 23, 20;
         pub partno, _: 15, 4;
         pub revision, _: 3, 0;
-    }
-
-    impl From<u32> for CPUID {
-        fn from(value: u32) -> Self {
-            Self(value)
-        }
-    }
-
-    impl From<CPUID> for u32 {
-        fn from(value: CPUID) -> Self {
-            value.0
-        }
-    }
-
-    impl DebugRegister for CPUID {
-        const ADDRESS: u32 = 0xD00;
-        const NAME: &'static str = "CPUID";
     }
 }

--- a/probe-rs/src/architecture/arm/component/tmc.rs
+++ b/probe-rs/src/architecture/arm/component/tmc.rs
@@ -6,12 +6,10 @@ use core::iter::Iterator;
 
 use crate::{
     architecture::arm::{
-        component::DebugRegister, memory::CoresightComponent, ArmError, ArmProbeInterface,
+        component::DebugComponentInterface, memory::CoresightComponent, ArmError, ArmProbeInterface,
     },
-    Error,
+    memory_mapped_bitfield_register, Error,
 };
-
-use bitfield::bitfield;
 
 const REGISTER_OFFSET_RSZ: u32 = 0x04;
 const REGISTER_OFFSET_RRD: u32 = 0x10;
@@ -158,10 +156,10 @@ impl<'a> TraceMemoryController<'a> {
     }
 }
 
-bitfield! {
-    #[derive(Clone, Default)]
+memory_mapped_bitfield_register! {
     pub struct FormatFlushControl(u32);
-    impl Debug;
+    0x304, "ETF_FFCR",
+    impl From;
 
     pub drainbuf, set_drainbuf: 14;
     pub stpontrgev, set_stpontrgev: 13;
@@ -175,27 +173,12 @@ bitfield! {
     pub enft, set_enft: 0;
 }
 
-impl From<u32> for FormatFlushControl {
-    fn from(raw: u32) -> Self {
-        FormatFlushControl(raw)
-    }
-}
+impl DebugComponentInterface for FormatFlushControl {}
 
-impl From<FormatFlushControl> for u32 {
-    fn from(status: FormatFlushControl) -> u32 {
-        status.0
-    }
-}
-
-impl DebugRegister for FormatFlushControl {
-    const ADDRESS: u32 = 0x304;
-    const NAME: &'static str = "ETF_FFCR";
-}
-
-bitfield! {
-    #[derive(Clone, Default)]
+memory_mapped_bitfield_register! {
     pub struct Status(u32);
-    impl Debug;
+    0xC, "ETF_STS",
+    impl From;
 
     pub empty, _: 4;
     pub ftempty, _: 3;
@@ -204,48 +187,18 @@ bitfield! {
     pub full, _: 0;
 }
 
-impl From<u32> for Status {
-    fn from(raw: u32) -> Status {
-        Status(raw)
-    }
-}
+impl DebugComponentInterface for Status {}
 
-impl From<Status> for u32 {
-    fn from(status: Status) -> u32 {
-        status.0
-    }
-}
-
-impl DebugRegister for Status {
-    const ADDRESS: u32 = 0xC;
-    const NAME: &'static str = "ETF_STS";
-}
-
-bitfield! {
-    #[derive(Clone, Default)]
+memory_mapped_bitfield_register! {
     pub struct EtfMode(u32);
-    impl Debug;
+    0x28, "ETF_MODE",
+    impl From;
 
     // The Mode register configures the operational mode of the FIFO.
     pub u8, mode, set_mode: 1, 0;
 }
 
-impl From<u32> for EtfMode {
-    fn from(raw: u32) -> EtfMode {
-        EtfMode(raw)
-    }
-}
-
-impl From<EtfMode> for u32 {
-    fn from(mode: EtfMode) -> u32 {
-        mode.0
-    }
-}
-
-impl DebugRegister for EtfMode {
-    const ADDRESS: u32 = 0x28;
-    const NAME: &'static str = "ETF_MODE";
-}
+impl DebugComponentInterface for EtfMode {}
 
 /// Trace ID (a.k.a. ATID or trace source ID)
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/probe-rs/src/architecture/arm/component/trace_funnel.rs
+++ b/probe-rs/src/architecture/arm/component/trace_funnel.rs
@@ -2,10 +2,10 @@
 //!
 //! # Description
 //! This module provides access and control of the trace funnel CoreSight component block.
-use super::DebugRegister;
+use super::DebugComponentInterface;
 use crate::architecture::arm::memory::romtable::CoresightComponent;
 use crate::architecture::arm::{ArmError, ArmProbeInterface};
-use bitfield::bitfield;
+use crate::memory_mapped_bitfield_register;
 
 const REGISTER_OFFSET_ACCESS: u32 = 0xFB0;
 
@@ -47,12 +47,13 @@ impl<'a> TraceFunnel<'a> {
     }
 }
 
-bitfield! {
+memory_mapped_bitfield_register! {
     /// The control register is described in "DDI0314H CoreSight Components Technical Reference
     /// Manual" on page 7-5.
-    #[derive(Clone, Default)]
+    #[derive(Default)]
     pub struct Control(u32);
-    impl Debug;
+    0x00, "CSTF/CTRL",
+    impl From;
 
     /// The minimum hold time specifics the number of transactions that the arbiter of the funnel
     /// will perform on individual active input before muxing to the next port. The arbiter uses a
@@ -64,19 +65,4 @@ bitfield! {
     pub u8, enable_slave_port, set_slave_enable: 7, 0;
 }
 
-impl DebugRegister for Control {
-    const ADDRESS: u32 = 0x00;
-    const NAME: &'static str = "CSTF/CTRL";
-}
-
-impl From<u32> for Control {
-    fn from(raw: u32) -> Control {
-        Control(raw)
-    }
-}
-
-impl From<Control> for u32 {
-    fn from(control: Control) -> u32 {
-        control.0
-    }
-}
+impl DebugComponentInterface for Control {}

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -173,7 +173,7 @@ impl From<Dhcsr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Dhcsr {
+impl MemoryMappedRegister<u32> for Dhcsr {
     const ADDRESS: u64 = 0xE000_EDF0;
     const NAME: &'static str = "DHCSR";
 }
@@ -194,7 +194,7 @@ impl From<Dcrdr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Dcrdr {
+impl MemoryMappedRegister<u32> for Dcrdr {
     const ADDRESS: u64 = 0xE000_EDF8;
     const NAME: &'static str = "DCRDR";
 }
@@ -231,7 +231,7 @@ impl From<BpCtrl> for u32 {
     }
 }
 
-impl MemoryMappedRegister for BpCtrl {
+impl MemoryMappedRegister<u32> for BpCtrl {
     const ADDRESS: u64 = 0xE000_2000;
     const NAME: &'static str = "BP_CTRL";
 }
@@ -279,7 +279,7 @@ impl From<BpCompx> for u32 {
     }
 }
 
-impl MemoryMappedRegister for BpCompx {
+impl MemoryMappedRegister<u32> for BpCompx {
     const ADDRESS: u64 = 0xE000_2008;
     const NAME: &'static str = "BP_CTRL0";
 }
@@ -367,7 +367,7 @@ impl Aircr {
     }
 }
 
-impl MemoryMappedRegister for Aircr {
+impl MemoryMappedRegister<u32> for Aircr {
     const ADDRESS: u64 = 0xE000_ED0C;
     const NAME: &'static str = "AIRCR";
 }
@@ -403,7 +403,7 @@ impl From<Demcr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Demcr {
+impl MemoryMappedRegister<u32> for Demcr {
     const ADDRESS: u64 = 0xe000_edfc;
     const NAME: &'static str = "DEMCR";
 }

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -1,24 +1,24 @@
 //! Register types and the core interface for armv6-M
 
 use super::{CortexMState, Dfsr, CORTEX_M_COMMON_REGS};
-
-use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
-use crate::architecture::arm::sequences::ArmDebugSequence;
-use crate::architecture::arm::ArmError;
-use crate::core::{
-    RegisterDataType, RegisterDescription, RegisterFile, RegisterKind, RegisterValue,
-};
-use crate::error::Error;
-use crate::memory::valid_32bit_address;
 use crate::{
+    architecture::arm::{
+        memory::adi_v5_memory_interface::ArmProbe, sequences::ArmDebugSequence, ArmError,
+    },
+    core::{
+        RegisterDataType, RegisterDescription, RegisterFile, RegisterId, RegisterKind,
+        RegisterValue,
+    },
+    error::Error,
+    memory::valid_32bit_address,
     Architecture, CoreInformation, CoreInterface, CoreStatus, CoreType, DebugProbeError,
-    HaltReason, InstructionSet, MemoryInterface, MemoryMappedRegister, RegisterId,
+    HaltReason, InstructionSet, MemoryInterface, MemoryMappedRegister,
 };
 use anyhow::Result;
 use bitfield::bitfield;
-use std::sync::Arc;
 use std::{
     mem::size_of,
+    sync::Arc,
     time::{Duration, Instant},
 };
 

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -1,31 +1,31 @@
 //! Register types and the core interface for armv7-a
 
-use crate::architecture::arm::core::armv7a_debug_regs::*;
-use crate::architecture::arm::core::register;
-use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
-use crate::architecture::arm::sequences::ArmDebugSequence;
-use crate::architecture::arm::ArmError;
-use crate::core::{RegisterFile, RegisterValue};
-use crate::error::Error;
-use crate::memory::valid_32bit_address;
-use crate::CoreInterface;
-use crate::CoreStatus;
-use crate::MemoryInterface;
-use crate::RegisterId;
-use crate::{Architecture, CoreInformation, CoreType, InstructionSet};
-use anyhow::Result;
-
-use super::instructions::aarch32::{
-    build_bx, build_ldc, build_mcr, build_mov, build_mrc, build_mrs, build_stc, build_vmov,
-    build_vmrs,
+use super::{
+    instructions::aarch32::{
+        build_bx, build_ldc, build_mcr, build_mov, build_mrc, build_mrs, build_stc, build_vmov,
+        build_vmrs,
+    },
+    CortexAState, AARCH32_COMMON_REGS, AARCH32_FP_16_REGS, AARCH32_FP_32_REGS,
 };
-use super::CortexAState;
-use super::{AARCH32_COMMON_REGS, AARCH32_FP_16_REGS, AARCH32_FP_32_REGS};
-
-use std::mem::size_of;
-use std::sync::Arc;
-use std::time::Duration;
-use std::time::Instant;
+use crate::{
+    architecture::arm::{
+        core::{armv7a_debug_regs::*, register},
+        memory::adi_v5_memory_interface::ArmProbe,
+        sequences::ArmDebugSequence,
+        ArmError,
+    },
+    core::{RegisterFile, RegisterId, RegisterValue},
+    error::Error,
+    memory::valid_32bit_address,
+    Architecture, CoreInformation, CoreInterface, CoreStatus, CoreType, InstructionSet,
+    MemoryInterface,
+};
+use anyhow::Result;
+use std::{
+    mem::size_of,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 /// Errors for the ARMv7-A state machine
 #[derive(thiserror::Error, Debug)]

--- a/probe-rs/src/architecture/arm/core/armv7a_debug_regs.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a_debug_regs.rs
@@ -1,28 +1,12 @@
 //! Debug register definitions
-use bitfield::bitfield;
-use std::mem::size_of;
 
-use crate::{core::BreakpointCause, HaltReason};
+use crate::{core::BreakpointCause, memory_mapped_bitfield_register, HaltReason};
 
-/// A debug register that is accessible to the external debugger
-pub trait Armv7DebugRegister {
-    /// Register number
-    const NUMBER: usize;
-
-    /// The register's name.
-    const NAME: &'static str;
-
-    /// Get the address in the memory map
-    fn get_mmio_address(base_address: u64) -> u64 {
-        base_address + (Self::NUMBER * size_of::<u32>()) as u64
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGDSCR - Debug Status and Control Registers
-    #[derive(Copy, Clone)]
     pub struct Dbgdscr(u32);
-    impl Debug;
+    34, "DBGDSCR",
+    impl From;
 
     /// DBGDTRRX register full. The possible values of this bit are:
     ///
@@ -258,28 +242,11 @@ impl Dbgdscr {
     }
 }
 
-impl Armv7DebugRegister for Dbgdscr {
-    const NUMBER: usize = 34;
-    const NAME: &'static str = "DBGDSCR";
-}
-
-impl From<u32> for Dbgdscr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgdscr> for u32 {
-    fn from(value: Dbgdscr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGDIDR - Debug ID Register
-    #[derive(Copy, Clone)]
     pub struct Dbgdidr(u32);
-    impl Debug;
+    0, "DBGDIDR",
+    impl From;
 
     /// The number of watchpoints implemented. The number of implemented watchpoints is one more than the value of this field.
     pub wrps, _: 31, 28;
@@ -329,28 +296,11 @@ bitfield! {
     pub revision, _: 3, 0;
 }
 
-impl Armv7DebugRegister for Dbgdidr {
-    const NUMBER: usize = 0;
-    const NAME: &'static str = "DBGDIDR";
-}
-
-impl From<u32> for Dbgdidr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgdidr> for u32 {
-    fn from(value: Dbgdidr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGDRCR - Debug Run Control Register
-    #[derive(Copy, Clone)]
     pub struct Dbgdrcr(u32);
-    impl Debug;
+    36, "DBGDRCR",
+    impl From;
 
     /// Cancel Bus Requests Request
     pub cbrrq, set_cbrrq: 4;
@@ -368,55 +318,21 @@ bitfield! {
     pub hrq, set_hrq: 0;
 }
 
-impl Armv7DebugRegister for Dbgdrcr {
-    const NUMBER: usize = 36;
-    const NAME: &'static str = "DBGDRCR";
-}
-
-impl From<u32> for Dbgdrcr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgdrcr> for u32 {
-    fn from(value: Dbgdrcr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGBVR - Breakpoint Value Register
-    #[derive(Copy, Clone)]
     pub struct Dbgbvr(u32);
-    impl Debug;
+    64, "DBGBVR",
+    impl From;
 
     /// Breakpoint address
     pub value, set_value : 31, 0;
 }
 
-impl Armv7DebugRegister for Dbgbvr {
-    const NUMBER: usize = 64;
-    const NAME: &'static str = "DBGBVR";
-}
-
-impl From<u32> for Dbgbvr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgbvr> for u32 {
-    fn from(value: Dbgbvr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGBCR - Breakpoint Control Register
-    #[derive(Copy, Clone)]
     pub struct Dbgbcr(u32);
-    impl Debug;
+    80, "DBGBCR",
+    impl From;
 
     /// Address range mask. Whether masking is supported is implementation defined.
     pub mask, set_mask : 28, 24;
@@ -443,56 +359,22 @@ bitfield! {
     pub e, set_e: 0;
 }
 
-impl Armv7DebugRegister for Dbgbcr {
-    const NUMBER: usize = 80;
-    const NAME: &'static str = "DBGBCR";
-}
-
-impl From<u32> for Dbgbcr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgbcr> for u32 {
-    fn from(value: Dbgbcr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGLAR - Lock Access Register
-    #[derive(Copy, Clone)]
     pub struct Dbglar(u32);
-    impl Debug;
+    1004, "DBGLAR",
+    impl From;
 
     /// Lock value
     pub value, set_value : 31, 0;
 
 }
 
-impl Armv7DebugRegister for Dbglar {
-    const NUMBER: usize = 1004;
-    const NAME: &'static str = "DBGLAR";
-}
-
-impl From<u32> for Dbglar {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbglar> for u32 {
-    fn from(value: Dbglar) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGDSCCR - State Cache Control Register
-    #[derive(Copy, Clone)]
     pub struct Dbgdsccr(u32);
-    impl Debug;
+    10, "DBGDSCCR",
+    impl From;
 
     /// Force Write-Through
     pub nwt, set_nwt: 2;
@@ -504,28 +386,11 @@ bitfield! {
     pub ndl, set_ndl: 0;
 }
 
-impl Armv7DebugRegister for Dbgdsccr {
-    const NUMBER: usize = 10;
-    const NAME: &'static str = "DBGDSCCR";
-}
-
-impl From<u32> for Dbgdsccr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgdsccr> for u32 {
-    fn from(value: Dbgdsccr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGDSMCR - Debug State MMU Control Register
-    #[derive(Copy, Clone)]
     pub struct Dbgdsmcr(u32);
-    impl Debug;
+    11, "DBGDSMCR",
+    impl From;
 
     /// Instruction TLB matching bit
     pub nium, set_nium: 3;
@@ -540,109 +405,41 @@ bitfield! {
     pub ndul, set_ndul: 0;
 }
 
-impl Armv7DebugRegister for Dbgdsmcr {
-    const NUMBER: usize = 11;
-    const NAME: &'static str = "DBGDSMCR";
-}
-
-impl From<u32> for Dbgdsmcr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgdsmcr> for u32 {
-    fn from(value: Dbgdsmcr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGITR - Instruction Transfer Register
-    #[derive(Copy, Clone)]
     pub struct Dbgitr(u32);
-    impl Debug;
+    33, "DBGITR",
+    impl From;
 
     /// Instruction value
     pub value, set_value: 31, 0;
 }
 
-impl Armv7DebugRegister for Dbgitr {
-    const NUMBER: usize = 33;
-    const NAME: &'static str = "DBGITR";
-}
-
-impl From<u32> for Dbgitr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgitr> for u32 {
-    fn from(value: Dbgitr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGDTRTX - Target to Host data transfer register
-    #[derive(Copy, Clone)]
     pub struct Dbgdtrtx(u32);
-    impl Debug;
+    35, "DBGDTRTX",
+    impl From;
 
     /// Value
     pub value, set_value: 31, 0;
 }
 
-impl Armv7DebugRegister for Dbgdtrtx {
-    const NUMBER: usize = 35;
-    const NAME: &'static str = "DBGDTRTX";
-}
-
-impl From<u32> for Dbgdtrtx {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgdtrtx> for u32 {
-    fn from(value: Dbgdtrtx) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGDTRRX - Host to Target data transfer register
-    #[derive(Copy, Clone)]
     pub struct Dbgdtrrx(u32);
-    impl Debug;
+    32, "DBGDTRRX",
+    impl From;
 
     /// Value
     pub value, set_value: 31, 0;
 }
 
-impl Armv7DebugRegister for Dbgdtrrx {
-    const NUMBER: usize = 32;
-    const NAME: &'static str = "DBGDTRRX";
-}
-
-impl From<u32> for Dbgdtrrx {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgdtrrx> for u32 {
-    fn from(value: Dbgdtrrx) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGPRCR - Powerdown and Reset Control Register
-    #[derive(Copy, Clone)]
     pub struct Dbgprcr(u32);
-    impl Debug;
+    196, "DBGPRCR",
+    impl From;
 
     /// Core powerup request
     pub corepurq, set_corepurq : 3;
@@ -657,28 +454,11 @@ bitfield! {
     pub corenpdrq, set_corenpdrq : 0;
 }
 
-impl Armv7DebugRegister for Dbgprcr {
-    const NUMBER: usize = 196;
-    const NAME: &'static str = "DBGPRCR";
-}
-
-impl From<u32> for Dbgprcr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgprcr> for u32 {
-    fn from(value: Dbgprcr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGPRSR - Powerdown and Reset Status Register
-    #[derive(Copy, Clone)]
     pub struct Dbgprsr(u32);
-    impl Debug;
+    197, "DBGPRSR",
+    impl From;
 
     /// OS Double Lock Status
     pub dlk, _ : 6;
@@ -700,21 +480,4 @@ bitfield! {
 
     /// Power up status
     pub pu, _ : 0;
-}
-
-impl Armv7DebugRegister for Dbgprsr {
-    const NUMBER: usize = 197;
-    const NAME: &'static str = "DBGPRSR";
-}
-
-impl From<u32> for Dbgprsr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgprsr> for u32 {
-    fn from(value: Dbgprsr) -> Self {
-        value.0
-    }
 }

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -200,7 +200,7 @@ impl From<Dhcsr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Dhcsr {
+impl MemoryMappedRegister<u32> for Dhcsr {
     const ADDRESS: u64 = 0xE000_EDF0;
     const NAME: &'static str = "DHCSR";
 }
@@ -221,7 +221,7 @@ impl From<Dcrdr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Dcrdr {
+impl MemoryMappedRegister<u32> for Dcrdr {
     const ADDRESS: u64 = 0xE000_EDF8;
     const NAME: &'static str = "DCRDR";
 }
@@ -307,7 +307,7 @@ impl Aircr {
     }
 }
 
-impl MemoryMappedRegister for Aircr {
+impl MemoryMappedRegister<u32> for Aircr {
     const ADDRESS: u64 = 0xE000_ED0C;
     const NAME: &'static str = "AIRCR";
 }
@@ -361,7 +361,7 @@ impl From<Demcr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Demcr {
+impl MemoryMappedRegister<u32> for Demcr {
     const ADDRESS: u64 = 0xe000_edfc;
     const NAME: &'static str = "DEMCR";
 }
@@ -403,7 +403,7 @@ impl FpCtrl {
     }
 }
 
-impl MemoryMappedRegister for FpCtrl {
+impl MemoryMappedRegister<u32> for FpCtrl {
     const ADDRESS: u64 = 0xE000_2000;
     const NAME: &'static str = "FP_CTRL";
 }
@@ -470,7 +470,7 @@ bitfield! {
     pub enable, set_enable: 0;
 }
 
-impl MemoryMappedRegister for FpRev1CompX {
+impl MemoryMappedRegister<u32> for FpRev1CompX {
     const ADDRESS: u64 = 0xE000_2008;
     const NAME: &'static str = "FP_CTRL";
 }
@@ -551,7 +551,7 @@ bitfield! {
     pub enable, set_enable: 0;
 }
 
-impl MemoryMappedRegister for FpRev2CompX {
+impl MemoryMappedRegister<u32> for FpRev2CompX {
     const ADDRESS: u64 = 0xE000_2008;
     const NAME: &'static str = "FP_CTRL";
 }

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -8,6 +8,7 @@ use super::{
     },
     CortexAState, AARCH32_FP_32_REGS,
 };
+use crate::core::memory_mapped_registers::MemoryMappedRegister;
 use crate::{
     architecture::arm::{
         core::armv8a_debug_regs::*, memory::adi_v5_memory_interface::ArmProbe,
@@ -71,7 +72,7 @@ impl<'probe> Armv8a<'probe> {
     ) -> Result<Self, Error> {
         if !state.initialized() {
             // determine current state
-            let address = Edscr::get_mmio_address(base_address);
+            let address = Edscr::get_mmio_address(Some(base_address));
             let edscr = Edscr(memory.read_word_32(address)?);
 
             tracing::debug!("State when connecting: {:x?}", edscr);
@@ -123,11 +124,11 @@ impl<'probe> Armv8a<'probe> {
         }
 
         // Run instruction
-        let address = Editr::get_mmio_address(self.base_address);
+        let address = Editr::get_mmio_address(Some(self.base_address));
         self.memory.write_word_32(address, final_instruction)?;
 
         // Wait for completion
-        let address = Edscr::get_mmio_address(self.base_address);
+        let address = Edscr::get_mmio_address(Some(self.base_address));
         let mut edscr = Edscr(self.memory.read_word_32(address)?);
 
         while !edscr.ite() {
@@ -136,7 +137,7 @@ impl<'probe> Armv8a<'probe> {
 
         // Check if we had any aborts, if so clear them and fail
         if edscr.err() || edscr.a() {
-            let address = Edrcr::get_mmio_address(self.base_address);
+            let address = Edrcr::get_mmio_address(Some(self.base_address));
             let mut edrcr = Edrcr(0);
             edrcr.set_cse(true);
 
@@ -155,12 +156,12 @@ impl<'probe> Armv8a<'probe> {
 
         // Wait for TXfull
         while !edscr.txfull() {
-            let address = Edscr::get_mmio_address(self.base_address);
+            let address = Edscr::get_mmio_address(Some(self.base_address));
             edscr = Edscr(self.memory.read_word_32(address)?);
         }
 
         // Read result
-        let address = Dbgdtrtx::get_mmio_address(self.base_address);
+        let address = Dbgdtrtx::get_mmio_address(Some(self.base_address));
         let result = self.memory.read_word_32(address)?;
 
         Ok(result)
@@ -173,15 +174,15 @@ impl<'probe> Armv8a<'probe> {
 
         // Wait for TXfull
         while !edscr.txfull() {
-            let address = Edscr::get_mmio_address(self.base_address);
+            let address = Edscr::get_mmio_address(Some(self.base_address));
             edscr = Edscr(self.memory.read_word_32(address)?);
         }
 
         // Read result
-        let address = Dbgdtrrx::get_mmio_address(self.base_address);
+        let address = Dbgdtrrx::get_mmio_address(Some(self.base_address));
         let mut result: u64 = (self.memory.read_word_32(address)? as u64) << 32;
 
-        let address = Dbgdtrtx::get_mmio_address(self.base_address);
+        let address = Dbgdtrtx::get_mmio_address(Some(self.base_address));
         result |= self.memory.read_word_32(address)? as u64;
 
         Ok(result)
@@ -193,11 +194,11 @@ impl<'probe> Armv8a<'probe> {
         value: u32,
     ) -> Result<(), Error> {
         // Move value
-        let address = Dbgdtrrx::get_mmio_address(self.base_address);
+        let address = Dbgdtrrx::get_mmio_address(Some(self.base_address));
         self.memory.write_word_32(address, value)?;
 
         // Wait for RXfull
-        let address = Edscr::get_mmio_address(self.base_address);
+        let address = Edscr::get_mmio_address(Some(self.base_address));
         let mut edscr = Edscr(self.memory.read_word_32(address)?);
 
         while !edscr.rxfull() {
@@ -219,14 +220,14 @@ impl<'probe> Armv8a<'probe> {
         let high_word = (value >> 32) as u32;
         let low_word = (value & 0xFFFF_FFFF) as u32;
 
-        let address = Dbgdtrtx::get_mmio_address(self.base_address);
+        let address = Dbgdtrtx::get_mmio_address(Some(self.base_address));
         self.memory.write_word_32(address, high_word)?;
 
-        let address = Dbgdtrrx::get_mmio_address(self.base_address);
+        let address = Dbgdtrrx::get_mmio_address(Some(self.base_address));
         self.memory.write_word_32(address, low_word)?;
 
         // Wait for RXfull
-        let address = Edscr::get_mmio_address(self.base_address);
+        let address = Edscr::get_mmio_address(Some(self.base_address));
         let mut edscr = Edscr(self.memory.read_word_32(address)?);
 
         while !edscr.rxfull() {
@@ -400,11 +401,11 @@ impl<'probe> Armv8a<'probe> {
         let mut ack = CtiIntack(0);
         ack.set_ack(0, 1);
 
-        let address = CtiIntack::get_mmio_address(self.cti_address);
+        let address = CtiIntack::get_mmio_address(Some(self.cti_address));
         self.memory.write_word_32(address, ack.into())?;
 
         loop {
-            let address = CtiTrigoutstatus::get_mmio_address(self.cti_address);
+            let address = CtiTrigoutstatus::get_mmio_address(Some(self.cti_address));
             let trig_status = CtiTrigoutstatus(self.memory.read_word_32(address)?);
 
             if trig_status.status(0) == 0 {
@@ -723,7 +724,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
         // Wait until halted state is active again.
         let start = Instant::now();
 
-        let address = Edscr::get_mmio_address(self.base_address);
+        let address = Edscr::get_mmio_address(Some(self.base_address));
 
         while start.elapsed() < timeout {
             let edscr = Edscr(self.memory.read_word_32(address)?);
@@ -736,7 +737,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
     }
 
     fn core_halted(&mut self) -> Result<bool, Error> {
-        let address = Edscr::get_mmio_address(self.base_address);
+        let address = Edscr::get_mmio_address(Some(self.base_address));
         let edscr = Edscr(self.memory.read_word_32(address)?);
 
         Ok(edscr.halted())
@@ -748,14 +749,14 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
             let mut cti_gate = CtiGate(0);
             cti_gate.set_en(0, 1);
 
-            let address = CtiGate::get_mmio_address(self.cti_address);
+            let address = CtiGate::get_mmio_address(Some(self.cti_address));
             self.memory.write_word_32(address, cti_gate.into())?;
 
             // Pulse it
             let mut pulse = CtiApppulse(0);
             pulse.set_apppulse(0, 1);
 
-            let address = CtiApppulse::get_mmio_address(self.cti_address);
+            let address = CtiApppulse::get_mmio_address(Some(self.cti_address));
             self.memory.write_word_32(address, pulse.into())?;
 
             // Wait for halt
@@ -771,7 +772,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
         // Gate halt channel
         let cti_gate = CtiGate(0);
 
-        let address = CtiGate::get_mmio_address(self.cti_address);
+        let address = CtiGate::get_mmio_address(Some(self.cti_address));
         self.memory.write_word_32(address, cti_gate.into())?;
 
         // try to read the program counter
@@ -797,18 +798,18 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
         let mut cti_gate = CtiGate(0);
         cti_gate.set_en(1, 1);
 
-        let address = CtiGate::get_mmio_address(self.cti_address);
+        let address = CtiGate::get_mmio_address(Some(self.cti_address));
         self.memory.write_word_32(address, cti_gate.into())?;
 
         // Pulse it
         let mut pulse = CtiApppulse(0);
         pulse.set_apppulse(1, 1);
 
-        let address = CtiApppulse::get_mmio_address(self.cti_address);
+        let address = CtiApppulse::get_mmio_address(Some(self.cti_address));
         self.memory.write_word_32(address, pulse.into())?;
 
         // Wait for ack
-        let address = Edprsr::get_mmio_address(self.base_address);
+        let address = Edprsr::get_mmio_address(Some(self.base_address));
 
         loop {
             let edprsr = Edprsr(self.memory.read_word_32(address)?);
@@ -824,7 +825,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
         // Gate restart channel
         let cti_gate = CtiGate(0);
 
-        let address = CtiGate::get_mmio_address(self.cti_address);
+        let address = CtiGate::get_mmio_address(Some(self.cti_address));
         self.memory.write_word_32(address, cti_gate.into())?;
 
         Ok(())
@@ -881,7 +882,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
         // Load EDECR, set SS bit for step mode
-        let edecr_address = Edecr::get_mmio_address(self.base_address);
+        let edecr_address = Edecr::get_mmio_address(Some(self.base_address));
         let mut edecr = Edecr(self.memory.read_word_32(edecr_address)?);
 
         edecr.set_ss(true);
@@ -947,7 +948,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
 
     fn available_breakpoint_units(&mut self) -> Result<u32, Error> {
         if self.num_breakpoints.is_none() {
-            let address = Eddfr::get_mmio_address(self.base_address);
+            let address = Eddfr::get_mmio_address(Some(self.base_address));
             let eddfr = Eddfr(self.memory.read_word_32(address)?);
 
             self.num_breakpoints = Some(eddfr.brps() + 1);
@@ -962,9 +963,9 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
 
     fn set_hw_breakpoint(&mut self, bp_unit_index: usize, addr: u64) -> Result<(), Error> {
         let bp_value_addr =
-            Dbgbvr::get_mmio_address(self.base_address) + (bp_unit_index * 16) as u64;
+            Dbgbvr::get_mmio_address(Some(self.base_address)) + (bp_unit_index * 16) as u64;
         let bp_control_addr =
-            Dbgbcr::get_mmio_address(self.base_address) + (bp_unit_index * 16) as u64;
+            Dbgbcr::get_mmio_address(Some(self.base_address)) + (bp_unit_index * 16) as u64;
         let mut bp_control = Dbgbcr(0);
 
         // Breakpoint type - address match
@@ -998,9 +999,9 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
 
     fn clear_hw_breakpoint(&mut self, bp_unit_index: usize) -> Result<(), Error> {
         let bp_value_addr =
-            Dbgbvr::get_mmio_address(self.base_address) + (bp_unit_index * 16) as u64;
+            Dbgbvr::get_mmio_address(Some(self.base_address)) + (bp_unit_index * 16) as u64;
         let bp_control_addr =
-            Dbgbcr::get_mmio_address(self.base_address) + (bp_unit_index * 16) as u64;
+            Dbgbcr::get_mmio_address(Some(self.base_address)) + (bp_unit_index * 16) as u64;
 
         self.memory.write_word_32(bp_value_addr, 0)?;
         self.memory.write_word_32(bp_value_addr + 4, 0)?;
@@ -1037,7 +1038,7 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
 
     fn status(&mut self) -> Result<crate::core::CoreStatus, Error> {
         // determine current state
-        let address = Edscr::get_mmio_address(self.base_address);
+        let address = Edscr::get_mmio_address(Some(self.base_address));
         let edscr = Edscr(self.memory.read_word_32(address)?);
 
         if edscr.halted() {
@@ -1065,12 +1066,12 @@ impl<'probe> CoreInterface for Armv8a<'probe> {
 
         for bp_unit_index in 0..num_hw_breakpoints {
             let bp_value_addr =
-                Dbgbvr::get_mmio_address(self.base_address) + (bp_unit_index * 16) as u64;
+                Dbgbvr::get_mmio_address(Some(self.base_address)) + (bp_unit_index * 16) as u64;
             let mut bp_value = self.memory.read_word_32(bp_value_addr)? as u64;
             bp_value |= (self.memory.read_word_32(bp_value_addr + 4)? as u64) << 32;
 
             let bp_control_addr =
-                Dbgbcr::get_mmio_address(self.base_address) + (bp_unit_index * 16) as u64;
+                Dbgbcr::get_mmio_address(Some(self.base_address)) + (bp_unit_index * 16) as u64;
             let bp_control = Dbgbcr(self.memory.read_word_32(bp_control_addr)?);
 
             if bp_control.e() {
@@ -1411,37 +1412,49 @@ mod test {
         if probe.is_64_bit {
             edscr.set_rw(0b1111);
         }
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
     }
 
     fn add_read_reg_expectations(probe: &mut MockProbe, reg: u16, value: u32) {
         probe.expected_write(
-            Editr::get_mmio_address(TEST_BASE_ADDRESS),
+            Editr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             prep_instr_for_itr_32(build_mcr(14, 0, reg, 0, 5, 0)),
         );
         let mut edscr = Edscr(0);
         edscr.set_ite(true);
         edscr.set_txfull(true);
 
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
-        probe.expected_read(Dbgdtrtx::get_mmio_address(TEST_BASE_ADDRESS), value);
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
+        probe.expected_read(Dbgdtrtx::get_mmio_address(Some(TEST_BASE_ADDRESS)), value);
     }
 
     fn add_read_reg_64_expectations(probe: &mut MockProbe, reg: u16, value: u64) {
         probe.expected_write(
-            Editr::get_mmio_address(TEST_BASE_ADDRESS),
+            Editr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             aarch64::build_msr(2, 3, 0, 4, 0, reg),
         );
         let mut edscr = Edscr(0);
         edscr.set_ite(true);
         edscr.set_txfull(true);
 
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
         probe.expected_read(
-            Dbgdtrrx::get_mmio_address(TEST_BASE_ADDRESS),
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
+        probe.expected_read(
+            Dbgdtrrx::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             (value >> 32) as u32,
         );
-        probe.expected_read(Dbgdtrtx::get_mmio_address(TEST_BASE_ADDRESS), value as u32);
+        probe.expected_read(
+            Dbgdtrtx::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            value as u32,
+        );
     }
 
     fn add_read_pc_expectations(probe: &mut MockProbe, value: u32) {
@@ -1450,10 +1463,13 @@ mod test {
         edscr.set_txfull(true);
 
         probe.expected_write(
-            Editr::get_mmio_address(TEST_BASE_ADDRESS),
+            Editr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             prep_instr_for_itr_32(build_mrc(15, 3, 0, 4, 5, 1)),
         );
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
         add_read_reg_expectations(probe, 0, value);
     }
 
@@ -1463,10 +1479,13 @@ mod test {
         edscr.set_txfull(true);
 
         probe.expected_write(
-            Editr::get_mmio_address(TEST_BASE_ADDRESS),
+            Editr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             aarch64::build_mrs(3, 3, 4, 5, 1, 0),
         );
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
         add_read_reg_64_expectations(probe, 0, value);
     }
 
@@ -1476,10 +1495,13 @@ mod test {
         edscr.set_txfull(true);
 
         probe.expected_write(
-            Editr::get_mmio_address(TEST_BASE_ADDRESS),
+            Editr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             prep_instr_for_itr_32(build_mrc(15, 3, 0, 4, 5, 0)),
         );
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
         add_read_reg_expectations(probe, 0, value);
     }
 
@@ -1489,10 +1511,13 @@ mod test {
         edscr.set_txfull(true);
 
         probe.expected_write(
-            Editr::get_mmio_address(TEST_BASE_ADDRESS),
+            Editr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             aarch64::build_mrs(3, 3, 4, 5, 0, 0),
         );
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
         add_read_reg_64_expectations(probe, 0, value.into());
     }
 
@@ -1500,13 +1525,16 @@ mod test {
         let mut cti_gate = CtiGate(0);
         cti_gate.set_en(0, 1);
 
-        probe.expected_write(CtiGate::get_mmio_address(TEST_CTI_ADDRESS), cti_gate.into());
+        probe.expected_write(
+            CtiGate::get_mmio_address(Some(TEST_CTI_ADDRESS)),
+            cti_gate.into(),
+        );
 
         let mut pulse = CtiApppulse(0);
         pulse.set_apppulse(0, 1);
 
         probe.expected_write(
-            CtiApppulse::get_mmio_address(TEST_CTI_ADDRESS),
+            CtiApppulse::get_mmio_address(Some(TEST_CTI_ADDRESS)),
             pulse.into(),
         );
     }
@@ -1514,46 +1542,64 @@ mod test {
     fn add_halt_cleanup_expectations(probe: &mut MockProbe) {
         let cti_gate = CtiGate(0);
 
-        probe.expected_write(CtiGate::get_mmio_address(TEST_CTI_ADDRESS), cti_gate.into());
+        probe.expected_write(
+            CtiGate::get_mmio_address(Some(TEST_CTI_ADDRESS)),
+            cti_gate.into(),
+        );
     }
 
     fn add_resume_expectations(probe: &mut MockProbe) {
         let mut ack = CtiIntack(0);
         ack.set_ack(0, 1);
 
-        probe.expected_write(CtiIntack::get_mmio_address(TEST_CTI_ADDRESS), ack.into());
+        probe.expected_write(
+            CtiIntack::get_mmio_address(Some(TEST_CTI_ADDRESS)),
+            ack.into(),
+        );
 
         let status = CtiTrigoutstatus(0);
         probe.expected_read(
-            CtiTrigoutstatus::get_mmio_address(TEST_CTI_ADDRESS),
+            CtiTrigoutstatus::get_mmio_address(Some(TEST_CTI_ADDRESS)),
             status.into(),
         );
 
         let mut cti_gate = CtiGate(0);
         cti_gate.set_en(1, 1);
-        probe.expected_write(CtiGate::get_mmio_address(TEST_CTI_ADDRESS), cti_gate.into());
+        probe.expected_write(
+            CtiGate::get_mmio_address(Some(TEST_CTI_ADDRESS)),
+            cti_gate.into(),
+        );
 
         let mut pulse = CtiApppulse(0);
         pulse.set_apppulse(1, 1);
         probe.expected_write(
-            CtiApppulse::get_mmio_address(TEST_CTI_ADDRESS),
+            CtiApppulse::get_mmio_address(Some(TEST_CTI_ADDRESS)),
             pulse.into(),
         );
 
         let mut edprsr = Edprsr(0);
         edprsr.set_sdr(true);
-        probe.expected_read(Edprsr::get_mmio_address(TEST_BASE_ADDRESS), edprsr.into());
+        probe.expected_read(
+            Edprsr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edprsr.into(),
+        );
     }
 
     fn add_resume_cleanup_expectations(probe: &mut MockProbe) {
         let cti_gate = CtiGate(0);
-        probe.expected_write(CtiGate::get_mmio_address(TEST_CTI_ADDRESS), cti_gate.into());
+        probe.expected_write(
+            CtiGate::get_mmio_address(Some(TEST_CTI_ADDRESS)),
+            cti_gate.into(),
+        );
     }
 
     fn add_idr_expectations(probe: &mut MockProbe, bp_count: u32) {
         let mut eddfr = Eddfr(0);
         eddfr.set_brps(bp_count - 1);
-        probe.expected_read(Eddfr::get_mmio_address(TEST_BASE_ADDRESS), eddfr.into());
+        probe.expected_read(
+            Eddfr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            eddfr.into(),
+        );
     }
 
     fn add_set_r0_expectation(probe: &mut MockProbe, value: u32) {
@@ -1561,14 +1607,20 @@ mod test {
         edscr.set_ite(true);
         edscr.set_rxfull(true);
 
-        probe.expected_write(Dbgdtrrx::get_mmio_address(TEST_BASE_ADDRESS), value);
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_write(Dbgdtrrx::get_mmio_address(Some(TEST_BASE_ADDRESS)), value);
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
 
         probe.expected_write(
-            Editr::get_mmio_address(TEST_BASE_ADDRESS),
+            Editr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             prep_instr_for_itr_32(build_mrc(14, 0, 0, 0, 5, 0)),
         );
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
     }
 
     fn add_set_x0_expectation(probe: &mut MockProbe, value: u64) {
@@ -1577,17 +1629,26 @@ mod test {
         edscr.set_rxfull(true);
 
         probe.expected_write(
-            Dbgdtrtx::get_mmio_address(TEST_BASE_ADDRESS),
+            Dbgdtrtx::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             (value >> 32) as u32,
         );
-        probe.expected_write(Dbgdtrrx::get_mmio_address(TEST_BASE_ADDRESS), value as u32);
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_write(
+            Dbgdtrrx::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            value as u32,
+        );
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
 
         probe.expected_write(
-            Editr::get_mmio_address(TEST_BASE_ADDRESS),
+            Editr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             aarch64::build_mrs(2, 3, 0, 4, 0, 0),
         );
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
     }
 
     fn add_read_memory_expectations(probe: &mut MockProbe, address: u64, value: u32) {
@@ -1598,17 +1659,23 @@ mod test {
         edscr.set_txfull(true);
 
         probe.expected_write(
-            Editr::get_mmio_address(TEST_BASE_ADDRESS),
+            Editr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             prep_instr_for_itr_32(build_ldr(1, 0, 4)),
         );
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
 
         probe.expected_write(
-            Editr::get_mmio_address(TEST_BASE_ADDRESS),
+            Editr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             prep_instr_for_itr_32(build_mcr(14, 0, 1, 0, 5, 0)),
         );
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
-        probe.expected_read(Dbgdtrtx::get_mmio_address(TEST_BASE_ADDRESS), value);
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
+        probe.expected_read(Dbgdtrtx::get_mmio_address(Some(TEST_BASE_ADDRESS)), value);
     }
 
     fn add_read_memory_aarch64_expectations(probe: &mut MockProbe, address: u64, value: u32) {
@@ -1619,17 +1686,23 @@ mod test {
         edscr.set_txfull(true);
 
         probe.expected_write(
-            Editr::get_mmio_address(TEST_BASE_ADDRESS),
+            Editr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             aarch64::build_ldrw(1, 0, 4),
         );
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
 
         probe.expected_write(
-            Editr::get_mmio_address(TEST_BASE_ADDRESS),
+            Editr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
             aarch64::build_msr(2, 3, 0, 5, 0, 1),
         );
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
-        probe.expected_read(Dbgdtrtx::get_mmio_address(TEST_BASE_ADDRESS), value);
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
+        probe.expected_read(Dbgdtrtx::get_mmio_address(Some(TEST_BASE_ADDRESS)), value);
     }
 
     #[test]
@@ -1665,10 +1738,16 @@ mod test {
 
         let mut edscr = Edscr(0);
         edscr.set_status(0b000010);
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
 
         edscr.set_status(0b010011);
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
 
         let mock_mem = Box::new(probe) as _;
 
@@ -1696,10 +1775,16 @@ mod test {
 
         let mut edscr = Edscr(0);
         edscr.set_status(0b000010);
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
 
         edscr.set_status(0b010011);
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
 
         let mock_mem = Box::new(probe) as _;
 
@@ -1728,7 +1813,10 @@ mod test {
 
         let mut edscr = Edscr(0);
         edscr.set_status(0b000010);
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
 
         let mock_mem = Box::new(probe) as _;
 
@@ -1754,7 +1842,10 @@ mod test {
 
         let mut edscr = Edscr(0);
         edscr.set_status(0b010011);
-        probe.expected_read(Edscr::get_mmio_address(TEST_BASE_ADDRESS), edscr.into());
+        probe.expected_read(
+            Edscr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            edscr.into(),
+        );
 
         let mock_mem = Box::new(probe) as _;
 
@@ -2112,27 +2203,48 @@ mod test {
         add_idr_expectations(&mut probe, BP_COUNT);
 
         // Read BP values and controls
-        probe.expected_read(Dbgbvr::get_mmio_address(TEST_BASE_ADDRESS), BP1 as u32);
-        probe.expected_read(Dbgbvr::get_mmio_address(TEST_BASE_ADDRESS) + 4, 0);
-        probe.expected_read(Dbgbcr::get_mmio_address(TEST_BASE_ADDRESS), 1);
-
-        probe.expected_read(Dbgbvr::get_mmio_address(TEST_BASE_ADDRESS) + 16, BP2 as u32);
-        probe.expected_read(Dbgbvr::get_mmio_address(TEST_BASE_ADDRESS) + 4 + 16, 0);
-        probe.expected_read(Dbgbcr::get_mmio_address(TEST_BASE_ADDRESS) + 16, 1);
-
-        probe.expected_read(Dbgbvr::get_mmio_address(TEST_BASE_ADDRESS) + (2 * 16), 0);
         probe.expected_read(
-            Dbgbvr::get_mmio_address(TEST_BASE_ADDRESS) + 4 + (2 * 16),
+            Dbgbvr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            BP1 as u32,
+        );
+        probe.expected_read(Dbgbvr::get_mmio_address(Some(TEST_BASE_ADDRESS)) + 4, 0);
+        probe.expected_read(Dbgbcr::get_mmio_address(Some(TEST_BASE_ADDRESS)), 1);
+
+        probe.expected_read(
+            Dbgbvr::get_mmio_address(Some(TEST_BASE_ADDRESS)) + 16,
+            BP2 as u32,
+        );
+        probe.expected_read(
+            Dbgbvr::get_mmio_address(Some(TEST_BASE_ADDRESS)) + 4 + 16,
             0,
         );
-        probe.expected_read(Dbgbcr::get_mmio_address(TEST_BASE_ADDRESS) + (2 * 16), 0);
+        probe.expected_read(Dbgbcr::get_mmio_address(Some(TEST_BASE_ADDRESS)) + 16, 1);
 
-        probe.expected_read(Dbgbvr::get_mmio_address(TEST_BASE_ADDRESS) + (3 * 16), 0);
         probe.expected_read(
-            Dbgbvr::get_mmio_address(TEST_BASE_ADDRESS) + 4 + (3 * 16),
+            Dbgbvr::get_mmio_address(Some(TEST_BASE_ADDRESS)) + (2 * 16),
             0,
         );
-        probe.expected_read(Dbgbcr::get_mmio_address(TEST_BASE_ADDRESS) + (3 * 16), 0);
+        probe.expected_read(
+            Dbgbvr::get_mmio_address(Some(TEST_BASE_ADDRESS)) + 4 + (2 * 16),
+            0,
+        );
+        probe.expected_read(
+            Dbgbcr::get_mmio_address(Some(TEST_BASE_ADDRESS)) + (2 * 16),
+            0,
+        );
+
+        probe.expected_read(
+            Dbgbvr::get_mmio_address(Some(TEST_BASE_ADDRESS)) + (3 * 16),
+            0,
+        );
+        probe.expected_read(
+            Dbgbvr::get_mmio_address(Some(TEST_BASE_ADDRESS)) + 4 + (3 * 16),
+            0,
+        );
+        probe.expected_read(
+            Dbgbcr::get_mmio_address(Some(TEST_BASE_ADDRESS)) + (3 * 16),
+            0,
+        );
 
         let mock_mem = Box::new(probe) as _;
 
@@ -2171,9 +2283,15 @@ mod test {
         // Enable
         dbgbcr.set_e(true);
 
-        probe.expected_write(Dbgbvr::get_mmio_address(TEST_BASE_ADDRESS), BP_VALUE as u32);
-        probe.expected_write(Dbgbvr::get_mmio_address(TEST_BASE_ADDRESS) + 4, 0);
-        probe.expected_write(Dbgbcr::get_mmio_address(TEST_BASE_ADDRESS), dbgbcr.into());
+        probe.expected_write(
+            Dbgbvr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            BP_VALUE as u32,
+        );
+        probe.expected_write(Dbgbvr::get_mmio_address(Some(TEST_BASE_ADDRESS)) + 4, 0);
+        probe.expected_write(
+            Dbgbcr::get_mmio_address(Some(TEST_BASE_ADDRESS)),
+            dbgbcr.into(),
+        );
 
         let mock_mem = Box::new(probe) as _;
 
@@ -2198,9 +2316,9 @@ mod test {
         add_status_expectations(&mut probe, true);
 
         // Update BP value and control
-        probe.expected_write(Dbgbvr::get_mmio_address(TEST_BASE_ADDRESS), 0);
-        probe.expected_write(Dbgbvr::get_mmio_address(TEST_BASE_ADDRESS) + 4, 0);
-        probe.expected_write(Dbgbcr::get_mmio_address(TEST_BASE_ADDRESS), 0);
+        probe.expected_write(Dbgbvr::get_mmio_address(Some(TEST_BASE_ADDRESS)), 0);
+        probe.expected_write(Dbgbvr::get_mmio_address(Some(TEST_BASE_ADDRESS)) + 4, 0);
+        probe.expected_write(Dbgbcr::get_mmio_address(Some(TEST_BASE_ADDRESS)), 0);
 
         let mock_mem = Box::new(probe) as _;
 

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -1,31 +1,29 @@
 //! Register types and the core interface for armv8-a
 
-use crate::architecture::arm::core::armv8a_debug_regs::*;
-use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
-use crate::architecture::arm::sequences::ArmDebugSequence;
-use crate::architecture::arm::ArmError;
-use crate::core::{RegisterFile, RegisterValue};
-use crate::error::Error;
-use crate::memory::valid_32bit_address;
-use crate::CoreInterface;
-use crate::CoreStatus;
-use crate::MemoryInterface;
-use crate::RegisterId;
-use crate::{Architecture, CoreInformation, CoreType, InstructionSet};
-use anyhow::Result;
-
-use super::armv8a_core_regs::AARCH64_REGISTER_FILE;
-use super::CortexAState;
-use super::AARCH32_FP_32_REGS;
-
-use super::instructions::aarch64;
-use super::instructions::thumb2::{
-    build_ldr, build_mcr, build_mrc, build_str, build_vmov, build_vmrs,
+use super::{
+    armv8a_core_regs::AARCH64_REGISTER_FILE,
+    instructions::{
+        aarch64,
+        thumb2::{build_ldr, build_mcr, build_mrc, build_str, build_vmov, build_vmrs},
+    },
+    CortexAState, AARCH32_FP_32_REGS,
 };
-
-use std::sync::Arc;
-use std::time::Duration;
-use std::time::Instant;
+use crate::{
+    architecture::arm::{
+        core::armv8a_debug_regs::*, memory::adi_v5_memory_interface::ArmProbe,
+        sequences::ArmDebugSequence, ArmError,
+    },
+    core::{RegisterFile, RegisterId, RegisterValue},
+    error::Error,
+    memory::valid_32bit_address,
+    Architecture, CoreInformation, CoreInterface, CoreStatus, CoreType, InstructionSet,
+    MemoryInterface,
+};
+use anyhow::Result;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 /// Errors for the ARMv8-A state machine
 #[derive(thiserror::Error, Debug)]

--- a/probe-rs/src/architecture/arm/core/armv8a_debug_regs.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a_debug_regs.rs
@@ -1,28 +1,12 @@
 //! Debug register definitions for ARMv8-A
-use bitfield::bitfield;
-use std::mem::size_of;
 
-use crate::{core::BreakpointCause, HaltReason};
+use crate::{core::BreakpointCause, memory_mapped_bitfield_register, HaltReason};
 
-/// A debug register that is accessible to the external debugger
-pub trait Armv8DebugRegister {
-    /// Register number
-    const NUMBER: usize;
-
-    /// The register's name.
-    const NAME: &'static str;
-
-    /// Get the address in the memory map
-    fn get_mmio_address(base_address: u64) -> u64 {
-        base_address + (Self::NUMBER * size_of::<u32>()) as u64
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// EDSCR - Debug Status and Control Register
-    #[derive(Copy, Clone)]
     pub struct Edscr(u32);
-    impl Debug;
+    34, "EDSCR",
+    impl From;
 
     /// Trace Filter Override. Overrides the Trace Filter controls allowing the external debugger to trace any visible Exception level.
     pub tfo, set_tfo: 31;
@@ -161,83 +145,32 @@ impl Edscr {
     }
 }
 
-impl Armv8DebugRegister for Edscr {
-    const NUMBER: usize = 34;
-    const NAME: &'static str = "EDSCR";
-}
-
-impl From<u32> for Edscr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Edscr> for u32 {
-    fn from(value: Edscr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// EDLAR - Lock Access Register
-    #[derive(Copy, Clone)]
     pub struct Edlar(u32);
-    impl Debug;
+    1004,"EDLAR",
+    impl From;
 
     /// Lock value
     pub value, set_value : 31, 0;
 
 }
 
-impl Armv8DebugRegister for Edlar {
-    const NUMBER: usize = 1004;
-    const NAME: &'static str = "EDLAR";
-}
-
-impl From<u32> for Edlar {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Edlar> for u32 {
-    fn from(value: Edlar) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGBVR - Breakpoint Value Register
-    #[derive(Copy, Clone)]
     pub struct Dbgbvr(u32);
-    impl Debug;
+    256, "DBGBVR",
+    impl From;
 
     /// Breakpoint address
     pub value, set_value : 31, 0;
 }
 
-impl Armv8DebugRegister for Dbgbvr {
-    const NUMBER: usize = 256;
-    const NAME: &'static str = "DBGBVR";
-}
-
-impl From<u32> for Dbgbvr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgbvr> for u32 {
-    fn from(value: Dbgbvr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGBCR - Breakpoint Control Register
-    #[derive(Copy, Clone)]
     pub struct Dbgbcr(u32);
-    impl Debug;
+    258, "DBGBCR",
+    impl From;
 
     /// Breakpoint type
     pub bt, set_bt : 23, 20;
@@ -261,28 +194,11 @@ bitfield! {
     pub e, set_e: 0;
 }
 
-impl Armv8DebugRegister for Dbgbcr {
-    const NUMBER: usize = 258;
-    const NAME: &'static str = "DBGBCR";
-}
-
-impl From<u32> for Dbgbcr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgbcr> for u32 {
-    fn from(value: Dbgbcr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// EDDFR - External Debug Feature Register
-    #[derive(Copy, Clone)]
     pub struct Eddfr(u32);
-    impl Debug;
+    842, "EDDFR",
+    impl From;
 
     /// Number of breakpoints that are context-aware, minus 1.
     pub ctx_cmps, _: 31, 28;
@@ -300,55 +216,21 @@ bitfield! {
     pub tracever, _: 7, 4;
 }
 
-impl Armv8DebugRegister for Eddfr {
-    const NUMBER: usize = 842;
-    const NAME: &'static str = "EDDFR";
-}
-
-impl From<u32> for Eddfr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Eddfr> for u32 {
-    fn from(value: Eddfr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// EDITR - External Debug Instruction Transfer Register
-    #[derive(Copy, Clone)]
     pub struct Editr(u32);
-    impl Debug;
+    33, "EDITR",
+    impl From;
 
     /// Instruction value
     pub value, set_value: 31, 0;
 }
 
-impl Armv8DebugRegister for Editr {
-    const NUMBER: usize = 33;
-    const NAME: &'static str = "EDITR";
-}
-
-impl From<u32> for Editr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Editr> for u32 {
-    fn from(value: Editr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// EDRCR - External Debug Reserve Control Register
-    #[derive(Copy, Clone)]
     pub struct Edrcr(u32);
-    impl Debug;
+    36, "EDRCR",
+    impl From;
 
     /// Allow imprecise entry to Debug state.
     pub cbrrq, set_cbrrq: 4;
@@ -360,28 +242,11 @@ bitfield! {
     pub cse, set_cse: 2;
 }
 
-impl Armv8DebugRegister for Edrcr {
-    const NUMBER: usize = 36;
-    const NAME: &'static str = "EDRCR";
-}
-
-impl From<u32> for Edrcr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Edrcr> for u32 {
-    fn from(value: Edrcr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// EDECR - External Debug Execution Control Register
-    #[derive(Copy, Clone)]
     pub struct Edecr(u32);
-    impl Debug;
+    9, "EDECR",
+    impl From;
 
     /// Halting step enable.
     pub ss, set_ss : 2;
@@ -393,28 +258,11 @@ bitfield! {
     pub osuce, set_osuce : 0;
 }
 
-impl Armv8DebugRegister for Edecr {
-    const NUMBER: usize = 9;
-    const NAME: &'static str = "EDECR";
-}
-
-impl From<u32> for Edecr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Edecr> for u32 {
-    fn from(value: Edecr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// EDPRCR - External Debug Power/Reset Control Register
-    #[derive(Copy, Clone)]
     pub struct Edprcr(u32);
-    impl Debug;
+    196, "EDPRCR",
+    impl From;
 
     /// COREPURQ
     pub corepurq, set_corepurq : 3;
@@ -426,82 +274,31 @@ bitfield! {
     pub corenpdrq, set_corenpdrq : 0;
 }
 
-impl Armv8DebugRegister for Edprcr {
-    const NUMBER: usize = 196;
-    const NAME: &'static str = "EDPRCR";
-}
-
-impl From<u32> for Edprcr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Edprcr> for u32 {
-    fn from(value: Edprcr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
-    /// DBGDTRTX - Debug Data Transfer Register, Transmi
-    #[derive(Copy, Clone)]
+memory_mapped_bitfield_register! {
+    /// DBGDTRTX - Debug Data Transfer Register, Transmit
     pub struct Dbgdtrtx(u32);
-    impl Debug;
+    35, "DBGDTRTX",
+    impl From;
 
     /// Instruction value
     pub value, set_value: 31, 0;
 }
 
-impl Armv8DebugRegister for Dbgdtrtx {
-    const NUMBER: usize = 35;
-    const NAME: &'static str = "DBGDTRTX";
-}
-
-impl From<u32> for Dbgdtrtx {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgdtrtx> for u32 {
-    fn from(value: Dbgdtrtx) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// DBGDTRRX - Debug Data Transfer Register, Receive
-    #[derive(Copy, Clone)]
     pub struct Dbgdtrrx(u32);
-    impl Debug;
+    32, "DBGDTRRX",
+    impl From;
 
     /// Instruction value
     pub value, set_value: 31, 0;
 }
 
-impl Armv8DebugRegister for Dbgdtrrx {
-    const NUMBER: usize = 32;
-    const NAME: &'static str = "DBGDTRRX";
-}
-
-impl From<u32> for Dbgdtrrx {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dbgdtrrx> for u32 {
-    fn from(value: Dbgdtrrx) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// EDPRSR - External Debug Processor Status Register
-    #[derive(Copy, Clone)]
     pub struct Edprsr(u32);
-    impl Debug;
+    197, "EDPRSR",
+    impl From;
 
     /// Sticky Debug Restart.
     pub sdr, set_sdr: 11;
@@ -540,181 +337,62 @@ bitfield! {
     pub pu, _: 0;
 }
 
-impl Armv8DebugRegister for Edprsr {
-    const NUMBER: usize = 197;
-    const NAME: &'static str = "EDPRSR";
-}
-
-impl From<u32> for Edprsr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Edprsr> for u32 {
-    fn from(value: Edprsr) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// CTICONTROL - CTI control register
-    #[derive(Copy, Clone)]
     pub struct CtiControl(u32);
-    impl Debug;
+    0, "CTICONTROL",
+    impl From;
 
     /// Enables or disables the CTI mapping functions.
     pub glben, set_glben : 0;
 }
 
-impl Armv8DebugRegister for CtiControl {
-    const NUMBER: usize = 0;
-    const NAME: &'static str = "CTICONTROL";
-}
-
-impl From<u32> for CtiControl {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<CtiControl> for u32 {
-    fn from(value: CtiControl) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// CTIGATE - CTI gate register
-    #[derive(Copy, Clone)]
     pub struct CtiGate(u32);
-    impl Debug;
+    80, "CTIGATE",
+    impl From;
 
     /// Enables or disables the CTI mapping functions.
     pub en, set_en : 0, 0, 32;
 }
 
-impl Armv8DebugRegister for CtiGate {
-    const NUMBER: usize = 80;
-    const NAME: &'static str = "CTIGATE";
-}
-
-impl From<u32> for CtiGate {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<CtiGate> for u32 {
-    fn from(value: CtiGate) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// CTIOUTEN<n> - CTI output enable register
-    #[derive(Copy, Clone)]
     pub struct CtiOuten(u32);
-    impl Debug;
+    40, "CTIOUTEN",
+    impl From;
 
     /// Enables or disables input <n> generating this output
     pub outen, set_outen : 0, 0, 32;
 }
 
-impl Armv8DebugRegister for CtiOuten {
-    const NUMBER: usize = 40;
-    const NAME: &'static str = "CTIOUTEN";
-}
-
-impl From<u32> for CtiOuten {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<CtiOuten> for u32 {
-    fn from(value: CtiOuten) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// CTIAPPPULSE - CTI application pulse register
-    #[derive(Copy, Clone)]
     pub struct CtiApppulse(u32);
-    impl Debug;
+    7, "CTIAPPPULSE",
+    impl From;
 
     /// Generate a pulse on channel N
     pub apppulse, set_apppulse : 0, 0, 32;
 }
 
-impl Armv8DebugRegister for CtiApppulse {
-    const NUMBER: usize = 7;
-    const NAME: &'static str = "CTIAPPPULSE";
-}
-
-impl From<u32> for CtiApppulse {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<CtiApppulse> for u32 {
-    fn from(value: CtiApppulse) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// CTIINTACK - CTI Output Trigger Acknowledge register
-    #[derive(Copy, Clone)]
     pub struct CtiIntack(u32);
-    impl Debug;
+    4, "CTIINTACK",
+    impl From;
 
     /// Ack trigger on channel N
     pub ack, set_ack : 0, 0, 32;
 }
 
-impl Armv8DebugRegister for CtiIntack {
-    const NUMBER: usize = 4;
-    const NAME: &'static str = "CTIINTACK";
-}
-
-impl From<u32> for CtiIntack {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<CtiIntack> for u32 {
-    fn from(value: CtiIntack) -> Self {
-        value.0
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// CTITRIGOUTSTATUS - CTI Trigger Out Status register
-    #[derive(Copy, Clone)]
     pub struct CtiTrigoutstatus(u32);
-    impl Debug;
+    77, "CTITRIGOUTSTATUS",
+    impl From;
 
     /// Status on channel N
     pub status, _ : 0, 0, 32;
-}
-
-impl Armv8DebugRegister for CtiTrigoutstatus {
-    const NUMBER: usize = 77;
-    const NAME: &'static str = "CTITRIGOUTSTATUS";
-}
-
-impl From<u32> for CtiTrigoutstatus {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<CtiTrigoutstatus> for u32 {
-    fn from(value: CtiTrigoutstatus) -> Self {
-        value.0
-    }
 }

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -37,14 +37,14 @@ impl<'probe> Armv8m<'probe> {
     ) -> Result<Self, Error> {
         if !state.initialized() {
             // determine current state
-            let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::get_mmio_address(None))?);
+            let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::get_mmio_address())?);
 
             tracing::debug!("State when connecting: {:x?}", dhcsr);
 
             let core_state = if dhcsr.s_sleep() {
                 CoreStatus::Sleeping
             } else if dhcsr.s_halt() {
-                let dfsr = Dfsr(memory.read_word_32(Dfsr::get_mmio_address(None))?);
+                let dfsr = Dfsr(memory.read_word_32(Dfsr::get_mmio_address())?);
 
                 let reason = dfsr.halt_reason();
 
@@ -59,11 +59,10 @@ impl<'probe> Armv8m<'probe> {
             // so we clear them here to ensure that that none are set.
             let dfsr_clear = Dfsr::clear_all();
 
-            memory.write_word_32(Dfsr::get_mmio_address(None), dfsr_clear.into())?;
+            memory.write_word_32(Dfsr::get_mmio_address(), dfsr_clear.into())?;
 
             state.current_state = core_state;
-            state.fp_present =
-                Mvfr0(memory.read_word_32(Mvfr0::get_mmio_address(None))?).fp_present();
+            state.fp_present = Mvfr0(memory.read_word_32(Mvfr0::get_mmio_address())?).fp_present();
 
             state.initialize();
         }
@@ -107,7 +106,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         value.enable_write();
 
         self.memory
-            .write_word_32(Dhcsr::get_mmio_address(None), value.into())?;
+            .write_word_32(Dhcsr::get_mmio_address(), value.into())?;
 
         self.wait_for_core_halted(timeout)?;
 
@@ -133,7 +132,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         value.enable_write();
 
         self.memory
-            .write_word_32(Dhcsr::get_mmio_address(None), value.into())?;
+            .write_word_32(Dhcsr::get_mmio_address(), value.into())?;
         self.memory.flush()?;
 
         // We assume that the core is running now
@@ -201,7 +200,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         value.enable_write();
 
         self.memory
-            .write_word_32(Dhcsr::get_mmio_address(None), value.into())?;
+            .write_word_32(Dhcsr::get_mmio_address(), value.into())?;
         self.memory.flush()?;
 
         self.wait_for_core_halted(Duration::from_millis(100))?;
@@ -219,7 +218,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
             {
                 tracing::debug!("Encountered a breakpoint instruction @ {}. We need to manually advance the program counter to the next instruction.", pc_after_step);
                 // Advance the program counter by the architecture specific byte size of the BKPT instruction.
-                pc_after_step.incremenet_address(2)?;
+                pc_after_step.increment_address(2)?;
                 self.write_core_reg(self.registers().program_counter().id, pc_after_step)?;
             }
             self.enable_breakpoints(true)?;
@@ -249,7 +248,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
     }
 
     fn available_breakpoint_units(&mut self) -> Result<u32, Error> {
-        let raw_val = self.memory.read_word_32(FpCtrl::get_mmio_address(None))?;
+        let raw_val = self.memory.read_word_32(FpCtrl::get_mmio_address())?;
 
         let reg = FpCtrl::from(raw_val);
 
@@ -262,7 +261,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         val.set_enable(state);
 
         self.memory
-            .write_word_32(FpCtrl::get_mmio_address(None), val.into())?;
+            .write_word_32(FpCtrl::get_mmio_address(), val.into())?;
         self.memory.flush()?;
 
         self.state.hw_breakpoints_enabled = state;
@@ -281,7 +280,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         val.set_bp_addr(comp_val);
         val.set_enable(true);
 
-        let reg_addr = FpCompN::get_mmio_address(None) + (bp_unit_index * size_of::<u32>()) as u64;
+        let reg_addr = FpCompN::get_mmio_address() + (bp_unit_index * size_of::<u32>()) as u64;
 
         self.memory.write_word_32(reg_addr, val.into())?;
 
@@ -301,7 +300,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         val.set_enable(false);
         val.set_bp_addr(0);
 
-        let reg_addr = FpCompN::get_mmio_address(None) + (bp_unit_index * size_of::<u32>()) as u64;
+        let reg_addr = FpCompN::get_mmio_address() + (bp_unit_index * size_of::<u32>()) as u64;
 
         self.memory.write_word_32(reg_addr, val.into())?;
 
@@ -325,7 +324,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
     }
 
     fn status(&mut self) -> Result<crate::core::CoreStatus, Error> {
-        let dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::get_mmio_address(None))?);
+        let dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::get_mmio_address())?);
 
         if dhcsr.s_lockup() {
             tracing::warn!(
@@ -351,13 +350,13 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         // TODO: Handle lockup
 
         if dhcsr.s_halt() {
-            let dfsr = Dfsr(self.memory.read_word_32(Dfsr::get_mmio_address(None))?);
+            let dfsr = Dfsr(self.memory.read_word_32(Dfsr::get_mmio_address())?);
 
             let reason = dfsr.halt_reason();
 
             // Clear bits from Dfsr register
             self.memory
-                .write_word_32(Dfsr::get_mmio_address(None), Dfsr::clear_all().into())?;
+                .write_word_32(Dfsr::get_mmio_address(), Dfsr::clear_all().into())?;
 
             // If the core was halted before, we cannot read the halt reason from the chip,
             // because we clear it directly after reading.
@@ -397,8 +396,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         let mut breakpoints = vec![];
         let num_hw_breakpoints = self.available_breakpoint_units()? as usize;
         for bp_unit_index in 0..num_hw_breakpoints {
-            let reg_addr =
-                FpCompN::get_mmio_address(None) + (bp_unit_index * size_of::<u32>()) as u64;
+            let reg_addr = FpCompN::get_mmio_address() + (bp_unit_index * size_of::<u32>()) as u64;
             // The raw breakpoint address as read from memory
             let register_value = self.memory.read_word_32(reg_addr)?;
             // The breakpoint address after it has been adjusted for FpRev 1 or 2

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -1,24 +1,22 @@
 //! Register types and the core interface for armv8-M
 
-use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
-use crate::architecture::arm::sequences::ArmDebugSequence;
-use crate::architecture::arm::ArmError;
-use crate::core::RegisterFile;
-use crate::error::Error;
-use crate::memory::valid_32bit_address;
-use crate::{architecture::arm::core::register, CoreStatus, HaltReason, MemoryInterface};
-use crate::{Architecture, CoreInformation};
-use crate::{CoreInterface, CoreType, InstructionSet, MemoryMappedRegister};
-use crate::{RegisterId, RegisterValue};
+use super::{cortex_m::Mvfr0, CortexMState, Dfsr, CORTEX_M_COMMON_REGS, CORTEX_M_WITH_FP_REGS};
+use crate::{
+    architecture::arm::{
+        core::register, memory::adi_v5_memory_interface::ArmProbe, sequences::ArmDebugSequence,
+        ArmError,
+    },
+    core::{RegisterFile, RegisterId, RegisterValue},
+    error::Error,
+    memory::valid_32bit_address,
+    Architecture, CoreInformation, CoreInterface, CoreStatus, CoreType, HaltReason, InstructionSet,
+    MemoryInterface, MemoryMappedRegister,
+};
 use anyhow::Result;
-
 use bitfield::bitfield;
-
-use super::cortex_m::Mvfr0;
-use super::{CortexMState, Dfsr, CORTEX_M_COMMON_REGS, CORTEX_M_WITH_FP_REGS};
-use std::sync::Arc;
 use std::{
     mem::size_of,
+    sync::Arc,
     time::{Duration, Instant},
 };
 

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -777,7 +777,7 @@ impl From<Dhcsr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Dhcsr {
+impl MemoryMappedRegister<u32> for Dhcsr {
     const ADDRESS: u64 = 0xE000_EDF0;
     const NAME: &'static str = "DHCSR";
 }
@@ -873,7 +873,7 @@ impl Aircr {
     }
 }
 
-impl MemoryMappedRegister for Aircr {
+impl MemoryMappedRegister<u32> for Aircr {
     const ADDRESS: u64 = 0xE000_ED0C;
     const NAME: &'static str = "AIRCR";
 }
@@ -894,7 +894,7 @@ impl From<Dcrdr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Dcrdr {
+impl MemoryMappedRegister<u32> for Dcrdr {
     const ADDRESS: u64 = 0xE000_EDF8;
     const NAME: &'static str = "DCRDR";
 }
@@ -957,7 +957,7 @@ impl From<Demcr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Demcr {
+impl MemoryMappedRegister<u32> for Demcr {
     const ADDRESS: u64 = 0xe000_edfc;
     const NAME: &'static str = "DEMCR";
 }
@@ -995,7 +995,7 @@ impl FpCtrl {
     }
 }
 
-impl MemoryMappedRegister for FpCtrl {
+impl MemoryMappedRegister<u32> for FpCtrl {
     const ADDRESS: u64 = 0xE000_2000;
     const NAME: &'static str = "FP_CTRL";
 }
@@ -1028,7 +1028,7 @@ bitfield! {
     pub enable, set_enable: 0;
 }
 
-impl MemoryMappedRegister for FpCompN {
+impl MemoryMappedRegister<u32> for FpCompN {
     const ADDRESS: u64 = 0xE000_2008;
     const NAME: &'static str = "FP_COMPn";
 }

--- a/probe-rs/src/architecture/arm/core/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/cortex_m.rs
@@ -49,7 +49,7 @@ impl From<Dhcsr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Dhcsr {
+impl MemoryMappedRegister<u32> for Dhcsr {
     const ADDRESS: u64 = 0xE000_EDF0;
     const NAME: &'static str = "DHCSR";
 }
@@ -75,7 +75,7 @@ impl From<Dcrsr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Dcrsr {
+impl MemoryMappedRegister<u32> for Dcrsr {
     const ADDRESS: u64 = 0xE000_EDF4;
     const NAME: &'static str = "DCRSR";
 }
@@ -95,7 +95,7 @@ impl From<Dcrdr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Dcrdr {
+impl MemoryMappedRegister<u32> for Dcrdr {
     const ADDRESS: u64 = 0xE000_EDF8;
     const NAME: &'static str = "DCRDR";
 }
@@ -126,7 +126,7 @@ impl From<Cpacr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Cpacr {
+impl MemoryMappedRegister<u32> for Cpacr {
     const ADDRESS: u64 = 0xE000_ED88;
     const NAME: &'static str = "CPACR";
 }
@@ -158,7 +158,7 @@ impl From<Mvfr0> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Mvfr0 {
+impl MemoryMappedRegister<u32> for Mvfr0 {
     const ADDRESS: u64 = 0xE000_EF40;
     const NAME: &'static str = "MVFR0";
 }

--- a/probe-rs/src/architecture/arm/core/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/cortex_m.rs
@@ -86,11 +86,11 @@ pub(crate) fn read_core_reg(memory: &mut dyn ArmProbe, addr: RegisterId) -> Resu
     dcrsr_val.set_regwnr(false); // Perform a read.
     dcrsr_val.set_regsel(addr.into()); // The address of the register to read.
 
-    memory.write_word_32(Dcrsr::get_mmio_address(None), dcrsr_val.into())?;
+    memory.write_word_32(Dcrsr::get_mmio_address(), dcrsr_val.into())?;
 
     wait_for_core_register_transfer(memory, Duration::from_millis(100))?;
 
-    let value = memory.read_word_32(Dcrdr::get_mmio_address(None))?;
+    let value = memory.read_word_32(Dcrdr::get_mmio_address())?;
 
     Ok(value)
 }
@@ -100,14 +100,14 @@ pub(crate) fn write_core_reg(
     addr: RegisterId,
     value: u32,
 ) -> Result<(), Error> {
-    memory.write_word_32(Dcrdr::get_mmio_address(None), value)?;
+    memory.write_word_32(Dcrdr::get_mmio_address(), value)?;
 
     // write the DCRSR value to select the register we want to write.
     let mut dcrsr_val = Dcrsr(0);
     dcrsr_val.set_regwnr(true); // Perform a write.
     dcrsr_val.set_regsel(addr.into()); // The address of the register to write.
 
-    memory.write_word_32(Dcrsr::get_mmio_address(None), dcrsr_val.into())?;
+    memory.write_word_32(Dcrsr::get_mmio_address(), dcrsr_val.into())?;
 
     wait_for_core_register_transfer(memory, Duration::from_millis(100))?;
 
@@ -123,7 +123,7 @@ fn wait_for_core_register_transfer(
     let start = Instant::now();
 
     while start.elapsed() < timeout {
-        let dhcsr_val = Dhcsr(memory.read_word_32(Dhcsr::get_mmio_address(None))?);
+        let dhcsr_val = Dhcsr(memory.read_word_32(Dhcsr::get_mmio_address())?);
 
         if dhcsr_val.s_regrdy() {
             return Ok(());

--- a/probe-rs/src/architecture/arm/core/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/cortex_m.rs
@@ -3,15 +3,14 @@
 use crate::{
     architecture::arm::{memory::adi_v5_memory_interface::ArmProbe, ArmError},
     core::RegisterId,
-    Error, MemoryMappedRegister,
+    memory_mapped_bitfield_register, Error, MemoryMappedRegister,
 };
-use bitfield::bitfield;
 use std::time::{Duration, Instant};
 
-bitfield! {
-    #[derive(Copy, Clone)]
+memory_mapped_bitfield_register! {
     pub struct Dhcsr(u32);
-    impl Debug;
+    0xE000_EDF0, "DHCSR",
+    impl From;
     pub s_reset_st, _: 25;
     pub s_retire_st, _: 24;
     pub s_lockup, _: 19;
@@ -37,74 +36,26 @@ impl Dhcsr {
     }
 }
 
-impl From<u32> for Dhcsr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dhcsr> for u32 {
-    fn from(value: Dhcsr) -> Self {
-        value.0
-    }
-}
-
-impl MemoryMappedRegister<u32> for Dhcsr {
-    const ADDRESS_OFFSET: u64 = 0xE000_EDF0;
-    const NAME: &'static str = "DHCSR";
-}
-
-bitfield! {
-    #[derive(Copy, Clone)]
+memory_mapped_bitfield_register! {
     pub struct Dcrsr(u32);
-    impl Debug;
+    0xE000_EDF4, "DCRSR",
+    impl From;
     pub _, set_regwnr: 16;
     // If the processor does not implement the FP extension the REGSEL field is bits [4:0], and bits [6:5] are Reserved, SBZ.
     pub _, set_regsel: 6,0;
 }
 
-impl From<u32> for Dcrsr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
+memory_mapped_bitfield_register! {
+    pub struct Dcrdr(u32);
+    0xE000_EDF8, "DCRDR",
+    impl From;
 }
 
-impl From<Dcrsr> for u32 {
-    fn from(value: Dcrsr) -> Self {
-        value.0
-    }
-}
-
-impl MemoryMappedRegister<u32> for Dcrsr {
-    const ADDRESS_OFFSET: u64 = 0xE000_EDF4;
-    const NAME: &'static str = "DCRSR";
-}
-
-#[derive(Debug, Copy, Clone)]
-pub struct Dcrdr(u32);
-
-impl From<u32> for Dcrdr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dcrdr> for u32 {
-    fn from(value: Dcrdr) -> Self {
-        value.0
-    }
-}
-
-impl MemoryMappedRegister<u32> for Dcrdr {
-    const ADDRESS_OFFSET: u64 = 0xE000_EDF8;
-    const NAME: &'static str = "DCRDR";
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     ///  Coprocessor Access Control Register
-    #[derive(Copy, Clone)]
     pub struct Cpacr(u32);
-    impl Debug;
+    0xE000_ED88, "CPACR",
+    impl From;
     pub fpu_privilige, _: 21,20;
 }
 
@@ -114,28 +65,11 @@ impl Cpacr {
     }
 }
 
-impl From<u32> for Cpacr {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Cpacr> for u32 {
-    fn from(value: Cpacr) -> Self {
-        value.0
-    }
-}
-
-impl MemoryMappedRegister<u32> for Cpacr {
-    const ADDRESS_OFFSET: u64 = 0xE000_ED88;
-    const NAME: &'static str = "CPACR";
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     ///  Media and VFP Feature Register 0
-    #[derive(Copy, Clone)]
     pub struct Mvfr0(u32);
-    impl Debug;
+    0xE000_EF40, "MVFR0",
+    impl From;
     pub fpdp, _: 11, 8;
     pub fpsp, _: 7, 4;
 }
@@ -144,23 +78,6 @@ impl Mvfr0 {
     pub fn fp_present(&self) -> bool {
         self.fpdp() != 0 || self.fpsp() != 0
     }
-}
-
-impl From<u32> for Mvfr0 {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Mvfr0> for u32 {
-    fn from(value: Mvfr0) -> Self {
-        value.0
-    }
-}
-
-impl MemoryMappedRegister<u32> for Mvfr0 {
-    const ADDRESS_OFFSET: u64 = 0xE000_EF40;
-    const NAME: &'static str = "MVFR0";
 }
 
 pub(crate) fn read_core_reg(memory: &mut dyn ArmProbe, addr: RegisterId) -> Result<u32, Error> {

--- a/probe-rs/src/architecture/arm/core/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/cortex_m.rs
@@ -2,9 +2,9 @@
 
 use crate::{
     architecture::arm::{memory::adi_v5_memory_interface::ArmProbe, ArmError},
-    Error, MemoryMappedRegister, RegisterId,
+    core::RegisterId,
+    Error, MemoryMappedRegister,
 };
-
 use bitfield::bitfield;
 use std::time::{Duration, Instant};
 

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -41,10 +41,7 @@ impl Dump {
 }
 
 pub(crate) mod register {
-    use crate::{
-        core::{RegisterDataType, RegisterDescription, RegisterKind},
-        RegisterId,
-    };
+    use crate::core::{RegisterDataType, RegisterDescription, RegisterId, RegisterKind};
 
     pub const PC: RegisterDescription = RegisterDescription {
         name: "PC",

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -980,7 +980,7 @@ impl From<Dfsr> for u32 {
     }
 }
 
-impl MemoryMappedRegister for Dfsr {
+impl MemoryMappedRegister<u32> for Dfsr {
     const ADDRESS: u64 = 0xE000_ED30;
     const NAME: &'static str = "DFSR";
 }

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -1,9 +1,9 @@
 use crate::{
     core::{
-        BreakpointCause, MemoryMappedRegister, RegisterDataType, RegisterDescription, RegisterFile,
-        RegisterId, RegisterKind, RegisterValue,
+        BreakpointCause, RegisterDataType, RegisterDescription, RegisterFile, RegisterId,
+        RegisterKind, RegisterValue,
     },
-    CoreStatus, HaltReason,
+    memory_mapped_bitfield_register, CoreStatus, HaltReason,
 };
 
 use bitfield::bitfield;
@@ -911,10 +911,9 @@ static CORTEX_M_WITH_FP_REGS: RegisterFile = RegisterFile {
     ..CORTEX_M_COMMON_REGS
 };
 
-bitfield! {
-    #[derive(Copy, Clone)]
+memory_mapped_bitfield_register! {
     pub struct Dfsr(u32);
-    impl Debug;
+    0xE000_ED30, "DFSR",
     pub external, set_external: 4;
     pub vcatch, set_vcatch: 3;
     pub dwttrap, set_dwttrap: 2;
@@ -978,11 +977,6 @@ impl From<Dfsr> for u32 {
     fn from(register: Dfsr) -> Self {
         register.0
     }
-}
-
-impl MemoryMappedRegister<u32> for Dfsr {
-    const ADDRESS_OFFSET: u64 = 0xE000_ED30;
-    const NAME: &'static str = "DFSR";
 }
 
 #[derive(Debug)]

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -6,8 +6,6 @@ use crate::{
     memory_mapped_bitfield_register, CoreStatus, HaltReason,
 };
 
-use bitfield::bitfield;
-
 pub mod armv6m;
 pub mod armv7a;
 pub mod armv7m;

--- a/probe-rs/src/architecture/arm/core/mod.rs
+++ b/probe-rs/src/architecture/arm/core/mod.rs
@@ -981,7 +981,7 @@ impl From<Dfsr> for u32 {
 }
 
 impl MemoryMappedRegister<u32> for Dfsr {
-    const ADDRESS: u64 = 0xE000_ED30;
+    const ADDRESS_OFFSET: u64 = 0xE000_ED30;
     const NAME: &'static str = "DFSR";
 }
 

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -131,6 +131,9 @@ pub enum ArmError {
 
     /// Failed to erase chip
     ChipEraseFailed,
+
+    /// Any other error occurred.
+    Other(#[from] anyhow::Error),
 }
 
 impl ArmError {

--- a/probe-rs/src/architecture/arm/sequences/efm32xg2.rs
+++ b/probe-rs/src/architecture/arm/sequences/efm32xg2.rs
@@ -42,12 +42,12 @@ impl ArmDebugSequence for EFM32xG2 {
 
         if reset_vector == 0xffff_ffff {
             tracing::info!("Enable reset vector catch");
-            let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address(None))?);
+            let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address())?);
             demcr.set_vc_corereset(true);
-            core.write_word_32(Demcr::get_mmio_address(None), demcr.into())?;
+            core.write_word_32(Demcr::get_mmio_address(), demcr.into())?;
         }
 
-        let _ = core.read_word_32(Dhcsr::get_mmio_address(None))?;
+        let _ = core.read_word_32(Dhcsr::get_mmio_address())?;
 
         Ok(())
     }
@@ -61,8 +61,8 @@ impl ArmDebugSequence for EFM32xG2 {
         core.write_word_32(0xE000_2008, 0x0)?;
         core.write_word_32(0xE000_2000, 0x2)?;
 
-        let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address(None))?);
+        let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address())?);
         demcr.set_vc_corereset(false);
-        core.write_word_32(Demcr::get_mmio_address(None), demcr.into())
+        core.write_word_32(Demcr::get_mmio_address(), demcr.into())
     }
 }

--- a/probe-rs/src/architecture/arm/sequences/efm32xg2.rs
+++ b/probe-rs/src/architecture/arm/sequences/efm32xg2.rs
@@ -42,12 +42,12 @@ impl ArmDebugSequence for EFM32xG2 {
 
         if reset_vector == 0xffff_ffff {
             tracing::info!("Enable reset vector catch");
-            let mut demcr = Demcr(core.read_word_32(Demcr::ADDRESS)?);
+            let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address(None))?);
             demcr.set_vc_corereset(true);
-            core.write_word_32(Demcr::ADDRESS, demcr.into())?;
+            core.write_word_32(Demcr::get_mmio_address(None), demcr.into())?;
         }
 
-        let _ = core.read_word_32(Dhcsr::ADDRESS)?;
+        let _ = core.read_word_32(Dhcsr::get_mmio_address(None))?;
 
         Ok(())
     }
@@ -61,8 +61,8 @@ impl ArmDebugSequence for EFM32xG2 {
         core.write_word_32(0xE000_2008, 0x0)?;
         core.write_word_32(0xE000_2000, 0x2)?;
 
-        let mut demcr = Demcr(core.read_word_32(Demcr::ADDRESS)?);
+        let mut demcr = Demcr(core.read_word_32(Demcr::get_mmio_address(None))?);
         demcr.set_vc_corereset(false);
-        core.write_word_32(Demcr::ADDRESS, demcr.into())
+        core.write_word_32(Demcr::get_mmio_address(None), demcr.into())
     }
 }

--- a/probe-rs/src/architecture/arm/sequences/infineon.rs
+++ b/probe-rs/src/architecture/arm/sequences/infineon.rs
@@ -196,8 +196,8 @@ impl ArmDebugSequence for XMC4000 {
         let application_entry = core.read_word_32(0x0C000004)? - 1;
 
         // Read FP state so we can restore it later
-        let fp_ctrl = FpCtrl(core.read_word_32(FpCtrl::ADDRESS)?);
-        let fpcomp0 = core.read_word_32(FpRev1CompX::ADDRESS)?;
+        let fp_ctrl = FpCtrl(core.read_word_32(FpCtrl::get_mmio_address(None))?);
+        let fpcomp0 = core.read_word_32(FpRev1CompX::get_mmio_address(None))?;
 
         // Indicate we're in the midst of a warm reset
         self.reset_state
@@ -214,7 +214,7 @@ impl ArmDebugSequence for XMC4000 {
         let mut fp_ctrl = FpCtrl(0);
         fp_ctrl.set_enable(true);
         fp_ctrl.set_key(true);
-        core.write_word_32(FpCtrl::ADDRESS, fp_ctrl.into())?;
+        core.write_word_32(FpCtrl::get_mmio_address(None), fp_ctrl.into())?;
 
         // Set a breakpoint at application_entry
         let val = if fp_ctrl.rev() == 0 {
@@ -228,7 +228,7 @@ impl ArmDebugSequence for XMC4000 {
             ))
             .into());
         };
-        core.write_word_32(FpRev1CompX::ADDRESS, val)?;
+        core.write_word_32(FpRev1CompX::get_mmio_address(None), val)?;
         tracing::debug!("Set a breakpoint at {:08x}", application_entry);
 
         core.flush()?;
@@ -260,10 +260,10 @@ impl ArmDebugSequence for XMC4000 {
                 let mut fpctrl = FpCtrl::from(0);
                 fpctrl.set_key(true);
                 fpctrl.set_enable(fpctrl_enabled);
-                core.write_word_32(FpCtrl::ADDRESS, fpctrl.into())?;
+                core.write_word_32(FpCtrl::get_mmio_address(None), fpctrl.into())?;
 
                 // Put FPCOMP0 back
-                core.write_word_32(FpRev1CompX::ADDRESS, fpcomp0)?;
+                core.write_word_32(FpRev1CompX::get_mmio_address(None), fpcomp0)?;
             }
             ResetState::Cold { .. } => {
                 // No op
@@ -302,13 +302,13 @@ impl ArmDebugSequence for XMC4000 {
         let mut aircr = Aircr(0);
         aircr.vectkey();
         aircr.set_sysresetreq(true);
-        core.write_word_32(Aircr::ADDRESS, aircr.into())?;
+        core.write_word_32(Aircr::get_mmio_address(None), aircr.into())?;
         tracing::debug!("Resetting via AIRCR.SYSRESETREQ");
 
         // Spin until CoreSight indicates the reset was processed
         let start = Instant::now();
         loop {
-            let dhcsr = Dhcsr(core.read_word_32(Dhcsr::ADDRESS)?);
+            let dhcsr = Dhcsr(core.read_word_32(Dhcsr::get_mmio_address(None))?);
 
             // Wait until the S_RESET_ST bit is cleared on a read
             if !dhcsr.s_reset_st() {
@@ -429,7 +429,7 @@ impl ArmDebugSequence for XMC4000 {
 fn spin_until_core_is_halted(core: &mut dyn ArmProbe, timeout: Duration) -> Result<(), ArmError> {
     let start = Instant::now();
     loop {
-        let dhcsr = Dhcsr(core.read_word_32(Dhcsr::ADDRESS)?);
+        let dhcsr = Dhcsr(core.read_word_32(Dhcsr::get_mmio_address(None))?);
         if dhcsr.s_halt() {
             tracing::debug!("Halted after reset");
             return Ok(());

--- a/probe-rs/src/architecture/arm/sequences/infineon.rs
+++ b/probe-rs/src/architecture/arm/sequences/infineon.rs
@@ -196,8 +196,8 @@ impl ArmDebugSequence for XMC4000 {
         let application_entry = core.read_word_32(0x0C000004)? - 1;
 
         // Read FP state so we can restore it later
-        let fp_ctrl = FpCtrl(core.read_word_32(FpCtrl::get_mmio_address(None))?);
-        let fpcomp0 = core.read_word_32(FpRev1CompX::get_mmio_address(None))?;
+        let fp_ctrl = FpCtrl(core.read_word_32(FpCtrl::get_mmio_address())?);
+        let fpcomp0 = core.read_word_32(FpRev1CompX::get_mmio_address())?;
 
         // Indicate we're in the midst of a warm reset
         self.reset_state
@@ -214,7 +214,7 @@ impl ArmDebugSequence for XMC4000 {
         let mut fp_ctrl = FpCtrl(0);
         fp_ctrl.set_enable(true);
         fp_ctrl.set_key(true);
-        core.write_word_32(FpCtrl::get_mmio_address(None), fp_ctrl.into())?;
+        core.write_word_32(FpCtrl::get_mmio_address(), fp_ctrl.into())?;
 
         // Set a breakpoint at application_entry
         let val = if fp_ctrl.rev() == 0 {
@@ -228,7 +228,7 @@ impl ArmDebugSequence for XMC4000 {
             ))
             .into());
         };
-        core.write_word_32(FpRev1CompX::get_mmio_address(None), val)?;
+        core.write_word_32(FpRev1CompX::get_mmio_address(), val)?;
         tracing::debug!("Set a breakpoint at {:08x}", application_entry);
 
         core.flush()?;
@@ -260,10 +260,10 @@ impl ArmDebugSequence for XMC4000 {
                 let mut fpctrl = FpCtrl::from(0);
                 fpctrl.set_key(true);
                 fpctrl.set_enable(fpctrl_enabled);
-                core.write_word_32(FpCtrl::get_mmio_address(None), fpctrl.into())?;
+                core.write_word_32(FpCtrl::get_mmio_address(), fpctrl.into())?;
 
                 // Put FPCOMP0 back
-                core.write_word_32(FpRev1CompX::get_mmio_address(None), fpcomp0)?;
+                core.write_word_32(FpRev1CompX::get_mmio_address(), fpcomp0)?;
             }
             ResetState::Cold { .. } => {
                 // No op
@@ -302,13 +302,13 @@ impl ArmDebugSequence for XMC4000 {
         let mut aircr = Aircr(0);
         aircr.vectkey();
         aircr.set_sysresetreq(true);
-        core.write_word_32(Aircr::get_mmio_address(None), aircr.into())?;
+        core.write_word_32(Aircr::get_mmio_address(), aircr.into())?;
         tracing::debug!("Resetting via AIRCR.SYSRESETREQ");
 
         // Spin until CoreSight indicates the reset was processed
         let start = Instant::now();
         loop {
-            let dhcsr = Dhcsr(core.read_word_32(Dhcsr::get_mmio_address(None))?);
+            let dhcsr = Dhcsr(core.read_word_32(Dhcsr::get_mmio_address())?);
 
             // Wait until the S_RESET_ST bit is cleared on a read
             if !dhcsr.s_reset_st() {
@@ -429,7 +429,7 @@ impl ArmDebugSequence for XMC4000 {
 fn spin_until_core_is_halted(core: &mut dyn ArmProbe, timeout: Duration) -> Result<(), ArmError> {
     let start = Instant::now();
     loop {
-        let dhcsr = Dhcsr(core.read_word_32(Dhcsr::get_mmio_address(None))?);
+        let dhcsr = Dhcsr(core.read_word_32(Dhcsr::get_mmio_address())?);
         if dhcsr.s_halt() {
             tracing::debug!("Halted after reset");
             return Ok(());

--- a/probe-rs/src/architecture/arm/sequences/nxp.rs
+++ b/probe-rs/src/architecture/arm/sequences/nxp.rs
@@ -121,11 +121,11 @@ impl ArmDebugSequence for LPC55Sxx {
         _debug_base: Option<u64>,
     ) -> Result<(), ArmError> {
         let mut reset_vector = 0xffff_ffff;
-        let mut demcr = Demcr(interface.read_word_32(Demcr::ADDRESS)?);
+        let mut demcr = Demcr(interface.read_word_32(Demcr::get_mmio_address(None))?);
 
         demcr.set_vc_corereset(false);
 
-        interface.write_word_32(Demcr::ADDRESS, demcr.into())?;
+        interface.write_word_32(Demcr::get_mmio_address(None), demcr.into())?;
 
         // Write some stuff
         interface.write_word_32(0x40034010, 0x00000000)?; // Program Flash Word Start Address to 0x0 to read reset vector (STARTA)
@@ -177,14 +177,14 @@ impl ArmDebugSequence for LPC55Sxx {
         if reset_vector == 0xffff_ffff {
             tracing::info!("Enable reset vector catch");
 
-            let mut demcr = Demcr(interface.read_word_32(Demcr::ADDRESS)?);
+            let mut demcr = Demcr(interface.read_word_32(Demcr::get_mmio_address(None))?);
 
             demcr.set_vc_corereset(true);
 
-            interface.write_word_32(Demcr::ADDRESS, demcr.into())?;
+            interface.write_word_32(Demcr::get_mmio_address(None), demcr.into())?;
         }
 
-        let _ = interface.read_word_32(Dhcsr::ADDRESS)?;
+        let _ = interface.read_word_32(Dhcsr::get_mmio_address(None))?;
 
         tracing::debug!("reset_catch_set -- done");
 
@@ -200,11 +200,11 @@ impl ArmDebugSequence for LPC55Sxx {
         interface.write_word_32(0xE000_2008, 0x0)?;
         interface.write_word_32(0xE000_2000, 0x2)?;
 
-        let mut demcr = Demcr(interface.read_word_32(Demcr::ADDRESS)?);
+        let mut demcr = Demcr(interface.read_word_32(Demcr::get_mmio_address(None))?);
 
         demcr.set_vc_corereset(false);
 
-        interface.write_word_32(Demcr::ADDRESS, demcr.into())
+        interface.write_word_32(Demcr::get_mmio_address(None), demcr.into())
     }
 
     fn reset_system(
@@ -217,7 +217,7 @@ impl ArmDebugSequence for LPC55Sxx {
         aircr.vectkey();
         aircr.set_sysresetreq(true);
 
-        let mut result = interface.write_word_32(Aircr::ADDRESS, aircr.into());
+        let mut result = interface.write_word_32(Aircr::get_mmio_address(None), aircr.into());
 
         if result.is_ok() {
             result = interface.flush();
@@ -251,7 +251,7 @@ fn wait_for_stop_after_reset(memory: &mut dyn ArmProbe) -> Result<(), ArmError> 
     tracing::info!("Polling for reset");
 
     while start.elapsed() < Duration::from_micros(50_0000) {
-        let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
+        let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::get_mmio_address(None))?);
 
         if !dhcsr.s_reset_st() {
             timeout = false;
@@ -263,7 +263,7 @@ fn wait_for_stop_after_reset(memory: &mut dyn ArmProbe) -> Result<(), ArmError> 
         return Err(ArmError::Timeout);
     }
 
-    let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::ADDRESS)?);
+    let dhcsr = Dhcsr(memory.read_word_32(Dhcsr::get_mmio_address(None))?);
 
     if !dhcsr.s_halt() {
         let mut dhcsr = Dhcsr(0);
@@ -271,7 +271,7 @@ fn wait_for_stop_after_reset(memory: &mut dyn ArmProbe) -> Result<(), ArmError> 
         dhcsr.set_c_halt(true);
         dhcsr.set_c_debugen(true);
 
-        memory.write_word_32(Dhcsr::ADDRESS, dhcsr.into())?;
+        memory.write_word_32(Dhcsr::get_mmio_address(None), dhcsr.into())?;
     }
 
     Ok(())
@@ -367,7 +367,9 @@ impl ArmDebugSequence for MIMXRT10xx {
 
         // Reset happens very quickly, and takes a bit. Ignore write and flush
         // errors that will occur due to the reset reaction.
-        interface.write_word_32(Aircr::ADDRESS, aircr.into()).ok();
+        interface
+            .write_word_32(Aircr::get_mmio_address(None), aircr.into())
+            .ok();
         interface.flush().ok();
 
         // Wait for the reset to finish...
@@ -375,7 +377,7 @@ impl ArmDebugSequence for MIMXRT10xx {
 
         let start = Instant::now();
         while start.elapsed() < Duration::from_micros(50_0000) {
-            let dhcsr = match interface.read_word_32(Dhcsr::ADDRESS) {
+            let dhcsr = match interface.read_word_32(Dhcsr::get_mmio_address(None)) {
                 Ok(val) => Dhcsr(val),
                 Err(ArmError::AccessPort {
                     source:
@@ -543,7 +545,7 @@ impl ArmDebugSequence for MIMXRT11xx {
         dhcsr.set_c_debugen(true);
         dhcsr.enable_write();
 
-        interface.write_word_32(Dhcsr::ADDRESS, dhcsr.into())?;
+        interface.write_word_32(Dhcsr::get_mmio_address(None), dhcsr.into())?;
         std::thread::sleep(Duration::from_millis(100));
 
         // Initial testing showed that a SYSRESET (the default reset approach)
@@ -557,12 +559,14 @@ impl ArmDebugSequence for MIMXRT11xx {
         aircr.vectkey();
         aircr.set_vectreset(true);
 
-        interface.write_word_32(Aircr::ADDRESS, aircr.into()).ok();
+        interface
+            .write_word_32(Aircr::get_mmio_address(None), aircr.into())
+            .ok();
         interface.flush().ok();
 
         std::thread::sleep(Duration::from_millis(100));
 
-        interface.read_word_32(Dhcsr::ADDRESS)?;
+        interface.read_word_32(Dhcsr::get_mmio_address(None))?;
         Ok(())
     }
 }

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -16,13 +16,12 @@ use crate::{
     probe::{CommandResult, DeferredResultIndex, JTAGAccess},
     DebugProbeError, Error as ProbeRsError, MemoryInterface, MemoryMappedRegister, Probe,
 };
-use bitfield::bitfield;
 use std::{
     collections::HashMap,
     time::{Duration, Instant},
 };
 
-/// Something error occurered when working with the RISC-V core.
+/// Some error occurered when working with the RISC-V core.
 #[derive(thiserror::Error, Debug)]
 pub enum RiscvError {
     /// An error during read/write of the DMI register happened.

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -481,17 +481,15 @@ impl RiscvCommunicationInterface {
         tracing::debug!(
             "Reading DM register '{}' at {:#010x}",
             R::NAME,
-            R::get_mmio_address(None)
+            R::get_mmio_address()
         );
 
-        let register_value = self
-            .read_dm_register_untyped(R::get_mmio_address(None))?
-            .into();
+        let register_value = self.read_dm_register_untyped(R::get_mmio_address())?.into();
 
         tracing::debug!(
             "Read DM register '{}' at {:#010x} = {:x?}",
             R::NAME,
-            R::get_mmio_address(None),
+            R::get_mmio_address(),
             register_value
         );
 
@@ -520,11 +518,11 @@ impl RiscvCommunicationInterface {
         tracing::debug!(
             "Write DM register '{}' at {:#010x} = {:x?}",
             R::NAME,
-            R::get_mmio_address(None),
+            R::get_mmio_address(),
             register
         );
 
-        self.write_dm_register_untyped(R::get_mmio_address(None), register.into())
+        self.write_dm_register_untyped(R::get_mmio_address(), register.into())
     }
 
     /// Write to a DM register
@@ -1305,11 +1303,11 @@ impl RiscvCommunicationInterface {
         tracing::debug!(
             "Write DM register '{}' at {:#010x} = {:x?}",
             R::NAME,
-            R::get_mmio_address(None),
+            R::get_mmio_address(),
             register
         );
 
-        self.schedule_write_dm_register_untyped(R::get_mmio_address(None), register.into())?;
+        self.schedule_write_dm_register_untyped(R::get_mmio_address(), register.into())?;
         Ok(())
     }
 
@@ -1331,10 +1329,10 @@ impl RiscvCommunicationInterface {
         tracing::debug!(
             "Reading DM register '{}' at {:#010x}",
             R::NAME,
-            R::get_mmio_address(None)
+            R::get_mmio_address()
         );
 
-        self.schedule_read_dm_register_untyped(R::get_mmio_address(None))
+        self.schedule_read_dm_register_untyped(R::get_mmio_address())
     }
 
     /// Read from a DM register

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -8,17 +8,13 @@ use super::{
     dtm::{DmiOperation, DmiOperationStatus, Dtm},
     register, Dmcontrol, Dmstatus,
 };
-use crate::DebugProbeError;
 use crate::{
     architecture::riscv::*,
-    probe::{CommandResult, DeferredResultIndex},
+    core::RegisterId,
+    memory::valid_32bit_address,
+    probe::{CommandResult, DeferredResultIndex, JTAGAccess},
+    DebugProbeError, Error as ProbeRsError, MemoryInterface, Probe,
 };
-use crate::{MemoryInterface, Probe};
-
-use crate::{probe::JTAGAccess, Error as ProbeRsError, RegisterId};
-
-use crate::memory::valid_32bit_address;
-
 use bitfield::bitfield;
 use std::{
     collections::HashMap,

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -7,13 +7,12 @@ use crate::{
         Architecture, BreakpointCause, CoreInformation, RegisterFile, RegisterId, RegisterValue,
     },
     memory::valid_32bit_address,
-    CoreInterface, CoreStatus, CoreType, Error, HaltReason, InstructionSet, MemoryInterface,
+    memory_mapped_bitfield_register, CoreInterface, CoreStatus, CoreType, Error, HaltReason,
+    InstructionSet, MemoryInterface,
 };
 use anyhow::{anyhow, Result};
 use bitfield::bitfield;
-use communication_interface::{
-    AbstractCommandErrorKind, DebugRegister, RiscvCommunicationInterface, RiscvError,
-};
+use communication_interface::{AbstractCommandErrorKind, RiscvCommunicationInterface, RiscvError};
 use register::RISCV_REGISTERS;
 use std::time::{Duration, Instant};
 
@@ -687,13 +686,12 @@ impl RiscVState {
     }
 }
 
-bitfield! {
+memory_mapped_bitfield_register! {
     /// `dmcontrol` register, located at
     /// address 0x10
-    #[derive(Copy, Clone)]
     pub struct Dmcontrol(u32);
-    impl Debug;
-
+    0x10, "dmcontrol",
+    impl From;
     _, set_haltreq: 31;
     _, set_resumereq: 30;
     hartreset, set_hartreset: 29;
@@ -725,29 +723,13 @@ impl Dmcontrol {
     }
 }
 
-impl DebugRegister for Dmcontrol {
-    const ADDRESS: u8 = 0x10;
-    const NAME: &'static str = "dmcontrol";
-}
-
-impl From<Dmcontrol> for u32 {
-    fn from(register: Dmcontrol) -> Self {
-        register.0
-    }
-}
-
-impl From<u32> for Dmcontrol {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// Readonly `dmstatus` register.
     ///
     /// Located at address 0x11
     pub struct Dmstatus(u32);
-    impl Debug;
+    0x11, "dmstatus",
+    impl From;
     impebreak, _: 22;
     allhavereset, _: 19;
     anyhavereset, _: 18;
@@ -768,23 +750,6 @@ bitfield! {
     version, _: 3, 0;
 }
 
-impl DebugRegister for Dmstatus {
-    const ADDRESS: u8 = 0x11;
-    const NAME: &'static str = "dmstatus";
-}
-
-impl From<u32> for Dmstatus {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Dmstatus> for u32 {
-    fn from(register: Dmstatus) -> Self {
-        register.0
-    }
-}
-
 bitfield! {
         struct Dcsr(u32);
         impl Debug;
@@ -803,10 +768,11 @@ bitfield! {
         prv, set_prv: 1,0;
 }
 
-bitfield! {
+memory_mapped_bitfield_register! {
     /// Abstract Control and Status (see 3.12.6)
     pub struct Abstractcs(u32);
-    impl Debug;
+    0x16, "abstractcs",
+    impl From;
 
     progbufsize, _: 28, 24;
     busy, _: 12;
@@ -814,27 +780,11 @@ bitfield! {
     datacount, _: 3, 0;
 }
 
-impl DebugRegister for Abstractcs {
-    const ADDRESS: u8 = 0x16;
-    const NAME: &'static str = "abstractcs";
-}
-
-impl From<Abstractcs> for u32 {
-    fn from(register: Abstractcs) -> Self {
-        register.0
-    }
-}
-
-impl From<u32> for Abstractcs {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-bitfield! {
+memory_mapped_bitfield_register! {
     /// Hart Info (see 3.12.3)
     pub struct Hartinfo(u32);
-    impl Debug;
+    0x12, "hartinfo",
+    impl From;
 
     nscratch, _: 23, 20;
     dataaccess, _: 16;
@@ -842,54 +792,37 @@ bitfield! {
     dataaddr, _: 11, 0;
 }
 
-impl DebugRegister for Hartinfo {
-    const ADDRESS: u8 = 0x12;
-    const NAME: &'static str = "hartinfo";
-}
+memory_mapped_bitfield_register! { pub struct Data0(u32); 0x04, "data0", impl From; }
+memory_mapped_bitfield_register! { pub struct Data1(u32); 0x05, "data1", impl From; }
+memory_mapped_bitfield_register! { pub struct Data2(u32); 0x06, "data2", impl From; }
+memory_mapped_bitfield_register! { pub struct Data3(u32); 0x07, "data3", impl From; }
+memory_mapped_bitfield_register! { pub struct Data4(u32); 0x08, "data4", impl From; }
+memory_mapped_bitfield_register! { pub struct Data5(u32); 0x09, "data5", impl From; }
+memory_mapped_bitfield_register! { pub struct Data6(u32); 0x0A, "data6", impl From; }
+memory_mapped_bitfield_register! { pub struct Data7(u32); 0x0B, "data7", impl From; }
+memory_mapped_bitfield_register! { pub struct Data8(u32); 0x0C, "data8", impl From; }
+memory_mapped_bitfield_register! { pub struct Data9(u32); 0x0D, "data9", impl From; }
+memory_mapped_bitfield_register! { pub struct Data10(u32); 0x0E, "data10", impl From; }
+memory_mapped_bitfield_register! { pub struct Data11(u32); 0x0f, "data11", impl From; }
 
-impl From<Hartinfo> for u32 {
-    fn from(register: Hartinfo) -> Self {
-        register.0
-    }
-}
+memory_mapped_bitfield_register! { struct Command(u32); 0x17, "command", impl From; }
 
-impl From<u32> for Hartinfo {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-data_register! { pub Data0, 0x04, "data0" }
-data_register! { pub Data1, 0x05, "data1" }
-data_register! { pub Data2, 0x06, "data2" }
-data_register! { pub Data3, 0x07, "data3" }
-data_register! { pub Data4, 0x08, "data4" }
-data_register! { pub Data5, 0x09, "data5" }
-data_register! { pub Data6, 0x0A, "data6" }
-data_register! { pub Data7, 0x0B, "data7" }
-data_register! { pub Data8, 0x0C, "data8" }
-data_register! { pub Data9, 0x0D, "data9" }
-data_register! { pub Data10, 0x0E, "data10" }
-data_register! { pub Data11, 0x0f, "data11" }
-
-data_register! { Command, 0x17, "command" }
-
-data_register! { pub Progbuf0, 0x20, "progbuf0" }
-data_register! { pub Progbuf1, 0x21, "progbuf1" }
-data_register! { pub Progbuf2, 0x22, "progbuf2" }
-data_register! { pub Progbuf3, 0x23, "progbuf3" }
-data_register! { pub Progbuf4, 0x24, "progbuf4" }
-data_register! { pub Progbuf5, 0x25, "progbuf5" }
-data_register! { pub Progbuf6, 0x26, "progbuf6" }
-data_register! { pub Progbuf7, 0x27, "progbuf7" }
-data_register! { pub Progbuf8, 0x28, "progbuf8" }
-data_register! { pub Progbuf9, 0x29, "progbuf9" }
-data_register! { pub Progbuf10, 0x2A, "progbuf10" }
-data_register! { pub Progbuf11, 0x2B, "progbuf11" }
-data_register! { pub Progbuf12, 0x2C, "progbuf12" }
-data_register! { pub Progbuf13, 0x2D, "progbuf13" }
-data_register! { pub Progbuf14, 0x2E, "progbuf14" }
-data_register! { pub Progbuf15, 0x2F, "progbuf15" }
+memory_mapped_bitfield_register! { pub struct Progbuf0(u32); 0x20, "progbuf0", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf1(u32); 0x21, "progbuf1", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf2(u32); 0x22, "progbuf2", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf3(u32); 0x23, "progbuf3", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf4(u32); 0x24, "progbuf4", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf5(u32); 0x25, "progbuf5", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf6(u32); 0x26, "progbuf6", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf7(u32); 0x27, "progbuf7", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf8(u32); 0x28, "progbuf8", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf9(u32); 0x29, "progbuf9", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf10(u32); 0x2A, "progbuf10", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf11(u32); 0x2B, "progbuf11", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf12(u32); 0x2C, "progbuf12", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf13(u32); 0x2D, "progbuf13", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf14(u32); 0x2E, "progbuf14", impl From; }
+memory_mapped_bitfield_register! { pub struct Progbuf15(u32); 0x2F, "progbuf15", impl From; }
 
 bitfield! {
     struct Mcontrol(u32);

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -2,18 +2,18 @@
 
 #![allow(clippy::inconsistent_digit_grouping)]
 
-use crate::core::{Architecture, BreakpointCause};
-use crate::{CoreInterface, CoreType, InstructionSet};
+use crate::{
+    core::{
+        Architecture, BreakpointCause, CoreInformation, RegisterFile, RegisterId, RegisterValue,
+    },
+    memory::valid_32bit_address,
+    CoreInterface, CoreStatus, CoreType, Error, HaltReason, InstructionSet, MemoryInterface,
+};
 use anyhow::{anyhow, Result};
+use bitfield::bitfield;
 use communication_interface::{
     AbstractCommandErrorKind, DebugRegister, RiscvCommunicationInterface, RiscvError,
 };
-
-use crate::core::{CoreInformation, RegisterFile, RegisterValue};
-use crate::memory::valid_32bit_address;
-use crate::{CoreStatus, Error, HaltReason, MemoryInterface, RegisterId};
-
-use bitfield::bitfield;
 use register::RISCV_REGISTERS;
 use std::time::{Duration, Instant};
 
@@ -298,7 +298,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         Ok(CoreInformation { pc: pc.try_into()? })
     }
 
-    fn read_core_reg(&mut self, address: crate::RegisterId) -> Result<RegisterValue, crate::Error> {
+    fn read_core_reg(&mut self, address: RegisterId) -> Result<RegisterValue, crate::Error> {
         self.read_csr(address.0)
             .map(|v| v.into())
             .map_err(|e| e.into())
@@ -306,7 +306,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
 
     fn write_core_reg(
         &mut self,
-        address: crate::RegisterId,
+        address: RegisterId,
         value: RegisterValue,
     ) -> Result<(), crate::Error> {
         let value: u32 = value.try_into()?;

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -246,9 +246,9 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
             let mut debug_pc = self.read_core_reg(RegisterId(0x7b1))?;
             // Advance the dpc by the size of the EBREAK (ebreak or c.ebreak) instruction.
             if matches!(self.instruction_set()?, InstructionSet::RV32C) {
-                debug_pc.incremenet_address(2)?;
+                debug_pc.increment_address(2)?;
             } else {
-                debug_pc.incremenet_address(4)?;
+                debug_pc.increment_address(4)?;
             }
 
             self.write_core_reg(RegisterId(0x7b1), debug_pc)?;

--- a/probe-rs/src/architecture/riscv/register.rs
+++ b/probe-rs/src/architecture/riscv/register.rs
@@ -1,6 +1,6 @@
 use crate::core::{RegisterDataType, RegisterDescription, RegisterFile, RegisterId, RegisterKind};
 
-static PC: RegisterDescription = RegisterDescription {
+const PC: RegisterDescription = RegisterDescription {
     name: "pc",
     _kind: RegisterKind::PC,
     /// This is a CSR register
@@ -9,7 +9,7 @@ static PC: RegisterDescription = RegisterDescription {
     size_in_bits: 32,
 };
 
-static RA: RegisterDescription = RegisterDescription {
+const RA: RegisterDescription = RegisterDescription {
     name: "ra",
     _kind: RegisterKind::General,
     /// This is a CSR register
@@ -18,7 +18,7 @@ static RA: RegisterDescription = RegisterDescription {
     size_in_bits: 32,
 };
 
-static SP: RegisterDescription = RegisterDescription {
+const SP: RegisterDescription = RegisterDescription {
     name: "sp",
     _kind: RegisterKind::General,
     /// This is a CSR register
@@ -27,7 +27,7 @@ static SP: RegisterDescription = RegisterDescription {
     size_in_bits: 32,
 };
 
-static FP: RegisterDescription = RegisterDescription {
+const FP: RegisterDescription = RegisterDescription {
     name: "fp",
     _kind: RegisterKind::General,
     /// This is a CSR register
@@ -36,7 +36,7 @@ static FP: RegisterDescription = RegisterDescription {
     size_in_bits: 32,
 };
 
-pub static S0: RegisterDescription = RegisterDescription {
+pub const S0: RegisterDescription = RegisterDescription {
     name: "s0",
     _kind: RegisterKind::General,
     /// This is a CSR register
@@ -45,7 +45,7 @@ pub static S0: RegisterDescription = RegisterDescription {
     size_in_bits: 32,
 };
 
-pub static S1: RegisterDescription = RegisterDescription {
+pub const S1: RegisterDescription = RegisterDescription {
     name: "s1",
     _kind: RegisterKind::General,
     /// This is a CSR register
@@ -54,7 +54,7 @@ pub static S1: RegisterDescription = RegisterDescription {
     size_in_bits: 32,
 };
 
-pub(super) static RISCV_REGISTERS: RegisterFile = RegisterFile {
+pub(super) const RISCV_REGISTERS: RegisterFile = RegisterFile {
     platform_registers: &[
         RegisterDescription {
             name: "x0",

--- a/probe-rs/src/architecture/riscv/register.rs
+++ b/probe-rs/src/architecture/riscv/register.rs
@@ -1,53 +1,5 @@
 use crate::core::{RegisterDataType, RegisterDescription, RegisterFile, RegisterId, RegisterKind};
 
-macro_rules! data_register {
-    ($(#[$outer:meta])* $i:ident, $addr:expr, $name:expr) => {
-        $(#[$outer])*
-        #[derive(Debug, Copy, Clone)]
-        struct $i(u32);
-
-        impl DebugRegister for $i {
-            const ADDRESS: u8 = $addr;
-            const NAME: &'static str = $name;
-        }
-
-        impl From<$i> for u32 {
-            fn from(register: $i) -> Self {
-                register.0
-            }
-        }
-
-        impl From<u32> for $i {
-            fn from(value: u32) -> Self {
-                Self(value)
-            }
-        }
-    };
-
-    (pub $i:ident, $addr:expr, $name:expr) => {
-        #[derive(Debug, Copy, Clone)]
-        #[doc = concat!(stringify!($name), " register.")]
-        pub struct $i(u32);
-
-        impl DebugRegister for $i {
-            const ADDRESS: u8 = $addr;
-            const NAME: &'static str = $name;
-        }
-
-        impl From<$i> for u32 {
-            fn from(register: $i) -> Self {
-                register.0
-            }
-        }
-
-        impl From<u32> for $i {
-            fn from(value: u32) -> Self {
-                Self(value)
-            }
-        }
-    };
-}
-
 static PC: RegisterDescription = RegisterDescription {
     name: "pc",
     _kind: RegisterKind::PC,

--- a/probe-rs/src/architecture/riscv/register.rs
+++ b/probe-rs/src/architecture/riscv/register.rs
@@ -1,8 +1,4 @@
-use crate::core::RegisterDescription;
-use crate::{
-    core::{RegisterDataType, RegisterFile, RegisterKind},
-    RegisterId,
-};
+use crate::core::{RegisterDataType, RegisterDescription, RegisterFile, RegisterId, RegisterKind};
 
 macro_rules! data_register {
     ($(#[$outer:meta])* $i:ident, $addr:expr, $name:expr) => {

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -467,14 +467,3 @@ impl<'probe> Core<'probe> {
         self.inner.on_session_stop()
     }
 }
-
-/// The id of a breakpoint.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct BreakpointId(usize);
-
-impl BreakpointId {
-    /// Creates a new breakpoint ID from an `usize`.
-    pub fn new(id: usize) -> Self {
-        BreakpointId(id)
-    }
-}

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -1,19 +1,18 @@
-use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
-use crate::architecture::riscv::RiscVState;
-use crate::{CoreType, InstructionSet};
-pub use probe_rs_target::{Architecture, CoreAccessOptions};
-
-use crate::architecture::{
-    arm::core::CortexAState, arm::core::CortexMState,
-    riscv::communication_interface::RiscvCommunicationInterface,
+use crate::{
+    architecture::{
+        arm::{
+            core::{CortexAState, CortexMState},
+            memory::adi_v5_memory_interface::ArmProbe,
+        },
+        riscv::{communication_interface::RiscvCommunicationInterface, RiscVState},
+    },
+    error, CoreType, Error, InstructionSet, MemoryInterface, Target,
 };
-use crate::error;
-use crate::Target;
-use crate::{Error, MemoryInterface};
 use anyhow::{anyhow, Result};
-use std::cmp::Ordering;
-use std::convert::Infallible;
+pub use probe_rs_target::{Architecture, CoreAccessOptions};
 use std::time::Duration;
+pub mod registers;
+pub use registers::*;
 
 /// A memory mapped register, for instance ARM debug registers (DHCSR, etc).
 pub trait MemoryMappedRegister: Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug {
@@ -28,444 +27,6 @@ pub trait MemoryMappedRegister: Clone + From<u32> + Into<u32> + Sized + std::fmt
 pub struct CoreInformation {
     /// The current Program Counter.
     pub pc: u64,
-}
-
-/// The type of data stored in a register
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RegisterDataType {
-    /// Unsigned integer data
-    UnsignedInteger,
-    /// Floating point data
-    FloatingPoint,
-}
-
-/// Describes a register with its properties.
-#[derive(Debug, Clone, PartialEq)]
-pub struct RegisterDescription {
-    pub(crate) name: &'static str,
-    pub(crate) _kind: RegisterKind,
-    pub(crate) id: RegisterId,
-    pub(crate) _type: RegisterDataType,
-    pub(crate) size_in_bits: usize,
-}
-
-impl RegisterDescription {
-    /// Get the display name of this register
-    pub fn name(&self) -> &'static str {
-        self.name
-    }
-
-    /// Get the type of data stored in this register
-    pub fn data_type(&self) -> RegisterDataType {
-        self._type.clone()
-    }
-
-    /// Get the size, in bits, of this register
-    pub fn size_in_bits(&self) -> usize {
-        self.size_in_bits
-    }
-
-    /// Get the size, in bytes, of this register
-    pub fn size_in_bytes(&self) -> usize {
-        // Always round up
-        (self.size_in_bits + 7) / 8
-    }
-
-    /// Get the width to format this register as a hex string
-    /// Assumes a format string like `{:#0<width>x}`
-    pub fn format_hex_width(&self) -> usize {
-        (self.size_in_bytes() * 2) + 2
-    }
-}
-
-impl From<RegisterDescription> for RegisterId {
-    fn from(description: RegisterDescription) -> RegisterId {
-        description.id
-    }
-}
-
-impl From<&RegisterDescription> for RegisterId {
-    fn from(description: &RegisterDescription) -> RegisterId {
-        description.id
-    }
-}
-
-/// The location of a CPU \register. This is not an actual memory address, but a core specific location that represents a specific core register.
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
-pub struct RegisterId(pub u16);
-
-impl From<RegisterId> for u32 {
-    fn from(value: RegisterId) -> Self {
-        u32::from(value.0)
-    }
-}
-
-impl From<u16> for RegisterId {
-    fn from(value: u16) -> Self {
-        RegisterId(value)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) enum RegisterKind {
-    General,
-    PC,
-    Fp,
-}
-
-/// A value of a core register
-///
-/// Creating a new `RegisterValue` should be done using From or Into.
-/// Converting a value back to a primitive type can be done with either
-/// a match arm or TryInto
-#[derive(Debug, Clone, Copy)]
-pub enum RegisterValue {
-    /// 32-bit unsigned integer
-    U32(u32),
-    /// 64-bit unsigned integer
-    U64(u64),
-    /// 128-bit unsigned integer, often used with SIMD / FP
-    U128(u128),
-}
-
-impl RegisterValue {
-    /// A helper function to increment an address by a fixed number of bytes.
-    pub fn incremenet_address(&mut self, bytes: usize) -> Result<(), Error> {
-        match self {
-            RegisterValue::U32(value) => {
-                if let Some(reg_val) = value.checked_add(bytes as u32) {
-                    *value = reg_val;
-                    Ok(())
-                } else {
-                    Err(Error::Other(anyhow!(
-                        "Overflow error: Attempting to add {} bytes to Register value {}",
-                        bytes,
-                        self
-                    )))
-                }
-            }
-            RegisterValue::U64(value) => {
-                if let Some(reg_val) = value.checked_add(bytes as u64) {
-                    *value = reg_val;
-                    Ok(())
-                } else {
-                    Err(Error::Other(anyhow!(
-                        "Overflow error: Attempting to add {} bytes to Register value {}",
-                        bytes,
-                        self
-                    )))
-                }
-            }
-            RegisterValue::U128(value) => {
-                if let Some(reg_val) = value.checked_add(bytes as u128) {
-                    *value = reg_val;
-                    Ok(())
-                } else {
-                    Err(Error::Other(anyhow!(
-                        "Overflow error: Attempting to add {} bytes to Register value {}",
-                        bytes,
-                        self
-                    )))
-                }
-            }
-        }
-    }
-
-    /// A helper function to determine if the contained register value is equal to the maximum value that can be stored in that datatype.
-    pub fn is_max_value(&self) -> bool {
-        match self {
-            RegisterValue::U32(register_value) => *register_value == u32::MAX,
-            RegisterValue::U64(register_value) => *register_value == u64::MAX,
-            RegisterValue::U128(register_value) => *register_value == u128::MAX,
-        }
-    }
-
-    /// A helper function to determine if the contained register value is zero.
-    pub fn is_zero(&self) -> bool {
-        matches!(
-            self,
-            RegisterValue::U32(0) | RegisterValue::U64(0) | RegisterValue::U128(0)
-        )
-    }
-}
-
-impl Default for RegisterValue {
-    fn default() -> Self {
-        // Smallest data storage as default.
-        RegisterValue::U32(0_u32)
-    }
-}
-
-impl PartialOrd for RegisterValue {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let self_value = match self {
-            RegisterValue::U32(self_value) => *self_value as u128,
-            RegisterValue::U64(self_value) => *self_value as u128,
-            RegisterValue::U128(self_value) => *self_value,
-        };
-        let other_value = match other {
-            RegisterValue::U32(other_value) => *other_value as u128,
-            RegisterValue::U64(other_value) => *other_value as u128,
-            RegisterValue::U128(other_value) => *other_value,
-        };
-        self_value.partial_cmp(&other_value)
-    }
-}
-
-impl PartialEq for RegisterValue {
-    fn eq(&self, other: &Self) -> bool {
-        let self_value = match self {
-            RegisterValue::U32(self_value) => *self_value as u128,
-            RegisterValue::U64(self_value) => *self_value as u128,
-            RegisterValue::U128(self_value) => *self_value,
-        };
-        let other_value = match other {
-            RegisterValue::U32(other_value) => *other_value as u128,
-            RegisterValue::U64(other_value) => *other_value as u128,
-            RegisterValue::U128(other_value) => *other_value,
-        };
-        self_value == other_value
-    }
-}
-
-impl core::fmt::Display for RegisterValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            RegisterValue::U32(register_value) => write!(f, "{register_value:#010x}"),
-            RegisterValue::U64(register_value) => write!(f, "{register_value:#018x}"),
-            RegisterValue::U128(register_value) => write!(f, "{register_value:#034x}"),
-        }
-    }
-}
-
-impl From<u32> for RegisterValue {
-    fn from(val: u32) -> Self {
-        Self::U32(val)
-    }
-}
-
-impl From<u64> for RegisterValue {
-    fn from(val: u64) -> Self {
-        Self::U64(val)
-    }
-}
-
-impl From<u128> for RegisterValue {
-    fn from(val: u128) -> Self {
-        Self::U128(val)
-    }
-}
-
-impl TryInto<u32> for RegisterValue {
-    type Error = crate::Error;
-
-    fn try_into(self) -> Result<u32, Self::Error> {
-        match self {
-            Self::U32(v) => Ok(v),
-            Self::U64(v) => v
-                .try_into()
-                .map_err(|_| crate::Error::Other(anyhow!("Value '{}' too large for u32", v))),
-            Self::U128(v) => v
-                .try_into()
-                .map_err(|_| crate::Error::Other(anyhow!("Value '{}' too large for u32", v))),
-        }
-    }
-}
-
-impl TryInto<u64> for RegisterValue {
-    type Error = crate::Error;
-
-    fn try_into(self) -> Result<u64, Self::Error> {
-        match self {
-            Self::U32(v) => Ok(v.into()),
-            Self::U64(v) => Ok(v),
-            Self::U128(v) => v
-                .try_into()
-                .map_err(|_| crate::Error::Other(anyhow!("Value '{}' too large for u64", v))),
-        }
-    }
-}
-
-impl TryInto<u128> for RegisterValue {
-    type Error = crate::Error;
-
-    fn try_into(self) -> Result<u128, Self::Error> {
-        match self {
-            Self::U32(v) => Ok(v.into()),
-            Self::U64(v) => Ok(v.into()),
-            Self::U128(v) => Ok(v),
-        }
-    }
-}
-
-/// Extension trait to support converting errors
-/// from TryInto calls into [probe_rs::Error]
-pub trait RegisterValueResultExt<T> {
-    /// Convert [Result<T,E>] into `Result<T, probe_rs::Error>`
-    fn into_crate_error(self) -> Result<T, Error>;
-}
-
-/// No translation conversion case
-impl<T> RegisterValueResultExt<T> for Result<T, Error> {
-    fn into_crate_error(self) -> Result<T, Error> {
-        self
-    }
-}
-
-/// Convert from Error = Infallible to Error = probe_rs::Error
-impl<T> RegisterValueResultExt<T> for Result<T, Infallible> {
-    fn into_crate_error(self) -> Result<T, Error> {
-        Ok(self.unwrap())
-    }
-}
-
-/// Register description for a core.
-#[derive(Debug, PartialEq)]
-pub struct RegisterFile {
-    pub(crate) platform_registers: &'static [RegisterDescription],
-
-    /// Register description for the program counter
-    pub(crate) program_counter: &'static RegisterDescription,
-
-    pub(crate) stack_pointer: &'static RegisterDescription,
-
-    pub(crate) return_address: &'static RegisterDescription,
-
-    pub(crate) frame_pointer: &'static RegisterDescription,
-
-    pub(crate) argument_registers: &'static [RegisterDescription],
-
-    pub(crate) result_registers: &'static [RegisterDescription],
-
-    pub(crate) msp: Option<&'static RegisterDescription>,
-
-    pub(crate) psp: Option<&'static RegisterDescription>,
-
-    pub(crate) psr: Option<&'static RegisterDescription>,
-
-    pub(crate) fp_status: Option<&'static RegisterDescription>,
-
-    pub(crate) fp_registers: Option<&'static [RegisterDescription]>,
-
-    pub(crate) other: &'static [RegisterDescription],
-}
-
-impl RegisterFile {
-    /// Returns an iterator over the descriptions of all the "platform" registers of this core.
-    pub fn platform_registers(&self) -> impl Iterator<Item = &RegisterDescription> {
-        self.platform_registers.iter()
-    }
-
-    /// The frame pointer.
-    pub fn frame_pointer(&self) -> &RegisterDescription {
-        self.frame_pointer
-    }
-
-    /// The program counter.
-    pub fn program_counter(&self) -> &RegisterDescription {
-        self.program_counter
-    }
-
-    /// The stack pointer.
-    pub fn stack_pointer(&self) -> &RegisterDescription {
-        self.stack_pointer
-    }
-
-    /// The link register.
-    pub fn return_address(&self) -> &RegisterDescription {
-        self.return_address
-    }
-
-    /// Returns the nth argument register.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the register at given index does not exist.
-    pub fn argument_register(&self, index: usize) -> &RegisterDescription {
-        &self.argument_registers[index]
-    }
-
-    /// Returns the nth argument register if it is exists, `None` otherwise.
-    pub fn get_argument_register(&self, index: usize) -> Option<&RegisterDescription> {
-        self.argument_registers.get(index)
-    }
-
-    /// Returns the nth result register.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the register at given index does not exist.
-    pub fn result_register(&self, index: usize) -> &RegisterDescription {
-        &self.result_registers[index]
-    }
-
-    /// Returns the nth result register if it is exists, `None` otherwise.
-    pub fn get_result_register(&self, index: usize) -> Option<&RegisterDescription> {
-        self.result_registers.get(index)
-    }
-
-    /// Returns the nth platform register.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the register at given index does not exist.
-    pub fn platform_register(&self, index: usize) -> &RegisterDescription {
-        &self.platform_registers[index]
-    }
-
-    /// Returns the nth platform register if it is exists, `None` otherwise.
-    pub fn get_platform_register(&self, index: usize) -> Option<&RegisterDescription> {
-        self.platform_registers.get(index)
-    }
-
-    /// The main stack pointer.
-    pub fn msp(&self) -> Option<&RegisterDescription> {
-        self.msp
-    }
-
-    /// The process stack pointer.
-    pub fn psp(&self) -> Option<&RegisterDescription> {
-        self.psp
-    }
-
-    /// The processor status register.
-    pub fn psr(&self) -> Option<&RegisterDescription> {
-        self.psr
-    }
-
-    /// Other architecture specific registers
-    pub fn other(&self) -> impl Iterator<Item = &RegisterDescription> {
-        self.other.iter()
-    }
-
-    /// Find an architecture specific register by name
-    pub fn other_by_name(&self, name: &str) -> Option<&RegisterDescription> {
-        self.other.iter().find(|r| r.name == name)
-    }
-
-    /// The fpu status register.
-    pub fn fpscr(&self) -> Option<&RegisterDescription> {
-        self.fp_status
-    }
-
-    /// Returns an iterator over the descriptions of all the registers of this core.
-    pub fn fpu_registers(&self) -> Option<impl Iterator<Item = &RegisterDescription>> {
-        self.fp_registers.map(|r| r.iter())
-    }
-
-    /// Returns the nth fpu register.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the register at given index does not exist.
-    pub fn fpu_register(&self, index: usize) -> Option<&RegisterDescription> {
-        self.fp_registers.map(|r| &r[index])
-    }
-
-    /// Returns the nth fpu register if it is exists, `None` otherwise.
-    pub fn get_fpu_register(&self, index: usize) -> Option<&RegisterDescription> {
-        self.fp_registers.and_then(|r| r.get(index))
-    }
 }
 
 /// A generic interface to control a MCU core.
@@ -504,13 +65,16 @@ pub trait CoreInterface: MemoryInterface {
     fn step(&mut self) -> Result<CoreInformation, error::Error>;
 
     /// Read the value of a core register.
-    fn read_core_reg(&mut self, address: RegisterId) -> Result<RegisterValue, error::Error>;
+    fn read_core_reg(
+        &mut self,
+        address: registers::RegisterId,
+    ) -> Result<registers::RegisterValue, error::Error>;
 
     /// Write the value of a core register.
     fn write_core_reg(
         &mut self,
-        address: RegisterId,
-        value: RegisterValue,
+        address: registers::RegisterId,
+        value: registers::RegisterValue,
     ) -> Result<(), error::Error>;
 
     /// Returns all the available breakpoint units of the core.
@@ -531,7 +95,7 @@ pub trait CoreInterface: MemoryInterface {
     fn clear_hw_breakpoint(&mut self, unit_index: usize) -> Result<(), error::Error>;
 
     /// Returns a list of all the registers of this core.
-    fn registers(&self) -> &'static RegisterFile;
+    fn registers(&self) -> &'static registers::RegisterFile;
 
     /// Returns `true` if hwardware breakpoints are enabled, `false` otherwise.
     fn hw_breakpoints_enabled(&self) -> bool;
@@ -887,10 +451,13 @@ impl<'probe> Core<'probe> {
     ///
     /// If `T` isn't large enough to hold the register value an error will be raised.
     #[tracing::instrument(skip(self, address), fields(address))]
-    pub fn read_core_reg<T>(&mut self, address: impl Into<RegisterId>) -> Result<T, error::Error>
+    pub fn read_core_reg<T>(
+        &mut self,
+        address: impl Into<registers::RegisterId>,
+    ) -> Result<T, error::Error>
     where
-        RegisterValue: TryInto<T>,
-        Result<T, <RegisterValue as TryInto<T>>::Error>: RegisterValueResultExt<T>,
+        registers::RegisterValue: TryInto<T>,
+        Result<T, <registers::RegisterValue as TryInto<T>>::Error>: RegisterValueResultExt<T>,
     {
         let address = address.into();
 
@@ -907,9 +474,13 @@ impl<'probe> Core<'probe> {
     ///
     /// If T is too large to write to the target register an error will be raised.
     #[tracing::instrument(skip(self, value))]
-    pub fn write_core_reg<T>(&mut self, address: RegisterId, value: T) -> Result<(), error::Error>
+    pub fn write_core_reg<T>(
+        &mut self,
+        address: registers::RegisterId,
+        value: T,
+    ) -> Result<(), error::Error>
     where
-        T: Into<RegisterValue>,
+        T: Into<registers::RegisterValue>,
     {
         self.inner.write_core_reg(address, value.into())
     }
@@ -931,7 +502,7 @@ impl<'probe> Core<'probe> {
     }
 
     /// Returns a list of all the registers of this core.
-    pub fn registers(&self) -> &'static RegisterFile {
+    pub fn registers(&self) -> &'static registers::RegisterFile {
         self.inner.registers()
     }
 

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -1,17 +1,12 @@
-use crate::{
-    architecture::{
-        arm::{
-            core::{CortexAState, CortexMState},
-            memory::adi_v5_memory_interface::ArmProbe,
-        },
-        riscv::{communication_interface::RiscvCommunicationInterface, RiscVState},
-    },
-    error, CoreType, Error, InstructionSet, MemoryInterface, Target,
-};
+use crate::{error, CoreType, Error, InstructionSet, MemoryInterface};
 use anyhow::{anyhow, Result};
 pub use probe_rs_target::{Architecture, CoreAccessOptions};
 use std::time::Duration;
+
+pub mod core_state;
 pub mod registers;
+
+pub use core_state::*;
 pub use registers::*;
 
 /// A memory mapped register, for instance ARM debug registers (DHCSR, etc).
@@ -198,158 +193,6 @@ impl<'probe> MemoryInterface for Core<'probe> {
     }
 }
 
-/// A generic core state which caches the generic parts of the core state.
-#[derive(Debug)]
-pub struct CoreState {
-    id: usize,
-
-    /// Information needed to access the core
-    core_access_options: CoreAccessOptions,
-}
-
-impl CoreState {
-    /// Creates a new core state from the core ID.
-    pub fn new(id: usize, core_access_options: CoreAccessOptions) -> Self {
-        Self {
-            id,
-            core_access_options,
-        }
-    }
-
-    /// Returns the core ID.
-
-    pub fn id(&self) -> usize {
-        self.id
-    }
-}
-
-/// The architecture specific core state.
-#[derive(Debug)]
-pub enum SpecificCoreState {
-    /// The state of an ARMv6-M core.
-    Armv6m(CortexMState),
-    /// The state of an ARMv7-A core.
-    Armv7a(CortexAState),
-    /// The state of an ARMv7-M core.
-    Armv7m(CortexMState),
-    /// The state of an ARMv7-EM core.
-    Armv7em(CortexMState),
-    /// The state of an ARMv8-A core.
-    Armv8a(CortexAState),
-    /// The state of an ARMv8-M core.
-    Armv8m(CortexMState),
-    /// The state of an RISC-V core.
-    Riscv(RiscVState),
-}
-
-impl SpecificCoreState {
-    pub(crate) fn from_core_type(typ: CoreType) -> Self {
-        match typ {
-            CoreType::Armv6m => SpecificCoreState::Armv6m(CortexMState::new()),
-            CoreType::Armv7a => SpecificCoreState::Armv7a(CortexAState::new()),
-            CoreType::Armv7m => SpecificCoreState::Armv7m(CortexMState::new()),
-            CoreType::Armv7em => SpecificCoreState::Armv7m(CortexMState::new()),
-            CoreType::Armv8a => SpecificCoreState::Armv8a(CortexAState::new()),
-            CoreType::Armv8m => SpecificCoreState::Armv8m(CortexMState::new()),
-            CoreType::Riscv => SpecificCoreState::Riscv(RiscVState::new()),
-        }
-    }
-
-    pub(crate) fn core_type(&self) -> CoreType {
-        match self {
-            SpecificCoreState::Armv6m(_) => CoreType::Armv6m,
-            SpecificCoreState::Armv7a(_) => CoreType::Armv7a,
-            SpecificCoreState::Armv7m(_) => CoreType::Armv7m,
-            SpecificCoreState::Armv7em(_) => CoreType::Armv7em,
-            SpecificCoreState::Armv8a(_) => CoreType::Armv8a,
-            SpecificCoreState::Armv8m(_) => CoreType::Armv8m,
-            SpecificCoreState::Riscv(_) => CoreType::Riscv,
-        }
-    }
-
-    pub(crate) fn attach_arm<'probe, 'target: 'probe>(
-        &'probe mut self,
-        state: &'probe mut CoreState,
-        memory: Box<dyn ArmProbe + 'probe>,
-        target: &'target Target,
-    ) -> Result<Core<'probe>, Error> {
-        let debug_sequence = match &target.debug_sequence {
-            crate::config::DebugSequence::Arm(sequence) => sequence.clone(),
-            crate::config::DebugSequence::Riscv(_) => {
-                return Err(Error::UnableToOpenProbe(
-                    "Core architecture and Probe mismatch.",
-                ))
-            }
-        };
-
-        let options = match &state.core_access_options {
-            CoreAccessOptions::Arm(options) => options,
-            CoreAccessOptions::Riscv(_) => {
-                return Err(Error::UnableToOpenProbe(
-                    "Core architecture and Probe mismatch.",
-                ))
-            }
-        };
-
-        Ok(match self {
-            SpecificCoreState::Armv6m(s) => Core::new(
-                crate::architecture::arm::armv6m::Armv6m::new(memory, s, debug_sequence)?,
-                state,
-            ),
-            SpecificCoreState::Armv7a(s) => Core::new(
-                crate::architecture::arm::armv7a::Armv7a::new(
-                    memory,
-                    s,
-                    options.debug_base.expect("base_address not specified"),
-                    debug_sequence,
-                )?,
-                state,
-            ),
-            SpecificCoreState::Armv7m(s) | SpecificCoreState::Armv7em(s) => Core::new(
-                crate::architecture::arm::armv7m::Armv7m::new(memory, s, debug_sequence)?,
-                state,
-            ),
-            SpecificCoreState::Armv8a(s) => Core::new(
-                crate::architecture::arm::armv8a::Armv8a::new(
-                    memory,
-                    s,
-                    options.debug_base.expect("base_address not specified"),
-                    options.cti_base.expect("cti_address not specified"),
-                    debug_sequence,
-                )?,
-                state,
-            ),
-            SpecificCoreState::Armv8m(s) => Core::new(
-                crate::architecture::arm::armv8m::Armv8m::new(memory, s, debug_sequence)?,
-                state,
-            ),
-            _ => {
-                return Err(Error::UnableToOpenProbe(
-                    "Core architecture and Probe mismatch.",
-                ))
-            }
-        })
-    }
-
-    pub(crate) fn attach_riscv<'probe>(
-        &'probe mut self,
-        state: &'probe mut CoreState,
-        interface: &'probe mut RiscvCommunicationInterface,
-    ) -> Result<Core<'probe>, Error> {
-        Ok(match self {
-            SpecificCoreState::Riscv(s) => Core::new(
-                crate::architecture::riscv::Riscv32::new(interface, s),
-                state,
-            ),
-            _ => {
-                return Err(Error::UnableToOpenProbe(
-                    "Core architecture and Probe mismatch.",
-                ))
-            }
-        })
-    }
-}
-
 /// Generic core handle representing a physical core on an MCU.
 ///
 /// This should be considere as a temporary view of the core which locks the debug probe driver to as single consumer by borrowing it.
@@ -377,7 +220,7 @@ impl<'probe> Core<'probe> {
 
     /// Returns the ID of this core.
     pub fn id(&self) -> usize {
-        self.state.id
+        self.state.id()
     }
 
     /// Wait until the core is halted. If the core does not halt on its own,

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -1,0 +1,163 @@
+use crate::{
+    architecture::{
+        arm::{
+            core::{CortexAState, CortexMState},
+            memory::adi_v5_memory_interface::ArmProbe,
+        },
+        riscv::{communication_interface::RiscvCommunicationInterface, RiscVState},
+    },
+    Core, CoreType, Error, Target,
+};
+pub use probe_rs_target::{Architecture, CoreAccessOptions};
+
+/// A generic core state which caches the generic parts of the core state.
+#[derive(Debug)]
+pub struct CoreState {
+    id: usize,
+
+    /// Information needed to access the core
+    core_access_options: CoreAccessOptions,
+}
+
+impl CoreState {
+    /// Creates a new core state from the core ID.
+    pub fn new(id: usize, core_access_options: CoreAccessOptions) -> Self {
+        Self {
+            id,
+            core_access_options,
+        }
+    }
+
+    /// Returns the core ID.
+
+    pub fn id(&self) -> usize {
+        self.id
+    }
+}
+
+/// The architecture specific core state.
+#[derive(Debug)]
+pub enum SpecificCoreState {
+    /// The state of an ARMv6-M core.
+    Armv6m(CortexMState),
+    /// The state of an ARMv7-A core.
+    Armv7a(CortexAState),
+    /// The state of an ARMv7-M core.
+    Armv7m(CortexMState),
+    /// The state of an ARMv7-EM core.
+    Armv7em(CortexMState),
+    /// The state of an ARMv8-A core.
+    Armv8a(CortexAState),
+    /// The state of an ARMv8-M core.
+    Armv8m(CortexMState),
+    /// The state of an RISC-V core.
+    Riscv(RiscVState),
+}
+
+impl SpecificCoreState {
+    pub(crate) fn from_core_type(typ: CoreType) -> Self {
+        match typ {
+            CoreType::Armv6m => SpecificCoreState::Armv6m(CortexMState::new()),
+            CoreType::Armv7a => SpecificCoreState::Armv7a(CortexAState::new()),
+            CoreType::Armv7m => SpecificCoreState::Armv7m(CortexMState::new()),
+            CoreType::Armv7em => SpecificCoreState::Armv7m(CortexMState::new()),
+            CoreType::Armv8a => SpecificCoreState::Armv8a(CortexAState::new()),
+            CoreType::Armv8m => SpecificCoreState::Armv8m(CortexMState::new()),
+            CoreType::Riscv => SpecificCoreState::Riscv(RiscVState::new()),
+        }
+    }
+
+    pub(crate) fn core_type(&self) -> CoreType {
+        match self {
+            SpecificCoreState::Armv6m(_) => CoreType::Armv6m,
+            SpecificCoreState::Armv7a(_) => CoreType::Armv7a,
+            SpecificCoreState::Armv7m(_) => CoreType::Armv7m,
+            SpecificCoreState::Armv7em(_) => CoreType::Armv7em,
+            SpecificCoreState::Armv8a(_) => CoreType::Armv8a,
+            SpecificCoreState::Armv8m(_) => CoreType::Armv8m,
+            SpecificCoreState::Riscv(_) => CoreType::Riscv,
+        }
+    }
+
+    pub(crate) fn attach_arm<'probe, 'target: 'probe>(
+        &'probe mut self,
+        state: &'probe mut CoreState,
+        memory: Box<dyn ArmProbe + 'probe>,
+        target: &'target Target,
+    ) -> Result<Core<'probe>, Error> {
+        let debug_sequence = match &target.debug_sequence {
+            crate::config::DebugSequence::Arm(sequence) => sequence.clone(),
+            crate::config::DebugSequence::Riscv(_) => {
+                return Err(Error::UnableToOpenProbe(
+                    "Core architecture and Probe mismatch.",
+                ))
+            }
+        };
+
+        let options = match &state.core_access_options {
+            CoreAccessOptions::Arm(options) => options,
+            CoreAccessOptions::Riscv(_) => {
+                return Err(Error::UnableToOpenProbe(
+                    "Core architecture and Probe mismatch.",
+                ))
+            }
+        };
+
+        Ok(match self {
+            SpecificCoreState::Armv6m(s) => Core::new(
+                crate::architecture::arm::armv6m::Armv6m::new(memory, s, debug_sequence)?,
+                state,
+            ),
+            SpecificCoreState::Armv7a(s) => Core::new(
+                crate::architecture::arm::armv7a::Armv7a::new(
+                    memory,
+                    s,
+                    options.debug_base.expect("base_address not specified"),
+                    debug_sequence,
+                )?,
+                state,
+            ),
+            SpecificCoreState::Armv7m(s) | SpecificCoreState::Armv7em(s) => Core::new(
+                crate::architecture::arm::armv7m::Armv7m::new(memory, s, debug_sequence)?,
+                state,
+            ),
+            SpecificCoreState::Armv8a(s) => Core::new(
+                crate::architecture::arm::armv8a::Armv8a::new(
+                    memory,
+                    s,
+                    options.debug_base.expect("base_address not specified"),
+                    options.cti_base.expect("cti_address not specified"),
+                    debug_sequence,
+                )?,
+                state,
+            ),
+            SpecificCoreState::Armv8m(s) => Core::new(
+                crate::architecture::arm::armv8m::Armv8m::new(memory, s, debug_sequence)?,
+                state,
+            ),
+            _ => {
+                return Err(Error::UnableToOpenProbe(
+                    "Core architecture and Probe mismatch.",
+                ))
+            }
+        })
+    }
+
+    pub(crate) fn attach_riscv<'probe>(
+        &'probe mut self,
+        state: &'probe mut CoreState,
+        interface: &'probe mut RiscvCommunicationInterface,
+    ) -> Result<Core<'probe>, Error> {
+        Ok(match self {
+            SpecificCoreState::Riscv(s) => Core::new(
+                crate::architecture::riscv::Riscv32::new(interface, s),
+                state,
+            ),
+            _ => {
+                return Err(Error::UnableToOpenProbe(
+                    "Core architecture and Probe mismatch.",
+                ))
+            }
+        })
+    }
+}

--- a/probe-rs/src/core/core_status.rs
+++ b/probe-rs/src/core/core_status.rs
@@ -1,0 +1,65 @@
+/// The status of the core.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum CoreStatus {
+    /// The core is currently running.
+    Running,
+    /// The core is currently halted. This also specifies the reason as a payload.
+    Halted(HaltReason),
+    /// This is a Cortex-M specific status, and will not be set or handled by RISCV code.
+    LockedUp,
+    /// The core is currently sleeping.
+    Sleeping,
+    /// The core state is currently unknown. This is always the case when the core is first created.
+    Unknown,
+}
+
+impl CoreStatus {
+    /// Returns `true` if the core is currently halted.
+    pub fn is_halted(&self) -> bool {
+        matches!(self, CoreStatus::Halted(_))
+    }
+
+    /// Returns `true` if the core is currently running.
+    pub fn is_running(&self) -> bool {
+        self == &Self::Running
+    }
+}
+
+/// When the core halts due to a breakpoint request, some architectures will allow us to distinguish between a software and hardware breakpoint.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum BreakpointCause {
+    /// We encountered a hardware breakpoint.
+    Hardware,
+    /// We encountered a software breakpoint instruction.
+    Software,
+    /// We were not able to distinguish if this was a hardware or software breakpoint.
+    Unknown,
+}
+
+/// The reason why a core was halted.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum HaltReason {
+    /// Multiple reasons for a halt.
+    ///
+    /// This can happen for example when a single instruction
+    /// step ends up on a breakpoint, after which both breakpoint and step / request
+    /// are set.
+    Multiple,
+    /// Core halted due to a breakpoint. The cause is `Unknown` if we cannot distinguish between a hardware and software breakpoint.
+    Breakpoint(BreakpointCause),
+    /// Core halted due to an exception, e.g. an
+    /// an interrupt.
+    Exception,
+    /// Core halted due to a data watchpoint
+    Watchpoint,
+    /// Core halted after single step
+    Step,
+    /// Core halted because of a debugger request
+    Request,
+    /// External halt request
+    External,
+    /// Unknown reason for halt.
+    ///
+    /// This can happen for example when the core is already halted when we connect.
+    Unknown,
+}

--- a/probe-rs/src/core/memory_mapped_registers.rs
+++ b/probe-rs/src/core/memory_mapped_registers.rs
@@ -81,7 +81,7 @@ macro_rules! memory_mapped_bitfield_register {
     ($(#[$outer:meta])* $vis_modifier:vis struct $struct_name:ident($reg_type:ty); $addr:expr, $reg_name:expr, $($rest:tt)*) => {
         // Using paste here, because as of bitfield = "0.14.0" they do not use the 'vis' specifier, and balks at being passed a visibility token.
         paste::paste!{
-        bitfield!{
+        bitfield::bitfield!{
             $(#[$outer])*
             #[doc= concat!("A [`bitfield::bitfield!`] register mapping for the register `",  $reg_name, "` located at address `", stringify!($addr), "`.")]
             #[derive(Copy, Clone)]

--- a/probe-rs/src/core/memory_mapped_registers.rs
+++ b/probe-rs/src/core/memory_mapped_registers.rs
@@ -15,7 +15,7 @@ pub trait MemoryMappedRegister<T>: Clone + From<T> + Into<T> + Sized + std::fmt:
                 mmio_address
             } else {
                 tracing::error!(
-                "Overflow while attempting to determine the MMIO address for register {} at offset {:#x} from address {:#x}",
+                "Overflow while attempting to determine the MMIO address for register {} at offset {:#x} from base address {:#x}",
                 Self::NAME,
                 Self::ADDRESS_OFFSET,
                 base_address
@@ -90,8 +90,8 @@ macro_rules! memory_mapped_bitfield_register {
         }
     }
 
-        impl MemoryMappedRegister<$reg_type> for $struct_name {
-            const ADDRESS: u64 = $addr;
+        impl $crate::MemoryMappedRegister<$reg_type> for $struct_name {
+            const ADDRESS_OFFSET: u64 = $addr;
             const NAME: &'static str = $reg_name;
         }
     };

--- a/probe-rs/src/core/memory_mapped_registers.rs
+++ b/probe-rs/src/core/memory_mapped_registers.rs
@@ -1,7 +1,76 @@
 /// A memory mapped register, for instance ARM debug registers (DHCSR, etc).
-pub trait MemoryMappedRegister: Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug {
+pub trait MemoryMappedRegister<T>: Clone + From<T> + Into<T> + Sized + std::fmt::Debug {
     /// The register's address in the target memory.
     const ADDRESS: u64;
     /// The register's name.
     const NAME: &'static str;
+}
+
+#[macro_export]
+/// Create a [`MemoryMappedRegister`] type, with the required method implementations for:
+/// - Trait implementations required by [`MemoryMappedRegister`]
+/// - Includes a `bitfield!` mapping for bitfield access to optionally defined fields.
+/// When no bitfields are defined, the default `.0` field must be used.
+///
+///! # Example
+/// ```
+/// use probe_rs::core::memory_mapped_registers::memory_mapped_bitfield_register;
+/// memory_mapped_bitfield_register! {
+///    /// Abstract Control and Status (see section xyz of some reference manual)
+///    pub struct Abstractcs(u32);
+///    0x16,"abstractcs",
+///    impl From;
+///    progbufsize, _: 28, 24;
+///    busy, _: 12;
+///    cmderr, set_cmderr: 10, 8;
+///    datacount, _: 3, 0;
+/// }
+/// ```
+/// This will generate a struct with the name `Abstractcs`, which has:
+/// - A `pub` visibility.
+/// - A `u32` register type.
+/// - A `Debug` implementation.
+/// - A `Copy` implementation.
+/// - A `Clone` implementation.
+/// - Default `From<u32>` and `From<MemoryMappedRegister>` impls for [`MemoryMappedRegister`] are generated.
+/// - A `bitfield!` mapping for the fields `progbufsize`, `busy`, `cmderr`, `datacount`.
+/// - `bitfield!` getters and setters for the fields as defined - See [`bitfield::bitfield!`] for more information.
+/// - A `const ADDRESS: u64 = 0x16;`.
+/// - A `const NAME: &'static str = "abstractcs";`.
+macro_rules! memory_mapped_bitfield_register {
+    ($(#[$outer:meta])* $visibility:vis struct $struct_name:ident($reg_type:ty); $addr:expr, $reg_name:expr, impl From; $($rest:tt)*) => {
+        $crate::memory_mapped_bitfield_register!{
+            $(#[$outer])* $visibility struct $struct_name($reg_type); $addr, $reg_name, $($rest)*
+        }
+
+        impl From<$struct_name> for $reg_type {
+            fn from(register: $struct_name) -> Self {
+                register.0
+            }
+        }
+
+        impl From<$reg_type> for $struct_name {
+            fn from(value: $reg_type) -> Self {
+                Self(value)
+            }
+        }
+    };
+    ($(#[$outer:meta])* $vis_modifier:vis struct $struct_name:ident($reg_type:ty); $addr:expr, $reg_name:expr, $($rest:tt)*) => {
+        // Using paste here, because as of bitfield = "0.14.0" they do not use the 'vis' specifier, and balks at being passed a visibility token.
+        paste::paste!{
+        bitfield!{
+            $(#[$outer])*
+            #[doc= concat!("A [`bitfield::bitfield!`] register mapping for the register `",  $reg_name, "` located at address `", stringify!($addr), "`.")]
+            #[derive(Copy, Clone)]
+            $vis_modifier struct $struct_name($reg_type);
+            impl Debug;
+            $($rest)*
+        }
+    }
+
+        impl MemoryMappedRegister<$reg_type> for $struct_name {
+            const ADDRESS: u64 = $addr;
+            const NAME: &'static str = $reg_name;
+        }
+    };
 }

--- a/probe-rs/src/core/memory_mapped_registers.rs
+++ b/probe-rs/src/core/memory_mapped_registers.rs
@@ -36,7 +36,8 @@ pub trait MemoryMappedRegister<T>: Clone + From<T> + Into<T> + Sized + std::fmt:
 ///
 ///! # Example
 /// ```
-/// use probe_rs::core::memory_mapped_registers::memory_mapped_bitfield_register;
+/// use bitfield::bitfield;
+/// use probe_rs::memory_mapped_bitfield_register;
 /// memory_mapped_bitfield_register! {
 ///    /// Abstract Control and Status (see section xyz of some reference manual)
 ///    pub struct Abstractcs(u32);

--- a/probe-rs/src/core/memory_mapped_registers.rs
+++ b/probe-rs/src/core/memory_mapped_registers.rs
@@ -1,0 +1,7 @@
+/// A memory mapped register, for instance ARM debug registers (DHCSR, etc).
+pub trait MemoryMappedRegister: Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug {
+    /// The register's address in the target memory.
+    const ADDRESS: u64;
+    /// The register's name.
+    const NAME: &'static str;
+}

--- a/probe-rs/src/core/registers.rs
+++ b/probe-rs/src/core/registers.rs
@@ -1,0 +1,443 @@
+//! Core registers are represented by the [RegisterDescription] struct, and collected in a [RegisterFile] for each of the supported architectures.
+
+use crate::Error;
+use anyhow::{anyhow, Result};
+use std::{cmp::Ordering, convert::Infallible};
+
+/// The type of data stored in a register
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegisterDataType {
+    /// Unsigned integer data
+    UnsignedInteger,
+    /// Floating point data
+    FloatingPoint,
+}
+
+/// Describes a register with its properties.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RegisterDescription {
+    pub(crate) name: &'static str,
+    pub(crate) _kind: RegisterKind,
+    pub(crate) id: RegisterId,
+    pub(crate) _type: RegisterDataType,
+    pub(crate) size_in_bits: usize,
+}
+
+impl RegisterDescription {
+    /// Get the display name of this register
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Get the type of data stored in this register
+    pub fn data_type(&self) -> RegisterDataType {
+        self._type.clone()
+    }
+
+    /// Get the size, in bits, of this register
+    pub fn size_in_bits(&self) -> usize {
+        self.size_in_bits
+    }
+
+    /// Get the size, in bytes, of this register
+    pub fn size_in_bytes(&self) -> usize {
+        // Always round up
+        (self.size_in_bits + 7) / 8
+    }
+
+    /// Get the width to format this register as a hex string
+    /// Assumes a format string like `{:#0<width>x}`
+    pub fn format_hex_width(&self) -> usize {
+        (self.size_in_bytes() * 2) + 2
+    }
+}
+
+impl From<RegisterDescription> for RegisterId {
+    fn from(description: RegisterDescription) -> RegisterId {
+        description.id
+    }
+}
+
+impl From<&RegisterDescription> for RegisterId {
+    fn from(description: &RegisterDescription) -> RegisterId {
+        description.id
+    }
+}
+
+/// The location of a CPU \register. This is not an actual memory address, but a core specific location that represents a specific core register.
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct RegisterId(pub u16);
+
+impl From<RegisterId> for u32 {
+    fn from(value: RegisterId) -> Self {
+        u32::from(value.0)
+    }
+}
+
+impl From<u16> for RegisterId {
+    fn from(value: u16) -> Self {
+        RegisterId(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum RegisterKind {
+    General,
+    PC,
+    Fp,
+}
+
+/// A value of a core register
+///
+/// Creating a new `RegisterValue` should be done using From or Into.
+/// Converting a value back to a primitive type can be done with either
+/// a match arm or TryInto
+#[derive(Debug, Clone, Copy)]
+pub enum RegisterValue {
+    /// 32-bit unsigned integer
+    U32(u32),
+    /// 64-bit unsigned integer
+    U64(u64),
+    /// 128-bit unsigned integer, often used with SIMD / FP
+    U128(u128),
+}
+
+impl RegisterValue {
+    /// A helper function to increment an address by a fixed number of bytes.
+    pub fn incremenet_address(&mut self, bytes: usize) -> Result<(), Error> {
+        match self {
+            RegisterValue::U32(value) => {
+                if let Some(reg_val) = value.checked_add(bytes as u32) {
+                    *value = reg_val;
+                    Ok(())
+                } else {
+                    Err(Error::Other(anyhow!(
+                        "Overflow error: Attempting to add {} bytes to Register value {}",
+                        bytes,
+                        self
+                    )))
+                }
+            }
+            RegisterValue::U64(value) => {
+                if let Some(reg_val) = value.checked_add(bytes as u64) {
+                    *value = reg_val;
+                    Ok(())
+                } else {
+                    Err(Error::Other(anyhow!(
+                        "Overflow error: Attempting to add {} bytes to Register value {}",
+                        bytes,
+                        self
+                    )))
+                }
+            }
+            RegisterValue::U128(value) => {
+                if let Some(reg_val) = value.checked_add(bytes as u128) {
+                    *value = reg_val;
+                    Ok(())
+                } else {
+                    Err(Error::Other(anyhow!(
+                        "Overflow error: Attempting to add {} bytes to Register value {}",
+                        bytes,
+                        self
+                    )))
+                }
+            }
+        }
+    }
+
+    /// A helper function to determine if the contained register value is equal to the maximum value that can be stored in that datatype.
+    pub fn is_max_value(&self) -> bool {
+        match self {
+            RegisterValue::U32(register_value) => *register_value == u32::MAX,
+            RegisterValue::U64(register_value) => *register_value == u64::MAX,
+            RegisterValue::U128(register_value) => *register_value == u128::MAX,
+        }
+    }
+
+    /// A helper function to determine if the contained register value is zero.
+    pub fn is_zero(&self) -> bool {
+        matches!(
+            self,
+            RegisterValue::U32(0) | RegisterValue::U64(0) | RegisterValue::U128(0)
+        )
+    }
+}
+
+impl Default for RegisterValue {
+    fn default() -> Self {
+        // Smallest data storage as default.
+        RegisterValue::U32(0_u32)
+    }
+}
+
+impl PartialOrd for RegisterValue {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let self_value = match self {
+            RegisterValue::U32(self_value) => *self_value as u128,
+            RegisterValue::U64(self_value) => *self_value as u128,
+            RegisterValue::U128(self_value) => *self_value,
+        };
+        let other_value = match other {
+            RegisterValue::U32(other_value) => *other_value as u128,
+            RegisterValue::U64(other_value) => *other_value as u128,
+            RegisterValue::U128(other_value) => *other_value,
+        };
+        self_value.partial_cmp(&other_value)
+    }
+}
+
+impl PartialEq for RegisterValue {
+    fn eq(&self, other: &Self) -> bool {
+        let self_value = match self {
+            RegisterValue::U32(self_value) => *self_value as u128,
+            RegisterValue::U64(self_value) => *self_value as u128,
+            RegisterValue::U128(self_value) => *self_value,
+        };
+        let other_value = match other {
+            RegisterValue::U32(other_value) => *other_value as u128,
+            RegisterValue::U64(other_value) => *other_value as u128,
+            RegisterValue::U128(other_value) => *other_value,
+        };
+        self_value == other_value
+    }
+}
+
+impl core::fmt::Display for RegisterValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            RegisterValue::U32(register_value) => write!(f, "{register_value:#010x}"),
+            RegisterValue::U64(register_value) => write!(f, "{register_value:#018x}"),
+            RegisterValue::U128(register_value) => write!(f, "{register_value:#034x}"),
+        }
+    }
+}
+
+impl From<u32> for RegisterValue {
+    fn from(val: u32) -> Self {
+        Self::U32(val)
+    }
+}
+
+impl From<u64> for RegisterValue {
+    fn from(val: u64) -> Self {
+        Self::U64(val)
+    }
+}
+
+impl From<u128> for RegisterValue {
+    fn from(val: u128) -> Self {
+        Self::U128(val)
+    }
+}
+
+impl TryInto<u32> for RegisterValue {
+    type Error = crate::Error;
+
+    fn try_into(self) -> Result<u32, Self::Error> {
+        match self {
+            Self::U32(v) => Ok(v),
+            Self::U64(v) => v
+                .try_into()
+                .map_err(|_| crate::Error::Other(anyhow!("Value '{}' too large for u32", v))),
+            Self::U128(v) => v
+                .try_into()
+                .map_err(|_| crate::Error::Other(anyhow!("Value '{}' too large for u32", v))),
+        }
+    }
+}
+
+impl TryInto<u64> for RegisterValue {
+    type Error = crate::Error;
+
+    fn try_into(self) -> Result<u64, Self::Error> {
+        match self {
+            Self::U32(v) => Ok(v.into()),
+            Self::U64(v) => Ok(v),
+            Self::U128(v) => v
+                .try_into()
+                .map_err(|_| crate::Error::Other(anyhow!("Value '{}' too large for u64", v))),
+        }
+    }
+}
+
+impl TryInto<u128> for RegisterValue {
+    type Error = crate::Error;
+
+    fn try_into(self) -> Result<u128, Self::Error> {
+        match self {
+            Self::U32(v) => Ok(v.into()),
+            Self::U64(v) => Ok(v.into()),
+            Self::U128(v) => Ok(v),
+        }
+    }
+}
+
+/// Extension trait to support converting errors
+/// from TryInto calls into [probe_rs::Error]
+pub trait RegisterValueResultExt<T> {
+    /// Convert [Result<T,E>] into `Result<T, probe_rs::Error>`
+    fn into_crate_error(self) -> Result<T, Error>;
+}
+
+/// No translation conversion case
+impl<T> RegisterValueResultExt<T> for Result<T, Error> {
+    fn into_crate_error(self) -> Result<T, Error> {
+        self
+    }
+}
+
+/// Convert from Error = Infallible to Error = probe_rs::Error
+impl<T> RegisterValueResultExt<T> for Result<T, Infallible> {
+    fn into_crate_error(self) -> Result<T, Error> {
+        Ok(self.unwrap())
+    }
+}
+
+/// Register description for a core.
+#[derive(Debug, PartialEq)]
+pub struct RegisterFile {
+    pub(crate) platform_registers: &'static [RegisterDescription],
+
+    /// Register description for the program counter
+    pub(crate) program_counter: &'static RegisterDescription,
+
+    pub(crate) stack_pointer: &'static RegisterDescription,
+
+    pub(crate) return_address: &'static RegisterDescription,
+
+    pub(crate) frame_pointer: &'static RegisterDescription,
+
+    pub(crate) argument_registers: &'static [RegisterDescription],
+
+    pub(crate) result_registers: &'static [RegisterDescription],
+
+    pub(crate) msp: Option<&'static RegisterDescription>,
+
+    pub(crate) psp: Option<&'static RegisterDescription>,
+
+    pub(crate) psr: Option<&'static RegisterDescription>,
+
+    pub(crate) fp_status: Option<&'static RegisterDescription>,
+
+    pub(crate) fp_registers: Option<&'static [RegisterDescription]>,
+
+    pub(crate) other: &'static [RegisterDescription],
+}
+
+impl RegisterFile {
+    /// Returns an iterator over the descriptions of all the "platform" registers of this core.
+    pub fn platform_registers(&self) -> impl Iterator<Item = &RegisterDescription> {
+        self.platform_registers.iter()
+    }
+
+    /// The frame pointer.
+    pub fn frame_pointer(&self) -> &RegisterDescription {
+        self.frame_pointer
+    }
+
+    /// The program counter.
+    pub fn program_counter(&self) -> &RegisterDescription {
+        self.program_counter
+    }
+
+    /// The stack pointer.
+    pub fn stack_pointer(&self) -> &RegisterDescription {
+        self.stack_pointer
+    }
+
+    /// The link register.
+    pub fn return_address(&self) -> &RegisterDescription {
+        self.return_address
+    }
+
+    /// Returns the nth argument register.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the register at given index does not exist.
+    pub fn argument_register(&self, index: usize) -> &RegisterDescription {
+        &self.argument_registers[index]
+    }
+
+    /// Returns the nth argument register if it is exists, `None` otherwise.
+    pub fn get_argument_register(&self, index: usize) -> Option<&RegisterDescription> {
+        self.argument_registers.get(index)
+    }
+
+    /// Returns the nth result register.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the register at given index does not exist.
+    pub fn result_register(&self, index: usize) -> &RegisterDescription {
+        &self.result_registers[index]
+    }
+
+    /// Returns the nth result register if it is exists, `None` otherwise.
+    pub fn get_result_register(&self, index: usize) -> Option<&RegisterDescription> {
+        self.result_registers.get(index)
+    }
+
+    /// Returns the nth platform register.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the register at given index does not exist.
+    pub fn platform_register(&self, index: usize) -> &RegisterDescription {
+        &self.platform_registers[index]
+    }
+
+    /// Returns the nth platform register if it is exists, `None` otherwise.
+    pub fn get_platform_register(&self, index: usize) -> Option<&RegisterDescription> {
+        self.platform_registers.get(index)
+    }
+
+    /// The main stack pointer.
+    pub fn msp(&self) -> Option<&RegisterDescription> {
+        self.msp
+    }
+
+    /// The process stack pointer.
+    pub fn psp(&self) -> Option<&RegisterDescription> {
+        self.psp
+    }
+
+    /// The processor status register.
+    pub fn psr(&self) -> Option<&RegisterDescription> {
+        self.psr
+    }
+
+    /// Other architecture specific registers
+    pub fn other(&self) -> impl Iterator<Item = &RegisterDescription> {
+        self.other.iter()
+    }
+
+    /// Find an architecture specific register by name
+    pub fn other_by_name(&self, name: &str) -> Option<&RegisterDescription> {
+        self.other.iter().find(|r| r.name == name)
+    }
+
+    /// The fpu status register.
+    pub fn fpscr(&self) -> Option<&RegisterDescription> {
+        self.fp_status
+    }
+
+    /// Returns an iterator over the descriptions of all the registers of this core.
+    pub fn fpu_registers(&self) -> Option<impl Iterator<Item = &RegisterDescription>> {
+        self.fp_registers.map(|r| r.iter())
+    }
+
+    /// Returns the nth fpu register.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the register at given index does not exist.
+    pub fn fpu_register(&self, index: usize) -> Option<&RegisterDescription> {
+        self.fp_registers.map(|r| &r[index])
+    }
+
+    /// Returns the nth fpu register if it is exists, `None` otherwise.
+    pub fn get_fpu_register(&self, index: usize) -> Option<&RegisterDescription> {
+        self.fp_registers.and_then(|r| r.get(index))
+    }
+}

--- a/probe-rs/src/core/registers.rs
+++ b/probe-rs/src/core/registers.rs
@@ -104,7 +104,7 @@ pub enum RegisterValue {
 
 impl RegisterValue {
     /// A helper function to increment an address by a fixed number of bytes.
-    pub fn incremenet_address(&mut self, bytes: usize) -> Result<(), Error> {
+    pub fn increment_address(&mut self, bytes: usize) -> Result<(), Error> {
         match self {
             RegisterValue::U32(value) => {
                 if let Some(reg_val) = value.checked_add(bytes as u32) {

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -4,8 +4,9 @@ use super::{
 };
 use crate::{
     core::Core,
+    core::RegisterValue,
     debug::{registers, source_statement::SourceStatements},
-    MemoryInterface, RegisterValue,
+    MemoryInterface,
 };
 use ::gimli::{FileEntry, LineProgramHeader, UnwindContext};
 use gimli::{BaseAddresses, ColumnType, DebugFrame, UnwindSection};

--- a/probe-rs/src/debug/registers.rs
+++ b/probe-rs/src/debug/registers.rs
@@ -1,6 +1,6 @@
 use crate::{
-    core::{Core, RegisterDataType, RegisterFile},
-    Error, RegisterId, RegisterValue,
+    core::{Core, RegisterDataType, RegisterFile, RegisterId, RegisterValue},
+    Error,
 };
 
 /// The group name of a register.

--- a/probe-rs/src/debug/stack_frame.rs
+++ b/probe-rs/src/debug/stack_frame.rs
@@ -1,6 +1,5 @@
-use crate::RegisterValue;
-
 use super::*;
+use crate::core::RegisterValue;
 use std;
 
 /// A full stack frame with all its information contained.

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -3,7 +3,7 @@ use super::{
     function_die::FunctionDie, registers, variable::*, DebugError, DebugRegisters, SourceLocation,
     VariableCache,
 };
-use crate::{core::Core, MemoryInterface, RegisterValue};
+use crate::{core::Core, core::RegisterValue, MemoryInterface};
 use gimli::{AttributeValue::Language, Location, UnitOffset};
 use num_traits::Zero;
 

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -32,6 +32,9 @@ pub enum Error {
     /// Then the correct permission needs to be given to automatically unlock the core to prevent accidental erases.
     #[error("An operation could not be performed because it lacked the permission to do so: {0}")]
     MissingPermissions(String),
+    /// An error that is not architecture specific occurred.
+    #[error("A generic core (not architecture specific) error occurred.")]
+    GenericCoreError(String),
     /// Any other error occurred.
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -89,9 +89,9 @@ mod session;
 
 pub use crate::config::{CoreType, InstructionSet, Target};
 pub use crate::core::{
-    Architecture, BreakpointCause, BreakpointId, Core, CoreInformation, CoreInterface, CoreState,
-    CoreStatus, HaltReason, MemoryMappedRegister, RegisterDescription, RegisterFile, RegisterId,
-    RegisterValue, SpecificCoreState,
+    Architecture, BreakpointCause, Core, CoreInformation, CoreInterface, CoreState, CoreStatus,
+    HaltReason, MemoryMappedRegister, RegisterDescription, RegisterFile, RegisterId, RegisterValue,
+    SpecificCoreState,
 };
 pub use crate::error::Error;
 pub use crate::memory::MemoryInterface;


### PR DESCRIPTION
While working on #1495 I ran into some code complications in the handling of various core and memory mapped registers. To avoid complicating that PR, I will do some of the most urgent code refactoring here, so that I can complete #1495.

- [x] Refactor `probe-rs/src/core.rs` to break it into smaller source files. 

- [x] Harmonize the handling of memory mapped (non core) registers. Currently there are a number of implementations ( `probe_rs::architecture::riscv::communication_interface` `pub(super) trait DebugRegister`, `probe_rs::architecture::arm::component` `pub trait DebugRegister`, `probe_rs::architecture::arm::core::armv7a_debug_regs` `pub trait Armv7DebugRegister`, `probe_rs::architecture::arm::core::armv8a_debug_regs` `pub trait Armv8DebugRegister`, 
`probe_rs::core` `pub trait MemoryMappedRegister` ) with only minor (avoidable) differences. The result makes it very messy to write common code for handling them.
    - [x]  Implemented a `core::memory_mapped_bitfield_register!` macro which allows the use of `core::MemoryMappedRegister` in all the above-mentioned modules.
    - [x] Refactored the RISC-V implementation to use the new `MemoryMappedRegister` instead of the architecture specific `DebugRegister`, and did thorough testing against ESP32C3.
    - [x] RISC-V where `RegisterDescription` entries in `RegisterFile` were declared as `static`, changed to `const`, as they are for all other architectures.
    - [x] Refactored the ARM implementation to use the new `MemoryMappedRegister` instead of the architecture and variant specific `DebugRegister`, and did thorough testing against STM32H745 and PICO/RP2040.
