### PR TITLE
probe-rs-cli: add a simple profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `dap-server`: In addition to `Elf` format, this adds support for binary formats `Bin`, `Hex`, and `Idf` (#1656).
 - Added PAC55XX series targets (#1655)
+- Added a simple profiler to the probe-rs cli toolkit (#1628)
 
 
 ### Fixed
@@ -199,7 +200,7 @@ Released 2023-01-28
 - target-gen: Add a command which enables the easy development and debugging of a flash algorithm.
 
   `target-gen test` is a new command to automatically upload, run, print RTT messages and test
-  a flash algorithm. Have a look at the [template](https://github.com/probe-rs/flash-algorithm-template)
+  a flash algorithm. Have a look at the - Added a simple profiler to the probe-rs cli toolkit (#1628)[template](https://github.com/probe-rs/flash-algorithm-template)
   to create a new flash algorithm.
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "static_assertions",
- "strum",
  "svd-parser",
  "svg",
  "terminal_size 0.2.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "cpp_demangle",
+ "fallible-iterator",
+ "gimli",
+ "memmap2",
+ "object 0.31.1",
+ "rustc-demangle",
+ "smallvec",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,7 +232,7 @@ version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
- "addr2line",
+ "addr2line 0.19.0",
  "cc",
  "cfg-if",
  "libc",
@@ -646,6 +661,15 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee34052ee3d93d6d8f3e6f81d85c47921f6653a19a7b70e939e3e602d893a674"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1974,6 +1998,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "miette"
 version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,7 +2187,9 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
+ "flate2",
  "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -2396,6 +2431,7 @@ dependencies = [
 name = "probe-rs"
 version = "0.19.0"
 dependencies = [
+ "addr2line 0.20.0",
  "anyhow",
  "base64 0.21.2",
  "bincode",
@@ -2452,6 +2488,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "static_assertions",
+ "strum",
  "svd-parser",
  "svg",
  "terminal_size 0.2.6",
@@ -2863,6 +2900,17 @@ dependencies = [
  "unicode-width",
  "utf8parse",
  "winapi",
+]
+
+[[package]]
+name = "ruzstd"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
+dependencies = [
+ "byteorder",
+ "thiserror",
+ "twox-hash",
 ]
 
 [[package]]
@@ -3808,6 +3856,16 @@ dependencies = [
  "crossterm",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -166,7 +166,6 @@ tui = { version = "0.19.0", default-features = false, features = ["crossterm"], 
 bytesize = { version = "1", optional = true }
 textwrap = { version = "0.16.0", optional = true }
 addr2line = { version = "0.20.0", optional = true }
-strum = { version = "0.24.1", features = ["derive"], optional= true }
 
 [build-dependencies]
 bincode = "1.3.3"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -70,6 +70,7 @@ cli = [
     "dep:tui",
     "dep:bytesize",
     "dep:textwrap",
+    "dep:addr2line",
 ]
 
 vendored-libusb = ["rusb/vendored"]
@@ -164,6 +165,8 @@ crossterm = { version = "<= 0.26.1", optional = true }
 tui = { version = "0.19.0", default-features = false, features = ["crossterm"], optional = true }
 bytesize = { version = "1", optional = true }
 textwrap = { version = "0.16.0", optional = true }
+addr2line = { version = "0.20.0", optional = true }
+strum = { version = "0.24.1", features = ["derive"], optional= true }
 
 [build-dependencies]
 bincode = "1.3.3"

--- a/probe-rs/src/architecture/arm/component/dwt.rs
+++ b/probe-rs/src/architecture/arm/component/dwt.rs
@@ -91,6 +91,15 @@ impl<'a> Dwt<'a> {
         ctrl.set_exctrcena(false);
         ctrl.store(self.component, self.interface)
     }
+
+    /// Enable PC sample trace output
+    pub fn enable_pc_sampling(&mut self) -> Result<(), ArmError> {
+        let mut ctrl = Ctrl::load(self.component, self.interface)?;
+        ctrl.set_pcsamplena(true);
+        ctrl.set_cyctap(true);
+        ctrl.set_postpreset(0x3);
+        ctrl.store(self.component, self.interface)
+    }
 }
 
 memory_mapped_bitfield_register! {

--- a/probe-rs/src/bin/probe-rs/cmd.rs
+++ b/probe-rs/src/bin/probe-rs/cmd.rs
@@ -13,4 +13,5 @@ pub mod itm;
 pub mod list;
 pub mod reset;
 pub mod run;
+pub mod profile;
 pub mod trace;

--- a/probe-rs/src/bin/probe-rs/cmd.rs
+++ b/probe-rs/src/bin/probe-rs/cmd.rs
@@ -11,7 +11,7 @@ pub mod gdb;
 pub mod info;
 pub mod itm;
 pub mod list;
+pub mod profile;
 pub mod reset;
 pub mod run;
-pub mod profile;
 pub mod trace;

--- a/probe-rs/src/bin/probe-rs/cmd/profile.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/profile.rs
@@ -6,7 +6,11 @@ use std::time::Duration;
 use anyhow::Context;
 use itm::TracePacket;
 use probe_rs::{
-    architecture::arm::{component::{TraceSink, Dwt, find_component}, SwoConfig, DpAddress, memory::PeripheralType},
+    architecture::arm::{
+        component::{find_component, Dwt, TraceSink},
+        memory::PeripheralType,
+        DpAddress, SwoConfig,
+    },
     flashing::{FileDownloadError, Format},
 };
 use time::Instant;
@@ -153,14 +157,9 @@ impl Cmd {
                 let iter = decoder.singles();
 
                 for packet in iter {
-                    match packet? {
-                        TracePacket::PCSample { pc } => {
-                            if let Some(pc) = pc {
-                                *samples.entry(pc).or_insert(1) += 1;
-                                reads += 1;
-                            }
-                        }
-                        _ => {}, // ignore other packets
+                    if let TracePacket::PCSample { pc: Some(pc) } = packet? {
+                        *samples.entry(pc).or_insert(1) += 1;
+                        reads += 1;
                     }
                     if Instant::now() - start > duration {
                         break;

--- a/probe-rs/src/bin/probe-rs/cmd/profile.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/profile.rs
@@ -1,0 +1,205 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Context;
+use probe_rs::flashing::{FileDownloadError, Format};
+use time::Instant;
+
+use addr2line::{
+    gimli::{EndianRcSlice, RunTimeEndian},
+    object::{read::File as ObjectFile, Object},
+    Context as ObjectContext, LookupResult,
+};
+
+use crate::util::common_options::{CargoOptions, FlashOptions};
+use crate::util::flash::run_flash_download;
+use tracing::info;
+
+#[derive(clap::Parser)]
+pub struct Cmd {
+    #[clap(flatten)]
+    run: super::run::Cmd,
+    /// Flash the ELF before profiling
+    #[clap(long)]
+    flash: bool,
+    /// Print file and line info for each entry
+    #[clap(long)]
+    line_info: bool,
+    /// Duration of profile in seconds.
+    #[clap(long)]
+    duration: u64, // Option<u64> If we could catch ctrl-c we can make this optional
+    /// Which core to profile
+    #[clap(long, default_value_t = 0)]
+    core: usize,
+    /// Limit the number of entries to output
+    #[clap(long, default_value_t = 25)]
+    limit: usize,
+    #[clap(long, default_value_t = ProfileMethod::Naive)]
+    /// Profile Method
+    method: ProfileMethod,
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ProfileMethod {
+    /// Naive, Halt -> Read PC -> Resume profiler
+    Naive,
+}
+
+impl core::fmt::Display for ProfileMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let s = format!("{:?}", self);
+        write!(f, "{}", s.to_lowercase())
+    }
+}
+
+impl Cmd {
+    pub fn run(self) -> anyhow::Result<()> {
+        let mut session = self.run.common.simple_attach()?;
+
+        let mut file = match File::open(&self.run.path) {
+            Ok(file) => file,
+            Err(e) => return Err(FileDownloadError::IO(e)).context("Failed to open binary file."),
+        };
+
+        let mut loader = session.target().flash_loader();
+
+        let format = self.run.format_options.into_format()?;
+        match format {
+            Format::Bin(options) => loader.load_bin_data(&mut file, options),
+            Format::Elf => loader.load_elf_data(&mut file),
+            Format::Hex => loader.load_hex_data(&mut file),
+            Format::Idf(options) => loader.load_idf_data(&mut session, &mut file, options),
+        }?;
+
+        let bytes = std::fs::read(&self.run.path)?;
+        let symbols = Symbols::try_from(&bytes)?;
+
+        if self.flash {
+            run_flash_download(
+                &mut session,
+                Path::new(&self.run.path),
+                &FlashOptions {
+                    disable_progressbars: false,
+                    disable_double_buffering: self.run.disable_double_buffering,
+                    reset_halt: false,
+                    log: None,
+                    restore_unwritten: false,
+                    flash_layout_output_path: None,
+                    elf: None,
+                    work_dir: None,
+                    cargo_options: CargoOptions::default(),
+                    probe_options: self.run.common,
+                },
+                loader,
+                self.run.chip_erase,
+            )?;
+        }
+
+        let mut core = session.core(self.core)?;
+        info!("Attached to Core {}", self.core);
+        core.reset()?;
+
+        let start = Instant::now();
+        let mut reads = 0;
+        let mut samples: HashMap<u32, u64> = HashMap::with_capacity(256 * (self.duration as usize));
+        let duration = Duration::from_secs(self.duration);
+        let pc_reg = core.program_counter();
+        info!("Profiling...");
+        loop {
+            core.halt(std::time::Duration::from_millis(10))?;
+            let pc: u32 = core.read_core_reg(pc_reg)?;
+            *samples.entry(pc).or_insert(1) += 1;
+            reads += 1;
+            core.run()?;
+            if Instant::now() - start > duration {
+                break;
+            }
+        }
+
+        let mut v = Vec::from_iter(samples);
+        // sort by frequency
+        v.sort_by(|&(_, a), &(_, b)| b.cmp(&a));
+
+        for (address, count) in v.into_iter().take(self.limit) {
+            let name = symbols
+                .get_name(address as u64)
+                .unwrap_or(format!("UNKNOWN - {:08X}", address));
+            let (file, num) = symbols
+                .get_location(address as u64)
+                .unwrap_or(("UNKNOWN".to_owned(), 0));
+            if self.line_info {
+                println!("{}:{}", file, num);
+            }
+            println!(
+                "{:>50} - {:.01}%",
+                name,
+                (count as f64 / reads as f64) * 100.0
+            );
+        }
+
+        Ok(())
+    }
+}
+
+// Wrapper around addr2line that allows to look up function names
+pub(crate) struct Symbols<'sym> {
+    file: ObjectFile<'sym, &'sym [u8]>,
+    ctx: ObjectContext<EndianRcSlice<RunTimeEndian>>,
+}
+
+impl<'sym> Symbols<'sym> {
+    pub fn try_from(bytes: &'sym [u8]) -> anyhow::Result<Self> {
+        let file = ObjectFile::parse(bytes)?;
+        let ctx = ObjectContext::new(&file)?;
+
+        Ok(Self { file, ctx })
+    }
+
+    /// Returns the name of the function at the given address, if one can be found.
+    pub fn get_name(&self, addr: u64) -> Option<String> {
+        // The basic steps here are:
+        //   1. find which frame `addr` is in
+        //   2. look up and demangle the function name
+        //   3. if no function name is found, try to look it up in the object file
+        //      directly
+        //   4. return a demangled function name, if one was found
+        let mut frames = match self.ctx.find_frames(addr) {
+            LookupResult::Output(result) => result.unwrap(),
+            LookupResult::Load { .. } => unimplemented!(),
+        };
+
+        frames
+            .next()
+            .ok()
+            .flatten()
+            .and_then(|frame| {
+                frame
+                    .function
+                    .and_then(|name| name.demangle().map(|s| s.into_owned()).ok())
+            })
+            .or_else(|| {
+                self.file
+                    .symbol_map()
+                    .get(addr)
+                    .map(|sym| sym.name().to_string())
+            })
+    }
+
+    /// Returns the file name and line number of the function at the given address, if one can be.
+    pub fn get_location(&self, addr: u64) -> Option<(String, u32)> {
+        // Find the location which `addr` is in. If we can dedetermine a file name and
+        // line number for this function we will return them both in a tuple.
+        self.ctx.find_location(addr).ok()?.map(|location| {
+            let file = location.file.map(|f| f.to_string());
+            let line = location.line;
+
+            match (file, line) {
+                (Some(file), Some(line)) => Some((file, line)),
+                _ => None,
+            }
+        })?
+    }
+}

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -15,21 +15,21 @@ use crate::FormatOptions;
 #[derive(clap::Parser)]
 pub struct Cmd {
     #[clap(flatten)]
-    common: ProbeOptions,
+    pub(crate) common: ProbeOptions,
 
     /// The path to the ELF file to flash and run
-    path: String,
+    pub(crate) path: String,
 
     /// Whether to erase the entire chip before downloading
     #[clap(long)]
-    chip_erase: bool,
+    pub(crate) chip_erase: bool,
 
     /// Disable double-buffering when downloading flash.  If downloading times out, try this option.
     #[clap(long = "disable-double-buffering")]
-    disable_double_buffering: bool,
+    pub(crate) disable_double_buffering: bool,
 
     #[clap(flatten)]
-    format_options: FormatOptions,
+    pub(crate) format_options: FormatOptions,
 }
 
 impl Cmd {

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -70,6 +70,7 @@ enum Subcommand {
     Itm(cmd::itm::Cmd),
     Chip(cmd::chip::Cmd),
     Benchmark(cmd::benchmark::Cmd),
+    Profile(cmd::profile::Cmd),
 }
 
 /// Shared options for core selection, shared between commands
@@ -254,6 +255,7 @@ fn main() -> Result<()> {
         Subcommand::Itm(cmd) => cmd.run(),
         Subcommand::Chip(cmd) => cmd.run(),
         Subcommand::Benchmark(cmd) => cmd.run(),
+        Subcommand::Profile(cmd) => cmd.run(),
     };
 
     tracing::info!("Wrote log to {:?}", log_path);


### PR DESCRIPTION
This PR adds a very naive profiler to the cli toolkit, the output looks something like this:

![image](https://github.com/probe-rs/probe-rs/assets/6977289/fba52911-551c-4fd7-9aa8-c447f2d63af0)

As discussed in matrix, there are several ways to improve this, but these are arch specific. For example, on RISCV, once we have support for the quick access abstract command interface we can poll the PC without halting the core. I'm sure there are ARM equivalents, and of course, we could plug this into SWO output too.
