### PR TITLE
Implement `attach` sumbcommand (closes #1616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `core`: Added vector catch for ARMv6-M and ARMv7-M (#1592)
   - Currently supported are HardFault and CoreReset.
 - `cli`: The run command now prints a stack trace on `HardFault` (#1592)
+- Added a simple profiler to the probe-rs cli toolkit (#1628)
+- Added MSP432E4 target (MSP432E401Y and MSP432E411Y). (#1139)
+- probe-rs-cli: added `attach` subcommand. (#1672, #1616)
 
 ### Changed
 

--- a/probe-rs/src/bin/probe-rs/cmd.rs
+++ b/probe-rs/src/bin/probe-rs/cmd.rs
@@ -1,3 +1,4 @@
+pub mod attach;
 pub mod benchmark;
 pub mod cargo_embed;
 pub mod cargo_flash;

--- a/probe-rs/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/attach.rs
@@ -1,0 +1,62 @@
+use std::io::Write;
+use std::path::Path;
+use std::time::Duration;
+
+use time::UtcOffset;
+
+use crate::util::common_options::ProbeOptions;
+use crate::util::rtt;
+
+#[derive(clap::Parser)]
+#[group(skip)]
+pub struct Cmd {
+    #[clap(flatten)]
+    pub(crate) common: ProbeOptions,
+
+    /// The path to the ELF file to flash and run
+    pub(crate) path: String,
+}
+
+impl Cmd {
+    pub fn run(self, timestamp_offset: UtcOffset) -> anyhow::Result<()> {
+        let mut session = self.common.simple_attach()?;
+
+        let rtt_config = rtt::RttConfig::default();
+
+        let memory_map = session.target().memory_map.clone();
+
+        let mut core = session.core(0)?;
+        core.reset()?;
+
+        let mut rtta = match rtt::attach_to_rtt(
+            &mut core,
+            &memory_map,
+            Path::new(&self.path),
+            &rtt_config,
+            timestamp_offset,
+        ) {
+            Ok(target_rtt) => Some(target_rtt),
+            Err(error) => {
+                log::error!("{:?} Continuing without RTT... ", error);
+                None
+            }
+        };
+
+        if let Some(rtta) = &mut rtta {
+            let mut stdout = std::io::stdout();
+            loop {
+                for (_ch, data) in rtta.poll_rtt_fallible(&mut core)? {
+                    stdout.write_all(data.as_bytes())?;
+                }
+
+                // Poll RTT with a frequency of 10 Hz
+                //
+                // If the polling frequency is too high,
+                // the USB connection to the probe can become unstable.
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/probe-rs/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/attach.rs
@@ -47,7 +47,7 @@ impl Cmd {
                     // the USB connection to the probe can become unstable.
                     std::thread::sleep(Duration::from_millis(100));
                 }
-            },
+            }
             Err(error) => {
                 log::error!("{:?} RTT is not available.", error);
             }

--- a/probe-rs/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/attach.rs
@@ -26,36 +26,32 @@ impl Cmd {
         let memory_map = session.target().memory_map.clone();
 
         let mut core = session.core(0)?;
-        core.reset()?;
 
-        let mut rtta = match rtt::attach_to_rtt(
+        match rtt::attach_to_rtt(
             &mut core,
             &memory_map,
             Path::new(&self.path),
             &rtt_config,
             timestamp_offset,
         ) {
-            Ok(target_rtt) => Some(target_rtt),
+            Ok(mut rtta) => {
+                let mut stdout = std::io::stdout();
+                loop {
+                    for (_ch, data) in rtta.poll_rtt_fallible(&mut core)? {
+                        stdout.write_all(data.as_bytes())?;
+                    }
+
+                    // Poll RTT with a frequency of 10 Hz
+                    //
+                    // If the polling frequency is too high,
+                    // the USB connection to the probe can become unstable.
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+            },
             Err(error) => {
-                log::error!("{:?} Continuing without RTT... ", error);
-                None
+                log::error!("{:?} RTT is not available.", error);
             }
         };
-
-        if let Some(rtta) = &mut rtta {
-            let mut stdout = std::io::stdout();
-            loop {
-                for (_ch, data) in rtta.poll_rtt_fallible(&mut core)? {
-                    stdout.write_all(data.as_bytes())?;
-                }
-
-                // Poll RTT with a frequency of 10 Hz
-                //
-                // If the polling frequency is too high,
-                // the USB connection to the probe can become unstable.
-                std::thread::sleep(Duration::from_millis(100));
-            }
-        }
 
         Ok(())
     }

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -62,6 +62,9 @@ enum Subcommand {
     /// Flash and run an ELF program
     #[clap(name = "run")]
     Run(cmd::run::Cmd),
+    /// Attach to rtt logging
+    #[clap(name = "attach")]
+    Attach(cmd::attach::Cmd),
     /// Trace a memory location on the target
     #[clap(name = "trace")]
     Trace(cmd::trace::Cmd),
@@ -250,6 +253,7 @@ fn main() -> Result<()> {
         Subcommand::Dump(cmd) => cmd.run(),
         Subcommand::Download(cmd) => cmd.run(),
         Subcommand::Run(cmd) => cmd.run(utc_offset),
+        Subcommand::Attach(cmd) => cmd.run(utc_offset),
         Subcommand::Erase(cmd) => cmd.run(),
         Subcommand::Trace(cmd) => cmd.run(),
         Subcommand::Itm(cmd) => cmd.run(),


### PR DESCRIPTION
To attach to rtt logging. Behaves exactly as `run`, but does not flash binary.