### PR TITLE
Add `--catch-reset` & `--catch-hardfault` flags

### DIFF
--- a/changelog/added-cli-flags-for-vector-catch.md
+++ b/changelog/added-cli-flags-for-vector-catch.md
@@ -1,0 +1,1 @@
+Add `--catch-reset` & `--catch-hardfault` cli flags

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     Core, CoreType, Error,
 };
-pub use probe_rs_target::{Architecture, CoreAccessOptions};
 
 use super::ResolvedCoreOptions;
 


### PR DESCRIPTION
I have an interesting boot process where the chip (arm) bootloader will reset at least once during the process; having the vector catch enabled during this process will cause `probe-rs run` to halt and stop the boot process. 

## Alternatives

We make this a negative flag, i.e `--no-vector-catch`.