### PR TITLE
treewide: occured → occurred

### DIFF
--- a/debugger/src/debug_adapter/dap/adapter.rs
+++ b/debugger/src/debug_adapter/dap/adapter.rs
@@ -1567,7 +1567,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                         ) {
                             // The core is still running.
                         } else {
-                            // Some other error occured, so we have to send an error response.
+                            // Some other error occurred, so we have to send an error response.
                             return Err(wait_error.into());
                         }
                     }

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -30,8 +30,8 @@ pub enum DebugPortError {
     #[error("A Debug Probe Error occurred")]
     DebugProbe(#[from] DebugProbeError),
 
-    /// A timeout occured.
-    #[error("Timeout occured")]
+    /// A timeout occurred.
+    #[error("Timeout occurred")]
     Timeout,
 
     /// Powerup of the target device failed.
@@ -42,8 +42,8 @@ pub enum DebugPortError {
     #[error("Debug port not supported: {0}")]
     Unsupported(String),
 
-    /// An error occured in the communication with an access port or debug port.
-    #[error("An error occured in the communication with an access port or debug port.")]
+    /// An error occurred in the communication with an access port or debug port.
+    #[error("An error occurred in the communication with an access port or debug port.")]
     Dap(#[from] DapError),
 }
 /// A typed interface to be implemented on drivers that can control a debug port.

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -37,13 +37,13 @@ pub use communication_interface::ArmProbeInterface;
 
 /// ARM-specific errors
 #[derive(Debug, thiserror::Error)]
-#[error("An ARM specific error occured.")]
+#[error("An ARM specific error occurred.")]
 pub enum ArmError {
     /// The operation requires a specific architecture.
     #[error("The operation requires one of the following architectures: {0:?}")]
     ArchitectureRequired(&'static [&'static str]),
-    /// A timeout occured during an operation
-    #[error("Timeout occured during operation.")]
+    /// A timeout occurred during an operation
+    #[error("Timeout occurred during operation.")]
     Timeout,
     /// The address is too large for the 32 bit address space.
     #[error("Address is not in 32 bit address space.")]
@@ -59,7 +59,7 @@ pub enum ArmError {
         /// Source of the error.
         source: AccessPortError,
     },
-    /// An error occured while using a debug port.
+    /// An error occurred while using a debug port.
     #[error("Error using a debug port.")]
     DebugPort(#[from] DebugPortError),
     /// The core has to be halted for the operation, but was not.
@@ -76,8 +76,8 @@ pub enum ArmError {
     #[error("An operation could not be performed because it lacked the permission to do so: {0}")]
     MissingPermissions(String),
 
-    /// An error occured in the communication with an access port or debug port.
-    #[error("An error occured in the communication with an access port or debug port.")]
+    /// An error occurred in the communication with an access port or debug port.
+    #[error("An error occurred in the communication with an access port or debug port.")]
     Dap(#[from] DapError),
 
     /// The debug probe encountered an error.
@@ -111,13 +111,13 @@ pub enum ArmError {
     #[error("Unable to create a breakpoint at address {0:#010X}. Hardware breakpoints are only supported at addresses < 0x2000'0000.")]
     UnsupportedBreakpointAddress(u32),
 
-    /// ARMv8a specifc erorr occured.
+    /// ARMv8a specifc erorr occurred.
     Armv8a(#[from] Armv8aError),
 
-    /// ARMv7a specifc erorr occured.
+    /// ARMv7a specifc erorr occurred.
     Armv7a(#[from] Armv7aError),
 
-    /// Error occured in a debug sequence.
+    /// Error occurred in a debug sequence.
     DebugSequence(#[from] ArmDebugSequenceError),
 
     /// Tracing has not been configured.

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -49,8 +49,8 @@ pub enum ArmDebugSequenceError {
     #[error("Core access requries cti_base to be specified, but it is not")]
     CtiBaseNotSpecified,
 
-    /// An error occured in a debug sequence.
-    #[error("An error occured in a debug sequnce: {0}")]
+    /// An error occurred in a debug sequence.
+    #[error("An error occurred in a debug sequnce: {0}")]
     SequenceSpecific(#[from] Box<dyn Error + Send + Sync + 'static>),
 }
 

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -11,11 +11,11 @@ pub enum Error {
     /// An error in the probe driver occurred.
     #[error("An error with the usage of the probe occurred")]
     Probe(#[from] DebugProbeError),
-    /// An ARM specific error occured.
-    #[error("An ARM specific error occured.")]
+    /// An ARM specific error occurred.
+    #[error("An ARM specific error occurred.")]
     Arm(#[source] ArmError),
-    /// A RISCV specific error occured.
-    #[error("A RISCV specific error occured.")]
+    /// A RISCV specific error occurred.
+    #[error("A RISCV specific error occurred.")]
     Riscv(#[source] RiscvError),
     /// The probe could not be opened.
     #[error("Probe could not be opened: {0}")]
@@ -37,8 +37,8 @@ pub enum Error {
     Other(#[from] anyhow::Error),
 
     // TODO: Errors below should be core specific
-    /// A timeout occured during an operation
-    #[error("A timeout occured.")]
+    /// A timeout occurred during an operation
+    #[error("A timeout occurred.")]
     Timeout,
 
     /// Unaligned memory access


### PR DESCRIPTION
it's #971 all over again
the same typo got introduced to the same error i previously fixed it for -_-