### PR TITLE
fix(embed): enable turning off logging messages

### DIFF
--- a/cargo-embed/CHANGELOG.md
+++ b/cargo-embed/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow setting `log_level = "OFF"` in the `.embed.toml` file.
+
 ## [0.18.0]
 
 Released 2023-03-31

--- a/cargo-embed/src/config/mod.rs
+++ b/cargo-embed/src/config/mod.rs
@@ -67,7 +67,7 @@ pub struct Reset {
 pub struct General {
     pub chip: Option<String>,
     pub chip_descriptions: Vec<String>,
-    pub log_level: log::Level,
+    pub log_level: log::LevelFilter,
     pub derives: Option<String>,
     /// Use this flag to assert the nreset & ntrst pins during attaching the probe to the chip.
     pub connect_under_reset: bool,

--- a/cargo-embed/src/main.rs
+++ b/cargo-embed/src/main.rs
@@ -177,7 +177,9 @@ fn main_try(metadata: Arc<Mutex<Metadata>>, offset: UtcOffset) -> Result<()> {
     let configs = config::Configs::new(work_dir.clone());
     let config = configs.select_defined(config_name)?;
 
-    logging::init(Some(config.general.log_level));
+    if config.general.log_level != log::LevelFilter::Off {
+        logging::init(config.general.log_level.to_level());
+    }
 
     // Make sure we load the config given in the cli parameters.
     for cdp in &config.general.chip_descriptions {


### PR DESCRIPTION
The documentation of the default.toml embed configuration suggests, that to turn of logging, one must change log_level to "OFF".

    Error Failed to parse supplied configuration:
        unknown variant: found `OFF`, expected `one of `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`` for key "default.general.log_level" in

This does not work yet, as this options is parsed to `log::Level`, which does not contain such option. Change it to `log::LogLevel` to enable this otpion.