### PR TITLE
Add RA4M1 Series flash algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added RA4M1 series target, R7FA4M1AB. (#1706)
+
 ### Changed
 
 - `cli`: Allow to interrupt `probe-rs run` during RTT scan (#1705).

--- a/probe-rs/targets/RA4M1.yaml
+++ b/probe-rs/targets/RA4M1.yaml
@@ -1,0 +1,50 @@
+name: RA4M1 Series
+variants:
+- name: R7FA4M1AB
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Nvm
+    range:
+      start: 0x0
+      end: 0x40000
+    is_boot_memory: true
+    cores:
+    - main
+  flash_algorithms:
+  - ra4m1-flash-algorithm
+flash_algorithms:
+- name: ra4m1-flash-algorithm
+  description: R7FA4M1AB 256kB Flash
+  default: true
+  instructions: sLUCrxtNFEYoeAixAPA8+AEgKHBgHgMoKNIXSJD4gBCBeQFoFUkKaELwBAIKYBRJSvIDUgqAACGA+IAQkPiAEMkG+9QBIQAigXECYIF1ICHBdYJ1AX/JB/zQCkkAIgFgASFBdIJxACApcLC9APA6+f7eAL8sAwAgIOABQBDgAOD+4wFAEREBELC1Aq8NSQEgCngBKhTRDEoAI0DyBEQ4JZBxE2BTdCSIkHUF6hQk1HWC+IAABUgLcE/0JUEBgAAgsL0AvywDACAg4AFA/uMBQNC1Aq8ERhJIAHgBKBzRAPC1+BBIIQwEgAGBBIIBg4QhAXOQ+CQQSQb71QAhAXOQ+CQQSQb71LD46EAA8MX4ACwYv0LyEnQA4AEkIEbQvQC/LAMAIAjBfkDwtQOvTfgEvQVGIUgAeAEoBNFIBwbQQvIUcADgASBd+AS78L0URk4ZAPB8+BlIT/CBDE/wAA61QiDQKQwFgAGB1OkAEwPqAQIBMhTQAYUJDAGGGQwDh4GHgPgMwJD4JBBJBvvVgPgM4JD4JBBJBvvUsPjoEBG5CDQINdznsPjoQADwdvgUsULyE3DI5wAgxucsAwAgCMF+QNC1Aq8SSAB4ASgd0QDwPvgQSAAhAYABgQGCBCEBg4YhAXOQ+CQQSQb71QAhAXOQ+CQQSQb71LD46EAA8E34ACwYv0LyEXQA4AEkIEbQvQC/LAMAIAjBfkBL9oAxSENP9HpxsPvx8EEeB0hBYAAhgWABaEHwAQEBYAFoyQP81QFoIfABAQFgcEcQ4ADgsLUCrw9ISvYBIQ9MpSUBgBIg7SEA8ET4kiBtIYT4gFAgcCFwfSEgcIIgAPBB+BcghPjYAAEghPgkAAAghPgkALC9AL+y/35AAMF+QLC1Aq8PTAEgpSVtIYT4JAAAIIT4JACSIADwHPgSIO0hhPiAUCBwIXD3ISBwCCAA8Bn4BUhP9CpBAYABiAAp/NGwvQC/AMF+QLL/fkCAtW9GAN7+3oT4gFAgcCFwIHACIP/3jr+E+IBQIHAhcCBwBSD/94a/ANTU1A==
+  load_address: 0x20000020
+  pc_init: 0x1
+  pc_uninit: 0x89
+  pc_program_page: 0x129
+  pc_erase_sector: 0xd1
+  pc_erase_all: 0x1c1
+  data_section_offset: 0x20000330
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x40000
+    page_size: 0x800
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 2000
+    sectors:
+    - size: 0x800
+      address: 0x0
+  cores:
+  - main


### PR DESCRIPTION
RA4M1 / R7FA4M1AB is the MCU used in Arduino Uno R4.

Source code of the FlashAlgo can be found here.
https://github.com/elfmimi/ra4m1-flash-algorithm

Known shortcoming: no data flash support yet.

---  
as a side note: here are hello-world and led-blinker demo.
https://github.com/elfmimi/rust-rtt-sample

Beware of option-setting memory section which is resident in sector 0 of the main code flash.
pyocd script below should help if you happen to make your target semi-bricked.
https://gist.github.com/elfmimi/d0a8ba4b469ce7d748c4dccf416ecd99