### PR TITLE
Fix regressions in `download` subcommand caused by PR #1649

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `dap-server`: In addition to `Elf` format, this adds support for binary formats `Bin`, `Hex`, and `Idf` (#1656).
 - Added PAC55XX series targets (#1655)
 
+
+### Fixed
+
+- probe-rs-cli: fixed `--base-address` having no effect
+- probe-rs-cli: fixed `--skip` not accepting hexadecimal values
+
+### Removed
+
+- probe-rs-cli: removed obsolete `--skip-bytes` (which had no effect), use `--skip` instead
+
 ## [0.19.0]
 
 Released 2023-06-27

--- a/probe-rs/src/bin/probe-rs/cmd/download.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/download.rs
@@ -8,21 +8,12 @@ use probe_rs::flashing::Format;
 use crate::util::common_options::ProbeOptions;
 use crate::util::common_options::{CargoOptions, FlashOptions};
 use crate::util::flash::run_flash_download;
-use crate::util::parse_u32;
-use crate::util::parse_u64;
 use crate::FormatOptions;
 
 #[derive(clap::Parser)]
 pub struct Cmd {
     #[clap(flatten)]
     common: ProbeOptions,
-
-    /// The address in memory where the binary will be put at. This is only considered when `bin` is selected as the format.
-    #[clap(long, value_parser = parse_u64)]
-    base_address: Option<u64>,
-    /// The number of bytes to skip at the start of the binary file. This is only considered when `bin` is selected as the format.
-    #[clap(long, value_parser = parse_u32)]
-    skip_bytes: Option<u32>,
 
     /// The path to the file to be downloaded to the flash
     path: String,

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -19,6 +19,9 @@ use tracing_subscriber::{
     EnvFilter, Layer,
 };
 
+use crate::util::parse_u32;
+use crate::util::parse_u64;
+
 #[derive(clap::Parser)]
 #[clap(
     name = "probe-rs",
@@ -93,11 +96,11 @@ pub(crate) struct FormatOptions {
     #[clap(value_enum, ignore_case = true, default_value = "elf", long)]
     #[serde(deserialize_with = "format_from_str")]
     format: Format,
-    /// The address in memory where the binary will be put at.
-    #[clap(long)]
+    /// The address in memory where the binary will be put at. This is only considered when `bin` is selected as the format.
+    #[clap(long, value_parser = parse_u64)]
     pub base_address: Option<u64>,
-    /// The number of bytes to skip at the start of the binary file.
-    #[clap(long, default_value = "0")]
+    /// The number of bytes to skip at the start of the binary file. This is only considered when `bin` is selected as the format.
+    #[clap(long, value_parser = parse_u32, default_value = "0")]
     pub skip: u32,
     /// The idf bootloader path
     #[clap(long)]


### PR DESCRIPTION
fix: download cmd `--base-address` collision

In debug mode this would cause a panic due to duplicate arg.
In release, it would effectively silently ignore `--base-address`.
Regression happened in PR #1649.

fix: download cmd removed obsolete `--skip-bytes`

Literally did nothing, correct arg is `--skip`.
Regression happened in #1649.

fix: download cmd `--skip` now supports hexadecimal

Obsolete `--skip-bytes` would accept hexadecimal, but had no effect.
Regression happened in PR #1649.