### PR TITLE
cli: Fix debug asssert in profile subcommand args parsing

### DIFF
--- a/changelog/fixed-profile-cmd-debug-assert.md
+++ b/changelog/fixed-profile-cmd-debug-assert.md
@@ -1,0 +1,1 @@
+cli: Rename struct to avoid debug assert in `profile` subcommand. Fix #1808.

--- a/probe-rs/src/bin/probe-rs/cmd/profile.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/profile.rs
@@ -25,7 +25,7 @@ use crate::util::flash::run_flash_download;
 use tracing::info;
 
 #[derive(clap::Parser)]
-pub struct Cmd {
+pub struct ProfileCmd {
     #[clap(flatten)]
     run: super::run::Cmd,
     /// Flash the ELF before profiling
@@ -71,7 +71,7 @@ impl core::fmt::Display for ProfileMethod {
     }
 }
 
-impl Cmd {
+impl ProfileCmd {
     pub fn run(self) -> anyhow::Result<()> {
         let (mut session, probe_options) = self.run.probe_options.simple_attach()?;
 

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -79,7 +79,7 @@ enum Subcommand {
     /// Measure the throughput of the selected debug probe
     Benchmark(cmd::benchmark::Cmd),
     /// Profile on-target runtime performance of target ELF program
-    Profile(cmd::profile::Cmd),
+    Profile(cmd::profile::ProfileCmd),
     Read(cmd::read::Cmd),
     Write(cmd::write::Cmd),
 }


### PR DESCRIPTION
Rename the struct to avoid an assert.

Fixes #1808.
