### PR TITLE
flashing: Select RAM region by fixed algorithm load address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - stlink: exit JTAG mode on idle to tristate debug interface (#1615).
 - probe-rs-debugger: The MS DAP Request `setBreapoints` clears existing breakpoints for the specified `Source`, and not for all `Source`'s (#1630)
 - probe-rs/flashing: Inconsistent address formatting in the "No flash memory contains the entire requested memory range" (`FlashError::NoSuitableNvm`) error message (#1644)
+- probe-rs/flashing: For targets whose flash algorithms require a fixed load address, always select a RAM region containing that address. (#1646)
 
 ### Added
 

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -75,8 +75,16 @@ impl<'session> Flasher<'session> {
                 _ => None,
             })
             .find(|ram| {
-                // The RAM must be accessible from the core we're going to run the algo on.
-                ram.cores.contains(core_name)
+                if let Some(load_addr) = raw_flash_algorithm.load_address {
+                    // The RAM must contain the forced load address _and_
+                    // be accessible from the core we're going to run the
+                    // algorithm on.
+                    ram.range.contains(&load_addr) && ram.cores.contains(core_name)
+                } else {
+                    // Any RAM is okay as long as it's accessible to the core;
+                    // the algorithm is presumably position-independent.
+                    ram.cores.contains(core_name)
+                }
             })
             .ok_or(FlashError::NoRamDefined {
                 name: session.target().name.clone(),


### PR DESCRIPTION
Some targets have constraints on where flash algorithms can be loaded, such as if the flash algorithm relies on target ROM routines that use certain RAM regions as scratch space, if the flash algorithm must run from secure memory (e.g. Arm TrustZone), or if the algorithm just doesn't use position-independent code for some reason.

The flash algorithm model already supported fixed load addresses, but the flasher did not take that into account when selecting a RAM region and so it worked only if the chosen load address happened to be in the very first RAM region.

Instead we'll now remove from consideration any RAM region that doesn't contain the required load address, and therefore choose the first region that contains that address. This will work only if the chosen load address leaves enough room for our overhead like the stack and header space, but this is still an improvement over the previous behavior of selecting the wrong region altogether.

(I originally wrote this while working on #1642 but have extracted it into its own PR because it's a general fix that would help any target with a fixed load address that isn't in the first RAM region.)
