### PR TITLE
Fix: Target description for LPC55S69

### DIFF
--- a/changelog/fixed-lpc55s69-debug-sequence.md
+++ b/changelog/fixed-lpc55s69-debug-sequence.md
@@ -1,0 +1,1 @@
+Update debug sequence for LPC55S69 with newest from pack, fixes an issue where the chip would not reset properly.

--- a/changelog/fixed-lpc55s69-target-desc.md
+++ b/changelog/fixed-lpc55s69-target-desc.md
@@ -1,0 +1,1 @@
+Fix core names and regions in LPC55S69 target description.

--- a/probe-rs-target/src/chip_family.rs
+++ b/probe-rs-target/src/chip_family.rs
@@ -225,6 +225,28 @@ impl ChipFamily {
                     }
                 }
             }
+
+            let core_names: Vec<_> = variant.cores.iter().map(|core| &core.name).collect();
+
+            for memory in &variant.memory_map {
+                // Ensure that the memory is assigned to a core, and that all the cores exist
+
+                for core in memory.cores() {
+                    if !core_names.contains(&core) {
+                        return Err(format!(
+                            "Variant {}, memory region {:?} is assigned to a non-existent core {}",
+                            variant.name, memory, core
+                        ));
+                    }
+                }
+
+                assert!(
+                    !memory.cores().is_empty(),
+                    "Variant {}, memory region {:?} is not assigned to a core",
+                    variant.name,
+                    memory
+                );
+            }
         }
 
         Ok(())

--- a/probe-rs-target/src/memory.rs
+++ b/probe-rs-target/src/memory.rs
@@ -142,6 +142,17 @@ pub enum MemoryRegion {
     Nvm(NvmRegion),
 }
 
