### PR TITLE
Give release workflow write permission

### DIFF
--- a/.github/workflows/release_crates.yml
+++ b/.github/workflows/release_crates.yml
@@ -64,19 +64,19 @@ jobs:
         run: |
           git checkout master
 
-          echo "::group:Setup auth for crates.io"
+          echo "::group::Setup auth for crates.io"
           cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}
           echo "::endgroup::"
 
-          echo "::group:Publishing on crates.io using 'cargo release publish'"
+          echo "::group::Publishing on crates.io using 'cargo release publish'"
           cargo release publish --no-confirm --execute
           echo "::endgroup::"
 
-          echo "::group:Tagging release using 'cargo release tag'"
+          echo "::group::Tagging release using 'cargo release tag'"
           cargo release tag --no-confirm --execute --sign-tag --tag-prefix ""
           echo "::endgroup::"
 
-          echo "::group:Pushing tags to remote using 'cargo release push'"
+          echo "::group::Pushing tags to remote using 'cargo release push'"
           cargo release push --no-confirm --execute --tag-prefix ""
           echo "::endgroup::"
         env:

--- a/.github/workflows/release_crates.yml
+++ b/.github/workflows/release_crates.yml
@@ -7,6 +7,9 @@ on:
     types: [closed]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 name: Release on crates.io
 
 jobs:


### PR DESCRIPTION
Seems to be necessary for tagging the release.
