### PR TITLE
Remove `-cli` postfix from the cli binary name

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename the cli binary from `probe-rs-cli` to `probe-rs` (#1635)
+
 ## [0.18.0]
 
 Released 2023-03-31

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -65,3 +65,10 @@ replace = "## [Unreleased]\n\n## [{{version}}]\n\nReleased {{date}}"
 file = "CHANGELOG.md"
 search = "\\[unreleased\\]: https://github.com/probe-rs/probe-rs/compare/v([a-z0-9.-]+)\\.\\.\\.master"
 replace = "[unreleased]: https://github.com/probe-rs/probe-rs/compare/v{{version}}...master\n[v{{version}}]: https://github.com/probe-rs/probe-rs/compare/v$1...v{{version}}"
+
+
+[[bin]]
+name = "probe-rs"
+test = false
+bench = false
+path = "src/main.rs"

--- a/cli/README.md
+++ b/cli/README.md
@@ -26,5 +26,5 @@ cargo install probe-rs-cli
 You can discover the available functionality
 
 ```bash
-probe-rs-cli help
+probe-rs help
 ```


### PR DESCRIPTION
I've brought this up a few times but only now got around to submitting a PR. This might be a bit controversial but imo this makes the cli more usable. Opinions welcome :)