### PR TITLE
Unlock the OS Lock when starting an ARMv8 core

### DIFF
--- a/changelog/fixed-os-lock.md
+++ b/changelog/fixed-os-lock.md
@@ -1,0 +1,1 @@
+Unlock the OS Lock when starting an ARMv8 core

--- a/probe-rs/src/architecture/arm/core/armv8a_debug_regs.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a_debug_regs.rs
@@ -157,6 +157,16 @@ memory_mapped_bitfield_register! {
 }
 
 memory_mapped_bitfield_register! {
+    /// OSLAR_EL1 - OS Lock Access Register
+    pub struct Oslar(u32);
+    0x300,"OSLAR_EL1",
+    impl From;
+
+    /// Lock value
+    pub oslk, set_oslk: 1, 0;
+}
+
+memory_mapped_bitfield_register! {
     /// DBGBVR - Breakpoint Value Register
     pub struct Dbgbvr(u32);
     0x400, "DBGBVR",

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -257,7 +257,7 @@ fn armv8a_core_start(
     cti_base: Option<u64>,
 ) -> Result<(), ArmError> {
     use crate::architecture::arm::core::armv8a_debug_regs::{
-        CtiControl, CtiGate, CtiOuten, Edlar, Edscr,
+        CtiControl, CtiGate, CtiOuten, Edlar, Edscr, Oslar,
     };
 
     let debug_base =
@@ -273,6 +273,10 @@ fn armv8a_core_start(
     // Lock OS register access to prevent race conditions
     let address = Edlar::get_mmio_address_from_base(debug_base)?;
     core.write_word_32(address, Edlar(0).into())?;
+
+    // Unlock the OS Lock to enable access to debug registers
+    let address = Oslar::get_mmio_address_from_base(debug_base)?;
+    core.write_word_32(address, Oslar(0).into())?;
 
     // Configure CTI
     let mut cticontrol = CtiControl(0);


### PR DESCRIPTION
It is necessary for the OS Lock to be unlocked when accessing various debug registers, including EDSCR which we access later. Do so.