### PR TITLE
Mark all ARM memory accesses as cacheable

### DIFF
--- a/changelog/fixed-mark-arm-memory-requests-cacheable.md
+++ b/changelog/fixed-mark-arm-memory-requests-cacheable.md
@@ -1,0 +1,2 @@
+* Mark all ARM memory accesses as cacheable, to indicate they must not bypass
+  the cache and instead should see the same data as the CPU. Fixes #1715.

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -353,15 +353,19 @@ impl CSW {
     /// ```text
     /// HPROT[0] == 1   - data           access
     /// HPROT[1] == 1   - privileged     access
-    /// HPROT[2] == 0   - non-cacheable  access
-    /// HPROT[3] == 0   - non-bufferable access
+    /// HPROT[2] == 0   - non-bufferable access
+    /// HPROT[3] == 1   - cacheable      access
     /// ```
+    ///
+    /// Setting cacheable indicates the request must not bypass the cache,
+    /// to ensure we observe the same state as the CPU core. On cores without
+    /// cache the bit is RAZ/WI.
     pub fn new(data_size: DataSize) -> Self {
         CSW {
             DbgSwEnable: 0b1,
             HNONSEC: 0b1,
             PROT: 0b110,
-            CACHE: 0b11,
+            CACHE: 0b1011,
             AddrInc: AddressIncrement::Single,
             SIZE: data_size,
             ..Default::default()

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -209,14 +209,18 @@ where
         // The CACHE bits are set for the following AHB access:
         //   HPROT[0] == 1   - data           access
         //   HPROT[1] == 1   - privileged     access
-        //   HPROT[2] == 0   - non-cacheable  access
-        //   HPROT[3] == 0   - non-bufferable access
+        //   HPROT[2] == 0   - non-bufferable access
+        //   HPROT[3] == 1   - cacheable      access
+        //
+        // Setting cacheable indicates the request must not bypass the cache,
+        // to ensure we observe the same state as the CPU core. On cores without
+        // cache the bit is RAZ/WI.
 
         CSW {
             DbgSwEnable: 0b1,
             HNONSEC: !self.ap_information.supports_hnonsec as u8,
             PROT: 0b10,
-            CACHE: 0b11,
+            CACHE: 0b1011,
             AddrInc: AddressIncrement::Single,
             SIZE: data_size,
             ..Default::default()


### PR DESCRIPTION
Fixes #1517

Patch is from that issue, thanks to @bcantrill.