### PR TITLE
Port to nusb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,18 +1997,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "jaylink"
-version = "0.3.0"
-source = "git+https://github.com/Dirbaio/jaylink?rev=15001acd2f3443423ee6994e039743aa0059a061#15001acd2f3443423ee6994e039743aa0059a061"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "futures-lite 1.13.0",
- "log",
- "nusb",
-]
-
-[[package]]
 name = "jep106"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,8 +2654,10 @@ dependencies = [
  "base64",
  "bincode",
  "bitfield",
+ "bitflags 1.3.2",
  "bitvec",
  "byte-unit",
+ "byteorder",
  "bytesize",
  "capstone",
  "cargo_metadata",
@@ -2695,7 +2685,6 @@ dependencies = [
  "is-terminal",
  "itertools 0.12.0",
  "itm",
- "jaylink",
  "jep106",
  "kmp",
  "libftdi1-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9d5715c2d329bf1b4da8d60455b99b187f27ba726df2883799af9af60997"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.0.1",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "tracing",
+ "waker-fn",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb2ab2aa8a746e221ab826c73f48bc6ba41be6763f0855cb249eb6d154cf1d7"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +285,12 @@ checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
  "critical-section",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -725,6 +762,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,10 +1229,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96b852f1345da36d551b9473fa1e2b1eb5c5195585c6c018118bc92a8d91160"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "fastrand"
@@ -1308,6 +1384,31 @@ name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3831c2651acb5177cbd83943f3d9c8912c5ad03c76afcc0e9511ba568ec5ebb"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1547,7 +1648,9 @@ checksum = "723777263b0dcc5730aec947496bd8c3940ba63c15f5633b288cc615f4f6af79"
 dependencies = [
  "cc",
  "libc",
+ "nix 0.26.2",
  "pkg-config",
+ "udev",
  "winapi",
 ]
 
@@ -1799,6 +1902,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-kit-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4769cb30e5dcf1710fc6730d3e94f78c47723a014a567de385e113c737394640"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,13 +1999,13 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "jaylink"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d891935e08397d85684c1d3c88b6a0a6941c6e15e9f04a1ae9e30079f0b0df0"
+source = "git+https://github.com/Dirbaio/jaylink?rev=15001acd2f3443423ee6994e039743aa0059a061#15001acd2f3443423ee6994e039743aa0059a061"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
+ "futures-lite 1.13.0",
  "log",
- "rusb",
+ "nusb",
 ]
 
 [[package]]
@@ -2103,6 +2216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miette"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2316,8 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+ "memoffset",
+ "pin-utils",
  "static_assertions",
 ]
 
