### PR TITLE
`target-gen`: Fix incorrect URL formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `target-gen`: Fix incorrect URL formatting (#1860).
+
 ## [0.21.1]
 
 Released 2023-10-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,6 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- `target-gen`: Fix incorrect URL formatting (#1860).
-
 ## [0.21.1]
 
 Released 2023-10-12

--- a/changelog/fixed-url-format.md
+++ b/changelog/fixed-url-format.md
@@ -1,0 +1,1 @@
+`target-gen`: Fix incorrect URL formatting (#1860).

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -312,7 +312,7 @@ pub(crate) async fn visit_arm_file(
     only_supported_familes: bool,
 ) -> Vec<ChipFamily> {
     let url = format!(
-        "{url}/{vendor}.{name}.{version}.pack",
+        "{url}{vendor}.{name}.{version}.pack",
         url = pack.url,
         vendor = pack.vendor,
         name = pack.name,

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -312,8 +312,8 @@ pub(crate) async fn visit_arm_file(
     only_supported_familes: bool,
 ) -> Vec<ChipFamily> {
     let url = format!(
-        "{url}{vendor}.{name}.{version}.pack",
-        url = pack.url,
+        "{url}/{vendor}.{name}.{version}.pack",
+        url = pack.url.trim_end_matches('/'),
         vendor = pack.vendor,
         name = pack.name,
         version = pack.version


### PR DESCRIPTION
This PR fixes #1859.

The `target-gen` utility downloads the CMSIS packs correctly now.