### PR TITLE
Add --test-address option to target-gen test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added RA4M1 series target, R7FA4M1AB. (#1706)
+- target-gen: Add new `--test-address` option to the `target-gen test` subcommand. (#1708)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3455,6 +3455,7 @@ dependencies = [
  "goblin",
  "indicatif",
  "log",
+ "parse_int",
  "predicates",
  "probe-rs",
  "probe-rs-target",

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -46,6 +46,7 @@ tracing-subscriber = { version = "0.3.17", features = [
 xshell = { version = "0.2", default-features = false }
 cargo_metadata = { version = "0.17", default-features = false }
 indicatif = { version = "0.17", default-features = false }
+parse_int = { version = "0.6.0" }
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::rc::Rc;
 use std::time::Instant;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use colored::Colorize;
 use probe_rs::flashing::erase_all;
 use probe_rs::MemoryInterface;
@@ -12,6 +12,7 @@ use probe_rs::{
     flashing::{erase_sectors, DownloadOptions, FlashLoader, FlashProgress},
     Permissions, Session,
 };
+use probe_rs_target::RawFlashAlgorithm;
 use xshell::{cmd, Shell};
 
 use crate::commands::elf::cmd_elf;
@@ -22,6 +23,7 @@ pub fn cmd_test(
     target_artifact: &Path,
     template_path: &Path,
     definition_export_path: &Path,
+    test_start_sector_address: Option<u64>,
 ) -> Result<()> {
     // Generate the binary
     println!("Generating the YAML file in `{definition_export_path:?}`");
@@ -43,10 +45,6 @@ pub fn cmd_test(
     probe_rs::config::add_target_from_yaml(file)?;
     let mut session =
         probe_rs::Session::auto_attach(ALGORITHM_NAME, Permissions::new().allow_erase_all())?;
-
-    let data_size = probe_rs::config::get_target_by_name(ALGORITHM_NAME)?.flash_algorithms[0]
-        .flash_properties
-        .page_size;
 
     // Register callback to update the progress.
     let t = Rc::new(RefCell::new(Instant::now()));
@@ -85,21 +83,51 @@ pub fn cmd_test(
         }
     });
 
-    let test = "Test".green();
-    let flash_properties = session.target().flash_algorithms[0]
-        .flash_properties
-        .clone();
+    let flash_algorithm = if let Some(test_start_sector_address) = test_start_sector_address {
+        let predicate = |x: &&RawFlashAlgorithm| {
+            x.flash_properties.address_range.start <= test_start_sector_address
+                && test_start_sector_address < x.flash_properties.address_range.end
+        };
+        let error_message = anyhow!("No flash algorithm matching specified address can be found");
+        session
+            .target()
+            .flash_algorithms
+            .iter()
+            .find(predicate)
+            .ok_or(error_message)?
+    } else {
+        &session.target().flash_algorithms[0]
+    };
+    let flash_properties = flash_algorithm.flash_properties.clone();
+    let start_address = flash_properties.address_range.start;
+    let end_address = flash_properties.address_range.end;
+    let data_size = flash_properties.page_size;
     let erased_state = flash_properties.erased_byte_value;
+    let sector_size = flash_properties.sectors[0].size;
 
+    let test_start_sector_address = test_start_sector_address.unwrap_or(start_address);
+    if test_start_sector_address < start_address
+        || test_start_sector_address > start_address + end_address - sector_size * 2
+        || test_start_sector_address % sector_size != 0
+    {
+        return Err(anyhow!(
+            "test_start_sector_address must be sector aligned address pointing flash range"
+        ));
+    }
+    let test_start_sector_index =
+        ((test_start_sector_address - start_address) / sector_size) as usize;
+
+    let test = "Test".green();
     println!("{test}: Erasing sectorwise and writing two pages ...");
-
-    run_flash_erase(&mut session, progress.clone(), false)?;
-    // TODO: The sector used here is not necessarily the sector the flash algorithm targets.
-    // Make this configurable.
-    let mut readback = vec![0; flash_properties.sectors[0].size as usize];
+    run_flash_erase(
+        &mut session,
+        progress.clone(),
+        EraseSectors(test_start_sector_index, 2),
+    )?;
+    let mut readback = vec![0; (sector_size * 2) as usize];
     session
         .core(0)?
-        .read_8(flash_properties.address_range.start, &mut readback)?;
+        .read_8(test_start_sector_address, &mut readback)?;
     assert!(
         !readback.iter().any(|v| *v != erased_state),
         "Not all sectors were erased"
@@ -107,22 +135,20 @@ pub fn cmd_test(
 
     let mut loader = session.target().flash_loader();
     let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
-    loader.add_data(flash_properties.address_range.start + 1, &data)?;
+    loader.add_data(test_start_sector_address + 1, &data)?;
     run_flash_download(&mut session, loader, progress.clone(), true)?;
     let mut readback = vec![0; data_size as usize];
     session
         .core(0)?
-        .read_8(flash_properties.address_range.start + 1, &mut readback)?;
+        .read_8(test_start_sector_address + 1, &mut readback)?;
     assert_eq!(readback, data);
 
     println!("{test}: Erasing the entire chip and writing two pages ...");
-    run_flash_erase(&mut session, progress.clone(), true)?;
-    // TODO: The sector used here is not necessarily the sector the flash algorithm targets.
-    // Make this configurable.
-    let mut readback = vec![0; flash_properties.sectors[0].size as usize];
+    run_flash_erase(&mut session, progress.clone(), EraseAll)?;
+    let mut readback = vec![0; (sector_size * 2) as usize];
     session
         .core(0)?
-        .read_8(flash_properties.address_range.start, &mut readback)?;
+        .read_8(test_start_sector_address, &mut readback)?;
     assert!(
         !readback.iter().any(|v| *v != erased_state),
         "Not all sectors were erased"
@@ -130,22 +156,24 @@ pub fn cmd_test(
 
     let mut loader = session.target().flash_loader();
     let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
-    loader.add_data(flash_properties.address_range.start + 1, &data)?;
+    loader.add_data(test_start_sector_address + 1, &data)?;
     run_flash_download(&mut session, loader, progress.clone(), true)?;
     let mut readback = vec![0; data_size as usize];
     session
         .core(0)?
-        .read_8(flash_properties.address_range.start + 1, &mut readback)?;
+        .read_8(test_start_sector_address + 1, &mut readback)?;
     assert_eq!(readback, data);
 
     println!("{test}: Erasing sectorwise and writing two pages double buffered ...");
-    run_flash_erase(&mut session, progress.clone(), false)?;
-    // TODO: The sector used here is not necessarily the sector the flash algorithm targets.
-    // Make this configurable.
-    let mut readback = vec![0; flash_properties.sectors[0].size as usize];
+    run_flash_erase(
+        &mut session,
+        progress.clone(),
+        EraseSectors(test_start_sector_index, 2),
+    )?;
+    let mut readback = vec![0; (sector_size * 2) as usize];
     session
         .core(0)?
-        .read_8(flash_properties.address_range.start, &mut readback)?;
+        .read_8(test_start_sector_address, &mut readback)?;
     assert!(
         !readback.iter().any(|v| *v != erased_state),
         "Not all sectors were erased"
@@ -153,12 +181,12 @@ pub fn cmd_test(
 
     let mut loader = session.target().flash_loader();
     let data = (0..data_size).map(|n| (n % 256) as u8).collect::<Vec<_>>();
-    loader.add_data(flash_properties.address_range.start + 1, &data)?;
+    loader.add_data(test_start_sector_address + 1, &data)?;
     run_flash_download(&mut session, loader, progress, false)?;
     let mut readback = vec![0; data_size as usize];
     session
         .core(0)?
-        .read_8(flash_properties.address_range.start + 1, &mut readback)?;
+        .read_8(test_start_sector_address + 1, &mut readback)?;
     assert_eq!(readback, data);
 
     Ok(())
@@ -184,17 +212,22 @@ pub fn run_flash_download(
     Ok(())
 }
 
-/// Erases the entire flash if `do_chip_erase` is true,
-/// Otherwise it erases sectors 0 and 1.
+pub enum EraseType {
+    EraseAll,
+    EraseSectors(usize, usize),
+}
+use EraseType::*;
+
+/// Erases the entire flash or just the sectors specified.
 pub fn run_flash_erase(
     session: &mut Session,
     progress: FlashProgress,
-    do_chip_erase: bool,
+    erase_type: EraseType,
 ) -> Result<()> {
-    if do_chip_erase {
-        erase_all(session, Some(progress))?;
+    if let EraseSectors(start_sector, sectors) = erase_type {
+        erase_sectors(session, Some(progress), start_sector, sectors)?;
     } else {
-        erase_sectors(session, Some(progress), 0, 2)?;
+        erase_all(session, Some(progress))?;
     }
 
     Ok(())

--- a/target-gen/src/main.rs
+++ b/target-gen/src/main.rs
@@ -20,6 +20,8 @@ use crate::commands::{
     test::cmd_test,
 };
 
+use core::num::ParseIntError;
+
 #[derive(clap::Parser)]
 enum TargetGen {
     /// Generate target description from ARM CMSIS-Packs
@@ -98,7 +100,14 @@ enum TargetGen {
         definition_export_path: PathBuf,
         /// The path to the ELF.
         target_artifact: PathBuf,
+        /// The address used as the start of flash memory area to perform test.
+        #[clap(long = "test-address", value_parser = parse_u64)]
+        test_start_sector_address: Option<u64>,
     },
+}
+
+pub fn parse_u64(input: &str) -> Result<u64, ParseIntError> {
+    parse_int::parse(input)
 }
 
 fn main() -> Result<()> {
@@ -135,10 +144,12 @@ fn main() -> Result<()> {
             target_artifact,
             template_path,
             definition_export_path,
+            test_start_sector_address,
         } => cmd_test(
             target_artifact.as_path(),
             template_path.as_path(),
             definition_export_path.as_path(),
+            test_start_sector_address,
         )?,
     }
 


### PR DESCRIPTION
Spun out of this comment. https://github.com/probe-rs/probe-rs/pull/1706#issuecomment-1656812105

it will be used to avoid writing to sector 0, by passing valid sector aligned address other than 0.
ex. `target-gen test template.yaml definition.yaml target/thumbv7em-none-eabi/algorithm --base-address 0x800`