### PR TITLE
Remove dynamic dependency on openSSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "cmsis-pack"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cacb9e006b34fae90b17594aef8fcf03e1fe909c00ce021ff0900d98c5cd5bc4"
+checksum = "857cf401f1f645ff5bcfbcb60b6573ed85919ebf20cd3a1851e45933d4bcb817"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2747,6 +2747,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2870,6 +2871,18 @@ dependencies = [
  "ring",
  "rustls-webpki",
  "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]

--- a/changelog/fixed-openssl-dependency.md
+++ b/changelog/fixed-openssl-dependency.md
@@ -1,0 +1,5 @@
+Change from openSSL to rustls. 
+
+The prebuilt binaries depended on the system openSSL installation on Linux.
+This meant that they required openSSL1, which is not supported e.g. on Ubuntu 22.04.
+Changing to rustls removes this dependency.

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -161,7 +161,8 @@ rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.11.22", features = [
     "blocking",
     "json",
-], optional = true }
+    "rustls-tls",
+], optional = true, default-features = false }
 ron = { version = "0.8.1", optional = true }
 rustyline = { version = "12.0.0", optional = true }
 sanitize-filename = { version = "0.5", optional = true }


### PR DESCRIPTION
The prebuilt binaries didn't work due to a dependency on openSSL, which is a different
version on Ubuntu 22.04 than on Ubuntu 20.04.
