### PR TITLE
Stack unwind : Consider `RegisterValue` byte size when doing arithmetic on register addresses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cli`: fixed `--skip` not accepting hexadecimal values (#1664).
 - `cli`: all the commands now load the chip description path and provide uniform config arguments (#1691).
 - `dap-server`: The VSCode extension reports all STDERR errors if process initialization fails (#1699).
+- `debug` : Consider `RegisterValue` byte size when doing arithmetic on register addresses. (#)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cli`: fixed `--skip` not accepting hexadecimal values (#1664).
 - `cli`: all the commands now load the chip description path and provide uniform config arguments (#1691).
 - `dap-server`: The VSCode extension reports all STDERR errors if process initialization fails (#1699).
-- `debug` : Consider `RegisterValue` byte size when doing arithmetic on register addresses. (#)
+- `debug` : Consider `RegisterValue` byte size when doing arithmetic on register addresses. (#1701)
 
 ### Removed
 

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -5,9 +5,6 @@
 //! The `debug` module contains various debug functionality, which can be
 //! used to implement a debugger based on `probe-rs`.
 
-// Bad things happen to the VSCode debug extenison and debug_adapter if we panic at the wrong time.
-#![warn(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
-
 /// Debug information which is parsed from DWARF debugging information.
 pub mod debug_info;
 /// Stepping through a program during debug, at various granularities.


### PR DESCRIPTION
This fixes an error in the stack unwind, caused when add/subtract against 32-bit register address values resulted in incorrect register addresses being read by the core. 