### PR TITLE
Fix source code location in DAP server

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
@@ -281,6 +281,10 @@ pub(crate) fn get_dap_source(source_location: &SourceLocation) -> Option<Source>
             }
         }
 
+        if let Some(file_name) = source_location.file.as_ref() {
+            native_path = native_path.join(file_name);
+        }
+
         if native_path.exists() {
             Some(Source {
                 name: source_location.file.clone(),


### PR DESCRIPTION
File name got omitted from source path by mistake.
