### PR TITLE
debugger: Refactor function lookup

### DIFF
--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -1570,7 +1570,7 @@ mod test {
             registers::cortex_m::CORTEX_M_CORE_REGISTERS,
         },
         core::exception_handler_for_core,
-        debug::{DebugInfo, DebugRegister, DebugRegisters},
+        debug::{stack_frame::TestFormatter, DebugInfo, DebugRegister, DebugRegisters},
         test::MockMemory,
         CoreDump, RegisterValue,
     };
@@ -1851,7 +1851,7 @@ mod test {
 
         let printed_backtrace = frames
             .into_iter()
-            .map(|f| f.to_string())
+            .map(|f| TestFormatter(&f).to_string())
             .collect::<Vec<String>>()
             .join("");
 
@@ -1956,7 +1956,7 @@ mod test {
 
         let printed_backtrace = frames
             .into_iter()
-            .map(|f| f.to_string())
+            .map(|f| TestFormatter(&f).to_string())
             .collect::<Vec<String>>()
             .join("");
 
@@ -2048,7 +2048,7 @@ mod test {
 
         let printed_backtrace = frames
             .into_iter()
-            .map(|f| f.to_string())
+            .map(|f| TestFormatter(&f).to_string())
             .collect::<Vec<String>>()
             .join("");
 
@@ -2078,7 +2078,7 @@ mod test {
 
         let printed_backtrace = stack_frames
             .into_iter()
-            .map(|f| f.to_string())
+            .map(|f| TestFormatter(&f).to_string())
             .collect::<Vec<String>>()
             .join("");
 

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -105,14 +105,13 @@ impl DebugInfo {
     // Until we have more tests we cannot be sure tho and it should stay like this.
     pub fn function_name(
         &self,
-        memory: &mut impl MemoryInterface,
         address: u64,
         find_inlined: bool,
     ) -> Result<Option<String>, DebugError> {
         let mut units = self.dwarf.units();
 
         while let Some(unit_info) = self.get_next_unit_info(&mut units) {
-            let mut functions = unit_info.get_function_dies(memory, address, None, find_inlined)?;
+            let mut functions = unit_info.get_function_dies(address, find_inlined)?;
 
             // Use the last functions from the list, this is the function which most closely
             // corresponds to the PC in case of multiple inlined functions.
@@ -302,6 +301,7 @@ impl DebugInfo {
             );
             static_root_variable.variable_node_type = VariableNodeType::DirectLookup;
             static_root_variable.name = VariableName::StaticScopeRoot;
+
             static_variable_cache.cache_variable(None, static_root_variable, memory)?;
         }
         Ok(static_variable_cache)
@@ -514,19 +514,19 @@ impl DebugInfo {
         let mut frames = Vec::new();
 
         while let Some(unit_info) = self.get_next_unit_info(&mut units) {
-            let functions =
-                unit_info.get_function_dies(memory, address, Some(unwind_registers), true)?;
+            let functions = unit_info.get_function_dies(address, true)?;
 
             if functions.is_empty() {
                 continue;
             }
 
+            // The first function is the non-inlined function, and the rest are inlined functions.
+            // The frame base only exists for the non-inlined function, so we can reuse it for all the inlined functions.
+            let frame_base = functions[0].frame_base(memory, unwind_registers)?;
+
             // Handle all functions which contain further inlined functions. For
             // these functions, the location is the call site of the inlined function.
             for (index, function_die) in functions[0..functions.len() - 1].iter().enumerate() {
-                let mut inlined_call_site: Option<RegisterValue> = None;
-                let mut inlined_caller_source_location: Option<SourceLocation> = None;
-
                 let function_name = function_die
                     .function_name()
                     .unwrap_or_else(|| unknown_function.clone());
@@ -542,17 +542,15 @@ impl DebugInfo {
 
                 if next_function.low_pc > address_size && next_function.low_pc < u32::MAX.into() {
                     // The first instruction of the inlined function is used as the call site
-                    inlined_call_site = Some(RegisterValue::from(next_function.low_pc));
+                    let inlined_call_site = RegisterValue::from(next_function.low_pc);
 
                     tracing::debug!(
                         "UNWIND: Callsite for inlined function {:?}",
                         next_function.function_name()
                     );
 
-                    inlined_caller_source_location = next_function.inline_call_location();
-                }
+                    let inlined_caller_source_location = next_function.inline_call_location();
 
-                if let Some(inlined_call_site) = inlined_call_site {
                     tracing::debug!("UNWIND: Call site: {:?}", inlined_caller_source_location);
 
                     // Now that we have the function_name and function_source_location, we can create the appropriate variable caches for this stack frame.
@@ -585,13 +583,12 @@ impl DebugInfo {
                         );
 
                     frames.push(StackFrame {
-                        // MS DAP Specification requires the id to be unique accross all threads, so using  so using unique `Variable::variable_key` of the `stackframe_root_variable` as the id.
                         id: get_sequential_key(),
                         function_name,
                         source_location: inlined_caller_source_location,
                         registers: unwind_registers.clone(),
                         pc: inlined_call_site,
-                        frame_base: function_die.frame_base,
+                        frame_base,
                         is_inlined: function_die.is_inline(),
                         static_variables,
                         local_variables,
@@ -645,7 +642,6 @@ impl DebugInfo {
                 );
 
             frames.push(StackFrame {
-                // MS DAP Specification requires the id to be unique accross all threads, so using  so using unique `Variable::variable_key` of the `stackframe_root_variable` as the id.
                 id: get_sequential_key(),
                 function_name,
                 source_location: function_location,
@@ -655,7 +651,7 @@ impl DebugInfo {
                     8 => RegisterValue::U64(address),
                     _ => RegisterValue::from(address),
                 },
-                frame_base: last_function.frame_base,
+                frame_base,
                 is_inlined: last_function.is_inline(),
                 static_variables,
                 local_variables,

--- a/probe-rs/src/debug/debug_step.rs
+++ b/probe-rs/src/debug/debug_step.rs
@@ -310,9 +310,7 @@ impl SteppingMode {
                 }
             }
             SteppingMode::OutOfStatement => {
-                if let Ok(function_dies) =
-                    program_unit.get_function_dies(core, program_counter, None, true)
-                {
+                if let Ok(function_dies) = program_unit.get_function_dies(program_counter, true) {
                     // We want the first qualifying (PC is in range) function from the back of this list, to access the 'innermost' functions first.
                     if let Some(function) = function_dies.iter().next_back() {
                         tracing::trace!(

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__print_stacktrace.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__print_stacktrace.snap
@@ -4,7 +4,7 @@ expression: printed_backtrace
 ---
 Frame:
  function:        read<nrf51_pac::timer0::events_compare::EVENTS_COMPARE_SPEC>
- source_location: 
+ source_location:
   directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf51-pac-0.10.1/src
   file: Some("generic.rs")
   line: Some(64)
@@ -12,7 +12,7 @@ Frame:
  frame_base:      Some(20003f38)
 Frame:
  function:        timer_running<nrf51_pac::TIMER0>
- source_location: 
+ source_location:
   directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
   file: Some("timer.rs")
   line: Some(397)
@@ -20,7 +20,7 @@ Frame:
  frame_base:      Some(20003f38)
 Frame:
  function:        wait<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
- source_location: 
+ source_location:
   directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
   file: Some("timer.rs")
   line: Some(266)
@@ -28,7 +28,7 @@ Frame:
  frame_base:      Some(20003f50)
 Frame:
  function:        <unknown function @ 0x0000019c>
- source_location: 
+ source_location:
   directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
   file: Some("timer.rs")
   line: Some(145)
@@ -36,7 +36,7 @@ Frame:
  frame_base:      Some(20003f78)
 Frame:
  function:        delay_us<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
- source_location: 
+ source_location:
   directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
   file: Some("timer.rs")
   line: Some(325)
@@ -44,7 +44,7 @@ Frame:
  frame_base:      Some(20003f88)
 Frame:
  function:        delay_ms<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
- source_location: 
+ source_location:
   directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
   file: Some("timer.rs")
   line: Some(298)
@@ -52,7 +52,7 @@ Frame:
  frame_base:      Some(20003fa8)
 Frame:
  function:        delay_ms<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
- source_location: 
+ source_location:
   directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
   file: Some("timer.rs")
   line: Some(307)
@@ -60,7 +60,7 @@ Frame:
  frame_base:      Some(20003fc0)
 Frame:
  function:        __cortex_m_rt_main
- source_location: 
+ source_location:
   directory: /Users/yatekii/repos/microbit/examples/gpio-hal-blinky/src
   file: Some("main.rs")
   line: Some(23)
@@ -68,7 +68,7 @@ Frame:
  frame_base:      Some(20003ff0)
 Frame:
  function:        __cortex_m_rt_main_trampoline
- source_location: 
+ source_location:
   directory: /Users/yatekii/repos/microbit/examples/gpio-hal-blinky/src
   file: Some("main.rs")
   line: Some(10)

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__print_stacktrace.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__print_stacktrace.snap
@@ -2,22 +2,76 @@
 source: probe-rs/src/debug/debug_info.rs
 expression: printed_backtrace
 ---
-Frame: read<nrf51_pac::timer0::events_compare::EVENTS_COMPARE_SPEC>
-	/Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf51-pac-0.10.1/src/generic.rs:64:27
-Frame: timer_running<nrf51_pac::TIMER0>
-	/Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs:397:9
-Frame: wait<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
-	/Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs:266:12
-Frame: <unknown function @ 0x0000019c>
-	/Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs:145:22
-Frame: delay_us<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
-	/Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs:325:6
-Frame: delay_ms<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
-	/Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs:298:6
-Frame: delay_ms<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
-	/Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs:307:6
-Frame: __cortex_m_rt_main
-	/Users/yatekii/repos/microbit/examples/gpio-hal-blinky/src/main.rs:23:9
-Frame: __cortex_m_rt_main_trampoline
-	/Users/yatekii/repos/microbit/examples/gpio-hal-blinky/src/main.rs:10:1
+Frame:
+ function:        read<nrf51_pac::timer0::events_compare::EVENTS_COMPARE_SPEC>
+ source_location: 
+  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf51-pac-0.10.1/src
+  file: Some("generic.rs")
+  line: Some(64)
+  column: Some(Column(27))
+ frame_base:      Some(20003f38)
+Frame:
+ function:        timer_running<nrf51_pac::TIMER0>
+ source_location: 
+  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
+  file: Some("timer.rs")
+  line: Some(397)
+  column: Some(Column(9))
+ frame_base:      Some(20003f38)
+Frame:
+ function:        wait<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
+ source_location: 
+  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
+  file: Some("timer.rs")
+  line: Some(266)
+  column: Some(Column(12))
+ frame_base:      Some(20003f50)
+Frame:
+ function:        <unknown function @ 0x0000019c>
+ source_location: 
+  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
+  file: Some("timer.rs")
+  line: Some(145)
+  column: Some(Column(22))
+ frame_base:      Some(20003f78)
+Frame:
+ function:        delay_us<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
+ source_location: 
+  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
+  file: Some("timer.rs")
+  line: Some(325)
+  column: Some(Column(6))
+ frame_base:      Some(20003f88)
+Frame:
+ function:        delay_ms<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
+ source_location: 
+  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
+  file: Some("timer.rs")
+  line: Some(298)
+  column: Some(Column(6))
+ frame_base:      Some(20003fa8)
+Frame:
+ function:        delay_ms<nrf51_pac::TIMER0, nrf_hal_common::timer::OneShot>
+ source_location: 
+  directory: /Users/yatekii/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
+  file: Some("timer.rs")
+  line: Some(307)
+  column: Some(Column(6))
+ frame_base:      Some(20003fc0)
+Frame:
+ function:        __cortex_m_rt_main
+ source_location: 
+  directory: /Users/yatekii/repos/microbit/examples/gpio-hal-blinky/src
+  file: Some("main.rs")
+  line: Some(23)
+  column: Some(Column(9))
+ frame_base:      Some(20003ff0)
+Frame:
+ function:        __cortex_m_rt_main_trampoline
+ source_location: 
+  directory: /Users/yatekii/repos/microbit/examples/gpio-hal-blinky/src
+  file: Some("main.rs")
+  line: Some(10)
+  column: Some(Column(1))
+ frame_base:      Some(20003ff8)
 

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_handler.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_handler.snap
@@ -4,7 +4,7 @@ expression: printed_backtrace
 ---
 Frame:
  function:        __cortex_m_rt_SVCall
- source_location: 
+ source_location:
   directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
   file: Some("main.rs")
   line: Some(26)
@@ -12,7 +12,7 @@ Frame:
  frame_base:      Some(2001ffc0)
 Frame:
  function:        __cortex_m_rt_SVCall_trampoline
- source_location: 
+ source_location:
   directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
   file: Some("main.rs")
   line: Some(22)
@@ -20,12 +20,12 @@ Frame:
  frame_base:      Some(2001ffc8)
 Frame:
  function:        SVCall
- source_location: 
+ source_location:
 None
  frame_base:      None
 Frame:
  function:        __cortex_m_rt_main
- source_location: 
+ source_location:
   directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
   file: Some("main.rs")
   line: Some(19)
@@ -33,7 +33,7 @@ Frame:
  frame_base:      Some(2001fff0)
 Frame:
  function:        __cortex_m_rt_main_trampoline
- source_location: 
+ source_location:
   directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
   file: Some("main.rs")
   line: Some(11)
@@ -41,12 +41,12 @@ Frame:
  frame_base:      Some(2001fff8)
 Frame:
  function:        memmove
- source_location: 
+ source_location:
 None
  frame_base:      Some(00000000)
 Frame:
  function:        memmove
- source_location: 
+ source_location:
 None
  frame_base:      Some(00000000)
 

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_handler.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_handler.snap
@@ -2,18 +2,51 @@
 source: probe-rs/src/debug/debug_info.rs
 expression: printed_backtrace
 ---
-Frame: __cortex_m_rt_SVCall
-	/home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs:26:5
-Frame: __cortex_m_rt_SVCall_trampoline
-	/home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs:22:1
-Frame: SVCall
-
-Frame: __cortex_m_rt_main
-	/home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs:19:5
-Frame: __cortex_m_rt_main_trampoline
-	/home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs:11:1
-Frame: memmove
-
-Frame: memmove
-
+Frame:
+ function:        __cortex_m_rt_SVCall
+ source_location: 
+  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
+  file: Some("main.rs")
+  line: Some(26)
+  column: Some(Column(5))
+ frame_base:      Some(2001ffc0)
+Frame:
+ function:        __cortex_m_rt_SVCall_trampoline
+ source_location: 
+  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
+  file: Some("main.rs")
+  line: Some(22)
+  column: Some(Column(1))
+ frame_base:      Some(2001ffc8)
+Frame:
+ function:        SVCall
+ source_location: 
+None
+ frame_base:      None
+Frame:
+ function:        __cortex_m_rt_main
+ source_location: 
+  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
+  file: Some("main.rs")
+  line: Some(19)
+  column: Some(Column(5))
+ frame_base:      Some(2001fff0)
+Frame:
+ function:        __cortex_m_rt_main_trampoline
+ source_location: 
+  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
+  file: Some("main.rs")
+  line: Some(11)
+  column: Some(Column(1))
+ frame_base:      Some(2001fff8)
+Frame:
+ function:        memmove
+ source_location: 
+None
+ frame_base:      Some(00000000)
+Frame:
+ function:        memmove
+ source_location: 
+None
+ frame_base:      Some(00000000)
 

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_trampoline.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_trampoline.snap
@@ -2,16 +2,43 @@
 source: probe-rs/src/debug/debug_info.rs
 expression: printed_backtrace
 ---
-Frame: __cortex_m_rt_SVCall_trampoline
-	/home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs:22
-Frame: SVCall
-
-Frame: __cortex_m_rt_main
-	/home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs:19:5
-Frame: __cortex_m_rt_main_trampoline
-	/home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src/main.rs:11:1
-Frame: memmove
-
-Frame: memmove
-
+Frame:
+ function:        __cortex_m_rt_SVCall_trampoline
+ source_location: 
+  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
+  file: Some("main.rs")
+  line: Some(22)
+  column: Some(LeftEdge)
+ frame_base:      Some(2001fff0)
+Frame:
+ function:        SVCall
+ source_location: 
+None
+ frame_base:      None
+Frame:
+ function:        __cortex_m_rt_main
+ source_location: 
+  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
+  file: Some("main.rs")
+  line: Some(19)
+  column: Some(Column(5))
+ frame_base:      Some(2001fff0)
+Frame:
+ function:        __cortex_m_rt_main_trampoline
+ source_location: 
+  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
+  file: Some("main.rs")
+  line: Some(11)
+  column: Some(Column(1))
+ frame_base:      Some(2001fff8)
+Frame:
+ function:        memmove
+ source_location: 
+None
+ frame_base:      Some(00000000)
+Frame:
+ function:        memmove
+ source_location: 
+None
+ frame_base:      Some(00000000)
 

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_trampoline.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_trampoline.snap
@@ -4,7 +4,7 @@ expression: printed_backtrace
 ---
 Frame:
  function:        __cortex_m_rt_SVCall_trampoline
- source_location: 
+ source_location:
   directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
   file: Some("main.rs")
   line: Some(22)
@@ -12,12 +12,12 @@ Frame:
  frame_base:      Some(2001fff0)
 Frame:
  function:        SVCall
- source_location: 
+ source_location:
 None
  frame_base:      None
 Frame:
  function:        __cortex_m_rt_main
- source_location: 
+ source_location:
   directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
   file: Some("main.rs")
   line: Some(19)
@@ -25,7 +25,7 @@ Frame:
  frame_base:      Some(2001fff0)
 Frame:
  function:        __cortex_m_rt_main_trampoline
- source_location: 
+ source_location:
   directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/exceptions/src
   file: Some("main.rs")
   line: Some(11)
@@ -33,12 +33,12 @@ Frame:
  frame_base:      Some(2001fff8)
 Frame:
  function:        memmove
- source_location: 
+ source_location:
 None
  frame_base:      Some(00000000)
 Frame:
  function:        memmove
- source_location: 
+ source_location:
 None
  frame_base:      Some(00000000)
 

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_inlined.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_inlined.snap
@@ -4,7 +4,7 @@ expression: printed_backtrace
 ---
 Frame:
  function:        wait<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
- source_location: 
+ source_location:
   directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
   file: Some("timer.rs")
   line: Some(266)
@@ -12,7 +12,7 @@ Frame:
  frame_base:      Some(20003ff0)
 Frame:
  function:        delay<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
- source_location: 
+ source_location:
   directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
   file: Some("timer.rs")
   line: Some(145)
@@ -20,7 +20,7 @@ Frame:
  frame_base:      Some(20003ff0)
 Frame:
  function:        delay_us<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
- source_location: 
+ source_location:
   directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
   file: Some("timer.rs")
   line: Some(324)
@@ -28,7 +28,7 @@ Frame:
  frame_base:      Some(20003ff0)
 Frame:
  function:        delay_ms<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
- source_location: 
+ source_location:
   directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
   file: Some("timer.rs")
   line: Some(297)
@@ -36,7 +36,7 @@ Frame:
  frame_base:      Some(20003ff0)
 Frame:
  function:        delay_ms<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
- source_location: 
+ source_location:
   directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
   file: Some("timer.rs")
   line: Some(306)
@@ -44,7 +44,7 @@ Frame:
  frame_base:      Some(20003ff0)
 Frame:
  function:        __cortex_m_rt_main
- source_location: 
+ source_location:
   directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/inlined-functions/src
   file: Some("main.rs")
   line: Some(20)
@@ -52,7 +52,7 @@ Frame:
  frame_base:      Some(20003ff0)
 Frame:
  function:        __cortex_m_rt_main_trampoline
- source_location: 
+ source_location:
   directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/inlined-functions/src
   file: Some("main.rs")
   line: Some(7)
@@ -60,12 +60,12 @@ Frame:
  frame_base:      Some(20003ff8)
 Frame:
  function:        <unknown function @ 0x0000013c>
- source_location: 
+ source_location:
 None
  frame_base:      None
 Frame:
  function:        <unknown function @ 0x0000013c>
- source_location: 
+ source_location:
 None
  frame_base:      None
 

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_inlined.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_inlined.snap
@@ -2,22 +2,70 @@
 source: probe-rs/src/debug/debug_info.rs
 expression: printed_backtrace
 ---
-Frame: wait<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
-	/home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs:266:12
-Frame: delay<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
-	/home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs:145:22
-Frame: delay_us<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
-	/home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs:324:9
-Frame: delay_ms<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
-	/home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs:297:14
-Frame: delay_ms<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
-	/home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src/timer.rs:306:14
-Frame: __cortex_m_rt_main
-	/home/dominik/code/probe-rs/probe-rs-repro/nrf/inlined-functions/src/main.rs:20:15
-Frame: __cortex_m_rt_main_trampoline
-	/home/dominik/code/probe-rs/probe-rs-repro/nrf/inlined-functions/src/main.rs:7:1
-Frame: <unknown function @ 0x0000013c>
-
-Frame: <unknown function @ 0x0000013c>
-
+Frame:
+ function:        wait<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
+ source_location: 
+  directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
+  file: Some("timer.rs")
+  line: Some(266)
+  column: Some(Column(12))
+ frame_base:      Some(20003ff0)
+Frame:
+ function:        delay<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
+ source_location: 
+  directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
+  file: Some("timer.rs")
+  line: Some(145)
+  column: Some(Column(22))
+ frame_base:      Some(20003ff0)
+Frame:
+ function:        delay_us<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
+ source_location: 
+  directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
+  file: Some("timer.rs")
+  line: Some(324)
+  column: Some(Column(9))
+ frame_base:      Some(20003ff0)
+Frame:
+ function:        delay_ms<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
+ source_location: 
+  directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
+  file: Some("timer.rs")
+  line: Some(297)
+  column: Some(Column(14))
+ frame_base:      Some(20003ff0)
+Frame:
+ function:        delay_ms<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
+ source_location: 
+  directory: /home/dominik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nrf-hal-common-0.14.1/src
+  file: Some("timer.rs")
+  line: Some(306)
+  column: Some(Column(14))
+ frame_base:      Some(20003ff0)
+Frame:
+ function:        __cortex_m_rt_main
+ source_location: 
+  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/inlined-functions/src
+  file: Some("main.rs")
+  line: Some(20)
+  column: Some(Column(15))
+ frame_base:      Some(20003ff0)
+Frame:
+ function:        __cortex_m_rt_main_trampoline
+ source_location: 
+  directory: /home/dominik/code/probe-rs/probe-rs-repro/nrf/inlined-functions/src
+  file: Some("main.rs")
+  line: Some(7)
+  column: Some(Column(1))
+ frame_base:      Some(20003ff8)
+Frame:
+ function:        <unknown function @ 0x0000013c>
+ source_location: 
+None
+ frame_base:      None
+Frame:
+ function:        <unknown function @ 0x0000013c>
+ source_location: 
+None
+ frame_base:      None
 

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_inlined_debug.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_inlined_debug.snap
@@ -1,0 +1,23 @@
+---
+source: probe-rs/src/debug/debug_info.rs
+expression: printed_backtrace
+---
+wait<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
+  frame_base: None
+delay<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
+  frame_base: None
+delay_us<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
+  frame_base: None
+delay_ms<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
+  frame_base: None
+delay_ms<nrf52833_pac::TIMER0, nrf_hal_common::timer::OneShot>
+  frame_base: None
+__cortex_m_rt_main
+  frame_base: Some(20003ff0)
+__cortex_m_rt_main_trampoline
+  frame_base: Some(20003ff8)
+<unknown function @ 0x0000013c>
+  frame_base: None
+<unknown function @ 0x0000013c>
+  frame_base: None
+

--- a/probe-rs/src/debug/stack_frame.rs
+++ b/probe-rs/src/debug/stack_frame.rs
@@ -2,6 +2,9 @@ use super::*;
 use crate::core::RegisterValue;
 use std;
 
+#[cfg(test)]
+pub use test::TestFormatter;
+
 /// A full stack frame with all its information contained.
 #[derive(Debug, Default, PartialEq)]
 pub struct StackFrame {
@@ -63,30 +66,34 @@ impl std::fmt::Display for StackFrame {
 }
 
 #[cfg(test)]
-pub struct TestFormatter<'s>(pub &'s StackFrame);
+mod test {
+    use super::StackFrame;
 
-#[cfg(test)]
-impl<'s> std::fmt::Display for TestFormatter<'s> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        writeln!(f, "Frame:")?;
-        writeln!(f, " function:        {}", self.0.function_name)?;
+    /// Helper struct used to format a StackFrame for testing.
+    pub struct TestFormatter<'s>(pub &'s StackFrame);
 
-        writeln!(f, " source_location: ")?;
-        match &self.0.source_location {
-            Some(location) => {
-                write!(f, "  directory: ")?;
-                match location.directory.as_ref() {
-                    Some(l) => writeln!(f, "{}", l.to_path().display())?,
-                    None => writeln!(f, "None")?,
+    impl<'s> std::fmt::Display for TestFormatter<'s> {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            writeln!(f, "Frame:")?;
+            writeln!(f, " function:        {}", self.0.function_name)?;
+
+            writeln!(f, " source_location:")?;
+            match &self.0.source_location {
+                Some(location) => {
+                    write!(f, "  directory: ")?;
+                    match location.directory.as_ref() {
+                        Some(l) => writeln!(f, "{}", l.to_path().display())?,
+                        None => writeln!(f, "None")?,
+                    }
+                    writeln!(f, "  file: {:?}", location.file)?;
+                    writeln!(f, "  line: {:?}", location.line)?;
+                    writeln!(f, "  column: {:?}", location.column)?;
                 }
-                writeln!(f, "  file: {:?}", location.file)?;
-                writeln!(f, "  line: {:?}", location.line)?;
-                writeln!(f, "  column: {:?}", location.column)?;
+                None => writeln!(f, "None")?,
             }
-            None => writeln!(f, "None")?,
-        }
-        writeln!(f, " frame_base:      {:08x?}", self.0.frame_base)?;
+            writeln!(f, " frame_base:      {:08x?}", self.0.frame_base)?;
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/probe-rs/src/debug/stack_frame.rs
+++ b/probe-rs/src/debug/stack_frame.rs
@@ -61,3 +61,32 @@ impl std::fmt::Display for StackFrame {
         writeln!(f)
     }
 }
+
+#[cfg(test)]
+pub struct TestFormatter<'s>(pub &'s StackFrame);
+
+#[cfg(test)]
+impl<'s> std::fmt::Display for TestFormatter<'s> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        writeln!(f, "Frame:")?;
+        writeln!(f, " function:        {}", self.0.function_name)?;
+
+        writeln!(f, " source_location: ")?;
+        match &self.0.source_location {
+            Some(location) => {
+                write!(f, "  directory: ")?;
+                match location.directory.as_ref() {
+                    Some(l) => writeln!(f, "{}", l.to_path().display())?,
+                    None => writeln!(f, "None")?,
+                }
+                writeln!(f, "  file: {:?}", location.file)?;
+                writeln!(f, "  line: {:?}", location.line)?;
+                writeln!(f, "  column: {:?}", location.column)?;
+            }
+            None => writeln!(f, "None")?,
+        }
+        writeln!(f, " frame_base:      {:08x?}", self.0.frame_base)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Print stack frame in unwind tests
- Don't use memory access to get function information
