### PR TITLE
Benchmark rewrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,6 +2732,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -4185,6 +4186,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "widestring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,7 +2454,6 @@ dependencies = [
  "probe-rs-target",
  "rand",
  "ratatui",
- "reqwest",
  "ron",
  "rusb",
  "rustyline",
@@ -2733,7 +2732,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -4187,12 +4185,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "widestring"

--- a/changelog/changed-benchmark-impl.md
+++ b/changelog/changed-benchmark-impl.md
@@ -1,0 +1,1 @@
+Rewrote benchmark cli tool, removing report submission and adding multiple speed/size/stride options

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -53,7 +53,6 @@ cli = [
     "dep:parse_int",
     "dep:pretty_env_logger",
     "dep:rand",
-    "dep:reqwest",
     "dep:ron",
     "dep:rustyline",
     "dep:sanitize-filename",
@@ -158,11 +157,6 @@ log = { version = "0.4.20", optional = true }
 parse_int = { version = "0.6.0", optional = true }
 pretty_env_logger = { workspace = true, optional = true }
 rand = { version = "0.8.5", optional = true }
-reqwest = { version = "0.11.22", features = [
-    "blocking",
-    "json",
-    "rustls-tls",
-], optional = true, default-features = false }
 ron = { version = "0.8.1", optional = true }
 rustyline = { version = "12.0.0", optional = true }
 sanitize-filename = { version = "0.5", optional = true }

--- a/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
@@ -9,7 +9,8 @@ use rand::prelude::*;
 
 use crate::util::common_options::ProbeOptions;
 
-const SIZE: usize = 0x1000;
+const PROBE_SPEEDS: [u32; 10] = [320, 640, 960, 3200, 6400, 9600, 32000, 64000, 96000, 320000];
+const TEST_SIZES: [usize; 5] = [1, 8, 32, 512, 8192];
 
 #[derive(clap::Parser)]
 pub struct Cmd {
@@ -21,98 +22,327 @@ pub struct Cmd {
     /// Should be located in RAM.
     #[clap(long = "address", value_parser= parse_hex)]
     address: u64,
+
+    /// Minimum speed for the debug probe.
+    ///
+    /// Some probes will panic if you request a speed lower than they support.
+    /// This option will set a lower-bound for the speeds that will be tested
+    #[clap(long = "min-speed", value_parser= parse_int, default_value="0")]
+    min_speed: u32,
+
+    /// Maximum speed for the debug probe.
+    ///
+    /// Some probes will panic if you request a speed higher than they support.
+    /// Data may also become corrupt at higher speeds due to cabling issues.
+    /// This option will set a upper-bound for the speeds that will be tested
+    #[clap(long = "max-speed", value_parser= parse_int, default_value="0")]
+    max_speed: u32,
+
+    /// Word size for read/write accesses.
+    ///
+    /// Set the read/write word size to 8/32/64bits.
+    /// Note: not all chips/probes support all sizes. 32bit is a safe default
+    #[clap(long = "word-size", value_parser= parse_int, default_value="32")]
+    word_size: u32,
+
+    /// Number of times to run each test
+    ///
+    /// Especially for short tests (high speed + low size) there will be some error
+    /// in measurement. By running multiple iterations of each test we should be able to
+    /// both reduce the amount of jitter, and also quantify it (via standard deviation calcs)
+    #[clap(long = "iterations", value_parser= parse_usize, default_value="5")]
+    iterations: usize,
 }
 
-impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
-        let common_options = self.common.load()?;
-        let probe = common_options.attach_probe()?;
+fn parse_usize(src: &str) -> Result<usize, ParseIntError> {
+    usize::from_str_radix(src, 10)
+}
 
-        let protocol_name = probe
-            .protocol()
-            .map(|p| p.to_string())
-            .unwrap_or_else(|| "Unknown protocol".to_string());
-
-        let protocol_speed = probe.speed_khz() as i32;
-
-        let target = common_options.get_target_selector()?;
-        let probe_name = probe.get_name();
-        let mut session = common_options.attach_session(probe, target)?;
-
-        let target_name = session.target().name.clone();
-
-        let mut core = session.core(0).context("Failed to attach to core")?;
-
-        let data_size_words = SIZE;
-
-        let data_size_bytes = data_size_words * 4;
-
-        let mut rng = rand::thread_rng();
-
-        let mut sample_data = vec![0u32; data_size_words];
-
-        rng.fill(&mut sample_data[..]);
-
-        core.halt(Duration::from_millis(100))
-            .context("Halting failed")?;
-
-        let write_start = Instant::now();
-        core.write_32(self.address, &sample_data)
-            .context("Writing the sample data failed")?;
-
-        let write_duration = write_start.elapsed();
-
-        let write_throughput = (data_size_bytes as f32) / write_duration.as_secs_f32();
-
-        println!(
-            "Wrote {} bytes in {:?} ({:>8.2} bytes/s)",
-            data_size_words * 4,
-            write_duration,
-            write_throughput
-        );
-
-        // read back data
-
-        let mut readback_data = vec![0u32; data_size_words];
-
-        let read_start = Instant::now();
-        core.read_32(self.address, &mut readback_data)
-            .expect("Reading the sample data failed");
-        let read_duration = read_start.elapsed();
-
-        let read_throughput = (data_size_bytes as f32) / read_duration.as_secs_f32();
-
-        println!(
-            "Read  {} bytes in {:?} ({:>8.2} bytes/s)",
-            data_size_words * 4,
-            read_duration,
-            read_throughput
-        );
-
-        if sample_data != readback_data {
-            let mismatch = sample_data
-                .iter()
-                .zip(readback_data.iter())
-                .position(|(sample, readback)| sample != readback);
-
-            eprintln!("Verification failed!");
-
-            if let Some(mismatch) = mismatch {
-                eprintln!(
-                    "Readback data differs at address {:08x}: expected word {:08x}, got word {:08x}",
-                    self.address, sample_data[mismatch], readback_data[mismatch]
-                );
-            }
-
-            Ok(())
-        } else {
-            println!("Verification succesful.");
-
-            Ok(())
-        }
-    }
+fn parse_int(src: &str) -> Result<u32, ParseIntError> {
+    u32::from_str_radix(src, 10)
 }
 
 fn parse_hex(src: &str) -> Result<u64, ParseIntError> {
     u64::from_str_radix(src.trim_start_matches("0x"), 16)
+}
+
+#[derive(Debug)]
+/// Provide different data arrays for each read/write stride size
+enum DataType {
+    U8(Vec<u8>, Vec<u8>),
+    U32(Vec<u32>, Vec<u32>),
+    U64(Vec<u64>, Vec<u64>),
+}
+
+#[derive(Debug)]
+/// Configuration and results for a test run
+struct TestData {
+    address: u64,
+    word_qty: usize,
+    pub data_type: DataType,
+    pub read_throughput: f64,
+    pub write_throughput: f64,
+}
+
+impl Cmd {
+    pub fn run(self) -> anyhow::Result<()> {
+        let speed = self.common.speed;
+        let common_options = self.common.load()?;
+        let mut max_speed = self.max_speed;
+        let mut speeds = vec![];
+        // if no max-speed specified, assume the user just wants to use a single speed (as per other cli cmds)
+        if self.max_speed == 0 {
+            max_speed = speed.unwrap_or(3000);
+            speeds.push(max_speed);
+        } else {
+            speeds.extend_from_slice(&PROBE_SPEEDS);
+        };
+        let mut first_pass = true;
+
+        for speed in speeds
+            .iter()
+            .filter(|speed| (self.min_speed..=max_speed).contains(*speed))
+        {
+            for size in TEST_SIZES {
+                let mut probe = common_options.attach_probe()?;
+
+                let protocol_name = probe
+                    .protocol()
+                    .map(|p| p.to_string())
+                    .unwrap_or_else(|| "not specified".to_string());
+
+                let target = common_options.get_target_selector()?;
+                let probe_name = probe.get_name();
+
+                if probe.set_speed(*speed).is_ok() {
+                    let mut session = common_options.attach_session(probe, target)?;
+                    let target_name = session.target().name.clone();
+                    if first_pass {
+                        first_pass = false;
+                        println!(
+                            "Probe: type {}, protocol {}, target chip {}\n",
+                            probe_name, protocol_name, target_name
+                        );
+                    }
+                    let mut test = TestData::new(self.address, self.word_size, size);
+                    println!(
+                        "Test: Speed {}, Word size {}bit, Data length {} bytes, Number of iterations {}",
+                        speed, self.word_size, test.data_type.size() * size, self.iterations
+                    );
+                    let mut core = session.core(0).context("Failed to attach to core")?;
+                    core.halt(Duration::from_millis(100))
+                        .context("Halting failed")?;
+
+                    let mut read_results = Vec::<f64>::with_capacity(self.iterations);
+                    let mut write_results = Vec::<f64>::with_capacity(self.iterations);
+                    'inner: for _ in 0..self.iterations {
+                        test.block_write(&mut core)?;
+                        test.block_read(&mut core)?;
+                        let verify_success = test.block_verify();
+                        if verify_success {
+                            read_results.push(test.read_throughput);
+                            write_results.push(test.write_throughput);
+                        } else {
+                            eprintln!("Verification failed.");
+                            break 'inner;
+                        }
+                    }
+                    println!(
+                        "Results: Read: {:.2} bytes/s Std Dev {:.2}, Write: {:.2} bytes/s Std Dev {:.2}",
+                        mean(&read_results).expect("invalid mean"),
+                        std_deviation(&read_results).expect("invalid std deviation"),
+                        mean(&write_results).expect("invalid mean"),
+                        std_deviation(&write_results).expect("invalid std deviation")
+                    );
+                    if read_results.len() != self.iterations
+                        || write_results.len() != self.iterations
+                    {
+                        println!(
+                            "Warning: {} reads and {} writes successful (out of {} iterations)",
+                            read_results.len(),
+                            write_results.len(),
+                            self.iterations
+                        )
+                    }
+                    println!("");
+                } else {
+                    println!("failed to set speed {}", speed);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl DataType {
+    pub fn new(word_size: u32) -> DataType {
+        match word_size {
+            8 => DataType::U8(Vec::new(), Vec::new()),
+            32 => DataType::U32(Vec::new(), Vec::new()),
+            64 => DataType::U64(Vec::new(), Vec::new()),
+            _ => panic!("Invalid word size"),
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        match self {
+            DataType::U8(_, _) => 1,
+            DataType::U32(_, _) => 4,
+            DataType::U64(_, _) => 8,
+        }
+    }
+
+    pub fn fill_data(&mut self, data_size_words: usize) {
+        let mut rng = rand::thread_rng();
+        match self {
+            DataType::U8(ref mut test_data, ref mut read_data) => {
+                *test_data = vec![0u8; data_size_words];
+                *read_data = vec![0u8; data_size_words];
+                rng.fill(&mut test_data[..]);
+            }
+            DataType::U32(ref mut test_data, ref mut read_data) => {
+                *test_data = vec![0u32; data_size_words];
+                *read_data = vec![0u32; data_size_words];
+                rng.fill(&mut test_data[..]);
+            }
+            DataType::U64(ref mut test_data, ref mut read_data) => {
+                *test_data = vec![0u64; data_size_words];
+                *read_data = vec![0u64; data_size_words];
+                rng.fill(&mut test_data[..]);
+            }
+        }
+    }
+
+    pub fn compare_data(&self) -> Option<usize> {
+        fn compare_data_inner<T: PartialEq>(
+            sample_data: &Vec<T>,
+            read_data: &Vec<T>,
+        ) -> Option<usize> {
+            let mismatch = sample_data
+                .iter()
+                .zip(read_data.iter())
+                .position(|(sample, readback)| sample != readback);
+            mismatch
+        }
+        match self {
+            DataType::U8(sample_data, read_data) => compare_data_inner(sample_data, read_data),
+            DataType::U32(sample_data, read_data) => compare_data_inner(sample_data, read_data),
+            DataType::U64(sample_data, read_data) => compare_data_inner(sample_data, read_data),
+        }
+    }
+
+    pub fn data_at_pos(&self, offset: usize) -> (u64, u64) {
+        match self {
+            DataType::U8(sample_data, read_data) => {
+                (sample_data[offset].into(), read_data[offset].into())
+            }
+            DataType::U32(sample_data, read_data) => {
+                (sample_data[offset].into(), read_data[offset].into())
+            }
+            DataType::U64(sample_data, read_data) => (sample_data[offset], read_data[offset]),
+        }
+    }
+}
+
+impl TestData {
+    fn new(address: u64, word_size: u32, word_qty: usize) -> TestData {
+        let mut data_type = DataType::new(word_size);
+        data_type.fill_data(word_qty);
+
+        TestData {
+            address,
+            data_type,
+            word_qty,
+            read_throughput: 0.0,
+            write_throughput: 0.0,
+        }
+    }
+
+    fn block_verify(&self) -> bool {
+        if let Some(mismatch) = self.data_type.compare_data() {
+            let (sample_data, readback_data) = self.data_type.data_at_pos(mismatch);
+            eprintln!(
+                "Readback data differs at address {:08x}: expected word {:08x}, got word {:08x}",
+                self.address + mismatch as u64,
+                sample_data,
+                readback_data
+            );
+            false
+        } else {
+            true
+        }
+    }
+
+    fn block_read(&mut self, core: &mut probe_rs::Core) -> Result<(), anyhow::Error> {
+        let read_start = Instant::now();
+        match &mut self.data_type {
+            DataType::U8(_, ref mut readback_data) => core
+                .read_8(self.address, readback_data)
+                .expect("Reading the sample data failed"),
+            DataType::U32(_, ref mut readback_data) => core
+                .read_32(self.address, readback_data)
+                .expect("Reading the sample data failed"),
+            DataType::U64(_, ref mut readback_data) => core
+                .read_64(self.address, readback_data)
+                .expect("Reading the sample data failed"),
+        }
+        let read_duration = read_start.elapsed();
+        let data_size_bytes = self.data_type.size() * self.word_qty;
+        self.read_throughput = (data_size_bytes as f64) / read_duration.as_secs_f64();
+
+        Ok(())
+    }
+
+    fn block_write(&mut self, core: &mut probe_rs::Core) -> Result<(), anyhow::Error> {
+        let write_start = Instant::now();
+        match &self.data_type {
+            DataType::U8(ref test_data, _) => core
+                .write_8(self.address, test_data)
+                .context("Writing the sample data failed")?,
+            DataType::U32(ref test_data, _) => core
+                .write_32(self.address, test_data)
+                .context("Writing the sample data failed")?,
+            DataType::U64(test_data, _) => core
+                .write_64(self.address, test_data)
+                .context("Writing the sample data failed")?,
+        }
+        let write_duration = write_start.elapsed();
+        let data_size_bytes = self.data_type.size() * self.word_qty;
+        let write_throughput = (data_size_bytes as f64) / write_duration.as_secs_f64();
+        self.write_throughput = write_throughput;
+
+        Ok(())
+    }
+}
+
+/// Calculate arithmetic mean for data
+fn mean(data: &[f64]) -> Option<f64> {
+    let sum = data.iter().sum::<f64>() as f64;
+    let count = data.len();
+
+    match count {
+        positive if positive > 0 => Some(sum / count as f64),
+        _ => None,
+    }
+}
+
+/// Calculate standard deviation across data
+fn std_deviation(data: &[f64]) -> Option<f64> {
+    match (mean(data), data.len()) {
+        (Some(data_mean), count) if count > 0 => {
+            let variance = data
+                .iter()
+                .map(|value| {
+                    let diff = data_mean - (*value as f64);
+
+                    diff * diff
+                })
+                .sum::<f64>()
+                / count as f64;
+
+            Some(variance.sqrt())
+        }
+        _ => None,
+    }
 }

--- a/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
@@ -56,11 +56,11 @@ pub struct Cmd {
 }
 
 fn parse_usize(src: &str) -> Result<usize, ParseIntError> {
-    usize::from_str_radix(src, 10)
+    src.parse::<usize>()
 }
 
 fn parse_int(src: &str) -> Result<u32, ParseIntError> {
-    u32::from_str_radix(src, 10)
+    src.parse::<u32>()
 }
 
 fn parse_hex(src: &str) -> Result<u64, ParseIntError> {
@@ -157,7 +157,7 @@ impl Cmd {
     ) -> Result<(), anyhow::Error> {
         let mut probe = common_options.attach_probe()?;
         let target = common_options.get_target_selector()?;
-        Ok(if probe.set_speed(speed).is_ok() {
+        if probe.set_speed(speed).is_ok() {
             let mut session = common_options.attach_session(probe, target)?;
             let mut test = TestData::new(address, word_size, size);
             println!(
@@ -200,10 +200,12 @@ impl Cmd {
                     iterations
                 )
             }
-            println!("");
+            // Insert another blank line to visually seperate results
+            println!();
         } else {
             println!("failed to set speed {}", speed);
-        })
+        }
+        Ok(())
     }
 }
 
@@ -248,8 +250,8 @@ impl DataType {
 
     pub fn compare_data(&self) -> Option<usize> {
         fn compare_data_inner<T: PartialEq>(
-            sample_data: &Vec<T>,
-            read_data: &Vec<T>,
+            sample_data: &[T],
+            read_data: &[T],
         ) -> Option<usize> {
             let mismatch = sample_data
                 .iter()
@@ -349,11 +351,11 @@ impl TestData {
 
 /// Calculate arithmetic mean for data
 fn mean(data: &[f64]) -> Option<f64> {
-    let sum = data.iter().sum::<f64>() as f64;
-    let count = data.len();
+    let sum = data.iter().sum::<f64>();
+    let count = data.len() as f64;
 
     match count {
-        positive if positive > 0 => Some(sum / count as f64),
+        positive if positive > 0.0 => Some(sum / count),
         _ => None,
     }
 }
@@ -365,7 +367,7 @@ fn std_deviation(data: &[f64]) -> Option<f64> {
             let variance = data
                 .iter()
                 .map(|value| {
-                    let diff = data_mean - (*value as f64);
+                    let diff = data_mean - *value;
 
                     diff * diff
                 })

--- a/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
@@ -1,15 +1,11 @@
 use std::{
-    env,
     num::ParseIntError,
-    process::Command,
-    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant},
 };
 
 use anyhow::Context;
 use probe_rs::MemoryInterface;
 use rand::prelude::*;
-use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 
 use crate::util::common_options::ProbeOptions;
 
@@ -25,11 +21,6 @@ pub struct Cmd {
     /// Should be located in RAM.
     #[clap(long = "address", value_parser= parse_hex)]
     address: u64,
-    #[clap(long = "pr")]
-    pr: Option<u64>,
-
-    #[clap(long)]
-    upload: bool,
 }
 
 impl Cmd {
@@ -117,60 +108,6 @@ impl Cmd {
         } else {
             println!("Verification succesful.");
 
-            if self.upload {
-                let start = SystemTime::now();
-                let since_the_epoch = start
-                    .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards")
-                    .as_secs();
-
-                let commit_hash = String::from_utf8_lossy(
-                    &Command::new("git")
-                        .args(["rev-parse", "--short", "HEAD"])
-                        .output()
-                        .unwrap()
-                        .stdout,
-                )
-                .trim()
-                .to_string();
-
-                let commit_name = if Command::new("git")
-                    .args(["diff-index", "--quiet", "HEAD", "--"])
-                    .output()
-                    .unwrap()
-                    .status
-                    .success()
-                {
-                    commit_hash
-                } else {
-                    commit_hash + "-changed"
-                };
-
-                let client = reqwest::blocking::Client::new();
-                const BASE_URL: &str = "https://perf.probe.rs/add";
-                client
-                    .post(if let Some(pr) = self.pr {
-                        format!("{BASE_URL}?pr={pr}")
-                    } else {
-                        BASE_URL.to_string()
-                    })
-                    .json(&NewLog {
-                        probe: probe_name,
-                        chip: target_name,
-                        os: env::consts::OS.to_string(),
-                        protocol: protocol_name,
-                        protocol_speed,
-                        commit_hash: commit_name,
-                        timestamp: OffsetDateTime::from_unix_timestamp(since_the_epoch as i64)
-                            .unwrap(),
-                        kind: "ram".into(),
-                        read_speed: read_throughput as i32,
-                        write_speed: write_throughput as i32,
-                    })
-                    .send()
-                    .with_context(|| format!("Failed to upload results to {BASE_URL}"))?;
-            }
-
             Ok(())
         }
     }
@@ -178,39 +115,4 @@ impl Cmd {
 
 fn parse_hex(src: &str) -> Result<u64, ParseIntError> {
     u64::from_str_radix(src.trim_start_matches("0x"), 16)
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct NewLog {
-    pub probe: String,
-    pub chip: String,
-    pub os: String,
-    pub protocol: String,
-    pub protocol_speed: i32,
-    pub commit_hash: String,
-    #[serde(with = "timestamp")]
-    pub timestamp: OffsetDateTime,
-    pub kind: String,
-    pub read_speed: i32,
-    pub write_speed: i32,
-}
-
-mod timestamp {
-    use serde::{self, Deserialize, Deserializer, Serializer};
-    use time::OffsetDateTime;
-
-    pub fn serialize<S>(date: &OffsetDateTime, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_i64(date.unix_timestamp())
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = i64::deserialize(deserializer)?;
-        Ok(OffsetDateTime::from_unix_timestamp(s).unwrap())
-    }
 }

--- a/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
@@ -249,10 +249,7 @@ impl DataType {
     }
 
     pub fn compare_data(&self) -> Option<usize> {
-        fn compare_data_inner<T: PartialEq>(
-            sample_data: &[T],
-            read_data: &[T],
-        ) -> Option<usize> {
+        fn compare_data_inner<T: PartialEq>(sample_data: &[T], read_data: &[T]) -> Option<usize> {
             let mismatch = sample_data
                 .iter()
                 .zip(read_data.iter())


### PR DESCRIPTION
The original benchmark implementation was a bit limited for my benchmarking purposes, so I've extended it.

This version will test different data lengths and speeds, and tries to do some basic stats to improve output.
It also supports targeting different word sizes (8/32/64bit), though only one at a time. This is not something I think is important to most people, and i know at least one target (esp32-c3) only supports 32bit reads/writes.
The whole thing definitely needs more error handling. It quits on most probe errors.

Oh, I also removed the http reporting since that isn't being used. Not bringing in reqwest should improve build times somewhat.