### PR TITLE
Fix spelling of error message for word "occurred"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,7 +167,7 @@ Released 2023-02-06
 
 - cmsis-dap: Avoid endless recursion when recovering from errors.
 
-  When an error occured, the cmsis-dap code tried to read the debug port CTRL register.
+  When an error occurred, the cmsis-dap code tried to read the debug port CTRL register.
   If that read failed, it would again try to read the same register, returning in an
   endless recursion.
 

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -156,8 +156,8 @@ pub enum DebugProbeError {
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 
-    /// A timeout occured during probe operation.
-    #[error("Timeout occured during probe operation.")]
+    /// A timeout occurred during probe operation.
+    #[error("Timeout occurred during probe operation.")]
     Timeout,
 }
 


### PR DESCRIPTION
This fixes every instance of the word "occured" to be "occurred"