### PR TITLE
dap-server: Add support for non `Elf` binary formats.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,12 +25,12 @@
           "kind": "bin"
         }
       },
-      "args": ["dap-server", "debug", "--port", "50001"],
+      "args": ["dap-server", "--port", "50001"],
       // "env": {
       //     "RUST_LOG": "error",
       //     "DEFMT_LOG": "info"
       // },
-      "cwd": "${workspaceFolder}/probe-rs/src/bin/probe-rs/dap_server"
+      "cwd": "${workspaceFolder}/probe-rs/src/bin/probe-rs/cmd/dap_server"
     },
     {
       "type": "lldb",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `dap-server`: In addition to `Elf` format, this adds support for binary formats `Bin`, `Hex`, and `Idf` (#1656).
+
 ## [0.19.0]
 
 Released 2023-06-27
 
 ### Changed
 
-- Merged `probe-rs-cli`, `probe-rs-debugger`, `cargo-embed`, `cargo-flash` binaries into the `probe-rs` crate. 
+- Merged `probe-rs-cli`, `probe-rs-debugger`, `cargo-embed`, `cargo-flash` binaries into the `probe-rs` crate.
   - `probe-rs-cli` is now available in `probe-rs`.
   - `probe-rs-debugger` is now available as `probe-rs dap-server`.
   - `cargo-embed` and `cargo-flash` functionality is unchanged, but they are now small shim binaries that invoke `probe-rs`.

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/configuration.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/configuration.rs
@@ -1,5 +1,5 @@
-use crate::cmd::dap_server::DebuggerError;
 use crate::util::rtt;
+use crate::{cmd::dap_server::DebuggerError, FormatOptions};
 use anyhow::{anyhow, Result};
 use probe_rs::{DebugProbeSelector, WireProtocol};
 use serde::Deserialize;
@@ -167,6 +167,10 @@ pub struct FlashingConfig {
     /// Restore erased bytes that will not be rewritten from ELF
     #[serde(default)]
     pub(crate) restore_unwritten_bytes: bool,
+
+    /// [`FormatOptions`] to control the flashing operation, depending on the type of binary ( [`probe_rs::flashing::Format`] ) to be flashed.
+    #[serde(default)]
+    pub(crate) format_options: FormatOptions,
 }
 
 /// Configuration options for all core level configuration.

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -20,7 +20,7 @@ use crate::cmd::dap_server::{
 };
 use anyhow::{anyhow, Context};
 use probe_rs::{
-    flashing::{download_file_with_options, DownloadOptions, FlashProgress, Format},
+    flashing::{download_file_with_options, DownloadOptions, FlashProgress},
     Architecture, CoreStatus,
 };
 use std::{
@@ -733,7 +733,11 @@ impl Debugger {
         let flash_result = download_file_with_options(
             &mut session_data.session,
             path_to_elf,
-            Format::Elf,
+            self.config
+                .flashing_config
+                .format_options
+                .clone()
+                .into_format()?,
             download_options,
         );
 

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -9,6 +9,7 @@ use std::{ffi::OsString, fs::File, path::PathBuf};
 use anyhow::{Context, Result};
 use clap::Parser;
 use probe_rs::flashing::{BinOptions, Format, IdfOptions};
+use serde::Deserialize;
 use time::{OffsetDateTime, UtcOffset};
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::{
@@ -73,7 +74,7 @@ pub(crate) struct CoreOptions {
     core: usize,
 }
 
-#[derive(clap::Parser)]
+#[derive(clap::Parser, Clone, Deserialize, Debug, Default)]
 pub(crate) struct FormatOptions {
     #[clap(value_enum, ignore_case = true, default_value = "elf", long)]
     format: Format,

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -28,7 +28,7 @@ pub struct IdfOptions {
 }
 
 /// A finite list of all the available binary formats probe-rs understands.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum Format {
     /// Marks a file in binary format. This means that the file contains the contents of the flash 1:1.
     /// [BinOptions] can be used to define the location in flash where the file contents should be put at.
@@ -37,6 +37,7 @@ pub enum Format {
     /// Marks a file in [Intel HEX](https://en.wikipedia.org/wiki/Intel_HEX) format.
     Hex,
     /// Marks a file in the [ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) format.
+    #[default]
     Elf,
     /// Marks a file in the [ESP-IDF bootloader](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html#app-image-structures) format.
     /// Use [IdfOptions] to configure flashing.


### PR DESCRIPTION
In addition to the currently supported `Elf` format, this adds support for binary formats `Bin`, `Hex`, and `Idf`.

Fixes #1647 

Note: Needs updated probe-rs VSCode extension from https://github.com/probe-rs/vscode/pull/62
