### PR TITLE
Fix Rust 1.73 clippy warnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,4 @@
 [alias]
 xtask = "run --package xtask --"
+probe-rs = "run --package probe-rs --features cli --bin probe-rs --"
+smoke-tester = "run --package smoke_tester --"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Install toolchain
-      uses: dtolnay/rust-toolchain@1.72.0
+      uses: dtolnay/rust-toolchain@1.73.0
       with:
         targets: ${{ inputs.targets }}
         components: ${{ inputs.components }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tag-name = "v{{version}}"
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.3.1"
 # The preferred Rust toolchain to use in CI (rustup toolchain syntax)
-rust-toolchain-version = "1.72.0"
+rust-toolchain-version = "1.73.0"
 # CI backends to support
 ci = ["github"]
 # Target platforms to build apps for (Rust target-triple syntax)

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -197,6 +197,8 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
                 // a single probe detected.
                 let list = Probe::list_all();
                 if list.len() > 1 {
+                    use std::fmt::Write;
+
                     return Err(anyhow!("The following devices were found:\n \
                                     {} \
                                         \
@@ -205,7 +207,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
                                     You can also set the [default.probe] config attribute \
                                     (in your Embed.toml) to select which probe to use. \
                                     For usage examples see https://github.com/probe-rs/cargo-embed/blob/master/src/config/default.toml .",
-                                    list.iter().enumerate().map(|(num, link)| format!("[{num}]: {link:?}\n")).collect::<String>()));
+                                    list.iter().enumerate().fold(String::new(), |mut s, (num, link)| { let _ = writeln!(s, "[{num}]: {link:?}"); s })));
                 }
                 Probe::open(
                     list.first()

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
@@ -13,7 +13,7 @@ use probe_rs::{
     debug::{ColumnType, SourceLocation},
     CoreType, InstructionSet, MemoryInterface,
 };
-use std::time::Duration;
+use std::{fmt::Write, time::Duration};
 
 use super::dap_types::{Breakpoint, InstructionBreakpoint, MemoryAddress};
 
@@ -180,7 +180,10 @@ pub(crate) fn disassemble_target_memory(
                                 instruction.op_str().unwrap_or("")
                             ),
                             instruction_bytes: Some(
-                                instruction.bytes().iter().map(|b| format!("{b:02X} ")).collect(),
+                                instruction.bytes().iter().fold(String::new(),|mut s, b| {
+                                    let _ = write!(s, "{b:02X} ");
+                                    s
+                                }),
                             ),
                             line,
                             location,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -191,16 +191,17 @@ impl Debugger {
                         {
                             let arguments: RttWindowOpenedArguments =
                                 get_arguments(debug_adapter, &request)?;
-                            debugger_rtt_target
+
+                            if let Some(rtt_channel) = debugger_rtt_target
                                 .debugger_rtt_channels
                                 .iter_mut()
                                 .find(|debugger_rtt_channel| {
                                     debugger_rtt_channel.channel_number == arguments.channel_number
                                 })
-                                .map_or(false, |rtt_channel| {
-                                    rtt_channel.has_client_window = arguments.window_is_open;
-                                    arguments.window_is_open
-                                });
+                            {
+                                rtt_channel.has_client_window = arguments.window_is_open;
+                            }
+
                             debug_adapter
                                 .send_response::<()>(&request, Ok(None))
                                 .map_err(|error| {

--- a/probe-rs/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/debug.rs
@@ -819,7 +819,7 @@ impl DebugCli {
         let mut command_parts = line.split_whitespace();
 
         match command_parts.next() {
-            Some(command) if command == "help" => {
+            Some("help") => {
                 println!("The following commands are available:");
 
                 for cmd in &self.commands {

--- a/probe-rs/src/probe/ftdi/commands.rs
+++ b/probe-rs/src/probe/ftdi/commands.rs
@@ -433,8 +433,7 @@ impl JtagCommand for IdleCommand {
         if self.cycles == 0 {
             return;
         }
-        let mut buf = vec![];
-        buf.resize((self.cycles + 7) / 8, 0);
+        let buf = vec![0; (self.cycles + 7) / 8];
 
         ShiftTmsCommand::new(buf, self.cycles).add_bytes(buffer);
     }

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -215,8 +215,7 @@ impl JtagAdapter {
         if cycles == 0 {
             return Ok(());
         }
-        let mut buf = vec![];
-        buf.resize((cycles + 7) / 8, 0);
+        let buf = vec![0; (cycles + 7) / 8];
         self.shift_tms(&buf, cycles)
     }
 

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -5,6 +5,7 @@ use crate::probe::{DebugProbeInfo, DebugProbeType};
 
 use super::usb_interface::USB_PID_EP_MAP;
 use super::usb_interface::USB_VID;
+use std::fmt::Write;
 use std::time::Duration;
 
 pub(super) fn is_stlink_device<T: UsbContext>(device: &Device<T>) -> bool {
@@ -79,10 +80,13 @@ pub(super) fn read_serial_number<T: rusb::UsbContext>(
         if s.len() < 24 {
             // Some STLink (especially V2) have their serial number stored as a 12 bytes binary string
             // containing non printable characters, so convert to a hex string to make them printable.
-            s.as_bytes().iter().map(|b| format!("{b:02X}")).collect()
+            s.as_bytes().iter().fold(String::new(), |mut s, b| {
+                let _ = write!(s, "{b:02X}"); // Writing a String never fails
+                s
+            })
         } else {
             // Other STlink (especially V2-1) have their serial number already stored as a 24 characters
-            // hex string so they don't need to ba converted
+            // hex string so they don't need to be converted
             s
         }
     })


### PR DESCRIPTION
Fix clippy warnings added with Rust 1.73, add some useful cargo aliases.
