### PR TITLE
Add target file for PY32F0 series chip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for the Olimex ARM-USB-TINY-H JTAG device (#1586).
 - Added support for propagating `CoreStatus` to the probe in use (#1588).
+- Added PY32F0xx series targets (#1619).
 
 ## [0.18.0]
 

--- a/probe-rs/targets/PY32F0_Series.yaml
+++ b/probe-rs/targets/PY32F0_Series.yaml
@@ -1,0 +1,995 @@
+name: PY32F0 Series
+generated_from_pack: true
+pack_file_release: 1.1.7
+variants:
+- name: PY32F002Ax5
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20000c00
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8005000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_20
+  - py32f0xx_opt
+- name: PY32F002Bx5
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20000c00
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8006000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f002bxx_24
+  - py32f002bxx_opt
+- name: PY32F003x4
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20000800
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_16
+  - py32f0xx_opt
+- name: PY32F003x6
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20001000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_32
+  - py32f0xx_opt
+- name: PY32F003x8
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_64
+  - py32f0xx_opt
+- name: PY32F030x3
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20000800
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8002000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_8
+  - py32f0xx_opt
+- name: PY32F030x4
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20000800
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_16
+  - py32f0xx_opt
+- name: PY32F030x6
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20001000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_32
+  - py32f0xx_opt
+- name: PY32F030x7
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20001800
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x800c000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_48
+  - py32f0xx_opt
+- name: PY32F030x8
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_64
+  - py32f0xx_opt
+- name: PY32F031x3
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20000800
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8002000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_8
+  - py32f0xx_opt
+- name: PY32F031x4
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20000800
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8004000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_16
+  - py32f0xx_opt
+- name: PY32F031x6
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20001000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_32
+  - py32f0xx_opt
+- name: PY32F031x7
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20001800
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x800c000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_48
+  - py32f0xx_opt
+- name: PY32F031x8
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f0xx_64
+  - py32f0xx_opt
+- name: PY32F071x6
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20001000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f071xx_32
+  - py32f071xx_opt
+- name: PY32F071x8
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f071xx_64
+  - py32f071xx_opt
+- name: PY32F071x9
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20003000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8018000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f071xx_96
+  - py32f071xx_opt
+- name: PY32F071xB
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f071xx_128
+  - py32f071xx_opt
+- name: PY32F072x6
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20001000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8008000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f072xx_32
+  - py32f072xx_opt
+- name: PY32F072x8
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8010000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f072xx_64
+  - py32f072xx_opt
+- name: PY32F072x9
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20003000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8018000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f072xx_96
+  - py32f072xx_opt
+- name: PY32F072xB
+  cores:
+  - name: main
+    type: armv6m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x8000000
+      end: 0x8020000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - py32f072xx_128
+  - py32f072xx_opt
+flash_algorithms:
+- name: py32f0xx_20
+  description: PY32F0xx 20kB Flash
+  default: true
+  instructions: jUhCaAchjUtJAwpAS0QaYEJoikMBIckDURhBYEFoiEpJCxJpSQPSBNIMEUNBYAFoSQX81YJIQDDBasqygUkKYMJqEgQSDgphwmrSAdINSmACa9KyimACa1IBUg3KYEJr0gPSC0phgmvSA9ILimHCa5KyymHAawAMCGJwRxC1c0xxSKBgckigYP/3uv8AICBgIGkBIQhDIGEgasAEBtRuSGxJAWAGIUFgbEmBYAAgEL1hSEJoByFJA4pDYElJRAloCkNCYAEjWwPKGl1JGNDSGhHQ0hoK0JpCQmgD0VILUgMJaRHgUgtSAwloDeBCaMloUgtSAwjgQmiJaFILUgMD4EJoSWhSC1IDyQTJDApDQmABaEkF/NVwRwC1//fJ/0tIQWmCBBFDQWEAIAC9cLVHShBpASMYQxBhUGkEJCBDUGFQaR0GKENQYf8g2QYIYL/zT49DSEBJAOAIYBZp9gP71FBpoENQYVBpqENQYRBpwAcB0AAgcL0QaRhDEGEBIHC9MLUySQppASMaQwphSmnMFCJDSmFKaR0GKkNKYf8iAmC/80+PLkgsSgDgEGALadsD+9RIaaBDSGFIaahDSGEAIDC9ASBwR/C1IE1/MckJK2nJAQEkI0MrYSYGKOBraQEkI0NrYWtpM0NrYQAjnAAXWQdRHisE0WxpASf/BDxDbGFbHNuyICvx07/zT48USxJMAOAjYC9p/wP71GtpWwhbAGtha2mzQ2thgDCAOYAyACnU0QAg8L0AAAAQAkAEAAAAAA//HwAhAkAjAWdFACACQKuJ781VVQAAADAAQP8PAACqqgAAAAAAAAAAAAA=
+  pc_init: 0x7d
+  pc_uninit: 0x119
+  pc_program_page: 0x1c7
+  pc_erase_sector: 0x181
+  pc_erase_all: 0x12d
+  data_section_offset: 0x264
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8005000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: py32f0xx_opt
+  description: PY32F0xx Flash Options
+  instructions: bUhCaAchbUtJAwpAS0QaYEJoikMBIckDURhBYEFoaEpJCxJpSQPSBNIMEUNBYAFoSQX81WJIQDDBasqyYUkKYMJqEgQSDgphwmrSAdINSmACa9KyimACa1IBUg3KYEJr0gPSC0phgmvSA9ILimHCa5KyymHAawAMCGJwRxC1U0xRSKBgUkigYP/3uv9RSOBgUUjgYAAgIGAgaQEhCEMgYSBqwAQG1E5ITEkBYAYhQWBMSYFgACAQvT9IQmgHIUkDikM+SUlECWgKQ0JgASNbA8oaO0kY0NIaEdDSGgrQmkJCaAPRUgtSAwlpEeBSC1IDCWgN4EJoyWhSC1IDCOBCaIloUgtSAwPgQmhJaFILUgPJBMkMCkNCYAFoSQX81XBHALX/98n/KUhBaYIEEUNBYUFpQgQRQ0FhACAAvQAgcEcAIHBHASBwRzC1IEgTiJGIkokEaQElLEMEYZuyA2KJskFikbLBYkJpaQQKQ0JhQmnLARpDQmETTP8igDwiYL/zT49CaYpDQmFBaZlDQWEAIDC9MLUUaFNo0mgFaKVCA9FEaJxCAdAAHTC9w2iTQgHQDDAwvUAYML0AEAJABAAAAAAP/x8AIQJAIwFnRQAgAkCrie/NOyoZCH9uXUxVVQAAADAAQP8PAAAAAAAAAAAAAA==
+  pc_init: 0x7d
+  pc_uninit: 0x121
+  pc_program_page: 0x149
+  pc_erase_sector: 0x141
+  pc_erase_all: 0x13d
+  data_section_offset: 0x1e8
+  flash_properties:
+    address_range:
+      start: 0x1fff0e80
+      end: 0x1fff0e90
+    page_size: 0x10
+    erased_byte_value: 0xff
+    program_page_timeout: 3000
+    erase_sector_timeout: 3000
+    sectors:
+    - size: 0x10
+      address: 0x0
+- name: py32f002bxx_24
+  description: PY32F002Bxx 24kB Flash
+  default: true
+  instructions: cEdjSGFJgWBiSYFgACEBYAFpASIRQwFhAGrABAbUX0hdSQFgBiFBYF1JgWAAIHBHcEdXSEFpggQRQ0FhACBwR3C1U0oQaQEjGEMQYVBpBCQgQ1BhUGkdBihDUGH/INkGCGC/80+PT0hMSQDgCGAWafYD+9RQaaBDUGFQaahDUGEQacAHAdAAIHC9EGkYQxBhASBwvTC1PkkKaQEjGkMKYUppzBQiQ0phSmkdBipDSmH/IgJgv/NPjzpIOEoA4BBgC2nbA/vUSGmgQ0hhSGmoQ0hhACAwvQEgcEfwtSxNfzHJCStpyQEBJCNDK2EmBijga2kBJCNDa2FraTNDa2EAI5wAF1kHUR4rBNFsaQEn/wQ8Q2xhWxzbsiAr8dO/80+PIEseTADgI2Avaf8D+9RraVsIWwBrYWtps0NrYYAwgDmAMgAp1NEAIPC9MLUQSQppASMaQwphSmkCJCJDSmFKaR0GKkNKYf8iAmC/80+PDUgKSgDgEGALadsD+9RIaaBDSGFIaahDSGEAIDC9IwFnRQAgAkCrie/NVVUAAAAwAED/DwAAqqoAAAAAAAAAAAAA
+  pc_init: 0x3
+  pc_uninit: 0x33
+  pc_program_page: 0xdb
+  pc_erase_sector: 0x95
+  pc_erase_all: 0x41
+  data_section_offset: 0x1a8
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8006000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: py32f002bxx_opt
+  description: PY32F002Bxx Flash Options
+  instructions: cEdFSENJgWBESYFgREnBYERJwWAAIQFgAWkBIhFDAWEAasAEBtRBSD9JAWAGIUFgP0mBYAAgcEdwRzdIQWmCBBFDQWFBaUIEEUNBYQAgcEcAIHBHACBwRwEgcEdwtS5IFIiTiBGJkokFaQEmNUMFYaSyBGKbskNiibKBYpGywWJCaXEECkNCYUJpywEaQ0JhIUz/IoA0ImC/80+PQmmKQ0JhQWmZQ0FhACBwvTC1FGhTaNJoBWilQgPRRGicQgHQAB0wvcNok0IB0AwwML1AGDC9MLUQSQppASMaQwphSmkCJCJDSmFKaR0GKkNKYf8iAmC/80+PD0gMSgDgEGALadsD+9RIaaBDSGFIaahDSGEAIDC9IwFnRQAgAkCrie/NOyoZCH9uXUxVVQAAADAAQP8PAACqqgAAAAAAAAAAAAA=
+  pc_init: 0x3
+  pc_uninit: 0x3b
+  pc_program_page: 0x5d
+  pc_erase_sector: 0x55
+  pc_erase_all: 0x51
+  data_section_offset: 0x138
+  flash_properties:
+    address_range:
+      start: 0x1fff0080
+      end: 0x1fff0090
+    page_size: 0x10
+    erased_byte_value: 0xff
+    program_page_timeout: 3000
+    erase_sector_timeout: 3000
+    sectors:
+    - size: 0x10
+      address: 0x0
+- name: py32f0xx_16
+  description: PY32F0xx 16kB Flash
+  default: true
+  instructions: jUhCaAchjUtJAwpAS0QaYEJoikMBIckDURhBYEFoiEpJCxJpSQPSBNIMEUNBYAFoSQX81YJIQDDBasqygUkKYMJqEgQSDgphwmrSAdINSmACa9KyimACa1IBUg3KYEJr0gPSC0phgmvSA9ILimHCa5KyymHAawAMCGJwRxC1c0xxSKBgckigYP/3uv8AICBgIGkBIQhDIGEgasAEBtRuSGxJAWAGIUFgbEmBYAAgEL1hSEJoByFJA4pDYElJRAloCkNCYAEjWwPKGl1JGNDSGhHQ0hoK0JpCQmgD0VILUgMJaRHgUgtSAwloDeBCaMloUgtSAwjgQmiJaFILUgMD4EJoSWhSC1IDyQTJDApDQmABaEkF/NVwRwC1//fJ/0tIQWmCBBFDQWEAIAC9cLVHShBpASMYQxBhUGkEJCBDUGFQaR0GKENQYf8g2QYIYL/zT49DSEBJAOAIYBZp9gP71FBpoENQYVBpqENQYRBpwAcB0AAgcL0QaRhDEGEBIHC9MLUySQppASMaQwphSmnMFCJDSmFKaR0GKkNKYf8iAmC/80+PLkgsSgDgEGALadsD+9RIaaBDSGFIaahDSGEAIDC9ASBwR/C1IE1/MckJK2nJAQEkI0MrYSYGKOBraQEkI0NrYWtpM0NrYQAjnAAXWQdRHisE0WxpASf/BDxDbGFbHNuyICvx07/zT48USxJMAOAjYC9p/wP71GtpWwhbAGtha2mzQ2thgDCAOYAyACnU0QAg8L0AAAAQAkAEAAAAAA//HwAhAkAjAWdFACACQKuJ781VVQAAADAAQP8PAACqqgAAAAAAAAAAAAA=
+  pc_init: 0x7d
+  pc_uninit: 0x119
+  pc_program_page: 0x1c7
+  pc_erase_sector: 0x181
+  pc_erase_all: 0x12d
+  data_section_offset: 0x264
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8004000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: py32f0xx_32
+  description: PY32F0xx 32kB Flash
+  default: true
+  instructions: jUhCaAchjUtJAwpAS0QaYEJoikMBIckDURhBYEFoiEpJCxJpSQPSBNIMEUNBYAFoSQX81YJIQDDBasqygUkKYMJqEgQSDgphwmrSAdINSmACa9KyimACa1IBUg3KYEJr0gPSC0phgmvSA9ILimHCa5KyymHAawAMCGJwRxC1c0xxSKBgckigYP/3uv8AICBgIGkBIQhDIGEgasAEBtRuSGxJAWAGIUFgbEmBYAAgEL1hSEJoByFJA4pDYElJRAloCkNCYAEjWwPKGl1JGNDSGhHQ0hoK0JpCQmgD0VILUgMJaRHgUgtSAwloDeBCaMloUgtSAwjgQmiJaFILUgMD4EJoSWhSC1IDyQTJDApDQmABaEkF/NVwRwC1//fJ/0tIQWmCBBFDQWEAIAC9cLVHShBpASMYQxBhUGkEJCBDUGFQaR0GKENQYf8g2QYIYL/zT49DSEBJAOAIYBZp9gP71FBpoENQYVBpqENQYRBpwAcB0AAgcL0QaRhDEGEBIHC9MLUySQppASMaQwphSmnMFCJDSmFKaR0GKkNKYf8iAmC/80+PLkgsSgDgEGALadsD+9RIaaBDSGFIaahDSGEAIDC9ASBwR/C1IE1/MckJK2nJAQEkI0MrYSYGKOBraQEkI0NrYWtpM0NrYQAjnAAXWQdRHisE0WxpASf/BDxDbGFbHNuyICvx07/zT48USxJMAOAjYC9p/wP71GtpWwhbAGtha2mzQ2thgDCAOYAyACnU0QAg8L0AAAAQAkAEAAAAAA//HwAhAkAjAWdFACACQKuJ781VVQAAADAAQP8PAACqqgAAAAAAAAAAAAA=
+  pc_init: 0x7d
+  pc_uninit: 0x119
+  pc_program_page: 0x1c7
+  pc_erase_sector: 0x181
+  pc_erase_all: 0x12d
+  data_section_offset: 0x264
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8008000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: py32f0xx_64
+  description: PY32F0xx 64kB Flash
+  default: true
+  instructions: jUhCaAchjUtJAwpAS0QaYEJoikMBIckDURhBYEFoiEpJCxJpSQPSBNIMEUNBYAFoSQX81YJIQDDBasqygUkKYMJqEgQSDgphwmrSAdINSmACa9KyimACa1IBUg3KYEJr0gPSC0phgmvSA9ILimHCa5KyymHAawAMCGJwRxC1c0xxSKBgckigYP/3uv8AICBgIGkBIQhDIGEgasAEBtRuSGxJAWAGIUFgbEmBYAAgEL1hSEJoByFJA4pDYElJRAloCkNCYAEjWwPKGl1JGNDSGhHQ0hoK0JpCQmgD0VILUgMJaRHgUgtSAwloDeBCaMloUgtSAwjgQmiJaFILUgMD4EJoSWhSC1IDyQTJDApDQmABaEkF/NVwRwC1//fJ/0tIQWmCBBFDQWEAIAC9cLVHShBpASMYQxBhUGkEJCBDUGFQaR0GKENQYf8g2QYIYL/zT49DSEBJAOAIYBZp9gP71FBpoENQYVBpqENQYRBpwAcB0AAgcL0QaRhDEGEBIHC9MLUySQppASMaQwphSmnMFCJDSmFKaR0GKkNKYf8iAmC/80+PLkgsSgDgEGALadsD+9RIaaBDSGFIaahDSGEAIDC9ASBwR/C1IE1/MckJK2nJAQEkI0MrYSYGKOBraQEkI0NrYWtpM0NrYQAjnAAXWQdRHisE0WxpASf/BDxDbGFbHNuyICvx07/zT48USxJMAOAjYC9p/wP71GtpWwhbAGtha2mzQ2thgDCAOYAyACnU0QAg8L0AAAAQAkAEAAAAAA//HwAhAkAjAWdFACACQKuJ781VVQAAADAAQP8PAACqqgAAAAAAAAAAAAA=
+  pc_init: 0x7d
+  pc_uninit: 0x119
+  pc_program_page: 0x1c7
+  pc_erase_sector: 0x181
+  pc_erase_all: 0x12d
+  data_section_offset: 0x264
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8010000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: py32f0xx_8
+  description: PY32F0xx 8kB Flash
+  default: true
+  instructions: jUhCaAchjUtJAwpAS0QaYEJoikMBIckDURhBYEFoiEpJCxJpSQPSBNIMEUNBYAFoSQX81YJIQDDBasqygUkKYMJqEgQSDgphwmrSAdINSmACa9KyimACa1IBUg3KYEJr0gPSC0phgmvSA9ILimHCa5KyymHAawAMCGJwRxC1c0xxSKBgckigYP/3uv8AICBgIGkBIQhDIGEgasAEBtRuSGxJAWAGIUFgbEmBYAAgEL1hSEJoByFJA4pDYElJRAloCkNCYAEjWwPKGl1JGNDSGhHQ0hoK0JpCQmgD0VILUgMJaRHgUgtSAwloDeBCaMloUgtSAwjgQmiJaFILUgMD4EJoSWhSC1IDyQTJDApDQmABaEkF/NVwRwC1//fJ/0tIQWmCBBFDQWEAIAC9cLVHShBpASMYQxBhUGkEJCBDUGFQaR0GKENQYf8g2QYIYL/zT49DSEBJAOAIYBZp9gP71FBpoENQYVBpqENQYRBpwAcB0AAgcL0QaRhDEGEBIHC9MLUySQppASMaQwphSmnMFCJDSmFKaR0GKkNKYf8iAmC/80+PLkgsSgDgEGALadsD+9RIaaBDSGFIaahDSGEAIDC9ASBwR/C1IE1/MckJK2nJAQEkI0MrYSYGKOBraQEkI0NrYWtpM0NrYQAjnAAXWQdRHisE0WxpASf/BDxDbGFbHNuyICvx07/zT48USxJMAOAjYC9p/wP71GtpWwhbAGtha2mzQ2thgDCAOYAyACnU0QAg8L0AAAAQAkAEAAAAAA//HwAhAkAjAWdFACACQKuJ781VVQAAADAAQP8PAACqqgAAAAAAAAAAAAA=
+  pc_init: 0x7d
+  pc_uninit: 0x119
+  pc_program_page: 0x1c7
+  pc_erase_sector: 0x181
+  pc_erase_all: 0x12d
+  data_section_offset: 0x264
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8002000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: py32f0xx_48
+  description: PY32F0xx 48kB Flash
+  default: true
+  instructions: jUhCaAchjUtJAwpAS0QaYEJoikMBIckDURhBYEFoiEpJCxJpSQPSBNIMEUNBYAFoSQX81YJIQDDBasqygUkKYMJqEgQSDgphwmrSAdINSmACa9KyimACa1IBUg3KYEJr0gPSC0phgmvSA9ILimHCa5KyymHAawAMCGJwRxC1c0xxSKBgckigYP/3uv8AICBgIGkBIQhDIGEgasAEBtRuSGxJAWAGIUFgbEmBYAAgEL1hSEJoByFJA4pDYElJRAloCkNCYAEjWwPKGl1JGNDSGhHQ0hoK0JpCQmgD0VILUgMJaRHgUgtSAwloDeBCaMloUgtSAwjgQmiJaFILUgMD4EJoSWhSC1IDyQTJDApDQmABaEkF/NVwRwC1//fJ/0tIQWmCBBFDQWEAIAC9cLVHShBpASMYQxBhUGkEJCBDUGFQaR0GKENQYf8g2QYIYL/zT49DSEBJAOAIYBZp9gP71FBpoENQYVBpqENQYRBpwAcB0AAgcL0QaRhDEGEBIHC9MLUySQppASMaQwphSmnMFCJDSmFKaR0GKkNKYf8iAmC/80+PLkgsSgDgEGALadsD+9RIaaBDSGFIaahDSGEAIDC9ASBwR/C1IE1/MckJK2nJAQEkI0MrYSYGKOBraQEkI0NrYWtpM0NrYQAjnAAXWQdRHisE0WxpASf/BDxDbGFbHNuyICvx07/zT48USxJMAOAjYC9p/wP71GtpWwhbAGtha2mzQ2thgDCAOYAyACnU0QAg8L0AAAAQAkAEAAAAAA//HwAhAkAjAWdFACACQKuJ781VVQAAADAAQP8PAACqqgAAAAAAAAAAAAA=
+  pc_init: 0x7d
+  pc_uninit: 0x119
+  pc_program_page: 0x1c7
+  pc_erase_sector: 0x181
+  pc_erase_all: 0x12d
+  data_section_offset: 0x264
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x800c000
+    page_size: 0x80
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x1000
+      address: 0x0
+- name: py32f071xx_32
+  description: PY32F071xx 32kB Flash
+  default: true
+  instructions: QLpwR8C6cEcoIUFD6EqJGIlrybLnShFgKCFBQ+RKiRiJawkECQ7jShFhKCFBQ+BKiRiJa8kByQ3eSlFgKCFBQ9tKiRgJbMmy2kqRYCghQUPXSokYCWxJAUkN1krRYCghQUPTSokYiWzJA8kL0UpRYSghQUPOSokYCW3JA8kLzUqRYSghQUPKSokYiW2JsslK0WEoIUFDxkqJGIltCQzFShFicEcAtcRIQGgHIUkDCEDCSUlECGDASEBoAAwABLxJCWoIQ7xJSGAAv7tIAGgBIYkCCECIQvjRBCD/95X/AL21SEBoByFJA4hDtElJRAloCEOxSUhgsUhIRABoASFJA0AaI9BAGhfQQBoL0EAaJ9GpSEBoAAwABKVJCWoIQ6ZJSGAn4KRIQGgADAAEoEmJaQhDoUlIYB3gn0hAaAAMAASbSQlpCEOcSUhgE+CaSEBoAAwABJZJiWgIQ5dJSGAJ4JVIQGgADAAEkUkJaAhDkklIYAC/AL8Av49IAGgBIYkCCECIQvjRcEcwtQNGDEYVRotIjEmIYIxIiGD/94P/iUgAaQEhCEOHSQhhCEYAaskUCECIQgbQhUiFSQhgBiBIYIRIiGB/SABqASEJAwhAiEIG0IFIQGj/IYExCEN+SUhgACAwvQC1Akb/93r/dUhAaQEhyQcIQ3NJSGEAIAC9cUgAaQEhCENvSQhhCEZAaQQhCENsSUhhCEZAaQEhCQYIQ2hJSGH/IAEhyQYIYL/zT48I4GlIAGh/IQhDZ0kIYGdIY0kIYF9IAGkBIQkECEAAKO/RXEhAaQQhiENaSUhhCEZAaQEhCQaIQ1ZJSGEIRgBpwAfADwAoB9EIRgBpASEIQ1BJCGEBIHBHACD85wFGTUgAaQEiEENLShBhEEZAadIUEENISlBhEEZAaQEiEgYQQ0RKUGH/IAhgv/NPjwjgRkgAaH8iEENEShBgREhAShBgPEgAaQEiEgQQQAAo79E5SEBpUhGQQzdKUGEQRkBpASISBpBDM0pQYQAgcEcDRgEgcEcwtQNGyB34MAEKCQItSABpASQgQytMIGFF4ClIQGkBJCBDJ0xgYSBGQGkBJCQGIEMkTGBhACAO4IQAFFmFAFxRPigG0R9MZGkBJe0ELEMcTWxhRBzgskAo7tO/80+PCOAdSABofyQgQxtMIGAbSBdMIGATSABpASQkBCBAACjv0RBIQGlACEAADkxgYSBGQGkBJCQGoEMKTGBh/zMBM/8yATL/OQE5ACm30QAgML0AMv8fACECQAAQAkAEAAAAIwFnRQAgAkCrie/NVVUAAAAwAED/DwAAACwAQKqqAAAAAAAAAAAAAA==
+  pc_init: 0x189
+  pc_uninit: 0x1e5
+  pc_program_page: 0x303
+  pc_erase_sector: 0x28d
+  pc_erase_all: 0x1ff
+  data_section_offset: 0x3e0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8008000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x2000
+      address: 0x0
+- name: py32f071xx_opt
+  description: PY32F071xx Flash Options
+  instructions: QLpwR8C6cEcoIUFDYEqJGIlrybJfShFgKCFBQ1xKiRiJawkECQ5bShFhKCFBQ1hKiRiJa8kByQ1WSlFgKCFBQ1NKiRgJbMmyUkqRYCghQUNPSokYCWxJAUkNTkrRYCghQUNLSokYiWzJA8kLSUpRYSghQUNGSokYCW3JA8kLRUqRYSghQUNCSokYiW2JskFK0WEoIUFDPkqJGIltCQw9ShFicEcAtTxIQGgHIUkDCEA6SUlECGA4SEBoAAwABDRJCWoIQzRJSGAAvzNIAGgBIYkCCECIQvjRBCD/95X/AL0tSEBoByFJA4hDLElJRAloCEMpSUhgKUhIRABoASFJA0AaI9BAGhfQQBoL0EAaJ9EhSEBoAAwABB1JCWoIQx5JSGAn4BxIQGgADAAEGEmJaQhDGUlIYB3gF0hAaAAMAAQTSQlpCEMUSUhgE+ASSEBoAAwABA5JiWgIQw9JSGAJ4A1IQGgADAAECUkJaAhDCklIYAC/AL8AvwdIAGgBIYkCCECIQvjRcEcDRgEgcEcAAAAy/x8AIQJAABACQAQAAAAAAAAAAAAAAA==
+  pc_program_page: 0x0
+  pc_erase_sector: 0x0
+  data_section_offset: 0x1a0
+  flash_properties:
+    address_range:
+      start: 0x1fff3100
+      end: 0x1fff3120
+    page_size: 0x20
+    erased_byte_value: 0xff
+    program_page_timeout: 3000
+    erase_sector_timeout: 3000
+    sectors:
+    - size: 0x20
+      address: 0x0
+- name: py32f071xx_64
+  description: PY32F071xx 64kB Flash
+  default: true
+  instructions: QLpwR8C6cEcoIUFD6EqJGIlrybLnShFgKCFBQ+RKiRiJawkECQ7jShFhKCFBQ+BKiRiJa8kByQ3eSlFgKCFBQ9tKiRgJbMmy2kqRYCghQUPXSokYCWxJAUkN1krRYCghQUPTSokYiWzJA8kL0UpRYSghQUPOSokYCW3JA8kLzUqRYSghQUPKSokYiW2JsslK0WEoIUFDxkqJGIltCQzFShFicEcAtcRIQGgHIUkDCEDCSUlECGDASEBoAAwABLxJCWoIQ7xJSGAAv7tIAGgBIYkCCECIQvjRBCD/95X/AL21SEBoByFJA4hDtElJRAloCEOxSUhgsUhIRABoASFJA0AaI9BAGhfQQBoL0EAaJ9GpSEBoAAwABKVJCWoIQ6ZJSGAn4KRIQGgADAAEoEmJaQhDoUlIYB3gn0hAaAAMAASbSQlpCEOcSUhgE+CaSEBoAAwABJZJiWgIQ5dJSGAJ4JVIQGgADAAEkUkJaAhDkklIYAC/AL8Av49IAGgBIYkCCECIQvjRcEcwtQNGDEYVRotIjEmIYIxIiGD/94P/iUgAaQEhCEOHSQhhCEYAaskUCECIQgbQhUiFSQhgBiBIYIRIiGB/SABqASEJAwhAiEIG0IFIQGj/IYExCEN+SUhgACAwvQC1Akb/93r/dUhAaQEhyQcIQ3NJSGEAIAC9cUgAaQEhCENvSQhhCEZAaQQhCENsSUhhCEZAaQEhCQYIQ2hJSGH/IAEhyQYIYL/zT48I4GlIAGh/IQhDZ0kIYGdIY0kIYF9IAGkBIQkECEAAKO/RXEhAaQQhiENaSUhhCEZAaQEhCQaIQ1ZJSGEIRgBpwAfADwAoB9EIRgBpASEIQ1BJCGEBIHBHACD85wFGTUgAaQEiEENLShBhEEZAadIUEENISlBhEEZAaQEiEgYQQ0RKUGH/IAhgv/NPjwjgRkgAaH8iEENEShBgREhAShBgPEgAaQEiEgQQQAAo79E5SEBpUhGQQzdKUGEQRkBpASISBpBDM0pQYQAgcEcDRgEgcEcwtQNGyB34MAEKCQItSABpASQgQytMIGFF4ClIQGkBJCBDJ0xgYSBGQGkBJCQGIEMkTGBhACAO4IQAFFmFAFxRPigG0R9MZGkBJe0ELEMcTWxhRBzgskAo7tO/80+PCOAdSABofyQgQxtMIGAbSBdMIGATSABpASQkBCBAACjv0RBIQGlACEAADkxgYSBGQGkBJCQGoEMKTGBh/zMBM/8yATL/OQE5ACm30QAgML0AMv8fACECQAAQAkAEAAAAIwFnRQAgAkCrie/NVVUAAAAwAED/DwAAACwAQKqqAAAAAAAAAAAAAA==
+  pc_init: 0x189
+  pc_uninit: 0x1e5
+  pc_program_page: 0x303
+  pc_erase_sector: 0x28d
+  pc_erase_all: 0x1ff
+  data_section_offset: 0x3e0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8010000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x2000
+      address: 0x0
+- name: py32f071xx_96
+  description: PY32F071xx 96kB Flash
+  default: true
+  instructions: QLpwR8C6cEcoIUFD6EqJGIlrybLnShFgKCFBQ+RKiRiJawkECQ7jShFhKCFBQ+BKiRiJa8kByQ3eSlFgKCFBQ9tKiRgJbMmy2kqRYCghQUPXSokYCWxJAUkN1krRYCghQUPTSokYiWzJA8kL0UpRYSghQUPOSokYCW3JA8kLzUqRYSghQUPKSokYiW2JsslK0WEoIUFDxkqJGIltCQzFShFicEcAtcRIQGgHIUkDCEDCSUlECGDASEBoAAwABLxJCWoIQ7xJSGAAv7tIAGgBIYkCCECIQvjRBCD/95X/AL21SEBoByFJA4hDtElJRAloCEOxSUhgsUhIRABoASFJA0AaI9BAGhfQQBoL0EAaJ9GpSEBoAAwABKVJCWoIQ6ZJSGAn4KRIQGgADAAEoEmJaQhDoUlIYB3gn0hAaAAMAASbSQlpCEOcSUhgE+CaSEBoAAwABJZJiWgIQ5dJSGAJ4JVIQGgADAAEkUkJaAhDkklIYAC/AL8Av49IAGgBIYkCCECIQvjRcEcwtQNGDEYVRotIjEmIYIxIiGD/94P/iUgAaQEhCEOHSQhhCEYAaskUCECIQgbQhUiFSQhgBiBIYIRIiGB/SABqASEJAwhAiEIG0IFIQGj/IYExCEN+SUhgACAwvQC1Akb/93r/dUhAaQEhyQcIQ3NJSGEAIAC9cUgAaQEhCENvSQhhCEZAaQQhCENsSUhhCEZAaQEhCQYIQ2hJSGH/IAEhyQYIYL/zT48I4GlIAGh/IQhDZ0kIYGdIY0kIYF9IAGkBIQkECEAAKO/RXEhAaQQhiENaSUhhCEZAaQEhCQaIQ1ZJSGEIRgBpwAfADwAoB9EIRgBpASEIQ1BJCGEBIHBHACD85wFGTUgAaQEiEENLShBhEEZAadIUEENISlBhEEZAaQEiEgYQQ0RKUGH/IAhgv/NPjwjgRkgAaH8iEENEShBgREhAShBgPEgAaQEiEgQQQAAo79E5SEBpUhGQQzdKUGEQRkBpASISBpBDM0pQYQAgcEcDRgEgcEcwtQNGyB34MAEKCQItSABpASQgQytMIGFF4ClIQGkBJCBDJ0xgYSBGQGkBJCQGIEMkTGBhACAO4IQAFFmFAFxRPigG0R9MZGkBJe0ELEMcTWxhRBzgskAo7tO/80+PCOAdSABofyQgQxtMIGAbSBdMIGATSABpASQkBCBAACjv0RBIQGlACEAADkxgYSBGQGkBJCQGoEMKTGBh/zMBM/8yATL/OQE5ACm30QAgML0AMv8fACECQAAQAkAEAAAAIwFnRQAgAkCrie/NVVUAAAAwAED/DwAAACwAQKqqAAAAAAAAAAAAAA==
+  pc_init: 0x189
+  pc_uninit: 0x1e5
+  pc_program_page: 0x303
+  pc_erase_sector: 0x28d
+  pc_erase_all: 0x1ff
+  data_section_offset: 0x3e0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8018000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x2000
+      address: 0x0
+- name: py32f071xx_128
+  description: PY32F071xx 128kB Flash
+  default: true
+  instructions: QLpwR8C6cEcoIUFD6EqJGIlrybLnShFgKCFBQ+RKiRiJawkECQ7jShFhKCFBQ+BKiRiJa8kByQ3eSlFgKCFBQ9tKiRgJbMmy2kqRYCghQUPXSokYCWxJAUkN1krRYCghQUPTSokYiWzJA8kL0UpRYSghQUPOSokYCW3JA8kLzUqRYSghQUPKSokYiW2JsslK0WEoIUFDxkqJGIltCQzFShFicEcAtcRIQGgHIUkDCEDCSUlECGDASEBoAAwABLxJCWoIQ7xJSGAAv7tIAGgBIYkCCECIQvjRBCD/95X/AL21SEBoByFJA4hDtElJRAloCEOxSUhgsUhIRABoASFJA0AaI9BAGhfQQBoL0EAaJ9GpSEBoAAwABKVJCWoIQ6ZJSGAn4KRIQGgADAAEoEmJaQhDoUlIYB3gn0hAaAAMAASbSQlpCEOcSUhgE+CaSEBoAAwABJZJiWgIQ5dJSGAJ4JVIQGgADAAEkUkJaAhDkklIYAC/AL8Av49IAGgBIYkCCECIQvjRcEcwtQNGDEYVRotIjEmIYIxIiGD/94P/iUgAaQEhCEOHSQhhCEYAaskUCECIQgbQhUiFSQhgBiBIYIRIiGB/SABqASEJAwhAiEIG0IFIQGj/IYExCEN+SUhgACAwvQC1Akb/93r/dUhAaQEhyQcIQ3NJSGEAIAC9cUgAaQEhCENvSQhhCEZAaQQhCENsSUhhCEZAaQEhCQYIQ2hJSGH/IAEhyQYIYL/zT48I4GlIAGh/IQhDZ0kIYGdIY0kIYF9IAGkBIQkECEAAKO/RXEhAaQQhiENaSUhhCEZAaQEhCQaIQ1ZJSGEIRgBpwAfADwAoB9EIRgBpASEIQ1BJCGEBIHBHACD85wFGTUgAaQEiEENLShBhEEZAadIUEENISlBhEEZAaQEiEgYQQ0RKUGH/IAhgv/NPjwjgRkgAaH8iEENEShBgREhAShBgPEgAaQEiEgQQQAAo79E5SEBpUhGQQzdKUGEQRkBpASISBpBDM0pQYQAgcEcDRgEgcEcwtQNGyB34MAEKCQItSABpASQgQytMIGFF4ClIQGkBJCBDJ0xgYSBGQGkBJCQGIEMkTGBhACAO4IQAFFmFAFxRPigG0R9MZGkBJe0ELEMcTWxhRBzgskAo7tO/80+PCOAdSABofyQgQxtMIGAbSBdMIGATSABpASQkBCBAACjv0RBIQGlACEAADkxgYSBGQGkBJCQGoEMKTGBh/zMBM/8yATL/OQE5ACm30QAgML0AMv8fACECQAAQAkAEAAAAIwFnRQAgAkCrie/NVVUAAAAwAED/DwAAACwAQKqqAAAAAAAAAAAAAA==
+  pc_init: 0x189
+  pc_uninit: 0x1e5
+  pc_program_page: 0x303
+  pc_erase_sector: 0x28d
+  pc_erase_all: 0x1ff
+  data_section_offset: 0x3e0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8020000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x2000
+      address: 0x0
+- name: py32f072xx_32
+  description: PY32F072xx 32kB Flash
+  default: true
+  instructions: QLpwR8C6cEfaSdtKkWDbSZFgKCFBQ9pKiRiJa8my2UoRYCghQUPWSokYiWsJBAkO1EoRYSghQUPRSokYiWvJAckN0EpRYCghQUPNSokYCWzJssxKkWAoIUFDyUqJGAlsSQFJDcdK0WAoIUFDxEqJGIlsyQPJC8NKUWEoIUFDwEqJGAltyQPJC75KkWEoIUFDu0qJGIltibK6StFhKCFBQ7dKiRiJbQkMtkoRYnBHALW1SEBoByFJAwhAtElJRAhgsUhAaAAMAAStSQlqCEOuSUhgAL+sSABoASGJAghAiEL40QQg//eQ/wC9p0hAaAchSQOIQ6VJSUQJaAhDoklIYKJISEQAaAEhSQNAGiPQQBoX0EAaC9BAGifRm0hAaAAMAASXSQlqCEOXSUhgJ+CWSEBoAAwABJJJiWkIQ5JJSGAd4JFIQGgADAAEjUkJaQhDjUlIYBPgjEhAaAAMAASISYloCEOISUhgCeCHSEBoAAwABINJCWgIQ4NJSGAAvwC/AL+BSABoASGJAghAiEL40XBHMLUDRgxGFUb/94j/dUh1SYhgdUiIYAhGAGkBIQhDcUkIYQhGAGrJFAhAACgG0XNIdEkIYAYgSGBzSIhgACAwvQFGaEhAaQEi0gcQQ2ZKUGEAIHBHZEgAaQEhCENiSQhhCEZAaQQhCENfSUhhCEZAaQEhCQYIQ1tJSGH/IAEhyQYIYL/zT48C4GBIXUkIYFVIAGkBIQkECEAAKPXRUkhAaQQhiENQSUhhCEZAaQEhCQaIQ0xJSGEIRgBpwAfADwAoB9EIRgBpASEIQ0ZJCGEBIHBHACD85wFGQ0gAaQEiEENBShBhEEZAadIUEEM+SlBhEEZAaQEiEgYQQzpKUGH/IAhgv/NPjwLgQEg9ShBgNUgAaQEiEgQQQAAo9dEySEBpUhGQQzBKUGEQRkBpASISBpBDLEpQYQAgcEcDRgEgcEcwtQNGyB34MAEKCQImSABpASQgQyRMIGE/4CJIQGkBJCBDIExgYSBGQGkBJCQGIEMdTGBhACAO4IQAFFmFAFxRPigG0RhMZGkBJe0ELEMVTWxhRBzgskAo7tO/80+PAuAaSBdMIGAPSABpASQkBCBAACj10QxIQGlACEAACkxgYSBGQGkBJCQGoEMGTGBh/zMBM/8yATL/OQE5ACm90QAgML0jAWdFACACQKuJ780AMv8fACECQAAQAkAEAAAAVVUAAAAwAED/DwAAqqoAAAAAAAAAAAAA
+  pc_init: 0x193
+  pc_uninit: 0x1d3
+  pc_program_page: 0x2d3
+  pc_erase_sector: 0x269
+  pc_erase_all: 0x1e7
+  data_section_offset: 0x3a0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8008000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x2000
+      address: 0x0
+- name: py32f072xx_opt
+  description: PY32F072xx Flash Options
+  instructions: QLpwR8C6cEepSapKkWCqSZFgKCFBQ6lKiRiJa8myqEoRYCghQUOlSokYiWsJBAkOo0oRYSghQUOgSokYiWvJAckNn0pRYCghQUOcSokYCWzJsptKkWAoIUFDmEqJGAlsSQFJDZZK0WAoIUFDk0qJGIlsyQPJC5JKUWEoIUFDj0qJGAltyQPJC41KkWEoIUFDikqJGIltibKJStFhKCFBQ4ZKiRiJbQkMhUoRYnBHALWESEBoByFJAwhAg0lJRAhggEhAaAAMAAR8SQlqCEN9SUhgAL97SABoASGJAghAiEL40QQg//eQ/wC9dkhAaAchSQOIQ3RJSUQJaAhDcUlIYHFISEQAaAEhSQNAGiPQQBoX0EAaC9BAGifRakhAaAAMAARmSQlqCENmSUhgJ+BlSEBoAAwABGFJiWkIQ2FJSGAd4GBIQGgADAAEXEkJaQhDXElIYBPgW0hAaAAMAARXSYloCENXSUhgCeBWSEBoAAwABFJJCWgIQ1JJSGAAvwC/AL9QSABoASGJAghAiEL40XBHMLUDRgxGFUb/94j/REhESYhgREiIYEhIyGBISMhgCEYAaQEhCEM+SQhhCEYAaskUCEAAKAbRQkhDSQhgBiBIYEJIiGAAIDC9ALUCRv/3hP80SEBpASHJBwhDMUlIYQhGQGlJBAhDLklIYQAgAL0AIHBHAUYAIHBHA0YBIHBH8LUFRg5GEWiTaJRpJUgAaQEnOEMjTzhhiLI4YixIGEB4YqCy+GI4RkBpASd/BDhDHE94YThGQGkBJz8GOEMZT3hh/yAXT4A3OGC/80+PFUhAaQEnfwS4QxJPeGE4RkBpASc/BrhDD094YQAg8L1wtQNGFGiVaJZpGGigQgHQGEZwvZhoqEIC0BhGCDD455hpsEIC0BhGGDDy51gY8OcAACMBZ0UAIAJAq4nvzQAy/x8AIQJAABACQAQAAAA7KhkIf25dTFVVAAAAMABA/w8AAB8fAAAAAAAAAAAAAA==
+  pc_init: 0x193
+  pc_uninit: 0x1db
+  pc_program_page: 0x211
+  pc_erase_sector: 0x205
+  pc_erase_all: 0x201
+  data_section_offset: 0x2e4
+  flash_properties:
+    address_range:
+      start: 0x1fff3100
+      end: 0x1fff3120
+    page_size: 0x20
+    erased_byte_value: 0xff
+    program_page_timeout: 3000
+    erase_sector_timeout: 3000
+    sectors:
+    - size: 0x20
+      address: 0x0
+- name: py32f072xx_64
+  description: PY32F072xx 64kB Flash
+  default: true
+  instructions: QLpwR8C6cEfaSdtKkWDbSZFgKCFBQ9pKiRiJa8my2UoRYCghQUPWSokYiWsJBAkO1EoRYSghQUPRSokYiWvJAckN0EpRYCghQUPNSokYCWzJssxKkWAoIUFDyUqJGAlsSQFJDcdK0WAoIUFDxEqJGIlsyQPJC8NKUWEoIUFDwEqJGAltyQPJC75KkWEoIUFDu0qJGIltibK6StFhKCFBQ7dKiRiJbQkMtkoRYnBHALW1SEBoByFJAwhAtElJRAhgsUhAaAAMAAStSQlqCEOuSUhgAL+sSABoASGJAghAiEL40QQg//eQ/wC9p0hAaAchSQOIQ6VJSUQJaAhDoklIYKJISEQAaAEhSQNAGiPQQBoX0EAaC9BAGifRm0hAaAAMAASXSQlqCEOXSUhgJ+CWSEBoAAwABJJJiWkIQ5JJSGAd4JFIQGgADAAEjUkJaQhDjUlIYBPgjEhAaAAMAASISYloCEOISUhgCeCHSEBoAAwABINJCWgIQ4NJSGAAvwC/AL+BSABoASGJAghAiEL40XBHMLUDRgxGFUb/94j/dUh1SYhgdUiIYAhGAGkBIQhDcUkIYQhGAGrJFAhAACgG0XNIdEkIYAYgSGBzSIhgACAwvQFGaEhAaQEi0gcQQ2ZKUGEAIHBHZEgAaQEhCENiSQhhCEZAaQQhCENfSUhhCEZAaQEhCQYIQ1tJSGH/IAEhyQYIYL/zT48C4GBIXUkIYFVIAGkBIQkECEAAKPXRUkhAaQQhiENQSUhhCEZAaQEhCQaIQ0xJSGEIRgBpwAfADwAoB9EIRgBpASEIQ0ZJCGEBIHBHACD85wFGQ0gAaQEiEENBShBhEEZAadIUEEM+SlBhEEZAaQEiEgYQQzpKUGH/IAhgv/NPjwLgQEg9ShBgNUgAaQEiEgQQQAAo9dEySEBpUhGQQzBKUGEQRkBpASISBpBDLEpQYQAgcEcDRgEgcEcwtQNGyB34MAEKCQImSABpASQgQyRMIGE/4CJIQGkBJCBDIExgYSBGQGkBJCQGIEMdTGBhACAO4IQAFFmFAFxRPigG0RhMZGkBJe0ELEMVTWxhRBzgskAo7tO/80+PAuAaSBdMIGAPSABpASQkBCBAACj10QxIQGlACEAACkxgYSBGQGkBJCQGoEMGTGBh/zMBM/8yATL/OQE5ACm90QAgML0jAWdFACACQKuJ780AMv8fACECQAAQAkAEAAAAVVUAAAAwAED/DwAAqqoAAAAAAAAAAAAA
+  pc_init: 0x193
+  pc_uninit: 0x1d3
+  pc_program_page: 0x2d3
+  pc_erase_sector: 0x269
+  pc_erase_all: 0x1e7
+  data_section_offset: 0x3a0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8010000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x2000
+      address: 0x0
+- name: py32f072xx_96
+  description: PY32F072xx 96kB Flash
+  default: true
+  instructions: QLpwR8C6cEfaSdtKkWDbSZFgKCFBQ9pKiRiJa8my2UoRYCghQUPWSokYiWsJBAkO1EoRYSghQUPRSokYiWvJAckN0EpRYCghQUPNSokYCWzJssxKkWAoIUFDyUqJGAlsSQFJDcdK0WAoIUFDxEqJGIlsyQPJC8NKUWEoIUFDwEqJGAltyQPJC75KkWEoIUFDu0qJGIltibK6StFhKCFBQ7dKiRiJbQkMtkoRYnBHALW1SEBoByFJAwhAtElJRAhgsUhAaAAMAAStSQlqCEOuSUhgAL+sSABoASGJAghAiEL40QQg//eQ/wC9p0hAaAchSQOIQ6VJSUQJaAhDoklIYKJISEQAaAEhSQNAGiPQQBoX0EAaC9BAGifRm0hAaAAMAASXSQlqCEOXSUhgJ+CWSEBoAAwABJJJiWkIQ5JJSGAd4JFIQGgADAAEjUkJaQhDjUlIYBPgjEhAaAAMAASISYloCEOISUhgCeCHSEBoAAwABINJCWgIQ4NJSGAAvwC/AL+BSABoASGJAghAiEL40XBHMLUDRgxGFUb/94j/dUh1SYhgdUiIYAhGAGkBIQhDcUkIYQhGAGrJFAhAACgG0XNIdEkIYAYgSGBzSIhgACAwvQFGaEhAaQEi0gcQQ2ZKUGEAIHBHZEgAaQEhCENiSQhhCEZAaQQhCENfSUhhCEZAaQEhCQYIQ1tJSGH/IAEhyQYIYL/zT48C4GBIXUkIYFVIAGkBIQkECEAAKPXRUkhAaQQhiENQSUhhCEZAaQEhCQaIQ0xJSGEIRgBpwAfADwAoB9EIRgBpASEIQ0ZJCGEBIHBHACD85wFGQ0gAaQEiEENBShBhEEZAadIUEEM+SlBhEEZAaQEiEgYQQzpKUGH/IAhgv/NPjwLgQEg9ShBgNUgAaQEiEgQQQAAo9dEySEBpUhGQQzBKUGEQRkBpASISBpBDLEpQYQAgcEcDRgEgcEcwtQNGyB34MAEKCQImSABpASQgQyRMIGE/4CJIQGkBJCBDIExgYSBGQGkBJCQGIEMdTGBhACAO4IQAFFmFAFxRPigG0RhMZGkBJe0ELEMVTWxhRBzgskAo7tO/80+PAuAaSBdMIGAPSABpASQkBCBAACj10QxIQGlACEAACkxgYSBGQGkBJCQGoEMGTGBh/zMBM/8yATL/OQE5ACm90QAgML0jAWdFACACQKuJ780AMv8fACECQAAQAkAEAAAAVVUAAAAwAED/DwAAqqoAAAAAAAAAAAAA
+  pc_init: 0x193
+  pc_uninit: 0x1d3
+  pc_program_page: 0x2d3
+  pc_erase_sector: 0x269
+  pc_erase_all: 0x1e7
+  data_section_offset: 0x3a0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8018000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x2000
+      address: 0x0
+- name: py32f072xx_128
+  description: PY32F072xx 128kB Flash
+  default: true
+  instructions: QLpwR8C6cEfaSdtKkWDbSZFgKCFBQ9pKiRiJa8my2UoRYCghQUPWSokYiWsJBAkO1EoRYSghQUPRSokYiWvJAckN0EpRYCghQUPNSokYCWzJssxKkWAoIUFDyUqJGAlsSQFJDcdK0WAoIUFDxEqJGIlsyQPJC8NKUWEoIUFDwEqJGAltyQPJC75KkWEoIUFDu0qJGIltibK6StFhKCFBQ7dKiRiJbQkMtkoRYnBHALW1SEBoByFJAwhAtElJRAhgsUhAaAAMAAStSQlqCEOuSUhgAL+sSABoASGJAghAiEL40QQg//eQ/wC9p0hAaAchSQOIQ6VJSUQJaAhDoklIYKJISEQAaAEhSQNAGiPQQBoX0EAaC9BAGifRm0hAaAAMAASXSQlqCEOXSUhgJ+CWSEBoAAwABJJJiWkIQ5JJSGAd4JFIQGgADAAEjUkJaQhDjUlIYBPgjEhAaAAMAASISYloCEOISUhgCeCHSEBoAAwABINJCWgIQ4NJSGAAvwC/AL+BSABoASGJAghAiEL40XBHMLUDRgxGFUb/94j/dUh1SYhgdUiIYAhGAGkBIQhDcUkIYQhGAGrJFAhAACgG0XNIdEkIYAYgSGBzSIhgACAwvQFGaEhAaQEi0gcQQ2ZKUGEAIHBHZEgAaQEhCENiSQhhCEZAaQQhCENfSUhhCEZAaQEhCQYIQ1tJSGH/IAEhyQYIYL/zT48C4GBIXUkIYFVIAGkBIQkECEAAKPXRUkhAaQQhiENQSUhhCEZAaQEhCQaIQ0xJSGEIRgBpwAfADwAoB9EIRgBpASEIQ0ZJCGEBIHBHACD85wFGQ0gAaQEiEENBShBhEEZAadIUEEM+SlBhEEZAaQEiEgYQQzpKUGH/IAhgv/NPjwLgQEg9ShBgNUgAaQEiEgQQQAAo9dEySEBpUhGQQzBKUGEQRkBpASISBpBDLEpQYQAgcEcDRgEgcEcwtQNGyB34MAEKCQImSABpASQgQyRMIGE/4CJIQGkBJCBDIExgYSBGQGkBJCQGIEMdTGBhACAO4IQAFFmFAFxRPigG0RhMZGkBJe0ELEMVTWxhRBzgskAo7tO/80+PAuAaSBdMIGAPSABpASQkBCBAACj10QxIQGlACEAACkxgYSBGQGkBJCQGoEMGTGBh/zMBM/8yATL/OQE5ACm90QAgML0jAWdFACACQKuJ780AMv8fACECQAAQAkAEAAAAVVUAAAAwAED/DwAAqqoAAAAAAAAAAAAA
+  pc_init: 0x193
+  pc_uninit: 0x1d3
+  pc_program_page: 0x2d3
+  pc_erase_sector: 0x269
+  pc_erase_all: 0x1e7
+  data_section_offset: 0x3a0
+  flash_properties:
+    address_range:
+      start: 0x8000000
+      end: 0x8020000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 600
+    erase_sector_timeout: 6000
+    sectors:
+    - size: 0x2000
+      address: 0x0


### PR DESCRIPTION
Adding support for PY32F0 series chip.

Generated via target-gen from https://www.puyasemi.com/uploadfiles/2023/PY32F030-PY32F003-PY32F002A-230410.rar
(Puya.PY32F0xx_DFP.1.1.7.pack inside)

Tested and working with cargo-embed/cargo-flash and cmsis-dap on PY32F002AF15P6.