### PR TITLE
esp-usb-serial-jtag: Add write batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,6 +333,7 @@ Released 2023-01-13
 - Added FPU register support for Cortex-A cores (#1154)
 - GDB now reports the core name in `info threads` (#1158)
 - Added a recover sequence for the nRF9160 (#1169)
+- Added support for `JTAGAccess::write_register_batch` the esp-serial-jtag probe (#1633)
 
 ### Changed
 

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -842,6 +842,7 @@ pub trait JTAGAccess: DebugProbe {
         &mut self,
         writes: &[JtagWriteCommand],
     ) -> Result<Vec<CommandResult>, BatchExecutionError> {
+        tracing::warn!("Using default `JTAGAccess::write_register_batch` this will hurt performance. Please implement proper batching for this probe.");
         let mut results = Vec::new();
 
         for write in writes {

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -842,7 +842,7 @@ pub trait JTAGAccess: DebugProbe {
         &mut self,
         writes: &[JtagWriteCommand],
     ) -> Result<Vec<CommandResult>, BatchExecutionError> {
-        tracing::warn!("Using default `JTAGAccess::write_register_batch` this will hurt performance. Please implement proper batching for this probe.");
+        tracing::debug!("Using default `JTAGAccess::write_register_batch` this will hurt performance. Please implement proper batching for this probe.");
         let mut results = Vec::new();
 
         for write in writes {

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -33,8 +33,6 @@ pub(crate) struct EspUsbJtag {
     jtag_idle_cycles: u8,
 
     current_ir_reg: u32,
-
-    speed_khz: u32,
 }
 
 impl EspUsbJtag {
@@ -244,7 +242,6 @@ impl EspUsbJtag {
 
         let tdi_enter_idle = [false, false];
 
-        // TODO: TDI data
         let mut tdi =
             Vec::with_capacity(tdi_enter_shift.len() + tdi_enter_idle.len() + register_bits);
 
@@ -442,7 +439,6 @@ impl DebugProbe for EspUsbJtag {
             protocol,
             jtag_idle_cycles: 0,
             current_ir_reg: 1,
-            speed_khz: 0,
         }))
     }
 
@@ -463,11 +459,12 @@ impl DebugProbe for EspUsbJtag {
     }
 
     fn speed_khz(&self) -> u32 {
-        self.speed_khz
+        self.protocol.base_speed_khz / self.protocol.div_min as u32
     }
 
     fn set_speed(&mut self, speed_khz: u32) -> Result<u32, DebugProbeError> {
         // TODO:
+        // can only go lower, base speed it max of 40000khz
 
         Ok(speed_khz)
     }

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     DebugProbe, DebugProbeError, DebugProbeSelector, WireProtocol,
 };
 
-use self::protocol::ProtocolHandler;
+use self::protocol::{BitIter, ProtocolHandler};
 
 use super::JTAGAccess;
 
@@ -64,6 +64,7 @@ impl EspUsbJtag {
         tms.extend(iter::repeat(false).take(self.idle_cycles() as usize));
 
         let mut response = self.protocol.jtag_io(tms, tdi, true)?;
+        let mut response = response.iter();
 
         tracing::trace!("Response: {:?}", response);
 
@@ -94,6 +95,24 @@ impl EspUsbJtag {
     /// will be truncated to `len` bits. If data has less
     /// than `len` bits, an error will be returned.
     fn write_ir(&mut self, data: &[u8], len: usize) -> Result<(), DebugProbeError> {
+        if len >= 8 {
+            return Err(DebugProbeError::NotImplemented(
+                "Not yet implemented for IR registers larger than 8 bit",
+            ));
+        }
+
+        self.prepare_write_ir(data, len)?;
+        let response = self.protocol.flush()?;
+        tracing::trace!("Response: {:?}", response);
+
+        // TODO: Why only store the first 8 bits?
+        self.current_ir_reg = data[0] as u32;
+
+        // Maybe we could return the previous state of the IR register here...
+        Ok(())
+    }
+
+    fn prepare_write_ir(&mut self, data: &[u8], len: usize) -> Result<usize, DebugProbeError> {
         tracing::debug!("Write IR: {:?}, len={}", data, len);
 
         // Check the bit length, enough data has to be
@@ -160,25 +179,52 @@ impl EspUsbJtag {
         tracing::trace!("tms: {:?}", tms);
         tracing::trace!("tdi: {:?}", tdi);
 
-        let response = self.protocol.jtag_io(tms, tdi, true)?;
+        let len = tms.len();
+        self.protocol.jtag_io_async(tms, tdi, true)?;
 
-        tracing::trace!("Response: {:?}", response);
-
-        if len >= 8 {
-            return Err(DebugProbeError::NotImplemented(
-                "Not yet implemented for IR registers larger than 8 bit",
-            ));
-        }
-
-        // TODO: Why only store the first 8 bits?
-        self.current_ir_reg = data[0] as u32;
-
-        // Maybe we could return the previous state of the IR register here...
-
-        Ok(())
+        Ok(len)
     }
 
     fn write_dr(&mut self, data: &[u8], register_bits: usize) -> Result<Vec<u8>, DebugProbeError> {
+        self.prepare_write_dr(data, register_bits)?;
+        let mut response = self.protocol.flush()?;
+        self.recieve_write_dr(response.iter(), register_bits)
+    }
+
+    fn recieve_write_dr(
+        &mut self,
+        mut response: BitIter,
+        register_bits: usize,
+    ) -> Result<Vec<u8>, DebugProbeError> {
+        let tms_enter_shift = [true, false, false]; // TODO taken from below, make a const in future
+
+        let _remainder = response.split_off(tms_enter_shift.len());
+
+        let mut remaining_bits = register_bits;
+
+        let mut result = Vec::new();
+
+        while remaining_bits >= 8 {
+            let byte = bits_to_byte(response.split_off(8)) as u8;
+            result.push(byte);
+            remaining_bits -= 8;
+        }
+
+        // Handle leftover bytes
+        if remaining_bits > 0 {
+            result.push(bits_to_byte(response.split_off(remaining_bits)) as u8);
+        }
+
+        tracing::trace!("result: {:?}", result);
+
+        Ok(result)
+    }
+
+    fn prepare_write_dr(
+        &mut self,
+        data: &[u8],
+        register_bits: usize,
+    ) -> Result<usize, DebugProbeError> {
         tracing::debug!("Write DR: {:?}, len={}", data, register_bits);
 
         let tms_enter_shift = [true, false, false];
@@ -233,31 +279,52 @@ impl EspUsbJtag {
         tms.extend(iter::repeat(false).take(self.idle_cycles() as usize));
         tdi.extend(iter::repeat(false).take(self.idle_cycles() as usize));
 
-        let mut response = self.protocol.jtag_io(tms, tdi, true)?;
+        let len = tms.len();
+        self.protocol.jtag_io_async(tms, tdi, true)?;
 
-        tracing::trace!("Response: {:?}", response);
-
-        let _remainder = response.split_off(tms_enter_shift.len());
-
-        let mut remaining_bits = register_bits;
-
-        let mut result = Vec::new();
-
-        while remaining_bits >= 8 {
-            let byte = bits_to_byte(response.split_off(8)) as u8;
-            result.push(byte);
-            remaining_bits -= 8;
-        }
-
-        // Handle leftover bytes
-        if remaining_bits > 0 {
-            result.push(bits_to_byte(response.split_off(remaining_bits)) as u8);
-        }
-
-        tracing::trace!("result: {:?}", result);
-
-        Ok(result)
+        Ok(len)
     }
+
+    /// Write the data register
+    fn prepare_write_register(
+        &mut self,
+        address: u32,
+        data: &[u8],
+        len: u32,
+    ) -> Result<DeferredRegisterWrite, DebugProbeError> {
+        let address_bits = address.to_le_bytes();
+
+        // TODO: This is limited to 5 bit addresses for now
+        if address > 0x1f {
+            return Err(DebugProbeError::NotImplemented(
+                "JTAG Register addresses are fixed to 5 bits",
+            ));
+        }
+
+        let write_ir_bits = if self.current_ir_reg != address {
+            // Write IR register
+            let def = self.prepare_write_ir(&address_bits[..1], 5)?;
+            self.current_ir_reg = data[0] as u32;
+            Some(def)
+        } else {
+            None
+        };
+
+        // write DR register
+        let write_dr_bits_total = self.prepare_write_dr(data, len as usize)?;
+
+        Ok(DeferredRegisterWrite {
+            write_ir_bits,
+            write_dr_bits_total,
+            write_dr_bits: len as usize,
+        })
+    }
+}
+
+pub struct DeferredRegisterWrite {
+    write_ir_bits: Option<usize>,
+    write_dr_bits_total: usize,
+    write_dr_bits: usize,
 }
 
 impl JTAGAccess for EspUsbJtag {
@@ -318,6 +385,50 @@ impl JTAGAccess for EspUsbJtag {
 
     fn get_idle_cycles(&self) -> u8 {
         self.jtag_idle_cycles
+    }
+
+    fn write_register_batch(
+        &mut self,
+        writes: &[super::JtagWriteCommand],
+    ) -> Result<Vec<super::CommandResult>, super::BatchExecutionError> {
+        let mut bits = Vec::with_capacity(writes.len());
+        let t1 = std::time::Instant::now();
+        tracing::debug!("Preparing {} writes...", writes.len());
+        for write in writes {
+            bits.push(
+                // If an error happens during prep, return no results as chip will be in an inconsistent state
+                self.prepare_write_register(write.address, &write.data, write.len)
+                    .map_err(|e| super::BatchExecutionError::new(e.into(), Vec::new()))?,
+            );
+        }
+
+        tracing::debug!("Sending to chip...");
+        // If an error happens during the final flush, also retry whole operation
+        let mut response = self
+            .protocol
+            .flush()
+            .map_err(|e| super::BatchExecutionError::new(e.into(), Vec::new()))?;
+        tracing::debug!("Got responses! Took {:?}! Processing...", t1.elapsed());
+        let mut response = response.iter();
+
+        let mut responses = Vec::with_capacity(bits.len());
+
+        for (index, bit) in bits.into_iter().enumerate() {
+            if let Some(ir_bits) = bit.write_ir_bits {
+                _ = response.split_off(ir_bits);
+            }
+            let dr_resp = response.split_off(bit.write_dr_bits_total);
+            let v = self
+                .recieve_write_dr(dr_resp, bit.write_dr_bits)
+                .map_err(|e| super::BatchExecutionError::new(e.into(), responses.clone()))?;
+
+            let transform = writes[index].transform;
+            let t =
+                transform(v).map_err(|e| super::BatchExecutionError::new(e, responses.clone()))?;
+            responses.push(t);
+        }
+
+        Ok(responses)
     }
 }
 

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -11,7 +11,7 @@ const JTAG_PROTOCOL_CAPABILITIES_VERSION: u8 = 1;
 const JTAG_PROTOCOL_CAPABILITIES_SPEED_APB_TYPE: u8 = 1;
 const MAX_COMMAND_REPETITIONS: usize = 1024;
 const OUT_BUFFER_SIZE: usize = OUT_EP_BUFFER_SIZE * 32;
-const OUT_EP_BUFFER_SIZE: usize = 64;
+const OUT_EP_BUFFER_SIZE: usize = 128;
 const IN_EP_BUFFER_SIZE: usize = 64;
 const HW_FIFO_SIZE: usize = 4;
 const USB_TIMEOUT: Duration = Duration::from_millis(5000);
@@ -352,13 +352,13 @@ impl ProtocolHandler {
         self.output_buffer.push(command);
 
         // If we reach a maximal size of the output buffer, we flush.
-        if self.output_buffer.len() == (OUT_BUFFER_SIZE * 2) {
+        if self.output_buffer.len() == OUT_BUFFER_SIZE {
             self.send_buffer()?;
         }
 
         // Undocumented condition to flush buffer.
-        // First check, as the output buff suitable for flushing? it should be modulo of the EP buffer size
-        if self.output_buffer.len() % (OUT_EP_BUFFER_SIZE * 2) == 0 {
+        // First check, whether the output buffer is suitable for flushing? it should be modulo of the EP buffer size
+        if self.output_buffer.len() % OUT_EP_BUFFER_SIZE == 0 {
             // Second check, if it is suitable, is there enough to flush
             if self.pending_in_bits > (IN_EP_BUFFER_SIZE + HW_FIFO_SIZE) * 8 {
                 self.send_buffer()?;


### PR DESCRIPTION
* Split single execution writes in `prepare_` and `recieve_` parts.
* Add batched writes which runs `prepare` x times and batches results.
* To facilitate batching, an `OwnedBitIter` struct was added to keep the
  bits around longer than a single write call.
* Added the ability to query the probe speed
* Finally, add a warning when using the default implementation for `JTAGAccess::write_register_batch`.