+impl MemoryRegion {
+    /// Get the cores to which this memory region belongs.
+    pub fn cores(&self) -> &[String] {
+        match self {
+            MemoryRegion::Ram(region) => &region.cores,
+            MemoryRegion::Generic(region) => &region.cores,
+            MemoryRegion::Nvm(region) => &region.cores,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/probe-rs/targets/LPC55S69.yaml
+++ b/probe-rs/targets/LPC55S69.yaml
@@ -1,9 +1,9 @@
 name: LPC55S69
-manufacturer:
-  cc: 0x00
-  id: 0x15
+-manufacturer:
+  - cc: 0x00
+  - id: 0x15
 generated_from_pack: true
-pack_file_release: 15.0.0
+pack_file_release: 17.0.0
 variants:
   - name: LPC55S69JBD100
     cores:
@@ -21,26 +21,37 @@ variants:
     #    psel: 0
     memory_map:
       - !Ram
-        name: SRAM + SRAM4
-        range:
-          start: 0x20000000
-          end: 0x20044000
-        cores:
-          - main
-      - !Ram
         name: SRAMX
         range:
           start: 0x4000000
           end: 0x4008000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
+      - !Ram
+        name: SRAM
+        range:
+          start: 0x20000000
+          end: 0x20040000
+        cores:
+          - cm33_core0
+          # - cm33_core1
+      - !Ram
+        name: SRAM4
+        range:
+          start: 0x20040000
+          end: 0x20044000
+        cores:
+          - cm33_core0
+          # - cm33_core1
       - !Ram
         name: USB_RAM
         range:
           start: 0x40100000
           end: 0x40104000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
       - !Nvm
         name: PROGRAM_FLASH
         range:
@@ -48,49 +59,64 @@ variants:
           end: 0x9d800
         is_boot_memory: true
         cores:
-          - main
-      - !Generic
-        name: PROGRAM_FLASH_alias
-        range:
-          start: 0x10000000
-          end: 0x1009d800
-        cores:
-          - main
-      - !Generic
-        name: SRAM_alias + SRAM4_alias
-        range:
-          start: 0x30000000
-          end: 0x30044000
-        cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
       - !Generic
         name: BootROM
         range:
           start: 0x3000000
           end: 0x3020000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
+      - !Generic
+        name: PROGRAM_FLASH_alias
+        range:
+          start: 0x10000000
+          end: 0x1009d800
+        cores:
+          - cm33_core0
+          # - cm33_core1
       - !Generic
         name: BootROM_alias
         range:
           start: 0x13000000
           end: 0x13020000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
       - !Generic
         name: SRAMX_alias
         range:
           start: 0x14000000
           end: 0x14008000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
+      - !Generic
+        name: SRAM_alias
+        range:
+          start: 0x30000000
+          end: 0x30040000
+        cores:
+          - cm33_core0
+          # - cm33_core1
+      - !Generic
+        name: SRAM4_alias
+        range:
+          start: 0x30040000
+          end: 0x30044000
+        cores:
+          - cm33_core0
+          # - cm33_core1
       - !Generic
         name: USB_RAM_alias
         range:
           start: 0x50100000
           end: 0x50104000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
     flash_algorithms:
       - lpc55xx_640
       - lpc55xx_s_640
@@ -101,33 +127,46 @@ variants:
         core_access_options: !Arm
           ap: 0
           psel: 0
-      - name: cm33_core1
-        type: armv8m
-        core_access_options: !Arm
-          ap: 1
-          psel: 0
+    # Connecting to the second core is not supported yet in probe-rs,
+    # and trying to connect to it will result in an error.
+    #  - name: cm33_core1
+    #    type: armv8m
+    #    core_access_options: !Arm
+    #      ap: 1
+    #      psel: 0
     memory_map:
-      - !Ram
-        name: SRAM + SRAM4
-        range:
-          start: 0x20000000
-          end: 0x20044000
-        cores:
-          - main
       - !Ram
         name: SRAMX
         range:
           start: 0x4000000
           end: 0x4008000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
+      - !Ram
+        name: SRAM
+        range:
+          start: 0x20000000
+          end: 0x20040000
+        cores:
+          - cm33_core0
+          # - cm33_core1
+      - !Ram
+        name: SRAM4
+        range:
+          start: 0x20040000
+          end: 0x20044000
+        cores:
+          - cm33_core0
+          # - cm33_core1
       - !Ram
         name: USB_RAM
         range:
           start: 0x40100000
           end: 0x40104000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
       - !Nvm
         name: PROGRAM_FLASH
         range:
@@ -135,49 +174,64 @@ variants:
           end: 0x9d800
         is_boot_memory: true
         cores:
-          - main
-      - !Generic
-        name: PROGRAM_FLASH_alias
-        range:
-          start: 0x10000000
-          end: 0x1009d800
-        cores:
-          - main
-      - !Generic
-        name: SRAM_alias + SRAM4_alias
-        range:
-          start: 0x30000000
-          end: 0x30044000
-        cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
       - !Generic
         name: BootROM
         range:
           start: 0x3000000
           end: 0x3020000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
+      - !Generic
+        name: PROGRAM_FLASH_alias
+        range:
+          start: 0x10000000
+          end: 0x1009d800
+        cores:
+          - cm33_core0
+          # - cm33_core1
       - !Generic
         name: BootROM_alias
         range:
           start: 0x13000000
           end: 0x13020000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
       - !Generic
         name: SRAMX_alias
         range:
           start: 0x14000000
           end: 0x14008000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
+      - !Generic
+        name: SRAM_alias
+        range:
+          start: 0x30000000
+          end: 0x30040000
+        cores:
+          - cm33_core0
+          # - cm33_core1
+      - !Generic
+        name: SRAM4_alias
+        range:
+          start: 0x30040000
+          end: 0x30044000
+        cores:
+          - cm33_core0
+          # - cm33_core1
       - !Generic
         name: USB_RAM_alias
         range:
           start: 0x50100000
           end: 0x50104000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
     flash_algorithms:
       - lpc55xx_640
       - lpc55xx_s_640
@@ -188,33 +242,46 @@ variants:
         core_access_options: !Arm
           ap: 0
           psel: 0
-      - name: cm33_core1
-        type: armv8m
-        core_access_options: !Arm
-          ap: 1
-          psel: 0
+    # Connecting to the second core is not supported yet in probe-rs,
+    # and trying to connect to it will result in an error.
+    # - name: cm33_core1
+    #   type: armv8m
+    #   core_access_options: !Arm
+    #     ap: 1
+    #     psel: 0
     memory_map:
-      - !Ram
-        name: SRAM + SRAM4
-        range:
-          start: 0x20000000
-          end: 0x20044000
-        cores:
-          - main
       - !Ram
         name: SRAMX
         range:
           start: 0x4000000
           end: 0x4008000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
+      - !Ram
+        name: SRAM
+        range:
+          start: 0x20000000
+          end: 0x20040000
+        cores:
+          - cm33_core0
+          # - cm33_core1
+      - !Ram
+        name: SRAM4
+        range:
+          start: 0x20040000
+          end: 0x20044000
+        cores:
+          - cm33_core0
+          # - cm33_core1
       - !Ram
         name: USB_RAM
         range:
           start: 0x40100000
           end: 0x40104000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
       - !Nvm
         name: PROGRAM_FLASH
         range:
@@ -222,49 +289,64 @@ variants:
           end: 0x9d800
         is_boot_memory: true
         cores:
-          - main
-      - !Generic
-        name: PROGRAM_FLASH_alias
-        range:
-          start: 0x10000000
-          end: 0x1009d800
-        cores:
-          - main
-      - !Generic
-        name: SRAM_alias + SRAM4_alias
-        range:
-          start: 0x30000000
-          end: 0x30044000
-        cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
       - !Generic
         name: BootROM
         range:
           start: 0x3000000
           end: 0x3020000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
+      - !Generic
+        name: PROGRAM_FLASH_alias
+        range:
+          start: 0x10000000
+          end: 0x1009d800
+        cores:
+          - cm33_core0
+          # - cm33_core1
       - !Generic
         name: BootROM_alias
         range:
           start: 0x13000000
           end: 0x13020000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
       - !Generic
         name: SRAMX_alias
         range:
           start: 0x14000000
           end: 0x14008000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
+      - !Generic
+        name: SRAM_alias
+        range:
+          start: 0x30000000
+          end: 0x30040000
+        cores:
+          - cm33_core0
+          # - cm33_core1
+      - !Generic
+        name: SRAM4_alias
+        range:
+          start: 0x30040000
+          end: 0x30044000
+        cores:
+          - cm33_core0
+          # - cm33_core1
       - !Generic
         name: USB_RAM_alias
         range:
           start: 0x50100000
           end: 0x50104000
         cores:
-          - main
+          - cm33_core0
+          # - cm33_core1
     flash_algorithms:
       - lpc55xx_640
       - lpc55xx_s_640
@@ -273,6 +355,7 @@ flash_algorithms:
     description: LPC55xx IAP 630kB Flash
     default: true
     instructions: gLVA8gQAwPIAAEL24GFJ+AAQQPIAIMXyAAAAIcD4gBDA+IQQwPiAEUf2+3EBYED2BGD/IcXyAADM8t4BAWBP8KBAAiEBcEDyDADA8gAASEQA8GL4ACgYvwEggL0AIHBHgLVA8gwAwPIAAE32AAJG8mxjSETA8gkCACHG9mUzAPBx+AAoGL8BIIC9AL+AtSDwcEFA8gwAwPIAAEbybGNIRMb2ZTNP9AByAPBc+AAoGL8BIIC9gLULRiDwcEFA8gwAwPIAAEhEs/UAf5i/T/QAcwDwcPgAKBi/ASCAvbC1DEYFRiDwcEARRiJGAPDt+QAoCL8lRChGsL2AtQpGIPBwQUDyDADA8gAASEQA8Hv4ACgYvwEggL0AAEHy9gzB8gA83PgKEIGxQPIIA8DyAAMAIkn4AyCc+AAgSWgDOrL6gvJSCUn4AyAIR0DyhkDA8gAAQPKTQcDyAAF4RHlEbiIA8HP5AL9A8ggMwPIADFn4DMC88QAPC9BB8gAcwfIAPNz4AMC88QAPB9Dc+AjAYEdE8jscwfIAPGBHQPI2QMDyAABA8kNBwPIAAXhEeUR/IgDwS/kAv0DyCAzA8gAMWfgMwLzxAA8L0EHyABzB8gA83PgAwLzxAA8H0Nz4DMBgR0TynRzB8gA8YEdA8uYwwPIAAEDy8zHA8gABeER5RI8iAPAj+QC/QfIAE8HyADMbaAuxG2kYR0DyujDA8gAAQPLHMcDyAAF4RHlElyIA8A35AL9A8ggMwPIADFn4DMC88QAPC9BB8gAcwfIAPNz4AMC88QAPB9Dc+BTAYEdE8n0swfIAPGBHQPJqMMDyAABA8ncxwPIAAXhEeUSrIgDw5fgAv0HyABPB8gAzG2gLsZtpGEdA8j4wwPIAAEDySzHA8gABeER5RLQiAPDP+AC/QfIAEcHyADEJaAmxyWkIR0DyEjDA8gAAQPIfMcDyAAF4RHlEviIA8Ln4AL9B8gARwfIAMQloCbEJaghHQPLmIMDyAABA8vMhwPIAAXhEeUTFIgDwo/gAv0HyABPB8gAzG2gLsVtqGEdA8rogwPIAAEDyxyHA8gABeER5RMwiAPCN+AC/QfIAHMHyADzc+ADAvPEADwLQ3PgswGBHQPKGIMDyAABA8pMhwPIAAXhEeUTTIgDwc/gAv0HyABLB8gAyEmgKsRJrEEdA8logwPIAAEDyZyHA8gABeER5RNoiAPBd+AC/QfIAEsHyADISaAqxUmsQR0DyLiDA8gAAQPI7IcDyAAF4RHlE4SIA8Ef4AL9B8gATwfIAMxtoC7GbaxhHQPICIMDyAABA8g8hwPIAAXhEeUToIgDwMfgAv0HyABLB8gAyEmgKsZJqEEdA8tYQwPIAAEDy4xHA8gABeER5RO8iAPAb+AC/QfIAHMHyADzc+ADAvPEADwLQ3PhAwGBHQPKiEMDyAABA8q8RwPIAAXhEeUT2IgDwAfgAAA61BUYURg5GE6AA8HD4KEYA8G34FqAA8Gr4MEYA8Gf4FaAA8GT4ACGN+AsQCiEN8QoAjfgKEAjglPvx8gH7EkKU+/H0MDIA+AEtACz03ADwTvgA8EH4AAAqKiogYXNzZXJ0aW9uIGZhaWxlZDogAAAsIGZpbGUgACwgbGluZSAAQOoBAxC1mwcP0QQqDdMQyAjJEh+cQvjQILoZuohCAdkBIBC9T/D/MBC9GrHTBwPQUhwH4AAgEL0Q+AE7EfgBSxsbB9EQ+AE7EfgBSxsbAdGSHvHRGEYQvRC1ACAA8B74r/MAgL3oEEABIADwEbgQtQRGAuBkHADwBPggeAAo+dEQvQi1aUaN+AAAAyCrvgi9AUkYIKu+/ucmAAIAELUA8Av4vegQQADwAbhwRwAoAdD/9+6/cEcAABC1ACECoADwE/gBIBC9AABTSUdBQlJUOiBBYm5vcm1hbCB0ZXJtaW5hdGlvbgAAAHC1BUYMRgogAOBtHP/3xf81sSh4ACj40QLgZBz/973/FLEgeAAo+NG96HBACiD/97S/RkxBU0hfQVBJX1RSRUUAaWFwMS9mc2xfaWFwMS5jAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    load_address: 0x20000020
     pc_init: 0x1
     pc_uninit: 0x5d
     pc_program_page: 0xb5
@@ -290,10 +373,12 @@ flash_algorithms:
       sectors:
         - size: 0x200
           address: 0x0
+    stack_size: 4096
   - name: lpc55xx_s_640
     description: LPC55xx S IAP 630kB Flash
     default: true
     instructions: gLVA8gQAwPIAAEL24GFJ+AAQQPIAIMXyAAAAIcD4gBDA+IQQwPiAEUf2+3EBYED2BGD/IcXyAADM8t4BAWBP8KBAAiEBcEDyDADA8gAASEQA8GL4ACgYvwEggL0AIHBHgLVA8gwAwPIAAE32AAJG8mxjSETA8gkCACHG9mUzAPBx+AAoGL8BIIC9AL+AtSDwcEFA8gwAwPIAAEbybGNIRMb2ZTNP9AByAPBc+AAoGL8BIIC9gLULRiDwcEFA8gwAwPIAAEhEs/UAf5i/T/QAcwDwcPgAKBi/ASCAvbC1DEYFRiDwcEARRiJGAPDt+QAoCL8lRChGsL2AtQpGIPBwQUDyDADA8gAASEQA8Hv4ACgYvwEggL0AAEHy9gzB8gA83PgKEIGxQPIIA8DyAAMAIkn4AyCc+AAgSWgDOrL6gvJSCUn4AyAIR0DyhkDA8gAAQPKTQcDyAAF4RHlEbiIA8HP5AL9A8ggMwPIADFn4DMC88QAPC9BB8gAcwfIAPNz4AMC88QAPB9Dc+AjAYEdE8jscwfIAPGBHQPI2QMDyAABA8kNBwPIAAXhEeUR/IgDwS/kAv0DyCAzA8gAMWfgMwLzxAA8L0EHyABzB8gA83PgAwLzxAA8H0Nz4DMBgR0TynRzB8gA8YEdA8uYwwPIAAEDy8zHA8gABeER5RI8iAPAj+QC/QfIAE8HyADMbaAuxG2kYR0DyujDA8gAAQPLHMcDyAAF4RHlElyIA8A35AL9A8ggMwPIADFn4DMC88QAPC9BB8gAcwfIAPNz4AMC88QAPB9Dc+BTAYEdE8n0swfIAPGBHQPJqMMDyAABA8ncxwPIAAXhEeUSrIgDw5fgAv0HyABPB8gAzG2gLsZtpGEdA8j4wwPIAAEDySzHA8gABeER5RLQiAPDP+AC/QfIAEcHyADEJaAmxyWkIR0DyEjDA8gAAQPIfMcDyAAF4RHlEviIA8Ln4AL9B8gARwfIAMQloCbEJaghHQPLmIMDyAABA8vMhwPIAAXhEeUTFIgDwo/gAv0HyABPB8gAzG2gLsVtqGEdA8rogwPIAAEDyxyHA8gABeER5RMwiAPCN+AC/QfIAHMHyADzc+ADAvPEADwLQ3PgswGBHQPKGIMDyAABA8pMhwPIAAXhEeUTTIgDwc/gAv0HyABLB8gAyEmgKsRJrEEdA8logwPIAAEDyZyHA8gABeER5RNoiAPBd+AC/QfIAEsHyADISaAqxUmsQR0DyLiDA8gAAQPI7IcDyAAF4RHlE4SIA8Ef4AL9B8gATwfIAMxtoC7GbaxhHQPICIMDyAABA8g8hwPIAAXhEeUToIgDwMfgAv0HyABLB8gAyEmgKsZJqEEdA8tYQwPIAAEDy4xHA8gABeER5RO8iAPAb+AC/QfIAHMHyADzc+ADAvPEADwLQ3PhAwGBHQPKiEMDyAABA8q8RwPIAAXhEeUT2IgDwAfgAAA61BUYURg5GE6AA8HD4KEYA8G34FqAA8Gr4MEYA8Gf4FaAA8GT4ACGN+AsQCiEN8QoAjfgKEAjglPvx8gH7EkKU+/H0MDIA+AEtACz03ADwTvgA8EH4AAAqKiogYXNzZXJ0aW9uIGZhaWxlZDogAAAsIGZpbGUgACwgbGluZSAAQOoBAxC1mwcP0QQqDdMQyAjJEh+cQvjQILoZuohCAdkBIBC9T/D/MBC9GrHTBwPQUhwH4AAgEL0Q+AE7EfgBSxsbB9EQ+AE7EfgBSxsbAdGSHvHRGEYQvRC1ACAA8B74r/MAgL3oEEABIADwEbgQtQRGAuBkHADwBPggeAAo+dEQvQi1aUaN+AAAAyCrvgi9AUkYIKu+/ucmAAIAELUA8Av4vegQQADwAbhwRwAoAdD/9+6/cEcAABC1ACECoADwE/gBIBC9AABTSUdBQlJUOiBBYm5vcm1hbCB0ZXJtaW5hdGlvbgAAAHC1BUYMRgogAOBtHP/3xf81sSh4ACj40QLgZBz/973/FLEgeAAo+NG96HBACiD/97S/RkxBU0hfQVBJX1RSRUUAaWFwMS9mc2xfaWFwMS5jAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    load_address: 0x20000020
     pc_init: 0x1
     pc_uninit: 0x5d
     pc_program_page: 0xb5
@@ -311,3 +396,4 @@ flash_algorithms:
       sectors:
         - size: 0x200
           address: 0x0
+    stack_size: 4096

--- a/probe-rs/targets/LPC55S69.yaml
+++ b/probe-rs/targets/LPC55S69.yaml
@@ -365,7 +365,7 @@ flash_algorithms:
     flash_properties:
       address_range:
         start: 0x0
-        end: 0x98000
+        end: 0x9d800
       page_size: 0x200
       erased_byte_value: 0xff
       program_page_timeout: 300

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -513,7 +513,7 @@ pub(crate) fn get_mem_map(device: &Device, cores: &[probe_rs_target::Core]) -> V
 
         match region.memory_type {
             MemoryType::Ram => {
-                if let Some(MemoryRegion::Ram(existing_region)) = mem_map.iter_mut().find(|existing_region| { 
+                if let Some(MemoryRegion::Ram(existing_region)) = mem_map.iter_mut().find(|existing_region| {
                         matches!(existing_region, MemoryRegion::Ram(ram_region) if ram_region.name == Some(region.name.clone()))
                     })
                 {

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -152,11 +152,13 @@ where
             .map(create_core)
             .collect::<Result<Vec<_>>>()?;
 
+        let memory_map = get_mem_map(&device, &cores);
+
         family.variants.push(Chip {
             name: device_name,
             part: None,
             cores,
-            memory_map: get_mem_map(&device),
+            memory_map,
             flash_algorithms: flash_algorithm_names,
             rtt_scan_ranges: None,
             scan_chain: None, // TODO, parse from sdf
@@ -464,7 +466,7 @@ struct DeviceMemory {
 /// Extracts the memory regions in the package.
 /// The new memory regions are sorted by memory type, then by boot memory, then by start address,
 /// with correctly assigned cores/processor names.
-pub(crate) fn get_mem_map(device: &Device) -> Vec<MemoryRegion> {
+pub(crate) fn get_mem_map(device: &Device, cores: &[probe_rs_target::Core]) -> Vec<MemoryRegion> {
     let mut device_memories: Vec<DeviceMemory> = device
         .memories
         .0
@@ -492,50 +494,68 @@ pub(crate) fn get_mem_map(device: &Device) -> Vec<MemoryRegion> {
     // Sort by memory type, then by processor name, then by boot memory, then by start address.
     device_memories.sort();
 
+    let all_cores: Vec<_> = cores.iter().map(|core| core.name.clone()).collect();
+
+    let is_multi_core = cores.len() > 1;
+
     // Convert DeviceMemory's to MemoryRegion's, and assign cores to shared reqions.
     let mut mem_map = vec![];
     for region in &device_memories {
-        let current_core = region
+        if is_multi_core && region.p_name.is_none() {
+            log::warn!("Device {}, memory region {} has no processor name, but this is required for a multicore device. Assigning memory to all cores!", device.name, region.name);
+        }
+
+        let cores = region
             .p_name
             .as_ref()
-            .map(|s| s.to_ascii_lowercase())
-            .unwrap_or_else(|| "main".to_string());
+            .map(|s| vec![s.to_ascii_lowercase()])
+            .unwrap_or_else(|| all_cores.clone());
+
         match region.memory_type {
-            MemoryType::Ram => if let Some(MemoryRegion::Ram(existing_region)) = mem_map.iter_mut().find(|existing_region|{
-                matches!(existing_region, MemoryRegion::Ram(ram_region) if ram_region.name == Some(region.name.clone()))})
+            MemoryType::Ram => {
+                if let Some(MemoryRegion::Ram(existing_region)) = mem_map.iter_mut().find(|existing_region| { 
+                        matches!(existing_region, MemoryRegion::Ram(ram_region) if ram_region.name == Some(region.name.clone()))
+                    })
                 {
-                    existing_region.cores.push(current_core);
+                    existing_region.cores.extend_from_slice(&cores);
                 } else {
                     mem_map.push(MemoryRegion::Ram(RamRegion {
                     name: Some(region.name.clone()),
                     range: region.memory_start..region.memory_end,
                     is_boot_memory: region.is_boot_memory,
-                    cores: vec![current_core],
+                    cores,
                     }));
-                },
-            MemoryType::Nvm => if let Some(MemoryRegion::Nvm(existing_region)) = mem_map.iter_mut().find(|existing_region|{
-                matches!(existing_region, MemoryRegion::Nvm(nvm_region) if nvm_region.name == Some(region.name.clone()))})
+                }
+            },
+            MemoryType::Nvm => {
+                if let Some(MemoryRegion::Nvm(existing_region)) = mem_map.iter_mut().find(|existing_region| {
+                        matches!(existing_region, MemoryRegion::Nvm(nvm_region) if nvm_region.name == Some(region.name.clone()))
+                    })
                 {
-                    existing_region.cores.push(current_core);
+                    existing_region.cores.extend_from_slice(&cores);
                 } else {
                     mem_map.push(MemoryRegion::Nvm(NvmRegion {
                     name: Some(region.name.clone()),
                     range: region.memory_start..region.memory_end,
                     is_boot_memory: region.is_boot_memory,
-                    cores: vec![current_core],
+                    cores,
                     }));
-                },
-            MemoryType::Generic => if let Some(MemoryRegion::Generic(existing_region)) = mem_map.iter_mut().find(|existing_region|{
-                matches!(existing_region, MemoryRegion::Generic(generic_region) if generic_region.name == Some(region.name.clone()))})
+                }
+            },
+            MemoryType::Generic => {
+                if let Some(MemoryRegion::Generic(existing_region)) = mem_map.iter_mut().find(|existing_region| {
+                        matches!(existing_region, MemoryRegion::Generic(generic_region) if generic_region.name == Some(region.name.clone()))
+                    })
                 {
-                    existing_region.cores.push(current_core);
+                    existing_region.cores.extend_from_slice(&cores);
                 } else {
                     mem_map.push(MemoryRegion::Generic(GenericRegion {
                     name: Some(region.name.clone()),
                     range: region.memory_start..region.memory_end,
-                    cores: vec![current_core],
+                    cores,
                     }));
-                },
+                }
+            },
         };
     }
     mem_map

--- a/target-gen/src/main.rs
+++ b/target-gen/src/main.rs
@@ -13,7 +13,7 @@ use std::{
     fs::create_dir,
     path::{Path, PathBuf},
 };
-use tracing_subscriber::EnvFilter;
+use tracing_subscriber::{filter::LevelFilter, EnvFilter};
 
 use crate::commands::{
     elf::{cmd_elf, serialize_to_yaml_file},
@@ -113,7 +113,11 @@ pub fn parse_u64(input: &str) -> Result<u64, ParseIntError> {
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .compact()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::WARN.into())
+                .from_env_lossy(),
+        )
         .init();
 
     let options = TargetGen::parse();


### PR DESCRIPTION
- fix: Core names in LPC55S69 target description
       
       Also update target-gen to handle memory descriptions with missing cores
       better.

- fix: Region for LPC55S69 flash algorithm
- Fix debug sequence for LPC55S69


These changes should fix #1829.
