### PR TITLE
Draft: Fix build for freebsd (hidapi lib fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "hidapi"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7461dc5aae7f2f360289bae7d169690e51c182d4b5a56adeb8c7f312965f0411"
+checksum = "75445a22bab0c1379be3fd255f7d391e7f6f19019601e40f6a0960b603ca8fa8"
 dependencies = [
  "cc",
  "libc",

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -40,8 +40,9 @@ gimli = { version = "0.27.2", default-features = false, features = [
     "read",
     "std",
 ] }
-hidapi = { version = "2.2.2", default-features = false, features = [
+hidapi = { version = "2.3.0" , default-features = false, features = [
     "linux-static-hidraw",
+    "illumos-static-libusb",
 ] }
 ihex = "3.0.0"
 jaylink = "0.3.0"


### PR DESCRIPTION
Turns out hidapi accidentally used a function from libusb, which is not (yet) available on freebsd.
Fix freebsd build by upgrading to fixed hidapi.

Note: The new version of hidapi supports the linux-native backend, which gets rid of the hidapi C library dependency, but I did not enable it for this PR.