### PR TITLE
Try cargo-dist 0.4 prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Rust
         run: rustup update "1.73.0" --no-self-update && rustup default "1.73.0"
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.0-prerelease.3/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.0/cargo-dist-installer.sh | sh"
       - id: plan
         run: |
           cargo dist plan ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }} --output-format=json > dist-manifest.json
@@ -146,7 +146,7 @@ jobs:
       - name: Install Rust
         run: rustup update "1.73.0" --no-self-update && rustup default "1.73.0"
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.0-prerelease.3/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.0/cargo-dist-installer.sh | sh"
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,9 @@ jobs:
         with:
           submodules: recursive
       - name: Install Rust
-        run: rustup update "1.72.0" --no-self-update && rustup default "1.72.0"
+        run: rustup update "1.73.0" --no-self-update && rustup default "1.73.0"
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.3.1/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.0-prerelease.2/cargo-dist-installer.sh | sh"
       - id: plan
         run: |
           cargo dist plan ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }} --output-format=json > dist-manifest.json
@@ -94,26 +94,30 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install Rust
-        run: rustup update "1.72.0" --no-self-update && rustup default "1.72.0"
-      # Manual addition of build deps
-      - name: Install libusb, libudev (linux)
-        run: |
-          sudo apt update
-          sudo apt install -y libusb-1.0-0-dev libudev-dev
-        # Only install on Linux
-        if: runner.os == 'Linux'
+        run: rustup update "1.73.0" --no-self-update && rustup default "1.73.0"
       - uses: swatinem/rust-cache@v2
       - name: Install cargo-dist
         run: ${{ matrix.install_dist }}
+      - name: Install dependencies
+        run: |
+          ${{ matrix.packages_install }}
       - name: Build artifacts
+        if: ${{ hashFiles('Brewfile') == '' }}
         run: |
           # Actually do builds and make zips and whatnot
-          cargo dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          cargo dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          echo "cargo dist ran successfully"
+      - name: Build artifacts (using Brewfile)
+        if: ${{ hashFiles('Brewfile') != '' }}
+        run: |
+          # Actually do builds and make zips and whatnot
+          brew bundle exec -- cargo dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "cargo dist ran successfully"
       - id: cargo-dist
         name: Post-build
