### PR TITLE
Add `--verify`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added --no-location option to the CLI run command, which suppresses the filename and line number
   information from the rtt log (#1704)
 - target-gen: Add new `--test-address` option to the `target-gen test` subcommand. (#1708)
-- `cli`: Add `--verify` flag to `download`, `flash` and `run`
+- `cli`: Add `--verify` flag to `download`, `flash` and `run` (#1727)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added --no-location option to the CLI run command, which suppresses the filename and line number
   information from the rtt log (#1704)
 - target-gen: Add new `--test-address` option to the `target-gen test` subcommand. (#1708)
+- `cli`: Add `--verify` flag to `download`, `flash` and `run`
 
 ### Changed
 

--- a/deny.toml
+++ b/deny.toml
@@ -76,6 +76,8 @@ notice = "warn"
 ignore = [
     #"RUSTSEC-0000-0000",
     "RUSTSEC-2020-0071",
+    "RUSTSEC-2023-0052",
+    "RUSTSEC-2023-0053",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -105,6 +105,9 @@ pub struct BinaryDownloadOptions {
         help = "Requests the flash builder to output the layout into the given file in SVG format."
     )]
     pub flash_layout_output_path: Option<String>,
+    /// After flashing, read back all the flashed data to verify it has been written correctly.
+    #[clap(long)]
+    pub verify: bool,
 }
 
 /// Common options and logic when interfacing with a [Probe].

--- a/probe-rs/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs/src/bin/probe-rs/util/flash.rs
@@ -30,6 +30,7 @@ pub fn run_flash_download(
     options.dry_run = probe_options.dry_run();
     options.do_chip_erase = do_chip_erase;
     options.disable_double_buffering = download_options.disable_double_buffering;
+    options.verify = download_options.verify;
 
     if !download_options.disable_progressbars {
         // Create progress bars.


### PR DESCRIPTION
This PR adds a `--verify` option to the `BinaryDownloadOptions`. So it gets added to the `download`, `flash` and `run` subcommands.

Testing it on my `nrf52840-dk` the verification shows up in the logs:
```console
$ probe-rs run --chip nRF52840_xxAA --verify target/thumbv7em-none-eabihf/debug/hello
<...>
DEBUG probe_rs::flashing::loader: committing RAM!
DEBUG probe_rs::flashing::loader:     region: 20000000-20040000 (262144 bytes)
DEBUG probe_rs::flashing::loader:      -- empty.
DEBUG probe_rs::flashing::loader: Verifying!
DEBUG probe_rs::flashing::loader:     data: 00000000-00001498 (5272 bytes)
<...>
```

---

Style question: For the other fields of the `BinaryDownloadOptions` you explicitly specify the `name`, `long` and `help`. Is there a reason for that? Usually `clap` just infers this info. So e.g. `restore_unwritten` could be simplified like following without changing the output:

```diff
-#[clap(
-    name = "restore-unwritten",
-    long = "restore-unwritten",
-    help = "Enable this flag to restore all bytes erased in the sector erase but not overwritten by any page."
-)]
+/// Enable this flag to restore all bytes erased in the sector erase but not overwritten by any page.
+#[clap(long)]
pub restore_unwritten: bool,
```

If you prefer the explicit style, I can adapt my PR. If you like the simple style, I can add a commit to adapt the other fields.