### PR TITLE
Add missing reset-and-halt timeout for rv32

### DIFF
--- a/changelog/fixed-rv32-reset-halt-timout.md
+++ b/changelog/fixed-rv32-reset-halt-timout.md
@@ -1,0 +1,1 @@
+Added missing reset and halt timeout handling for RV32 targets.


### PR DESCRIPTION
Timeout in reset-and-halt is necessary for some MCUs(in my case: CH32V003).

- Add the missing timeout handling
- The original logic is not changed, so this won't break any old targets.
- The default timeout value is set to 500ms(in `fn reset`), which is enough for almost all targets