### PR TITLE
Improve error handling in target-gen test

### DIFF
--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -20,7 +20,8 @@ pub fn cmd_elf(
     update: bool,
     name: Option<String>,
 ) -> Result<()> {
-    let elf_file = File::open(file)?;
+    let elf_file =
+        File::open(file).with_context(|| format!("Failed to open ELF file {}", file.display()))?;
 
     let mut algorithm = extract_flash_algo(elf_file, file, true, fixed_load_address)?;
 


### PR DESCRIPTION
Don't fail with errors which don't say which path is to blame.