### PR TITLE
Assemble changelog out of fragments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -8,7 +8,7 @@ Please make sure that your submission includes the following:
 - [ ] The code compiles without `errors` or `warnings`.
 - [ ] All tests pass and in the best case you also added new tests.
 - [ ] `cargo fmt` was run.
-- [ ] Add a changelog fragment describing your canges in `changelogs/`. See https://github.com/probe-rs/probe-rs/blob/master/CONTRIBUTING.md#changelog-entries. 
+- [ ] Add a changelog fragment describing your changes in `changelogs/`. See https://github.com/probe-rs/probe-rs/blob/master/CONTRIBUTING.md#changelog-entries. 
 
 ### Nice to have
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -8,7 +8,7 @@ Please make sure that your submission includes the following:
 - [ ] The code compiles without `errors` or `warnings`.
 - [ ] All tests pass and in the best case you also added new tests.
 - [ ] `cargo fmt` was run.
-- [ ] Your changes were added to the `CHANGELOG.md` in the proper section.
+- [ ] Add a changelog fragment describing your canges in `changelogs/`. See https://github.com/probe-rs/probe-rs/blob/master/CONTRIBUTING.md#changelog-entries. 
 
 ### Nice to have
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,3 +22,4 @@ jobs:
         run:  cargo xtask check-changelog
         env:
           GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.number }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -23,9 +23,6 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: swatinem/rust-cache@v2
-      
-      - name: Check that fragments are valid
-        run:  cargo xtask check-changelog
 
       - name: Check that fragments are valid
         run:  cargo xtask check-changelog

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,14 +15,13 @@ jobs:
     name: Changelog
     runs-on: ubuntu-latest
 
-    env:
-      CARGO_TERM_COLOR: always
-
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
 
       - uses: swatinem/rust-cache@v2
+        with:
+          cache-on-failure: "true"
 
       - name: Check that fragments are valid
         run:  cargo xtask check-changelog

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,9 +14,18 @@ jobs:
   changelog:
     name: Changelog
     runs-on: ubuntu-latest
+
+    env:
+      CARGO_TERM_COLOR: always
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+
+      - uses: swatinem/rust-cache@v2
+      
+      - name: Check that fragments are valid
+        run:  cargo xtask check-changelog
 
       - name: Check that fragments are valid
         run:  cargo xtask check-changelog

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,11 +18,5 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Check that changelog updated
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: CHANGELOG.md
-          skipLabels: 'needs-changelog, skip-changelog'
-          missingUpdateErrorMessage: 'Please add a changelog entry in the CHANGELOG.md file.'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check that fragments are valid
+        run:  cargo xtask check-changelog

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,3 +20,5 @@ jobs:
 
       - name: Check that fragments are valid
         run:  cargo xtask check-changelog
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,19 @@
 
 Thanks for your contributions :)
 
+
+## Changelog entries
+
+To avoid conflicts in the changelog file, the changelog is assembled out of fragments at release time. To describe the changes in a PR, add a new file in `changelog/`.
+The filename should start with one of the following categories:
+
+- added
+- changed
+- fixed
+- removed
+
+For example, `added-ultra-fast-flashing.md` would lead to an entry in the `## Added` section of the changelog. The content of the file should be a single line or paragraph describing your changes.
+
 ## How to build cargo-embed/ cargo-flash from source
 
 cargo-embed is a so called [cargo subcommand](https://doc.rust-lang.org/book/ch14-05-extending-cargo.html). It is a programm named cargo-embed which is installed in the users path. Thus when applying some small fixes cargo-embed you can run `cargo build` and then use the executable in the target folder named cargo-embed directly. You can also use [cargo install --path .](https://doc.rust-lang.org/cargo/commands/cargo-install.html) to install your current checkout locally overriding what you previously had installed using `cargo install cargo-embed`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -406,7 +406,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -587,7 +587,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1232,7 +1232,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2058,7 +2058,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2251,7 +2251,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2371,7 +2371,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2574,7 +2574,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
  "version_check",
  "yansi",
 ]
@@ -3048,7 +3048,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3095,22 +3095,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.174"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b88756493a5bd5e5395d53baa70b194b05764ab85b59e43e4b8f4e1192fa9b1"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.174"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5c3a298c7f978e53536f95a63bdc4c4a64550582f31a0359a9afda6aede62e"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3141,7 +3141,7 @@ checksum = "e168eaaf71e8f9bd6037feb05190485708e019f4fd87d161b3c0a0d37daf85e5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3404,7 +3404,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3483,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3635,7 +3635,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3717,7 +3717,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3840,7 +3840,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4138,7 +4138,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -4172,7 +4172,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4456,6 +4456,8 @@ dependencies = [
  "chrono",
  "clap",
  "regex",
+ "serde",
+ "serde_json",
  "xshell",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +530,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.48.1",
+]
 
 [[package]]
 name = "cipher"
@@ -1557,6 +1586,29 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4198,6 +4250,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.1",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4391,6 +4452,8 @@ checksum = "7e2c411759b501fb9501aac2b1b2d287a6e93e5bdcf13c25306b23e1b716dd0e"
 name = "xtask"
 version = "0.20.0"
 dependencies = [
+ "anyhow",
+ "chrono",
  "clap",
  "regex",
  "xshell",

--- a/changelog/added-fragment.md
+++ b/changelog/added-fragment.md
@@ -1,0 +1,1 @@
+Just a test fragment.

--- a/changelog/added-fragment.md
+++ b/changelog/added-fragment.md
@@ -1,1 +1,0 @@
-Just a test fragment.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,3 +11,5 @@ regex = "1.9"
 clap = { version = "4", features = ["derive"] }
 chrono = "0.4.31"
 anyhow.workspace = true
+serde_json = "1.0.107"
+serde = { version = "1.0.188", features = ["derive"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,3 +9,5 @@ publish = false
 xshell = "0.2"
 regex = "1.9"
 clap = { version = "4", features = ["derive"] }
+chrono = "0.4.31"
+anyhow.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -110,7 +110,7 @@ fn get_changelog_fragments(
         if path.is_file() {
             let filename = path
                 .file_name()
-                .expect("All files should have a nmae")
+                .expect("All files should have a name")
                 .to_str()
                 .with_context(|| format!("Filename {path:?} is not valid UTF-8"))?;
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -142,7 +142,9 @@ struct PrInfo {
 fn check_changelog() -> Result<()> {
     let sh = Shell::new()?;
 
-    let info_json = cmd!(sh, "gh pr view --json labels,files").read()?;
+    let pr_number = std::env::var("PR").unwrap_or_default();
+
+    let info_json = cmd!(sh, "gh pr view {pr_number} --json labels,files").read()?;
 
     let info: PrInfo = serde_json::from_str(&info_json)?;
 


### PR DESCRIPTION
To avoid the endless conflicts in a single changelog file.

The idea is to place a file in `changelog`, in the form `added-new-fancy-stuffs.md`. The first part of the filename
should match a changelog category, the rest doesn't matter. The xtask can then be used to collect all the entries into
the changelog at release time.

### Remaining todos

- [x] Document how to add changelog fragments.
- [x] Update changelog check workflow
- [ ] Automatically assemble changelog in release workflow