### PR TITLE
Add Bin, Idf, Uf2 support to cargo flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added STM32U5A and STM32U59 targets. (#1744)
 - Added AT32F4 series targets (#1759)
 - Allowed JTAG scan chain information to be encoded in targets (#1731)
+- Added support for IDF and BIN to cargo flash.  Added UF2 support to cargo
+  flash and probe-rs. (#1765)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,6 +2486,7 @@ dependencies = [
  "time",
  "tracing",
  "tracing-subscriber",
+ "uf2-decode",
 ]
 
 [[package]]
@@ -3917,6 +3918,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "uf2-decode"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d923a093a7d70f036269d3519ffa97bbf9d0a1e78caad6308db844d135763c5"
 
 [[package]]
 name = "uncased"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3921,8 +3921,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "uf2-decode"
-version = "0.1.0"
-source = "git+https://github.com/tommy-gilligan/uf2-decode.git#3e65ea8f840f3cb959580a272e21d34f4c7fb2ac"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca77d41ab27e3fa45df42043f96c79b80c6d8632eed906b54681d8d47ab00623"
 
 [[package]]
 name = "uncased"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3922,8 +3922,7 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 [[package]]
 name = "uf2-decode"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d923a093a7d70f036269d3519ffa97bbf9d0a1e78caad6308db844d135763c5"
+source = "git+https://github.com/tommy-gilligan/uf2-decode.git#3e65ea8f840f3cb959580a272e21d34f4c7fb2ac"
 
 [[package]]
 name = "uncased"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -186,7 +186,7 @@ tracing-subscriber = { version = "0.3.17", features = [
 ratatui = { version = "0.23.0", default-features = false, features = [
     "crossterm",
 ], optional = true }
-uf2-decode = "0.1.0"
+uf2-decode = { git = "https://github.com/tommy-gilligan/uf2-decode.git" }
 
 [build-dependencies]
 bincode = "1.3.3"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -186,6 +186,7 @@ tracing-subscriber = { version = "0.3.17", features = [
 ratatui = { version = "0.23.0", default-features = false, features = [
     "crossterm",
 ], optional = true }
+uf2-decode = "0.1.0"
 
 [build-dependencies]
 bincode = "1.3.3"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -186,7 +186,7 @@ tracing-subscriber = { version = "0.3.17", features = [
 ratatui = { version = "0.23.0", default-features = false, features = [
     "crossterm",
 ], optional = true }
-uf2-decode = { git = "https://github.com/tommy-gilligan/uf2-decode.git" }
+uf2-decode = "0.2.0"
 
 [build-dependencies]
 bincode = "1.3.3"

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
@@ -29,7 +29,6 @@ pub(crate) fn render_diagnostics(error: OperationError) {
                 "For a guide on how to set up your probes, see https://probe.rs/docs/getting-started/probe-setup".into(),
             ],
         ),
-        #[allow(dead_code)]
         OperationError::FailedToOpenElf { source, path } => (
             error.to_string(),
             match source.kind() {
@@ -39,7 +38,6 @@ pub(crate) fn render_diagnostics(error: OperationError) {
                 _ => vec![]
             },
         ),
-        #[allow(dead_code)]
         OperationError::FailedToLoadElfData(e) => match e {
             FileDownloadError::NoLoadableSegments => (
                 e.to_string(),

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
@@ -8,7 +8,7 @@ use bytesize::ByteSize;
 use probe_rs::{
     config::MemoryRegion,
     config::{RegistryError, TargetDescriptionSource},
-    flashing::{FileDownloadError, FlashError},
+    flashing::FlashError,
     Error as ProbeRsError, Target,
 };
 
@@ -29,42 +29,6 @@ pub(crate) fn render_diagnostics(error: OperationError) {
                 "For a guide on how to set up your probes, see https://probe.rs/docs/getting-started/probe-setup".into(),
             ],
         ),
-        OperationError::FailedToOpenElf { source, path } => (
-            error.to_string(),
-            match source.kind() {
-                std::io::ErrorKind::NotFound => vec![
-                    format!("Make sure the path '{}' is the correct location of your ELF binary.", path.display())
-                ],
-                _ => vec![]
-            },
-        ),
-        OperationError::FailedToLoadElfData(e) => match e {
-            FileDownloadError::NoLoadableSegments => (
-                e.to_string(),
-                vec![
-                    "Please make sure your linker script is correct and not missing at all.".into(),
-                    "If you are working with Rust, check your `.cargo/config.toml`? If you are new to the rust-embedded ecosystem, please head over to https://github.com/rust-embedded/cortex-m-quickstart.".into()
-                ],
-            ),
-            FileDownloadError::Flash(e) => match e {
-                FlashError::NoSuitableNvm {..} => (
-                    e.to_string(),
-                    vec![
-                        "Make sure the flash region specified in the linkerscript matches the one specified in the datasheet of your chip.".into()
-                    ]
-                ),
-                _ => (
-                    e.to_string(),
-                    vec![]
-                ),
-            },
-            _ => (
-                e.to_string(),
-                vec![
-                    "Make sure you are compiling for the correct architecture of your chip.".into()
-                ],
-            ),
-        },
         OperationError::FailedToOpenProbe(_e) => (
             error.to_string(),
             vec![

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
@@ -29,6 +29,7 @@ pub(crate) fn render_diagnostics(error: OperationError) {
                 "For a guide on how to set up your probes, see https://probe.rs/docs/getting-started/probe-setup".into(),
             ],
         ),
+        #[allow(dead_code)]
         OperationError::FailedToOpenElf { source, path } => (
             error.to_string(),
             match source.kind() {
@@ -38,6 +39,7 @@ pub(crate) fn render_diagnostics(error: OperationError) {
                 _ => vec![]
             },
         ),
+        #[allow(dead_code)]
         OperationError::FailedToLoadElfData(e) => match e {
             FileDownloadError::NoLoadableSegments => (
                 e.to_string(),

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -95,13 +95,13 @@ fn main_try(mut args: Vec<OsString>) -> Result<(), OperationError> {
     let (mut session, probe_options) = opt.probe_options.simple_attach()?;
 
     // Flash the binary
-    let flashloader = flash::build_elf_flashloader(&mut session, &path)?;
+    let loader = flash::build_loader(&mut session, &path, opt.format_options).unwrap();
     flash::run_flash_download(
         &mut session,
         &path,
         &opt.download_options,
         &probe_options,
-        flashloader,
+        loader,
         false,
     )?;
 

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -62,9 +62,9 @@ fn main_try(mut args: Vec<OsString>) -> Result<(), OperationError> {
     })?;
     log::debug!("Changed working directory to {}", work_dir.display());
 
-    // Get the path to the ELF binary we want to flash.
+    // Get the path to the binary we want to flash.
     // This can either be give from the arguments or can be a cargo build artifact.
-    let path: PathBuf = if let Some(path) = &opt.elf {
+    let path: PathBuf = if let Some(path) = &opt.path {
         path.into()
     } else {
         // Build the project, and extract the path of the built artifact.

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -95,7 +95,7 @@ fn main_try(mut args: Vec<OsString>) -> Result<(), OperationError> {
     let (mut session, probe_options) = opt.probe_options.simple_attach()?;
 
     // Flash the binary
-    let flashloader = flash::build_flashloader(&mut session, &path)?;
+    let flashloader = flash::build_elf_flashloader(&mut session, &path)?;
     flash::run_flash_download(
         &mut session,
         &path,

--- a/probe-rs/src/bin/probe-rs/cmd/download.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/download.rs
@@ -46,6 +46,7 @@ impl Cmd {
             Format::Elf => loader.load_elf_data(&mut file),
             Format::Hex => loader.load_hex_data(&mut file),
             Format::Idf(options) => loader.load_idf_data(&mut session, &mut file, options),
+            Format::Uf2 => loader.load_uf2_data(&mut file),
         }?;
 
         run_flash_download(

--- a/probe-rs/src/bin/probe-rs/cmd/profile.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/profile.rs
@@ -88,6 +88,7 @@ impl Cmd {
             Format::Elf => loader.load_elf_data(&mut file),
             Format::Hex => loader.load_hex_data(&mut file),
             Format::Idf(options) => loader.load_idf_data(&mut session, &mut file, options),
+            Format::Uf2 => loader.load_uf2_data(&mut file),
         }?;
 
         let bytes = std::fs::read(&self.run.path)?;

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -69,6 +69,7 @@ impl Cmd {
                 Format::Elf => loader.load_elf_data(&mut file),
                 Format::Hex => loader.load_hex_data(&mut file),
                 Format::Idf(options) => loader.load_idf_data(&mut session, &mut file, options),
+                Format::Uf2 => loader.load_uf2_data(&mut file),
             }?;
 
             run_flash_download(

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -162,6 +162,7 @@ impl FormatOptions {
                     partition_table,
                 })
             }
+            Format::Uf2 => Format::Uf2,
         })
     }
 }

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -115,7 +115,7 @@ fn format_from_str<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Format,
 
 #[derive(clap::Parser, Clone, Deserialize, Debug, Default)]
 #[serde(default)]
-pub(crate) struct FormatOptions {
+pub struct FormatOptions {
     #[clap(value_enum, ignore_case = true, default_value = "elf", long)]
     #[serde(deserialize_with = "format_from_str")]
     format: Format,

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -460,12 +460,14 @@ pub enum OperationError {
     #[error("No connected probes were found.")]
     NoProbesFound,
     #[error("Failed to open the ELF file '{path}' for flashing.")]
+    #[allow(dead_code)]
     FailedToOpenElf {
         #[source]
         source: std::io::Error,
         path: PathBuf,
     },
     #[error("Failed to load the ELF data.")]
+    #[allow(dead_code)]
     FailedToLoadElfData(#[source] FileDownloadError),
     #[error("Failed to open the debug probe.")]
     FailedToOpenProbe(#[source] DebugProbeError),

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -72,6 +72,9 @@ pub struct FlashOptions {
     #[command(flatten)]
     /// Argument relating to probe/chip selection/configuration.
     pub download_options: BinaryDownloadOptions,
+
+    #[command(flatten)]
+    pub format_options: crate::FormatOptions,
 }
 
 /// Common options when flashing a target device.

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -56,9 +56,9 @@ pub struct FlashOptions {
     /// Default is `warning`. Possible choices are [error, warning, info, debug, trace].
     #[arg(value_name = "level", long)]
     pub log: Option<log::Level>,
-    /// The path to the ELF file to be flashed.
-    #[arg(value_name = "elf file", long)]
-    pub elf: Option<PathBuf>,
+    /// The path to the file to be flashed.
+    #[arg(value_name = "path", long)]
+    pub path: Option<PathBuf>,
     /// The work directory from which cargo-flash should operate from.
     #[arg(value_name = "directory", long)]
     pub work_dir: Option<PathBuf>,

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -39,7 +39,7 @@ use crate::util::parse_u64;
 use clap;
 use probe_rs::{
     config::{RegistryError, TargetSelector},
-    flashing::FlashError,
+    flashing::{FileDownloadError, FlashError},
     DebugProbeError, DebugProbeSelector, FakeProbe, Permissions, Probe, Session, Target,
     WireProtocol,
 };
@@ -459,6 +459,14 @@ CARGO BUILD OPTIONS:
 pub enum OperationError {
     #[error("No connected probes were found.")]
     NoProbesFound,
+    #[error("Failed to open the ELF file '{path}' for flashing.")]
+    FailedToOpenElf {
+        #[source]
+        source: std::io::Error,
+        path: PathBuf,
+    },
+    #[error("Failed to load the ELF data.")]
+    FailedToLoadElfData(#[source] FileDownloadError),
     #[error("Failed to open the debug probe.")]
     FailedToOpenProbe(#[source] DebugProbeError),
     #[error("{number} probes were found.")]

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -39,7 +39,7 @@ use crate::util::parse_u64;
 use clap;
 use probe_rs::{
     config::{RegistryError, TargetSelector},
-    flashing::{FileDownloadError, FlashError},
+    flashing::FlashError,
     DebugProbeError, DebugProbeSelector, FakeProbe, Permissions, Probe, Session, Target,
     WireProtocol,
 };
@@ -459,14 +459,6 @@ CARGO BUILD OPTIONS:
 pub enum OperationError {
     #[error("No connected probes were found.")]
     NoProbesFound,
-    #[error("Failed to open the ELF file '{path}' for flashing.")]
-    FailedToOpenElf {
-        #[source]
-        source: std::io::Error,
-        path: PathBuf,
-    },
-    #[error("Failed to load the ELF data.")]
-    FailedToLoadElfData(#[source] FileDownloadError),
     #[error("Failed to open the debug probe.")]
     FailedToOpenProbe(#[source] DebugProbeError),
     #[error("{number} probes were found.")]

--- a/probe-rs/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs/src/bin/probe-rs/util/flash.rs
@@ -175,7 +175,7 @@ pub fn run_flash_download(
 /// Builds a new flash loader for the given target and ELF. This
 /// will check the ELF for validity and check what pages have to be
 /// flashed etc.
-pub fn build_flashloader(
+pub fn build_elf_flashloader(
     session: &mut Session,
     elf_path: &Path,
 ) -> Result<FlashLoader, OperationError> {

--- a/probe-rs/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs/src/bin/probe-rs/util/flash.rs
@@ -201,6 +201,7 @@ pub fn build_loader(
         Format::Elf => loader.load_elf_data(&mut file),
         Format::Hex => loader.load_hex_data(&mut file),
         Format::Idf(options) => loader.load_idf_data(session, &mut file, options),
+        Format::Uf2 => loader.load_uf2_data(&mut file),
     }?;
 
     Ok(loader)

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -42,6 +42,8 @@ pub enum Format {
     /// Marks a file in the [ESP-IDF bootloader](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html#app-image-structures) format.
     /// Use [IdfOptions] to configure flashing.
     Idf(IdfOptions),
+    /// Marks a file in the [UF2](https://github.com/microsoft/uf2) format.
+    Uf2,
 }
 
 impl FromStr for Format {
@@ -56,6 +58,7 @@ impl FromStr for Format {
             "idf" | "esp-idf" => Ok(Format::Idf(Default::default())),
             "hex" | "ihex" | "intelhex" => Ok(Format::Hex),
             "elf" => Ok(Format::Elf),
+            "uf2" => Ok(Format::Uf2),
             _ => Err(format!("Format '{s}' is unknown.")),
         }
     }
@@ -180,6 +183,7 @@ pub fn download_file_with_options<P: AsRef<Path>>(
         Format::Elf => loader.load_elf_data(&mut file),
         Format::Hex => loader.load_hex_data(&mut file),
         Format::Idf(options) => loader.load_idf_data(session, &mut file, options),
+        Format::Uf2 => loader.load_uf2_data(&mut file),
     }?;
 
     loader

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -238,7 +238,7 @@ impl FlashLoader {
         let target_addresses = family_to_target.values();
         let num_sections = family_to_target.len();
 
-        if let Some(target_address) =  target_addresses.min() {
+        if let Some(target_address) = target_addresses.min() {
             tracing::info!("Found {} loadable sections:", num_sections);
             if num_sections > 1 {
                 tracing::warn!("More than 1 section found in UF2 file.  Using first section.");

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -235,10 +235,16 @@ impl FlashLoader {
         file.read_to_end(&mut uf2_buffer)?;
 
         let (converted, family_to_target) = uf2_decode::convert_from_uf2(&uf2_buffer).unwrap();
+        let mut target_addresses = family_to_target.values();
+        let num_sections = family_to_target.len();
 
-        if let Some((_family, target)) = family_to_target.iter().next() {
-            tracing::info!("Found {} loadable sections:", family_to_target.len());
-            self.add_data(*target, &converted)?;
+        if let Some(target_address) =  target_addresses.next() {
+            tracing::info!("Found {} loadable sections:", num_sections);
+            if num_sections > 1 {
+                tracing::warn!("More than 1 section found in UF2 file.  Using first section.");
+            }
+            self.add_data(*target_address, &converted)?;
+
             Ok(())
         } else {
             tracing::warn!("No loadable segments were found in the UF2 file.");

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -228,6 +228,26 @@ impl FlashLoader {
         Ok(())
     }
 
+    /// Prepares the data sections that have to be loaded into flash from an UF2 file.
+    /// This will validate the UF2 file and transform all its data into sections but no flash loader commands yet.
+    pub fn load_uf2_data<T: Read>(&mut self, file: &mut T) -> Result<(), FileDownloadError> {
+        let mut uf2_buffer = Vec::new();
+        file.read_to_end(&mut uf2_buffer)?;
+
+        let (converted, family_to_target) = uf2_decode::convert_from_uf2(&uf2_buffer).unwrap();
+        self.add_data(
+            family_to_target
+                .into_iter()
+                .next()
+                .unwrap()
+                .1
+                .try_into()
+                .unwrap(),
+            &converted,
+        )?;
+        Ok(())
+    }
+
     /// Writes all the stored data chunks to flash.
     ///
     /// Requires a session with an attached target that has a known flash algorithm.

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -238,7 +238,7 @@ impl FlashLoader {
 
         if let Some((_family, target)) = family_to_target.iter().next() {
             tracing::info!("Found {} loadable sections:", family_to_target.len());
-            self.add_data((*target).try_into().unwrap(), &converted)?;
+            self.add_data(*target, &converted)?;
             Ok(())
         } else {
             tracing::warn!("No loadable segments were found in the UF2 file.");

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -235,10 +235,10 @@ impl FlashLoader {
         file.read_to_end(&mut uf2_buffer)?;
 
         let (converted, family_to_target) = uf2_decode::convert_from_uf2(&uf2_buffer).unwrap();
-        let mut target_addresses = family_to_target.values();
+        let target_addresses = family_to_target.values();
         let num_sections = family_to_target.len();
 
-        if let Some(target_address) =  target_addresses.next() {
+        if let Some(target_address) =  target_addresses.min() {
             tracing::info!("Found {} loadable sections:", num_sections);
             if num_sections > 1 {
                 tracing::warn!("More than 1 section found in UF2 file.  Using first section.");


### PR DESCRIPTION
#1758

This is very rough so far.  In trying to add UF2 support to cargo flash, it helped to bring across some stuff that was only available on probe-rs so far ie. Bin and Idf support.  Is this desirable?

I've 'cheated' with errors for now through `unwrap`.  Should I create more error types or use `anyhow`? For now I've just deleted a now unused error type.  [44d69bfdbec2d768aa388dbb3f142b3b7cb033af](https://github.com/probe-rs/probe-rs/commit/44d69bfdbec2d768aa388dbb3f142b3b7cb033af)

I've used my own crate for UF2 but I'm not married to it.  I haven't evaluated other options very well yet and my crate does not have very good support for multiple sections.