### PR TITLE
Colored defmt logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cli`: Allow to interrupt `probe-rs run` during RTT scan (#1705).
 - `cli`: Ignore errors from `enable_vector_catch` (#1714).
 - `cli`: Retry RTT attach before continuing (#1722).
-- `cli`: Clean clap attributes (#xxxx)
+- `cli`: Clean clap attributes (#1730)
 - `target-gen`: (#1745)
   - Memory regions in target.yaml are now sorted with lowest address first.
   - Use `.pdsc` flash algorithm `RAMstart` field to calculate `load_address` for target yaml.
 - Target definitions can now constrain the RTT automatic scanning ranges to just a subset of all available RAM, to support targets that have large amounts of RAM that would take a long time to scan. (#1738, #1749)
+- `cli`: Output `defmt` logs as colored (#xxxx)
 
 ## [0.20.0]
 

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -278,7 +278,7 @@ impl RttActiveChannel {
                                             match stream_decoder.decode() {
                                                 Ok(frame) => {
                                                     let loc = locs.as_ref().and_then(|locs| locs.get(&frame.index()) );
-                                                    writeln!(formatted_data, "{}", frame.display(false)).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
+                                                    writeln!(formatted_data, "{}", frame.display(true)).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
                                                     if self.show_location {
                                                         if let Some(loc) = loc {
                                                             let relpath = if let Ok(relpath) =


### PR DESCRIPTION
This PR makes the log levels of the `defmt` logs colorful. The coloring is done by the `defmt-decoder` crate[^1].

Before: ![Screenshot from 2023-09-11 12-27-03](https://github.com/probe-rs/probe-rs/assets/37087391/22c1c5b1-a45e-4c17-b0ae-792c8f493d5c)

After: ![Screenshot from 2023-09-11 12-27-20](https://github.com/probe-rs/probe-rs/assets/37087391/fef637c2-296f-456d-83b9-2cd17a79dc09)


[^1]: Since recently the `defmt-decoder` allows to configure the output format. Also it will soon™️ be possible to style the output. There will be PRs to implement that in `probe-rs`.