### PR TITLE
Add --no-location option to the run command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Released 2023-07-19
 - Added a simple profiler to the probe-rs cli toolkit (#1628)
 - Added MSP432E4 target (MSP432E401Y and MSP432E411Y). (#1139)
 - probe-rs-cli: added `attach` subcommand. (#1672, #1616)
+- probe-rs-cli: added --no-locations option to the run command, which suppresses the filename and line number
+                information from the rtt log (#1704)
 
 ### Changed
 

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -37,6 +37,10 @@ pub struct Cmd {
     #[clap(long)]
     pub(crate) chip_erase: bool,
 
+    /// Suppress filename and line number information from the rtt log
+    #[clap(long)]
+    pub(crate) no_location: bool,
+
     #[clap(flatten)]
     pub(crate) format_options: FormatOptions,
 }
@@ -89,6 +93,7 @@ impl Cmd {
             path,
             timestamp_offset,
             self.always_print_stacktrace,
+            self.no_location,
         )?;
 
         Ok(())
@@ -103,8 +108,15 @@ fn run_loop(
     path: &Path,
     timestamp_offset: UtcOffset,
     always_print_stacktrace: bool,
+    no_location: bool,
 ) -> Result<bool, anyhow::Error> {
-    let rtt_config = rtt::RttConfig::default();
+    let mut rtt_config = rtt::RttConfig::default();
+    rtt_config.channels.push(rtt::RttChannelConfig {
+        channel_number: Some(0),
+        show_location: !no_location,
+        ..Default::default()
+    });
+
     let mut rtta = attach_to_rtt(core, memory_map, path, rtt_config, timestamp_offset);
 
     let exit = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
This will suppress the filename and line number information from the RTT log.

Without `--no-location`:
```
2252 >cargo run --bin probe-rs --features=cli -- run --chip rp2040 ~/pico-rust/embassy/examples/rp/target/thumbv6m-none-eabi/release/wifi_blinky
   Compiling probe-rs v0.19.0 (/home/dhylands/rust/probe-rs/probe-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 16.24s
     Running `/home/dhylands/rust/probe-rs/target/debug/probe-rs run --chip rp2040 /home/dhylands/pico-rust/embassy/examples/rp/target/thumbv6m-none-eabi/release/wifi_blinky`
     Erasing sectors ✔ [00:00:04] [############################################################################################################] 284.00 KiB/284.00 KiB @ 68.19 KiB/s (eta 0s )
 Programming pages   ✔ [00:00:10] [############################################################################################################] 284.00 KiB/284.00 KiB @ 27.19 KiB/s (eta 0s )    Finished in 14.695s
0.273723 DEBUG waiting for clock...
└─ /home/dhylands/pico-rust/embassy/cyw43/src/fmt.rs:127
0.273805 DEBUG clock ok
└─ /home/dhylands/pico-rust/embassy/cyw43/src/fmt.rs:127
0.273985 DEBUG chip ID: 43439
└─ /home/dhylands/pico-rust/embassy/cyw43/src/fmt.rs:127
0.276736 DEBUG loading fw
└─ /home/dhylands/pico-rust/embassy/cyw43/src/fmt.rs:127
0.397258 DEBUG loading nvram
└─ /home/dhylands/pico-rust/embassy/cyw43/src/fmt.rs:127
0.397912 DEBUG starting up core...
└─ /home/dhylands/pico-rust/embassy/cyw43/src/fmt.rs:127
0.419094 DEBUG waiting for wifi init...
└─ /home/dhylands/pico-rust/embassy/cyw43/src/fmt.rs:127
0.503323 DEBUG shared_addr 00016070
└─ /home/dhylands/pico-rust/embassy/cyw43/src/fmt.rs:127
0.503541 DEBUG wifi init done
└─ /home/dhylands/pico-rust/embassy/cyw43/src/fmt.rs:127
0.503656 DEBUG Downloading CLM...
└─ /home/dhylands/pico-rust/embassy/cyw43/src/fmt.rs:127
```

With `--no-location`:
```
2250 >cargo run --bin probe-rs --features=cli -- run --chip rp2040 --no-location  ~/pico-rust/embassy/examples/rp/target/thumbv6m-none-eabi/release/wifi_blinky
   Compiling probe-rs v0.19.0 (/home/dhylands/rust/probe-rs/probe-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 16.54s
     Running `/home/dhylands/rust/probe-rs/target/debug/probe-rs run --chip rp2040 --no-location /home/dhylands/pico-rust/embassy/examples/rp/target/thumbv6m-none-eabi/release/wifi_blinky`
     Erasing sectors ✔ [00:00:04] [############################################################################################################] 284.00 KiB/284.00 KiB @ 68.55 KiB/s (eta 0s )
 Programming pages   ✔ [00:00:10] [############################################################################################################] 284.00 KiB/284.00 KiB @ 27.59 KiB/s (eta 0s )    Finished in 14.519s
0.273705 DEBUG waiting for clock...
0.273783 DEBUG clock ok
0.273966 DEBUG chip ID: 43439
0.276704 DEBUG loading fw
0.397144 DEBUG loading nvram
0.397796 DEBUG starting up core...
0.418976 DEBUG waiting for wifi init...
0.503198 DEBUG shared_addr 00016070
0.503409 DEBUG wifi init done
0.503522 DEBUG Downloading CLM...
```