### PR TITLE
Sync rustc version in release CI with other builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install Rust
-        run: rustup update "1.70.0" --no-self-update && rustup default "1.70.0"
+        run: rustup update "1.72.0" --no-self-update && rustup default "1.72.0"
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.2.0/cargo-dist-installer.sh | sh"
       - id: plan
@@ -117,7 +117,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install Rust
-        run: rustup update "1.70.0" --no-self-update && rustup default "1.70.0"
+        run: rustup update "1.72.0" --no-self-update && rustup default "1.72.0"
         # Manual addition of build deps
       - name: Install libusb, libudev (linux)
         run: |
@@ -156,7 +156,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install Rust
-        run: rustup update "1.70.0" --no-self-update && rustup default "1.70.0"
+        run: rustup update "1.72.0" --no-self-update && rustup default "1.72.0"
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.2.0/cargo-dist-installer.sh | sh"
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)


### PR DESCRIPTION
Uses the same version as used in the other CI workflows.

cargo-dist recommends the use of `rust-toolchain.toml` instead of, but I think that doesn't work together with the action we currently use to install rustc.

What do you think, should we switch to `rust-toolchain.toml`?