### PR TITLE
flashing: Fix small inconsistency in FlashError::NoSuitableNvm error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - probe-rs-cli-util: replace unwanted instance of `println` with `eprintln` (#1595, fixes #1593).
 - stlink: exit JTAG mode on idle to tristate debug interface (#1615).
 - probe-rs-debugger: The MS DAP Request `setBreapoints` clears existing breakpoints for the specified `Source`, and not for all `Source`'s (#1630)
+- probe-rs/flashing: Inconsistent address formatting in the "No flash memory contains the entire requested memory range" (`FlashError::NoSuitableNvm`) error message (#1644)
 
 ### Added
 

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 pub enum FlashError {
     /// No flash memory contains the entire requested memory range.
     #[error(
-        "No flash memory contains the entire requested memory range {start:#010x}..{end:#10x}."
+        "No flash memory contains the entire requested memory range {start:#010x}..{end:#010x}."
     )]
     NoSuitableNvm {
         /// The start of the requested memory range.


### PR DESCRIPTION
The start address was zero-padded, but the end address was not. This is an entirely cosmetic change to make it easier to read this error message.

(I originally wrote this while working on #1642 but have extracted it into its own PR because it's independent of what I was doing over there.)
