### PR TITLE
Allow to customize the `defmt` log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added getters to registry : `get_targets_by_family_name` & `get_target_and_family_by_name`, change `get_target_by_name`. (#1770)
 - Support for vector catch in Armv8-M targets (#1709)
 - Add log rotation to stop disks from filling. Currently a maximum of 20 logs is kept. (#1780)
+- Allow to customize the defmt log format with `--log-format`. (#1788)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,8 +789,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 [[package]]
 name = "defmt-decoder"
 version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69494bdf0927405e6d22641d1307c664ad3e9483452b85078940529883945044"
+source = "git+https://github.com/knurling-rs/defmt/?branch=decoder-add-formatter#5cebef69bca26cf8dd5e87fab289a53068f7a7ba"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -811,8 +810,7 @@ dependencies = [
 [[package]]
 name = "defmt-json-schema"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b04d228e57a61cf385d86bc8980bb41b47c6fc0eace90592668df97b2dad6a"
+source = "git+https://github.com/knurling-rs/defmt/?branch=decoder-add-formatter#5cebef69bca26cf8dd5e87fab289a53068f7a7ba"
 dependencies = [
  "log",
  "serde",
@@ -821,8 +819,7 @@ dependencies = [
 [[package]]
 name = "defmt-parser"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269924c02afd7f94bc4cecbfa5c379f6ffcf9766b3408fe63d22c728654eccd0"
+source = "git+https://github.com/knurling-rs/defmt/?branch=decoder-add-formatter#5cebef69bca26cf8dd5e87fab289a53068f7a7ba"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "cpp_demangle",
- "fallible-iterator 0.3.0",
+ "fallible-iterator",
  "gimli 0.28.0",
  "memmap2",
  "object 0.32.1",
@@ -788,8 +788,9 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "defmt-decoder"
-version = "0.3.8"
-source = "git+https://github.com/knurling-rs/defmt/?branch=decoder-add-formatter#da03a4b9e4a2e9c28f83f7075f5d06283eafa88b"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc8c950fcaefdfce609498332b92c9b235c431d85c6c71908142cbb55709140"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -797,10 +798,10 @@ dependencies = [
  "defmt-json-schema",
  "defmt-parser",
  "dissimilar",
- "gimli 0.27.3",
+ "gimli 0.28.0",
  "log",
  "nom",
- "object 0.31.1",
+ "object 0.32.1",
  "ryu",
  "serde",
  "serde_json",
@@ -810,7 +811,8 @@ dependencies = [
 [[package]]
 name = "defmt-json-schema"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt/?branch=decoder-add-formatter#da03a4b9e4a2e9c28f83f7075f5d06283eafa88b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b04d228e57a61cf385d86bc8980bb41b47c6fc0eace90592668df97b2dad6a"
 dependencies = [
  "log",
  "serde",
@@ -819,7 +821,8 @@ dependencies = [
 [[package]]
 name = "defmt-parser"
 version = "0.3.3"
-source = "git+https://github.com/knurling-rs/defmt/?branch=decoder-add-formatter#da03a4b9e4a2e9c28f83f7075f5d06283eafa88b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269924c02afd7f94bc4cecbfa5c379f6ffcf9766b3408fe63d22c728654eccd0"
 dependencies = [
  "thiserror",
 ]
@@ -1046,12 +1049,6 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
@@ -1273,10 +1270,6 @@ name = "gimli"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
-dependencies = [
- "fallible-iterator 0.2.0",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "gimli"
@@ -1284,7 +1277,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 dependencies = [
- "fallible-iterator 0.3.0",
+ "fallible-iterator",
  "stable_deref_trait",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 [[package]]
 name = "defmt-decoder"
 version = "0.3.8"
-source = "git+https://github.com/knurling-rs/defmt/?branch=decoder-add-formatter#5cebef69bca26cf8dd5e87fab289a53068f7a7ba"
+source = "git+https://github.com/knurling-rs/defmt/?branch=decoder-add-formatter#da03a4b9e4a2e9c28f83f7075f5d06283eafa88b"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "defmt-json-schema"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt/?branch=decoder-add-formatter#5cebef69bca26cf8dd5e87fab289a53068f7a7ba"
+source = "git+https://github.com/knurling-rs/defmt/?branch=decoder-add-formatter#da03a4b9e4a2e9c28f83f7075f5d06283eafa88b"
 dependencies = [
  "log",
  "serde",
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "defmt-parser"
 version = "0.3.3"
-source = "git+https://github.com/knurling-rs/defmt/?branch=decoder-add-formatter#5cebef69bca26cf8dd5e87fab289a53068f7a7ba"
+source = "git+https://github.com/knurling-rs/defmt/?branch=decoder-add-formatter#da03a4b9e4a2e9c28f83f7075f5d06283eafa88b"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,6 @@ allow-dirty = ["ci"]
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+[patch.crates-io]
+defmt-decoder = { git = "https://github.com/knurling-rs/defmt/", branch = "decoder-add-formatter" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,3 @@ allow-dirty = ["ci"]
 [profile.dist]
 inherits = "release"
 lto = "thin"
-
-[patch.crates-io]
-defmt-decoder = { git = "https://github.com/knurling-rs/defmt/", branch = "decoder-add-formatter" }

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -141,7 +141,7 @@ cargo_toml = { version = "0.16.3", optional = true }
 clap = { version = "4.4", features = ["derive"], optional = true }
 colored = { version = "2.0.4", optional = true }
 crossterm = { version = "<= 0.27.0", optional = true }
-defmt-decoder = { version = "0.3.8", features = ["unstable"], optional = true }
+defmt-decoder = { version = "0.3.9", features = ["unstable"], optional = true }
 directories = { version = "5", optional = true }
 dunce = { version = "1.0.4", optional = true }
 figment = { version = "0.10", features = [

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -192,7 +192,7 @@ impl<'p> CoreHandle<'p> {
             })
             .and_then(|rtt| {
                 tracing::info!("RTT initialized.");
-                RttActiveTarget::new(rtt, program_binary, rtt_config, timestamp_offset)
+                RttActiveTarget::new(rtt, program_binary, rtt_config, timestamp_offset, None)
             }) {
             Ok(target_rtt) => {
                 for any_channel in target_rtt.active_channels.iter() {

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -46,6 +46,9 @@ pub struct Cmd {
 
     #[clap(flatten)]
     pub(crate) format_options: FormatOptions,
+
+    #[clap(long)]
+    pub(crate) log_format: Option<String>,
 }
 
 impl Cmd {
@@ -102,6 +105,7 @@ impl Cmd {
             timestamp_offset,
             self.always_print_stacktrace,
             self.no_location,
+            self.log_format.as_deref(),
         )?;
 
         Ok(())
@@ -120,6 +124,7 @@ fn run_loop(
     timestamp_offset: UtcOffset,
     always_print_stacktrace: bool,
     no_location: bool,
+    log_format: Option<&str>,
 ) -> Result<(), anyhow::Error> {
     let mut rtt_config = rtt::RttConfig::default();
     rtt_config.channels.push(rtt::RttChannelConfig {
@@ -135,6 +140,7 @@ fn run_loop(
         path,
         rtt_config,
         timestamp_offset,
+        log_format,
     );
 
     let exit = Arc::new(AtomicBool::new(false));
@@ -285,6 +291,7 @@ fn attach_to_rtt(
     path: &Path,
     rtt_config: RttConfig,
     timestamp_offset: UtcOffset,
+    log_format: Option<&str>,
 ) -> Option<rtt::RttActiveTarget> {
     for _ in 0..RTT_RETRIES {
         match rtt::attach_to_rtt(
@@ -294,6 +301,7 @@ fn attach_to_rtt(
             path,
             &rtt_config,
             timestamp_offset,
+            log_format,
         ) {
             Ok(target_rtt) => return Some(target_rtt),
             Err(error) => {

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -116,6 +116,7 @@ impl Cmd {
 /// exception or when ctrl + c is pressed.
 ///
 /// Returns `Ok(())` if the core gracefully halted, or an error.
+#[allow(clippy::too_many_arguments)]
 fn run_loop(
     core: &mut Core<'_>,
     memory_map: &[MemoryRegion],

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -417,7 +417,7 @@ impl RttActiveTarget {
                 // 3. Default with timestamp without location
                 // 4. Default without timestamp with location
                 // 5. Default without timestamp without location
-                let format = log_format.unwrap_or_else(|| match (show_location, has_timestamp) {
+                let format = log_format.unwrap_or(match (show_location, has_timestamp) {
                     (true, true) => "{t} {L} {s}\n└─ {m} @ {F}:{l}",
                     (true, false) => "{L} {s}\n└─ {m} @ {F}:{l}",
                     (false, true) => "{t} {L} {s}",

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -243,7 +243,11 @@ impl RttActiveChannel {
     pub fn get_rtt_data(
         &mut self,
         core: &mut Core,
-        defmt_state: Option<&(defmt_decoder::Table, Option<defmt_decoder::Locations>)>,
+        defmt_state: Option<&(
+            defmt_decoder::Table,
+            Option<defmt_decoder::Locations>,
+            defmt_decoder::log::Formatter,
+        )>,
     ) -> Result<Option<(String, String)>, anyhow::Error> {
         self
             .poll_rtt(core)
@@ -271,33 +275,25 @@ impl RttActiveChannel {
                             }
                             DataFormat::Defmt => {
                                 match defmt_state {
-                                    Some((table, locs)) => {
+                                    Some((table, locs, formatter)) => {
                                         let mut stream_decoder = table.new_stream_decoder();
                                         stream_decoder.received(&self.rtt_buffer.0[..bytes_read]);
                                         loop {
                                             match stream_decoder.decode() {
                                                 Ok(frame) => {
                                                     let loc = locs.as_ref().and_then(|locs| locs.get(&frame.index()) );
-                                                    writeln!(formatted_data, "{}", frame.display(true)).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
-                                                    if self.show_location {
+                                                    let (a, b, c) = if self.show_location {
                                                         if let Some(loc) = loc {
-                                                            let relpath = if let Ok(relpath) =
-                                                                loc.file.strip_prefix(&std::env::current_dir().unwrap())
-                                                            {
-                                                                relpath
-                                                            } else {
-                                                                // not relative; use full path
-                                                                &loc.file
-                                                            };
-                                                            writeln!(formatted_data,
-                                                                "└─ {}:{}",
-                                                                relpath.display(),
-                                                                loc.line
-                                                            ).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
+                                                            let relpath = loc.file.strip_prefix(&std::env::current_dir().unwrap()).unwrap_or(&loc.file);
+                                                            (Some(relpath.display().to_string()), Some(loc.line.try_into().unwrap()), Some(loc.module.as_str()))
                                                         } else {
-                                                            writeln!(formatted_data, "└─ <invalid location: defmt frame-index: {}>", frame.index()).map_or_else(|err| log::error!("Failed to format RTT data - {:?}", err), |r|r);
+                                                            (Some(format!("└─ <invalid location: defmt frame-index: {}>", frame.index())), None, None)
                                                         }
-                                                    }
+                                                    } else {
+                                                        (None, None, None)
+                                                    };
+                                                    let s = formatter.format_to_string(frame, a.as_deref(), b, c);
+                                                    writeln!(formatted_data, "{s}")?;
                                                     continue;
                                                 },
                                                 Err(DecodeError::UnexpectedEof) => break,
@@ -341,7 +337,11 @@ impl RttActiveChannel {
 #[derive(Debug)]
 pub struct RttActiveTarget {
     pub active_channels: Vec<RttActiveChannel>,
-    pub defmt_state: Option<(defmt_decoder::Table, Option<defmt_decoder::Locations>)>,
+    pub defmt_state: Option<(
+        defmt_decoder::Table,
+        Option<defmt_decoder::Locations>,
+        defmt_decoder::log::Formatter,
+    )>,
 }
 
 impl RttActiveTarget {
@@ -403,6 +403,8 @@ impl RttActiveTarget {
                     err
                 )
             })?;
+            const DEFAULT_LOG_FORMAT: &str = "{t} {L} {s}\n└─ {m} @ {F}:{l}";
+            let formatter = defmt_decoder::log::Formatter::new(DEFAULT_LOG_FORMAT);
             if let Some(table) = defmt_decoder::Table::parse(&elf)? {
                 let locs = {
                     let locs = table.get_locations(&elf)?;
@@ -419,7 +421,7 @@ impl RttActiveTarget {
                         None
                     }
                 };
-                Some((table, locs))
+                Some((table, locs, formatter))
             } else {
                 log::warn!("No `Table` definition in DWARF info; compile your program with `debug = 2` to enable location info.");
                 None

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -284,17 +284,13 @@ impl RttActiveChannel {
                                             match stream_decoder.decode() {
                                                 Ok(frame) => {
                                                     let loc = locs.as_ref().and_then(|locs| locs.get(&frame.index()) );
-                                                    let (a, b, c) = if self.show_location {
-                                                        if let Some(loc) = loc {
-                                                            let relpath = loc.file.strip_prefix(&std::env::current_dir().unwrap()).unwrap_or(&loc.file);
-                                                            (Some(relpath.display().to_string()), Some(loc.line.try_into().unwrap()), Some(loc.module.as_str()))
-                                                        } else {
-                                                            (Some(format!("└─ <invalid location: defmt frame-index: {}>", frame.index())), None, None)
-                                                        }
+                                                    let (file, line, module) = if let Some(loc) = loc {
+                                                        let relpath = loc.file.strip_prefix(&std::env::current_dir().unwrap()).unwrap_or(&loc.file);
+                                                        (Some(relpath.display().to_string()), Some(loc.line.try_into().unwrap()), Some(loc.module.as_str()))
                                                     } else {
-                                                        (None, None, None)
+                                                        (Some(format!("└─ <invalid location: defmt frame-index: {}>", frame.index())), None, None)
                                                     };
-                                                    let s = formatter.format_to_string(frame, a.as_deref(), b, c);
+                                                    let s = formatter.format_to_string(frame, file.as_deref(), line, module);
                                                     writeln!(formatted_data, "{s}")?;
                                                     continue;
                                                 },


### PR DESCRIPTION
This PR adds the `--log-format` flag to `probe-rs run`. It allows to specify a custom log format for the defmt logs.

# Defaults

If no log format is specified a default format is chosen depending on if there is a timestamp available and if the location should be shown.

```rust
// Format options:
// 1. Custom format
// 2. Default with timestamp with location
// 3. Default with timestamp without location
// 4. Default without timestamp with location
// 5. Default without timestamp without location
let format = log_format.unwrap_or_else(|| match (show_location, has_timestamp) {
    (true, true) => "{t} {L} {s}\n└─ {m} @ {F}:{l}",
    (true, false) => "{L} {s}\n└─ {m} @ {F}:{l}",
    (false, true) => "{t} {L} {s}",
    (false, false) => "{L} {s}",
});
```

# Log format format

The log format is simple, a few examples can be seen in the default section above. A specification of it can be found [here](https://github.com/knurling-rs/defmt/blob/729c3740323a522244789fd681739d106ed6251e/decoder/src/log/format.rs#L1-L117) and will soon be published in the defmt book where it will be rendered nicely.

It is also possible to style the log format. Please refer to the specification above.

For example the log format `"{t} {L} {s}\n└─ {m} @ {F}:{l}"` does the following: It shows the timestamp, the log level, the actual log line, followed by a newline, then the module path, a literal `@`, the filename and lastly the line number.

# Drawbacks

Because of how `cargo` parses its `.cargo/config.toml` the `runner` needs to switch to an array of strings. Otherwise cargo does not accept `"` or `'` as part of `runner`. But this isn't really a drawback of this PR, more of how cargo parses cli parameters in the runner field.

Before:
```toml
[target.'cfg(all(target_arch = "arm", target_os = "none"))']
runner = "probe-run --chip nRF52840_xxAA"
```

After:
```toml
[target.'cfg(all(target_arch = "arm", target_os = "none"))']
runner = [
  "probe-rs", "run",
  "--chip", "nRF52840_xxAA",
  "--log-format", "{t:010} [{L:bold}] {f}:{l} {s}",
]
```

(At least we could not figure out how to use the `--log-format` with a string. We only got it to work with the array of strings. Please tell us if you make it work!).

# TODO
- [ ] Switch to crates-io version, as soon as merged in defmt-decoder https://github.com/knurling-rs/defmt/pull/781