### PR TITLE
Fixed address offsets for the armv7a and armv8a debug registers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Released 2023-07-19
 - `cli`: all the commands now load the chip description path and provide uniform config arguments (#1691).
 - `dap-server`: The VSCode extension reports all STDERR errors if process initialization fails (#1699).
 - `debug` : Consider `RegisterValue` byte size when doing arithmetic on register addresses. (#1701)
+- ARMv7-A, ARMv8-A: Fixed incorrect addresses for registers.
 
 ### Removed
 

--- a/probe-rs/src/architecture/arm/core/armv7a_debug_regs.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a_debug_regs.rs
@@ -5,7 +5,7 @@ use crate::{core::BreakpointCause, memory_mapped_bitfield_register, HaltReason};
 memory_mapped_bitfield_register! {
     /// DBGDSCR - Debug Status and Control Registers
     pub struct Dbgdscr(u32);
-    34, "DBGDSCR",
+    0x088, "DBGDSCR",
     impl From;
 
     /// DBGDTRRX register full. The possible values of this bit are:
@@ -245,7 +245,7 @@ impl Dbgdscr {
 memory_mapped_bitfield_register! {
     /// DBGDIDR - Debug ID Register
     pub struct Dbgdidr(u32);
-    0, "DBGDIDR",
+    0x000, "DBGDIDR",
     impl From;
 
     /// The number of watchpoints implemented. The number of implemented watchpoints is one more than the value of this field.
@@ -299,7 +299,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGDRCR - Debug Run Control Register
     pub struct Dbgdrcr(u32);
-    36, "DBGDRCR",
+    0x090, "DBGDRCR",
     impl From;
 
     /// Cancel Bus Requests Request
@@ -321,7 +321,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGBVR - Breakpoint Value Register
     pub struct Dbgbvr(u32);
-    64, "DBGBVR",
+    0x100, "DBGBVR",
     impl From;
 
     /// Breakpoint address
@@ -331,7 +331,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGBCR - Breakpoint Control Register
     pub struct Dbgbcr(u32);
-    80, "DBGBCR",
+    0x140, "DBGBCR",
     impl From;
 
     /// Address range mask. Whether masking is supported is implementation defined.
@@ -362,7 +362,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGLAR - Lock Access Register
     pub struct Dbglar(u32);
-    1004, "DBGLAR",
+    0xFB0, "DBGLAR",
     impl From;
 
     /// Lock value
@@ -373,7 +373,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGDSCCR - State Cache Control Register
     pub struct Dbgdsccr(u32);
-    10, "DBGDSCCR",
+    0x028, "DBGDSCCR",
     impl From;
 
     /// Force Write-Through
@@ -389,7 +389,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGDSMCR - Debug State MMU Control Register
     pub struct Dbgdsmcr(u32);
-    11, "DBGDSMCR",
+    0x02C, "DBGDSMCR",
     impl From;
 
     /// Instruction TLB matching bit
@@ -408,7 +408,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGITR - Instruction Transfer Register
     pub struct Dbgitr(u32);
-    33, "DBGITR",
+    0x084, "DBGITR",
     impl From;
 
     /// Instruction value
@@ -418,7 +418,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGDTRTX - Target to Host data transfer register
     pub struct Dbgdtrtx(u32);
-    35, "DBGDTRTX",
+    0x08C, "DBGDTRTX",
     impl From;
 
     /// Value
@@ -428,7 +428,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGDTRRX - Host to Target data transfer register
     pub struct Dbgdtrrx(u32);
-    32, "DBGDTRRX",
+    0x080, "DBGDTRRX",
     impl From;
 
     /// Value
@@ -438,7 +438,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGPRCR - Powerdown and Reset Control Register
     pub struct Dbgprcr(u32);
-    196, "DBGPRCR",
+    0x310, "DBGPRCR",
     impl From;
 
     /// Core powerup request
@@ -457,7 +457,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGPRSR - Powerdown and Reset Status Register
     pub struct Dbgprsr(u32);
-    197, "DBGPRSR",
+    0x314, "DBGPRSR",
     impl From;
 
     /// OS Double Lock Status

--- a/probe-rs/src/architecture/arm/core/armv8a_debug_regs.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a_debug_regs.rs
@@ -5,7 +5,7 @@ use crate::{core::BreakpointCause, memory_mapped_bitfield_register, HaltReason};
 memory_mapped_bitfield_register! {
     /// EDSCR - Debug Status and Control Register
     pub struct Edscr(u32);
-    34, "EDSCR",
+    0x088, "EDSCR",
     impl From;
 
     /// Trace Filter Override. Overrides the Trace Filter controls allowing the external debugger to trace any visible Exception level.
@@ -148,7 +148,7 @@ impl Edscr {
 memory_mapped_bitfield_register! {
     /// EDLAR - Lock Access Register
     pub struct Edlar(u32);
-    1004,"EDLAR",
+    0xFB0,"EDLAR",
     impl From;
 
     /// Lock value
@@ -159,7 +159,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGBVR - Breakpoint Value Register
     pub struct Dbgbvr(u32);
-    256, "DBGBVR",
+    0x400, "DBGBVR",
     impl From;
 
     /// Breakpoint address
@@ -169,7 +169,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGBCR - Breakpoint Control Register
     pub struct Dbgbcr(u32);
-    258, "DBGBCR",
+    0x408, "DBGBCR",
     impl From;
 
     /// Breakpoint type
@@ -197,7 +197,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// EDDFR - External Debug Feature Register
     pub struct Eddfr(u32);
-    842, "EDDFR",
+    0xD28, "EDDFR",
     impl From;
 
     /// Number of breakpoints that are context-aware, minus 1.
@@ -219,7 +219,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// EDITR - External Debug Instruction Transfer Register
     pub struct Editr(u32);
-    33, "EDITR",
+    0x084, "EDITR",
     impl From;
 
     /// Instruction value
@@ -229,7 +229,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// EDRCR - External Debug Reserve Control Register
     pub struct Edrcr(u32);
-    36, "EDRCR",
+    0x090, "EDRCR",
     impl From;
 
     /// Allow imprecise entry to Debug state.
@@ -245,7 +245,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// EDECR - External Debug Execution Control Register
     pub struct Edecr(u32);
-    9, "EDECR",
+    0x024, "EDECR",
     impl From;
 
     /// Halting step enable.
@@ -261,7 +261,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// EDPRCR - External Debug Power/Reset Control Register
     pub struct Edprcr(u32);
-    196, "EDPRCR",
+    0x310, "EDPRCR",
     impl From;
 
     /// COREPURQ
@@ -277,7 +277,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGDTRTX - Debug Data Transfer Register, Transmit
     pub struct Dbgdtrtx(u32);
-    35, "DBGDTRTX",
+    0x08C, "DBGDTRTX",
     impl From;
 
     /// Instruction value
@@ -287,7 +287,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// DBGDTRRX - Debug Data Transfer Register, Receive
     pub struct Dbgdtrrx(u32);
-    32, "DBGDTRRX",
+    0x080, "DBGDTRRX",
     impl From;
 
     /// Instruction value
@@ -297,7 +297,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// EDPRSR - External Debug Processor Status Register
     pub struct Edprsr(u32);
-    197, "EDPRSR",
+    0x314, "EDPRSR",
     impl From;
 
     /// Sticky Debug Restart.
@@ -340,7 +340,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// CTICONTROL - CTI control register
     pub struct CtiControl(u32);
-    0, "CTICONTROL",
+    0x000, "CTICONTROL",
     impl From;
 
     /// Enables or disables the CTI mapping functions.
@@ -350,7 +350,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// CTIGATE - CTI gate register
     pub struct CtiGate(u32);
-    80, "CTIGATE",
+    0x140, "CTIGATE",
     impl From;
 
     /// Enables or disables the CTI mapping functions.
@@ -360,7 +360,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// CTIOUTEN<n> - CTI output enable register
     pub struct CtiOuten(u32);
-    40, "CTIOUTEN",
+    0x0A0, "CTIOUTEN",
     impl From;
 
     /// Enables or disables input <n> generating this output
@@ -370,7 +370,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// CTIAPPPULSE - CTI application pulse register
     pub struct CtiApppulse(u32);
-    7, "CTIAPPPULSE",
+    0x01C, "CTIAPPPULSE",
     impl From;
 
     /// Generate a pulse on channel N
@@ -380,7 +380,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// CTIINTACK - CTI Output Trigger Acknowledge register
     pub struct CtiIntack(u32);
-    4, "CTIINTACK",
+    0x010, "CTIINTACK",
     impl From;
 
     /// Ack trigger on channel N
@@ -390,7 +390,7 @@ memory_mapped_bitfield_register! {
 memory_mapped_bitfield_register! {
     /// CTITRIGOUTSTATUS - CTI Trigger Out Status register
     pub struct CtiTrigoutstatus(u32);
-    77, "CTITRIGOUTSTATUS",
+    0x134, "CTITRIGOUTSTATUS",
     impl From;
 
     /// Status on channel N


### PR DESCRIPTION
The  refactor in #1604 interpreted the register numbers used before here as addresses, which results in the offsets being off by a factor of 4. This fixes that.