### PR TITLE
Fix an issue where non JTAG transports would on setting scan_chain

### DIFF
--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -721,12 +721,6 @@ impl DebugProbe for CmsisDap {
     }
 
     fn set_scan_chain(&mut self, scan_chain: Vec<ScanChainElement>) -> Result<(), DebugProbeError> {
-        // A scan chain only makes sense in JTAG mode. Quit early if a different protocol is used.
-        if self.active_protocol() != Some(WireProtocol::Jtag) {
-            return Err(DebugProbeError::CommandNotSupportedByProbe(
-                "Setting Scan Chain is only supported in JTAG mode",
-            ));
-        }
         tracing::info!("Setting scan chain to {:?}", scan_chain);
         self.scan_chain = Some(scan_chain);
         Ok(())

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -475,12 +475,6 @@ impl DebugProbe for EspUsbJtag {
     }
 
     fn set_scan_chain(&mut self, scan_chain: Vec<ScanChainElement>) -> Result<(), DebugProbeError> {
-        // A scan chain only makes sense in JTAG mode. Quit early if a different protocol is used.
-        if self.active_protocol() != Some(WireProtocol::Jtag) {
-            return Err(DebugProbeError::CommandNotSupportedByProbe(
-                "Setting Scan Chain is only supported in JTAG mode",
-            ));
-        }
         tracing::info!("Setting scan chain to {:?}", scan_chain);
         self.scan_chain = Some(scan_chain);
         Ok(())

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -471,12 +471,6 @@ impl DebugProbe for FtdiProbe {
     }
 
     fn set_scan_chain(&mut self, scan_chain: Vec<ScanChainElement>) -> Result<(), DebugProbeError> {
-        // A scan chain only makes sense in JTAG mode. Quit early if a different protocol is used.
-        if self.active_protocol() != Some(WireProtocol::Jtag) {
-            return Err(DebugProbeError::CommandNotSupportedByProbe(
-                "Setting Scan Chain is only supported in JTAG mode",
-            ));
-        }
         tracing::info!("Setting scan chain to {:?}", scan_chain);
         self.scan_chain = Some(scan_chain);
         Ok(())

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -142,12 +142,6 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
     }
 
     fn set_scan_chain(&mut self, scan_chain: Vec<ScanChainElement>) -> Result<(), DebugProbeError> {
-        // A scan chain only makes sense in JTAG mode. Quit early if a different protocol is used.
-        if self.active_protocol() != Some(WireProtocol::Jtag) {
-            return Err(DebugProbeError::CommandNotSupportedByProbe(
-                "Setting Scan Chain is only supported in JTAG mode",
-            ));
-        }
         tracing::info!("Setting scan chain to {:?}", scan_chain);
         self.scan_chain = Some(scan_chain);
         Ok(())


### PR DESCRIPTION


 * Session.rs was updated to unconditionally set scan chain information
 * This would only be allowed when JTAG was the active transport
 * Remove this restriction