### PR TITLE
`dap-server`: Ensure VSCode extension catches all STDERR errors if process initialization fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cli`: fixed `--base-address` having no effect (#1664).
 - `cli`: fixed `--skip` not accepting hexadecimal values (#1664).
 - `cli`: all the commands now load the chip description path and provide uniform config arguments (#1691).
+- `dap-server`: The VSCode extension reports all STDERR errors if process initialization fails (#).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cli`: fixed `--base-address` having no effect (#1664).
 - `cli`: fixed `--skip` not accepting hexadecimal values (#1664).
 - `cli`: all the commands now load the chip description path and provide uniform config arguments (#1691).
-- `dap-server`: The VSCode extension reports all STDERR errors if process initialization fails (#).
+- `dap-server`: The VSCode extension reports all STDERR errors if process initialization fails (#1699).
 
 ### Removed
 

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/debugProtocol.json
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/debugProtocol.json
@@ -1414,7 +1414,7 @@
 		"SetExceptionBreakpointsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to `setExceptionBreakpoints` request.\nThe response contains an array of `Breakpoint` objects with information about each exception breakpoint or filter. The `Breakpoint` objects are in the same order as the elements of the `filters`, `filterOptions`, `exceptionOptions` arrays given as arguments. If both `filters` and `filterOptions` are given, the returned array must start with `filters` information first, followed by `filterOptions` information.\nThe `verified` property of a `Breakpoint` object signals whether the exception breakpoint or filter could be successfully created and whether the condition or hit count expressions are valid. In case of an error the `message` property explains the problem. The `id` property can be used to introduce a unique ID for the exception breakpoint or filter so that it can be updated subsequently by sending breakpoint events.\nFor backward compatibility both the `breakpoints` array and the enclosing `body` are optional. If these elements are missing a client is not able to show problems for individual exception breakpoints or filters.",
+				"description": "Response to `setExceptionBreakpoints` request.\nThe response contains an array of `Breakpoint` objects with information about each exception breakpoint or filter. The `Breakpoint` objects are in the same order as the elements of the `filters`, `filterOptions`, `exceptionOptions` arrays given as arguments. If both `filters` and `filterOptions` are given, the returned array must start with `filters` information first, followed by `filterOptions` information.\nThe `verified` property of a `Breakpoint` object signals whether the exception breakpoint or filter could be successfully created and whether the condition is valid. In case of an error the `message` property explains the problem. The `id` property can be used to introduce a unique ID for the exception breakpoint or filter so that it can be updated subsequently by sending breakpoint events.\nFor backward compatibility both the `breakpoints` array and the enclosing `body` are optional. If these elements are missing a client is not able to show problems for individual exception breakpoints or filters.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -1477,7 +1477,7 @@
 						"properties": {
 							"dataId": {
 								"type": [ "string", "null" ],
-								"description": "An identifier for the data on which a data breakpoint can be registered with the `setDataBreakpoints` request or null if no data breakpoint is available."
+								"description": "An identifier for the data on which a data breakpoint can be registered with the `setDataBreakpoints` request or null if no data breakpoint is available. If a `variablesReference` or `frameId` is passed, the `dataId` is valid in the current suspended state, otherwise it's valid indefinitely. See 'Lifetime of Object References' in the Overview section for details. Breakpoints set using the `dataId` in the `setDataBreakpoints` request may outlive the lifetime of the associated `dataId`."
 							},
 							"description": {
 								"type": "string",

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -46,7 +46,7 @@ pub(crate) enum DebugSessionStatus {
 /// The DAP Server will usually be managed automatically by the VSCode client.
 /// The DAP Server can optionally be run from the command line as a "server" process.
 /// - In this case, the management (start and stop) of the server process is the responsibility of the user. e.g.
-///   - `probe-rs-debug --debug --port <IP port number> <other options>` : Uses TCP Sockets to the defined IP port number to service DAP requests.
+///   - `probe-rs dap-server --port <IP port number> <other options>` : Uses TCP Sockets to the defined IP port number to service DAP requests.
 pub struct Debugger {
     config: configuration::SessionConfig,
 


### PR DESCRIPTION
Please see the [VSCode extension PR](https://github.com/probe-rs/vscode/pull/63) for details on this fix.

Additional changes here are to prevent duplicate messages from being reported in the VSCode extension.