### PR TITLE
Support semihosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cli`: Add `--verify` flag to `download`, `flash` and `run` (#1727)
 - `cli`: Add `read` and `write` commands to interact with target memory (8,32,64 bit words) (#1746)
 - Added STM32U5A and STM32U59 targets. (#1744)
+- Support for handling an Arm Cortex-M Semihosting 'Exit Success' or 'Exit Failure' command. (#1755)
 
 ### Changed
 

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -22,6 +22,8 @@ STLINKv1, v2 and v2-1. Written in C.
 [CoreSight Technical Introduction](http://infocenter.arm.com/help/topic/com.arm.doc.epm039795/coresight_technical_introduction_EPM_039795.pdf)
 [CMSIS Packs](https://developer.arm.com/tools-and-software/embedded/cmsis/cmsis-packs)
 
+[Semihosting Specification](https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst)
+
 ### Armv6-M Architecture 
 
 [Architecture Reference Manual](https://static.docs.arm.com/ddi0419/d/DDI0419D_armv6m_arm.pdf)

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -549,8 +549,8 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
                 let instruction1 = self.read_word_8((pc + 1) as u64)?;
                 if instruction1 == 0xBE && instruction2 == 0xAB {
                     // 0xAB breakpoint -> we are semihosting
-                    // This is defined by the ARM Compiler Software Development Guide.
-                    // <https://developer.arm.com/documentation/dui0471/m/what-is-semihosting->
+                    // This is defined by the ARM Semihosting Specification:
+                    // <https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst#the-semihosting-interface>
                     const SYS_EXIT: u32 = 0x18;
                     const SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT: u32 = 0x20026;
                     match (r0, r1) {

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -730,8 +730,8 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
                 let instruction1 = self.read_word_8((pc + 1) as u64)?;
                 if instruction1 == 0xBE && instruction2 == 0xAB {
                     // 0xAB breakpoint -> we are semihosting
-                    // This is defined by the ARM Compiler Software Development Guide.
-                    // <https://developer.arm.com/documentation/dui0471/m/what-is-semihosting->
+                    // This is defined by the ARM Semihosting Specification:
+                    // <https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst#the-semihosting-interface>
                     const SYS_EXIT: u32 = 0x18;
                     const SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT: u32 = 0x20026;
                     match (r0, r1) {

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -18,8 +18,7 @@ use crate::{
     },
     error::Error,
     memory::valid_32bit_address,
-    BreakpointCause, CoreRegister, CoreType, DebugProbeError, InstructionSet, MemoryInterface,
-    SemihostingCommand,
+    CoreRegister, CoreType, DebugProbeError, InstructionSet, MemoryInterface,
 };
 use anyhow::{anyhow, Result};
 use bitfield::bitfield;
@@ -719,38 +718,12 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
                 );
             }
 
+            // Set the status so any semihosting operations will know we're halted
             self.set_core_status(CoreStatus::Halted(reason));
 
             if let HaltReason::Breakpoint(_) = reason {
-                // Check for semihosting
-                let pc: u32 = self.read_core_reg(RegisterId(15))?.try_into()?;
-                let r0: u32 = self.read_core_reg(RegisterId(0))?.try_into()?;
-                let r1: u32 = self.read_core_reg(RegisterId(1))?.try_into()?;
-                let instruction2 = self.read_word_8(pc as u64)?;
-                let instruction1 = self.read_word_8((pc + 1) as u64)?;
-                if instruction1 == 0xBE && instruction2 == 0xAB {
-                    // 0xAB breakpoint -> we are semihosting
-                    // This is defined by the ARM Semihosting Specification:
-                    // <https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst#the-semihosting-interface>
-                    const SYS_EXIT: u32 = 0x18;
-                    const SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT: u32 = 0x20026;
-                    match (r0, r1) {
-                        (SYS_EXIT, SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT) => {
-                            reason = HaltReason::Breakpoint(BreakpointCause::Semihosting(
-                                SemihostingCommand::ExitSuccess,
-                            ));
-                        }
-                        (SYS_EXIT, code) => {
-                            reason = HaltReason::Breakpoint(BreakpointCause::Semihosting(
-                                SemihostingCommand::ExitError { code: code as u64 },
-                            ));
-                        }
-                        _ => {
-                            tracing::warn!("Unknown semihosting operation r0={r0:08x} r1={r1:08x}");
-                        }
-                    }
-                }
-                // Update the reason
+                reason = super::cortex_m::check_for_semihosting(reason, self)?;
+                // Set it again if it's changed
                 self.set_core_status(CoreStatus::Halted(reason));
             }
 

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -18,7 +18,8 @@ use crate::{
     },
     error::Error,
     memory::valid_32bit_address,
-    CoreRegister, CoreType, DebugProbeError, InstructionSet, MemoryInterface,
+    BreakpointCause, CoreRegister, CoreType, DebugProbeError, InstructionSet, MemoryInterface,
+    SemihostingCommand,
 };
 use anyhow::{anyhow, Result};
 use bitfield::bitfield;
@@ -694,7 +695,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
         if dhcsr.s_halt() {
             let dfsr = Dfsr(self.memory.read_word_32(Dfsr::get_mmio_address())?);
 
-            let reason = dfsr.halt_reason();
+            let mut reason = dfsr.halt_reason();
 
             // Clear bits from Dfsr register
             self.memory
@@ -719,6 +720,39 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
             }
 
             self.set_core_status(CoreStatus::Halted(reason));
+
+            if let HaltReason::Breakpoint(_) = reason {
+                // Check for semihosting
+                let pc: u32 = self.read_core_reg(RegisterId(15))?.try_into()?;
+                let r0: u32 = self.read_core_reg(RegisterId(0))?.try_into()?;
+                let r1: u32 = self.read_core_reg(RegisterId(1))?.try_into()?;
+                let instruction2 = self.read_word_8(pc as u64)?;
+                let instruction1 = self.read_word_8((pc + 1) as u64)?;
+                if instruction1 == 0xBE && instruction2 == 0xAB {
+                    // 0xAB breakpoint -> we are semihosting
+                    // This is defined by the ARM Compiler Software Development Guide.
+                    // <https://developer.arm.com/documentation/dui0471/m/what-is-semihosting->
+                    const SYS_EXIT: u32 = 0x18;
+                    const SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT: u32 = 0x20026;
+                    match (r0, r1) {
+                        (SYS_EXIT, SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT) => {
+                            reason = HaltReason::Breakpoint(BreakpointCause::Semihosting(
+                                SemihostingCommand::ExitSuccess,
+                            ));
+                        }
+                        (SYS_EXIT, code) => {
+                            reason = HaltReason::Breakpoint(BreakpointCause::Semihosting(
+                                SemihostingCommand::ExitError { code: code as u64 },
+                            ));
+                        }
+                        _ => {
+                            tracing::warn!("Unknown semihosting operation r0={r0:08x} r1={r1:08x}");
+                        }
+                    }
+                }
+                // Update the reason
+                self.set_core_status(CoreStatus::Halted(reason));
+            }
 
             return Ok(CoreStatus::Halted(reason));
         }

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -171,8 +171,8 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
                 let instruction1 = self.read_word_8((pc + 1) as u64)?;
                 if instruction1 == 0xBE && instruction2 == 0xAB {
                     // 0xAB breakpoint -> we are semihosting
-                    // This is defined by the ARM Compiler Software Development Guide.
-                    // <https://developer.arm.com/documentation/dui0471/m/what-is-semihosting->
+                    // This is defined by the ARM Semihosting Specification:
+                    // <https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst#the-semihosting-interface>
                     const SYS_EXIT: u32 = 0x18;
                     const SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT: u32 = 0x20026;
                     match (r0, r1) {

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -15,8 +15,9 @@ use crate::{
     core::{CoreRegisters, RegisterId, RegisterValue},
     error::Error,
     memory::valid_32bit_address,
-    Architecture, CoreInformation, CoreInterface, CoreRegister, CoreStatus, CoreType, HaltReason,
-    InstructionSet, MemoryInterface, MemoryMappedRegister,
+    Architecture, BreakpointCause, CoreInformation, CoreInterface, CoreRegister, CoreStatus,
+    CoreType, HaltReason, InstructionSet, MemoryInterface, MemoryMappedRegister,
+    SemihostingCommand,
 };
 use anyhow::Result;
 use bitfield::bitfield;
@@ -138,7 +139,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         if dhcsr.s_halt() {
             let dfsr = Dfsr(self.memory.read_word_32(Dfsr::get_mmio_address())?);
 
-            let reason = dfsr.halt_reason();
+            let mut reason = dfsr.halt_reason();
 
             // Clear bits from Dfsr register
             self.memory
@@ -160,6 +161,36 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
                     &self.state.current_state,
                     &reason
                 );
+            }
+            if let HaltReason::Breakpoint(_) = reason {
+                // Check for semihosting
+                let pc: u32 = self.read_core_reg(RegisterId(15))?.try_into()?;
+                let r0: u32 = self.read_core_reg(RegisterId(0))?.try_into()?;
+                let r1: u32 = self.read_core_reg(RegisterId(1))?.try_into()?;
+                let instruction2 = self.read_word_8(pc as u64)?;
+                let instruction1 = self.read_word_8((pc + 1) as u64)?;
+                if instruction1 == 0xBE && instruction2 == 0xAB {
+                    // 0xAB breakpoint -> we are semihosting
+                    // This is defined by the ARM Compiler Software Development Guide.
+                    // <https://developer.arm.com/documentation/dui0471/m/what-is-semihosting->
+                    const SYS_EXIT: u32 = 0x18;
+                    const SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT: u32 = 0x20026;
+                    match (r0, r1) {
+                        (SYS_EXIT, SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT) => {
+                            reason = HaltReason::Breakpoint(BreakpointCause::Semihosting(
+                                SemihostingCommand::ExitSuccess,
+                            ));
+                        }
+                        (SYS_EXIT, code) => {
+                            reason = HaltReason::Breakpoint(BreakpointCause::Semihosting(
+                                SemihostingCommand::ExitError { code: code as u64 },
+                            ));
+                        }
+                        _ => {
+                            tracing::warn!("Unknown semihosting operation r0={r0:08x} r1={r1:08x}");
+                        }
+                    }
+                }
             }
 
             self.set_core_status(CoreStatus::Halted(reason));

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -15,9 +15,8 @@ use crate::{
     core::{CoreRegisters, RegisterId, RegisterValue},
     error::Error,
     memory::valid_32bit_address,
-    Architecture, BreakpointCause, CoreInformation, CoreInterface, CoreRegister, CoreStatus,
-    CoreType, HaltReason, InstructionSet, MemoryInterface, MemoryMappedRegister,
-    SemihostingCommand,
+    Architecture, CoreInformation, CoreInterface, CoreRegister, CoreStatus, CoreType, HaltReason,
+    InstructionSet, MemoryInterface, MemoryMappedRegister,
 };
 use anyhow::Result;
 use bitfield::bitfield;
@@ -162,38 +161,15 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
                     &reason
                 );
             }
-            if let HaltReason::Breakpoint(_) = reason {
-                // Check for semihosting
-                let pc: u32 = self.read_core_reg(RegisterId(15))?.try_into()?;
-                let r0: u32 = self.read_core_reg(RegisterId(0))?.try_into()?;
-                let r1: u32 = self.read_core_reg(RegisterId(1))?.try_into()?;
-                let instruction2 = self.read_word_8(pc as u64)?;
-                let instruction1 = self.read_word_8((pc + 1) as u64)?;
-                if instruction1 == 0xBE && instruction2 == 0xAB {
-                    // 0xAB breakpoint -> we are semihosting
-                    // This is defined by the ARM Semihosting Specification:
-                    // <https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst#the-semihosting-interface>
-                    const SYS_EXIT: u32 = 0x18;
-                    const SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT: u32 = 0x20026;
-                    match (r0, r1) {
-                        (SYS_EXIT, SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT) => {
-                            reason = HaltReason::Breakpoint(BreakpointCause::Semihosting(
-                                SemihostingCommand::ExitSuccess,
-                            ));
-                        }
-                        (SYS_EXIT, code) => {
-                            reason = HaltReason::Breakpoint(BreakpointCause::Semihosting(
-                                SemihostingCommand::ExitError { code: code as u64 },
-                            ));
-                        }
-                        _ => {
-                            tracing::warn!("Unknown semihosting operation r0={r0:08x} r1={r1:08x}");
-                        }
-                    }
-                }
-            }
 
+            // Set the status so any semihosting operations will know we're halted
             self.set_core_status(CoreStatus::Halted(reason));
+
+            if let HaltReason::Breakpoint(_) = reason {
+                reason = super::cortex_m::check_for_semihosting(reason, self)?;
+                // Set it again if it's changed
+                self.set_core_status(CoreStatus::Halted(reason));
+            }
 
             return Ok(CoreStatus::Halted(reason));
         }

--- a/probe-rs/src/architecture/arm/core/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/cortex_m.rs
@@ -124,7 +124,7 @@ pub(crate) fn check_for_semihosting(
 ) -> Result<HaltReason, Error> {
     let mut reason = old_reason;
     // Check for semihosting instruction
-    let pc: u32 = core.read_core_reg(RegisterId(15))?.try_into()?;
+    let pc: u32 = core.read_core_reg(core.program_counter().id)?.try_into()?;
     let instruction2 = core.read_word_8(pc as u64)?;
     let instruction1 = core.read_word_8((pc + 1) as u64)?;
     tracing::debug!(

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -6,10 +6,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use probe_rs::debug::DebugInfo;
 use probe_rs::flashing::{FileDownloadError, Format};
-use probe_rs::{Core, HaltReason, RegisterId, VectorCatchCondition};
+use probe_rs::{BreakpointCause, Core, HaltReason, SemihostingCommand, VectorCatchCondition};
 use probe_rs_target::MemoryRegion;
 use signal_hook::consts::signal;
 use time::UtcOffset;
@@ -107,8 +107,10 @@ impl Cmd {
     }
 }
 
-/// Print all RTT messsages and a stacktrace when the core stops due to an exception
-/// or when ctrl + c is pressed.
+/// Print all RTT messsages and a stacktrace when the core stops due to an
+/// exception or when ctrl + c is pressed.
+///
+/// Returns `Ok(())` if the core gracefully halted, or an error.
 fn run_loop(
     core: &mut Core<'_>,
     memory_map: &[MemoryRegion],
@@ -117,7 +119,7 @@ fn run_loop(
     timestamp_offset: UtcOffset,
     always_print_stacktrace: bool,
     no_location: bool,
-) -> Result<bool, anyhow::Error> {
+) -> Result<(), anyhow::Error> {
     let mut rtt_config = rtt::RttConfig::default();
     rtt_config.channels.push(rtt::RttChannelConfig {
         channel_number: Some(0),
@@ -141,7 +143,7 @@ fn run_loop(
     while !exit.load(Ordering::Relaxed) {
         let had_rtt_data = poll_rtt(&mut rtta, core, &mut stdout)?;
         if poll_stacktrace(core, path)? {
-            return Ok(false);
+            return Ok(());
         }
 
         // Poll RTT with a frequency of 10 Hz if we do not receive any new data.
@@ -166,51 +168,39 @@ fn run_loop(
 
     signal_hook::low_level::unregister(sig_id);
     signal_hook::flag::register_conditional_default(signal::SIGINT, exit)?;
-    Ok(manually_halted)
+    Ok(())
 }
 
 /// Try to fetch the necessary data of the core to print its stacktrace.
+///
+/// Returns `Ok(true)` if the debuger should stop polling, or `Ok(false)` if the
+/// polling should continue, or an error.
 fn poll_stacktrace(core: &mut Core<'_>, path: &Path) -> Result<bool> {
     let status = core.status()?;
     let registers = core.registers();
     let pc_register = registers.pc().expect("a program counter register");
-    if let probe_rs::CoreStatus::Halted(reason) = status {
-        let mut skip_stacktrace = false;
-        if core.architecture() == probe_rs::Architecture::Arm {
-            if let HaltReason::Breakpoint(_kind) = reason {
-                use probe_rs::MemoryInterface;
-                // Maybe this was a semihosting operation.
-                // Grab the breakpoint instruction and the registers R0 and R1
-                let pc: u32 = core.read_core_reg(pc_register)?;
-                let r0: u32 = core.read_core_reg(RegisterId(0))?;
-                let r1: u32 = core.read_core_reg(RegisterId(1))?;
-                let instruction2 = core.read_word_8(pc as u64)?;
-                let instruction1 = core.read_word_8((pc + 1) as u64)?;
-                if instruction1 == 0xBE && instruction2 == 0xAB {
-                    // 0xAB breakpoint -> we are semihosting
-                    const SYS_EXIT: u32 = 0x18;
-                    const SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT: u32 = 0x20026;
-                    match (r0, r1) {
-                        (SYS_EXIT, SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT) => {
-                            skip_stacktrace = true;
-                            println!("Program exited successfully");
-                        }
-                        (SYS_EXIT, _) => {
-                            println!("Exited with unknown error code r1={r1:08x}");
-                        }
-                        _ => {
-                            println!("Unknown semihosting operation r0={r0:08x} r1={r1:08x}");
-                        }
-                    }
-                }
-            }
-        }
-        if !skip_stacktrace {
+    match status {
+        probe_rs::CoreStatus::Halted(HaltReason::Breakpoint(BreakpointCause::Semihosting(
+            SemihostingCommand::ExitSuccess,
+        ))) => Ok(true),
+        probe_rs::CoreStatus::Halted(HaltReason::Breakpoint(BreakpointCause::Semihosting(
+            SemihostingCommand::ExitError { code },
+        ))) => Err(anyhow!(
+            "Semihosting indicates exit with failure code: {code:#08x} ({code})"
+        )),
+        probe_rs::CoreStatus::Halted(_reason) => {
+            // Try and give the user some info as to why it halted.
             print_stacktrace(core, pc_register, path)?;
+            // Report this as an error
+            Err(anyhow!("CPU halted unexpectedly."))
         }
-        Ok(true)
-    } else {
-        Ok(false)
+        probe_rs::CoreStatus::Running
+        | probe_rs::CoreStatus::LockedUp
+        | probe_rs::CoreStatus::Sleeping
+        | probe_rs::CoreStatus::Unknown => {
+            // Carry on
+            Ok(false)
+        }
     }
 }
 

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use probe_rs::debug::DebugInfo;
 use probe_rs::flashing::{FileDownloadError, Format};
-use probe_rs::{Core, VectorCatchCondition};
+use probe_rs::{Core, HaltReason, RegisterId, VectorCatchCondition};
 use probe_rs_target::MemoryRegion;
 use signal_hook::consts::signal;
 use time::UtcOffset;
@@ -174,12 +174,44 @@ fn poll_stacktrace(core: &mut Core<'_>, path: &Path) -> Result<bool> {
     let status = core.status()?;
     let registers = core.registers();
     let pc_register = registers.pc().expect("a program counter register");
-    Ok(if let probe_rs::CoreStatus::Halted(_) = status {
-        print_stacktrace(core, pc_register, path)?;
-        true
+    if let probe_rs::CoreStatus::Halted(reason) = status {
+        let mut skip_stacktrace = false;
+        if core.architecture() == probe_rs::Architecture::Arm {
+            if let HaltReason::Breakpoint(_kind) = reason {
+                use probe_rs::MemoryInterface;
+                // Maybe this was a semihosting operation.
+                // Grab the breakpoint instruction and the registers R0 and R1
+                let pc: u32 = core.read_core_reg(pc_register)?;
+                let r0: u32 = core.read_core_reg(RegisterId(0))?;
+                let r1: u32 = core.read_core_reg(RegisterId(1))?;
+                let instruction2 = core.read_word_8(pc as u64)?;
+                let instruction1 = core.read_word_8((pc + 1) as u64)?;
+                if instruction1 == 0xBE && instruction2 == 0xAB {
+                    // 0xAB breakpoint -> we are semihosting
+                    const SYS_EXIT: u32 = 0x18;
+                    const SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT: u32 = 0x20026;
+                    match (r0, r1) {
+                        (SYS_EXIT, SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT) => {
+                            skip_stacktrace = true;
+                            println!("Program exited successfully");
+                        }
+                        (SYS_EXIT, _) => {
+                            println!("Exited with unknown error code r1={r1:08x}");
+                        }
+                        _ => {
+                            println!("Unknown semihosting operation r0={r0:08x} r1={r1:08x}");
+                        }
+                    }
+                }
+            }
+        }
+        if !skip_stacktrace {
+            print_stacktrace(core, pc_register, path)?;
+        }
+        Ok(true)
     } else {
-        false
-    })
+        Ok(false)
+    }
 }
 
 /// Prints the stacktrace of the current execution state.

--- a/probe-rs/src/core/core_status.rs
+++ b/probe-rs/src/core/core_status.rs
@@ -25,6 +25,20 @@ impl CoreStatus {
     }
 }
 
+/// Indicates the operation the target would like the debugger to perform.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum SemihostingCommand {
+    /// The target indicates that it completed successfully and no-longer wishes
+    /// to run.
+    ExitSuccess,
+    /// The target indicates that it completed unsuccessfully, with an error
+    /// code, and no-longer wishes to run.
+    ExitError {
+        /// Some architecture-specific or application specific exit code
+        code: u64,
+    },
+}
+
 /// When the core halts due to a breakpoint request, some architectures will allow us to distinguish between a software and hardware breakpoint.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum BreakpointCause {
@@ -34,6 +48,12 @@ pub enum BreakpointCause {
     Software,
     /// We were not able to distinguish if this was a hardware or software breakpoint.
     Unknown,
+    /// The target requested the host perform a semihosting operation.
+    ///
+    /// The core set up some registers into a well-specified state and then hit
+    /// a breakpoint. This indicates the core would like the debug probe to do
+    /// some work.
+    Semihosting(SemihostingCommand),
 }
 
 /// The reason why a core was halted.

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -93,7 +93,7 @@ pub use crate::config::{CoreType, InstructionSet, Target};
 pub use crate::core::{
     Architecture, BreakpointCause, Core, CoreInformation, CoreInterface, CoreRegister,
     CoreRegisters, CoreState, CoreStatus, HaltReason, MemoryMappedRegister, RegisterId,
-    RegisterRole, RegisterValue, SpecificCoreState, VectorCatchCondition,
+    RegisterRole, RegisterValue, SemihostingCommand, SpecificCoreState, VectorCatchCondition,
 };
 pub use crate::error::Error;
 pub use crate::memory::MemoryInterface;


### PR DESCRIPTION
Adds support for Semihosting on ARMv6-M, ARMv7-M, and ARMv8-M.

The motivation for this is to allow the target application to indicate to the debugger that a) execution is complete and b) everything was successful. This is use, for example, in the [Knurling app-template](https://github.com/knurling-rs/app-template/pull/71).