### PR TITLE
Build target-gen with RTT enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,19 +26,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `cli`: more descriptive error messages for ambigous chips
+- `cli`: more descriptive error messages for ambigous chips (#1671).
 - `cli`: When using `memory` as the trace sink for an ITM trace, the trace is now read
-  out through the debug registers (#2651)
+  out through the debug registers (#1688)
+- `target-gen`: RTT is enabled by default now in the `test` command (#1690).
 
 ### Fixed
 
 - `core`: Added a missing reset catch clear that prevented the CPU from properly starting after flashing RTT from attaching (#1675).
-- `cli`: fixed `--base-address` having no effect
-- `cli`: fixed `--skip` not accepting hexadecimal values
+- `cli`: fixed `--base-address` having no effect (#1664).
+- `cli`: fixed `--skip` not accepting hexadecimal values (#1664).
 
 ### Removed
 
-- cli: removed obsolete `--skip-bytes` (which had no effect), use `--skip` instead
+- cli: removed obsolete `--skip-bytes` (which had no effect), use `--skip` instead (#1664).
 
 ## [0.19.0]
 

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -15,7 +15,9 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-probe-rs = { path = "../probe-rs", version = "0.19.0", default-features = false }
+probe-rs = { path = "../probe-rs", version = "0.19.0", default-features = false, features = [
+    "rtt",
+] }
 probe-rs-target = { path = "../probe-rs-target", version = "0.19.0", default-features = false }
 cmsis-pack = { version = "0.6.2" }
 goblin = { version = "0.7.1", default-features = false, features = [


### PR DESCRIPTION
Fix https://github.com/probe-rs/flash-algorithm-template/issues/3