### PR TITLE
rtthost: Add reset flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2811,6 +2811,7 @@ dependencies = [
 name = "rtthost"
 version = "0.21.1"
 dependencies = [
+ "anyhow",
  "clap",
  "pretty_env_logger",
  "probe-rs",

--- a/changelog/added-reset-flag-to-rtthost.md
+++ b/changelog/added-reset-flag-to-rtthost.md
@@ -1,0 +1,1 @@
+The rtthost gets the ability to reset the targert after the RTT session is established.

--- a/rtthost/Cargo.toml
+++ b/rtthost/Cargo.toml
@@ -10,4 +10,5 @@ repository.workspace = true
 [dependencies]
 pretty_env_logger = "0.5.0"
 probe-rs = { workspace = true }
+anyhow = { workspace = true }
 clap = { version = "4", features = ["cargo", "derive"] }

--- a/rtthost/src/main.rs
+++ b/rtthost/src/main.rs
@@ -94,6 +94,9 @@ struct Opts {
     )]
     down: Option<usize>,
 
+    #[clap(short, long, help = "Reset the target after RTT session was opened")]
+    reset: bool,
+
     #[clap(
         long,
         default_value="",
@@ -212,6 +215,10 @@ fn main() -> Result<()> {
 
     let mut up_buf = [0u8; 1024];
     let mut down_buf = vec![];
+
+    if opts.reset {
+        core.reset()?;
+    }
 
     loop {
         if let Some(up_channel) = up_channel.as_ref() {


### PR DESCRIPTION
I've needed a simple RTT logger of an (non-rust) application, which just prints the RTT log into stdout. rtthost is perfect for that, but sadly I can't connect to the target and reset it afterwards as the probe is in use. 

I've added a simple `--reset` flag similar to `--reset` flags of `cargo-flash` etc.

Additionally, I've moved `rtthost` to use anyhow instead of exit codes.