### PR TITLE
ATSAM chip erase

### DIFF
--- a/changelog/added-debug-squences-for-atsam.md
+++ b/changelog/added-debug-squences-for-atsam.md
@@ -1,0 +1,1 @@
+Custom debug sequences for ATSAMD1x, D2x, DAx micros.  Enables DSU-based chip erase.

--- a/probe-rs/src/architecture/arm/sequences/atsam.rs
+++ b/probe-rs/src/architecture/arm/sequences/atsam.rs
@@ -1,4 +1,4 @@
-//! Sequences for ATSAM D5x/E5x target families
+//! Sequences for ATSAM D1x/D2x/DAx/D5x/E5x target families
 
 use super::{ArmDebugSequence, ArmDebugSequenceError, DebugEraseSequence};
 use crate::{
@@ -23,19 +23,23 @@ bitfield! {
     pub struct DsuCtrl(u8);
     impl Debug;
     /// Chip-Erase
-    /// Writing a '0' to this bit has no effect.
+    ///
+    /// Writing a '0' to this bit has no effect.\
     /// Writing a '1' to this bit starts the Chip-Erase operation.
     pub _, set_ce: 4;
     /// Memory Built-In Self-Test
-    /// Writing a '0' to this bit has no effect.
+    ///
+    /// Writing a '0' to this bit has no effect.\
     /// Writing a '1' to this bit starts the memory BIST algorithm.
     pub _, set_mbist: 3;
     /// 32-bit Cyclic Redundancy Check
-    /// Writing a '0' to this bit has no effect.
+    ///
+    /// Writing a '0' to this bit has no effect.\
     /// Writing a '1' to this bit starts the cyclic redundancy check algorithm.
     pub _, set_crc: 2;
     /// Software Reset
-    /// Writing a '0' to this bit has no effect.
+    ///
+    /// Writing a '0' to this bit has no effect.\
     /// Writing a '1' to this bit resets the module.
     pub _, set_swrst: 0;
 }
@@ -58,38 +62,48 @@ impl From<DsuCtrl> for u8 {
 }
 
 bitfield! {
-    /// Device Service Unit Control Register, DSU - CTRL
+    /// Device Service Unit Status A Register, DSU - STATUSA
     #[derive(Copy, Clone)]
     pub struct DsuStatusA(u8);
     impl Debug;
     /// Protection Error
-    /// Writing a '0' to this bit has no effect.
-    /// Writing a '1' to this bit clears the Protection Error bit.
+    ///
     /// This bit is set when a command that is not allowed in Protected state is issued.
+    ///
+    /// Writing a '0' to this bit has no effect.\
+    /// Writing a '1' to this bit clears the Protection Error bit.
     pub perr, set_perr: 4;
 
     /// Failure
-    /// Writing a '0' to this bit has no effect.
-    /// Writing a '1' to this bit clears the Failure bit.
+    ///
     /// This bit is set when a DSU operation failure is detected.
+    ///
+    /// Writing a '0' to this bit has no effect.\
+    /// Writing a '1' to this bit clears the Failure bit.
     pub fail, set_fail: 3;
 
     /// Bus Error
-    /// Writing a '0' to this bit has no effect.
-    /// Writing a '1' to this bit clears the Bus Error bit.
+    ///
     /// This bit is set when a bus error is detected.
+    ///
+    /// Writing a '0' to this bit has no effect.\
+    /// Writing a '1' to this bit clears the Bus Error bit.
     pub berr, set_berr: 2;
 
     /// CPU Reset Phase Extension
-    /// Writing a '0' to this bit has no effect.
-    /// Writing a '1' to this bit clears the CPU Reset Phase Extension bit.
+    ///
     /// This bit is set when a debug adapter Cold-Plugging is detected, which extends the CPU Reset phase.
+    ///
+    /// Writing a '0' to this bit has no effect.\
+    /// Writing a '1' to this bit clears the CPU Reset Phase Extension bit.
     pub crstext, set_crstext: 1;
 
     /// Done
-    /// Writing a '0' to this bit has no effect.
-    /// Writing a '1' to this bit clears the Done bit.
+    ///
     /// This bit is set when a DSU operation is completed.
+    ///
+    /// Writing a '0' to this bit has no effect.\
+    /// Writing a '1' to this bit clears the Done bit.
     pub done, set_done: 0;
 }
 
@@ -111,34 +125,43 @@ impl DsuStatusA {
 }
 
 bitfield! {
-    /// Device Service Unit Control Register, DSU - CTRL
+    /// Device Service Unit Status B Register, DSU - STATUSB
     #[derive(Copy, Clone)]
     pub struct DsuStatusB(u8);
     impl Debug;
 
     /// Chip Erase Locked
-    /// This bit is set when Chip Erase is locked.
+    ///
+    /// This feature is not available on SAMD1x, SAMD2x, SAMDAx
+    ///
+    /// This bit is set when Chip Erase is locked.\
     /// This bit is cleared when Chip Erase is unlocked.
     pub celck, _: 5;
     /// Hot-Plugging Enable
-    /// This bit is set when Hot-Plugging is enabled.
-    /// This bit is cleared when Hot-Plugging is disabled. This is the case when the SWCLK function is changed.
-    /// Only a power-reset or a external reset can set it again.
+    ///
+    /// This bit is set when Hot-Plugging is enabled.\
+    /// This bit is cleared when Hot-Plugging is disabled. This is the case when
+    /// the SWCLK function is changed. Only a power-reset or a external reset
+    /// can set it again.
     pub hpe, _: 4;
     /// Debug Communication Channel 1 Dirty
-    /// This bit is set when DCC is written.
+    ///
+    /// This bit is set when DCC is written.\
     /// This bit is cleared when DCC is read.
     pub dccd1, _: 3;
     /// Debug Communication Channel 0 Dirty
-    /// This bit is set when DCC is written.
+    ///
+    /// This bit is set when DCC is written.\
     /// This bit is cleared when DCC is read.
     pub dccd0, _: 2;
     /// Debugger Present
-    /// This bit is set when a debugger probe is detected.
+    ///
+    /// This bit is set when a debugger probe is detected.\
     /// This bit is never cleared.
     pub dbgpres, _: 1;
     /// Protected
-    /// This bit is set at power-up when the device is protected.
+    ///
+    /// This bit is set at power-up when the device is protected.\
     /// This bit is never cleared.
     pub prot, _: 0;
 
@@ -187,11 +210,11 @@ impl<'a> architecture::arm::communication_interface::SwdSequence for SwdSequence
     }
 }
 
