### PR TITLE
Fix the address mapping for esp32c3 RAM regions

### DIFF
--- a/changelog/fixed-esp32c3-memory-map.md
+++ b/changelog/fixed-esp32c3-memory-map.md
@@ -1,0 +1,1 @@
+Fix the RAM address mapping for the esp32c3.

--- a/probe-rs/targets/esp32c3.yaml
+++ b/probe-rs/targets/esp32c3.yaml
@@ -31,21 +31,21 @@ variants:
       - !Ram
         range: # 384 Kb SRAM on Data Bus
           start: 0x3fc80000
-          end: 0x3fc90000
+          end: 0x3fce0000
         is_boot_memory: false
         cores:
           - main
       - !Nvm
         range: # External Flash on Instruction Bus (Read Only)
           start: 0x42000000
-          end: 0x42800000
+          end: 0x43000000
         is_boot_memory: false
         cores:
           - main
       - !Nvm
         range: # External Flash on Data Bus (Read Only)
           start: 0x3c000000
-          end: 0x3c800000
+          end: 0x3d000000
         is_boot_memory: false
         cores:
           - main


### PR DESCRIPTION
Update from DM discussion:
The Flash range in this PR represents max addressable space, and not necessarily physical flash memory available, since the latter is external to the chip. This is deemed OK, since the flash loader will error if we try and flash (write) past the size of the fitted flash, and reads will return 0's beyond the physically available flash memory.