### PR TITLE
DAP fixes for non-VSCode DAP clients (e.g. vimspector).

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,13 @@ The `cargo-flash` utility can be used as a cargo subcommand to download a compil
 
 If you are looking for a more extended debugging experience, please have a look at [cargo-embed](https://probe.rs/docs/tools/cargo-embed/) which provides support for GDB, RTT, and config files.
 
-### VSCode
+### Editors and IDEs
 
-We have implemented the [Microsoft DAP protocol](https://microsoft.github.io/debug-adapter-protocol/). This makes embedded debugging via probe-rs available in modern code editors implementing the standard, such as VSCode. Please see the [website](https://probe.rs/docs/tools/vscode/) for more information.
+We have implemented the [Microsoft Debug Adapter Protocol (DAP)](https://microsoft.github.io/debug-adapter-protocol/). This makes embedded debugging via probe-rs available in modern code editors implementing the standard, such as VSCode. The DAP website includes [a list of editors and IDEs which support DAP](https://microsoft.github.io/debug-adapter-protocol/implementors/tools/).
+
+#### VSCode
+
+The probe-rs website includes [VSCode configuration instructions](https://probe.rs/docs/tools/vscode/).
 
 ## Usage Examples
 

--- a/changelog/fixed-dap-non-compliance.md
+++ b/changelog/fixed-dap-non-compliance.md
@@ -1,0 +1,1 @@
+Prevent Debug Adapter Protocol workarounds for VSCode quirks from breaking other DAP clients.

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1808,7 +1808,11 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         id
     }
 
-    pub fn start_progress(&mut self, title: &str, request_id: Option<i64>) -> Result<ProgressId> {
+    pub fn start_progress(
+        &mut self,
+        title: &str,
+        request_id: Option<ProgressId>,
+    ) -> Result<ProgressId> {
         anyhow::ensure!(
             self.supports_progress_reporting,
             "Progress reporting is not supported by client."

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -40,6 +40,8 @@ use std::{convert::TryInto, str, string::ToString, time::Duration};
 /// Progress ID used for progress reporting when the debug adapter protocol is used.
 type ProgressId = i64;
 
+/// A Debug Adapter Protocol "Debug Adapter"
+/// https://microsoft.github.io/debug-adapter-protocol/overview
 pub struct DebugAdapter<P: ProtocolAdapter> {
     pub(crate) halt_after_reset: bool,
     /// NOTE: VSCode sends a 'threads' request when it receives the response from the `ConfigurationDone` request, irrespective of target state.
@@ -273,7 +275,8 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                         offset: None,
                     })),
                 )?;
-                // TODO: This doesn't trigger the UI to reload the variables effected. Investigate if we can force it in some other way, or if it is a known issue.
+                // TODO: This doesn't trigger the VSCode UI to reload the variables effected.
+                // Investigate if we can force it in some other way, or if it is a known issue.
                 self.send_event(
                     "memory",
                     Some(MemoryEventBody {

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -64,12 +64,16 @@ pub struct DebugAdapter<P: ProtocolAdapter> {
     pub(crate) lines_start_at_1: bool,
     /// DWARF spec at Sect 2.14 uses 1 based numbering, with a 0 indicating not-specified. We will follow that standard, and translate incoming requests depending on the DAP Client treatment of 0 or 1 based numbering.
     pub(crate) columns_start_at_1: bool,
+    /// Flag to indicate that workarounds for VSCode-specific spec deviations etc. should be
+    /// enabled.
+    pub(crate) vscode_quirks: bool,
     adapter: P,
 }
 
 impl<P: ProtocolAdapter> DebugAdapter<P> {
     pub fn new(adapter: P) -> DebugAdapter<P> {
         DebugAdapter {
+            vscode_quirks: false,
             halt_after_reset: false,
             configuration_done: false,
             all_cores_halted: true,
@@ -189,8 +193,9 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 break;
             }
         }
-        if !result_buffer.is_empty() || arguments.count.is_zero() {
-            // Currently, VSCode sends a request with count=0 after the last successful one ... so let's ignore it.
+        // Currently, VSCode sends a request with count=0 after the last successful one ... so
+        // let's ignore it.
+        if !result_buffer.is_empty() || (self.vscode_quirks && arguments.count.is_zero()) {
             let response = base64_engine::STANDARD.encode(&result_buffer);
             self.send_response(
                 request,
@@ -998,8 +1003,9 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         let start_frame = arguments.start_frame.unwrap_or(0);
 
         // VSCode sends multiple StackTrace requests, which lead to out of synch frame_id numbers.
-        // We only refresh the stacktrace when the `startFrame` is 0 and `levels` is 1.
-        if levels == 1 && start_frame == 0 {
+        // If our client is VSCode, then we only refresh the stacktrace when the `startFrame` is 0
+        // and `levels` is 1.
+        if !self.vscode_quirks || (levels == 1 && start_frame == 0) {
             tracing::debug!(
                 "Updating the stack frame data for core #{}",
                 target_core.core.id()

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
@@ -69,15 +69,20 @@ pub struct Cmd {
     #[clap(long)]
     port: u16,
 
-    /// The debug adapter processed was launched by VSCode, and should terminate itself at the end of every debug session (when receiving `Disconnect` or `Terminate` Request from VSCode). The "false"(default) state of this option implies that the process was launched (and will be managed) by the user.
-    #[clap(long, hide = true)]
-    vscode: bool,
+    /// Some editors and IDEs expect the debug adapter processes to exit at the end of every debug
+    /// session (on receiving a `Disconnect` or `Terminate` request).
+    ///
+    /// OTHERWISE the probe-rs will persist and continue to listen for new DAP client connections
+    /// ("multi-session" mode), and it becomes the user's responsibility to terminate the debug
+    /// adapter process.
+    #[clap(long, alias("vscode"))]
+    single_session: bool,
 }
 
 pub fn run(cmd: Cmd, time_offset: UtcOffset) -> Result<()> {
     let log_info_message = setup_logging(time_offset)?;
 
-    debug(cmd.port, cmd.vscode, &log_info_message, time_offset)
+    debug(cmd.port, cmd.single_session, &log_info_message, time_offset)
 }
 
 /// Setup logging, according to the following rules.

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
@@ -62,7 +62,7 @@ pub enum DebuggerError {
 }
 
 /// Open target in debug mode and accept debug commands.
-/// This only works as a [debug_adapter::protocol::DapAdapter] and uses DAP Protocol debug commands (enables connections from clients such as Microsoft Visual Studio Code).
+/// This only works as a [debug_adapter::protocol::DapAdapter] and uses Debug Adapter Protocol (DAP) commands (enables connections from clients such as Microsoft Visual Studio Code).
 #[derive(clap::Parser)]
 pub struct Cmd {
     /// IP port number to listen for incoming DAP connections, e.g. "50000"

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
@@ -72,7 +72,7 @@ pub struct Cmd {
     /// Some editors and IDEs expect the debug adapter processes to exit at the end of every debug
     /// session (on receiving a `Disconnect` or `Terminate` request).
     ///
-    /// OTHERWISE the probe-rs will persist and continue to listen for new DAP client connections
+    /// OTHERWISE probe-rs will persist and continue to listen for new DAP client connections
     /// ("multi-session" mode), and it becomes the user's responsibility to terminate the debug
     /// adapter process.
     #[clap(long, alias("vscode"))]

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -775,6 +775,16 @@ impl Debugger {
         let initialize_arguments =
             get_arguments::<InitializeRequestArguments, _>(debug_adapter, &initialize_request)?;
 
+        // Enable quirks specific to particular DAP clients...
+        if let Some(client_id) = initialize_arguments.client_id {
+            if client_id == "vscode" {
+                tracing::info!(
+                    "DAP client reports its 'ClientID' is 'vscode', enabling vscode_quirks."
+                );
+                debug_adapter.vscode_quirks = true;
+            }
+        }
+
         if !(initialize_arguments.columns_start_at_1.unwrap_or(true)
             && initialize_arguments.lines_start_at_1.unwrap_or(true))
         {

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -43,8 +43,10 @@ pub(crate) enum DebugSessionStatus {
 }
 
 /// #Debugger Overview
-/// The DAP Server will usually be managed automatically by the VSCode client.
-/// The DAP Server can optionally be run from the command line as a "server" process.
+/// The DAP Server may either be managed automatically by the development tool (typically an IDE or
+/// editor the "DAP client") e.g. VSCode, or...
+/// The DAP Server can optionally be run from the command line as a "server" process, and the
+/// development tool can be configured to connect to it via a TCP connection.
 /// - In this case, the management (start and stop) of the server process is the responsibility of the user. e.g.
 ///   - `probe-rs dap-server --port <IP port number> <other options>` : Uses TCP Sockets to the defined IP port number to service DAP requests.
 pub struct Debugger {

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
@@ -80,7 +80,8 @@ pub fn debug(
                         tracing::error!("probe-rs-debugger enountered unexpected `DebuggerStatus` in debug() execution. Please report this as a bug.");
                     }
                 }
-                // Terminate this process if it was started by VSCode
+                // Terminate after a single debug session. This is the behavour expected by VSCode
+                // if it started probe-rs as a child process.
                 if single_session {
                     break;
                 }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
@@ -32,7 +32,7 @@ impl std::str::FromStr for TargetSessionType {
 
 pub fn debug(
     port: u16,
-    vscode: bool,
+    single_session: bool,
     log_info_message: &str,
     timestamp_offset: UtcOffset,
 ) -> Result<()> {
@@ -81,7 +81,7 @@ pub fn debug(
                     }
                 }
                 // Terminate this process if it was started by VSCode
-                if vscode {
+                if single_session {
                     break;
                 }
             }


### PR DESCRIPTION
Minor fixes to prevent Debug Adapter Protocol workarounds (which result in DAP standard violations) which were added to probe-rs as a result of VSCode quirks from breaking other DAP clients.