### PR TITLE
dap-adapter: Refresh stack trace when core halts, instead of on StackTrace request.

### DIFF
--- a/changelog/changed-stack-refresh-on-halt.md
+++ b/changelog/changed-stack-refresh-on-halt.md
@@ -1,0 +1,1 @@
+Move the stack refresh functionality to poll_cores, and trigger a refresh when the state changes from 'running' to 'halted'.

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -28,7 +28,6 @@ use probe_rs::{
         ColumnType, DebugRegisters, ObjectRef, SourceLocation, SteppingMode, VariableName,
         VariableNodeType, VerifiedBreakpoint,
     },
-    exception_handler_for_core,
     Architecture::Riscv,
     CoreStatus, Error, HaltReason, MemoryInterface, RegisterValue,
 };
@@ -1015,25 +1014,6 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         // The DAP spec says that the `startFrame` is optional and should be 0 if not specified.
         let start_frame = arguments.start_frame.unwrap_or(0);
 
-        // VSCode sends multiple StackTrace requests, which lead to out of synch frame_id numbers.
-        // If our client is VSCode, then we only refresh the stacktrace when the `startFrame` is 0
-        // and `levels` is 1.
-        if !self.vscode_quirks || (levels == 1 && start_frame == 0) {
-            tracing::debug!(
-                "Updating the stack frame data for core #{}",
-                target_core.core.id()
-            );
-
-            let initial_registers = DebugRegisters::from_core(&mut target_core.core);
-            let exception_interface = exception_handler_for_core(target_core.core.core_type());
-            let instruction_set = target_core.core.instruction_set().ok();
-            target_core.core_data.stack_frames = target_core.core_data.debug_info.unwind(
-                &mut target_core.core,
-                initial_registers,
-                exception_interface.as_ref(),
-                instruction_set,
-            )?;
-        }
         // Update the `levels` to the number of available frames if it is 0.
         if levels == 0 {
             levels = target_core.core_data.stack_frames.len() as i64;

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -11,8 +11,9 @@ use crate::cmd::dap_server::{
 use anyhow::{anyhow, Result};
 use probe_rs::{
     config::TargetSelector,
-    debug::{debug_info::DebugInfo, SourceLocation},
-    CoreStatus, DebugProbeError, Permissions, Probe, ProbeCreationError, Session,
+    debug::{debug_info::DebugInfo, DebugRegisters, SourceLocation},
+    exception_handler_for_core, CoreStatus, DebugProbeError, Permissions, Probe,
+    ProbeCreationError, Session,
 };
 use std::env::set_current_dir;
 use time::UtcOffset;
@@ -257,6 +258,8 @@ impl SessionData {
 
         let timestamp_offset = self.timestamp_offset;
 
+        let previous_state = debug_adapter.all_cores_halted;
+
         // Always set `all_cores_halted` to true, until one core is found to be running.
         debug_adapter.all_cores_halted = true;
         for core_config in session_config.core_configs.iter() {
@@ -311,6 +314,23 @@ impl SessionData {
             // By setting it here, we ensure that RTT will be checked at least once after the core has halted.
             if !current_core_status.is_halted() {
                 debug_adapter.all_cores_halted = false;
+            // If currently halted, and was previously running
+            // update the stack frames
+            } else if !previous_state {
+                tracing::debug!(
+                    "Updating the stack frame data for core #{}",
+                    target_core.core.id()
+                );
+
+                let initial_registers = DebugRegisters::from_core(&mut target_core.core);
+                let exception_interface = exception_handler_for_core(target_core.core.core_type());
+                let instruction_set = target_core.core.instruction_set().ok();
+                target_core.core_data.stack_frames = target_core.core_data.debug_info.unwind(
+                    &mut target_core.core,
+                    initial_registers,
+                    exception_interface.as_ref(),
+                    instruction_set,
+                )?;
             }
             status_of_cores.push(current_core_status);
         }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -316,7 +316,7 @@ impl SessionData {
                 debug_adapter.all_cores_halted = false;
             // If currently halted, and was previously running
             // update the stack frames
-            } else if !previous_state {
+            } else if !cores_halted_previously {
                 tracing::debug!(
                     "Updating the stack frame data for core #{}",
                     target_core.core.id()

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -258,7 +258,7 @@ impl SessionData {
 
         let timestamp_offset = self.timestamp_offset;
 
-        let previous_state = debug_adapter.all_cores_halted;
+        let cores_halted_previously = debug_adapter.all_cores_halted;
 
         // Always set `all_cores_halted` to true, until one core is found to be running.
         debug_adapter.all_cores_halted = true;


### PR DESCRIPTION
Hi,

Currently if a DAP client sends multiple `stackTrace` requests per suspend state, (in my case [nvim-dap](https://github.com/mfussenegger/nvim-dap)), the stack trace is refreshed for every request.

This results in the variable references also being refreshed; for `nvim-dap` this means it is unable to do anything with local variables. 
From my reading these references should stay valid for the entire suspend state:
https://pub.dev/documentation/dap/latest/dap/SetVariableResponseBody/variablesReference.html

This PR moves the stack refresh functionality to `poll_cores`, and triggers a refresh when the state changes from 'running' to 'halted'.

I have tested with both `nvim-dap` and `vscode` and had no issues.

Thanks :)