### PR TITLE
[run]: don't output the vector catch error if it hasn't been implemented

### DIFF
--- a/changelog/changed-vector-catch-output.md
+++ b/changelog/changed-vector-catch-output.md
@@ -1,0 +1,1 @@
+Hide vector catch errors when it hasn't been implemented for the target.

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context, Result};
 use probe_rs::debug::{DebugInfo, DebugRegisters};
 use probe_rs::flashing::{FileDownloadError, Format};
 use probe_rs::{
-    exception_handler_for_core, BreakpointCause, Core, CoreInterface, HaltReason,
+    exception_handler_for_core, BreakpointCause, Core, CoreInterface, Error, HaltReason,
     SemihostingCommand, VectorCatchCondition,
 };
 use probe_rs_target::MemoryRegion;
@@ -94,8 +94,9 @@ impl Cmd {
 
         if run_download {
             core.reset_and_halt(Duration::from_millis(100))?;
-            if let Err(e) = core.enable_vector_catch(VectorCatchCondition::All) {
-                tracing::error!("Failed to enable_vector_catch: {:?}", e);
+            match core.enable_vector_catch(VectorCatchCondition::All) {
+                Ok(_) | Err(Error::NotImplemented(_)) => {} // Don't output an error if vector_catch hasn't been implemented
+                Err(e) => tracing::error!("Failed to enable_vector_catch: {:?}", e),
             }
             core.run()?;
         }


### PR DESCRIPTION
On RISCV you get a confusing message which might make users think it's not working, when in reality it is. This hides the vector catch error in that case.