### PR TITLE
dap-adapter: Move initial core state check from threads request to configuration_done 

### DIFF
--- a/changelog/changed-config-done-threads.md
+++ b/changelog/changed-config-done-threads.md
@@ -1,1 +1,1 @@
-Move initial check of core state from `threads` request to `configuration_done` request.
+`dap-server`: Move initial check of core state from `threads` request to `configuration_done` request.

--- a/changelog/changed-config-done-threads.md
+++ b/changelog/changed-config-done-threads.md
@@ -1,0 +1,1 @@
+Move initial check of core state from `threads` request to `configuration_done` request.

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -959,14 +959,12 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         let mut threads: Vec<Thread> = vec![];
         if self.configuration_is_done() {
             // We can handle this request normally.
-            if current_core_status.is_halted() {
-                let single_thread = Thread {
-                    id: target_core.core.id() as i64,
-                    name: target_core.core_data.target_name.clone(),
-                };
-                threads.push(single_thread);
-                return self.send_response(request, Ok(Some(ThreadsResponseBody { threads })));
-            }
+            let single_thread = Thread {
+                id: target_core.core.id() as i64,
+                name: target_core.core_data.target_name.clone(),
+            };
+            threads.push(single_thread);
+            return self.send_response(request, Ok(Some(ThreadsResponseBody { threads })));
         }
         self.send_response::<()>(
             request,


### PR DESCRIPTION
This should have been submitted with #1902, apologies.

Currently if the core stops before configuraiton is complete, a `stopped` event is not generated until a `threads` request is sent. 

In my use case (again using `nvim-dap`), a `threads` request is only sent after seeing a `stopped` event; thus the DAP client hangs.

This PR moves the initial check of the core state (and thus the generation of a `stopped` event), to the `configuration_done` request handler.

This means `threads` requests received before the `configuration_done` request will be sent an error response; imo that is a valid response, but happy to hear your thoughts and implement a different response if required.
