### PR TITLE
Fix defmt decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `target-gen`: (#1745)
   - Memory regions in target.yaml are now sorted with lowest address first.
   - Use `.pdsc` flash algorithm `RAMstart` field to calculate `load_address` for target yaml.
-- Target definitions can now constrain the RTT automatic scanning ranges to just a subset of all available RAM, to support targets that have large amounts of RAM that would take a long time to scan. (#xxx)
+- Target definitions can now constrain the RTT automatic scanning ranges to just a subset of all available RAM, to support targets that have large amounts of RAM that would take a long time to scan. (#1738, #1749)
 
 ## [0.20.0]
 

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -125,7 +125,14 @@ fn run_loop(
         ..Default::default()
     });
 
-    let mut rtta = attach_to_rtt(core, memory_map, rtt_scan_regions, path, rtt_config, timestamp_offset);
+    let mut rtta = attach_to_rtt(
+        core,
+        memory_map,
+        rtt_scan_regions,
+        path,
+        rtt_config,
+        timestamp_offset,
+    );
 
     let exit = Arc::new(AtomicBool::new(false));
     let sig_id = signal_hook::flag::register(signal::SIGINT, exit.clone())?;
@@ -257,7 +264,14 @@ fn attach_to_rtt(
     timestamp_offset: UtcOffset,
 ) -> Option<rtt::RttActiveTarget> {
     for _ in 0..RTT_RETRIES {
-        match rtt::attach_to_rtt(core, memory_map, scan_regions, path, &rtt_config, timestamp_offset) {
+        match rtt::attach_to_rtt(
+            core,
+            memory_map,
+            scan_regions,
+            path,
+            &rtt_config,
+            timestamp_offset,
+        ) {
             Ok(target_rtt) => return Some(target_rtt),
             Err(error) => {
                 log::debug!("{:?} RTT attach error", error);

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -5,6 +5,7 @@ use num_traits::Zero;
 pub use probe_rs::rtt::ChannelMode;
 use probe_rs::rtt::{DownChannel, Rtt, ScanRegion, UpChannel};
 use probe_rs::Core;
+use probe_rs_target::MemoryRegion;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs::File;
@@ -19,6 +20,7 @@ use time::{OffsetDateTime, UtcOffset};
 
 pub fn attach_to_rtt(
     core: &mut Core,
+    memory_map: &[MemoryRegion],
     scan_regions: &[std::ops::Range<u64>],
     elf_file: &Path,
     rtt_config: &RttConfig,
@@ -42,7 +44,7 @@ pub fn attach_to_rtt(
         }
     }
 
-    match Rtt::attach_region(core, &[], &rtt_header_address) {
+    match Rtt::attach_region(core, memory_map, &rtt_header_address) {
         Ok(rtt) => {
             log::info!("RTT initialized.");
             let app = RttActiveTarget::new(rtt, elf_file, rtt_config, timestamp_offset)?;


### PR DESCRIPTION
This reverts parts of f77360e2 without removing the new feature. This causes some redundancy in the passed values, though. (memory_map and rtt_scan_regions contain similar information).

Closes #1748