### PR TITLE
Better error message for ambigous chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a simple profiler to the probe-rs cli toolkit (#1628)
 
 
+### Changed
+
+- probe-rs-cli: more descriptive error messages for ambigous chips
+
 ### Fixed
 
 - probe-rs-cli: fixed `--base-address` having no effect


### PR DESCRIPTION
### Before:
```
Error: The chip 'stm32l4r5zi' was not found in the database.

Caused by:
    Found multiple chips matching 'stm32l4r5zi', unable to select a single chip.
```

### After:

```
Error: The chip 'stm32l4r5zi' was not found in the database.

Caused by:
    Found multiple chips matching 'stm32l4r5zi', unable to select a single chip. (STM32L4R5ZITx, STM32L4R5ZITxP, STM32L4R5ZIYx)
```

----
This helps beginners like me who don't appreciate the difference between the order code (Nucleo-L4R5ZI) and the actual target board (STM32L4R5ZIT6U)