### PR TITLE
Allow JTAG scan information to be encoded in targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cli`: Add `read` and `write` commands to interact with target memory (8,32,64 bit words) (#1746)
 - Added STM32U5A and STM32U59 targets. (#1744)
 - Added AT32F4 series targets (#1759)
+- Allowed JTAG scan chain information to be encoded in targets (#1731)
 
 ### Changed
 

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -1,6 +1,42 @@
 use super::memory::MemoryRegion;
 use crate::{serialize::hex_option, CoreType};
 use serde::{Deserialize, Serialize};
+
+/// Represents a DAP scan chain element.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ScanChainDap {
+    /// Unique name of the DAP
+    pub name: Option<String>,
+    /// Specifies the type of the DAP (e.g. ARMCS-DP)
+    pub dap_type: Option<String>,
+    /// Specifies the IR length of the DAP (default value: 4).
+    pub ir_len: Option<u8>,
+    /// List of protocols via which the DAP can be use. Possible values are SWD, JTAG, and cJTAG.
+    pub protocols: Option<Vec<String>>,
+    /// Specifies the SW-DPv2 TARGETSEL register value that selects this DAP in a serial-wire debug multi-drop system
+    pub targetsel: Option<u8>,
+}
+
+/// Represents a non DAP device in the scan chain. This can be other TAPs.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ScanChainDevice {
+    /// Unique name of the device
+    pub name: Option<String>,
+    /// Specifies the type of the device (e.g. ARMCS-DP)
+    pub device_type: Option<String>,
+    /// Specifies the IR length of the device (default value: 4).
+    pub ir_len: Option<u8>,
+}
+
+/// Declares the type of a scan chain as defined by CMSIS-Pack SDF
+/// ref: https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ScanChain {
+    /// Scan chain element is a DAP
+    Dap(ScanChainDap),
+    /// Scan chain element is another JTAG device such as other TAPs
+    Device(ScanChainDevice),
+}
 /// A single chip variant.
 ///
 /// This describes an exact chip variant, including the cores, flash and memory size. For example,
@@ -43,6 +79,11 @@ pub struct Chip {
     /// executable image that includes the `_SEGGER_RTT` symbol pointing
     /// to the exact address of the RTT header.
     pub rtt_scan_ranges: Option<Vec<std::ops::Range<u64>>>,
+    /// Describes the scan chain
+    ///
+    /// ref: https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain
+    #[serde(default)]
+    pub scan_chain: Option<Vec<ScanChain>>,
 }
 
 impl Chip {
@@ -61,6 +102,7 @@ impl Chip {
             memory_map: vec![],
             flash_algorithms: vec![],
             rtt_scan_ranges: None,
+            scan_chain: Some(vec![]),
         }
     }
 }

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -4,39 +4,13 @@ use serde::{Deserialize, Serialize};
 
 /// Represents a DAP scan chain element.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ScanChainDap {
+pub struct ScanChainElement {
     /// Unique name of the DAP
     pub name: Option<String>,
-    /// Specifies the type of the DAP (e.g. ARMCS-DP)
-    pub dap_type: Option<String>,
     /// Specifies the IR length of the DAP (default value: 4).
     pub ir_len: Option<u8>,
-    /// List of protocols via which the DAP can be use. Possible values are SWD, JTAG, and cJTAG.
-    pub protocols: Option<Vec<String>>,
-    /// Specifies the SW-DPv2 TARGETSEL register value that selects this DAP in a serial-wire debug multi-drop system
-    pub targetsel: Option<u8>,
 }
 
-/// Represents a non DAP device in the scan chain. This can be other TAPs.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ScanChainDevice {
-    /// Unique name of the device
-    pub name: Option<String>,
-    /// Specifies the type of the device (e.g. ARMCS-DP)
-    pub device_type: Option<String>,
-    /// Specifies the IR length of the device (default value: 4).
-    pub ir_len: Option<u8>,
-}
-
-/// Declares the type of a scan chain as defined by CMSIS-Pack SDF
-/// ref: https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum ScanChain {
-    /// Scan chain element is a DAP
-    Dap(ScanChainDap),
-    /// Scan chain element is another JTAG device such as other TAPs
-    Device(ScanChainDevice),
-}
 /// A single chip variant.
 ///
 /// This describes an exact chip variant, including the cores, flash and memory size. For example,
@@ -81,9 +55,9 @@ pub struct Chip {
     pub rtt_scan_ranges: Option<Vec<std::ops::Range<u64>>>,
     /// Describes the scan chain
     ///
-    /// ref: https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain
+    /// ref: `<https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain>`
     #[serde(default)]
-    pub scan_chain: Option<Vec<ScanChain>>,
+    pub scan_chain: Option<Vec<ScanChainElement>>,
 }
 
 impl Chip {
@@ -151,3 +125,16 @@ pub struct ArmCoreAccessOptions {
 /// The data required to access a Risc-V core
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RiscvCoreAccessOptions {}
+
+/// Helper function that interates the scan chain and returns a vector of all of
+/// the ir_lengths of the scan chain elements.
+/// If an element does not contain an ir_length, the default value of 4 is used.
+/// The first element of the vector is the first element of the scan chain.
+pub fn get_ir_lengths(scan_chain: &Vec<ScanChainElement>) -> Vec<u8> {
+    let mut ir_lengths = Vec::new();
+    for element in scan_chain {
+        let ir_len = element.ir_len.unwrap_or(4);
+        ir_lengths.push(ir_len);
+    }
+    ir_lengths
+}

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -19,8 +19,8 @@ mod memory;
 pub(crate) mod serialize;
 
 pub use chip::{
-    ArmCoreAccessOptions, Chip, Core, CoreAccessOptions, RiscvCoreAccessOptions, ScanChain,
-    ScanChainDap, ScanChainDevice,
+    get_ir_lengths, ArmCoreAccessOptions, Chip, Core, CoreAccessOptions, RiscvCoreAccessOptions,
+    ScanChainElement,
 };
 pub use chip_family::{
     Architecture, ChipFamily, CoreType, InstructionSet, TargetDescriptionSource,

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -18,7 +18,10 @@ mod flash_properties;
 mod memory;
 pub(crate) mod serialize;
 
-pub use chip::{ArmCoreAccessOptions, Chip, Core, CoreAccessOptions, RiscvCoreAccessOptions};
+pub use chip::{
+    ArmCoreAccessOptions, Chip, Core, CoreAccessOptions, RiscvCoreAccessOptions, ScanChain,
+    ScanChainDap, ScanChainDevice,
+};
 pub use chip_family::{
     Architecture, ChipFamily, CoreType, InstructionSet, TargetDescriptionSource,
 };

--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -28,8 +28,8 @@ mod target;
 
 pub use probe_rs_target::{
     Chip, ChipFamily, Core, CoreType, FlashProperties, GenericRegion, InstructionSet, MemoryRange,
-    MemoryRegion, NvmRegion, PageInfo, RamRegion, RawFlashAlgorithm, ScanChain, SectorDescription,
-    SectorInfo, TargetDescriptionSource,
+    MemoryRegion, NvmRegion, PageInfo, RamRegion, RawFlashAlgorithm, ScanChainElement,
+    SectorDescription, SectorInfo, TargetDescriptionSource,
 };
 
 pub use registry::{

--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -28,8 +28,8 @@ mod target;
 
 pub use probe_rs_target::{
     Chip, ChipFamily, Core, CoreType, FlashProperties, GenericRegion, InstructionSet, MemoryRange,
-    MemoryRegion, NvmRegion, PageInfo, RamRegion, RawFlashAlgorithm, SectorDescription, SectorInfo,
-    TargetDescriptionSource,
+    MemoryRegion, NvmRegion, PageInfo, RamRegion, RawFlashAlgorithm, ScanChain, SectorDescription,
+    SectorInfo, TargetDescriptionSource,
 };
 
 pub use registry::{

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -382,9 +382,13 @@ fn match_name_prefix(pattern: &str, name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use probe_rs_target::get_ir_lengths;
     use std::fs::File;
-    use probe_rs_target::ScanChain;
     type TestResult = Result<(), RegistryError>;
+
+    // Need to synchronize this with probe-rs/tests/scan_chain_test.yaml
+    const FIRST_IR_LENGTH: u8 = 4;
+    const SECOND_IR_LENGTH: u8 = 6;
 
     #[test]
     fn try_fetch_not_unique() {
@@ -458,17 +462,10 @@ mod tests {
         let mut target = get_target_by_name("FULL_SCAN_CHAIN").unwrap();
         let scan_chain = target.scan_chain.unwrap();
         for device in scan_chain {
-            match device {
-                ScanChain::Dap(ref dap) => {
-                    assert_eq!(dap.name, Some("core0".to_string()));
-                    assert_eq!(dap.dap_type, Some("armv6m".to_string()));
-                    assert_eq!(dap.ir_len, Some(4));
-                    assert_eq!(dap.protocols, Some(vec!["jtag".to_string() ,"swd".to_string()]));
-                }
-                ScanChain::Device(ref device) => {
-                    assert_eq!(device.name, Some("ICEPICK".to_string()));
-                    assert_eq!(device.ir_len, Some(6));
-                }
+            if device.name == Some("core0".to_string()) {
+                assert_eq!(device.ir_len, Some(FIRST_IR_LENGTH));
+            } else if device.name == Some("ICEPICK".to_string()) {
+                assert_eq!(device.ir_len, Some(SECOND_IR_LENGTH));
             }
         }
 
@@ -479,21 +476,22 @@ mod tests {
         // Check a device with a minimal scan chain
         target = get_target_by_name("PARTIAL_SCAN_CHAIN").unwrap();
         let scan_chain = target.scan_chain.unwrap();
-        for device in scan_chain {
-            match device {
-                ScanChain::Dap(ref dap) => {
-                    assert_eq!(dap.name, None);
-                    assert_eq!(dap.dap_type, None);
-                    assert_eq!(dap.ir_len, Some(4));
-                    assert_eq!(dap.protocols, None);
-                }
-                ScanChain::Device(ref device) => {
-                    assert_eq!(device.name, None);
-                    assert_eq!(device.ir_len, Some(6));
-                }
-            }
-        }
+        assert_eq!(scan_chain[0].ir_len, Some(FIRST_IR_LENGTH));
+        assert_eq!(scan_chain[1].ir_len, Some(SECOND_IR_LENGTH));
 
+        Ok(())
+    }
+
+    #[test]
+    fn check_get_ir_lengths_helper() -> TestResult {
+        let file = File::open("tests/scan_chain_test.yaml")?;
+        add_target_from_yaml(file)?;
+
+        // Check that the scan chain can read from a target correctly
+        let target = get_target_by_name("FULL_SCAN_CHAIN").unwrap();
+        let scan_chain = target.scan_chain.unwrap();
+        let ir_lengths = get_ir_lengths(&scan_chain);
+        assert_eq!(ir_lengths, vec![FIRST_IR_LENGTH, SECOND_IR_LENGTH]);
 
         Ok(())
     }

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -1,9 +1,5 @@
-use probe_rs_target::{Architecture, ChipFamily, MemoryRange};
-
-use super::{Core, MemoryRegion, RawFlashAlgorithm, RegistryError, TargetDescriptionSource};
-
 use super::{
-    Core, MemoryRegion, RawFlashAlgorithm, RegistryError, ScanChain, TargetDescriptionSource,
+    Core, MemoryRegion, RawFlashAlgorithm, RegistryError, ScanChainElement, TargetDescriptionSource,
 };
 use crate::architecture::arm::{
     ap::MemoryAp,
@@ -25,6 +21,7 @@ use crate::architecture::arm::{
 use crate::architecture::riscv::sequences::{esp32c3::ESP32C3, esp32c6::ESP32C6};
 use crate::architecture::riscv::sequences::{DefaultRiscvSequence, RiscvDebugSequence};
 use crate::flashing::FlashLoader;
+use probe_rs_target::{Architecture, ChipFamily, MemoryRange};
 use std::sync::Arc;
 
 use crate::architecture::arm::sequences::DefaultArmSequence;
@@ -49,8 +46,12 @@ pub struct Target {
     /// Each region must be enclosed in exactly one RAM region from
     /// `memory_map`.
     pub rtt_scan_regions: Vec<std::ops::Range<u64>>,
-    /// Description of scan chain
-    pub scan_chain: Option<Vec<ScanChain>>,
+    /// The Description of the scan chain
+    ///
+    /// The scan chain can be parsed from the CMSIS-SDF file, or specified
+    /// manually in the target.yaml file. It is used by some probes to determine
+    /// the number devices in the scan chain and their ir lengths.
+    pub scan_chain: Option<Vec<ScanChainElement>>,
 }
 
 impl std::fmt::Debug for Target {
@@ -327,9 +328,9 @@ impl From<Target> for TargetSelector {
     }
 }
 
-/// This is the type to denote a general debug sequence.  
-/// It can differentiate between ARM and RISC-V for now.  
-/// Currently, only the ARM variant does something sensible;  
+/// This is the type to denote a general debug sequence.
+/// It can differentiate between ARM and RISC-V for now.
+/// Currently, only the ARM variant does something sensible;
 /// RISC-V will be ignored when encountered.
 #[derive(Clone)]
 pub enum DebugSequence {

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -1,6 +1,10 @@
 use probe_rs_target::{Architecture, ChipFamily, MemoryRange};
 
 use super::{Core, MemoryRegion, RawFlashAlgorithm, RegistryError, TargetDescriptionSource};
+
+use super::{
+    Core, MemoryRegion, RawFlashAlgorithm, RegistryError, ScanChain, TargetDescriptionSource,
+};
 use crate::architecture::arm::{
     ap::MemoryAp,
     sequences::{
@@ -45,6 +49,8 @@ pub struct Target {
     /// Each region must be enclosed in exactly one RAM region from
     /// `memory_map`.
     pub rtt_scan_regions: Vec<std::ops::Range<u64>>,
+    /// Description of scan chain
+    pub scan_chain: Option<Vec<ScanChain>>,
 }
 
 impl std::fmt::Debug for Target {
@@ -215,6 +221,7 @@ impl Target {
             memory_map: chip.memory_map.clone(),
             debug_sequence,
             rtt_scan_regions,
+            scan_chain: chip.scan_chain.clone(),
         })
     }
 

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -30,6 +30,7 @@ use crate::{
     Permissions,
 };
 use jlink::list_jlink_devices;
+use probe_rs_target::ScanChain;
 use std::{convert::TryFrom, fmt};
 
 /// Used to log warnings when the measured target voltage is

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -30,7 +30,7 @@ use crate::{
     Permissions,
 };
 use jlink::list_jlink_devices;
-use probe_rs_target::ScanChain;
+use probe_rs_target::ScanChainElement;
 use std::{convert::TryFrom, fmt};
 
 /// Used to log warnings when the measured target voltage is
@@ -421,6 +421,20 @@ impl Probe {
         }
     }
 
+    /// Configure the scan chain to use for the attached target.
+    ///
+    /// See [`DebugProbe::set_scan_chain`] for more information and usage
+    pub fn set_scan_chain(
+        &mut self,
+        scan_chain: Vec<ScanChainElement>,
+    ) -> Result<(), DebugProbeError> {
+        if self.attached {
+            self.inner.set_scan_chain(scan_chain)
+        } else {
+            Err(DebugProbeError::Attached)
+        }
+    }
+
     /// Get the currently used maximum speed for the debug protocol in kHz.
     ///
     /// Not all probes report which speed is used, meaning this value is not
@@ -539,6 +553,23 @@ pub trait DebugProbe: Send + fmt::Debug {
     /// `DebugProbeError::UnsupportedSpeed` will be returned.
     ///
     fn set_speed(&mut self, speed_khz: u32) -> Result<u32, DebugProbeError>;
+
+    /// Set the JTAG scan chain information for the target under debug.
+    ///
+    /// This allows the probe to know which TAPs are in the scan chain and their
+    /// position and IR lengths.
+    ///
+    /// If the scan chain is provided, and the selected protocol is JTAG, the
+    /// probe will automatically configure the JTAG interface to match the
+    /// scan chain configuration without trying to deteremine the chain at
+    /// runtime.
+    ///
+    /// This is called by the `Session` when attaching to a target.
+    /// So this does not need to be called manually, unless you want to
+    /// modify the scan chain. You must be attached to a target to set the
+    /// scan_chain since the scan chain only applys to the attached target.
+    ///
+    fn set_scan_chain(&mut self, scan_chain: Vec<ScanChainElement>) -> Result<(), DebugProbeError>;
 
     /// Attach to the chip.
     ///

--- a/probe-rs/src/probe/arm_jtag.rs
+++ b/probe-rs/src/probe/arm_jtag.rs
@@ -1356,7 +1356,7 @@ mod test {
 
     use crate::{
         architecture::arm::{PortType, RawDapAccess},
-        probe::JTAGAccess,
+        probe::{JTAGAccess, ScanChainElement},
         DebugProbe, DebugProbeError,
     };
 
@@ -1687,6 +1687,13 @@ mod test {
         }
 
         fn set_speed(&mut self, _speed_khz: u32) -> Result<u32, crate::DebugProbeError> {
+            todo!()
+        }
+
+        fn set_scan_chain(
+            &mut self,
+            _scan_chain: Vec<ScanChainElement>,
+        ) -> Result<(), DebugProbeError> {
             todo!()
         }
 

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -1,5 +1,7 @@
 use std::{fmt::Debug, sync::Arc};
 
+use probe_rs_target::ScanChainElement;
+
 use crate::{
     architecture::arm::{
         ap::{memory_ap::mock::MockMemoryAp, AccessPort, MemoryAp},
@@ -20,6 +22,7 @@ use crate::{
 pub struct FakeProbe {
     protocol: WireProtocol,
     speed: u32,
+    scan_chain: Option<Vec<ScanChainElement>>,
 
     dap_register_read_handler: Option<Box<dyn Fn(PortType, u8) -> Result<u32, ArmError> + Send>>,
 
@@ -42,6 +45,7 @@ impl FakeProbe {
         FakeProbe {
             protocol: WireProtocol::Swd,
             speed: 1000,
+            scan_chain: None,
 
             dap_register_read_handler: None,
             dap_register_write_handler: None,
@@ -95,6 +99,11 @@ impl DebugProbe for FakeProbe {
 
     fn speed_khz(&self) -> u32 {
         self.speed
+    }
+
+    fn set_scan_chain(&mut self, scan_chain: Vec<ScanChainElement>) -> Result<(), DebugProbeError> {
+        self.scan_chain = Some(scan_chain);
+        Ok(())
     }
 
     fn set_speed(&mut self, speed_khz: u32) -> Result<u32, DebugProbeError> {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -1,6 +1,7 @@
 //! Support for J-Link Debug probes
 
 use jaylink::{Capability, Interface, JayLink, SpeedConfig, SwoMode};
+use probe_rs_target::ScanChainElement;
 
 use std::convert::{TryFrom, TryInto};
 use std::iter;
@@ -47,6 +48,8 @@ pub(crate) struct JLink {
     current_ir_reg: u32,
 
     speed_khz: u32,
+
+    scan_chain: Option<Vec<ScanChainElement>>,
 
     probe_statistics: ProbeStatistics,
     swd_settings: SwdSettings,
@@ -395,6 +398,7 @@ impl DebugProbe for JLink {
             protocol: None,
             current_ir_reg: 1,
             speed_khz: 0,
+            scan_chain: None,
             swd_settings: SwdSettings::default(),
             probe_statistics: ProbeStatistics::default(),
         }))
@@ -424,6 +428,11 @@ impl DebugProbe for JLink {
 
     fn speed_khz(&self) -> u32 {
         self.speed_khz
+    }
+
+    fn set_scan_chain(&mut self, scan_chain: Vec<ScanChainElement>) -> Result<(), DebugProbeError> {
+        self.scan_chain = Some(scan_chain);
+        Ok(())
     }
 
     fn set_speed(&mut self, speed_khz: u32) -> Result<u32, DebugProbeError> {

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     DebugProbeSelector, Error as ProbeRsError, Probe,
 };
 use constants::{commands, JTagFrequencyToDivider, Mode, Status, SwdFrequencyToDelayCount};
+use probe_rs_target::ScanChainElement;
 use scroll::{Pread, Pwrite, BE, LE};
 use std::{cmp::Ordering, convert::TryInto, sync::Arc, time::Duration};
 use usb_interface::TIMEOUT;
@@ -47,6 +48,7 @@ pub(crate) struct StLink<D: StLinkUsb> {
     swd_speed_khz: u32,
     jtag_speed_khz: u32,
     swo_enabled: bool,
+    scan_chain: Option<Vec<ScanChainElement>>,
 
     /// List of opened APs
     opened_aps: Vec<u8>,
@@ -66,6 +68,7 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
             swd_speed_khz: 1_800,
             jtag_speed_khz: 1_120,
             swo_enabled: false,
+            scan_chain: None,
 
             opened_aps: vec![],
         };
@@ -136,6 +139,18 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
             }
             Ordering::Greater => unimplemented!(),
         }
+    }
+
+    fn set_scan_chain(&mut self, scan_chain: Vec<ScanChainElement>) -> Result<(), DebugProbeError> {
+        // A scan chain only makes sense in JTAG mode. Quit early if a different protocol is used.
+        if self.active_protocol() != Some(WireProtocol::Jtag) {
+            return Err(DebugProbeError::CommandNotSupportedByProbe(
+                "Setting Scan Chain is only supported in JTAG mode",
+            ));
+        }
+        tracing::info!("Setting scan chain to {:?}", scan_chain);
+        self.scan_chain = Some(scan_chain);
+        Ok(())
     }
 
     #[tracing::instrument(skip(self))]
@@ -1713,6 +1728,7 @@ mod test {
                 jtag_version: 0,
                 swd_speed_khz: 0,
                 jtag_speed_khz: 0,
+                scan_chain: None,
                 swo_enabled: false,
                 opened_aps: vec![],
             }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -161,13 +161,15 @@ impl Session {
         }
 
         probe.inner_attach()?;
+        if let Some(scan_chain) = target.scan_chain.clone() {
+            probe.set_scan_chain(scan_chain)?;
+        }
 
         let interface = probe.try_into_arm_interface().map_err(|(_, err)| err)?;
 
         let mut interface = interface
             .initialize(sequence_handle.clone())
             .map_err(|(_interface, e)| e)?;
-
         let unlock_span = tracing::debug_span!("debug_device_unlock").entered();
 
         // Enable debug mode
@@ -259,8 +261,10 @@ impl Session {
                 panic!("Mismatch between architecture and sequence type!")
             }
         };
-
         probe.inner_attach()?;
+        if let Some(scan_chain) = target.scan_chain.clone() {
+            probe.set_scan_chain(scan_chain)?;
+        }
 
         let interface = probe
             .try_into_riscv_interface()

--- a/probe-rs/tests/scan_chain_test.yaml
+++ b/probe-rs/tests/scan_chain_test.yaml
@@ -1,20 +1,13 @@
+---
 name: TEMP_FAM
 variants:
   - name: FULL_SCAN_CHAIN
     # https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain
     scan_chain:
-      - !Dap
-          name: core0
-          dap_type: armv6m
-          ir_len: 4
-          protocols: 
-          - jtag
-          - swd
-          targetsel:
-      - !Device
-          name: ICEPICK
-          device_type: Other
-          ir_len: 6
+      - name: core0
+        ir_len: 4
+      - name: ICEPICK
+        ir_len: 6
     cores:
       - name: core0
         type: armv6m
@@ -49,10 +42,8 @@ variants:
   - name: PARTIAL_SCAN_CHAIN
     # https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain
     scan_chain:
-      - !Dap
-          ir_len: 4
-      - !Device
-          ir_len: 6
+      - ir_len: 4
+      - ir_len: 6
     cores:
       - name: core0
         type: armv6m

--- a/probe-rs/tests/scan_chain_test.yaml
+++ b/probe-rs/tests/scan_chain_test.yaml
@@ -1,0 +1,71 @@
+name: TEMP_FAM
+variants:
+  - name: FULL_SCAN_CHAIN
+    # https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain
+    scan_chain:
+      - !Dap
+          name: core0
+          dap_type: armv6m
+          ir_len: 4
+          protocols: 
+          - jtag
+          - swd
+          targetsel:
+      - !Device
+          name: ICEPICK
+          device_type: Other
+          ir_len: 6
+    cores:
+      - name: core0
+        type: armv6m
+        core_access_options:
+          !Arm
+            ap: 0x0
+            psel: 0x1002927
+    memory_map:
+      - !Ram
+          range:
+            start: 0x20000000
+            end: 0x20040000
+          is_boot_memory: false
+          cores:
+            - core0
+  - name: NO_SCAN_CHAIN
+    cores:
+      - name: core0
+        type: armv6m
+        core_access_options:
+          !Arm
+            ap: 0x0
+            psel: 0x0
+    memory_map:
+      - !Ram
+          range:
+            start: 0x20000000
+            end: 0x20040000
+          is_boot_memory: true
+          cores:
+            - core0
+  - name: PARTIAL_SCAN_CHAIN
+    # https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain
+    scan_chain:
+      - !Dap
+          ir_len: 4
+      - !Device
+          ir_len: 6
+    cores:
+      - name: core0
+        type: armv6m
+        core_access_options:
+          !Arm
+            ap: 0x0
+            psel: 0x1002927
+    memory_map:
+      - !Ram
+          range:
+            start: 0x20000000
+            end: 0x20040000
+          is_boot_memory: false
+          cores:
+            - core0
+flash_algorithms: []

--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -104,6 +104,7 @@ pub fn cmd_elf(
                 ],
                 flash_algorithms: vec![algorithm_name],
                 rtt_scan_ranges: None,
+                scan_chain: None,
             }],
             flash_algorithms: vec![algorithm],
             source: BuiltIn,

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -159,6 +159,7 @@ where
             memory_map: get_mem_map(&device),
             flash_algorithms: flash_algorithm_names,
             rtt_scan_ranges: None,
+            scan_chain: None, // TODO, parse from sdf
         });
     }
 


### PR DESCRIPTION
The scan chain information structure is a direct implementation of [Scan Chain](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain) from CMSIS pack's System Description File (SDF)

It aims to resolve #1682 by adding scan chain information to the target, passing scan chain information to the probe, and finally allowing the `CmsisDap` probe to use scan chain information if its provided.

Having scan chain information opens the possibly for the following (these are open ideas, not yet implemented)

 * Refactoring of existing `stlink` and other probes that are already working with `ir_len`. Clean them up, use scan chain instead.
 * Updating `target-gen` to parse scan chain information from the SDF if its included in a CMSIS pack

Places where I am looking for feedback:

1. [ScanChain definition](https://github.com/seanmlyons22/probe-rs/blob/specify_ir_lengths/probe-rs-target/src/chip.rs#L6-L39). 
1. Should I have so many optional fields? Its defined that way in CMSIS pack, but makes the code a bit mess. Similiar is the `Device` vs. `Dap` distinction even necessary?
1. How about the connection between Target and Probe? Now I am copying the scan chain into probe, but I am not really satisfied with how this came out...it feels clunky. End of the day, the interface (e.g. `CmsisDap`) just needs to know the scan chain for its currently connected target.