### PR TITLE
cli: retry RTT attach a few times before giving up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `cli`: Allow to interrupt `probe-rs run` during RTT scan (#1705).
 - `cli`: Ignore errors from `enable_vector_catch` (#1714).
+- `cli`: Retry RTT attach before continuing (#1722).
 ## [0.20.0]
 
 Released 2023-07-19


### PR DESCRIPTION
I found it could be unreliable, especially when using a bootloader which executes before the main application. This PR now retries a few times before continuing.