### PR TITLE
Make the cli options more generic and reusable. Load the chip description path for every command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `core`: Added a missing reset catch clear that prevented the CPU from properly starting after flashing RTT from attaching (#1675).
 - `cli`: fixed `--base-address` having no effect (#1664).
 - `cli`: fixed `--skip` not accepting hexadecimal values (#1664).
+- `cli`: all the commands now load the chip description path and provide uniform config arguments (#1691).
 
 ### Removed
 

--- a/probe-rs/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/attach.rs
@@ -19,7 +19,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(self, timestamp_offset: UtcOffset) -> anyhow::Result<()> {
-        let mut session = self.common.simple_attach()?;
+        let (mut session, _probe_options) = self.common.simple_attach()?;
 
         let rtt_config = rtt::RttConfig::default();
 

--- a/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
@@ -34,7 +34,8 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(self) -> anyhow::Result<()> {
-        let probe = self.common.attach_probe()?;
+        let common_options = self.common.load()?;
+        let probe = common_options.attach_probe()?;
 
         let protocol_name = probe
             .protocol()
@@ -43,9 +44,9 @@ impl Cmd {
 
         let protocol_speed = probe.speed_khz() as i32;
 
-        let target = self.common.get_target_selector()?;
+        let target = common_options.get_target_selector()?;
         let probe_name = probe.get_name();
-        let mut session = self.common.attach_session(probe, target)?;
+        let mut session = common_options.attach_session(probe, target)?;
 
         let target_name = session.target().name.clone();
 

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
@@ -78,6 +78,10 @@ pub(crate) fn render_diagnostics(error: OperationError) {
             ],
         ),
         OperationError::FlashingFailed { source, target, target_spec, .. } => generate_flash_error_hints(source, target, target_spec),
+        OperationError::ChipDescriptionNotFound{ .. } => (
+            error.to_string(),
+            vec![],
+        ),
         OperationError::FailedChipDescriptionParsing { .. } => (
             error.to_string(),
             vec![],

--- a/probe-rs/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/debug.rs
@@ -37,7 +37,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(self) -> anyhow::Result<()> {
-        let mut session = self.common.simple_attach()?;
+        let (mut session, _probe_options) = self.common.simple_attach()?;
 
         let di = self
             .exe

--- a/probe-rs/src/bin/probe-rs/cmd/dump.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dump.rs
@@ -24,7 +24,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(self) -> anyhow::Result<()> {
-        let mut session = self.common.simple_attach()?;
+        let (mut session, _probe_options) = self.common.simple_attach()?;
 
         let mut data = vec![0_u32; self.words as usize];
 

--- a/probe-rs/src/bin/probe-rs/cmd/erase.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/erase.rs
@@ -10,7 +10,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(self) -> anyhow::Result<()> {
-        let mut session = self.common.simple_attach()?;
+        let (mut session, _probe_options) = self.common.simple_attach()?;
 
         erase_all(&mut session, None)?;
 

--- a/probe-rs/src/bin/probe-rs/cmd/gdb.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/gdb.rs
@@ -24,7 +24,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(self) -> anyhow::Result<()> {
-        let mut session = self.common.simple_attach()?;
+        let (mut session, _probe_options) = self.common.simple_attach()?;
 
         if self.reset_halt {
             session

--- a/probe-rs/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/info.rs
@@ -29,9 +29,10 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(self) -> anyhow::Result<()> {
-        let mut probe = self.common.attach_probe()?;
+        let probe_options = self.common.load()?;
+        let mut probe = probe_options.attach_probe()?;
 
-        let protocols = if let Some(protocol) = self.common.protocol {
+        let protocols = if let Some(protocol) = probe_options.protocol() {
             vec![protocol]
         } else {
             vec![WireProtocol::Jtag, WireProtocol::Swd]
@@ -42,7 +43,7 @@ impl Cmd {
             println!();
 
             let (new_probe, result) =
-                try_show_info(probe, protocol, self.common.connect_under_reset);
+                try_show_info(probe, protocol, probe_options.connect_under_reset());
 
             probe = new_probe;
 

--- a/probe-rs/src/bin/probe-rs/cmd/itm.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/itm.rs
@@ -66,7 +66,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(self) -> anyhow::Result<()> {
-        let mut session = self.common.simple_attach()?;
+        let (mut session, _probe_options) = self.common.simple_attach()?;
 
         match self.source {
             ItmSource::TraceMemory { coreclk } => {

--- a/probe-rs/src/bin/probe-rs/cmd/profile.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/profile.rs
@@ -21,7 +21,6 @@ use addr2line::{
     Context as ObjectContext, LookupResult,
 };
 
-use crate::util::common_options::{CargoOptions, FlashOptions};
 use crate::util::flash::run_flash_download;
 use tracing::info;
 
@@ -74,7 +73,7 @@ impl core::fmt::Display for ProfileMethod {
 
 impl Cmd {
     pub fn run(self) -> anyhow::Result<()> {
-        let mut session = self.run.common.simple_attach()?;
+        let (mut session, probe_options) = self.run.probe_options.simple_attach()?;
 
         let mut file = match File::open(&self.run.path) {
             Ok(file) => file,
@@ -98,18 +97,8 @@ impl Cmd {
             run_flash_download(
                 &mut session,
                 Path::new(&self.run.path),
-                &FlashOptions {
-                    disable_progressbars: false,
-                    disable_double_buffering: self.run.disable_double_buffering,
-                    reset_halt: false,
-                    log: None,
-                    restore_unwritten: false,
-                    flash_layout_output_path: None,
-                    elf: None,
-                    work_dir: None,
-                    cargo_options: CargoOptions::default(),
-                    probe_options: self.run.common,
-                },
+                &self.run.download_options,
+                &probe_options,
                 loader,
                 self.run.chip_erase,
             )?;

--- a/probe-rs/src/bin/probe-rs/cmd/reset.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/reset.rs
@@ -14,7 +14,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(self) -> anyhow::Result<()> {
-        let mut session = self.common.simple_attach()?;
+        let (mut session, _probe_options) = self.common.simple_attach()?;
 
         session.core(self.shared.core)?.reset()?;
 

--- a/probe-rs/src/bin/probe-rs/cmd/trace.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/trace.rs
@@ -1,6 +1,10 @@
+use std::io::prelude::*;
+use std::thread::sleep;
+use std::time::Duration;
 use std::time::Instant;
 
 use probe_rs::MemoryInterface;
+use scroll::{Pwrite, LE};
 
 use crate::util::{common_options::ProbeOptions, parse_u64};
 use crate::CoreOptions;
@@ -20,18 +24,12 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(self) -> anyhow::Result<()> {
-        use std::io::prelude::*;
-        use std::thread::sleep;
-        use std::time::Duration;
-
-        use scroll::{Pwrite, LE};
-
         let mut xs = vec![];
         let mut ys = vec![];
 
         let start = Instant::now();
 
-        let mut session = self.common.simple_attach()?;
+        let (mut session, _probe_options) = self.common.simple_attach()?;
 
         let mut core = session.core(self.shared.core)?;
 

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -172,6 +172,7 @@ fn default_logfile_location() -> Result<PathBuf> {
     Ok(log_path)
 }
 
+/// Returns the cleaned arguments for the handler of the respective end binary (cli, cargo-flash, cargo-embed, etc.).
 fn multicall_check(args: &[OsString], want: &str) -> Option<Vec<OsString>> {
     let argv0 = Path::new(&args[0]);
     if let Some(command) = argv0.file_stem().and_then(|f| f.to_str()) {


### PR DESCRIPTION
Fix #1680.