### PR TITLE
Issue DAPABORT at startup and after receiving WAIT response from CMSI…

### DIFF
--- a/changelog/fixed-wait-dapabort.md
+++ b/changelog/fixed-wait-dapabort.md
@@ -1,0 +1,1 @@
+Issue DAPABORT at startup and after receiving WAIT response from CMSIS-DAP

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -520,6 +520,7 @@ pub trait ArmDebugSequence: Send + Sync {
         // CMSIS says this is only necessary to do inside the `if powered_down`, but
         // without it here, nRF52840 faults in the next access.
         let mut abort = Abort(0);
+        abort.set_dapabort(true);
         abort.set_orunerrclr(true);
         abort.set_wderrclr(true);
         abort.set_stkerrclr(true);

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -523,6 +523,16 @@ impl CmsisDap {
                     Ack::Wait => {
                         tracing::trace!("wait",);
 
+                        let mut abort = Abort(0);
+                        abort.set_dapabort(true);
+
+                        RawDapAccess::raw_write_register(
+                            self,
+                            PortType::DebugPort,
+                            Abort::ADDRESS,
+                            abort.into(),
+                        )?;
+
                         return Err(DapError::WaitResponse.into());
                     }
                 }


### PR DESCRIPTION
…S-DAP

The ADIv5 spec states that DAPABORT should be issued after receiving WAIT responses over an extended period. Generally a WAIT response from a CMSIS-DAP probe means that the probe has timed out after receiving multiple WAITs from the target, so it would be appropriate to issue a DAPABORT.

Do the same at startup in case the DP was left in a bad state from a previous tool run.