### PR TITLE
stlink: send JTAG_EXIT when entering idle mode for JTAG

### DIFF
--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -407,6 +407,12 @@ impl<D: StLinkUsb> StLink<D> {
         let mode = self.get_current_mode()?;
 
         match mode {
+            Mode::Jtag => self.device.write(
+                &[commands::JTAG_COMMAND, commands::JTAG_EXIT],
+                &[],
+                &mut [],
+                TIMEOUT,
+            ),
             Mode::Dfu => self.device.write(
                 &[commands::DFU_COMMAND, commands::DFU_EXIT],
                 &[],


### PR DESCRIPTION
Send JTAG_EXIT in `StLink::enter_idle` to tri-state the ST-LINK output drivers, 
allowing an external debugger connected to the same pins to debug the target 
after probe-rs has detached the probe.

Tested on an STM32H747I-DISCO with Lauterbach LA-7742U connected to 
CN13 (i.e. parallel with the embedded ST-LINK V3E).