@@ -2269,6 +2393,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "nusb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed578456ade6b3642c40fad8aa25cd7584725f5170628619f21b24e8fb8d125f"
+dependencies = [
+ "atomic-waker",
+ "core-foundation",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "log",
+ "once_cell",
+ "rustix",
+ "slab",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "object"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +2458,12 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -2433,6 +2580,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "polling"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53b6af1f60f36f8c2ac2aad5459d75a5a9b4be1e8cdd40264f315d78193e531"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,6 +2662,7 @@ version = "0.22.0"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
+ "async-io",
  "base64",
  "bincode",
  "bitfield",
@@ -2520,6 +2682,7 @@ dependencies = [
  "esp-idf-part",
  "espflash",
  "figment",
+ "futures-lite 1.13.0",
  "gdbstub",
  "gimli 0.28.1",
  "git-version",
@@ -2539,6 +2702,7 @@ dependencies = [
  "log",
  "miniz_oxide",
  "num-traits",
+ "nusb",
  "object 0.32.2",
  "once_cell",
  "parse_int",
@@ -2550,7 +2714,6 @@ dependencies = [
  "ratatui",
  "rmp-serde",
  "ron",
- "rusb",
  "rustyline",
  "sanitize-filename",
  "schemafy",
@@ -2995,16 +3158,6 @@ dependencies = [
  "clap",
  "pretty_env_logger",
  "probe-rs",
-]
-
-[[package]]
-name = "rusb"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fff149b6033f25e825cbb7b2c625a11ee8e6dac09264d49beb125e39aa97bf"
-dependencies = [
- "libc",
- "libusb1-sys",
 ]
 
 [[package]]
@@ -3462,9 +3615,9 @@ checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
@@ -3769,7 +3922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.0",
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.48.0",
@@ -4231,6 +4384,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "udev"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebdbbd670373442a12fe9ef7aeb53aec4147a5a27a00bbc3ab639f08f48191a"
+dependencies = [
+ "libc",
+ "libudev-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "uf2-decode"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4365,6 +4529,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"

--- a/changelog/changed-nusb.md
+++ b/changelog/changed-nusb.md
@@ -1,0 +1,1 @@
+Use the `nusb` crate for USB I/O. (pure-Rust replacement for `rusb`/`libusb`).

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -95,8 +95,6 @@ gimli = { version = "0.28.1", default-features = false, features = [
 ] }
 hidapi = { version = "2.4.1", default-features = false, features = [ "linux-native" ] }
 ihex = "3.0.0"
-jaylink = { git = "https://github.com/Dirbaio/jaylink", rev = "15001acd2f3443423ee6994e039743aa0059a061", features = ["nusb"]}
-#jaylink = { path = "../jaylink", features = ["nusb"]}
 jep106 = "0.2.8"
 kmp = { version = "0.1", optional = true }
 once_cell = "1.19.0"
@@ -121,6 +119,8 @@ tracing = { version = "0.1.40", features = ["log"] }
 uf2-decode = "0.2.0"
 rmp-serde = "1.1.2"
 typed-path = "0.7.0"
+bitflags = "1.2.1"
+byteorder = "1.3.2"
 
 espflash = { version = "2.1.0", default-features = false }
 esp-idf-part = "0.4"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -72,8 +72,6 @@ cli = [
     "dep:addr2line",
 ]
 
-vendored-libusb = ["rusb/vendored"]
-
 # Enable all built in targets.
 builtin-targets = []
 
@@ -95,11 +93,10 @@ gimli = { version = "0.28.1", default-features = false, features = [
     "read",
     "std",
 ] }
-hidapi = { version = "2.4.1", default-features = false, features = [
-    "linux-static-hidraw",
-] }
+hidapi = { version = "2.4.1", default-features = false, features = [ "linux-native" ] }
 ihex = "3.0.0"
-jaylink = "0.3.0"
+jaylink = { git = "https://github.com/Dirbaio/jaylink", rev = "15001acd2f3443423ee6994e039743aa0059a061", features = ["nusb"]}
+#jaylink = { path = "../jaylink", features = ["nusb"]}
 jep106 = "0.2.8"
 kmp = { version = "0.1", optional = true }
 once_cell = "1.19.0"
@@ -111,7 +108,9 @@ object = { version = "0.32.2", default-features = false, features = [
     "std",
 ] }
 paste = "1.0.14"
-rusb = "0.9.3"
+nusb = { version = "0.1.3" }
+futures-lite = "1.13.0"
+async-io = "2.1.0"
 scroll = "0.12.0"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1,5 +1,6 @@
 pub(crate) mod arm_jtag;
 pub(crate) mod common;
+pub(crate) mod usb_util;
 
 pub(crate) mod cmsisdap;
 pub(crate) mod espusbjtag;
@@ -103,7 +104,7 @@ impl fmt::Display for BatchCommand {
 pub enum DebugProbeError {
     /// Something with the USB communication went wrong.
     #[error("USB Communication Error")]
-    Usb(#[source] Option<Box<dyn std::error::Error + Send + Sync>>),
+    Usb(#[source] std::io::Error),
     /// The firmware of the probe is outdated. This error is especially prominent with ST-Links.
     /// You can use their official updater utility to update your probe firmware.
     #[error("The firmware on the probe is outdated, and not supported by probe-rs.")]
@@ -186,9 +187,9 @@ pub enum ProbeCreationError {
     /// Some error with HID API occurred.
     #[error("{0}")]
     HidApi(#[from] hidapi::HidError),
-    /// Some error with rusb occurred.
+    /// Some USB error occurred.
     #[error("{0}")]
-    Rusb(#[from] rusb::Error),
+    Usb(std::io::Error),
     /// An error specific with the selected probe occurred.
     #[error("An error specific to a probe type occurred: {0}")]
     ProbeSpecific(#[source] Box<dyn std::error::Error + Send + Sync>),

--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -6,7 +6,9 @@ pub mod swo;
 pub mod transfer;
 
 use crate::probe::cmsisdap::commands::general::info::PacketSizeCommand;
+use crate::probe::usb_util::InterfaceExt;
 use crate::DebugProbeError;
+use std::io::ErrorKind;
 use std::str::Utf8Error;
 use std::time::Duration;
 
@@ -28,7 +30,7 @@ pub enum CmsisDapError {
     #[error("Requested SWO mode is not available on this probe")]
     SwoModeNotAvailable,
     #[error("USB Error reading SWO data.")]
-    SwoReadError(#[source] rusb::Error),
+    SwoReadError(#[source] std::io::Error),
     #[error("Could not determine a suitable packet size for this probe")]
     NoPacketSize,
     #[error("Invalid IDCODE detected")]
@@ -42,7 +44,7 @@ pub enum SendError {
     #[error("Error in the USB HID access")]
     HidApi(#[from] hidapi::HidError),
     #[error("Error in the USB access")]
-    UsbError(rusb::Error),
+    UsbError(std::io::Error),
     #[error("Not enough data in response from probe")]
     NotEnoughData,
     #[error("Status can only be 0x00 or 0xFF")]
@@ -63,15 +65,6 @@ pub enum SendError {
     Timeout,
 }
 
-impl From<rusb::Error> for SendError {
-    fn from(error: rusb::Error) -> Self {
-        match error {
-            rusb::Error::Timeout => SendError::Timeout,
-            other => SendError::UsbError(other),
-        }
-    }
-}
-
 impl From<CmsisDapError> for DebugProbeError {
     fn from(error: CmsisDapError) -> Self {
         DebugProbeError::ProbeSpecific(Box::new(error))
@@ -87,10 +80,10 @@ pub enum CmsisDapDevice {
     },
 
     /// CMSIS-DAP v2 over WinUSB/Bulk.
-    /// Stores an rusb device handle, out/in EP addresses, maximum DAP packet size,
+    /// Stores an usb device handle, out/in EP addresses, maximum DAP packet size,
     /// and an optional SWO streaming EP address and SWO maximum packet size.
     V2 {
-        handle: rusb::DeviceHandle<rusb::Context>,
+        handle: nusb::Interface,
         out_ep: u8,
         in_ep: u8,
         max_packet_size: usize,
@@ -109,7 +102,9 @@ impl CmsisDapDevice {
             },
             CmsisDapDevice::V2 { handle, in_ep, .. } => {
                 let timeout = Duration::from_millis(100);
-                Ok(handle.read_bulk(*in_ep, buf, timeout)?)
+                handle
+                    .read_bulk(*in_ep, buf, timeout)
+                    .map_err(SendError::UsbError)
             }
         }
     }
@@ -121,7 +116,9 @@ impl CmsisDapDevice {
             CmsisDapDevice::V2 { handle, out_ep, .. } => {
                 let timeout = Duration::from_millis(100);
                 // Skip first byte as it's set to 0 for HID transfers
-                Ok(handle.write_bulk(*out_ep, &buf[1..], timeout)?)
+                handle
+                    .write_bulk(*out_ep, &buf[1..], timeout)
+                    .map_err(SendError::UsbError)
             }
         }
     }
@@ -242,7 +239,7 @@ impl CmsisDapDevice {
                             buf.truncate(n);
                             Ok(buf)
                         }
-                        Err(rusb::Error::Timeout) => {
+                        Err(e) if e.kind() == ErrorKind::TimedOut => {
                             buf.truncate(0);
                             Ok(buf)
                         }

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -3,28 +3,39 @@ use crate::{
     probe::{cmsisdap::CmsisDapSource, DebugProbeInfo, ProbeCreationError},
     DebugProbeSelector,
 };
+use async_io::{block_on, Timer};
+use futures_lite::FutureExt;
 use hidapi::HidApi;
-use rusb::{constants::LIBUSB_CLASS_HID, Device, DeviceDescriptor, UsbContext};
-use std::time::Duration;
+use nusb::{
+    descriptors::InterfaceAltSetting,
+    transfer::{ControlIn, ControlType, Direction, EndpointType},
+    DeviceInfo,
+};
+use std::{io, time::Duration};
+
+const USB_CLASS_HID: u8 = 0x03;
 
 /// Finds all CMSIS-DAP devices, either v1 (HID) or v2 (WinUSB Bulk).
 ///
-/// This method uses rusb to read device strings, which might fail due
+/// This method uses nusb to read device strings, which might fail due
 /// to permission or driver errors, so it falls back to listing only
 /// HID devices if it does not find any suitable devices.
 #[tracing::instrument(skip_all)]
 pub fn list_cmsisdap_devices() -> Vec<DebugProbeInfo> {
-    tracing::debug!("Searching for CMSIS-DAP probes using libusb");
-    let mut probes = match rusb::Context::new().and_then(|ctx| ctx.devices()) {
+    tracing::debug!("Searching for CMSIS-DAP probes using nusb");
+
+    let mut probes = match nusb::list_devices() {
         Ok(devices) => devices
-            .iter()
             .filter_map(|device| get_cmsisdap_info(&device))
             .collect(),
-        Err(_) => vec![],
+        Err(e) => {
+            tracing::warn!("error listing devices with nusb: {:?}", e);
+            vec![]
+        }
     };
 
     tracing::debug!(
-        "Found {} CMSIS-DAP probes using libusb, searching HID",
+        "Found {} CMSIS-DAP probes using nusb, searching HID",
         probes.len()
     );
 
@@ -49,50 +60,102 @@ pub fn list_cmsisdap_devices() -> Vec<DebugProbeInfo> {
     probes
 }
 
+fn read_interface_string(
+    device: &nusb::Device,
+    iface_info: &InterfaceAltSetting,
+) -> std::io::Result<String> {
+    const USB_REQUEST_GET_DESCRIPTOR: u8 = 0x06;
+    const USB_DESCRIPTOR_TYPE_STRING: u8 = 0x03;
+
+    let index = iface_info
+        .string_index()
+        .ok_or_else(|| io::Error::other("No description string index in iface"))?;
+
+    // nusb supports doing control requests on the device without claiming an
+    // interface, but only on linux.
+    #[cfg(not(target_os = "linux"))]
+    let device = device.claim_interface(iface_info.interface_number())?;
+
+    let control = ControlIn {
+        recipient: nusb::transfer::Recipient::Device,
+        control_type: ControlType::Standard,
+        request: USB_REQUEST_GET_DESCRIPTOR,
+        value: (USB_DESCRIPTOR_TYPE_STRING as u16) << 8 | index as u16,
+        index: 0,
+        length: 255,
+    };
+    let timeout = Duration::from_millis(1000);
+
+    let fut = async {
+        let comp = device.control_in(control).await;
+        comp.status.map_err(io::Error::other)?;
+
+        Ok(comp.data)
+    };
+
+    let data = block_on(fut.or(async {
+        Timer::after(timeout).await;
+        Err(std::io::Error::from(std::io::ErrorKind::TimedOut))
+    }))?;
+
+    let data16: Vec<u16> = data[2..]
+        .chunks_exact(2)
+        .map(|a| u16::from_le_bytes([a[0], a[1]]))
+        .collect();
+
+    String::from_utf16(&data16).map_err(io::Error::other)
+}
+
 /// Checks if a given Device is a CMSIS-DAP probe, returning Some(DebugProbeInfo) if so.
-fn get_cmsisdap_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
+fn get_cmsisdap_info(device: &DeviceInfo) -> Option<DebugProbeInfo> {
     // Open device handle and read basic information
-    let timeout = Duration::from_millis(100);
-    let d_desc = device.device_descriptor().ok()?;
-    let handle = device.open().ok()?;
-    let language = handle.read_languages(timeout).ok()?.first().cloned()?;
-    let prod_str = handle
-        .read_product_string(language, &d_desc, timeout)
-        .ok()?;
-    let sn_str = handle
-        .read_serial_number_string(language, &d_desc, timeout)
-        .ok();
+    let prod_str = device.product_string()?;
+    let sn_str = device.serial_number();
 
     // Most CMSIS-DAP probes say something like "CMSIS-DAP"
-    let cmsis_dap_product = is_cmsis_dap(&prod_str) || is_known_cmsis_dap_dev(&d_desc);
+    let cmsis_dap_product = is_cmsis_dap(prod_str) || is_known_cmsis_dap_dev(device);
+
+    let dev = match device.open() {
+        Ok(dev) => dev,
+        Err(e) => {
+            tracing::debug!(
+                "failed to open usb device to check for cmsisdap interfaces: {:?} {:?}",
+                e,
+                device
+            );
+            return None;
+        }
+    };
 
     // Iterate all interfaces, looking for:
     // 1. Any with CMSIS-DAP in their interface string
     // 2. Any that are HID, if the product string says CMSIS-DAP,
     //    to save for potential HID-only operation.
-    let config_descriptor = device.active_config_descriptor().ok()?;
+    let config_descriptor = dev.configurations().next()?;
     let mut cmsis_dap_interface = false;
     let mut hid_interface = None;
     for interface in config_descriptor.interfaces() {
-        for descriptor in interface.descriptors() {
-            let interface_desc = match handle.read_interface_string(language, &descriptor, timeout)
-            {
+        for descriptor in interface.alt_settings() {
+            let interface_desc = match read_interface_string(&dev, &descriptor) {
                 Ok(desc) => desc,
                 Err(_) => {
                     tracing::trace!(
                         "Could not read string for interface {}, skipping",
-                        interface.number()
+                        interface.interface_number()
                     );
                     continue;
                 }
             };
-
             if is_cmsis_dap(&interface_desc) {
-                tracing::trace!("  Interface {}: {}", interface.number(), interface_desc);
+                tracing::trace!(
+                    "  Interface {}: {}",
+                    interface.interface_number(),
+                    interface_desc
+                );
                 cmsis_dap_interface = true;
-                if descriptor.class_code() == LIBUSB_CLASS_HID {
+                if descriptor.class() == USB_CLASS_HID {
                     tracing::trace!("    HID interface found");
-                    hid_interface = Some(interface.number());
+                    hid_interface = Some(interface.interface_number());
                 }
             }
         }
@@ -112,10 +175,10 @@ fn get_cmsisdap_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
         }
 
         Some(DebugProbeInfo::new(
-            prod_str,
-            d_desc.vendor_id(),
-            d_desc.product_id(),
-            sn_str,
+            prod_str.to_string(),
+            device.vendor_id(),
+            device.product_id(),
+            sn_str.map(Into::into),
             &CmsisDapSource,
             hid_interface,
         ))
@@ -150,14 +213,12 @@ fn get_cmsisdap_hid_info(device: &hidapi::DeviceInfo) -> Option<DebugProbeInfo> 
 }
 
 /// Attempt to open the given device in CMSIS-DAP v2 mode
-pub fn open_v2_device(device: Device<rusb::Context>) -> Option<CmsisDapDevice> {
+pub fn open_v2_device(device: &DeviceInfo) -> Option<CmsisDapDevice> {
     // Open device handle and read basic information
-    let timeout = Duration::from_millis(100);
-    let d_desc = device.device_descriptor().ok()?;
-    let vid = d_desc.vendor_id();
-    let pid = d_desc.product_id();
-    let mut handle = device.open().ok()?;
-    let language = handle.read_languages(timeout).ok()?.first().cloned()?;
+    let vid = device.vendor_id();
+    let pid = device.product_id();
+
+    let device = device.open().ok()?;
 
     // Go through interfaces to try and find a v2 interface.
     // The CMSIS-DAPv2 spec says that v2 interfaces should use a specific
@@ -165,11 +226,11 @@ pub fn open_v2_device(device: Device<rusb::Context>) -> Option<CmsisDapDevice> {
     // official DAPLink firmware doesn't use it. Instead, we scan for an
     // interface whose string like "CMSIS-DAP" and has two or three
     // endpoints of the correct type and direction.
-    let c_desc = device.config_descriptor(0).ok()?;
+    let c_desc = device.configurations().next()?;
     for interface in c_desc.interfaces() {
-        for i_desc in interface.descriptors() {
+        for i_desc in interface.alt_settings() {
             // Skip interfaces without "CMSIS-DAP" like pattern in their string
-            match handle.read_interface_string(language, &i_desc, timeout) {
+            match read_interface_string(&device, &i_desc) {
                 Ok(i_str) if !is_cmsis_dap(&i_str) => continue,
                 Err(_) => continue,
                 Ok(_) => (),
@@ -181,19 +242,16 @@ pub fn open_v2_device(device: Device<rusb::Context>) -> Option<CmsisDapDevice> {
                 continue;
             }
 
-            let eps: Vec<_> = i_desc.endpoint_descriptors().collect();
+            let eps: Vec<_> = i_desc.endpoints().collect();
 
-            // Check the first interface is bulk out
-            if eps[0].transfer_type() != rusb::TransferType::Bulk
-                || eps[0].direction() != rusb::Direction::Out
+            // Check the first endpoint is bulk out
+            if eps[0].transfer_type() != EndpointType::Bulk || eps[0].direction() != Direction::Out
             {
                 continue;
             }
 
-            // Check the second interface is bulk in
-            if eps[1].transfer_type() != rusb::TransferType::Bulk
-                || eps[1].direction() != rusb::Direction::In
-            {
+            // Check the second endpoint is bulk in
+            if eps[1].transfer_type() != EndpointType::Bulk || eps[1].direction() != Direction::In {
                 continue;
             }
 
@@ -201,22 +259,22 @@ pub fn open_v2_device(device: Device<rusb::Context>) -> Option<CmsisDapDevice> {
             let mut swo_ep = None;
 
             if eps.len() > 2
-                && eps[2].transfer_type() == rusb::TransferType::Bulk
-                && eps[2].direction() == rusb::Direction::In
+                && eps[2].transfer_type() == EndpointType::Bulk
+                && eps[2].direction() == Direction::In
             {
-                swo_ep = Some((eps[2].address(), eps[2].max_packet_size() as usize));
+                swo_ep = Some((eps[2].address(), eps[2].max_packet_size()));
             }
 
             // Attempt to claim this interface
-            match handle.claim_interface(interface.number()) {
-                Ok(()) => {
+            match device.claim_interface(interface.interface_number()) {
+                Ok(handle) => {
                     tracing::debug!("Opening {:04x}:{:04x} in CMSIS-DAPv2 mode", vid, pid);
                     return Some(CmsisDapDevice::V2 {
                         handle,
                         out_ep: eps[0].address(),
                         in_ep: eps[1].address(),
                         swo_ep,
-                        max_packet_size: eps[1].max_packet_size() as usize,
+                        max_packet_size: eps[1].max_packet_size(),
                     });
                 }
                 Err(_) => continue,
@@ -233,16 +291,10 @@ pub fn open_v2_device(device: Device<rusb::Context>) -> Option<CmsisDapDevice> {
     None
 }
 
-fn device_matches(
-    device_descriptor: DeviceDescriptor,
-    selector: &DebugProbeSelector,
-    serial_str: Option<String>,
-) -> bool {
-    if device_descriptor.vendor_id() == selector.vendor_id
-        && device_descriptor.product_id() == selector.product_id
-    {
+fn device_matches(device: &DeviceInfo, selector: &DebugProbeSelector) -> bool {
+    if device.vendor_id() == selector.vendor_id && device.product_id() == selector.product_id {
         if selector.serial_number.is_some() {
-            serial_str == selector.serial_number
+            device.serial_number() == selector.serial_number.as_deref()
         } else {
             true
         }
@@ -258,73 +310,40 @@ pub fn open_device_from_selector(
 ) -> Result<CmsisDapDevice, ProbeCreationError> {
     tracing::trace!("Attempting to open device matching {}", selector);
 
-    // We need to use rusb to detect the proper HID interface to use
+    // We need to use nusb to detect the proper HID interface to use
     // if a probe has multiple HID interfaces. The hidapi lib unfortunately
     // offers no method to get the interface description string directly,
-    // so we retrieve the device information using rusb and store it here.
+    // so we retrieve the device information using nusb and store it here.
     //
-    // If rusb cannot be used, we will just use the first HID interface and
+    // If nusb cannot be used, we will just use the first HID interface and
     // try to open that.
     let mut hid_device_info = None;
 
-    // Try using rusb to open a v2 device. This might fail if
+    // Try using nusb to open a v2 device. This might fail if
     // the device does not support v2 operation or due to driver
     // or permission issues with opening bulk devices.
-    if let Ok(devices) = rusb::Context::new().and_then(|ctx| ctx.devices()) {
-        for device in devices.iter() {
+    if let Ok(devices) = nusb::list_devices() {
+        for device in devices {
             tracing::trace!("Trying device {:?}", device);
 
-            let d_desc = match device.device_descriptor() {
-                Ok(d_desc) => d_desc,
-                Err(err) => {
-                    tracing::trace!("Error reading descriptor: {:?}", err);
-                    continue;
-                }
-            };
-
-            let handle = match device.open() {
-                Ok(handle) => handle,
-                Err(err) => {
-                    tracing::trace!("Error opening: {:?}", err);
-                    continue;
-                }
-            };
-
-            let timeout = Duration::from_millis(100);
-            let sn_str = match handle.read_languages(timeout) {
-                Ok(langs) => langs.first().and_then(|lang| {
-                    handle
-                        .read_serial_number_string(*lang, &d_desc, timeout)
-                        .ok()
-                }),
-                Err(err) => {
-                    tracing::trace!("Error getting languages: {:?}", err);
-                    continue;
-                }
-            };
-
-            // We have to ensure the handle gets closed after reading the serial number,
-            // multiple open handles are not allowed on Windows.
-            drop(handle);
-
-            if device_matches(d_desc, selector, sn_str) {
+            if device_matches(&device, selector) {
                 hid_device_info = get_cmsisdap_info(&device);
 
                 if hid_device_info.is_some() {
                     // If the VID, PID, and potentially SN all match,
                     // and the device is a valid CMSIS-DAP probe,
                     // attempt to open the device in v2 mode.
-                    if let Some(device) = open_v2_device(device) {
+                    if let Some(device) = open_v2_device(&device) {
                         return Ok(device);
                     }
                 }
             }
         }
     } else {
-        tracing::debug!("No devices matched using rusb");
+        tracing::debug!("No devices matched using nusb");
     }
 
-    // If rusb failed or the device didn't support v2, try using hidapi to open in v1 mode.
+    // If nusb failed or the device didn't support v2, try using hidapi to open in v1 mode.
     let vid = selector.vendor_id;
     let pid = selector.product_id;
     let sn = selector.serial_number.as_deref();
@@ -392,12 +411,12 @@ fn is_cmsis_dap(id: &str) -> bool {
 
 /// Some devices don't have a CMSIS-DAP interface string, but are still
 /// CMSIS-DAP probes. We hardcode a list of known VID/PID pairs here.
-fn is_known_cmsis_dap_dev(device_descriptor: &DeviceDescriptor) -> bool {
+fn is_known_cmsis_dap_dev(device: &DeviceInfo) -> bool {
     // - 1a86:8012 WCH-Link in DAP mode, This shares the same description string as the
     //   WCH-Link in RV mode, so we have to check by vendor ID and product ID.
     const KNOWN_DAPS: &[(u16, u16)] = &[(0x1a86, 0x8012)];
 
-    KNOWN_DAPS.iter().any(|&(vid, pid)| {
-        device_descriptor.vendor_id() == vid && device_descriptor.product_id() == pid
-    })
+    KNOWN_DAPS
+        .iter()
+        .any(|&(vid, pid)| device.vendor_id() == vid && device.product_id() == pid)
 }

--- a/probe-rs/src/probe/jlink/jaylink/bits.rs
+++ b/probe-rs/src/probe/jlink/jaylink/bits.rs
@@ -1,0 +1,302 @@
+use std::fmt;
+
+/// An iterator over a received bit stream.
+#[derive(Clone)]
+pub struct BitIter<'a> {
+    buf: &'a [u8],
+    next_bit: u8,
+    bits_left: usize,
+}
+
+impl<'a> BitIter<'a> {
+    pub(crate) fn new(buf: &'a [u8], total_bits: usize) -> Self {
+        assert!(
+            buf.len() * 8 >= total_bits,
+            "cannot pull {} bits out of {} bytes",
+            total_bits,
+            buf.len()
+        );
+
+        Self {
+            buf,
+            next_bit: 0,
+            bits_left: total_bits,
+        }
+    }
+
+    /// Returns the number of bits left in `self`.
+    pub fn bits_left(&self) -> usize {
+        self.bits_left
+    }
+
+    /// Splits off another `BitIter` from `self`s current position that will return `count` bits.
+    ///
+    /// After this call, `self` will be advanced by `count` bits.
+    pub fn split_off(&mut self, count: usize) -> BitIter<'a> {
+        assert!(count <= self.bits_left);
+        let other = Self {
+            buf: self.buf,
+            next_bit: self.next_bit,
+            bits_left: count,
+        };
+
+        // Update self
+        let next_byte = (count + self.next_bit as usize) / 8;
+        self.next_bit = (count as u8 + self.next_bit) % 8;
+        self.buf = &self.buf[next_byte..];
+        self.bits_left -= count;
+        other
+    }
+}
+
+impl Iterator for BitIter<'_> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<bool> {
+        if self.bits_left > 0 {
+            let byte = self.buf.first().unwrap();
+            let bit = byte & (1 << self.next_bit) != 0;
+            if self.next_bit < 7 {
+                self.next_bit += 1;
+            } else {
+                self.next_bit = 0;
+                self.buf = &self.buf[1..];
+            }
+
+            self.bits_left -= 1;
+            Some(bit)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.bits_left, Some(self.bits_left))
+    }
+}
+
+impl ExactSizeIterator for BitIter<'_> {}
+
+impl fmt::Debug for BitIter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = self
+            .clone()
+            .map(|bit| if bit { '1' } else { '0' })
+            .collect::<String>();
+        write!(f, "BitIter({})", s)
+    }
+}
+
+pub(crate) trait IteratorExt: Sized {
+    fn collapse_bytes(self) -> ByteIter<Self>;
+}
+
+impl<I: Iterator<Item = bool>> IteratorExt for I {
+    fn collapse_bytes(self) -> ByteIter<Self> {
+        ByteIter { inner: self }
+    }
+}
+
+pub(crate) struct ByteIter<I> {
+    inner: I,
+}
+
+impl<I: Iterator<Item = bool>> Iterator for ByteIter<I> {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<u8> {
+        // Collapse 8 bits from `inner` into a byte (LSb first).
+        let mut byte = 0;
+        let mut empty = true;
+        for pos in 0..8 {
+            let bit = if let Some(bit) = self.inner.next() {
+                bit
+            } else {
+                break;
+            };
+            empty = false;
+            let mask = if bit { 1 } else { 0 } << pos;
+            byte |= mask;
+        }
+
+        if empty {
+            None
+        } else {
+            Some(byte)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collapse_bytes() {
+        fn collapse(v: Vec<bool>) -> Vec<u8> {
+            v.into_iter().collapse_bytes().collect()
+        }
+
+        assert_eq!(collapse(vec![]), vec![]);
+        assert_eq!(collapse(vec![true]), vec![0x01]);
+        assert_eq!(collapse(vec![false, true]), vec![0x02]);
+        assert_eq!(collapse(vec![true, false]), vec![0x01]);
+        assert_eq!(collapse(vec![false]), vec![0x00]);
+        assert_eq!(collapse(vec![false; 8]), vec![0x00]);
+        assert_eq!(collapse(vec![true; 8]), vec![0xFF]);
+        assert_eq!(collapse(vec![true; 7]), vec![0x7F]);
+        assert_eq!(collapse(vec![true; 9]), vec![0xFF, 0x01]);
+    }
+
+    #[test]
+    fn bit_iter() {
+        fn bit_iter(b: Vec<u8>, num: usize) -> Vec<bool> {
+            BitIter::new(&b, num).collect()
+        }
+
+        assert_eq!(bit_iter(vec![], 0), Vec::<bool>::new());
+        assert_eq!(bit_iter(vec![0xFF], 0), Vec::<bool>::new());
+        assert_eq!(bit_iter(vec![0xFF, 0xFF], 0), Vec::<bool>::new());
+        assert_eq!(bit_iter(vec![0xFF], 1), vec![true]);
+        assert_eq!(bit_iter(vec![0x00], 1), vec![false]);
+        assert_eq!(bit_iter(vec![0x01], 1), vec![true]);
+        assert_eq!(bit_iter(vec![0x01], 2), vec![true, false]);
+        assert_eq!(bit_iter(vec![0x02], 2), vec![false, true]);
+        assert_eq!(bit_iter(vec![0x02], 3), vec![false, true, false]);
+
+        assert_eq!(
+            bit_iter(vec![0x01, 0x01], 9),
+            vec![true, false, false, false, false, false, false, false, true]
+        );
+    }
+
+    #[test]
+    fn bit_iter_split_off() {
+        fn split(b: Vec<u8>, split: usize, total: usize) -> (Vec<bool>, Vec<bool>) {
+            let mut bits = BitIter::new(&b, total);
+            let first = bits.split_off(split);
+            let (first, second) = (first.collect::<Vec<_>>(), bits.collect::<Vec<_>>());
+            assert_eq!(first.len(), split);
+            assert_eq!(second.len(), total - split);
+            (first, second)
+        }
+
+        assert_eq!(split(vec![0xF0], 4, 8), (vec![false; 4], vec![true; 4]));
+        assert_eq!(
+            split(vec![0xF0], 5, 8),
+            (vec![false, false, false, false, true], vec![true; 3])
+        );
+        assert_eq!(
+            split(vec![0xF0], 3, 8),
+            (vec![false; 3], vec![false, true, true, true, true])
+        );
+
+        assert_eq!(
+            split(vec![0xF0, 0x01], 4, 9),
+            (vec![false; 4], vec![true; 5])
+        );
+        assert_eq!(
+            split(vec![0xF0, 0xFE], 4, 9),
+            (vec![false; 4], vec![true, true, true, true, false])
+        );
+
+        assert_eq!(
+            split(vec![0xFF, 0x01], 9, 16),
+            (vec![true; 9], vec![false; 7])
+        );
+
+        assert_eq!(
+            split(vec![0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55], 35, 64),
+            (
+                vec![
+                    false, true, false, true, false, true, false, true, true, false, true, false,
+                    true, false, true, false, false, true, false, true, false, true, false, true,
+                    true, false, true, false, true, false, true, false, false, true, false
+                ],
+                vec![
+                    true, false, true, false, true, true, false, true, false, true, false, true,
+                    false, false, true, false, true, false, true, false, true, true, false, true,
+                    false, true, false, true, false
+                ]
+            )
+        );
+
+        assert_eq!(
+            split(vec![0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55], 40, 64),
+            (
+                vec![
+                    false, true, false, true, false, true, false, true, true, false, true, false,
+                    true, false, true, false, false, true, false, true, false, true, false, true,
+                    true, false, true, false, true, false, true, false, false, true, false, true,
+                    false, true, false, true,
+                ],
+                vec![
+                    true, false, true, false, true, false, true, false, false, true, false, true,
+                    false, true, false, true, true, false, true, false, true, false, true, false
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn bit_iter_split_off_large_test() {
+        let mut iterator = BitIter::new(
+            &[
+                0xFF, 0x10, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x40, 0x04, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0x11, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x24, 0x08, 0x00, 0x00, 0x9E, 0xFF,
+            ],
+            208,
+        );
+
+        assert_eq!(
+            iterator.split_off(4).collect::<Vec<bool>>(),
+            vec![true, true, true, true]
+        );
+        assert_eq!(
+            iterator.split_off(8).collect::<Vec<bool>>(),
+            vec![true, true, true, true, false, false, false, false]
+        );
+        assert_eq!(
+            iterator.split_off(3).collect::<Vec<bool>>(),
+            vec![true, false, false]
+        );
+        assert_eq!(
+            iterator.split_off(35).collect::<Vec<bool>>(),
+            vec![
+                false, true, false, false, false, false, false, false, false, true, true, true,
+                true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+                true, true, true, true, true, true, true, true, true,
+            ]
+        );
+
+        assert_eq!(
+            iterator.split_off(4).collect::<Vec<bool>>(),
+            vec![true, true, true, true]
+        );
+        assert_eq!(
+            iterator.split_off(8).collect::<Vec<bool>>(),
+            vec![true, true, false, false, false, false, false, false]
+        );
+        assert_eq!(
+            iterator.split_off(3).collect::<Vec<bool>>(),
+            vec![true, false, false]
+        );
+
+        for _ in 0..35 {
+            iterator.next();
+        }
+
+        assert_eq!(
+            iterator.split_off(4).collect::<Vec<bool>>(),
+            vec![true, true, true, true]
+        );
+        assert_eq!(
+            iterator.split_off(8).collect::<Vec<bool>>(),
+            vec![true, true, true, true, true, true, true, true]
+        );
+        assert_eq!(
+            iterator.split_off(3).collect::<Vec<bool>>(),
+            vec![true, false, false]
+        );
+    }
+}

--- a/probe-rs/src/probe/jlink/jaylink/capabilities.rs
+++ b/probe-rs/src/probe/jlink/jaylink/capabilities.rs
@@ -1,0 +1,123 @@
+#![allow(non_upper_case_globals)]
+
+use std::fmt;
+
+enum_and_set!(
+    /// List of capabilities that may be advertised by a probe.
+    ///
+    /// Not many of these are actually used, and a lot of these have unknown meaning.
+    #[non_exhaustive]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum Capability {
+        Reserved0 = 0,  // Reserved, seems to be always set
+        GetHwVersion = 1,
+        WriteDcc = 2,
+        AdaptiveClocking = 3,
+        ReadConfig = 4,
+        WriteConfig = 5,
+        Trace = 6,
+        WriteMem = 7,
+        ReadMem = 8,
+        SpeedInfo = 9,
+        ExecCode = 10,
+        GetMaxBlockSize = 11,
+        GetHwInfo = 12,
+        SetKsPower = 13,
+        ResetStopTimed = 14,
+        // 15 = Reserved, seems to never be set
+        MeasureRtckReact = 16,
+        SelectIf = 17,
+        RwMemArm79 = 18,
+        GetCounters = 19,
+        ReadDcc = 20,
+        GetCpuCaps = 21,
+        ExecCpuCmd = 22,
+        Swo = 23,
+        WriteDccEx = 24,
+        UpdateFirmwareEx = 25,
+        FileIo = 26,
+        Register = 27,
+        Indicators = 28,
+        TestNetSpeed = 29,
+        RawTrace = 30,
+        // For the legacy capabilities, bit 31 is documented as reserved, but it must be
+        // GET_CAPS_EX, since there'd be no other way to know if GET_CAPS_EX is supported.
+        GetCapsEx = 31,
+
+        // Extended capabilities
+
+        HwJtagWrite = 32,
+        Com = 33,
+    }
+
+    flags CapabilityFlags: u128;
+);
+
+impl CapabilityFlags {
+    fn from_capability(cap: Capability) -> Self {
+        Self::from_bits(1 << cap as u32).unwrap()
+    }
+}
+
+/// A set of capabilities advertised by a probe.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct Capabilities(CapabilityFlags);
+
+impl Capabilities {
+    /// Creates a `Capabilities` instance from 32 raw bits.
+    pub(crate) fn from_raw_legacy(raw: u32) -> Self {
+        let mut capabilities = CapabilityFlags::from_bits_truncate(u128::from(raw));
+        if capabilities.bits() != u128::from(raw) {
+            tracing::debug!(
+                "unknown capability bits: 0x{:08X} truncated to 0x{:08X} ({:?})",
+                raw,
+                capabilities.bits(),
+                capabilities,
+            );
+        }
+        // Hide reserved bits from user-facing output.
+        capabilities.remove(CapabilityFlags::Reserved0);
+        Self(capabilities)
+    }
+
+    /// Creates a `Capabilities` instance from a 256-bit bitset.
+    pub(crate) fn from_raw_ex(raw: [u8; 32]) -> Self {
+        if raw[16..] != [0; 16] {
+            tracing::debug!(
+                "unknown ext. capability bits: dropping high 16 bytes {:02X?}",
+                &raw[16..],
+            );
+        }
+        let mut bytes = [0; 16];
+        bytes.copy_from_slice(&raw[..16]);
+        let raw = u128::from_le_bytes(bytes);
+        let mut capabilities = CapabilityFlags::from_bits_truncate(raw);
+        if capabilities.bits() != raw {
+            tracing::debug!(
+                "unknown ext. capability bits: 0x{:08X} truncated to 0x{:08X} ({:?})",
+                raw,
+                capabilities.bits(),
+                capabilities,
+            );
+        }
+        // Hide reserved bits from user-facing output.
+        capabilities.remove(CapabilityFlags::Reserved0);
+        Self(capabilities)
+    }
+
+    /// Determines whether `self` contains capability `cap`.
+    pub fn contains(&self, cap: Capability) -> bool {
+        self.0.contains(CapabilityFlags::from_capability(cap))
+    }
+
+    /// Determines whether `self` contains all capabilities in `caps`.
+    pub fn contains_all(&self, caps: Capabilities) -> bool {
+        self.0.contains(caps.0)
+    }
+}
+
+impl fmt::Debug for Capabilities {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/probe-rs/src/probe/jlink/jaylink/error.rs
+++ b/probe-rs/src/probe/jlink/jaylink/error.rs
@@ -1,0 +1,159 @@
+use std::fmt;
+
+type BoxedError = Box<dyn std::error::Error + Send + Sync>;
+
+#[allow(unused_imports)] // for intra-doc links
+use super::{scan_usb, Capabilities, JayLink};
+
+/// List of specific errors that may occur when using this library.
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ErrorKind {
+    /// A USB transport error occurred.
+    ///
+    /// This variant is used for all errors reported by the operating system when performing a USB
+    /// operation. It may indicate that the USB device was unplugged, that another application or an
+    /// operating system driver is currently using it, or that the current user does not have
+    /// permission to access it.
+    Usb,
+
+    /// No (matching) J-Link device was found.
+    ///
+    /// This error occurs when calling [`JayLink::open_by_serial`] while no J-Link device is connected
+    /// (or no device matching the serial number is connected).
+    DeviceNotFound,
+
+    /// Automatic device connection failed because multiple devices were found.
+    ///
+    /// This error occurs when calling [`JayLink::open_by_serial`] without a serial number while
+    /// multiple J-Link devices are connected. This library will refuse to "guess" a device and
+    /// requires specifying a serial number in this case. The [`scan_usb`] function can also be used
+    /// to find a specific device to connect to.
+    MultipleDevicesFound,
+
+    /// A operation was attempted that is not supported by the probe.
+    ///
+    /// Some operations are not supported by all firmware/hardware versions, and are instead
+    /// advertised as optional *capability* bits. This error occurs when the capability bit for an
+    /// operation isn't set when that operation is attempted.
+    ///
+    /// Capabilities can be read by calling [`JayLink::capabilities`], which returns a
+    /// [`Capabilities`] bitflags struct.
+    MissingCapability,
+
+    /// The device does not support the selected target interface.
+    InterfaceNotSupported,
+
+    /// An unspecified error occurred.
+    Other,
+}
+
+pub(crate) trait Cause {
+    const KIND: ErrorKind;
+}
+
+/// The error type used by this library.
+///
+/// Errors can be introspected by the user by calling [`Error::kind`] and inspecting the returned
+/// [`ErrorKind`].
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+    inner: BoxedError,
+    while_: Option<&'static str>,
+}
+
+impl Error {
+    pub(crate) fn new(kind: ErrorKind, inner: impl Into<BoxedError>) -> Self {
+        Self {
+            kind,
+            inner: inner.into(),
+            while_: None,
+        }
+    }
+
+    pub(crate) fn with_while(
+        kind: ErrorKind,
+        inner: impl Into<BoxedError>,
+        while_: &'static str,
+    ) -> Self {
+        Self {
+            kind,
+            inner: inner.into(),
+            while_: Some(while_),
+        }
+    }
+
+    fn fmt_while(&self) -> String {
+        if let Some(while_) = self.while_ {
+            format!(" while {}", while_)
+        } else {
+            String::new()
+        }
+    }
+
+    /// Returns the [`ErrorKind`] describing this error.
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Prefix foreign errors with further explanation where they're coming from
+        match self.kind {
+            ErrorKind::Usb => write!(f, "USB error{}: {}", self.fmt_while(), self.inner),
+            _ => {
+                if let Some(while_) = self.while_ {
+                    write!(f, "error{}: {}", while_, self.inner)
+                } else {
+                    self.inner.fmt(f)
+                }
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
+
+pub(crate) trait ResultExt<T, E> {
+    fn jaylink_err(self) -> Result<T, Error>
+    where
+        E: Cause + Into<BoxedError>;
+
+    fn jaylink_err_while(self, while_: &'static str) -> Result<T, Error>
+    where
+        E: Cause + Into<BoxedError>;
+}
+
+impl<T, E> ResultExt<T, E> for Result<T, E> {
+    fn jaylink_err(self) -> Result<T, Error>
+    where
+        E: Cause + Into<BoxedError>,
+    {
+        self.map_err(|e| Error::new(E::KIND, e))
+    }
+
+    fn jaylink_err_while(self, while_: &'static str) -> Result<T, Error>
+    where
+        E: Cause + Into<BoxedError>,
+    {
+        self.map_err(|e| Error::with_while(E::KIND, e, while_))
+    }
+}
+
+macro_rules! error_mapping {
+    ($errty:ty => $kind:ident) => {
+        impl Cause for $errty {
+            const KIND: ErrorKind = ErrorKind::$kind;
+        }
+    };
+}
+
+error_mapping!(std::io::Error => Usb);
+error_mapping!(nusb::transfer::TransferError => Usb);
+error_mapping!(String => Other);

--- a/probe-rs/src/probe/jlink/jaylink/interface.rs
+++ b/probe-rs/src/probe/jlink/jaylink/interface.rs
@@ -1,0 +1,181 @@
+#![allow(non_upper_case_globals)]
+
+use std::fmt;
+
+enum_and_set!(
+    /// List of target interfaces.
+    ///
+    /// Note that this library might not support all of them, despite listing them here.
+    #[non_exhaustive]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum Interface {
+        /// JTAG interface (IEEE 1149.1). Supported by most J-Link probes (some embedded J-Links might
+        /// only support SWD).
+        Jtag = 0,
+        /// SWD interface (Serial Wire Debug), used by most Cortex-M chips, and supported by almost all
+        /// J-Link probes.
+        Swd = 1,
+        /// Background Debug Mode 3, a single-wire debug interface used on some NXP microcontrollers.
+        Bdm3 = 2,
+        /// FINE, a two-wire debugging interface used by Renesas RX MCUs.
+        ///
+        /// **Note**: due to a bug, attempting to select FINE with [`JayLink::select_inferface`] will
+        /// currently hang the probe.
+        ///
+        /// [`JayLink::select_inferface`]: crate::JayLink::select_interface
+        // FIXME: There's a curious bug that hangs the probe when selecting the FINE interface.
+        // Specifically, the probe never sends back the previous interface after it receives the `c7 03`
+        // SELECT_IF cmd, even though the normal J-Link software also just sends `c7 03` and gets back
+        // the right response.
+        Fine = 3,
+        /// In-Circuit System Programming (ICSP) interface of PIC32 chips.
+        Pic32Icsp = 4,
+        /// Serial Peripheral Interface (for SPI Flash programming).
+        Spi = 5,
+        /// Silicon Labs' 2-wire debug interface.
+        C2 = 6,
+        /// [cJTAG], or compact JTAG, as specified in IEEE 1149.7.
+        ///
+        /// [cJTAG]: https://wiki.segger.com/J-Link_cJTAG_specifics.
+        CJtag = 7,
+        /// 2-wire debugging interface used by Microchip's IS208x MCUs.
+        Mc2WireJtag = 10,
+        // (*)
+        // NOTE: When changing this enum, also change all other places with a (*) in addition to
+        // anything that fails to compile.
+        // NOTE 2: Keep the docs in sync with the bitflags below!
+    }
+
+    flags InterfaceFlags: u32;
+);
+
+impl Interface {
+    pub(crate) fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl fmt::Display for Interface {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Interface::Jtag => "JTAG",
+            Interface::Swd => "SWD",
+            Interface::Bdm3 => "BDM3",
+            Interface::Fine => "FINE",
+            Interface::Pic32Icsp => "PIC32 ICSP",
+            Interface::Spi => "SPI",
+            Interface::C2 => "C2",
+            Interface::CJtag => "cJTAG",
+            Interface::Mc2WireJtag => "Microchip 2-wire JTAG",
+        })
+    }
+}
+
+impl InterfaceFlags {
+    fn from_interface(interface: Interface) -> Self {
+        InterfaceFlags::from_bits(1 << interface as u32).unwrap()
+    }
+}
+
+/// A set of supported target interfaces.
+///
+/// This implements `IntoIterator`, so you can call `.into_iter()` to iterate over the contained
+/// [`Interface`]s.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct Interfaces(InterfaceFlags);
+
+impl Interfaces {
+    pub(crate) fn from_bits_warn(raw: u32) -> Self {
+        let flags = InterfaceFlags::from_bits_truncate(raw);
+        if flags.bits() != raw {
+            tracing::debug!(
+                "unknown bits in interface mask: 0x{:08X} truncated to 0x{:08X} ({:?})",
+                raw,
+                flags.bits(),
+                flags,
+            );
+        }
+        Self(flags)
+    }
+
+    pub(crate) fn single(interface: Interface) -> Self {
+        Self(InterfaceFlags::from_interface(interface))
+    }
+
+    /// Returns whether `interface` is contained in `self`.
+    pub fn contains(&self, interface: Interface) -> bool {
+        self.0.contains(InterfaceFlags::from_interface(interface))
+    }
+}
+
+impl fmt::Debug for Interfaces {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl IntoIterator for Interfaces {
+    type Item = Interface;
+    type IntoIter = InterfaceIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        InterfaceIter {
+            interfaces: self,
+            next: 0,
+        }
+    }
+}
+
+/// Iterator over supported [`Interface`]s.
+#[derive(Debug)]
+pub struct InterfaceIter {
+    interfaces: Interfaces,
+    next: usize,
+}
+
+impl Iterator for InterfaceIter {
+    type Item = Interface;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let next = Interface::ALL.get(self.next)?;
+            self.next += 1;
+            if self.interfaces.contains(*next) {
+                return Some(*next);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iter() {
+        assert_eq!(
+            Interfaces(InterfaceFlags::empty())
+                .into_iter()
+                .collect::<Vec<_>>(),
+            &[]
+        );
+        assert_eq!(
+            Interfaces(InterfaceFlags::Jtag)
+                .into_iter()
+                .collect::<Vec<_>>(),
+            &[Interface::Jtag]
+        );
+        assert_eq!(
+            Interfaces(InterfaceFlags::Swd)
+                .into_iter()
+                .collect::<Vec<_>>(),
+            &[Interface::Swd]
+        );
+        assert_eq!(
+            Interfaces(InterfaceFlags::Jtag | InterfaceFlags::Swd)
+                .into_iter()
+                .collect::<Vec<_>>(),
+            &[Interface::Jtag, Interface::Swd]
+        );
+    }
+}

--- a/probe-rs/src/probe/jlink/jaylink/macros.rs
+++ b/probe-rs/src/probe/jlink/jaylink/macros.rs
@@ -1,0 +1,36 @@
+macro_rules! enum_and_set {
+    (
+        $( #[$enum_attr:meta] )*
+        $enum_vis:vis enum $enum_name:ident {
+            $(
+                $( #[$attr:meta] )*
+                $name:ident = $id:expr,
+            )+
+        }
+
+        flags $flags_name:ident: $flags_ty:ty;
+    ) => {
+        $( #[$enum_attr] )*
+        $enum_vis enum $enum_name {
+            $(
+                $( #[$attr] )*
+                $name = $id,
+            )+
+        }
+
+        impl $enum_name {
+            #[allow(dead_code)]
+            const ALL: &'static [Self] = &[
+                $( Self::$name ),+
+            ];
+        }
+
+        ::bitflags::bitflags! {
+            struct $flags_name: $flags_ty {
+                $(
+                    const $name = 1 << $id;
+                )+
+            }
+        }
+    };
+}

--- a/probe-rs/src/probe/jlink/jaylink/mod.rs
+++ b/probe-rs/src/probe/jlink/jaylink/mod.rs
@@ -1,0 +1,1364 @@
+//! A crate for talking to J-Link debug probes connected via USB.
+//!
+//! This crate allows access to the vendor-specific USB interface used to control JTAG / SWD
+//! operations and other functionality. It does *not* provide access to the virtual COM port
+//! functionality (which is a regular CDC device, so no special support is needed).
+//!
+//! Inspired by [libjaylink] (though this library is not a port).
+//!
+//! [libjaylink]: https://repo.or.cz/libjaylink.git
+//!
+//! # Pinout
+//!
+//! J-Link uses a pinout based on the standard 20-pin ARM JTAG connector, extended for SWD
+//! compatibility and with pins for UART.
+//!
+//! JTAG pinout:
+//!
+//! ```notrust
+//!            ┌───────────┐
+//!     VTref  │ *  1  2 * │ NC
+//!     nTRST  │ *  3  4 * │ GND
+//!       TDI  │ *  5  6 * │ GND
+//!       TMS  │ *  7  8 * │ GND
+//!       TCK ┌┘ *  9 10 * │ GND
+//!      RTCK └┐ * 11 12 * │ GND
+//!       TDO  │ * 13 14 * │ GND
+//!     RESET  │ * 15 16 * │ GND
+//!     DBGRQ  │ * 17 18 * │ GND
+//! 5V-Supply  │ * 19 20 * │ GND
+//!            └───────────┘
+//! ```
+//!
+//! SWD (+ UART) pinout:
+//!
+//! ```notrust
+//!            ┌───────────┐
+//!     VTref  │ *  1  2 * │ NC
+//!         -  │ *  3  4 * │ GND
+//! J-Link TX  │ *  5  6 * │ GND
+//!     SWDIO  │ *  7  8 * │ GND
+//!     SWCLK ┌┘ *  9 10 * │ GND
+//!         - └┐ * 11 12 * │ GND
+//!       SWO  │ * 13 14 * │ GND
+//!     RESET  │ * 15 16 * │ GND
+//! J-Link RX  │ * 17 18 * │ GND
+//! 5V-Supply  │ * 19 20 * │ GND
+//!            └───────────┘
+//! ```
+//!
+//! PIC32 ICSP pinout (untested):
+//!
+//! ```notrust
+//!            ┌───────────┐
+//!     VTref  │ *  1  2 * │ NC
+//!         -  │ *  3  4 * │ GND
+//!         -  │ *  5  6 * │ GND
+//!      PGED  │ *  7  8 * │ GND
+//!      PGEC ┌┘ *  9 10 * │ GND
+//!         - └┐ * 11 12 * │ GND
+//!         -  │ * 13 14 * │ GND
+//!     RESET  │ * 15 16 * │ GND
+//!         -  │ * 17 18 * │ GND
+//! 5V-Supply  │ * 19 20 * │ GND
+//!            └───────────┘
+//! ```
+//!
+//! # Reference
+//!
+//! Segger has released a PDF documenting the USB protocol: "Reference manual for J-Link USB
+//! Protocol" (Document RM08001-R2).
+//!
+//! The archive.org version is the most up-to-date one.
+
+#![warn(missing_debug_implementations, unreachable_pub)]
+// We use explicit lifetimes to make APIs easier to understand (this also affects rustdoc)
+#![allow(clippy::needless_lifetimes)]
+#![allow(unreachable_pub)]
+#![allow(unused)]
+
+#[macro_use]
+mod macros;
+mod bits;
+mod capabilities;
+mod error;
+mod interface;
+
+use crate::probe::usb_util::InterfaceExt;
+
+pub(crate) use self::bits::BitIter;
+pub(crate) use self::capabilities::{Capabilities, Capability};
+pub(crate) use self::error::{Error, ErrorKind};
+pub(crate) use self::interface::{Interface, Interfaces};
+
+use self::bits::IteratorExt as _;
+use self::error::ResultExt as _;
+use bitflags::bitflags;
+use byteorder::{LittleEndian, ReadBytesExt};
+use io::Cursor;
+use nusb::transfer::{Direction, EndpointType};
+use nusb::DeviceInfo;
+use std::cell::{Cell, RefCell, RefMut};
+use std::convert::{TryFrom, TryInto};
+use std::time::{Duration, Instant};
+use std::{
+    cmp, fmt,
+    io::{self, Read},
+    ops::Deref,
+    thread,
+};
+use tracing::{debug, trace, warn};
+
+/// A result type with the error hardwired to [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;
+
+const VID_SEGGER: u16 = 0x1366;
+
+const TIMEOUT_DEFAULT: Duration = Duration::from_millis(500);
+
+#[repr(u8)]
+#[allow(dead_code)]
+enum Command {
+    Version = 0x01,
+    GetSpeeds = 0xC0,
+    GetMaxMemBlock = 0xD4,
+    GetCaps = 0xE8,
+    GetCapsEx = 0xED,
+    GetHwVersion = 0xF0,
+
+    GetState = 0x07,
+    GetHwInfo = 0xC1,
+    GetCounters = 0xC2,
+    MeasureRtckReact = 0xF6,
+
+    ResetTrst = 0x02,
+    SetSpeed = 0x05,
+    SelectIf = 0xC7,
+    SetKsPower = 0x08,
+    HwClock = 0xC8,
+    HwTms0 = 0xC9,
+    HwTms1 = 0xCA,
+    HwData0 = 0xCB,
+    HwData1 = 0xCC,
+    HwJtag = 0xCD,
+    HwJtag2 = 0xCE,
+    HwJtag3 = 0xCF,
+    HwJtagWrite = 0xD5,
+    HwJtagGetResult = 0xD6,
+    HwTrst0 = 0xDE,
+    HwTrst1 = 0xDF,
+    Swo = 0xEB,
+    WriteDcc = 0xF1,
+
+    ResetTarget = 0x03,
+    HwReleaseResetStopEx = 0xD0,
+    HwReleaseResetStopTimed = 0xD1,
+    HwReset0 = 0xDC,
+    HwReset1 = 0xDD,
+    GetCpuCaps = 0xE9,
+    ExecCpuCmd = 0xEA,
+    WriteMem = 0xF4,
+    ReadMem = 0xF5,
+    WriteMemArm79 = 0xF7,
+    ReadMemArm79 = 0xF8,
+
+    ReadConfig = 0xF2,
+    WriteConfig = 0xF3,
+}
+
+#[repr(u8)]
+enum SwoCommand {
+    Start = 0x64,
+    Stop = 0x65,
+    Read = 0x66,
+    GetSpeeds = 0x6E,
+}
+
+#[repr(u8)]
+enum SwoParam {
+    Mode = 0x01,
+    Baudrate = 0x02,
+    ReadSize = 0x03,
+    BufferSize = 0x04,
+    // FIXME: Do these have hardware/firmware version requirements to be recognized?
+}
+
+/// The supported SWO data encoding modes.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u32)]
+#[non_exhaustive]
+pub enum SwoMode {
+    Uart = 0x00000000,
+    // FIXME: Manchester encoding?
+}
+
+bitflags! {
+    /// SWO status returned by probe on SWO buffer read.
+    struct SwoStatus: u32 {
+        /// The on-probe buffer has overflowed. Device data was lost.
+        const OVERRUN = 1 << 0;
+    }
+}
+
+impl SwoStatus {
+    fn new(bits: u32) -> Self {
+        let flags = SwoStatus::from_bits_truncate(bits);
+        if flags.bits() != bits {
+            warn!("Unknown SWO status flag bits: 0x{:08X}", bits);
+        }
+        flags
+    }
+}
+
+/// A handle to a J-Link USB device.
+///
+/// This is the main interface type of this library. There are multiple ways of obtaining an
+/// instance of it:
+///
+/// * [`JayLink::open_by_serial`]: Either opens the only J-Link device connected to the computer, or
+///   opens a specific one by its serial number. Recommended for applications that interact with one
+///   J-Link device only (ie. most of them).
+/// * [`JayLink::open_usb`]: Opens a specific J-Link device according to the given
+///   [`UsbDeviceInfo`]. Also see [`scan_usb`].
+pub struct JayLink {
+    handle: nusb::Interface,
+
+    read_ep: u8,
+    write_ep: u8,
+    cmd_buf: RefCell<Vec<u8>>,
+
+    /// The capabilities reported by the device. They're fetched once, when the device is opened.
+    caps: Capabilities,
+
+    /// The supported interfaces. Like `caps`, this is fetched once when opening the device.
+    interfaces: Interfaces,
+
+    /// The currently selected target interface. This is stored here to avoid unnecessary roundtrips
+    /// when performing target I/O operations.
+    interface: Interface,
+}
+
+impl JayLink {
+    /// Opens a specific J-Link USB device.
+    ///
+    /// **Note**: Probes remember their selected interfaces between reconnections, so it is
+    /// recommended to always call [`JayLink::select_interface`] after opening a probe.
+    pub fn open_usb(usb_device: DeviceInfo) -> Result<Self> {
+        fn open_error(e: std::io::Error, while_: &'static str) -> Error {
+            let inner: Box<dyn std::error::Error + Send + Sync> = if cfg!(windows) {
+                format!(
+                    "{} (this error may be caused by not having the \
+                        WinUSB driver installed; use Zadig (https://zadig.akeo.ie/) to install it \
+                        for the J-Link device; this will replace the SEGGER J-Link driver)",
+                    e
+                )
+                .into()
+            } else {
+                Box::new(e)
+            };
+
+            Error::with_while(ErrorKind::Usb, inner, while_)
+        }
+
+        let handle = usb_device
+            .open()
+            .map_err(|e| open_error(e, "opening USB device"))?;
+
+        let configs: Vec<_> = handle.configurations().collect();
+
+        if configs.len() != 1 {
+            warn!("device has {} configurations, expected 1", configs.len());
+        }
+
+        let conf = &configs[0];
+        debug!("scanning {} interfaces", conf.interfaces().count());
+        trace!("active configuration descriptor: {:#x?}", conf);
+
+        let mut jlink_intf = None;
+        for intf in conf.interfaces() {
+            trace!("interface #{} descriptors:", intf.interface_number());
+
+            for descr in intf.alt_settings() {
+                trace!("{:#x?}", descr);
+
+                // We detect the proprietary J-Link interface using the vendor-specific class codes
+                // and the endpoint properties
+                if descr.class() == 0xff && descr.subclass() == 0xff && descr.protocol() == 0xff {
+                    if let Some((intf, _, _)) = jlink_intf {
+                        return Err(format!(
+                            "found multiple matching USB interfaces ({} and {})",
+                            intf,
+                            descr.interface_number()
+                        ))
+                        .jaylink_err();
+                    }
+
+                    let endpoints: Vec<_> = descr.endpoints().collect();
+                    trace!("endpoint descriptors: {:#x?}", endpoints);
+                    if endpoints.len() != 2 {
+                        warn!("vendor-specific interface with {} endpoints, expected 2 (skipping interface)", endpoints.len());
+                        continue;
+                    }
+
+                    if !endpoints
+                        .iter()
+                        .all(|ep| ep.transfer_type() == EndpointType::Bulk)
+                    {
+                        warn!(
+                            "encountered non-bulk endpoints, skipping interface: {:#x?}",
+                            endpoints
+                        );
+                        continue;
+                    }
+
+                    let (read_ep, write_ep) = if endpoints[0].direction() == Direction::In {
+                        (endpoints[0].address(), endpoints[1].address())
+                    } else {
+                        (endpoints[1].address(), endpoints[0].address())
+                    };
+
+                    jlink_intf = Some((descr.interface_number(), read_ep, write_ep));
+                    debug!("J-Link interface is #{}", descr.interface_number());
+                }
+            }
+        }
+
+        let (intf, read_ep, write_ep) = if let Some(intf) = jlink_intf {
+            intf
+        } else {
+            return Err("device is not a J-Link device".to_string()).jaylink_err();
+        };
+
+        let handle = handle
+            .claim_interface(intf)
+            .map_err(|e| open_error(e, "taking control over USB device"))?;
+
+        let mut this = Self {
+            read_ep,
+            write_ep,
+            cmd_buf: RefCell::new(Vec::new()),
+            caps: Capabilities::from_raw_legacy(0), // dummy value
+            interface: Interface::Spi,              // dummy value, must not be JTAG
+            interfaces: Interfaces::from_bits_warn(0), // dummy value
+            handle,
+        };
+        this.fill_capabilities()?;
+        this.fill_interfaces()?;
+
+        Ok(this)
+    }
+
+    /// Reads the advertised capabilities from the device.
+    fn fill_capabilities(&mut self) -> Result<()> {
+        self.write_cmd(&[Command::GetCaps as u8])?;
+
+        let mut buf = [0; 4];
+        self.read(&mut buf)?;
+
+        let mut caps = Capabilities::from_raw_legacy(u32::from_le_bytes(buf));
+        debug!("legacy caps: {:?}", caps);
+
+        // If the `GET_CAPS_EX` capability is set, use the extended capability command to fetch
+        // all the capabilities.
+        if caps.contains(Capability::GetCapsEx) {
+            self.write_cmd(&[Command::GetCapsEx as u8])?;
+
+            let mut buf = [0; 32];
+            self.read(&mut buf)?;
+            let real_caps = Capabilities::from_raw_ex(buf);
+            if !real_caps.contains_all(caps) {
+                return Err(format!(
+                    "ext. caps are not a superset of legacy caps (legacy: {:?}, ex: {:?})",
+                    caps, real_caps
+                ))
+                .jaylink_err();
+            }
+            debug!("extended caps: {:?}", real_caps);
+            caps = real_caps;
+        } else {
+            debug!("extended caps not supported");
+        }
+
+        self.caps = caps;
+        Ok(())
+    }
+
+    fn fill_interfaces(&mut self) -> Result<()> {
+        if !self.capabilities().contains(Capability::SelectIf) {
+            // Pre-SELECT_IF probes only support JTAG.
+            self.interfaces = Interfaces::single(Interface::Jtag);
+            self.interface = Interface::Jtag;
+
+            return Ok(());
+        }
+
+        self.write_cmd(&[Command::SelectIf as u8, 0xFF])?;
+
+        let mut buf = [0; 4];
+        self.read(&mut buf)?;
+
+        let intfs = Interfaces::from_bits_warn(u32::from_le_bytes(buf));
+        self.interfaces = intfs;
+        Ok(())
+    }
+
+    fn buf(&self, len: usize) -> RefMut<'_, Vec<u8>> {
+        let mut vec = self.cmd_buf.borrow_mut();
+        vec.resize(len, 0);
+        vec
+    }
+
+    fn write_cmd(&self, cmd: &[u8]) -> Result<()> {
+        trace!("write {} bytes: {:x?}", cmd.len(), cmd);
+
+        let n = self
+            .handle
+            .write_bulk(self.write_ep, cmd, TIMEOUT_DEFAULT)
+            .jaylink_err_while("writing data to device")?;
+
+        if n != cmd.len() {
+            return Err(format!(
+                "incomplete write (expected {} bytes, wrote {})",
+                cmd.len(),
+                n
+            ))
+            .jaylink_err();
+        }
+        Ok(())
+    }
+
+    fn read(&self, buf: &mut [u8]) -> Result<()> {
+        let mut total = 0;
+
+        while total < buf.len() {
+            let n = self
+                .handle
+                .read_bulk(self.read_ep, &mut buf[total..], TIMEOUT_DEFAULT)
+                .jaylink_err_while("reading from device")?;
+            total += n;
+        }
+
+        trace!("read {} bytes: {:x?}", buf.len(), buf);
+
+        Ok(())
+    }
+
+    fn require_capability(&self, cap: Capability) -> Result<()> {
+        if self.capabilities().contains(cap) {
+            Ok(())
+        } else {
+            Err(Error::new(
+                ErrorKind::MissingCapability,
+                format!("device is missing capabilities ({:?}) for operation", cap),
+            ))
+        }
+    }
+
+    fn require_interface_supported(&self, intf: Interface) -> Result<()> {
+        if self.interfaces.contains(intf) {
+            Ok(())
+        } else {
+            Err(Error::new(
+                ErrorKind::InterfaceNotSupported,
+                format!("probe does not support target interface {:?}", intf),
+            ))
+        }
+    }
+
+    fn require_interface_selected(&self, intf: Interface) -> Result<()> {
+        if self.interface == intf {
+            Ok(())
+        } else {
+            Err(Error::new(
+                ErrorKind::Other,
+                format!("interface {} must be selected for this operation (currently using interface {})", intf, self.interface),
+            ))
+        }
+    }
+
+    /// Reads the firmware version string from the device.
+    pub fn read_firmware_version(&self) -> Result<String> {
+        self.write_cmd(&[Command::Version as u8])?;
+
+        let mut buf = [0; 2];
+        self.read(&mut buf)?;
+        let num_bytes = u16::from_le_bytes(buf);
+        let mut buf = self.buf(num_bytes.into());
+        let buf = &mut buf[..usize::from(num_bytes)];
+        self.read(buf)?;
+
+        Ok(String::from_utf8_lossy(
+            // The firmware version string returned may contain null bytes. If
+            // this happens, only return the preceding bytes.
+            match buf.iter().position(|&b| b == 0) {
+                Some(pos) => &buf[..pos],
+                None => buf,
+            },
+        )
+        .into_owned())
+    }
+
+    /// Reads the hardware version from the device.
+    ///
+    /// This requires the probe to support [`Capability::GetHwVersion`].
+    pub fn read_hardware_version(&self) -> Result<HardwareVersion> {
+        self.require_capability(Capability::GetHwVersion)?;
+
+        self.write_cmd(&[Command::GetHwVersion as u8])?;
+
+        let mut buf = [0; 4];
+        self.read(&mut buf)?;
+
+        Ok(HardwareVersion::from_u32(u32::from_le_bytes(buf)))
+    }
+
+    /// Reads the probe's communication speed information about the currently selected interface.
+    ///
+    /// Supported speeds may differ between [`Interface`]s, so the right interface needs to be
+    /// selected for the returned value to make sense.
+    ///
+    /// This requires the probe to support [`Capability::SpeedInfo`].
+    pub fn read_speeds(&self) -> Result<SpeedInfo> {
+        self.require_capability(Capability::SpeedInfo)?;
+
+        self.write_cmd(&[Command::GetSpeeds as u8])?;
+
+        let mut buf = [0; 6];
+        self.read(&mut buf)?;
+        let mut buf = &buf[..];
+
+        Ok(SpeedInfo {
+            base_freq: buf.read_u32::<LittleEndian>().unwrap(),
+            min_div: buf.read_u16::<LittleEndian>().unwrap(),
+        })
+    }
+
+    /// Reads the probe's SWO capture speed information.
+    ///
+    /// This requires the probe to support [`Capability::Swo`].
+    pub fn read_swo_speeds(&self, mode: SwoMode) -> Result<SwoSpeedInfo> {
+        self.require_capability(Capability::Swo)?;
+
+        let mut buf = [0; 9];
+        buf[0] = Command::Swo as u8;
+        buf[1] = SwoCommand::GetSpeeds as u8;
+        buf[2] = 0x04; // Next param has 4 data Bytes
+        buf[3] = SwoParam::Mode as u8;
+        buf[4..8].copy_from_slice(&(mode as u32).to_le_bytes());
+        buf[8] = 0x00;
+
+        self.write_cmd(&buf)?;
+
+        let mut buf = [0; 28];
+        self.read(&mut buf)?;
+
+        let mut len = [0; 4];
+        len.copy_from_slice(&buf[0..4]);
+        let len = u32::from_le_bytes(len);
+        if len != 28 {
+            return Err(Error::new(
+                ErrorKind::Other,
+                format!("Unexpected response length {}, expected 28", len),
+            ));
+        }
+
+        // Skip length and reserved word.
+        // FIXME: What's the word after the length for?
+        let mut buf = &buf[8..];
+
+        Ok(SwoSpeedInfo {
+            base_freq: buf.read_u32::<LittleEndian>().unwrap(),
+            min_div: buf.read_u32::<LittleEndian>().unwrap(),
+            max_div: buf.read_u32::<LittleEndian>().unwrap(),
+            min_presc: buf.read_u32::<LittleEndian>().unwrap(),
+            max_presc: buf.read_u32::<LittleEndian>().unwrap(),
+        })
+    }
+
+    /// Reads the maximum mem block size in Bytes.
+    ///
+    /// This requires the probe to support [`Capability::GetMaxBlockSize`].
+    pub fn read_max_mem_block(&self) -> Result<u32> {
+        // This cap refers to a nonexistent command `GET_MAX_BLOCK_SIZE`, but it probably means
+        // `GET_MAX_MEM_BLOCK`.
+        self.require_capability(Capability::GetMaxBlockSize)?;
+
+        self.write_cmd(&[Command::GetMaxMemBlock as u8])?;
+
+        let mut buf = [0; 4];
+        self.read(&mut buf)?;
+
+        Ok(u32::from_le_bytes(buf))
+    }
+
+    /// Returns the capabilities advertised by the probe.
+    pub fn capabilities(&self) -> Capabilities {
+        self.caps
+    }
+
+    /// Returns the set of target interfaces supported by the probe.
+    pub fn available_interfaces(&self) -> Interfaces {
+        self.interfaces
+    }
+
+    /// Reads the currently selected target interface.
+    ///
+    /// **Note**: There is no guarantee that the returned interface is actually supported (ie. it
+    /// might not be in the list returned by [`JayLink::available_interfaces`]). In particular, some
+    /// embedded J-Link probes start up with JTAG selected, but only support SWD.
+    pub fn current_interface(&self) -> Interface {
+        self.interface
+    }
+
+    /// Selects the interface to use for talking to the target MCU.
+    ///
+    /// Switching interfaces will reset the configured transfer speed, so [`JayLink::set_speed`]
+    /// needs to be called *after* `select_interface`.
+    ///
+    /// This requires the probe to support [`Capability::SelectIf`].
+    ///
+    /// **Note**: Selecting a different interface may cause the J-Link to perform target I/O!
+    pub fn select_interface(&mut self, intf: Interface) -> Result<()> {
+        if self.interface == intf {
+            return Ok(());
+        }
+
+        self.require_capability(Capability::SelectIf)?;
+
+        self.require_interface_supported(intf)?;
+
+        self.write_cmd(&[Command::SelectIf as u8, intf.as_u8()])?;
+
+        // Returns the previous interface, ignore it
+        let mut buf = [0; 4];
+        self.read(&mut buf)?;
+
+        self.interface = intf;
+
+        Ok(())
+    }
+
+    /// Changes the state of the TMS / SWDIO pin (pin 7).
+    ///
+    /// The pin will be set to the level of `VTref` if `tms` is `true`, and to GND if it is `false`.
+    ///
+    /// **Note**: On some hardware, detaching `VTref` might not affect the internal reading, so the
+    /// old level might still be used afterwards.
+    pub fn set_tms(&mut self, tms: bool) -> Result<()> {
+        let cmd = if tms {
+            Command::HwTms1
+        } else {
+            Command::HwTms0
+        };
+        self.write_cmd(&[cmd as u8])
+    }
+
+    /// Changes the state of the TDI / TX pin (pin 5).
+    ///
+    /// The pin will be set to the level of `VTref` if `tdi` is `true`, and to GND if it is `false`.
+    ///
+    /// **Note**: On some hardware, detaching `VTref` might not affect the internal reading, so the
+    /// old level might still be used afterwards.
+    pub fn set_tdi(&mut self, tdi: bool) -> Result<()> {
+        let cmd = if tdi {
+            Command::HwData1
+        } else {
+            Command::HwData0
+        };
+        self.write_cmd(&[cmd as u8])
+    }
+
+    /// Changes the state of the (n)TRST pin (pin 3).
+    ///
+    /// The pin will be set to the level of `VTref` if `trst` is `true`, and to GND if it is
+    /// `false`.
+    ///
+    /// **Note**: On some hardware, detaching `VTref` might not affect the internal reading, so the
+    /// old level might still be used afterwards.
+    ///
+    /// **Note**: Some embedded J-Link probes may not expose this pin or may not allow controlling
+    /// it using this function.
+    pub fn set_trst(&mut self, trst: bool) -> Result<()> {
+        let cmd = if trst {
+            Command::HwTrst1
+        } else {
+            Command::HwTrst0
+        };
+        self.write_cmd(&[cmd as u8])
+    }
+
+    /// Changes the state of the RESET pin (pin 15).
+    ///
+    /// RESET is an open-collector / open-drain output. If `reset` is `true`, the output will float.
+    /// If `reset` is `false`, the output will be pulled to ground.
+    ///
+    /// **Note**: Some embedded J-Link probes may not expose this pin or may not allow controlling
+    /// it using this function.
+    pub fn set_reset(&mut self, reset: bool) -> Result<()> {
+        let cmd = if reset {
+            Command::HwReset1
+        } else {
+            Command::HwReset0
+        };
+        self.write_cmd(&[cmd as u8])
+    }
+
+    /// Resets the target's JTAG TAP controller by temporarily asserting (n)TRST (Pin 3).
+    ///
+    /// This might not do anything if the pin is not connected to the target. It does not affect
+    /// non-JTAG target interfaces.
+    pub fn reset_trst(&mut self) -> Result<()> {
+        self.write_cmd(&[Command::ResetTrst as u8])
+    }
+
+    /// Resets the target by temporarily asserting the RESET pin (pin 15).
+    ///
+    /// This might not do anything if the RESET pin is not connected to the target.
+    pub fn reset_target(&mut self) -> Result<()> {
+        self.write_cmd(&[Command::ResetTarget as u8])
+    }
+
+    /// Sets the target communication speed.
+    ///
+    /// If `speed` is set to [`SpeedConfig::ADAPTIVE`], then the probe has to support
+    /// [`Capability::AdaptiveClocking`]. Note that adaptive clocking may not work for all target
+    /// interfaces (eg. SWD).
+    ///
+    /// When the selected target interface is switched (by calling [`JayLink::select_interface`], or
+    /// any API method that automatically selects an interface), the communication speed is reset to
+    /// some unspecified default value.
+    pub fn set_speed(&mut self, speed: SpeedConfig) -> Result<()> {
+        if speed.raw == SpeedConfig::ADAPTIVE.raw {
+            self.require_capability(Capability::AdaptiveClocking)?;
+        }
+
+        let mut buf = [Command::SetSpeed as u8, 0, 0];
+        buf[1..3].copy_from_slice(&speed.raw.to_le_bytes());
+        self.write_cmd(&buf)?;
+
+        Ok(())
+    }
+
+    /// Reads the target voltage measured on the `VTref` pin, in millivolts.
+    ///
+    /// In order to use the J-Link, this voltage must be present, since it will be used as the level
+    /// of the I/O signals to the target.
+    pub fn read_target_voltage(&self) -> Result<u16> {
+        self.write_cmd(&[Command::GetState as u8])?;
+
+        let mut buf = [0; 8];
+        self.read(&mut buf)?;
+
+        let voltage = [buf[0], buf[1]];
+        Ok(u16::from_le_bytes(voltage))
+    }
+
+    /// Enables or disables the 5V Power supply on pin 19.
+    ///
+    /// This requires the probe to support [`Capability::SetKsPower`].
+    ///
+    /// **Note**: The startup state of the power supply can be configured in non-volatile memory.
+    ///
+    /// **Note**: Some embedded J-Links may not provide this feature or do not have the 5V supply
+    /// routed to a pin. In that case this function might return an error, or it might return
+    /// successfully, but without doing anything.
+    ///
+    /// **Note**: The 5V supply is protected against overcurrent. Check the device manual for more
+    /// information on this.
+    ///
+    /// [`SET_KS_POWER`]: Capabilities::SET_KS_POWER
+    pub fn set_kickstart_power(&mut self, enable: bool) -> Result<()> {
+        self.require_capability(Capability::SetKsPower)?;
+        self.write_cmd(&[Command::SetKsPower as u8, enable as u8])?;
+        Ok(())
+    }
+
+    /// Performs a JTAG I/O operation.
+    ///
+    /// This will shift out data on `TMS` (pin 7) and `TDI` (pin 5), while reading data shifted
+    /// into `TDO` (pin 13).
+    ///
+    /// The data received on `TDO` is returned to the caller as an iterator yielding `bool`s.
+    ///
+    /// The caller must ensure that the probe is in JTAG mode by calling
+    /// [`JayLink::select_interface`]`(`[`Interface::Jtag`]`)`.
+    ///
+    /// # Parameters
+    ///
+    /// * `tms`: TMS bits to transmit.
+    /// * `tdi`: TDI bits to transmit.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `tms` and `tdi` have different lengths. It will also panic if any
+    /// of them contains more then 65535 bits of data, which is the maximum amount that can be
+    /// transferred in one operation.
+    ///
+    // NB: Explicit `'a` lifetime used to improve rustdoc output
+    pub fn jtag_io<'a, M, D>(&'a mut self, tms: M, tdi: D) -> Result<BitIter<'a>>
+    where
+        M: IntoIterator<Item = bool>,
+        D: IntoIterator<Item = bool>,
+    {
+        self.require_interface_selected(Interface::Jtag)?;
+
+        let mut has_status_byte = false;
+        // There's 3 commands for doing a JTAG transfer. The older 2 are obsolete with hardware
+        // version 5 and above, which adds the 3rd command. Unfortunately we cannot reliably use the
+        // HW version to determine this since some embedded J-Link probes have a HW version of
+        // 1.0.0, but still support SWD, so we use the `SELECT_IF` capability instead.
+        let cmd = if self.capabilities().contains(Capability::SelectIf) {
+            // Use the new JTAG3 command, make sure to select the JTAG interface mode
+            self.select_interface(Interface::Jtag)?;
+            has_status_byte = true;
+            Command::HwJtag3
+        } else {
+            // Use the legacy JTAG2 command
+            // FIXME is HW_JTAG relevant at all?
+            Command::HwJtag2
+        };
+
+        // Collect the bit iterators into the buffer. We don't know the length in advance.
+        let tms = tms.into_iter();
+        let tdi = tdi.into_iter();
+        let bit_count_hint = cmp::max(tms.size_hint().0, tdi.size_hint().0);
+        let capacity = 1 + 1 + 2 + ((bit_count_hint + 7) / 8) * 2;
+        let mut buf = self.buf(capacity);
+        buf.resize(4, 0);
+        buf[0] = cmd as u8;
+        // buf[1] is dummy data for alignment
+        // buf[2..=3] is the bit count, which we'll fill in later
+        let mut tms_bit_count = 0;
+        buf.extend(tms.inspect(|_| tms_bit_count += 1).collapse_bytes());
+        let mut tdi_bit_count = 0;
+        buf.extend(tdi.inspect(|_| tdi_bit_count += 1).collapse_bytes());
+
+        assert_eq!(
+            tms_bit_count, tdi_bit_count,
+            "TMS and TDI must have the same number of bits"
+        );
+
+        let bit_count = u16::try_from(tms_bit_count).expect("too much data to transfer");
+
+        // JTAG3 and JTAG2 use the same format for JTAG operations
+        buf[2..=3].copy_from_slice(&bit_count.to_le_bytes());
+
+        self.write_cmd(&buf)?;
+
+        // Round bit count up to multple of 8 to get the number of response bytes.
+        let num_resp_bytes = (tms_bit_count + 7) >> 3;
+        trace!(
+            "{} TMS/TDI bits sent; reading {} response bytes",
+            tms_bit_count,
+            num_resp_bytes
+        );
+
+        // Response is `num_resp_bytes` TDO data bytes and one status byte,
+        // if the JTAG3 command is used.
+        let mut read_len = num_resp_bytes;
+
+        if has_status_byte {
+            read_len += 1;
+        }
+
+        self.read(&mut buf[..read_len])?;
+
+        // Check the status if a JTAG3 command was used.
+        if has_status_byte && buf[read_len - 1] != 0 {
+            return Err(Error::new(
+                ErrorKind::Other,
+                format!(
+                    "probe I/O command returned error code {:#x}",
+                    buf[read_len - 1]
+                ),
+            ));
+        }
+
+        drop(buf);
+
+        Ok(BitIter::new(
+            &self.cmd_buf.get_mut()[..num_resp_bytes],
+            tms_bit_count,
+        ))
+    }
+
+    /// Performs an SWD I/O operation.
+    ///
+    /// This requires the probe to support [`Capability::SelectIf`] and support for
+    /// [`Interface::Swd`].
+    ///
+    /// The caller must ensure that the probe is in SWD mode by calling
+    /// [`JayLink::select_interface`]`(`[`Interface::Swd`]`)`.
+    ///
+    /// # Parameters
+    ///
+    /// * `dir`: Transfer directions of the `swdio` bits (`false` = 0 = Input, `true` = 1 = Output).
+    /// * `swdio`: SWD data bits.
+    ///
+    /// If `dir` is `true`, the corresponding bit in `swdio` will be written to the target; if it is
+    /// `false`, the bit in `swdio` is ignored and a bit is read from the target instead.
+    ///
+    /// # Return Value
+    ///
+    /// An iterator over the `SWDIO` bits is returned. Bits that were sent to the target (where
+    /// `dir` = `true`) are undefined, and bits that were read from the target (`dir` = `false`)
+    /// will have whatever value the target sent.
+    // NB: Explicit `'a` lifetime used to improve rustdoc output
+    pub fn swd_io<'a, D, S>(&'a mut self, dir: D, swdio: S) -> Result<BitIter<'a>>
+    where
+        D: IntoIterator<Item = bool>,
+        S: IntoIterator<Item = bool>,
+    {
+        self.require_interface_selected(Interface::Swd)?;
+
+        // Collect the bit iterators into the buffer. We don't know the length in advance.
+        let dir = dir.into_iter();
+        let swdio = swdio.into_iter();
+        let bit_count_hint = cmp::max(dir.size_hint().0, swdio.size_hint().0);
+        let capacity = 1 + 1 + 2 + ((bit_count_hint + 7) / 8) * 2;
+        let mut buf = self.buf(capacity);
+        buf.resize(4, 0);
+        buf[0] = Command::HwJtag3 as u8;
+        buf[1] = 0;
+        // buf[1] is dummy data for alignment
+        // buf[2..=3] is the bit count, which we'll fill in later
+        let mut dir_bit_count = 0;
+        buf.extend(dir.inspect(|_| dir_bit_count += 1).collapse_bytes());
+        let mut swdio_bit_count = 0;
+        buf.extend(swdio.inspect(|_| swdio_bit_count += 1).collapse_bytes());
+
+        assert_eq!(
+            dir_bit_count, swdio_bit_count,
+            "`dir` and `swdio` must have the same number of bits"
+        );
+        assert!(dir_bit_count < 65535, "too much data to transfer");
+
+        let num_bits = dir_bit_count as u16;
+        buf[2..=3].copy_from_slice(&num_bits.to_le_bytes());
+        let num_bytes = usize::from((num_bits + 7) >> 3);
+
+        self.write_cmd(&buf)?;
+
+        // Response is `num_bytes` SWDIO data bytes and one status byte
+        self.read(&mut buf[..num_bytes + 1])?;
+
+        if buf[num_bytes] != 0 {
+            return Err(format!(
+                "probe I/O command returned error code {:#x}",
+                buf[num_bytes]
+            ))
+            .jaylink_err();
+        }
+
+        drop(buf);
+
+        Ok(BitIter::new(
+            &self.cmd_buf.get_mut()[..num_bytes],
+            dir_bit_count,
+        ))
+    }
+
+    /// Starts capturing SWO data.
+    ///
+    /// This will switch the probe to SWD interface mode if necessary (required for SWO capture).
+    ///
+    /// Requires the probe to support [`Capability::Swo`].
+    ///
+    /// # Parameters
+    ///
+    /// - `mode`: The SWO data encoding mode to use.
+    /// - `speed`: The data rate to capture at (when using [`SwoMode::Uart`], this is the UART baud
+    ///   rate).
+    /// - `buf_size`: The size (in Bytes) of the on-device buffer to allocate for the SWO data. You
+    ///   can call [`JayLink::read_max_mem_block`] to get an approximation of the available memory
+    ///   on the probe.
+    ///
+    /// # Return Value
+    ///
+    /// This returns a [`SwoStream`] object, which can be used to directly read the captured SWO
+    /// data via [`std::io::Read`]. If blocking reads are undesired (or the [`JayLink`] instance
+    /// needs to be used for something else while SWO capture is in progress), the [`SwoStream`]
+    /// can be ignored and [`JayLink::swo_read`] be used instead.
+    pub fn swo_start<'a>(
+        &'a mut self,
+        mode: SwoMode,
+        speed: u32,
+        buf_size: u32,
+    ) -> Result<SwoStream<'a>> {
+        self.require_capability(Capability::Swo)?;
+
+        // The probe must be in SWD mode for SWO capture to work.
+        self.require_interface_selected(Interface::Swd)?;
+
+        let mut buf = [0; 21];
+        buf[0] = Command::Swo as u8;
+        buf[1] = SwoCommand::Start as u8;
+        buf[2] = 0x04;
+        buf[3] = SwoParam::Mode as u8;
+        buf[4..8].copy_from_slice(&(mode as u32).to_le_bytes());
+        buf[8] = 0x04;
+        buf[9] = SwoParam::Baudrate as u8;
+        buf[10..14].copy_from_slice(&speed.to_le_bytes());
+        buf[14] = 0x04;
+        buf[15] = SwoParam::BufferSize as u8;
+        buf[16..20].copy_from_slice(&buf_size.to_le_bytes());
+        buf[20] = 0x00;
+
+        self.write_cmd(&buf)?;
+
+        let mut status = [0; 4];
+        self.read(&mut status)?;
+        let status = SwoStatus::new(u32::from_le_bytes(status));
+
+        Ok(SwoStream {
+            jaylink: self,
+            speed,
+            buf_size,
+            buf: Cursor::new(Vec::new()),
+            next_poll: Instant::now(),
+            status: Cell::new(status),
+        })
+    }
+
+    /// Stops capturing SWO data.
+    pub fn swo_stop(&mut self) -> Result<()> {
+        self.require_capability(Capability::Swo)?;
+
+        let buf = [
+            Command::Swo as u8,
+            SwoCommand::Stop as u8,
+            0x00, // no parameters
+        ];
+
+        self.write_cmd(&buf)?;
+
+        let mut status = [0; 4];
+        self.read(&mut status)?;
+        let _status = SwoStatus::new(u32::from_le_bytes(status));
+        // FIXME: What to do with the status?
+
+        Ok(())
+    }
+
+    /// Reads captured SWO data from the probe and writes it to `data`.
+    ///
+    /// This needs to be called regularly after SWO capturing has been started. If it is not called
+    /// often enough, the buffer on the probe will fill up and device data will be dropped. You can
+    /// call [`SwoData::did_overrun`] to check for this condition.
+    ///
+    /// **Note**: the probe firmware seems to dislike many short SWO reads (as in, the probe will
+    /// *fall off the bus and reset*), so it is recommended to use a buffer that is the same size as
+    /// the on-probe data buffer.
+    pub fn swo_read<'a>(&self, data: &'a mut [u8]) -> Result<SwoData<'a>> {
+        let mut cmd = [0; 9];
+        cmd[0] = Command::Swo as u8;
+        cmd[1] = SwoCommand::Read as u8;
+        cmd[2] = 0x04;
+        cmd[3] = SwoParam::ReadSize as u8;
+        cmd[4..8].copy_from_slice(&(data.len() as u32).to_le_bytes());
+        cmd[8] = 0x00;
+
+        self.write_cmd(&cmd)?;
+
+        let mut header = [0; 8];
+        self.read(&mut header)?;
+
+        let status = {
+            let mut status = [0; 4];
+            status.copy_from_slice(&header[0..4]);
+            let bits = u32::from_le_bytes(status);
+            SwoStatus::new(bits)
+        };
+        let length = {
+            let mut length = [0; 4];
+            length.copy_from_slice(&header[4..8]);
+            u32::from_le_bytes(length)
+        };
+
+        if status.contains(SwoStatus::OVERRUN) {
+            warn!("SWO probe buffer overrun");
+        }
+
+        let len = length as usize;
+        let buf = &mut data[..len];
+        self.read(buf)?;
+
+        Ok(SwoData { data: buf, status })
+    }
+}
+
+impl fmt::Debug for JayLink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JayLink").finish()
+    }
+}
+
+/// A SWO data stream that implements [`std::io::Read`].
+///
+/// This is one way to consume SWO data. The other is to call [`JayLink::swo_read`] after SWO
+/// capturing has been started.
+///
+/// Reading from this stream will block until some data is captured by the probe.
+#[derive(Debug)]
+pub struct SwoStream<'a> {
+    jaylink: &'a JayLink,
+    speed: u32,
+    buf_size: u32,
+    next_poll: Instant,
+    /// Internal buffer the size of the on-probe buffer. This is filled in one go to avoid
+    /// performing small reads which may crash the probe.
+    buf: Cursor<Vec<u8>>,
+    /// Accumulated SWO errors.
+    status: Cell<SwoStatus>,
+}
+
+impl SwoStream<'_> {
+    /// Returns whether the probe-internal buffer overflowed at some point, and clears the flag.
+    ///
+    /// This indicates that some device data was lost, and should be communicated to the end-user.
+    pub fn did_overrun(&self) -> bool {
+        let did = self.status.get().contains(SwoStatus::OVERRUN);
+        self.status.set(self.status.get() & !SwoStatus::OVERRUN);
+        did
+    }
+
+    /// Computes the suggested polling interval to avoid buffer overruns.
+    fn poll_interval(&self) -> Duration {
+        const MULTIPLIER: u32 = 2;
+
+        let bytes_per_sec = self.speed / 8;
+        let buffers_per_sec =
+            cmp::max(1, bytes_per_sec / self.buf.get_ref().len() as u32) * MULTIPLIER;
+        Duration::from_micros(1_000_000 / u64::from(buffers_per_sec))
+    }
+}
+
+fn to_io_error(error: Error) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, error)
+}
+
+impl<'a> Read for SwoStream<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.buf.position() == self.buf.get_ref().len() as u64 {
+            // At end of buffer. (Blocking) Refill.
+            self.buf.get_mut().resize(self.buf_size as usize, 0);
+            loop {
+                // If we have recently polled, wait until the next poll is useful to avoid 100% CPU
+                // usage.
+                let now = Instant::now();
+                if now < self.next_poll {
+                    thread::sleep(self.next_poll - now);
+                }
+
+                let buf = self.buf.get_mut();
+                let data = self.jaylink.swo_read(buf).map_err(to_io_error)?;
+                self.status.set(self.status.get() | data.status);
+                let len = data.len();
+
+                // Since `self.buf` is the same length as the on-probe buffer, the probe buffer is
+                // now empty and we can wait `self.poll_interval()` until the next read.
+                self.next_poll += self.poll_interval();
+
+                if len != 0 {
+                    // There's now *some* data in the buffer.
+                    self.buf.get_mut().truncate(len);
+                    self.buf.set_position(0);
+                    break;
+                }
+
+                // If `data.len() == 0`, no data from the target has arrived. Since we can't return 0
+                // bytes (it indicates the end of the stream, in reality the stream is just very slow),
+                // we just loop (and sleep appropriately to not waste CPU).
+            }
+        }
+
+        self.buf.read(buf)
+    }
+}
+
+/// SWO data that was read via [`JayLink::swo_read`].
+#[derive(Debug)]
+pub struct SwoData<'a> {
+    data: &'a [u8],
+    status: SwoStatus,
+}
+
+impl<'a> SwoData<'a> {
+    /// Returns whether the probe-internal buffer overflowed before the last read.
+    ///
+    /// This indicates that some device data was lost.
+    pub fn did_overrun(&self) -> bool {
+        self.status.contains(SwoStatus::OVERRUN)
+    }
+}
+
+impl<'a> AsRef<[u8]> for SwoData<'a> {
+    fn as_ref(&self) -> &[u8] {
+        self.data
+    }
+}
+
+impl<'a> Deref for SwoData<'a> {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        self.data
+    }
+}
+
+/// A hardware version returned by [`JayLink::read_hardware_version`].
+///
+/// Note that the reported hardware version does not allow reliable feature detection, since
+/// embedded J-Link probes might return a hardware version of 1.0.0 despite supporting SWD and other
+/// much newer features.
+#[derive(Debug)]
+pub struct HardwareVersion(u32);
+
+impl HardwareVersion {
+    fn from_u32(raw: u32) -> Self {
+        HardwareVersion(raw)
+    }
+
+    /// Returns the type of hardware (or `None` if the hardware type is unknown).
+    pub fn hardware_type(&self) -> Option<HardwareType> {
+        Some(match (self.0 / 1000000) % 100 {
+            0 => HardwareType::JLink,
+            1 => HardwareType::JTrace,
+            2 => HardwareType::Flasher,
+            3 => HardwareType::JLinkPro,
+            _ => return None,
+        })
+    }
+
+    /// The major version.
+    pub fn major(&self) -> u8 {
+        // Decimal coded Decimal, cool cool
+        (self.0 / 10000) as u8
+    }
+
+    /// The minor version.
+    pub fn minor(&self) -> u8 {
+        ((self.0 % 10000) / 100) as u8
+    }
+
+    /// The hardware revision.
+    pub fn revision(&self) -> u8 {
+        (self.0 % 100) as u8
+    }
+}
+
+impl fmt::Display for HardwareVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(hw) = self.hardware_type() {
+            write!(f, "{} ", hw)?;
+        }
+        write!(f, "{}.{}.{}", self.major(), self.minor(), self.revision())
+    }
+}
+
+/// The hardware/product type of the device.
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum HardwareType {
+    JLink,
+    JTrace,
+    Flasher,
+    JLinkPro,
+}
+
+impl fmt::Display for HardwareType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            HardwareType::JLink => "J-Link",
+            HardwareType::JTrace => "J-Trace",
+            HardwareType::Flasher => "J-Flash",
+            HardwareType::JLinkPro => "J-Link Pro",
+        })
+    }
+}
+
+/// J-Link communication speed info.
+#[derive(Debug)]
+pub struct SpeedInfo {
+    base_freq: u32,
+    min_div: u16,
+}
+
+impl SpeedInfo {
+    /// Returns the maximum supported speed for target communication (in Hz).
+    pub fn max_speed_hz(&self) -> u32 {
+        self.base_freq / u32::from(self.min_div)
+    }
+
+    /// Returns a `SpeedConfig` that configures the fastest supported speed.
+    pub fn max_speed_config(&self) -> SpeedConfig {
+        let khz = cmp::min(self.max_speed_hz() / 1000, 0xFFFE);
+        SpeedConfig::khz(khz.try_into().unwrap()).unwrap()
+    }
+}
+
+/// Supported SWO capture speed info.
+#[derive(Debug)]
+pub struct SwoSpeedInfo {
+    base_freq: u32,
+    min_div: u32,
+    #[allow(dead_code)]
+    max_div: u32,
+
+    min_presc: u32,
+    #[allow(dead_code)]
+    max_presc: u32,
+}
+
+impl SwoSpeedInfo {
+    /// Returns the maximum supported speed for SWO capture (in Hz).
+    pub fn max_speed_hz(&self) -> u32 {
+        self.base_freq / self.min_div / cmp::max(1, self.min_presc)
+    }
+}
+
+/// Target communication speed setting.
+///
+/// This determines the clock frequency of the target communication. Supported speeds for the
+/// currently selected target interface can be fetched via [`JayLink::read_speeds`].
+#[derive(Debug, Copy, Clone)]
+pub struct SpeedConfig {
+    raw: u16,
+}
+
+impl SpeedConfig {
+    /// Let the J-Link probe decide the speed.
+    ///
+    /// Requires the probe to support [`Capability::AdaptiveClocking`].
+    pub const ADAPTIVE: Self = Self { raw: 0xFFFF };
+
+    /// Manually specify speed in kHz.
+    ///
+    /// Returns `None` if the value is the invalid value `0xFFFF`. Note that this doesn't mean that
+    /// every other value will be accepted by the device.
+    pub fn khz(khz: u16) -> Option<Self> {
+        if khz == 0xFFFF {
+            None
+        } else {
+            Some(Self { raw: khz })
+        }
+    }
+}
+
+impl fmt::Display for SpeedConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.raw == Self::ADAPTIVE.raw {
+            f.write_str("adaptive")
+        } else {
+            write!(f, "{} kHz", self.raw)
+        }
+    }
+}
+
+/// Scans for J-Link USB devices.
+///
+/// The returned iterator will yield all devices made by Segger, without filtering the product ID.
+pub fn scan_usb() -> Result<impl Iterator<Item = DeviceInfo>> {
+    Ok(nusb::list_devices()
+        .jaylink_err()?
+        .filter(|dev| dev.vendor_id() == VID_SEGGER))
+}

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1171,7 +1171,13 @@ pub(crate) enum StlinkError {
     #[error("Unaligned")]
     UnalignedAddress,
     #[error("USB")]
-    Usb(#[from] rusb::Error),
+    Usb(Box<dyn std::error::Error + Sync + Send>),
+}
+
+impl From<nusb::Error> for StlinkError {
+    fn from(e: nusb::Error) -> Self {
+        StlinkError::Usb(Box::new(e))
+    }
 }
 
 impl From<StlinkError> for DebugProbeError {

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -1,83 +1,46 @@
-use rusb::Device;
-use rusb::UsbContext;
-
 use crate::probe::stlink::StLinkSource;
 use crate::probe::DebugProbeInfo;
 
 use super::usb_interface::USB_PID_EP_MAP;
 use super::usb_interface::USB_VID;
 use std::fmt::Write;
-use std::time::Duration;
 
-pub(super) fn is_stlink_device<T: UsbContext>(device: &Device<T>) -> bool {
+pub(super) fn is_stlink_device(device: &nusb::DeviceInfo) -> bool {
     // Check the VID/PID.
-    if let Ok(descriptor) = device.device_descriptor() {
-        (descriptor.vendor_id() == USB_VID)
-            && (USB_PID_EP_MAP.contains_key(&descriptor.product_id()))
-    } else {
-        false
-    }
+    (device.vendor_id() == USB_VID) && (USB_PID_EP_MAP.contains_key(&device.product_id()))
 }
 
 #[tracing::instrument(skip_all)]
 pub fn list_stlink_devices() -> Vec<DebugProbeInfo> {
-    rusb::Context::new()
-        .and_then(|context| context.devices())
-        .map_or(vec![], |devices| {
-            devices
-                .iter()
-                .filter(is_stlink_device)
-                .filter_map(|device| {
-                    let descriptor = device.device_descriptor().ok()?;
+    let devices = match nusb::list_devices() {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::warn!("listing stlink devices failed: {:?}", e);
+            return vec![];
+        }
+    };
 
-                    let sn_str = match read_serial_number(&device, &descriptor) {
-                        Ok(serial_number) => Some(serial_number),
-                        Err(e) => {
-                            // Reading the serial number can fail, e.g. if the driver for the probe
-                            // is not installed. In this case we can still list the probe,
-                            // just without serial number.
-                            tracing::debug!(
-                                "Failed to read serial number of device {:04x}:{:04x} : {}",
-                                descriptor.vendor_id(),
-                                descriptor.product_id(),
-                                e
-                            );
-                            tracing::debug!("This might be happening because of a missing driver.");
-                            None
-                        }
-                    };
-
-                    Some(DebugProbeInfo::new(
-                        format!(
-                            "STLink {}",
-                            &USB_PID_EP_MAP[&descriptor.product_id()].version_name
-                        ),
-                        descriptor.vendor_id(),
-                        descriptor.product_id(),
-                        sn_str,
-                        &StLinkSource,
-                        None,
-                    ))
-                })
-                .collect::<Vec<_>>()
+    devices
+        .filter(is_stlink_device)
+        .map(|device| {
+            DebugProbeInfo::new(
+                format!(
+                    "STLink {}",
+                    &USB_PID_EP_MAP[&device.product_id()].version_name
+                ),
+                device.vendor_id(),
+                device.product_id(),
+                read_serial_number(&device),
+                &StLinkSource,
+                None,
+            )
         })
+        .collect()
 }
 
 /// Try to read the serial number of a USB device.
-pub(super) fn read_serial_number<T: rusb::UsbContext>(
-    device: &rusb::Device<T>,
-    descriptor: &rusb::DeviceDescriptor,
-) -> Result<String, rusb::Error> {
-    let timeout = Duration::from_millis(100);
-
-    let handle = device.open()?;
-    let language = handle
-        .read_languages(timeout)?
-        .first()
-        .cloned()
-        .ok_or(rusb::Error::BadDescriptor)?;
-    let sn = handle.read_serial_number_string(language, descriptor, timeout);
-    sn.map(|s| {
+pub(super) fn read_serial_number(device: &nusb::DeviceInfo) -> Option<String> {
+    device.serial_number().map(|s| {
         if s.len() < 24 {
             // Some STLink (especially V2) have their serial number stored as a 12 bytes binary string
             // containing non printable characters, so convert to a hex string to make them printable.
@@ -88,7 +51,7 @@ pub(super) fn read_serial_number<T: rusb::UsbContext>(
         } else {
             // Other STlink (especially V2-1) have their serial number already stored as a 24 characters
             // hex string so they don't need to be converted
-            s
+            s.to_string()
         }
     })
 }

--- a/probe-rs/src/probe/usb_util.rs
+++ b/probe-rs/src/probe/usb_util.rs
@@ -1,0 +1,60 @@
+use async_io::{block_on, Timer};
+use futures_lite::FutureExt;
+use nusb::{
+    transfer::{ControlIn, RequestBuffer},
+    Interface,
+};
+use std::{io, time::Duration};
+
+pub trait InterfaceExt {
+    fn read_control(&self, data: ControlIn, timeout: Duration) -> io::Result<Vec<u8>>;
+    fn read_bulk(&self, endpoint: u8, buf: &mut [u8], timeout: Duration) -> io::Result<usize>;
+    fn write_bulk(&self, endpoint: u8, buf: &[u8], timeout: Duration) -> io::Result<usize>;
+}
+
+impl InterfaceExt for Interface {
+    fn read_control(&self, data: ControlIn, timeout: Duration) -> io::Result<Vec<u8>> {
+        let fut = async {
+            let comp = self.control_in(data).await;
+            comp.status.map_err(io::Error::other)?;
+
+            Ok(comp.data)
+        };
+
+        block_on(fut.or(async {
+            Timer::after(timeout).await;
+            Err(std::io::ErrorKind::TimedOut.into())
+        }))
+    }
+
+    fn write_bulk(&self, endpoint: u8, buf: &[u8], timeout: Duration) -> io::Result<usize> {
+        let fut = async {
+            let comp = self.bulk_out(endpoint, buf.to_vec()).await;
+            comp.status.map_err(io::Error::other)?;
+
+            let n = comp.data.actual_length();
+            Ok(n)
+        };
+
+        block_on(fut.or(async {
+            Timer::after(timeout).await;
+            Err(std::io::ErrorKind::TimedOut.into())
+        }))
+    }
+
+    fn read_bulk(&self, endpoint: u8, buf: &mut [u8], timeout: Duration) -> io::Result<usize> {
+        let fut = async {
+            let comp = self.bulk_in(endpoint, RequestBuffer::new(buf.len())).await;
+            comp.status.map_err(io::Error::other)?;
+
+            let n = comp.data.len();
+            buf[..n].copy_from_slice(&comp.data);
+            Ok(n)
+        };
+
+        block_on(fut.or(async {
+            Timer::after(timeout).await;
+            Err(std::io::ErrorKind::TimedOut.into())
+        }))
+    }
+}

--- a/probe-rs/src/probe/wlink/usb_interface.rs
+++ b/probe-rs/src/probe/wlink/usb_interface.rs
@@ -1,8 +1,10 @@
 use std::time::Duration;
 
-use rusb::{DeviceHandle, UsbContext};
+use nusb::Interface;
 
-use crate::{DebugProbeError, DebugProbeSelector, ProbeCreationError};
+use crate::{
+    probe::usb_util::InterfaceExt, DebugProbeError, DebugProbeSelector, ProbeCreationError,
+};
 
 use super::{commands::WchLinkCommand, get_wlink_info, WchLinkError};
 
@@ -12,79 +14,56 @@ const ENDPOINT_IN: u8 = 0x81;
 // const RAW_ENDPOINT_OUT: u8 = 0x02;
 // const RAW_ENDPOINT_IN: u8 = 0x82;
 
-#[derive(Debug)]
 pub struct WchLinkUsbDevice {
-    device_handle: DeviceHandle<rusb::Context>,
+    device_handle: Interface,
 }
 
 impl WchLinkUsbDevice {
     pub fn new_from_selector(selector: &DebugProbeSelector) -> Result<Self, ProbeCreationError> {
-        let context = rusb::Context::new()?;
-
-        tracing::trace!("Acquired libusb context.");
-        let device = context
-            .devices()?
-            .iter()
+        let device = nusb::list_devices()
+            .map_err(ProbeCreationError::Usb)?
             .filter(|device| {
-                device
-                    .device_descriptor()
-                    .map(|desc| {
-                        desc.vendor_id() == selector.vendor_id
-                            && desc.product_id() == selector.product_id
-                    })
-                    .unwrap_or(false)
+                device.vendor_id() == selector.vendor_id
+                    && device.product_id() == selector.product_id
             })
             .find(|device| get_wlink_info(device).is_some())
             .map_or(Err(ProbeCreationError::NotFound), Ok)?;
 
-        let mut device_handle = device.open()?;
-
-        tracing::trace!("Aquired handle for probe");
-
-        let config = device.active_config_descriptor()?;
-
-        tracing::trace!("Active config descriptor: {:?}", &config);
-
-        let descriptor = device.device_descriptor()?;
-
-        tracing::trace!("Device descriptor: {:?}", &descriptor);
-
-        device_handle.claim_interface(0)?;
-
-        tracing::trace!("Claimed interface 0 of USB device.");
-
         let mut endpoint_out = false;
         let mut endpoint_in = false;
 
-        if let Some(interface) = config.interfaces().next() {
-            if let Some(descriptor) = interface.descriptors().next() {
-                for endpoint in descriptor.endpoint_descriptors() {
-                    if endpoint.address() == ENDPOINT_OUT {
-                        endpoint_out = true;
-                    } else if endpoint.address() == ENDPOINT_IN {
-                        endpoint_in = true;
+        let device_handle = device.open().map_err(ProbeCreationError::Usb)?;
+
+        let mut configs = device_handle.configurations();
+        if let Some(config) = configs.next() {
+            if let Some(interface) = config.interfaces().next() {
+                if let Some(altsetting) = interface.alt_settings().next() {
+                    for endpoint in altsetting.endpoints() {
+                        if endpoint.address() == ENDPOINT_OUT {
+                            endpoint_out = true;
+                        } else if endpoint.address() == ENDPOINT_IN {
+                            endpoint_in = true;
+                        }
                     }
                 }
             }
         }
 
-        if !endpoint_out {
+        if !endpoint_out || !endpoint_in {
             return Err(WchLinkError::EndpointNotFound.into());
         }
 
-        if !endpoint_in {
-            return Err(WchLinkError::EndpointNotFound.into());
-        }
+        tracing::trace!("Aquired handle for probe");
+        let device_handle = device_handle
+            .claim_interface(0)
+            .map_err(ProbeCreationError::Usb)?;
+        tracing::trace!("Claimed interface 0 of USB device.");
 
         let usb_wlink = Self { device_handle };
 
         tracing::debug!("Succesfully attached to WCH-Link.");
 
         Ok(usb_wlink)
-    }
-
-    fn close(&mut self) -> Result<(), rusb::Error> {
-        self.device_handle.release_interface(0)
     }
 
     pub(crate) fn send_command<C: WchLinkCommand + std::fmt::Debug>(
@@ -101,7 +80,7 @@ impl WchLinkUsbDevice {
         let written_bytes = self
             .device_handle
             .write_bulk(ENDPOINT_OUT, &rxbuf[..len], timeout)
-            .map_err(|e| DebugProbeError::Usb(Some(Box::new(e))))?;
+            .map_err(DebugProbeError::Usb)?;
 
         if written_bytes != len {
             return Err(WchLinkError::NotEnoughBytesWritten {
@@ -115,7 +94,7 @@ impl WchLinkUsbDevice {
         let read_bytes = self
             .device_handle
             .read_bulk(ENDPOINT_IN, &mut rxbuf[..], timeout)
-            .map_err(|e| DebugProbeError::Usb(Some(Box::new(e))))?;
+            .map_err(DebugProbeError::Usb)?;
 
         if read_bytes < 3 {
             return Err(WchLinkError::NotEnoughBytesRead {
@@ -135,12 +114,5 @@ impl WchLinkUsbDevice {
         let response = cmd.parse_response(&rxbuf[..read_bytes])?;
 
         Ok(response)
-    }
-}
-
-impl Drop for WchLinkUsbDevice {
-    fn drop(&mut self) {
-        // We ignore the error case as we can't do much about it anyways.
-        let _ = self.close();
     }
 }


### PR DESCRIPTION
[nusb](https://github.com/kevinmehall/nusb) is a pure-Rust libusb replacement. It can help a lot with the issues we're having with libusb (cross compiling pain, segfaults).

- [x] Port probe drivers
  - [x] stlink
  - [x] cmsisdap
  - [x] espusbjtag
  - [x] jaylink
  - [x] ftdi
  - [x] wlink
- [x] Test probe drivers
  - [x] stlink
  - [x] cmsisdap
  - [x] espusbjtag
  - [x] jaylink
  - [x] ftdi
  - [ ] wlink
- [x] Tested working on Linux
- [x] Tested working on Windows
- [x] nusb macos support support  https://github.com/kevinmehall/nusb/issues/3
- [ ] test on macos
- [x] ~~jaylink release~~ integrated jaylink into probe-rs.

~~I'm not sure what strategy we should follow. Either port probe drivers one-by-one, or port them all. Also, nusb doesn't support macos yet...~~