### PR TITLE
fix: Also use serial number to distinguish CMSIS-DAP probes

### DIFF
--- a/changelog/fixed-cmsis-serial.md
+++ b/changelog/fixed-cmsis-serial.md
@@ -1,0 +1,1 @@
+Also use serial number to distinguish CMSIS-DAP probes. Fix #1835.

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -31,10 +31,11 @@ pub fn list_cmsisdap_devices() -> Vec<DebugProbeInfo> {
     if let Ok(api) = hidapi::HidApi::new() {
         for device in api.device_list() {
             if let Some(info) = get_cmsisdap_hid_info(device) {
-                if !probes
-                    .iter()
-                    .any(|p| p.vendor_id == info.vendor_id && p.product_id == info.product_id)
-                {
+                if !probes.iter().any(|p| {
+                    p.vendor_id == info.vendor_id
+                        && p.product_id == info.product_id
+                        && p.serial_number == info.serial_number
+                }) {
                     tracing::trace!("Adding new HID-only probe {:?}", info);
                     probes.push(info)
                 } else {


### PR DESCRIPTION
When connected to multiple probes with the same vid/pid it is necessary to use the serial number to distinguish them.