### PR TITLE
UNWIND: Clarify WARN and TRACE  messages during exception handling.

### DIFF
--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -742,7 +742,7 @@ impl DebugInfo {
                     None
                 }
                 Err(e) => {
-                    tracing::warn!("UNWIND: Error while checking for exception context. Unwinding will stop at the first exception handler. : {}", e);
+                    tracing::warn!("UNWIND: Error while checking for exception context. The stack trace will not include the calling frames. : {}", e);
                     None
                 }
             };

--- a/probe-rs/src/debug/registers.rs
+++ b/probe-rs/src/debug/registers.rs
@@ -79,8 +79,8 @@ impl DebugRegisters {
                     },
                 });
             } else {
-                tracing::warn!(
-                    "Unsupported platform register type or size for register: {:?}",
+                tracing::trace!(
+                    "Unwind will use the default rule for this register : {:?}",
                     core_register
                 );
             }


### PR DESCRIPTION
Some messages reported during stack unwind were too aggressive and caused noise and/or needed clarification.

Note: Temporarily added `skip-changelog` label until the changes are verified.