### PR TITLE
rtt: Allow targets to constrain the ranges of RTT scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cli`: Ignore errors from `enable_vector_catch` (#1714).
 - `cli`: Retry RTT attach before continuing (#1722).
 - `cli`: Clean clap attributes (#xxxx)
+- Target definitions can now constrain the RTT automatic scanning ranges to just a subset of all available RAM, to support targets that have large amounts of RAM that would take a long time to scan. (#xxx)
 
 ## [0.20.0]
 

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -27,6 +27,22 @@ pub struct Chip {
     /// [`ChipFamily::flash_algorithms`]: crate::ChipFamily::flash_algorithms
     #[serde(default)]
     pub flash_algorithms: Vec<String>,
+    /// Specific memory ranges to search for a dynamic RTT header for code
+    /// running on this chip.
+    ///
+    /// This need not be specified for most chips because the default is
+    /// to search all RAM regions specified in `memory_map`. However,
+    /// that behavior isn't appropriate for some chips, such as those which
+    /// have a very large amount of RAM that would be time-consuming to
+    /// scan exhaustively.
+    ///
+    /// If specified then this is a list of zero or more address ranges to
+    /// scan. Each address range must be enclosed in exactly one RAM region
+    /// from `memory_map`. An empty list disables automatic scanning
+    /// altogether, in which case RTT will be enabled only when using an
+    /// executable image that includes the `_SEGGER_RTT` symbol pointing
+    /// to the exact address of the RTT header.
+    pub rtt_scan_ranges: Option<Vec<std::ops::Range<u64>>>,
 }
 
 impl Chip {
@@ -44,6 +60,7 @@ impl Chip {
             }],
             memory_map: vec![],
             flash_algorithms: vec![],
+            rtt_scan_ranges: None,
         }
     }
 }

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::io::Write;
+use std::ops::Range;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -9,7 +10,6 @@ use anyhow::{Context, Result};
 use probe_rs::debug::DebugInfo;
 use probe_rs::flashing::{FileDownloadError, Format};
 use probe_rs::{Core, VectorCatchCondition};
-use probe_rs_target::MemoryRegion;
 use signal_hook::consts::signal;
 use time::UtcOffset;
 
@@ -80,7 +80,7 @@ impl Cmd {
             )?;
         }
 
-        let memory_map = session.target().memory_map.clone();
+        let rtt_scan_regions = session.target().rtt_scan_regions.clone();
         let mut core = session.core(0)?;
 
         if run_download {
@@ -93,7 +93,7 @@ impl Cmd {
 
         run_loop(
             &mut core,
-            &memory_map,
+            &rtt_scan_regions,
             path,
             timestamp_offset,
             self.always_print_stacktrace,
@@ -108,7 +108,7 @@ impl Cmd {
 /// or when ctrl + c is pressed.
 fn run_loop(
     core: &mut Core<'_>,
-    memory_map: &[MemoryRegion],
+    rtt_scan_regions: &[Range<u64>],
     path: &Path,
     timestamp_offset: UtcOffset,
     always_print_stacktrace: bool,
@@ -121,7 +121,7 @@ fn run_loop(
         ..Default::default()
     });
 
-    let mut rtta = attach_to_rtt(core, memory_map, path, rtt_config, timestamp_offset);
+    let mut rtta = attach_to_rtt(core, rtt_scan_regions, path, rtt_config, timestamp_offset);
 
     let exit = Arc::new(AtomicBool::new(false));
     let sig_id = signal_hook::flag::register(signal::SIGINT, exit.clone())?;
@@ -246,13 +246,13 @@ fn poll_rtt(
 /// Attach to the RTT buffers.
 fn attach_to_rtt(
     core: &mut Core<'_>,
-    memory_map: &[MemoryRegion],
+    scan_regions: &[Range<u64>],
     path: &Path,
     rtt_config: RttConfig,
     timestamp_offset: UtcOffset,
 ) -> Option<rtt::RttActiveTarget> {
     for _ in 0..RTT_RETRIES {
-        match rtt::attach_to_rtt(core, memory_map, path, &rtt_config, timestamp_offset) {
+        match rtt::attach_to_rtt(core, scan_regions, path, &rtt_config, timestamp_offset) {
             Ok(target_rtt) => return Some(target_rtt),
             Err(error) => {
                 log::debug!("{:?} RTT attach error", error);

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -37,6 +37,9 @@ pub enum RegistryError {
     /// An invalid [`ChipFamily`] was encountered.
     #[error("Invalid chip family definition ({})", .0.name)]
     InvalidChipFamilyDefinition(Box<ChipFamily>, String),
+    /// One of the RTT scan ranges is not enclosed in exactly one RAM region.
+    #[error("Chip's RTT scan region {:#010x}..{:#010x} is not enclosed by any single RAM region.", .0.start, .0.end)]
+    InvalidRttScanRange(std::ops::Range<u64>),
 }
 
 fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
@@ -105,6 +108,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
                 }],
                 memory_map: vec![],
                 flash_algorithms: vec![],
+                rtt_scan_ranges: None,
             }],
             flash_algorithms: vec![],
             source: TargetDescriptionSource::Generic,

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -1,4 +1,4 @@
-use probe_rs_target::{Architecture, ChipFamily};
+use probe_rs_target::{Architecture, ChipFamily, MemoryRange};
 
 use super::{Core, MemoryRegion, RawFlashAlgorithm, RegistryError, TargetDescriptionSource};
 use crate::architecture::arm::{
@@ -40,6 +40,11 @@ pub struct Target {
     pub(crate) source: TargetDescriptionSource,
     /// Debug sequences for the given target.
     pub debug_sequence: DebugSequence,
+    /// The regions of memory to scan to try to find an RTT header.
+    ///
+    /// Each region must be enclosed in exactly one RAM region from
+    /// `memory_map`.
+    pub rtt_scan_regions: Vec<std::ops::Range<u64>>,
 }
 
 impl std::fmt::Debug for Target {
@@ -171,6 +176,37 @@ impl Target {
             debug_sequence = DebugSequence::Arm(XMC4000::create());
         }
 
+        let rtt_scan_regions = match &chip.rtt_scan_ranges {
+            Some(ranges) => {
+                // The custom ranges must all be enclosed by exactly one of
+                // the defined RAM regions.
+                for rng in ranges {
+                    let region = chip.memory_map.iter().find(|region| {
+                        if let MemoryRegion::Ram(region) = region {
+                            region.range.contains_range(rng)
+                        } else {
+                            false
+                        }
+                    });
+                    if region.is_none() {
+                        return Err(RegistryError::InvalidRttScanRange(rng.clone()));
+                    }
+                }
+                ranges.clone()
+            }
+            None => {
+                // By default we use all of the RAM ranges from the
+                // memory map.
+                chip.memory_map
+                    .iter()
+                    .filter_map(|region| match region {
+                        MemoryRegion::Ram(region) => Some(region.range.clone()),
+                        _ => None,
+                    })
+                    .collect()
+            }
+        };
+
         Ok(Target {
             name: chip.name.clone(),
             cores: chip.cores.clone(),
@@ -178,6 +214,7 @@ impl Target {
             source: family.source.clone(),
             memory_map: chip.memory_map.clone(),
             debug_sequence,
+            rtt_scan_regions,
         })
     }
 

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -223,7 +223,7 @@ impl Rtt {
         memory_map: &[MemoryRegion],
         region: &ScanRegion,
     ) -> Result<Rtt, Error> {
-        let ranges: Vec<Range<u32>> = match region {
+        let ranges: Vec<Range<u64>> = match region {
             ScanRegion::Exact(addr) => {
                 tracing::debug!("Scanning at exact address: 0x{:X}", addr);
 
@@ -237,40 +237,75 @@ impl Rtt {
                     .iter()
                     .filter_map(|r| match r {
                         MemoryRegion::Ram(r) => Some(Range {
-                            start: r.range.start as u32,
-                            end: r.range.end as u32,
+                            start: r.range.start,
+                            end: r.range.end,
                         }),
                         _ => None,
                     })
                     .collect()
             }
+            ScanRegion::Ranges(regions) => regions.clone(),
             ScanRegion::Range(region) => {
                 tracing::debug!("Scanning region: {:?}", region);
 
-                vec![region.clone()]
+                vec![Range {
+                    start: region.start as u64,
+                    end: region.end as u64,
+                }]
             }
         };
 
         let mut instances = ranges
             .into_iter()
             .filter_map(|range| {
-                if range.len() < Self::MIN_SIZE {
-                    return None;
-                }
+                let range_len = match range.end.checked_sub(range.start) {
+                    Some(v) => if v < (Self::MIN_SIZE as u64) {
+                        return None;
+                    } else {
+                        v
+                    },
+                    None => return None,
+                };
 
-                let mut mem = vec![0; range.len()];
+                let range_len_usize: usize = match range_len.try_into() {
+                    Ok(v) => v,
+                    Err(_) => {
+                        // FIXME: This is not ideal because it means that we
+                        // won't consider a >4GiB region if probe-rs is running
+                        // on a 32-bit host, but it would be relatively unusual
+                        // to use a 32-bit host to debug a 64-bit target.
+                        tracing::warn!("ignoring region of length {} because it is too long to buffer in host memory", range_len);
+                        return None;
+                    }
+                };
+
+                let mut mem = vec![0; range_len_usize];
                 {
-                    core.read(range.start.into(), mem.as_mut()).ok()?;
+                    core.read(range.start, mem.as_mut()).ok()?;
                 }
 
                 match kmp::kmp_find(&Self::RTT_ID, mem.as_slice()) {
-                    Some(offset) => Rtt::from(
-                        core,
-                        memory_map,
-                        range.start + offset as u32,
-                        Some(&mem[offset..]),
-                    )
-                    .transpose(),
+                    Some(offset) => {
+                        let target_ptr = range.start + (offset as u64);
+                        let target_ptr: u32 = match target_ptr.try_into() {
+                            Ok(v) => v,
+                            Err(_) => {
+                                // FIXME: The RTT API currently supports only
+                                // 32-bit addresses, and so it can't accept
+                                // an RTT block at an address >4GiB.
+                                tracing::warn!("can't use RTT block at {:#010x}; must be at a location reachable by 32-bit addressing", target_ptr);
+                                return None;
+                            },
+                        };
+
+                        Rtt::from(
+                            core,
+                            memory_map,
+                            target_ptr,
+                            Some(&mem[offset..]),
+                        )
+                        .transpose()
+                    },
                     None => None,
                 }
             })
@@ -315,7 +350,15 @@ pub enum ScanRegion {
 
     /// Limit scanning to these memory addresses in target memory. It is up to the user to ensure
     /// that reading from this range will not read from undefined memory.
+    ///
+    /// This variant is equivalent to using [`Self::Ranges`] with a single range as long as the
+    /// memory region fits into a 32-bit address space. This variant is for backward compatibility
+    /// for code written before the addition of [`Self::Ranges`].
     Range(Range<u32>),
+
+    /// Limit scanning to the memory addresses covered by all of the given ranges. It is up to the
+    /// user to ensure that reading from this range will not read from undefined memory.
+    Ranges(Vec<Range<u64>>),
 
     /// Tries to find the control block starting at this exact address. It is up to the user to
     /// ensure that reading the necessary bytes after the pointer will no read from undefined

--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -103,6 +103,7 @@ pub fn cmd_elf(
                     }),
                 ],
                 flash_algorithms: vec![algorithm_name],
+                rtt_scan_ranges: None,
             }],
             flash_algorithms: vec![algorithm],
             source: BuiltIn,

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -145,6 +145,7 @@ where
             cores,
             memory_map: get_mem_map(&device),
             flash_algorithms: flash_algorithm_names,
+            rtt_scan_ranges: None,
         });
     }
 


### PR DESCRIPTION
For targets that have very large amounts of RAM, that have some RAM regions that don't make sense for RTT, or that have multiple aliases for the same RAM, the default behavior of scanning the entirety of all RAM regions is sub-optimal.

This allows such targets to specify the what subset of RAM to scan for a RTT block. In extreme cases, a target can specify no ranges at all if there's no reasonable way to narrow down the search space.

The `_SEGGER_RTT` symbol will still always "win" and totally prevent any attempt to scan, and so applications are in practice still free to place their RTT header anywhere as long as they include that symbol in the given ELF executable, even if that symbol points outside of any of the configured scan regions.

This PR is part of my work on supporting i.MX RT500-series targets in #1642, but I've pulled it out here for separate review. If this PR is accepted then I intend to declare those targets as having no automatic scanning regions at all, because they have large amounts of RAM which makes scanning take multiple minutes with the probe I'm using. That effectively assumes that anyone targeting those platforms will use the explicit `_SEGGER_RTT` symbol if they intend to use RTT.

I don't have any other hardware on my bench right now beyond my RT595-EVK board and so I tested the case of this _not_ being set by just temporarily removing the setting from my new target definitions and watching `probe-rs` spend multiple minutes scanning the full RAM as before. If possible I think it'd be best for a reviewer to try this on another known-good target that doesn't have any RTT scan range constraints to verify that this does indeed preserve the previous behavior.

---

Another possibility I considered was to constrain RTT scanning only to writable memory segments declared in the ELF headers, but that seemed like both a more invasive and potentially-more-controversial change of approach that would potentially affect all users, whereas this target-specific setting should cause no change in behavior for any targets that don't make use of it.

If using the ELF headers to dynamically select scan ranges were added in future then I imagine it being complementary to this target-specific setting, either by scanning only the intersection of the target-specific ranges and the ELF writable segment ranges, or by using the target-specific settings as a fallback for situations where no ELF executable is available. I'd leave it up to a future implementer of that feature to decide which behavior seems most appropriate.

---

While working on this I noticed a bit of a schism in the code where different subsystems use different types to represent target memory addresses and sizes: `u64` in some, `u32` in others (the RTT implementation in particular), and also some use of `usize` where data is being buffered in host memory.

After a little archaeology I concluded that there's a migration in process from `u32` to `u64`, presumably to support 64-bit targets, and so I used `u64` as far as I could without getting into the weeds of the RTT implementation, with some non-ideal fallible conversions to reduce to `u32`/`usize` where required. As far as I can tell these should always succeed in the common case, but there are some less likely edge cases like trying to debug a 64-bit target from a 32-bit host but only if we end up needing a buffer too large to fit into the host's memory space.

If you have any suggestions for better ways to deal with this I'd be happy to attempt them, although I don't think I have sufficient time and energy to take on a full retrofit of `u64` throughout the RTT implementation, so if you'd consider that a prerequisite then I may need to just sit on this PR until someone else has attempted that. (If I'm misunderstanding how much work this is likely to be, please let me know,)
