### PR TITLE
probe-rs-debugger: Fix MS DAP Request `setBrakpoints` cleared too many breakpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - probe-rs-debugger: Show errors that happen before VSCode/DAP Client session initializion has completed (#1581).
 - probe-rs-cli-util: replace unwanted instance of `println` with `eprintln` (#1595, fixes #1593).
 - stlink: exit JTAG mode on idle to tristate debug interface (#1615).
+- probe-rs-debugger: The MS DAP Request `setBreapoints` clears existing breakpoints for the specified `Source`, and not for all `Source` 's (#1630)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - probe-rs-debugger: Show errors that happen before VSCode/DAP Client session initializion has completed (#1581).
 - probe-rs-cli-util: replace unwanted instance of `println` with `eprintln` (#1595, fixes #1593).
 - stlink: exit JTAG mode on idle to tristate debug interface (#1615).
-- probe-rs-debugger: The MS DAP Request `setBreapoints` clears existing breakpoints for the specified `Source`, and not for all `Source` 's (#1630)
+- probe-rs-debugger: The MS DAP Request `setBreapoints` clears existing breakpoints for the specified `Source`, and not for all `Source`'s (#1630)
 
 ### Added
 

--- a/debugger/src/debug_adapter/dap/adapter.rs
+++ b/debugger/src/debug_adapter/dap/adapter.rs
@@ -13,7 +13,11 @@ use crate::{
         },
         protocol::ProtocolAdapter,
     },
-    server::{configuration::ConsoleLog, core_data::CoreHandle, session_data::BreakpointType},
+    server::{
+        configuration::ConsoleLog,
+        core_data::CoreHandle,
+        session_data::{BreakpointType, SourceLocationScope},
+    },
     DebuggerError,
 };
 use anyhow::{anyhow, Result};
@@ -770,9 +774,10 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         if let Some(source_path) = args.source.path.as_ref().map(Path::new) {
             // Always clear existing breakpoints for the specified `[crate::debug_adapter::dap_types::Source]` before setting new ones.
             // The DAP Specification doesn't make allowances for deleting and setting individual breakpoints for a specific `Source`.
-            match target_core
-                .clear_breakpoints(BreakpointType::SourceBreakpoint(args.source.clone(), None))
-            {
+            match target_core.clear_breakpoints(BreakpointType::SourceBreakpoint {
+                source: args.source.clone(),
+                location: SourceLocationScope::All,
+            }) {
                 Ok(_) => {}
                 Err(error) => {
                     return self.send_response::<()>(

--- a/debugger/src/debug_adapter/dap/adapter.rs
+++ b/debugger/src/debug_adapter/dap/adapter.rs
@@ -767,7 +767,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
         let mut created_breakpoints: Vec<Breakpoint> = Vec::new(); // For returning in the Response
 
-        if let Some(source_path) = args.source.clone().path.as_ref().map(Path::new) {
+        if let Some(source_path) = args.source.path.as_ref().map(Path::new) {
             // Always clear existing breakpoints for the specified `[crate::debug_adapter::dap_types::Source]` before setting new ones.
             // The DAP Specification doesn't make allowances for deleting and setting individual breakpoints for a specific `Source`.
             match target_core

--- a/debugger/src/debug_adapter/dap/debugProtocol.json
+++ b/debugger/src/debug_adapter/dap/debugProtocol.json
@@ -2126,11 +2126,11 @@
 				},
 				"start": {
 					"type": "integer",
-					"description": "The index of the first variable to return; if omitted children start at 0."
+					"description": "The index of the first variable to return; if omitted children start at 0.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsVariablePaging` is true."
 				},
 				"count": {
 					"type": "integer",
-					"description": "The number of variables to return. If count is missing or 0, all variables are returned."
+					"description": "The number of variables to return. If count is missing or 0, all variables are returned.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsVariablePaging` is true."
 				},
 				"format": {
 					"$ref": "#/definitions/ValueFormat",
@@ -3374,20 +3374,6 @@
 				}
 			},
 			"required": [ "attributeName", "label"]
-		},
-
-		"ModulesViewDescriptor": {
-			"type": "object",
-			"description": "The ModulesViewDescriptor is the container for all declarative configuration options of a module view.\nFor now it only specifies the columns to be shown in the modules view.",
-			"properties": {
-				"columns": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/ColumnDescriptor"
-					}
-				}
-			},
-			"required": [ "columns" ]
 		},
 
 		"Thread": {

--- a/debugger/src/server/core_data.rs
+++ b/debugger/src/server/core_data.rs
@@ -288,7 +288,7 @@ impl<'p> CoreHandle<'p> {
                  || matches!(
                         &target_breakpoint.breakpoint_type,
                         BreakpointType::SourceBreakpoint{source: breakpoint_source, location: _}
-                            if matches!(&breakpoint_type, BreakpointType::SourceBreakpoint{source: clear_breakpoint_source, location:_}
+                            if matches!(&breakpoint_type, BreakpointType::SourceBreakpoint{source: clear_breakpoint_source, ..}
                                 if clear_breakpoint_source == breakpoint_source)
                     )
             })

--- a/debugger/src/server/core_data.rs
+++ b/debugger/src/server/core_data.rs
@@ -287,7 +287,7 @@ impl<'p> CoreHandle<'p> {
                 target_breakpoint.breakpoint_type == breakpoint_type
                  || matches!(
                         &target_breakpoint.breakpoint_type,
-                        BreakpointType::SourceBreakpoint(breakpoint_source, _) 
+                        BreakpointType::SourceBreakpoint(breakpoint_source, _)
                             if matches!(&breakpoint_type, BreakpointType::SourceBreakpoint(clear_breakpoint_source, _)
                                 if clear_breakpoint_source == breakpoint_source)
                     )

--- a/debugger/src/server/core_data.rs
+++ b/debugger/src/server/core_data.rs
@@ -288,7 +288,7 @@ impl<'p> CoreHandle<'p> {
                  || matches!(
                         &target_breakpoint.breakpoint_type,
                         BreakpointType::SourceBreakpoint(breakpoint_source, _) 
-                            if matches!(&breakpoint_type, BreakpointType::SourceBreakpoint(clear_breakpoint_source, _) 
+                            if matches!(&breakpoint_type, BreakpointType::SourceBreakpoint(clear_breakpoint_source, _)
                                 if clear_breakpoint_source == breakpoint_source)
                     )
             })

--- a/debugger/src/server/session_data.rs
+++ b/debugger/src/server/session_data.rs
@@ -25,7 +25,7 @@ pub enum BreakpointType {
     InstructionBreakpoint,
     /// A breakpoint was requested using a source location, and usually a result of a user requesting a
     /// breakpoint while in a 'source' view.
-    SourceBreakpoint(Source, SourceLocation),
+    SourceBreakpoint(Source, Option<SourceLocation>),
 }
 
 /// Provide the storage and methods to handle various [`BreakpointType`]

--- a/debugger/src/server/session_data.rs
+++ b/debugger/src/server/session_data.rs
@@ -23,10 +23,19 @@ pub(crate) enum BreakpointType {
     /// A breakpoint was requested using an instruction address, and usually a result of a user requesting a
     /// breakpoint while in a 'disassembly' view.
     InstructionBreakpoint,
-    /// A breakpoint was requested using a source location, and usually a result of a user requesting a
-    /// breakpoint while in a 'source' view.
-    /// Note: SourceLocation is optional, and when `None`, can be used to identify all breakpoints for a `Source`, as is required by MS DAP `setBreakPoints` request.
-    SourceBreakpoint(Source, Option<SourceLocation>),
+    /// A breakpoint that has a Source, and usually a result of a user requesting a breakpoint while in a 'source' view.
+    SourceBreakpoint {
+        source: Source,
+        location: SourceLocationScope,
+    },
+}
+
+/// Breakpoint requests will either be refer to a specific SourceLcoation, or unspecified, in which case it will refer to
+/// all breakpoints for the Source.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum SourceLocationScope {
+    All,
+    Specific(SourceLocation),
 }
 
 /// Provide the storage and methods to handle various [`BreakpointType`]

--- a/debugger/src/server/session_data.rs
+++ b/debugger/src/server/session_data.rs
@@ -19,18 +19,19 @@ use time::UtcOffset;
 
 /// The supported breakpoint types
 #[derive(Clone, Debug, PartialEq)]
-pub enum BreakpointType {
+pub(crate) enum BreakpointType {
     /// A breakpoint was requested using an instruction address, and usually a result of a user requesting a
     /// breakpoint while in a 'disassembly' view.
     InstructionBreakpoint,
     /// A breakpoint was requested using a source location, and usually a result of a user requesting a
     /// breakpoint while in a 'source' view.
+    /// Note: SourceLocation is optional, and when `None`, can be used to identify all breakpoints for a `Source`, as is required by MS DAP `setBreakPoints` request.
     SourceBreakpoint(Source, Option<SourceLocation>),
 }
 
 /// Provide the storage and methods to handle various [`BreakpointType`]
 #[derive(Clone, Debug)]
-pub struct ActiveBreakpoint {
+pub(crate) struct ActiveBreakpoint {
     pub(crate) breakpoint_type: BreakpointType,
     pub(crate) address: u64,
 }
@@ -38,7 +39,7 @@ pub struct ActiveBreakpoint {
 /// SessionData is designed to be similar to [probe_rs::Session], in as much that it provides handles to the [CoreHandle] instances for each of the available [probe_rs::Core] involved in the debug session.
 /// To get access to the [CoreHandle] for a specific [probe_rs::Core], the
 /// TODO: Adjust [SessionConfig] to allow multiple cores (and if appropriate, their binaries) to be specified.
-pub struct SessionData {
+pub(crate) struct SessionData {
     pub(crate) session: Session,
     /// [SessionData] will manage one [CoreData] per target core, that is also present in [SessionConfig::core_configs]
     pub(crate) core_data: Vec<CoreData>,

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -351,7 +351,7 @@ impl Probe {
         Session::new(self, target.into(), AttachMethod::UnderReset, permissions).map_err(|e| {
             if matches!(e, Error::Arm(ArmError::Timeout) | Error::Riscv(RiscvError::Timeout)) {
                 Error::Other(
-                anyhow::anyhow!("Timeout while attaching to target under reset. This can happen if the target is not responding to the reset sequence. Ensure the chip's reset pin is connected, or try attaching without reset."))
+                anyhow::anyhow!("Timeout while attaching to target under reset. This can happen if the target is not responding to the reset sequence. Ensure the chip's reset pin is connected, or try attaching without reset (`connectUnderReset = false` for DAP Clients, or remove `connect-under-reset` option from CLI options.)."))
             } else {
                 e
             }


### PR DESCRIPTION
- Updated MS DAP Protocol to version 1.61.0

- Fix an "unreported" issue, where the MS DAP Request `setBreapoints` cleared breakpoints for all `Source` 's, instead of only clearing existing breakpoints for the specified `Source`.