### PR TITLE
Simplify `RttActiveChannel::get_rtt_data`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Released 2023-10-04
   - Use `.pdsc` flash algorithm `RAMstart` field to calculate `load_address` for target yaml.
 - Target definitions can now constrain the RTT automatic scanning ranges to just a subset of all available RAM, to support targets that have large amounts of RAM that would take a long time to scan. (#1738, #1749)
 - `cli`: Output `defmt` logs as colored (#1752)
-- `cli`:  Simplify `RttActiveChannel::get_rtt_data` (#1806) 
 
 ### Fixed
   - Handle non-secure RESET peripheral in nRF5340 `debug_core_unlock` sequence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ Released 2023-10-04
   - Memory regions in target.yaml are now sorted with lowest address first.
   - Use `.pdsc` flash algorithm `RAMstart` field to calculate `load_address` for target yaml.
 - Target definitions can now constrain the RTT automatic scanning ranges to just a subset of all available RAM, to support targets that have large amounts of RAM that would take a long time to scan. (#1738, #1749)
-- `cli`: Output `defmt` logs as colored (#xxxx)
+- `cli`: Output `defmt` logs as colored (#1752)
+- `cli`:  Simplify `RttActiveChannel::get_rtt_data` (#1806) 
 
 ### Fixed
   - Handle non-secure RESET peripheral in nRF5340 `debug_core_unlock` sequence.

--- a/changelog/changed-simplify-rtt-get-data.md
+++ b/changelog/changed-simplify-rtt-get-data.md
@@ -1,0 +1,1 @@
+`cli`: Simplify `RttActiveChannel::get_rtt_data` (#1806)

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -288,25 +288,16 @@ impl RttActiveChannel {
                     "{} :",
                     OffsetDateTime::now_utc().to_offset(self.timestamp_offset)
                 )
-                .map_or_else(
-                    |err| log::error!("Failed to format RTT data - {:?}", err),
-                    |r| r,
-                );
+                .expect("Writing to String cannot fail");
             }
-            writeln!(formatted_data, "{line}").map_or_else(
-                |err| log::error!("Failed to format RTT data - {:?}", err),
-                |r| r,
-            );
+            writeln!(formatted_data, "{line}").expect("Writing to String cannot fail");
         }
     }
 
     fn get_binary_le(&self, bytes_read: usize, formatted_data: &mut String) {
         for element in &self.rtt_buffer.0[..bytes_read] {
             // Width of 4 allows 0xFF to be printed.
-            write!(formatted_data, "{element:#04x}").map_or_else(
-                |err| log::error!("Failed to format RTT data - {:?}", err),
-                |r| r,
-            );
+            write!(formatted_data, "{element:#04x}").expect("Writing to String cannot fail");
         }
     }
 
@@ -350,7 +341,7 @@ impl RttActiveChannel {
                             };
                             let s =
                                 formatter.format_to_string(frame, file.as_deref(), line, module);
-                            writeln!(formatted_data, "{s}")?;
+                            writeln!(formatted_data, "{s}").expect("Writing to String cannot fail");
                             continue;
                         }
                         Err(DecodeError::UnexpectedEof) => break,
@@ -370,10 +361,7 @@ impl RttActiveChannel {
                     formatted_data,
                     "Running rtt in defmt mode but table or locations could not be loaded."
                 )
-                .map_or_else(
-                    |err| log::error!("Failed to format RTT data - {:?}", err),
-                    |r| r,
-                );
+                .expect("Writing to String cannot fail");
             }
         }
         Ok(())


### PR DESCRIPTION
This PR
- creates a utility function for each data format; this decreases the indentation and therefore makes `rustfmt` work again
- replaces `write!(...).map_or_else` with `write!(...).expect`, because writing to strings cannot fail