-/// Marker struct indicating initialization sequencing for ATSAM D5x/E5x family parts.
-pub struct AtSAME5x {}
+/// Marker struct indicating initialization sequencing for Atmel/Microchip ATSAM family parts.
+pub struct AtSAM {}
 
-impl AtSAME5x {
-    /// Create the sequencer for the ATSAM D5x/E5x family of parts.
+impl AtSAM {
+    /// Create the sequencer for the ATSAM family of parts.
     pub fn create() -> Arc<Self> {
         Arc::new(Self {})
     }
@@ -344,8 +367,8 @@ impl AtSAME5x {
     }
 }
 
-impl ArmDebugSequence for AtSAME5x {
-    /// `reset_hardware_assert` for ATSAM D5x/E5x devices
+impl ArmDebugSequence for AtSAM {
+    /// `reset_hardware_assert` for ATSAM devices
     ///
     /// Instead of keeping `nReset` asserted, the device is instead put into CPU Reset Extension
     /// which will keep the CPU Core in reset until manually released by the debugger probe.
@@ -357,7 +380,7 @@ impl ArmDebugSequence for AtSAME5x {
         self.reset_hardware_with_extension(&mut shim)
     }
 
-    /// `reset_hardware_deassert` for ATSAM D5x/E5x devices
+    /// `reset_hardware_deassert` for ATSAM devices
     ///
     /// Instead of de-asserting `nReset` here (this was already done during the CPU Reset Extension process),
     /// the device is released from Reset Extension.
@@ -377,7 +400,7 @@ impl ArmDebugSequence for AtSAME5x {
         self.release_reset_extension(memory)
     }
 
-    /// `debug_device_unlock` for ATSAM D5x/E5x devices
+    /// `debug_device_unlock` for ATSAM devices
     ///
     /// First check the device lock status by querying its Device Service Unit (DSU).
     /// If the device is already unlocked then return `Ok` directly.
@@ -410,7 +433,7 @@ impl ArmDebugSequence for AtSAME5x {
     }
 }
 
-impl DebugEraseSequence for AtSAME5x {
+impl DebugEraseSequence for AtSAM {
     fn erase_all(&self, interface: &mut dyn ArmProbeInterface) -> Result<(), ArmError> {
         let mem_ap = MemoryAp::new(ApAddress {
             dp: DpAddress::Default,
@@ -419,6 +442,6 @@ impl DebugEraseSequence for AtSAME5x {
 
         let mut memory = interface.memory_interface(mem_ap)?;
 
-        AtSAME5x::erase_all(self, &mut *memory, &Permissions::new().allow_erase_all())
+        AtSAM::erase_all(self, &mut *memory, &Permissions::new().allow_erase_all())
     }
 }

--- a/probe-rs/src/architecture/arm/sequences/mod.rs
+++ b/probe-rs/src/architecture/arm/sequences/mod.rs
@@ -1,6 +1,6 @@
 //! Debug sequences to operate special requirements ARM targets.
 
-pub mod atsame5x;
+pub mod atsam;
 pub mod efm32xg2;
 pub mod infineon;
 mod nrf;

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -179,7 +179,12 @@ impl Target {
         } else if chip.name.starts_with("STM32H7") {
             tracing::warn!("Using custom sequence for STM32H7");
             debug_sequence = DebugSequence::Arm(Stm32h7::create());
-        } else if chip.name.starts_with("ATSAMD5") || chip.name.starts_with("ATSAME5") {
+        } else if chip.name.starts_with("ATSAMD1")
+            || chip.name.starts_with("ATSAMD2")
+            || chip.name.starts_with("ATSAMDA")
+            || chip.name.starts_with("ATSAMD5")
+            || chip.name.starts_with("ATSAME5")
+        {
             tracing::warn!("Using custom sequence for {}", chip.name);
             debug_sequence = DebugSequence::Arm(AtSAME5x::create());
         } else if chip.name.starts_with("XMC4") {

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -4,7 +4,7 @@ use super::{
 use crate::architecture::arm::{
     ap::MemoryAp,
     sequences::{
-        atsame5x::AtSAME5x,
+        atsam::AtSAM,
         efm32xg2::EFM32xG2,
         infineon::XMC4000,
         nrf52::Nrf52,
@@ -186,7 +186,7 @@ impl Target {
             || chip.name.starts_with("ATSAME5")
         {
             tracing::warn!("Using custom sequence for {}", chip.name);
-            debug_sequence = DebugSequence::Arm(AtSAME5x::create());
+            debug_sequence = DebugSequence::Arm(AtSAM::create());
         } else if chip.name.starts_with("XMC4") {
             tracing::warn!("Using custom sequence for XMC4000");
             debug_sequence = DebugSequence::Arm(XMC4000::create());


### PR DESCRIPTION
This addresses https://github.com/probe-rs/probe-rs/issues/1854 ; the sequence that @jgust implemented for SAMD5x parts works perfectly for the smaller ATSAM parts, so I've just enabled it for those parts and done a little tidying of names/docs.