### PR TITLE
gitignore: ignore all target dirs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,6 @@
-/target
+target
+!/gdb-server/src/target
 **/*.rs.bk
-
-# Needed for RLS
-probe-rs/target
-cli/target
-cargo-flash/target
-debugger/target
 
 # It's a Mac Thing
 **/.DS_Store 


### PR DESCRIPTION
We have a lot of crates, it's easier to blanket ban all `target` dirs instead of listing every crate.