@@ -126,11 +130,15 @@ jobs:
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
-          path: ${{ steps.cargo-dist.outputs.paths }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
 
   # Build and package all the platform-agnostic(ish) things
   upload-global-artifacts:
@@ -143,9 +151,9 @@ jobs:
         with:
           submodules: recursive
       - name: Install Rust
-        run: rustup update "1.72.0" --no-self-update && rustup default "1.72.0"
+        run: rustup update "1.73.0" --no-self-update && rustup default "1.73.0"
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.3.1/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.0-prerelease.2/cargo-dist-installer.sh | sh"
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
         uses: actions/download-artifact@v3
@@ -179,7 +187,7 @@ jobs:
       - name: print tag
         run: echo "ok we're publishing!"
 
-  # Create a Github Release with all the results once everything is done,
+  # Create a Github Release with all the results once everything is done
   publish-release:
     needs: [plan, should-publish]
     runs-on: ubuntu-latest
@@ -194,6 +202,10 @@ jobs:
         with:
           name: artifacts
           path: artifacts
+      - name: Cleanup
+        run: |
+          # Remove the granular manifests
+          rm artifacts/*-dist-manifest.json
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Rust
         run: rustup update "1.73.0" --no-self-update && rustup default "1.73.0"
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.0-prerelease.2/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.0-prerelease.3/cargo-dist-installer.sh | sh"
       - id: plan
         run: |
           cargo dist plan ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }} --output-format=json > dist-manifest.json
@@ -108,16 +108,9 @@ jobs:
         run: |
           ${{ matrix.packages_install }}
       - name: Build artifacts
-        if: ${{ hashFiles('Brewfile') == '' }}
         run: |
           # Actually do builds and make zips and whatnot
           cargo dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
-          echo "cargo dist ran successfully"
-      - name: Build artifacts (using Brewfile)
-        if: ${{ hashFiles('Brewfile') != '' }}
-        run: |
-          # Actually do builds and make zips and whatnot
-          brew bundle exec -- cargo dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "cargo dist ran successfully"
       - id: cargo-dist
         name: Post-build
@@ -153,7 +146,7 @@ jobs:
       - name: Install Rust
         run: rustup update "1.73.0" --no-self-update && rustup default "1.73.0"
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.0-prerelease.2/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.0-prerelease.3/cargo-dist-installer.sh | sh"
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
         uses: actions/download-artifact@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ libudev1 = { stage = ["run"] }
 libftdi1-dev = '*'
 libftdi1 = { stage = ["run"] }
 
-libusb-1.0-0-dev = '*'
-libusb-1.0-0 = { stage = ["run"] }
+"libusb-1.0-0-dev" = '*'
+"libusb-1.0-0" = { stage = ["run"] }
 
 
 # The profile that 'cargo dist' will build with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tag-name = "v{{version}}"
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.4.0-prerelease.3"
+cargo-dist-version = "0.4.0"
 # The preferred Rust toolchain to use in CI (rustup toolchain syntax)
 rust-toolchain-version = "1.73.0"
 # CI backends to support
@@ -61,10 +61,6 @@ libftdi1 = { stage = ["run"] }
 
 "libusb-1.0-0-dev" = '*'
 "libusb-1.0-0" = { stage = ["run"] }
-
-[workspace.metadata.dist.dependencies.homebrew]
-#libusb = { stage = ["build", "run"], targets = ["x86_64-apple-darwin"] }
-libusb = { stage = ["build", "run"] }
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tag-name = "v{{version}}"
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.4.0-prerelease.2"
+cargo-dist-version = "0.4.0-prerelease.3"
 # The preferred Rust toolchain to use in CI (rustup toolchain syntax)
 rust-toolchain-version = "1.73.0"
 # CI backends to support
@@ -50,7 +50,7 @@ unix-archive = ".tar.xz"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Publish jobs to run in CI
-pr-run-mode = "upload"  # Should be plan, temporarily changed for testing
+pr-run-mode = "upload"
 
 [workspace.metadata.dist.dependencies.apt]
 libudev-dev = '*'
@@ -63,7 +63,8 @@ libftdi1 = { stage = ["run"] }
 "libusb-1.0-0" = { stage = ["run"] }
 
 [workspace.metadata.dist.dependencies.homebrew]
-libusb = { stage = ["build", "run"], targets = ["x86_64-apple-darwin"] }
+#libusb = { stage = ["build", "run"], targets = ["x86_64-apple-darwin"] }
+libusb = { stage = ["build", "run"] }
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tag-name = "v{{version}}"
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.3.1"
+cargo-dist-version = "0.4.0-prerelease.2"
 # The preferred Rust toolchain to use in CI (rustup toolchain syntax)
 rust-toolchain-version = "1.73.0"
 # CI backends to support
@@ -52,8 +52,16 @@ installers = ["shell", "powershell"]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
 
-# Needed because the file is edited to add Linux build deps
-allow-dirty = ["ci"]
+[workspace.metadata.dist.dependencies.apt]
+libudev-dev = '*'
+libudev1 = { stage = ["run"] }
+
+libftdi1-dev = '*'
+libftdi1 = { stage = ["run"] }
+
+libusb-1.0-0-dev = '*'
+libusb-1.0-0 = { stage = ["run"] }
+
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ unix-archive = ".tar.xz"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Publish jobs to run in CI
-pr-run-mode = "plan"
+pr-run-mode = "upload" # Should be plan, temporarily changed for testing
 
 [workspace.metadata.dist.dependencies.apt]
 libudev-dev = '*'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ libftdi1 = { stage = ["run"] }
 "libusb-1.0-0" = { stage = ["run"] }
 
 [workspace.metadata.dist.dependencies.homebrew]
-libusb = { stage = ["build", "run"]}
+libusb = { stage = ["build", "run"], targets = ["x86_64-apple-darwin"] }
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ unix-archive = ".tar.xz"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Publish jobs to run in CI
-pr-run-mode = "upload" # Should be plan, temporarily changed for testing
+pr-run-mode = "upload"  # Should be plan, temporarily changed for testing
 
 [workspace.metadata.dist.dependencies.apt]
 libudev-dev = '*'
@@ -62,6 +62,8 @@ libftdi1 = { stage = ["run"] }
 "libusb-1.0-0-dev" = '*'
 "libusb-1.0-0" = { stage = ["run"] }
 
+[workspace.metadata.dist.dependencies.homebrew]
+libusb = { stage = ["build", "run"]}
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ unix-archive = ".tar.xz"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Publish jobs to run in CI
-pr-run-mode = "upload"
+pr-run-mode = "plan"
 
 [workspace.metadata.dist.dependencies.apt]
 libudev-dev = '*'

--- a/changelog/changed-static-libusb.md
+++ b/changelog/changed-static-libusb.md
@@ -1,0 +1,1 @@
+For CLI builds, statically link to libusb to make installation of precompiled binaries easier.

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -34,7 +34,6 @@ gdb-server = ["dep:gdbstub", "dep:itertools"]
 rtt = ["dep:kmp"]
 
 cli = [
-    "vendored-libusb",
     "gdb-server",
 
     "dep:log",
@@ -218,4 +217,4 @@ replace = "[unreleased]: https://github.com/probe-rs/probe-rs/compare/v{{version
 
 # Config for 'cargo dist'
 [package.metadata.dist]
-features = ["cli"]
+features = ["cli", "vendored-libusb"]

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -34,6 +34,7 @@ gdb-server = ["dep:gdbstub", "dep:itertools"]
 rtt = ["dep:kmp"]
 
 cli = [
+    "vendored-libusb",
     "gdb-server",
 
     "dep:log",


### PR DESCRIPTION
This will allow us to specify dependencies in the Cargo.toml,
so we don't have to edit the generated workflows anymore.
