### PR TITLE
Register SIGINT handler after RTT scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `cli`: Allow to interrupt `probe-rs run` during RTT scan (#1705).
+
 ## [0.20.0]
 
 Released 2023-07-19

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -104,11 +104,11 @@ fn run_loop(
     timestamp_offset: UtcOffset,
     always_print_stacktrace: bool,
 ) -> Result<bool, anyhow::Error> {
-    let exit = Arc::new(AtomicBool::new(false));
-    let sig_id = signal_hook::flag::register(signal::SIGINT, exit.clone())?;
-
     let rtt_config = rtt::RttConfig::default();
     let mut rtta = attach_to_rtt(core, memory_map, path, rtt_config, timestamp_offset);
+
+    let exit = Arc::new(AtomicBool::new(false));
+    let sig_id = signal_hook::flag::register(signal::SIGINT, exit.clone())?;
 
     let mut stdout = std::io::stdout();
     while !exit.load(Ordering::Relaxed) {


### PR DESCRIPTION
If no RTT location is found in the ELF file, probe-rs tries to find the RTT block by scanning all memory regions. That can take a while, during which it should be possible to interrupt it with CTRL-C.

This patch achieves that by only registering the SIGINT signal  handler after calling `attach_to_rtt`.

As an alternative, the `exit` flag could be passed down into `attach_to_rtt` and the memory scanning routine, and the scan could be aborted as soon as the flag is `true`. That would be a lot of boilerplate, and I don't see a significant advantage.