### PR TITLE
Set DbgSwEnable to 1 during memory access

### DIFF
--- a/changelog/fixed-dbgswenable.md
+++ b/changelog/fixed-dbgswenable.md
@@ -1,0 +1,1 @@
+Set DbgSwEnable to 1 during memory access

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -213,6 +213,7 @@ where
         //   HPROT[3] == 0   - non-bufferable access
 
         CSW {
+            DbgSwEnable: 0b1,
             HNONSEC: !self.ap_information.supports_hnonsec as u8,
             PROT: 0b10,
             CACHE: 0b11,


### PR DESCRIPTION
This appears to be an oversight. As mentioned in the ADIv5 spec, setting DbgSwEnable to 0 "can cause software that is executing on the target to malfunction".