### PR TITLE
dap-adapter: Fix type for error response

### DIFF
--- a/changelog/fixed-vscode-error-response.md
+++ b/changelog/fixed-vscode-error-response.md
@@ -1,0 +1,1 @@
+dap-server: Return correct type for error response.

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -432,7 +432,6 @@ impl Debugger {
             Ok(session_data) => session_data,
             Err(error) => {
                 let err = anyhow!("{error:?}");
-                //debug_adapter.show_error_message(&error)?;
                 debug_adapter.send_response::<()>(&launch_attach_request, Err(error))?;
 
                 return Err(err.into());

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -424,14 +424,20 @@ impl Debugger {
             let err = anyhow!("{e:?}");
 
             debug_adapter.send_response::<()>(&launch_attach_request, Err(e))?;
+
             return Err(err.into());
         }
 
-        let mut session_data =
-            SessionData::new(&mut self.config, self.timestamp_offset).or_else(|error| {
-                debug_adapter.show_error_message(&error)?;
-                Err(error)
-            })?;
+        let mut session_data = match SessionData::new(&mut self.config, self.timestamp_offset) {
+            Ok(session_data) => session_data,
+            Err(error) => {
+                let err = anyhow!("{error:?}");
+                //debug_adapter.show_error_message(&error)?;
+                debug_adapter.send_response::<()>(&launch_attach_request, Err(error))?;
+
+                return Err(err.into());
+            }
+        };
 
         debug_adapter.halt_after_reset = self.config.flashing_config.halt_after_reset;
 


### PR DESCRIPTION
The error response had the wrong type, and was ignored by vscode. The additional show_message call before the
error response is removed, because that led to duplicate message popups.

Calls to `show_message` and `log_to_console` are also removed from the `send_event` function, to prevent endless recursion.
