### PR TITLE
Add semihosting sys_exit support to riscv

### DIFF
--- a/changelog/added-riscv-semihostring.md
+++ b/changelog/added-riscv-semihostring.md
@@ -1,0 +1,1 @@
+Added support for riscv semihosting SYS_EXIT syscall.

--- a/probe-rs/src/architecture/arm/core/cortex_m.rs
+++ b/probe-rs/src/architecture/arm/core/cortex_m.rs
@@ -4,7 +4,7 @@ use crate::{
     architecture::arm::{memory::adi_v5_memory_interface::ArmProbe, ArmError},
     core::RegisterId,
     memory_mapped_bitfield_register, BreakpointCause, CoreInterface, Error, HaltReason,
-    MemoryMappedRegister, SemihostingCommand,
+    MemoryMappedRegister,
 };
 use std::time::{Duration, Instant};
 
@@ -176,7 +176,7 @@ pub(crate) fn write_core_reg(
     Ok(())
 }
 
-/// Check if the current breakpoint is a semihosting call.
+/// Check if the current breakpoint is a semihosting call. Does nothing unless feature rtt is enabled.
 ///
 /// Call this if you get some kind of breakpoint. Works on ARMv6-M, ARMv7-M and ARMv8-M.
 pub(crate) fn check_for_semihosting(
@@ -184,35 +184,38 @@ pub(crate) fn check_for_semihosting(
     core: &mut dyn CoreInterface,
 ) -> Result<HaltReason, Error> {
     let mut reason = old_reason;
-    // Check for semihosting instruction
-    let pc: u32 = core.read_core_reg(core.program_counter().id)?.try_into()?;
-    let instruction2 = core.read_word_8(pc as u64)?;
-    let instruction1 = core.read_word_8((pc + 1) as u64)?;
-    tracing::debug!(
-        "Semihosting check pc={pc:#x} instruction={instruction1:#02x}{instruction2:02x}"
-    );
-    if instruction1 == 0xBE && instruction2 == 0xAB {
-        // BKPT 0xAB -> we are semihosting
-        let r0: u32 = core.read_core_reg(RegisterId(0))?.try_into()?;
-        let r1: u32 = core.read_core_reg(RegisterId(1))?.try_into()?;
-        tracing::info!("Semihosting found pc={pc:#x} r0={r0:#x} r1={r1:#x}");
-        // This is defined by the ARM Semihosting Specification:
+
+    #[cfg(feature = "rtt")]
+    {
+        use crate::rtt::decode_semihosting_syscall;
+        let pc: u32 = core.read_core_reg(core.program_counter().id)?.try_into()?;
+
+        // The Arm Semihosting Specification, specificies that the instruction
+        // "BKPT 0xAB" (encoded as 0xBEAB) triggers a semihosting call.
         // <https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst#the-semihosting-interface>
-        const SYS_EXIT: u32 = 0x18;
-        const SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT: u32 = 0x20026;
-        match (r0, r1) {
-            (SYS_EXIT, SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT) => {
-                reason = HaltReason::Breakpoint(BreakpointCause::Semihosting(
-                    SemihostingCommand::ExitSuccess,
-                ));
-            }
-            (SYS_EXIT, code) => {
-                reason = HaltReason::Breakpoint(BreakpointCause::Semihosting(
-                    SemihostingCommand::ExitError { code: code as u64 },
-                ));
-            }
-            _ => {
-                tracing::warn!("Unknown semihosting operation r0={r0:08x} r1={r1:08x}");
+        const TRAP_INSTRUCTION: [u8; 2] = [
+            // instruction encoded as little endian
+            0xAB, 0xBE,
+        ];
+
+        let mut actual_instruction = [0u8; 2];
+        core.read_8(pc as u64, &mut actual_instruction)?;
+        let actual_instruction = actual_instruction.as_slice();
+
+        tracing::debug!(
+            "Semihosting check pc={pc:#x} instruction={0:#02x}{1:#02x}",
+            actual_instruction[1],
+            actual_instruction[0]
+        );
+
+        if TRAP_INSTRUCTION == actual_instruction {
+            // BKPT 0xAB -> we are semihosting
+            let r0: u32 = core.read_core_reg(RegisterId(0))?.try_into()?;
+            let r1: u32 = core.read_core_reg(RegisterId(1))?.try_into()?;
+            tracing::info!("Semihosting found pc={pc:#x} r0={r0:#x} r1={r1:#x}");
+
+            if let Some(command) = decode_semihosting_syscall(r0, r1) {
+                reason = HaltReason::Breakpoint(BreakpointCause::Semihosting(command));
             }
         }
     }

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -115,6 +115,57 @@ impl<'probe> Riscv32<'probe> {
             Ok(dmstatus.hasresethaltreq())
         }
     }
+
+    /// Check if the current breakpoint is a semihosting call. Does nothing unless feature rtt is enabled.
+    fn check_for_semihosting(
+        old_reason: HaltReason,
+        core: &mut dyn CoreInterface,
+    ) -> Result<HaltReason, Error> {
+        let mut reason = old_reason;
+
+        #[cfg(feature = "rtt")]
+        {
+            use crate::rtt::decode_semihosting_syscall;
+            let pc: u32 = core.read_core_reg(core.program_counter().id)?.try_into()?;
+
+            // The Riscv Semihosting Specification, specificies the following sequence of instructions,
+            // to trigger a semihosting call:
+            // <https://github.com/riscv-software-src/riscv-semihosting/blob/main/riscv-semihosting-spec.adoc>
+
+            const TRAP_INSTRUCTIONS: [u32; 3] = [
+                0x01f01013, // slli x0, x0, 0x1f (Entry Nop)
+                0x00100073, // ebreak (Break to debugger)
+                0x40705013, // srai x0, x0, 7 (NOP encoding the semihosting call number 7)
+            ];
+
+            // Read the actual instructions, starting at the instruction before the ebreak (PC-4)
+            let mut actual_instructions = [0u32; 3];
+            core.read_32((pc - 4) as u64, &mut actual_instructions)?;
+            let actual_instructions = actual_instructions.as_slice();
+
+            tracing::debug!(
+                "Semihosting check pc={pc:#x} instructions={0:#08x} {1:#08x} {2:#08x}",
+                actual_instructions[0],
+                actual_instructions[1],
+                actual_instructions[2]
+            );
+
+            if TRAP_INSTRUCTIONS == actual_instructions {
+                // Trap sequence found -> we're semihosting
+                let a0: u32 = core
+                    .read_core_reg(core.registers().get_argument_register(0).unwrap().id())?
+                    .try_into()?;
+                let a1: u32 = core
+                    .read_core_reg(core.registers().get_argument_register(1).unwrap().id())?
+                    .try_into()?;
+
+                if let Some(command) = decode_semihosting_syscall(a0, a1) {
+                    reason = HaltReason::Breakpoint(BreakpointCause::Semihosting(command));
+                }
+            }
+        }
+        Ok(reason)
+    }
 }
 
 impl<'probe> CoreInterface for Riscv32<'probe> {
@@ -152,7 +203,10 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
 
             let reason = match dcsr.cause() {
                 // An ebreak instruction was hit
-                1 => HaltReason::Breakpoint(BreakpointCause::Software),
+                1 => {
+                    let reason = HaltReason::Breakpoint(BreakpointCause::Software);
+                    Riscv32::check_for_semihosting(reason, self)?
+                }
                 // Trigger module caused halt
                 2 => HaltReason::Breakpoint(BreakpointCause::Hardware),
                 // Debugger requested a halt
@@ -294,6 +348,9 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         dmcontrol.set_ackhavereset(true);
 
         self.interface.write_dm_register(dmcontrol)?;
+
+        // Reenable halt on breakpoint because this gets disabled if we reset the core
+        self.debug_on_sw_breakpoint(true)?; // TODO: only restore if enabled before?
 
         let pc = self.read_core_reg(RegisterId(0x7b1))?;
 

--- a/probe-rs/src/architecture/riscv/registers.rs
+++ b/probe-rs/src/architecture/riscv/registers.rs
@@ -7,7 +7,6 @@ use once_cell::sync::Lazy;
 /// The program counter register.
 pub const PC: CoreRegister = CoreRegister {
     roles: &[RegisterRole::Core("pc"), RegisterRole::ProgramCounter],
-    /// This is a CSR register
     id: RegisterId(0x7b1),
     data_type: RegisterDataType::UnsignedInteger(32),
     unwind_rule: UnwindRule::Clear,

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -44,6 +44,9 @@
 mod channel;
 pub use channel::*;
 
+mod syscall;
+pub use syscall::*;
+
 pub mod channels;
 pub use channels::Channels;
 

--- a/probe-rs/src/rtt/syscall.rs
+++ b/probe-rs/src/rtt/syscall.rs
@@ -1,0 +1,19 @@
+use crate::SemihostingCommand;
+
+/// Decode a semihosting syscall. Only SYS_EXIT is supported at the moment
+pub fn decode_semihosting_syscall(operation: u32, parameter: u32) -> Option<SemihostingCommand> {
+    // This is defined by the ARM Semihosting Specification:
+    // <https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst#semihosting-operations>
+    const SYS_EXIT: u32 = 0x18;
+    const SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT: u32 = 0x20026;
+    match (operation, parameter) {
+        (SYS_EXIT, SYS_EXIT_ADP_STOPPED_APPLICATIONEXIT) => Some(SemihostingCommand::ExitSuccess),
+        (SYS_EXIT, code) => Some(SemihostingCommand::ExitError { code: code as u64 }),
+        _ => {
+            tracing::warn!(
+                "Unknown semihosting operation={operation:04x} parameter={parameter:04x}"
+            );
+            None
+        }
+    }
+}


### PR DESCRIPTION
I've implemented SYS_EXIT semihosting support for riscv, similar on how its done for the cortex-m.

Works with a simple test program on my esp32c6:

```
riscv32-esp-elf-objdump  -d target/riscv32imac-unknown-none-elf/debug/riscv_semihosting_example --section=.text | grep ebreak -C1
42001150:	01f01013          	slli	zero,zero,0x1f
42001154:	00100073          	ebreak
42001158:	40705013          	srai	zero,zero,0x7
```

```
probe-rs run --chip esp32c6 --format idf target/riscv32imac-unknown-none-elf/debug/riscv_semihosting_example
```




Please advise on:
* the todo regarding renabling breakpoints:  https://github.com/probe-rs/probe-rs/compare/master...t-moe:probe-rs:features/riscv_semihosting?expand=1#diff-30133d43f1cf396fea0c96eaf00b38660fa961edf89b716da104dc0288c4ae36R327
