### PR TITLE
Ignore the error when calling enable_vector_catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `cli`: Allow to interrupt `probe-rs run` during RTT scan (#1705).
-
+- `cli`: Ignore errors from `enable_vector_catch` (#1714).
 ## [0.20.0]
 
 Released 2023-07-19

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -83,7 +83,7 @@ impl Cmd {
 
         if run_download {
             core.reset_and_halt(Duration::from_millis(100))?;
-            core.enable_vector_catch(VectorCatchCondition::All)?;
+            core.enable_vector_catch(VectorCatchCondition::All).ok();
             core.run()?;
         }
 

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -83,7 +83,9 @@ impl Cmd {
 
         if run_download {
             core.reset_and_halt(Duration::from_millis(100))?;
-            core.enable_vector_catch(VectorCatchCondition::All).ok();
+            if let Err(e) = core.enable_vector_catch(VectorCatchCondition::All) {
+                tracing::error!("Failed to enable_vector_catch: {:?}", e);
+            }
             core.run()?;
         }
 


### PR DESCRIPTION
The run command would fail for targets that don't currently support enable_vector_catch. We now just ignore the error.