### PR TITLE
Add read/write probe-rs cli commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   information from the rtt log (#1704)
 - target-gen: Add new `--test-address` option to the `target-gen test` subcommand. (#1708)
 - `cli`: Add `--verify` flag to `download`, `flash` and `run` (#1727)
+- `cli`: Add `read` and `write` commands to interact with target memory (8,32,64 bit words) (#1746)
 
 ### Changed
 

--- a/probe-rs/src/bin/probe-rs/cmd.rs
+++ b/probe-rs/src/bin/probe-rs/cmd.rs
@@ -13,6 +13,8 @@ pub mod info;
 pub mod itm;
 pub mod list;
 pub mod profile;
+pub mod read;
 pub mod reset;
 pub mod run;
 pub mod trace;
+pub mod write;

--- a/probe-rs/src/bin/probe-rs/cmd/read.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/read.rs
@@ -1,0 +1,56 @@
+use probe_rs::MemoryInterface;
+
+use crate::util::common_options::{ProbeOptions, ReadWriteBitWidth, ReadWriteOptions};
+use crate::CoreOptions;
+
+#[derive(clap::Parser)]
+pub struct Cmd {
+    #[clap(flatten)]
+    shared: CoreOptions,
+
+    #[clap(flatten)]
+    probe_options: ProbeOptions,
+
+    #[clap(flatten)]
+    read_write_options: ReadWriteOptions,
+
+    /// Number of words to read from the target
+    words: u64,
+}
+
+impl Cmd {
+    pub fn run(self) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.probe_options.simple_attach()?;
+        let mut core = session.core(self.shared.core)?;
+        let words = self.words as usize;
+
+        match self.read_write_options.width {
+            ReadWriteBitWidth::B8 => {
+                let mut values = vec![0; words];
+                core.read_8(self.read_write_options.address, &mut values)?;
+                for val in values {
+                    print!("{:02x} ", val);
+                }
+                println!();
+            }
+            ReadWriteBitWidth::B32 => {
+                let mut values = vec![0; words];
+                core.read_32(self.read_write_options.address, &mut values)?;
+                for val in values {
+                    print!("{:08x} ", val);
+                }
+                println!();
+            }
+            ReadWriteBitWidth::B64 => {
+                let mut values = vec![0; words];
+                core.read_64(self.read_write_options.address, &mut values)?;
+                for val in values {
+                    print!("{:016x} ", val);
+                }
+                println!();
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/probe-rs/src/bin/probe-rs/cmd/write.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/write.rs
@@ -1,0 +1,65 @@
+use probe_rs::MemoryInterface;
+
+use crate::util::common_options::{ProbeOptions, ReadWriteBitWidth, ReadWriteOptions};
+use crate::util::parse_u64;
+use crate::CoreOptions;
+
+#[derive(clap::Parser)]
+pub struct Cmd {
+    #[clap(flatten)]
+    shared: CoreOptions,
+
+    #[clap(flatten)]
+    probe_options: ProbeOptions,
+
+    #[clap(flatten)]
+    read_write_options: ReadWriteOptions,
+
+    /// Values to write to the target.
+    /// Takes a list of integer values and can be specified in decimal (16), hexadecimal (0x10) or octal (0o20) format.
+    #[clap(value_parser = parse_u64)]
+    values: Vec<u64>,
+}
+
+impl Cmd {
+    pub fn run(self) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.probe_options.simple_attach()?;
+        let mut core = session.core(self.shared.core)?;
+
+        match self.read_write_options.width {
+            ReadWriteBitWidth::B8 => {
+                let mut bvalues = Vec::new();
+                for val in &self.values {
+                    if val > &(u8::max_value() as u64) {
+                        return Err(anyhow::anyhow!(
+                            "{} in {:?} is too large for an 8 bit write.",
+                            val,
+                            self.values,
+                        ));
+                    }
+                    bvalues.push(*val as u8);
+                }
+                core.write_8(self.read_write_options.address, &bvalues)?;
+            }
+            ReadWriteBitWidth::B32 => {
+                let mut bvalues = Vec::new();
+                for val in &self.values {
+                    if val > &(u32::max_value() as u64) {
+                        return Err(anyhow::anyhow!(
+                            "{} in {:?} is too large for a 32 bit write.",
+                            val,
+                            self.values,
+                        ));
+                    }
+                    bvalues.push(*val as u32);
+                }
+                core.write_32(self.read_write_options.address, &bvalues)?;
+            }
+            ReadWriteBitWidth::B64 => {
+                core.write_64(self.read_write_options.address, &self.values)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -74,6 +74,25 @@ enum Subcommand {
     Chip(cmd::chip::Cmd),
     Benchmark(cmd::benchmark::Cmd),
     Profile(cmd::profile::Cmd),
+    /// Read from target memory address
+    /// e.g. probe-rs read b32 0x400E1490 2
+    ///      Reads 2 32-bit words from address 0x400E1490
+    /// Output is a space separated list of hex values padded to the read word width.
+    /// e.g. 2 words
+    ///     00 00 (8-bit)
+    ///     00000000 00000000 (32-bit)
+    ///     0000000000000000 0000000000000000 (64-bit)
+    ///
+    /// NOTE: Only supports RAM addresses
+    #[clap(verbatim_doc_comment)]
+    Read(cmd::read::Cmd),
+    /// Write to target memory address
+    /// e.g. probe-rs write b32 0x400E1490 0xDEADBEEF 0xCAFEF00D
+    ///      Writes 0xDEADBEEF to address 0x400E1490 and 0xCAFEF00D to address 0x400E1494
+    ///
+    /// NOTE: Only supports RAM addresses
+    #[clap(verbatim_doc_comment)]
+    Write(cmd::write::Cmd),
 }
 
 /// Shared options for core selection, shared between commands
@@ -261,6 +280,8 @@ fn main() -> Result<()> {
         Subcommand::Chip(cmd) => cmd.run(),
         Subcommand::Benchmark(cmd) => cmd.run(),
         Subcommand::Profile(cmd) => cmd.run(),
+        Subcommand::Read(cmd) => cmd.run(),
+        Subcommand::Write(cmd) => cmd.run(),
     };
 
     tracing::info!("Wrote log to {:?}", log_path);

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -35,6 +35,7 @@ use super::ArtifactError;
 
 use std::{fs::File, path::Path, path::PathBuf};
 
+use crate::util::parse_u64;
 use clap;
 use probe_rs::{
     config::{RegistryError, TargetSelector},
@@ -42,6 +43,7 @@ use probe_rs::{
     DebugProbeError, DebugProbeSelector, FakeProbe, Permissions, Probe, Session, Target,
     WireProtocol,
 };
+use serde::{Deserialize, Serialize};
 
 /// Common options when flashing a target device.
 #[derive(Debug, clap::Parser)]
@@ -90,6 +92,29 @@ pub struct BinaryDownloadOptions {
     /// After flashing, read back all the flashed data to verify it has been written correctly.
     #[arg(long)]
     pub verify: bool,
+}
+
+/// Supported bit-widths for read/write commands (not every device may support each width).
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, clap::ValueEnum)]
+pub enum ReadWriteBitWidth {
+    /// 8-bit width
+    B8 = 8,
+    /// 32-bit width
+    B32 = 32,
+    /// 64-bit width
+    B64 = 64,
+}
+
+/// Common options for read/write operations to a target device.
+#[derive(Debug, clap::Parser)]
+pub struct ReadWriteOptions {
+    /// Width of the data to read/write.
+    #[clap(value_enum, ignore_case = true)]
+    pub width: ReadWriteBitWidth,
+    /// The address to start from.
+    /// Takes an integer as an argument, and can be specified in decimal (16), hexadecimal (0x10) or octal (0o20) format.
+    #[clap(value_parser = parse_u64)]
+    pub address: u64,
 }
 
 /// Common options and logic when interfacing with a [Probe].


### PR DESCRIPTION
- Fixes #1641
- Simple tool to read/write from target memory addresses
- Handles 8,32,64 bit words

Example (using general purpose backup registers on ATSAM4S8B)

```bash
: probe-rs read --probe 1fc9:0143 b32 0x400E1490 2 --chip ATSAM4S8B
00000000 00000000
: probe-rs write --probe 1fc9:0143 b32 0x400E1490 0xDEADBEEF 0xBEEFDEAD --chip ATSAM4S8B
: probe-rs read --probe 1fc9:0143 b32 0x400E1490 2 --chip ATSAM4S8B
deadbeef beefdead
: probe-rs read --probe 1fc9:0143 b8 0x400E1490 2 --chip ATSAM4S8B
ef be
: probe-rs read --probe 1fc9:0143 b64 0x400E1490 2 --chip ATSAM4S8B
beefdeaddeadbeef 0000000000000000
```