### PR TITLE
cli/itm/memory: read trace through the debug registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `cli`: more descriptive error messages for ambigous chips
+- `cli`: When using `memory` as the trace sink for an ITM trace, the trace is now read
+  out through the debug registers (#2651)
 
 ### Fixed
 


### PR DESCRIPTION
The `memory` subcommand of the CLI `itm` tool currently attempts to use
SWO to read out the trace.
This won't work as with `TraceMemory` as the sink, the TMC is configured
in software mode to be read out through the debug registers
(see https://github.com/probe-rs/probe-rs/blob/5f9c30a9de90516480cefb14b91b710b47d9256f/probe-rs/src/architecture/arm/component/mod.rs#L264-L266).
This implements reading out the trace through the debug registers,
implements parsing the timestamped packets and outputs them.
The code is taken from `etf-trace`
(https://github.com/quartiq/etf-trace/blob/main/src/main.rs) which is
made redundant by this change.

```
$ cargo run --release --bin probe-rs --features=cli -- itm --chip STM32H743ZITx memory 400000000

Ok(TimestampedTracePackets { timestamp: Sync(5.528µs), packets: [Extension { page: 0 }, ExceptionTrace { exception: Interrupt { irqn: 15 }, action: Entered }], malformed_packets: [], consumed
_packets: 3 })
Ok(TimestampedTracePackets { timestamp: Sync(10.208µs), packets: [ExceptionTrace { exception: Interrupt { irqn: 15 }, action: Exited }], malformed_packets: [], consumed_packets: 2 })
Ok(TimestampedTracePackets { timestamp: Sync(10.228µs), packets: [ExceptionTrace { exception: ThreadMode, action: Returned }], malformed_packets: [], consumed_packets: 2 })
Ok(TimestampedTracePackets { timestamp: Sync(15.761µs), packets: [ExceptionTrace { exception: Interrupt { irqn: 15 }, action: Entered }], malformed_packets: [], consumed_packets: 2 })
Ok(TimestampedTracePackets { timestamp: Sync(20.366µs), packets: [ExceptionTrace { exception: Interrupt { irqn: 15 }, action: Exited }], malformed_packets: [], consumed_packets: 2 })
Ok(TimestampedTracePackets { timestamp: Sync(20.386µs), packets: [ExceptionTrace { exception: ThreadMode, action: Returned }], malformed_packets: [], consumed_packets: 2 })
Ok(TimestampedTracePackets { timestamp: Sync(25.994µs), packets: [ExceptionTrace { exception: Interrupt { irqn: 15 }, action: Entered }], malformed_packets: [], consumed_packets: 2 })
Ok(TimestampedTracePackets { timestamp: Sync(30.687µs), packets: [ExceptionTrace { exception: Interrupt { irqn: 15 }, action: Exited }], malformed_packets: [], consumed_packets: 2 })
```
