### PR TITLE
Initial tests for the DAP debugger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,7 @@ dependencies = [
  "paste",
  "pretty_assertions",
  "pretty_env_logger",
+ "probe-rs",
  "probe-rs-target",
  "rand",
  "ratatui",

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -79,6 +79,9 @@ builtin-targets = []
 ftdi = ["libftdi1-sys"]
 ftdi-vendored = ["libftdi1-sys/vendored", "libftdi1-sys/libusb1-sys"]
 
+# Enable helpers for testing
+test = []
+
 [dependencies]
 anyhow = { workspace = true }
 base64 = "0.21.5"
@@ -202,6 +205,9 @@ itm = { version = "0.9.0-rc.1", default-features = false }
 insta = { version = "1.34.0", features = ["yaml", "filters"] }
 pretty_assertions = "1.4.0"
 termtree = "0.4.1"
+
+# Enable the test feature for dev builds
+probe-rs = { path = ".", features = ["test"] }
 
 [[package.metadata.release.pre-release-replacements]]
 file = "../CHANGELOG.md"

--- a/probe-rs/examples/multidrop_raw.rs
+++ b/probe-rs/examples/multidrop_raw.rs
@@ -1,14 +1,17 @@
 use anyhow::Result;
-use probe_rs::{architecture::arm::DpAddress, Probe};
+use probe_rs::{architecture::arm::DpAddress, AllProbesLister, Probe, ProbeLister};
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
 
     // Get a list of all available debug probes.
-    let probes = Probe::list_all();
+
+    let probe_lister = AllProbesLister::new();
+
+    let probes = probe_lister.list_all();
 
     // Use the first probe found.
-    let mut probe: Probe = probes[0].open()?;
+    let mut probe: Probe = probes[0].open(&probe_lister)?;
 
     probe.set_speed(100)?;
     probe.attach_to_unspecified()?;

--- a/probe-rs/examples/multidrop_raw.rs
+++ b/probe-rs/examples/multidrop_raw.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
-use probe_rs::{architecture::arm::DpAddress, AllProbesLister, Probe, ProbeLister};
+use probe_rs::{architecture::arm::DpAddress, Lister, Probe};
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
 
     // Get a list of all available debug probes.
 
-    let probe_lister = AllProbesLister::new();
+    let probe_lister = Lister::new();
 
     let probes = probe_lister.list_all();
 

--- a/probe-rs/examples/nrf53_recover.rs
+++ b/probe-rs/examples/nrf53_recover.rs
@@ -1,17 +1,19 @@
 use anyhow::Result;
 use probe_rs::{
     architecture::arm::{ApAddress, DpAddress},
-    Probe,
+    AllProbesLister, Probe, ProbeLister,
 };
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
 
+    let lister = AllProbesLister::new();
+
     // Get a list of all available debug probes.
-    let probes = Probe::list_all();
+    let probes = lister.list_all();
 
     // Use the first probe found.
-    let mut probe = probes[0].open()?;
+    let mut probe = probes[0].open(&lister)?;
 
     probe.attach_to_unspecified()?;
     let mut iface = probe

--- a/probe-rs/examples/nrf53_recover.rs
+++ b/probe-rs/examples/nrf53_recover.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 use probe_rs::{
     architecture::arm::{ApAddress, DpAddress},
-    AllProbesLister, ProbeLister,
+    Lister,
 };
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
 
-    let lister = AllProbesLister::new();
+    let lister = Lister::new();
 
     // Get a list of all available debug probes.
     let probes = lister.list_all();

--- a/probe-rs/examples/nrf53_recover.rs
+++ b/probe-rs/examples/nrf53_recover.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use probe_rs::{
     architecture::arm::{ApAddress, DpAddress},
-    AllProbesLister, Probe, ProbeLister,
+    AllProbesLister, ProbeLister,
 };
 
 fn main() -> Result<()> {

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -1,5 +1,5 @@
+use probe_rs::Lister;
 use probe_rs::{config::TargetSelector, MemoryInterface, Permissions, Probe, WireProtocol};
-use probe_rs::{AllProbesLister, ProbeLister};
 
 use clap::Parser;
 use std::num::ParseIntError;
@@ -148,7 +148,7 @@ fn main() -> Result<()> {
 }
 
 fn open_probe(index: Option<usize>) -> Result<Probe> {
-    let lister = AllProbesLister::new();
+    let lister = Lister::new();
 
     let list = lister.list_all();
 

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -1,4 +1,5 @@
 use probe_rs::{config::TargetSelector, MemoryInterface, Permissions, Probe, WireProtocol};
+use probe_rs::{AllProbesLister, ProbeLister};
 
 use clap::Parser;
 use std::num::ParseIntError;
@@ -147,7 +148,9 @@ fn main() -> Result<()> {
 }
 
 fn open_probe(index: Option<usize>) -> Result<Probe> {
-    let list = Probe::list_all();
+    let lister = AllProbesLister::new();
+
+    let list = lister.list_all();
 
     let device = match index {
         Some(index) => list
@@ -163,7 +166,7 @@ fn open_probe(index: Option<usize>) -> Result<Probe> {
         }
     };
 
-    let probe = device.open().context("Failed to open probe")?;
+    let probe = device.open(&lister).context("Failed to open probe")?;
 
     Ok(probe)
 }

--- a/probe-rs/examples/raw_dap_access.rs
+++ b/probe-rs/examples/raw_dap_access.rs
@@ -1,17 +1,19 @@
 use anyhow::Result;
 use probe_rs::{
     architecture::arm::{sequences::DefaultArmSequence, ApAddress, DpAddress},
-    Probe,
+    AllProbesLister, Probe,
 };
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
 
+    let lister = AllProbesLister::new();
+
     // Get a list of all available debug probes.
-    let probes = Probe::list_all();
+    let probes = AllProbesLister::list_all();
 
     // Use the first probe found.
-    let mut probe = probes[0].open()?;
+    let mut probe = probes[0].open(&lister)?;
 
     probe.attach_to_unspecified()?;
     let iface = probe.try_into_arm_interface().unwrap();

--- a/probe-rs/examples/raw_dap_access.rs
+++ b/probe-rs/examples/raw_dap_access.rs
@@ -1,16 +1,16 @@
 use anyhow::Result;
 use probe_rs::{
     architecture::arm::{sequences::DefaultArmSequence, ApAddress, DpAddress},
-    AllProbesLister,
+    Lister,
 };
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
 
-    let lister = AllProbesLister::new();
+    let lister = Lister::new();
 
     // Get a list of all available debug probes.
-    let probes = AllProbesLister::list_all();
+    let probes = lister.list_all();
 
     // Use the first probe found.
     let mut probe = probes[0].open(&lister)?;

--- a/probe-rs/examples/raw_dap_access.rs
+++ b/probe-rs/examples/raw_dap_access.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use probe_rs::{
     architecture::arm::{sequences::DefaultArmSequence, ApAddress, DpAddress},
-    AllProbesLister, Probe,
+    AllProbesLister,
 };
 
 fn main() -> Result<()> {

--- a/probe-rs/examples/tcp_itm.rs
+++ b/probe-rs/examples/tcp_itm.rs
@@ -1,5 +1,5 @@
 use probe_rs::architecture::arm::{component::TraceSink, swo::SwoConfig};
-use probe_rs::{Error, Permissions};
+use probe_rs::{AllProbesLister, Error, Permissions, ProbeLister};
 
 use itm::{Decoder, DecoderOptions, TracePacket};
 
@@ -12,13 +12,13 @@ use std::{any::Any, io::prelude::*};
 fn main() -> Result<(), Error> {
     pretty_env_logger::init();
 
-    use probe_rs::Probe;
+    let lister = AllProbesLister::new();
 
     // Get a list of all available debug probes.
-    let probes = Probe::list_all();
+    let probes = lister.list_all();
 
     // Use the first probe found.
-    let probe = probes[0].open()?;
+    let probe = probes[0].open(&lister)?;
 
     // Attach to a chip.
     let mut session = probe.attach("stm32f407", Permissions::default())?;

--- a/probe-rs/examples/tcp_itm.rs
+++ b/probe-rs/examples/tcp_itm.rs
@@ -1,5 +1,5 @@
 use probe_rs::architecture::arm::{component::TraceSink, swo::SwoConfig};
-use probe_rs::{AllProbesLister, Error, Permissions, ProbeLister};
+use probe_rs::{Error, Lister, Permissions};
 
 use itm::{Decoder, DecoderOptions, TracePacket};
 
@@ -12,7 +12,7 @@ use std::{any::Any, io::prelude::*};
 fn main() -> Result<(), Error> {
     pretty_env_logger::init();
 
-    let lister = AllProbesLister::new();
+    let lister = Lister::new();
 
     // Get a list of all available debug probes.
     let probes = lister.list_all();

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -51,6 +51,7 @@ pub struct ApAddress {
 }
 
 impl ApAddress {
+    /// Create a new `ApAddress` belonging to the default debug port.
     pub fn with_default_dp(ap: u8) -> Self {
         Self {
             dp: DpAddress::Default,

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -50,6 +50,15 @@ pub struct ApAddress {
     pub ap: u8,
 }
 
+impl ApAddress {
+    pub fn with_default_dp(ap: u8) -> Self {
+        Self {
+            dp: DpAddress::Default,
+            ap,
+        }
+    }
+}
+
 /// Low-level DAP register access.
 ///
 /// Operations on this trait closely match the transactions on the wire. Implementors

--- a/probe-rs/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/attach.rs
@@ -1,3 +1,4 @@
+use probe_rs::ProbeLister;
 use time::UtcOffset;
 
 #[derive(clap::Parser)]
@@ -8,8 +9,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, timestamp_offset: UtcOffset) -> anyhow::Result<()> {
-        self.run.run(false, timestamp_offset)?;
+    pub fn run(self, lister: &impl ProbeLister, timestamp_offset: UtcOffset) -> anyhow::Result<()> {
+        self.run.run(lister, false, timestamp_offset)?;
 
         Ok(())
     }

--- a/probe-rs/src/bin/probe-rs/cmd/attach.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/attach.rs
@@ -1,4 +1,4 @@
-use probe_rs::ProbeLister;
+use probe_rs::Lister;
 use time::UtcOffset;
 
 #[derive(clap::Parser)]
@@ -9,7 +9,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister, timestamp_offset: UtcOffset) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister, timestamp_offset: UtcOffset) -> anyhow::Result<()> {
         self.run.run(lister, false, timestamp_offset)?;
 
         Ok(())

--- a/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Context;
-use probe_rs::MemoryInterface;
+use probe_rs::{MemoryInterface, ProbeLister};
 use rand::prelude::*;
 
 use crate::util::common_options::LoadedProbeOptions;
@@ -84,7 +84,7 @@ struct TestData {
 }
 
 impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
         let speed = self.common.speed;
         let common_options = self.common.load()?;
         let mut max_speed = self.max_speed;
@@ -97,7 +97,7 @@ impl Cmd {
             speeds.extend_from_slice(&PROBE_SPEEDS);
         };
         // if we can't print basic info, we're probably not going to succeed with testing so bubble up the error
-        Cmd::print_info(&common_options)?;
+        Cmd::print_info(&common_options, lister)?;
 
         for speed in speeds
             .iter()
@@ -106,6 +106,7 @@ impl Cmd {
             for size in TEST_SIZES {
                 let res = Cmd::benchmark(
                     &common_options,
+                    lister,
                     *speed,
                     size,
                     self.address,
@@ -128,8 +129,11 @@ impl Cmd {
     }
 
     /// Print probe and target info
-    fn print_info(common_options: &LoadedProbeOptions) -> anyhow::Result<()> {
-        let probe = common_options.attach_probe()?;
+    fn print_info(
+        common_options: &LoadedProbeOptions,
+        lister: &impl ProbeLister,
+    ) -> anyhow::Result<()> {
+        let probe = common_options.attach_probe(lister)?;
         let protocol_name = probe
             .protocol()
             .map(|p| p.to_string())
@@ -149,13 +153,14 @@ impl Cmd {
     /// Run a specific benchmark
     fn benchmark(
         common_options: &LoadedProbeOptions,
+        lister: &impl ProbeLister,
         speed: u32,
         size: usize,
         address: u64,
         word_size: u32,
         iterations: usize,
     ) -> Result<(), anyhow::Error> {
-        let mut probe = common_options.attach_probe()?;
+        let mut probe = common_options.attach_probe(lister)?;
         let target = common_options.get_target_selector()?;
         if probe.set_speed(speed).is_ok() {
             let mut session = common_options.attach_session(probe, target)?;

--- a/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/benchmark.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Context;
-use probe_rs::{MemoryInterface, ProbeLister};
+use probe_rs::{Lister, MemoryInterface};
 use rand::prelude::*;
 
 use crate::util::common_options::LoadedProbeOptions;
@@ -84,7 +84,7 @@ struct TestData {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let speed = self.common.speed;
         let common_options = self.common.load()?;
         let mut max_speed = self.max_speed;
@@ -129,10 +129,7 @@ impl Cmd {
     }
 
     /// Print probe and target info
-    fn print_info(
-        common_options: &LoadedProbeOptions,
-        lister: &impl ProbeLister,
-    ) -> anyhow::Result<()> {
+    fn print_info(common_options: &LoadedProbeOptions, lister: &Lister) -> anyhow::Result<()> {
         let probe = common_options.attach_probe(lister)?;
         let protocol_name = probe
             .protocol()
@@ -153,7 +150,7 @@ impl Cmd {
     /// Run a specific benchmark
     fn benchmark(
         common_options: &LoadedProbeOptions,
-        lister: &impl ProbeLister,
+        lister: &Lister,
         speed: u32,
         size: usize,
         address: u64,

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -11,7 +11,7 @@ use probe_rs::rtt::{Rtt, ScanRegion};
 use probe_rs::{
     config::TargetSelector,
     flashing::{download_file_with_options, DownloadOptions, FlashProgress, Format, ProgressEvent},
-    DebugProbeSelector, Permissions, Probe, Session,
+    DebugProbeSelector, Permissions, Session,
 };
 use probe_rs::{AllProbesLister, ProbeLister};
 use std::ffi::OsString;
@@ -176,7 +176,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
 
     // If we got a probe selector in the config, open the probe matching the selector if possible.
     let mut probe = if let Some(ref selector) = opt.probe_selector {
-        lister.open(selector.clone())?
+        lister.open(selector)?
     } else {
         match (config.probe.usb_vid.as_ref(), config.probe.usb_pid.as_ref()) {
             (Some(vid), Some(pid)) => {
@@ -186,7 +186,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
                     serial_number: config.probe.serial.clone(),
                 };
                 // if two probes with the same VID:PID pair exist we just choose one
-                lister.open(selector)?
+                lister.open(&selector)?
             }
             _ => {
                 if config.probe.usb_vid.is_some() {
@@ -214,8 +214,10 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
                 }
 
                 lister.open(
-                    list.first()
-                        .ok_or_else(|| anyhow!("No supported probe was found"))?,
+                    &(list
+                        .first()
+                        .ok_or_else(|| anyhow!("No supported probe was found"))?
+                        .into()),
                 )?
             }
         }

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -8,12 +8,12 @@ use colored::*;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use probe_rs::gdb_server::GdbInstanceConfiguration;
 use probe_rs::rtt::{Rtt, ScanRegion};
+use probe_rs::Lister;
 use probe_rs::{
     config::TargetSelector,
     flashing::{download_file_with_options, DownloadOptions, FlashProgress, Format, ProgressEvent},
     DebugProbeSelector, Permissions, Session,
 };
-use probe_rs::{AllProbesLister, ProbeLister};
 use std::ffi::OsString;
 use std::{
     fs,
@@ -172,7 +172,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
         path.display()
     ));
 
-    let lister = AllProbesLister::new();
+    let lister = Lister::new();
 
     // If we got a probe selector in the config, open the probe matching the selector if possible.
     let mut probe = if let Some(ref selector) = opt.probe_selector {
@@ -186,7 +186,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
                     serial_number: config.probe.serial.clone(),
                 };
                 // if two probes with the same VID:PID pair exist we just choose one
-                lister.open(&selector)?
+                lister.open(selector)?
             }
             _ => {
                 if config.probe.usb_vid.is_some() {
@@ -214,10 +214,8 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
                 }
 
                 lister.open(
-                    &(list
-                        .first()
-                        .ok_or_else(|| anyhow!("No supported probe was found"))?
-                        .into()),
+                    list.first()
+                        .ok_or_else(|| anyhow!("No supported probe was found"))?,
                 )?
             }
         }

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -13,6 +13,7 @@ use probe_rs::{
     flashing::{download_file_with_options, DownloadOptions, FlashProgress, Format, ProgressEvent},
     DebugProbeSelector, Permissions, Probe, Session,
 };
+use probe_rs::{AllProbesLister, ProbeLister};
 use std::ffi::OsString;
 use std::{
     fs,
@@ -171,9 +172,11 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
         path.display()
     ));
 
+    let lister = AllProbesLister::new();
+
     // If we got a probe selector in the config, open the probe matching the selector if possible.
     let mut probe = if let Some(ref selector) = opt.probe_selector {
-        Probe::open(selector.clone())?
+        lister.open(selector.clone())?
     } else {
         match (config.probe.usb_vid.as_ref(), config.probe.usb_pid.as_ref()) {
             (Some(vid), Some(pid)) => {
@@ -183,7 +186,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
                     serial_number: config.probe.serial.clone(),
                 };
                 // if two probes with the same VID:PID pair exist we just choose one
-                Probe::open(selector)?
+                lister.open(selector)?
             }
             _ => {
                 if config.probe.usb_vid.is_some() {
@@ -195,7 +198,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
 
                 // Only automatically select a probe if there is only
                 // a single probe detected.
-                let list = Probe::list_all();
+                let list = lister.list_all();
                 if list.len() > 1 {
                     use std::fmt::Write;
 
@@ -209,7 +212,8 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
                                     For usage examples see https://github.com/probe-rs/cargo-embed/blob/master/src/config/default.toml .",
                                     list.iter().enumerate().fold(String::new(), |mut s, (num, link)| { let _ = writeln!(s, "[{num}]: {link:?}"); s })));
                 }
-                Probe::open(
+
+                lister.open(
                     list.first()
                         .ok_or_else(|| anyhow!("No supported probe was found"))?,
                 )?

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -2,7 +2,7 @@ mod diagnostics;
 
 use colored::*;
 use diagnostics::render_diagnostics;
-use probe_rs::{AllProbesLister, ProbeLister};
+use probe_rs::Lister;
 use std::ffi::OsString;
 use std::{path::PathBuf, process};
 
@@ -13,9 +13,9 @@ use clap::{CommandFactory, FromArgMatches};
 use crate::util::{build_artifact, logging};
 
 pub fn main(args: Vec<OsString>) {
-    let lister = AllProbesLister::new();
+    let lister = Lister::new();
 
-    match main_try(args, lister) {
+    match main_try(args, &lister) {
         Ok(_) => (),
         Err(e) => {
             // Ensure stderr is flushed before calling process::exit,
@@ -30,7 +30,7 @@ pub fn main(args: Vec<OsString>) {
     }
 }
 
-fn main_try(mut args: Vec<OsString>, lister: impl ProbeLister) -> Result<(), OperationError> {
+fn main_try(mut args: Vec<OsString>, lister: &Lister) -> Result<(), OperationError> {
     // When called by Cargo, the first argument after the binary name will be `flash`. If that's the
     // case, remove one argument (`Opt::from_iter` will remove the binary name by itself).
     if args.get(1).and_then(|t| t.to_str()) == Some("flash") {
@@ -95,7 +95,7 @@ fn main_try(mut args: Vec<OsString>, lister: impl ProbeLister) -> Result<(), Ope
     ));
 
     // Attach to specified probe
-    let (mut session, probe_options) = opt.probe_options.simple_attach(&lister)?;
+    let (mut session, probe_options) = opt.probe_options.simple_attach(lister)?;
 
     // Flash the binary
     let loader = flash::build_loader(&mut session, &path, opt.format_options).unwrap();

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -2,6 +2,7 @@ mod diagnostics;
 
 use colored::*;
 use diagnostics::render_diagnostics;
+use probe_rs::{AllProbesLister, ProbeLister};
 use std::ffi::OsString;
 use std::{path::PathBuf, process};
 
@@ -12,7 +13,9 @@ use clap::{CommandFactory, FromArgMatches};
 use crate::util::{build_artifact, logging};
 
 pub fn main(args: Vec<OsString>) {
-    match main_try(args) {
+    let lister = AllProbesLister::new();
+
+    match main_try(args, lister) {
         Ok(_) => (),
         Err(e) => {
             // Ensure stderr is flushed before calling process::exit,
@@ -27,7 +30,7 @@ pub fn main(args: Vec<OsString>) {
     }
 }
 
-fn main_try(mut args: Vec<OsString>) -> Result<(), OperationError> {
+fn main_try(mut args: Vec<OsString>, lister: impl ProbeLister) -> Result<(), OperationError> {
     // When called by Cargo, the first argument after the binary name will be `flash`. If that's the
     // case, remove one argument (`Opt::from_iter` will remove the binary name by itself).
     if args.get(1).and_then(|t| t.to_str()) == Some("flash") {
@@ -92,7 +95,7 @@ fn main_try(mut args: Vec<OsString>) -> Result<(), OperationError> {
     ));
 
     // Attach to specified probe
-    let (mut session, probe_options) = opt.probe_options.simple_attach()?;
+    let (mut session, probe_options) = opt.probe_options.simple_attach(&lister)?;
 
     // Flash the binary
     let loader = flash::build_loader(&mut session, &path, opt.format_options).unwrap();

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -8,7 +8,7 @@ use super::{
     },
 };
 use crate::cmd::dap_server::{
-    debug_adapter::protocol::ProtocolAdapter,
+    debug_adapter::protocol::{ProtocolAdapter, ProtocolHelper},
     server::{
         configuration::ConsoleLog,
         core_data::CoreHandle,
@@ -100,7 +100,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 let new_status = match target_core.core.status() {
                     Ok(new_status) => new_status,
                     Err(error) => {
-                        self.send_response::<()>(request, Err(DebuggerError::ProbeRs(error)))?;
+                        self.send_response::<()>(request, Err(&DebuggerError::ProbeRs(error)))?;
                         return Err(anyhow!("Failed to retrieve core status"));
                     }
                 };
@@ -127,7 +127,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 Ok(())
             }
             Err(error) => {
-                self.send_response::<()>(request, Err(DebuggerError::Other(anyhow!("{}", error))))
+                self.send_response::<()>(request, Err(&DebuggerError::Other(anyhow!("{}", error))))
             }
         }
     }
@@ -164,7 +164,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             } else {
                 return self.send_response::<()>(
                     request,
-                    Err(DebuggerError::Other(anyhow!(
+                    Err(&DebuggerError::Other(anyhow!(
                         "Could not read any data at address {:?}",
                         arguments.memory_reference
                     ))),
@@ -217,7 +217,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         } else {
             self.send_response::<()>(
                 request,
-                Err(DebuggerError::Other(anyhow!(
+                Err(&DebuggerError::Other(anyhow!(
                     "Could not read any data at address {:#010x}",
                     address
                 ))),
@@ -237,7 +237,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     Ok(modified_address) => modified_address,
                     Err(error) => return self.send_response::<()>(
                     request,
-                    Err(DebuggerError::Other(anyhow!(
+                    Err(&DebuggerError::Other(anyhow!(
                         "Could not convert memory_reference: {} and offset: {:?} into a 32-bit memory address: {:?}",
                         arguments.memory_reference, arguments.offset, error
                     ))),
@@ -246,7 +246,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         } else {
             return self.send_response::<()>(
                 request,
-                Err(DebuggerError::Other(anyhow!(
+                Err(&DebuggerError::Other(anyhow!(
                     "Could not read any data at address {:?}",
                     arguments.memory_reference
                 ))),
@@ -257,7 +257,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             Err(error) => {
                 return self.send_response::<()>(
                     request,
-                    Err(DebuggerError::Other(anyhow!(
+                    Err(&DebuggerError::Other(anyhow!(
                         "Could not decode base64 data:{:?} :  {:?}",
                         arguments.data,
                         error
@@ -289,7 +289,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     }),
                 )
             }
-            Err(error) => self.send_response::<()>(request, Err(error)),
+            Err(error) => self.send_response::<()>(request, Err(&error)),
         }
     }
 
@@ -564,7 +564,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     // TODO: Does it make sense for us to consider implementing an update of platform registers?
                     return self.send_response::<SetVariableResponseBody>(
                         request,
-                        Err(DebuggerError::Other(anyhow!(
+                        Err(&DebuggerError::Other(anyhow!(
                             "Set Register values is not yet supported."
                         ))),
                     );
@@ -621,7 +621,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                         Err(error) => {
                             return self.send_response::<SetVariableResponseBody>(
                                 request,
-                                Err(DebuggerError::Other(anyhow!(
+                                Err(&DebuggerError::Other(anyhow!(
                                     "Failed to update variable: {}, with new value {:?} : {:?}",
                                     cache_variable.name,
                                     new_value,
@@ -638,7 +638,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             // If we get here, it is a bug.
             self.send_response::<SetVariableResponseBody>(
                                 request,
-                                Err(DebuggerError::Other(anyhow!(
+                                Err(&DebuggerError::Other(anyhow!(
                                     "Failed to update variable: {}, with new value {:?} : Please report this as a bug.",
                                     arguments.name,
                                     arguments.value
@@ -660,7 +660,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 if let Some(request) = request {
                     return self.send_response::<()>(
                         request,
-                        Err(DebuggerError::Other(anyhow!("{}", error))),
+                        Err(&DebuggerError::Other(anyhow!("{}", error))),
                     );
                 } else {
                     return self.show_error_message(&DebuggerError::Other(anyhow!("{}", error)));
@@ -674,8 +674,10 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         if let Some(request) = request {
             // Use reset_and_halt(), and then resume again afterwards, depending on the reset_after_halt flag.
             if let Err(error) = target_core.core.reset_and_halt(Duration::from_millis(500)) {
-                return self
-                    .send_response::<()>(request, Err(DebuggerError::Other(anyhow!("{}", error))));
+                return self.send_response::<()>(
+                    request,
+                    Err(&DebuggerError::Other(anyhow!("{}", error))),
+                );
             }
 
             // Ensure ebreak enters debug mode, this is necessary for soft breakpoints to work on architectures like RISC-V.
@@ -716,7 +718,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     }
                     Err(error) => self.send_response::<()>(
                         request,
-                        Err(DebuggerError::Other(anyhow!("{}", error))),
+                        Err(&DebuggerError::Other(anyhow!("{}", error))),
                     ),
                 }
             } else {
@@ -799,7 +801,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 Err(error) => {
                     return self.send_response::<()>(
                         request,
-                        Err(DebuggerError::Other(anyhow!(
+                        Err(&DebuggerError::Other(anyhow!(
                             "Failed to clear existing breakpoints before setting new ones : {}",
                             error
                         ))),
@@ -877,7 +879,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         } else {
             self.send_response::<()>(
                 request,
-                Err(DebuggerError::Other(anyhow!(
+                Err(&DebuggerError::Other(anyhow!(
                     "Could not get a valid source path from arguments: {args:?}"
                 ))),
             )
@@ -980,7 +982,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         }
         self.send_response::<()>(
             request,
-            Err(DebuggerError::Other(anyhow!(
+            Err(&DebuggerError::Other(anyhow!(
                 "Received request for `threads`, while last known core status was {:?}",
                 current_core_status
             ))),
@@ -997,14 +999,14 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 if !status.is_halted() {
                     return self.send_response::<()>(
                         request,
-                        Err(DebuggerError::Other(anyhow!(
+                        Err(&DebuggerError::Other(anyhow!(
                             "Core must be halted before requesting a stack trace"
                         ))),
                     );
                 }
             }
             Err(error) => {
-                return self.send_response::<()>(request, Err(DebuggerError::ProbeRs(error)))
+                return self.send_response::<()>(request, Err(&DebuggerError::ProbeRs(error)))
             }
         };
 
@@ -1084,7 +1086,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         } else {
             return self.send_response::<()>(
                 request,
-                Err(DebuggerError::Other(anyhow!(
+                Err(&DebuggerError::Other(anyhow!(
                     "Request for stack trace failed with invalid arguments: {:?}",
                     arguments
                 ))),
@@ -1328,13 +1330,13 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                     })),
                 ),
                 Err(error) => {
-                    self.send_response::<()>(request, Err(DebuggerError::Other(anyhow!(error))))
+                    self.send_response::<()>(request, Err(&DebuggerError::Other(anyhow!(error))))
                 }
             }
         } else {
             self.send_response::<()>(
                 request,
-                Err(DebuggerError::Other(anyhow!(
+                Err(&DebuggerError::Other(anyhow!(
                     "Invalid memory reference {:?}",
                     arguments.memory_reference
                 ))),
@@ -1420,132 +1422,135 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             }
         }
 
-        let response = {
-            let mut parent_variable: Option<probe_rs::debug::Variable> = None;
-            let mut variable_cache: Option<&mut probe_rs::debug::VariableCache> = None;
-            let mut stack_frame_registers: Option<&DebugRegisters> = None;
-            let mut frame_base: Option<u64> = None;
+        let mut parent_variable: Option<probe_rs::debug::Variable> = None;
+        let mut variable_cache: Option<&mut probe_rs::debug::VariableCache> = None;
+        let mut stack_frame_registers: Option<&DebugRegisters> = None;
+        let mut frame_base: Option<u64> = None;
 
-            for stack_frame in target_core.core_data.stack_frames.iter_mut() {
-                if let Some(search_cache) = &mut stack_frame.local_variables {
-                    if let Some(search_variable) = search_cache.get_variable_by_key(variable_ref) {
-                        parent_variable = Some(search_variable);
-                        variable_cache = Some(search_cache);
-                        stack_frame_registers = Some(&stack_frame.registers);
-                        frame_base = stack_frame.frame_base;
-                        break;
-                    }
+        for stack_frame in target_core.core_data.stack_frames.iter_mut() {
+            if let Some(search_cache) = &mut stack_frame.local_variables {
+                if let Some(search_variable) = search_cache.get_variable_by_key(variable_ref) {
+                    parent_variable = Some(search_variable);
+                    variable_cache = Some(search_cache);
+                    stack_frame_registers = Some(&stack_frame.registers);
+                    frame_base = stack_frame.frame_base;
+                    break;
                 }
-                if let Some(search_cache) = &mut stack_frame.static_variables {
-                    if let Some(search_variable) = search_cache.get_variable_by_key(variable_ref) {
-                        parent_variable = Some(search_variable);
-                        variable_cache = Some(search_cache);
-                        stack_frame_registers = Some(&stack_frame.registers);
-                        frame_base = stack_frame.frame_base;
-                        break;
-                    }
-                }
-
-                if stack_frame.id == variable_ref {
-                    // This is a special case, where we just want to return the stack frame registers.
-
-                    let dap_variables: Vec<Variable> = stack_frame
-                        .registers
-                        .0
-                        .iter()
-                        .map(|register| Variable {
-                            name: register.get_register_name(),
-                            evaluate_name: Some(register.get_register_name()),
-                            memory_reference: None,
-                            indexed_variables: None,
-                            named_variables: None,
-                            presentation_hint: None, // TODO: Implement hint as Hex for registers
-                            type_: Some(format!("{}", VariableName::RegistersRoot)),
-                            value: register.value.unwrap_or_default().to_string(),
-                            variables_reference: 0,
-                        })
-                        .collect();
-                    return self.send_response(
-                        request,
-                        Ok(Some(VariablesResponseBody {
-                            variables: dap_variables,
-                        })),
-                    );
+            }
+            if let Some(search_cache) = &mut stack_frame.static_variables {
+                if let Some(search_variable) = search_cache.get_variable_by_key(variable_ref) {
+                    parent_variable = Some(search_variable);
+                    variable_cache = Some(search_cache);
+                    stack_frame_registers = Some(&stack_frame.registers);
+                    frame_base = stack_frame.frame_base;
+                    break;
                 }
             }
 
-            // During the intial stack unwind operation, if encounter [Variable]'s with [VariableNodeType::is_deferred()], they will not be auto-expanded and included in the variable cache.
-            // TODO: Use the DAP "Invalidated" event to refresh the variables for this stackframe. It will allow the UI to see updated compound values for pointer variables based on the newly resolved children.
-            if let Some(variable_cache) = variable_cache {
-                if let Some(parent_variable) = parent_variable.as_mut() {
-                    if parent_variable.variable_node_type.is_deferred()
-                        && !variable_cache.has_children(parent_variable)?
-                    {
-                        if let Some(stack_frame_registers) = stack_frame_registers {
-                            target_core.core_data.debug_info.cache_deferred_variables(
-                                variable_cache,
-                                &mut target_core.core,
-                                parent_variable,
-                                stack_frame_registers,
-                                frame_base,
-                            )?;
-                        } else {
-                            tracing::error!("Could not cache deferred child variables for variable: {}. No register data available.", parent_variable.name);
-                        }
-                    }
-                }
+            if stack_frame.id == variable_ref {
+                // This is a special case, where we just want to return the stack frame registers.
 
-                let dap_variables: Vec<Variable> = variable_cache
-                    .get_children(variable_ref)?
+                let dap_variables: Vec<Variable> = stack_frame
+                    .registers
+                    .0
                     .iter()
-                    // Filter out requested children, then map them as DAP variables
-                    .filter(|variable| match &arguments.filter {
-                        Some(filter) => match filter.as_str() {
-                            "indexed" => variable.is_indexed(),
-                            "named" => !variable.is_indexed(),
-                            other => {
-                                // This will yield an empty Vec, which will result in a user facing error as well as the log below.
-                                tracing::error!("Received invalid variable filter: {}", other);
-                                false
-                            }
-                        },
-                        None => true,
-                    })
-                    // Convert the `probe_rs::debug::Variable` to `probe_rs_debugger::dap_types::Variable`
-                    .map(|variable| {
-                        let (
-                            variables_reference,
-                            named_child_variables_cnt,
-                            indexed_child_variables_cnt,
-                        ) = get_variable_reference(variable, variable_cache);
-                        Variable {
-                            name: variable.name.to_string(),
-                            // evaluate_name: Some(variable.name.to_string()),
-                            // Do NOT use evaluate_name. It is impossible to distinguish between duplicate variable
-                            // TODO: Implement qualified names.
-                            evaluate_name: None,
-                            memory_reference: Some(variable.memory_location.to_string()),
-                            indexed_variables: Some(indexed_child_variables_cnt),
-                            named_variables: Some(named_child_variables_cnt),
-                            presentation_hint: None,
-                            type_: Some(format!("{:?}", variable.type_name)),
-                            value: variable.get_value(variable_cache),
-                            variables_reference: variables_reference.into(),
-                        }
+                    .map(|register| Variable {
+                        name: register.get_register_name(),
+                        evaluate_name: Some(register.get_register_name()),
+                        memory_reference: None,
+                        indexed_variables: None,
+                        named_variables: None,
+                        presentation_hint: None, // TODO: Implement hint as Hex for registers
+                        type_: Some(format!("{}", VariableName::RegistersRoot)),
+                        value: register.value.unwrap_or_default().to_string(),
+                        variables_reference: 0,
                     })
                     .collect();
+                return self.send_response(
+                    request,
+                    Ok(Some(VariablesResponseBody {
+                        variables: dap_variables,
+                    })),
+                );
+            }
+        }
+
+        // During the intial stack unwind operation, if encounter [Variable]'s with [VariableNodeType::is_deferred()], they will not be auto-expanded and included in the variable cache.
+        // TODO: Use the DAP "Invalidated" event to refresh the variables for this stackframe. It will allow the UI to see updated compound values for pointer variables based on the newly resolved children.
+        if let Some(variable_cache) = variable_cache {
+            if let Some(parent_variable) = parent_variable.as_mut() {
+                if parent_variable.variable_node_type.is_deferred()
+                    && !variable_cache.has_children(parent_variable)?
+                {
+                    if let Some(stack_frame_registers) = stack_frame_registers {
+                        target_core.core_data.debug_info.cache_deferred_variables(
+                            variable_cache,
+                            &mut target_core.core,
+                            parent_variable,
+                            stack_frame_registers,
+                            frame_base,
+                        )?;
+                    } else {
+                        tracing::error!("Could not cache deferred child variables for variable: {}. No register data available.", parent_variable.name);
+                    }
+                }
+            }
+
+            let dap_variables: Vec<Variable> = variable_cache
+                .get_children(variable_ref)?
+                .iter()
+                // Filter out requested children, then map them as DAP variables
+                .filter(|variable| match &arguments.filter {
+                    Some(filter) => match filter.as_str() {
+                        "indexed" => variable.is_indexed(),
+                        "named" => !variable.is_indexed(),
+                        other => {
+                            // This will yield an empty Vec, which will result in a user facing error as well as the log below.
+                            tracing::error!("Received invalid variable filter: {}", other);
+                            false
+                        }
+                    },
+                    None => true,
+                })
+                // Convert the `probe_rs::debug::Variable` to `probe_rs_debugger::dap_types::Variable`
+                .map(|variable| {
+                    let (
+                        variables_reference,
+                        named_child_variables_cnt,
+                        indexed_child_variables_cnt,
+                    ) = get_variable_reference(variable, variable_cache);
+                    Variable {
+                        name: variable.name.to_string(),
+                        // evaluate_name: Some(variable.name.to_string()),
+                        // Do NOT use evaluate_name. It is impossible to distinguish between duplicate variable
+                        // TODO: Implement qualified names.
+                        evaluate_name: None,
+                        memory_reference: Some(variable.memory_location.to_string()),
+                        indexed_variables: Some(indexed_child_variables_cnt),
+                        named_variables: Some(named_child_variables_cnt),
+                        presentation_hint: None,
+                        type_: Some(format!("{:?}", variable.type_name)),
+                        value: variable.get_value(variable_cache),
+                        variables_reference: variables_reference.into(),
+                    }
+                })
+                .collect();
+            self.send_response(
+                request,
                 Ok(Some(VariablesResponseBody {
                     variables: dap_variables,
-                }))
-            } else {
-                Err(DebuggerError::Other(anyhow!(
-                    "No variable information found for {}!",
-                    arguments.variables_reference
-                )))
-            }
-        };
+                })),
+            )
+        } else {
+            let err = DebuggerError::Other(anyhow!(
+                "No variable information found for {}!",
+                arguments.variables_reference
+            ));
 
-        self.send_response(request, response)
+            let res: Result<Option<u32>, _> = Err(&err);
+
+            self.send_response(request, res)
+        }
     }
 
     pub(crate) fn r#continue(
@@ -1597,7 +1602,10 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 Ok(())
             }
             Err(error) => {
-                self.send_response::<()>(request, Err(DebuggerError::Other(anyhow!("{}", error))))?;
+                self.send_response::<()>(
+                    request,
+                    Err(&DebuggerError::Other(anyhow!("{}", error))),
+                )?;
                 Err(error.into())
             }
         }
@@ -1720,10 +1728,10 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
     /// DebuggerError. For the DAP Client, it forwards the response, while for
     /// the CLI, it will print the body for success, or the message for
     /// failure.
-    pub fn send_response<S: Serialize>(
+    pub fn send_response<S: Serialize + std::fmt::Debug>(
         &mut self,
         request: &Request,
-        response: Result<Option<S>, DebuggerError>,
+        response: Result<Option<S>, &DebuggerError>,
     ) -> Result<()> {
         self.adapter.send_response(request, response)
     }
@@ -1899,7 +1907,7 @@ pub fn get_arguments<T: DeserializeOwned, P: ProtocolAdapter>(
     req: &Request,
 ) -> Result<T, DebuggerError> {
     let Some(raw_arguments) = &req.arguments else {
-        debug_adapter.send_response::<()>(req, Err(DebuggerError::InvalidRequest))?;
+        debug_adapter.send_response::<()>(req, Err(&DebuggerError::InvalidRequest))?;
         return Err(DebuggerError::Other(anyhow!(
             "Failed to get {} arguments",
             req.command
@@ -1909,7 +1917,7 @@ pub fn get_arguments<T: DeserializeOwned, P: ProtocolAdapter>(
     match serde_json::from_value(raw_arguments.to_owned()) {
         Ok(value) => Ok(value),
         Err(e) => {
-            debug_adapter.send_response::<()>(req, Err(e.into()))?;
+            debug_adapter.send_response::<()>(req, Err(&e.into()))?;
             Err(DebuggerError::Other(anyhow!(
                 "Failed to deserialize {} arguments",
                 req.command

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
@@ -334,7 +334,7 @@ pub(crate) fn halt_core(
 ) -> Result<probe_rs::CoreInformation, DebuggerError> {
     match target_core.halt(Duration::from_millis(100)) {
         Ok(cpu_info) => Ok(cpu_info),
-        Err(error) => Err(DebuggerError::Other(anyhow!("{}", error))),
+        Err(error) => Err(DebuggerError::Other(anyhow!("{:#}", error))),
     }
 }
 

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
@@ -4,12 +4,14 @@
 mod debug_adapter;
 mod peripherals;
 mod server;
+
+#[cfg(test)]
 mod test;
 
 use anyhow::{Context, Result};
 use probe_rs::{
     architecture::arm::ap::AccessPortError, flashing::FileDownloadError, CoreDumpError,
-    DebugProbeError, Error, ProbeLister,
+    DebugProbeError, Error, Lister,
 };
 use server::startup::debug;
 use std::{env::var, fs::File, io::stderr};
@@ -80,7 +82,7 @@ pub struct Cmd {
     single_session: bool,
 }
 
-pub fn run(cmd: Cmd, lister: &impl ProbeLister, time_offset: UtcOffset) -> Result<()> {
+pub fn run(cmd: Cmd, lister: &Lister, time_offset: UtcOffset) -> Result<()> {
     let log_info_message = setup_logging(time_offset)?;
 
     debug(

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
@@ -4,11 +4,12 @@
 mod debug_adapter;
 mod peripherals;
 mod server;
+mod test;
 
 use anyhow::{Context, Result};
 use probe_rs::{
     architecture::arm::ap::AccessPortError, flashing::FileDownloadError, CoreDumpError,
-    DebugProbeError, Error,
+    DebugProbeError, Error, ProbeLister,
 };
 use server::startup::debug;
 use std::{env::var, fs::File, io::stderr};
@@ -79,10 +80,16 @@ pub struct Cmd {
     single_session: bool,
 }
 
-pub fn run(cmd: Cmd, time_offset: UtcOffset) -> Result<()> {
+pub fn run(cmd: Cmd, lister: &impl ProbeLister, time_offset: UtcOffset) -> Result<()> {
     let log_info_message = setup_logging(time_offset)?;
 
-    debug(cmd.port, cmd.single_session, &log_info_message, time_offset)
+    debug(
+        lister,
+        cmd.port,
+        cmd.single_session,
+        &log_info_message,
+        time_offset,
+    )
 }
 
 /// Setup logging, according to the following rules.

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/configuration.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/configuration.rs
@@ -2,11 +2,11 @@ use crate::util::rtt;
 use crate::{cmd::dap_server::DebuggerError, FormatOptions};
 use anyhow::{anyhow, Result};
 use probe_rs::{DebugProbeSelector, WireProtocol};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{env::current_dir, path::PathBuf};
 
 /// Shared options for all session level configuration.
-#[derive(Clone, Deserialize, Debug, Default)]
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionConfig {
     /// Level of information to be logged to the debugger console (Error, Info or Debug )
@@ -149,7 +149,7 @@ fn get_absolute_path(
 }
 
 /// Configuration options to control flashing.
-#[derive(Clone, Deserialize, Debug, Default)]
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct FlashingConfig {
     /// Flash the target before debugging
@@ -174,7 +174,7 @@ pub struct FlashingConfig {
 }
 
 /// Configuration options for all core level configuration.
-#[derive(Clone, Deserialize, Debug, Default)]
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct CoreConfig {
     /// The MCU Core to debug. Default is 0

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -21,7 +21,7 @@ use crate::cmd::dap_server::{
 use anyhow::{anyhow, Context};
 use probe_rs::{
     flashing::{download_file_with_options, DownloadOptions, FlashProgress},
-    Architecture, CoreStatus,
+    Architecture, CoreStatus, ProbeLister,
 };
 use std::{
     cell::RefCell,
@@ -173,7 +173,7 @@ impl Debugger {
                                 Err(error) => {
                                     debug_adapter.send_response::<()>(
                                         &request,
-                                        Err(DebuggerError::Other(anyhow!("{}", error))),
+                                        Err(&DebuggerError::Other(anyhow!("{}", error))),
                                     )?;
                                     return Err(error.into());
                                 }
@@ -268,7 +268,7 @@ impl Debugger {
                         // Unimplemented command.
                         debug_adapter.send_response::<()>(
                             &request,
-                            Err(DebuggerError::Other(anyhow!("Received request '{}', which is not supported or not implemented yet", other_command))),)
+                            Err(&DebuggerError::Other(anyhow!("Received request '{}', which is not supported or not implemented yet", other_command))),)
                             .and(Ok(()))
                     }
                 };
@@ -300,6 +300,7 @@ impl Debugger {
         &mut self,
         mut debug_adapter: DebugAdapter<P>,
         log_info_message: &str,
+        lister: &impl ProbeLister,
     ) -> Result<DebugSessionStatus, DebuggerError> {
         debug_adapter.log_to_console("Starting debug session...");
         debug_adapter.log_to_console(log_info_message);
@@ -315,14 +316,21 @@ impl Debugger {
             return Ok(DebugSessionStatus::Terminate);
         }
 
-        // Process either the Launch or Attach request.
-        let (mut debug_adapter, mut session_data) = match self.handle_launch_attach(debug_adapter) {
-            Ok((debug_adapter, session_data)) => (debug_adapter, session_data),
-            Err(_) => {
-                // The request handler has already reported this error to the user.
-                return Ok(DebugSessionStatus::Terminate);
+        let launch_attach_request = loop {
+            if let Some(request) = debug_adapter.listen_for_request()? {
+                break request;
             }
         };
+
+        // Process either the Launch or Attach request.
+        let (mut debug_adapter, mut session_data) =
+            match self.handle_launch_attach(&launch_attach_request, debug_adapter, lister) {
+                Ok((debug_adapter, session_data)) => (debug_adapter, session_data),
+                Err(_) => {
+                    // The request handler has already reported this error to the user.
+                    return Ok(DebugSessionStatus::Terminate);
+                }
+            };
 
         if debug_adapter
             .send_event::<Event>("initialized", None)
@@ -372,14 +380,10 @@ impl Debugger {
     /// Process launch or attach request
     fn handle_launch_attach<P: ProtocolAdapter + 'static>(
         &mut self,
+        launch_attach_request: &Request,
         mut debug_adapter: DebugAdapter<P>,
+        lister: &impl ProbeLister,
     ) -> Result<(DebugAdapter<P>, SessionData), DebuggerError> {
-        let launch_attach_request = loop {
-            if let Some(request) = debug_adapter.listen_for_request()? {
-                break request;
-            }
-        };
-
         let requested_target_session_type = match launch_attach_request.command.as_str() {
             "attach" => TargetSessionType::AttachRequest,
             "launch" => TargetSessionType::LaunchRequest,
@@ -389,7 +393,7 @@ impl Debugger {
 
                 debug_adapter.send_response::<()>(
                     &launch_attach_request,
-                    Err(DebuggerError::Other(anyhow!(error_msg.clone()))),
+                    Err(&DebuggerError::Other(anyhow!(error_msg.clone()))),
                 )?;
                 return Err(DebuggerError::Other(anyhow!(error_msg)));
             }
@@ -408,7 +412,7 @@ impl Debugger {
             {
                 debug_adapter.send_response::<()>(
                                         &launch_attach_request,
-                                        Err(DebuggerError::Other(anyhow!(
+                                        Err(&DebuggerError::Other(anyhow!(
                                             "Please do not use any of the `flashing_enabled`, `reset_after_flashing`, halt_after_reset`, `full_chip_erase`, or `restore_unwritten_bytes` options when using `attach` request type."))),
                                     )?;
 
@@ -421,22 +425,20 @@ impl Debugger {
             .set_console_log_level(self.config.console_log_level.unwrap_or(ConsoleLog::Console));
 
         if let Err(e) = self.config.validate_config_files() {
-            let err = anyhow!("{e:?}");
+            debug_adapter.send_response::<()>(&launch_attach_request, Err(&e))?;
 
-            debug_adapter.send_response::<()>(&launch_attach_request, Err(e))?;
-
-            return Err(err.into());
+            return Err(e.into());
         }
 
-        let mut session_data = match SessionData::new(&mut self.config, self.timestamp_offset) {
-            Ok(session_data) => session_data,
-            Err(error) => {
-                let err = anyhow!("{error:?}");
-                debug_adapter.send_response::<()>(&launch_attach_request, Err(error))?;
+        let mut session_data =
+            match SessionData::new(lister, &mut self.config, self.timestamp_offset) {
+                Ok(session_data) => session_data,
+                Err(error) => {
+                    debug_adapter.send_response::<()>(&launch_attach_request, Err(&error))?;
 
-                return Err(err.into());
-            }
-        };
+                    return Err(error);
+                }
+            };
 
         debug_adapter.halt_after_reset = self.config.flashing_config.halt_after_reset;
 
@@ -446,10 +448,10 @@ impl Debugger {
                     "Cannot continue unless one target core configuration is defined."
                 ))
             })?;
+
             let Some(path_to_elf) = target_core_config.program_binary.clone() else {
                 let err =  DebuggerError::Other(anyhow!("Please specify use the `program-binary` option in `launch.json` to specify an executable"));
-
-                debug_adapter.show_error_message(&err)?;
+                debug_adapter.send_response::<()>(&launch_attach_request, Err(&err))?;
                 return Err(err);
             };
 
@@ -799,7 +801,7 @@ impl Debugger {
         {
             debug_adapter.send_response::<()>(
                 &initialize_request,
-                Err(DebuggerError::Other(anyhow!(
+                Err(&DebuggerError::Other(anyhow!(
                     "Unsupported Capability: Client requested column and row numbers start at 0."
                 ))),
             )?;
@@ -867,12 +869,11 @@ fn expect_request<P: ProtocolAdapter>(
     } else {
         debug_adapter.send_response::<()>(
             &next_request,
-            Err(anyhow!(
+            Err(&DebuggerError::Other(anyhow!(
                 "Initial command was '{}', expected '{}'",
                 next_request.command,
                 expected_command
-            )
-            .into()),
+            ))),
         )?;
 
         Err(DebuggerError::Other(anyhow!(
@@ -910,5 +911,460 @@ pub(crate) fn is_file_newer(
             .ok()
             .flatten();
         true
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::panic;
+    use std::collections::VecDeque;
+    use std::path::PathBuf;
+
+    use probe_rs::architecture::arm::ApAddress;
+    use probe_rs::ProbeOperation;
+    use probe_rs::{DebugProbeInfo, FakeProbe};
+    use serde_json::json;
+    use time::UtcOffset;
+
+    use crate::cmd::dap_server::server::configuration::CoreConfig;
+    use crate::cmd::dap_server::{
+        debug_adapter::{
+            dap::{
+                adapter::DebugAdapter,
+                dap_types::{Capabilities, InitializeRequestArguments, Request},
+            },
+            protocol::ProtocolAdapter,
+        },
+        server::{configuration::SessionConfig, debugger::DebugSessionStatus},
+        test::TestLister,
+        DebuggerError,
+    };
+
+    use super::Debugger;
+
+    struct MockProtocolAdapter {
+        requests: VecDeque<Option<Request>>,
+
+        response_index: usize,
+        expected_responses:
+            Vec<Result<Option<serde_json::Value>, crate::cmd::dap_server::DebuggerError>>,
+
+        event_index: usize,
+        expected_events: Vec<(String, Option<serde_json::Value>)>,
+    }
+
+    impl MockProtocolAdapter {
+        fn new() -> Self {
+            Self {
+                requests: VecDeque::new(),
+                response_index: 0,
+                expected_responses: Vec::new(),
+                expected_events: Vec::new(),
+                event_index: 0,
+            }
+        }
+
+        fn add_request(&mut self, response: Option<Request>) {
+            self.requests.push_back(response);
+        }
+
+        fn expect_response(
+            &mut self,
+            response: Result<Option<impl serde::Serialize>, DebuggerError>,
+        ) {
+            let response = response.map(|r| r.map(|s| serde_json::to_value(s).unwrap()));
+
+            self.expected_responses.push(response);
+        }
+
+        fn expect_event(&mut self, event_type: &str, event_body: Option<impl serde::Serialize>) {
+            let event_body = event_body.map(|s| serde_json::to_value(s).unwrap());
+
+            self.expected_events
+                .push((event_type.to_owned(), event_body));
+        }
+    }
+
+    impl ProtocolAdapter for MockProtocolAdapter {
+        fn listen_for_request(&mut self) -> anyhow::Result<Option<Request>> {
+            self.requests
+                .pop_front()
+                .ok_or_else(|| anyhow::anyhow!("No more responses to listen for."))
+        }
+
+        fn send_event<S: serde::Serialize>(
+            &mut self,
+            event_type: &str,
+            event_body: Option<S>,
+        ) -> anyhow::Result<()> {
+            let event_body = event_body.map(|s| serde_json::to_value(s).unwrap());
+
+            if self.event_index >= self.expected_events.len() {
+                panic!(
+                    "No more events expected, but got event_type={:?}, event_body={:?}",
+                    event_type, event_body
+                );
+            }
+
+            let (expected_event_type, expected_event_body) =
+                &self.expected_events[self.event_index];
+
+            pretty_assertions::assert_eq!(event_type, expected_event_type);
+            pretty_assertions::assert_eq!(&event_body, expected_event_body);
+
+            self.event_index += 1;
+
+            Ok(())
+        }
+
+        fn set_console_log_level(
+            &mut self,
+            _log_level: crate::cmd::dap_server::server::configuration::ConsoleLog,
+        ) {
+        }
+
+        fn send_response<S: serde::Serialize + std::fmt::Debug>(
+            &mut self,
+            _request: &crate::cmd::dap_server::debug_adapter::dap::dap_types::Request,
+            response: Result<Option<S>, &crate::cmd::dap_server::DebuggerError>,
+        ) -> anyhow::Result<()> {
+            if self.response_index >= self.expected_responses.len() {
+                panic!("No more responses expected, but got {response:?}");
+            }
+
+            let expected_response = &self.expected_responses[self.response_index];
+
+            let response = response.map(|r| r.map(|s| serde_json::to_value(s).unwrap()));
+
+            match (response, expected_response) {
+                (Ok(actual_response), Ok(expected_response)) => {
+                    pretty_assertions::assert_eq!(&actual_response, expected_response);
+                }
+                (Err(actual_error), Err(expected_error)) => {
+                    assert_eq!(actual_error.to_string(), expected_error.to_string());
+                }
+                (Ok(actual_response), Err(expected_error)) => {
+                    panic!(
+                        "Expected error {:?} but got response {:?}",
+                        expected_error, actual_response
+                    );
+                }
+                (Err(actual_error), Ok(expected_response)) => {
+                    panic!(
+                        "Expected response {:?} but got error {:?}",
+                        expected_response, actual_error
+                    );
+                }
+            }
+
+            self.response_index += 1;
+
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_initalize_request() {
+        let mut protocol_adapter = MockProtocolAdapter::new();
+
+        let initialize_args = InitializeRequestArguments {
+            client_id: Some("mock_client".to_owned()),
+            client_name: Some("Mock client for testing".to_owned()),
+            adapter_id: "mock_adapter".to_owned(),
+            columns_start_at_1: None,
+            lines_start_at_1: None,
+            locale: None,
+            path_format: None,
+            supports_args_can_be_interpreted_by_shell: None,
+            supports_invalidated_event: None,
+            supports_memory_event: None,
+            supports_memory_references: None,
+            supports_progress_reporting: None,
+            supports_run_in_terminal_request: None,
+            supports_start_debugging_request: None,
+            supports_variable_paging: None,
+            supports_variable_type: None,
+        };
+
+        let args = serde_json::to_value(initialize_args).unwrap();
+
+        let request = Request {
+            arguments: Some(args),
+            command: "initialize".to_string(),
+            seq: 1,
+            type_: "request".to_string(),
+        };
+
+        protocol_adapter.add_request(Some(request));
+        protocol_adapter.expect_response(Ok(Some(Capabilities {
+            support_suspend_debuggee: Some(true),
+            support_terminate_debuggee: Some(true),
+            supports_clipboard_context: Some(true),
+            supports_completions_request: Some(true),
+            supports_configuration_done_request: Some(true),
+            supports_delayed_stack_trace_loading: Some(true),
+            supports_disassemble_request: Some(true),
+            supports_instruction_breakpoints: Some(true),
+            supports_read_memory_request: Some(true),
+            supports_write_memory_request: Some(true),
+            supports_restart_request: Some(true),
+            supports_set_variable: Some(true),
+            supports_stepping_granularity: Some(true),
+
+            ..Default::default()
+        })));
+        protocol_adapter.expect_event(
+            "output",
+            Some(json!({
+                "category": "console",
+                "group": "probe-rs-debug",
+                "output": "Starting debug session...\n"
+            })),
+        );
+        protocol_adapter.expect_event(
+            "output",
+            Some(json!({
+                "category": "console",
+                "group": "probe-rs-debug",
+                "output": "Some message?\n"
+            })),
+        );
+
+        let debug_adapter = DebugAdapter::new(protocol_adapter);
+
+        let mut debugger = Debugger::new(UtcOffset::UTC);
+
+        let lister = TestLister::new();
+
+        // TODO: Check proper return value
+        debugger
+            .debug_session(debug_adapter, "Some message?", &lister)
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_launch_no_probes() {
+        let mut protocol_adapter = MockProtocolAdapter::new();
+
+        let initialize_args = InitializeRequestArguments {
+            client_id: Some("mock_client".to_owned()),
+            client_name: Some("Mock client for testing".to_owned()),
+            adapter_id: "mock_adapter".to_owned(),
+            columns_start_at_1: None,
+            lines_start_at_1: None,
+            locale: None,
+            path_format: None,
+            supports_args_can_be_interpreted_by_shell: None,
+            supports_invalidated_event: None,
+            supports_memory_event: None,
+            supports_memory_references: None,
+            supports_progress_reporting: None,
+            supports_run_in_terminal_request: None,
+            supports_start_debugging_request: None,
+            supports_variable_paging: None,
+            supports_variable_type: None,
+        };
+
+        let args = serde_json::to_value(initialize_args).unwrap();
+
+        let request = Request {
+            arguments: Some(args),
+            command: "initialize".to_string(),
+            seq: 1,
+            type_: "request".to_string(),
+        };
+
+        protocol_adapter.add_request(Some(request));
+        protocol_adapter.expect_event(
+            "output",
+            Some(json!({
+                "category": "console",
+                "group": "probe-rs-debug",
+                "output": "Starting debug session...\n"
+            })),
+        );
+        protocol_adapter.expect_event(
+            "output",
+            Some(json!({
+                "category": "console",
+                "group": "probe-rs-debug",
+                "output": "initial info message\n"
+            })),
+        );
+        protocol_adapter.expect_response(Ok(Some(Capabilities {
+            support_suspend_debuggee: Some(true),
+            support_terminate_debuggee: Some(true),
+            supports_clipboard_context: Some(true),
+            supports_completions_request: Some(true),
+            supports_configuration_done_request: Some(true),
+            supports_delayed_stack_trace_loading: Some(true),
+            supports_disassemble_request: Some(true),
+            supports_instruction_breakpoints: Some(true),
+            supports_read_memory_request: Some(true),
+            supports_write_memory_request: Some(true),
+            supports_restart_request: Some(true),
+            supports_set_variable: Some(true),
+            supports_stepping_granularity: Some(true),
+
+            ..Default::default()
+        })));
+
+        protocol_adapter.expect_response(Err::<Option<u32>, _>(DebuggerError::Other(
+            anyhow::anyhow!("No probes found. Please check your USB connections."),
+        )));
+
+        let launch_args = SessionConfig::default();
+
+        let args = serde_json::to_value(launch_args).unwrap();
+
+        let request = Request {
+            arguments: Some(args),
+            command: "launch".to_string(),
+            seq: 2,
+            type_: "request".to_string(),
+        };
+
+        protocol_adapter.add_request(Some(request));
+
+        let debug_adapter = DebugAdapter::new(protocol_adapter);
+
+        let mut debugger = Debugger::new(UtcOffset::UTC);
+
+        let lister = TestLister::new();
+
+        let status = debugger
+            .debug_session(debug_adapter, "initial info message", &lister)
+            .unwrap();
+
+        assert_eq!(status, DebugSessionStatus::Terminate);
+    }
+
+    #[test]
+    fn test_launch() {
+        let manifest_dir = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
+
+        let debug_info = manifest_dir.join("tests/debug-unwind-tests/nRF52833_xxAA.elf");
+
+        let mut protocol_adapter = MockProtocolAdapter::new();
+
+        let initialize_args = InitializeRequestArguments {
+            client_id: Some("mock_client".to_owned()),
+            client_name: Some("Mock client for testing".to_owned()),
+            adapter_id: "mock_adapter".to_owned(),
+            columns_start_at_1: None,
+            lines_start_at_1: None,
+            locale: None,
+            path_format: None,
+            supports_args_can_be_interpreted_by_shell: None,
+            supports_invalidated_event: None,
+            supports_memory_event: None,
+            supports_memory_references: None,
+            supports_progress_reporting: None,
+            supports_run_in_terminal_request: None,
+            supports_start_debugging_request: None,
+            supports_variable_paging: None,
+            supports_variable_type: None,
+        };
+
+        let args = serde_json::to_value(initialize_args).unwrap();
+
+        let request = Request {
+            arguments: Some(args),
+            command: "initialize".to_string(),
+            seq: 1,
+            type_: "request".to_string(),
+        };
+
+        protocol_adapter.add_request(Some(request));
+        protocol_adapter.expect_event(
+            "output",
+            Some(json!({
+                "category": "console",
+                "group": "probe-rs-debug",
+                "output": "Starting debug session...\n"
+            })),
+        );
+        protocol_adapter.expect_event(
+            "output",
+            Some(json!({
+                "category": "console",
+                "group": "probe-rs-debug",
+                "output": "initial info message\n"
+            })),
+        );
+        protocol_adapter.expect_response(Ok(Some(Capabilities {
+            support_suspend_debuggee: Some(true),
+            support_terminate_debuggee: Some(true),
+            supports_clipboard_context: Some(true),
+            supports_completions_request: Some(true),
+            supports_configuration_done_request: Some(true),
+            supports_delayed_stack_trace_loading: Some(true),
+            supports_disassemble_request: Some(true),
+            supports_instruction_breakpoints: Some(true),
+            supports_read_memory_request: Some(true),
+            supports_write_memory_request: Some(true),
+            supports_restart_request: Some(true),
+            supports_set_variable: Some(true),
+            supports_stepping_granularity: Some(true),
+
+            ..Default::default()
+        })));
+
+        protocol_adapter.expect_response(Err::<Option<u32>, _>(DebuggerError::Other(
+            anyhow::anyhow!("No probes found. Please check your USB connections."),
+        )));
+
+        let launch_args = SessionConfig {
+            chip: Some("nrf52833_xxaa".to_owned()),
+            core_configs: vec![CoreConfig {
+                core_index: 0,
+                program_binary: Some(debug_info),
+                ..CoreConfig::default()
+            }],
+            ..SessionConfig::default()
+        };
+
+        let args = serde_json::to_value(launch_args).unwrap();
+
+        let request = Request {
+            arguments: Some(args),
+            command: "launch".to_string(),
+            seq: 2,
+            type_: "request".to_string(),
+        };
+
+        protocol_adapter.add_request(Some(request));
+
+        let debug_adapter = DebugAdapter::new(protocol_adapter);
+
+        let mut debugger = Debugger::new(UtcOffset::UTC);
+
+        let lister = TestLister::new();
+
+        let probe_info = DebugProbeInfo::<TestLister>::new(
+            "Mock probe",
+            0x12,
+            0x23,
+            Some("mock_serial".to_owned()),
+            probe_rs::DebugProbeType::CmsisDap,
+            None,
+        );
+
+        let fake_probe = FakeProbe::new();
+
+        // Indicate that the core is unlocked
+        fake_probe.expect_operation(ProbeOperation::ReadRawApRegister {
+            ap: ApAddress::with_default_dp(1),
+            address: 0xC,
+            result: 1,
+        });
+
+        lister.probes.borrow_mut().push((probe_info, fake_probe));
+
+        let status = debugger
+            .debug_session(debug_adapter, "initial info message", &lister)
+            .unwrap();
+
+        assert_eq!(status, DebugSessionStatus::Terminate);
     }
 }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -12,8 +12,8 @@ use anyhow::{anyhow, Result};
 use probe_rs::{
     config::TargetSelector,
     debug::{debug_info::DebugInfo, DebugRegisters, SourceLocation},
-    exception_handler_for_core, CoreStatus, DebugProbeError, Permissions, ProbeCreationError,
-    ProbeLister, Session,
+    exception_handler_for_core, CoreStatus, DebugProbeError, Lister, Permissions,
+    ProbeCreationError, Session,
 };
 use std::env::set_current_dir;
 use time::UtcOffset;
@@ -62,7 +62,7 @@ pub(crate) struct SessionData {
 
 impl SessionData {
     pub(crate) fn new(
-        lister: &impl ProbeLister,
+        lister: &Lister,
         config: &mut configuration::SessionConfig,
         timestamp_offset: UtcOffset,
     ) -> Result<Self, DebuggerError> {
@@ -90,7 +90,7 @@ impl SessionData {
                 }
 
                 if let Some(info) = list.first() {
-                    lister.open(&info.into()).map_err(DebuggerError::DebugProbe)
+                    lister.open(info).map_err(DebuggerError::DebugProbe)
                 } else {
                     return Err(DebuggerError::Other(anyhow!(
                         "No probes found. Please check your USB connections."

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -12,7 +12,7 @@ use anyhow::{anyhow, Result};
 use probe_rs::{
     config::TargetSelector,
     debug::{debug_info::DebugInfo, SourceLocation},
-    CoreStatus, DebugProbeError, Permissions, Probe, ProbeCreationError, ProbeLister, Session,
+    CoreStatus, DebugProbeError, Permissions, ProbeCreationError, ProbeLister, Session,
 };
 use std::env::set_current_dir;
 use time::UtcOffset;
@@ -67,7 +67,7 @@ impl SessionData {
     ) -> Result<Self, DebuggerError> {
         // `SessionConfig` Probe/Session level configurations initialization.
         let mut target_probe = match config.probe_selector.clone() {
-            Some(selector) => lister.open(selector.clone()).map_err(|e| match e {
+            Some(selector) => lister.open(&selector).map_err(|e| match e {
                 DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::NotFound) => {
                     DebuggerError::Other(anyhow!(
                         "Could not find the probe_selector specified as {:04x}:{:04x}:{:?}",
@@ -89,7 +89,7 @@ impl SessionData {
                 }
 
                 if let Some(info) = list.first() {
-                    lister.open(info).map_err(DebuggerError::DebugProbe)
+                    lister.open(&info.into()).map_err(DebuggerError::DebugProbe)
                 } else {
                     return Err(DebuggerError::Other(anyhow!(
                         "No probes found. Please check your USB connections."

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
@@ -1,7 +1,7 @@
 use super::debugger::{DebugSessionStatus, Debugger};
 use crate::cmd::dap_server::debug_adapter::{dap::adapter::*, protocol::DapAdapter};
 use anyhow::{Context, Result};
-use probe_rs::{ProbeLister};
+use probe_rs::Lister;
 use serde::Deserialize;
 use std::{
     fs,
@@ -32,7 +32,7 @@ impl std::str::FromStr for TargetSessionType {
 }
 
 pub fn debug(
-    lister: &impl ProbeLister,
+    lister: &Lister,
     port: u16,
     single_session: bool,
     log_info_message: &str,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
@@ -1,7 +1,7 @@
 use super::debugger::{DebugSessionStatus, Debugger};
 use crate::cmd::dap_server::debug_adapter::{dap::adapter::*, protocol::DapAdapter};
 use anyhow::{Context, Result};
-use probe_rs::{AllProbesLister, ProbeLister};
+use probe_rs::{ProbeLister};
 use serde::Deserialize;
 use std::{
     fs,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
@@ -1,6 +1,7 @@
 use super::debugger::{DebugSessionStatus, Debugger};
 use crate::cmd::dap_server::debug_adapter::{dap::adapter::*, protocol::DapAdapter};
 use anyhow::{Context, Result};
+use probe_rs::{AllProbesLister, ProbeLister};
 use serde::Deserialize;
 use std::{
     fs,
@@ -31,6 +32,7 @@ impl std::str::FromStr for TargetSessionType {
 }
 
 pub fn debug(
+    lister: &impl ProbeLister,
     port: u16,
     single_session: bool,
     log_info_message: &str,
@@ -69,7 +71,7 @@ pub fn debug(
 
                 let debug_adapter = DebugAdapter::new(dap_adapter);
 
-                match debugger.debug_session(debug_adapter, log_info_message) {
+                match debugger.debug_session(debug_adapter, log_info_message, lister) {
                     Err(error) => {
                         tracing::error!("probe-rs-debugger session ended: {}", error);
                     }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/test.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/test.rs
@@ -1,0 +1,46 @@
+use std::{cell::RefCell};
+
+use probe_rs::{
+    DebugProbeError, DebugProbeInfo, DebugProbeSelector, FakeProbe, Probe, ProbeLister,
+};
+
+#[derive(Debug)]
+pub struct TestLister {
+    pub probes: RefCell<Vec<(DebugProbeInfo, FakeProbe)>>,
+}
+
+impl TestLister {
+    pub fn new() -> Self {
+        Self {
+            probes: RefCell::new(Vec::new()),
+        }
+    }
+}
+
+impl ProbeLister for TestLister {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Probe, DebugProbeError> {
+        let probe_index = self.probes.borrow().iter().position(|(info, _)| {
+            info.product_id == selector.product_id
+                && info.vendor_id == selector.vendor_id
+                && info.serial_number == selector.serial_number
+        });
+
+        if let Some(index) = probe_index {
+            let (_info, probe) = self.probes.borrow_mut().swap_remove(index);
+
+            Ok(Probe::from_specific_probe(Box::new(probe)))
+        } else {
+            Err(DebugProbeError::ProbeCouldNotBeCreated(
+                probe_rs::ProbeCreationError::CouldNotOpen,
+            ))
+        }
+    }
+
+    fn list_all(&self) -> Vec<DebugProbeInfo> {
+        self.probes
+            .borrow()
+            .iter()
+            .map(|(info, _)| info.clone())
+            .collect()
+    }
+}

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/test.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/test.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell};
+use std::cell::RefCell;
 
 use probe_rs::{
     DebugProbeError, DebugProbeInfo, DebugProbeSelector, FakeProbe, Probe, ProbeLister,

--- a/probe-rs/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/debug.rs
@@ -14,7 +14,7 @@ use probe_rs::exception_handler_for_core;
 use probe_rs::flashing::FileDownloadError;
 use probe_rs::CoreDumpError;
 use probe_rs::DebugProbeError;
-use probe_rs::ProbeLister;
+use probe_rs::Lister;
 use probe_rs::{
     debug::{debug_info::DebugInfo, registers::DebugRegisters, stack_frame::StackFrame},
     Core, CoreType, InstructionSet, MemoryInterface, RegisterValue,
@@ -37,7 +37,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, _probe_options) = self.common.simple_attach(lister)?;
 
         let di = self

--- a/probe-rs/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/debug.rs
@@ -14,6 +14,7 @@ use probe_rs::exception_handler_for_core;
 use probe_rs::flashing::FileDownloadError;
 use probe_rs::CoreDumpError;
 use probe_rs::DebugProbeError;
+use probe_rs::ProbeLister;
 use probe_rs::{
     debug::{debug_info::DebugInfo, registers::DebugRegisters, stack_frame::StackFrame},
     Core, CoreType, InstructionSet, MemoryInterface, RegisterValue,
@@ -36,8 +37,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.common.simple_attach()?;
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.common.simple_attach(lister)?;
 
         let di = self
             .exe

--- a/probe-rs/src/bin/probe-rs/cmd/download.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/download.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use anyhow::Context;
 use probe_rs::flashing::FileDownloadError;
 use probe_rs::flashing::Format;
-use probe_rs::ProbeLister;
+use probe_rs::Lister;
 
 use crate::util::common_options::BinaryDownloadOptions;
 use crate::util::common_options::ProbeOptions;
@@ -31,7 +31,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, probe_options) = self.probe_options.simple_attach(lister)?;
 
         let mut file = match File::open(&self.path) {

--- a/probe-rs/src/bin/probe-rs/cmd/download.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/download.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use anyhow::Context;
 use probe_rs::flashing::FileDownloadError;
 use probe_rs::flashing::Format;
+use probe_rs::ProbeLister;
 
 use crate::util::common_options::BinaryDownloadOptions;
 use crate::util::common_options::ProbeOptions;
@@ -30,8 +31,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
-        let (mut session, probe_options) = self.probe_options.simple_attach()?;
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+        let (mut session, probe_options) = self.probe_options.simple_attach(lister)?;
 
         let mut file = match File::open(&self.path) {
             Ok(file) => file,

--- a/probe-rs/src/bin/probe-rs/cmd/erase.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/erase.rs
@@ -1,4 +1,4 @@
-use probe_rs::flashing::erase_all;
+use probe_rs::{flashing::erase_all, ProbeLister};
 
 use crate::util::common_options::ProbeOptions;
 
@@ -9,8 +9,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.common.simple_attach()?;
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.common.simple_attach(lister)?;
 
         erase_all(&mut session, None)?;
 

--- a/probe-rs/src/bin/probe-rs/cmd/erase.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/erase.rs
@@ -1,4 +1,4 @@
-use probe_rs::{flashing::erase_all, ProbeLister};
+use probe_rs::{flashing::erase_all, Lister};
 
 use crate::util::common_options::ProbeOptions;
 
@@ -9,7 +9,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, _probe_options) = self.common.simple_attach(lister)?;
 
         erase_all(&mut session, None)?;

--- a/probe-rs/src/bin/probe-rs/cmd/gdb.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/gdb.rs
@@ -1,6 +1,8 @@
 use std::sync::Mutex;
 use std::time::Duration;
 
+use probe_rs::ProbeLister;
+
 use crate::util::common_options::ProbeOptions;
 
 #[derive(clap::Parser)]
@@ -23,8 +25,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.common.simple_attach()?;
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.common.simple_attach(lister)?;
 
         if self.reset_halt {
             session

--- a/probe-rs/src/bin/probe-rs/cmd/gdb.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/gdb.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 use std::time::Duration;
 
-use probe_rs::ProbeLister;
+use probe_rs::Lister;
 
 use crate::util::common_options::ProbeOptions;
 
@@ -25,7 +25,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, _probe_options) = self.common.simple_attach(lister)?;
 
         if self.reset_halt {

--- a/probe-rs/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/info.rs
@@ -15,7 +15,7 @@ use probe_rs::{
         },
         riscv::communication_interface::RiscvCommunicationInterface,
     },
-    MemoryMappedRegister, Probe, WireProtocol,
+    MemoryMappedRegister, Probe, ProbeLister, WireProtocol,
 };
 use termtree::Tree;
 
@@ -28,9 +28,9 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
         let probe_options = self.common.load()?;
-        let mut probe = probe_options.attach_probe()?;
+        let mut probe = probe_options.attach_probe(lister)?;
 
         let protocols = if let Some(protocol) = probe_options.protocol() {
             vec![protocol]

--- a/probe-rs/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/info.rs
@@ -15,7 +15,7 @@ use probe_rs::{
         },
         riscv::communication_interface::RiscvCommunicationInterface,
     },
-    MemoryMappedRegister, Probe, ProbeLister, WireProtocol,
+    Lister, MemoryMappedRegister, Probe, WireProtocol,
 };
 use termtree::Tree;
 
@@ -28,7 +28,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let probe_options = self.common.load()?;
         let mut probe = probe_options.attach_probe(lister)?;
 

--- a/probe-rs/src/bin/probe-rs/cmd/itm.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/itm.rs
@@ -1,6 +1,7 @@
 //! Provides ITM tracing capabilities.
 
 use probe_rs::architecture::arm::{component::TraceSink, swo::SwoConfig};
+use probe_rs::ProbeLister;
 
 use crate::util::common_options::ProbeOptions;
 use crate::CoreOptions;
@@ -65,8 +66,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.common.simple_attach()?;
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.common.simple_attach(lister)?;
 
         match self.source {
             ItmSource::TraceMemory { coreclk } => {

--- a/probe-rs/src/bin/probe-rs/cmd/itm.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/itm.rs
@@ -1,7 +1,7 @@
 //! Provides ITM tracing capabilities.
 
 use probe_rs::architecture::arm::{component::TraceSink, swo::SwoConfig};
-use probe_rs::ProbeLister;
+use probe_rs::Lister;
 
 use crate::util::common_options::ProbeOptions;
 use crate::CoreOptions;
@@ -66,7 +66,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, _probe_options) = self.common.simple_attach(lister)?;
 
         match self.source {

--- a/probe-rs/src/bin/probe-rs/cmd/list.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/list.rs
@@ -1,11 +1,11 @@
-use probe_rs::Probe;
+use probe_rs::ProbeLister;
 
 #[derive(clap::Parser)]
 pub struct Cmd {}
 
 impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
-        let probes = Probe::list_all();
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+        let probes = lister.list_all();
 
         if !probes.is_empty() {
             println!("The following debug probes were found:");

--- a/probe-rs/src/bin/probe-rs/cmd/list.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/list.rs
@@ -1,10 +1,10 @@
-use probe_rs::ProbeLister;
+use probe_rs::Lister;
 
 #[derive(clap::Parser)]
 pub struct Cmd {}
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let probes = lister.list_all();
 
         if !probes.is_empty() {

--- a/probe-rs/src/bin/probe-rs/cmd/profile.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/profile.rs
@@ -12,6 +12,7 @@ use probe_rs::{
         DpAddress, SwoConfig,
     },
     flashing::{FileDownloadError, Format},
+    ProbeLister,
 };
 use time::Instant;
 
@@ -72,8 +73,8 @@ impl core::fmt::Display for ProfileMethod {
 }
 
 impl ProfileCmd {
-    pub fn run(self) -> anyhow::Result<()> {
-        let (mut session, probe_options) = self.run.probe_options.simple_attach()?;
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+        let (mut session, probe_options) = self.run.probe_options.simple_attach(lister)?;
 
         let mut file = match File::open(&self.run.path) {
             Ok(file) => file,

--- a/probe-rs/src/bin/probe-rs/cmd/profile.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/profile.rs
@@ -12,7 +12,7 @@ use probe_rs::{
         DpAddress, SwoConfig,
     },
     flashing::{FileDownloadError, Format},
-    ProbeLister,
+    Lister,
 };
 use time::Instant;
 
@@ -73,7 +73,7 @@ impl core::fmt::Display for ProfileMethod {
 }
 
 impl ProfileCmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, probe_options) = self.run.probe_options.simple_attach(lister)?;
 
         let mut file = match File::open(&self.run.path) {

--- a/probe-rs/src/bin/probe-rs/cmd/read.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/read.rs
@@ -1,4 +1,4 @@
-use probe_rs::MemoryInterface;
+use probe_rs::{MemoryInterface, ProbeLister};
 
 use crate::util::common_options::{ProbeOptions, ReadWriteBitWidth, ReadWriteOptions};
 use crate::CoreOptions;
@@ -32,8 +32,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.probe_options.simple_attach()?;
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.probe_options.simple_attach(lister)?;
         let mut core = session.core(self.shared.core)?;
         let words = self.words as usize;
 

--- a/probe-rs/src/bin/probe-rs/cmd/read.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/read.rs
@@ -1,4 +1,4 @@
-use probe_rs::{MemoryInterface, ProbeLister};
+use probe_rs::{Lister, MemoryInterface};
 
 use crate::util::common_options::{ProbeOptions, ReadWriteBitWidth, ReadWriteOptions};
 use crate::CoreOptions;
@@ -32,7 +32,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, _probe_options) = self.probe_options.simple_attach(lister)?;
         let mut core = session.core(self.shared.core)?;
         let words = self.words as usize;

--- a/probe-rs/src/bin/probe-rs/cmd/reset.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/reset.rs
@@ -1,4 +1,4 @@
-use probe_rs::ProbeLister;
+use probe_rs::Lister;
 
 use crate::{util::common_options::ProbeOptions, CoreOptions};
 
@@ -15,7 +15,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, _probe_options) = self.common.simple_attach(lister)?;
 
         session.core(self.shared.core)?.reset()?;

--- a/probe-rs/src/bin/probe-rs/cmd/reset.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/reset.rs
@@ -1,3 +1,5 @@
+use probe_rs::ProbeLister;
+
 use crate::{util::common_options::ProbeOptions, CoreOptions};
 
 #[derive(clap::Parser)]
@@ -13,8 +15,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.common.simple_attach()?;
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.common.simple_attach(lister)?;
 
         session.core(self.shared.core)?.reset()?;
 

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -11,7 +11,7 @@ use probe_rs::debug::{DebugInfo, DebugRegisters};
 use probe_rs::flashing::{FileDownloadError, Format};
 use probe_rs::{
     exception_handler_for_core, BreakpointCause, Core, CoreInterface, Error, HaltReason,
-    SemihostingCommand, VectorCatchCondition,
+    ProbeLister, SemihostingCommand, VectorCatchCondition,
 };
 use probe_rs_target::MemoryRegion;
 use signal_hook::consts::signal;
@@ -55,8 +55,13 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, run_download: bool, timestamp_offset: UtcOffset) -> Result<()> {
-        let (mut session, probe_options) = self.probe_options.simple_attach()?;
+    pub fn run(
+        self,
+        lister: &impl ProbeLister,
+        run_download: bool,
+        timestamp_offset: UtcOffset,
+    ) -> Result<()> {
+        let (mut session, probe_options) = self.probe_options.simple_attach(lister)?;
         let path = Path::new(&self.path);
 
         if run_download {

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -10,8 +10,8 @@ use anyhow::{anyhow, Context, Result};
 use probe_rs::debug::{DebugInfo, DebugRegisters};
 use probe_rs::flashing::{FileDownloadError, Format};
 use probe_rs::{
-    exception_handler_for_core, BreakpointCause, Core, CoreInterface, Error, HaltReason,
-    ProbeLister, SemihostingCommand, VectorCatchCondition,
+    exception_handler_for_core, BreakpointCause, Core, CoreInterface, Error, HaltReason, Lister,
+    SemihostingCommand, VectorCatchCondition,
 };
 use probe_rs_target::MemoryRegion;
 use signal_hook::consts::signal;
@@ -57,7 +57,7 @@ pub struct Cmd {
 impl Cmd {
     pub fn run(
         self,
-        lister: &impl ProbeLister,
+        lister: &Lister,
         run_download: bool,
         timestamp_offset: UtcOffset,
     ) -> Result<()> {

--- a/probe-rs/src/bin/probe-rs/cmd/trace.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/trace.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use probe_rs::MemoryInterface;
+use probe_rs::ProbeLister;
 use scroll::{Pwrite, LE};
 
 use crate::util::{common_options::ProbeOptions, parse_u64};
@@ -23,13 +24,13 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
         let mut xs = vec![];
         let mut ys = vec![];
 
         let start = Instant::now();
 
-        let (mut session, _probe_options) = self.common.simple_attach()?;
+        let (mut session, _probe_options) = self.common.simple_attach(lister)?;
 
         let mut core = session.core(self.shared.core)?;
 

--- a/probe-rs/src/bin/probe-rs/cmd/trace.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/trace.rs
@@ -3,8 +3,8 @@ use std::thread::sleep;
 use std::time::Duration;
 use std::time::Instant;
 
+use probe_rs::Lister;
 use probe_rs::MemoryInterface;
-use probe_rs::ProbeLister;
 use scroll::{Pwrite, LE};
 
 use crate::util::{common_options::ProbeOptions, parse_u64};
@@ -24,7 +24,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let mut xs = vec![];
         let mut ys = vec![];
 

--- a/probe-rs/src/bin/probe-rs/cmd/write.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/write.rs
@@ -1,4 +1,4 @@
-use probe_rs::MemoryInterface;
+use probe_rs::{MemoryInterface, ProbeLister};
 
 use crate::util::common_options::{ProbeOptions, ReadWriteBitWidth, ReadWriteOptions};
 use crate::util::parse_u64;
@@ -29,8 +29,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self) -> anyhow::Result<()> {
-        let (mut session, _probe_options) = self.probe_options.simple_attach()?;
+    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+        let (mut session, _probe_options) = self.probe_options.simple_attach(lister)?;
         let mut core = session.core(self.shared.core)?;
 
         match self.read_write_options.width {

--- a/probe-rs/src/bin/probe-rs/cmd/write.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/write.rs
@@ -1,4 +1,4 @@
-use probe_rs::{MemoryInterface, ProbeLister};
+use probe_rs::{Lister, MemoryInterface};
 
 use crate::util::common_options::{ProbeOptions, ReadWriteBitWidth, ReadWriteOptions};
 use crate::util::parse_u64;
@@ -29,7 +29,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, lister: &impl ProbeLister) -> anyhow::Result<()> {
+    pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, _probe_options) = self.probe_options.simple_attach(lister)?;
         let mut core = session.core(self.shared.core)?;
 

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -14,7 +14,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use itertools::Itertools;
 use probe_rs::flashing::{BinOptions, Format, IdfOptions};
-use probe_rs::{AllProbesLister, Target};
+use probe_rs::{Lister, Target};
 use serde::Serialize;
 use serde::{de::Error, Deserialize, Deserializer};
 use serde_json::Value;
@@ -260,7 +260,7 @@ fn main() -> Result<()> {
     let matches = Cli::parse_from(args);
 
     // Setup the probe lister, list all probes normally
-    let lister = AllProbesLister::new();
+    let lister = Lister::new();
 
     // the DAP server has special logging requirements. Run it before initializing logging,
     // so it can do its own special init.

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -240,7 +240,7 @@ impl LoadedProbeOptions {
             // matching the selector if possible.
             match &self.0.probe_selector {
                 Some(selector) => lister
-                    .open(selector.clone())
+                    .open(selector)
                     .map_err(OperationError::FailedToOpenProbe),
                 None => {
                     // Only automatically select a probe if there is
@@ -251,7 +251,9 @@ impl LoadedProbeOptions {
                     }
 
                     if let Some(info) = list.first() {
-                        lister.open(info).map_err(OperationError::FailedToOpenProbe)
+                        lister
+                            .open(&info.into())
+                            .map_err(OperationError::FailedToOpenProbe)
                     } else {
                         Err(OperationError::NoProbesFound)
                     }

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -40,8 +40,8 @@ use clap;
 use probe_rs::{
     config::{RegistryError, TargetSelector},
     flashing::{FileDownloadError, FlashError},
-    DebugProbeError, DebugProbeSelector, FakeProbe, Permissions, Probe, ProbeLister, Session,
-    Target, WireProtocol,
+    DebugProbeError, DebugProbeSelector, FakeProbe, Lister, Permissions, Probe, Session, Target,
+    WireProtocol,
 };
 use serde::{Deserialize, Serialize};
 
@@ -162,7 +162,7 @@ impl ProbeOptions {
     /// and target session.
     pub fn simple_attach(
         self,
-        lister: &impl ProbeLister,
+        lister: &Lister,
     ) -> Result<(Session, LoadedProbeOptions), OperationError> {
         let common_options = self.load()?;
 
@@ -230,7 +230,7 @@ impl LoadedProbeOptions {
     }
 
     /// Attaches to specified probe and configures it.
-    pub fn attach_probe(&self, lister: &impl ProbeLister) -> Result<Probe, OperationError> {
+    pub fn attach_probe(&self, lister: &Lister) -> Result<Probe, OperationError> {
         let mut probe = {
             if self.0.dry_run {
                 Probe::from_specific_probe(Box::new(FakeProbe::new()));
@@ -251,9 +251,7 @@ impl LoadedProbeOptions {
                     }
 
                     if let Some(info) = list.first() {
-                        lister
-                            .open(&info.into())
-                            .map_err(OperationError::FailedToOpenProbe)
+                        lister.open(info).map_err(OperationError::FailedToOpenProbe)
                     } else {
                         Err(OperationError::NoProbesFound)
                     }

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -90,7 +90,7 @@ impl FromStr for DataFormat {
 }
 
 /// The initial configuration for RTT (Real Time Transfer). This configuration is complimented with the additional information specified for each of the channels in `RttChannel`.
-#[derive(clap::Parser, Debug, Clone, Deserialize, Default)]
+#[derive(clap::Parser, Debug, Clone, Serialize, Deserialize, Default)]
 pub struct RttConfig {
     #[structopt(skip)]
     #[serde(default, rename = "rttEnabled")]
@@ -102,7 +102,7 @@ pub struct RttConfig {
 }
 
 /// The User specified configuration for each active RTT Channel. The configuration is passed via a DAP Client configuration (`launch.json`). If no configuration is specified, the defaults will be `Dataformat::String` and `show_timestamps=false`.
-#[derive(clap::Parser, Debug, Clone, serde::Deserialize, Default)]
+#[derive(clap::Parser, Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RttChannelConfig {
     pub channel_number: Option<usize>,

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -12,13 +12,15 @@
 //! ## Halting the attached chip
 //! ```no_run
 //! # use probe_rs::Error;
-//! use probe_rs::{Probe, Permissions};
+//! use probe_rs::{Probe, Permissions, ProbeLister, AllProbesLister};
 //!
 //! // Get a list of all available debug probes.
-//! let probes = Probe::list_all();
+//! let lister = AllProbesLister::new();
+//!
+//! let probes = lister.list_all();
 //!
 //! // Use the first probe found.
-//! let mut probe = probes[0].open()?;
+//! let mut probe = probes[0].open(&lister)?;
 //!
 //! // Attach to a chip.
 //! let mut session = probe.attach("nrf52", Permissions::default())?;
@@ -100,10 +102,10 @@ pub use crate::core::{
 pub use crate::error::Error;
 pub use crate::memory::MemoryInterface;
 pub use crate::probe::{
-    AttachMethod, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType,
-    Probe, ProbeCreationError, WireProtocol,
+    AllProbesLister, AttachMethod, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
+    DebugProbeType, Probe, ProbeCreationError, ProbeLister, WireProtocol,
 };
 pub use crate::session::{Permissions, Session};
 
-// TODO: Hide behind feature
 pub use crate::probe::fake_probe::FakeProbe;
+pub use crate::probe::fake_probe::Operation as ProbeOperation;

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -102,8 +102,8 @@ pub use crate::core::{
 pub use crate::error::Error;
 pub use crate::memory::MemoryInterface;
 pub use crate::probe::{
-    fake_probe::FakeProbe, AttachMethod, DebugProbe, DebugProbeError, DebugProbeInfo,
-    DebugProbeSelector, DebugProbeType, Lister, Probe, ProbeCreationError, WireProtocol,
+    fake_probe::FakeProbe, list::Lister, AttachMethod, DebugProbe, DebugProbeError, DebugProbeInfo,
+    DebugProbeSelector, DebugProbeType, Probe, ProbeCreationError, WireProtocol,
 };
 pub use crate::session::{Permissions, Session};
 
@@ -111,4 +111,4 @@ pub use crate::session::{Permissions, Session};
 #[cfg(feature = "test")]
 pub use crate::probe::fake_probe::Operation as ProbeOperation;
 #[cfg(feature = "test")]
-pub use crate::probe::ProbeLister;
+pub use crate::probe::list::ProbeLister;

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -12,10 +12,10 @@
 //! ## Halting the attached chip
 //! ```no_run
 //! # use probe_rs::Error;
-//! use probe_rs::{Probe, Permissions, ProbeLister, AllProbesLister};
+//! use probe_rs::{Lister, Probe, Permissions};
 //!
 //! // Get a list of all available debug probes.
-//! let lister = AllProbesLister::new();
+//! let lister = Lister::new();
 //!
 //! let probes = lister.list_all();
 //!
@@ -102,10 +102,13 @@ pub use crate::core::{
 pub use crate::error::Error;
 pub use crate::memory::MemoryInterface;
 pub use crate::probe::{
-    AllProbesLister, AttachMethod, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
-    DebugProbeType, Probe, ProbeCreationError, ProbeLister, WireProtocol,
+    fake_probe::FakeProbe, AttachMethod, DebugProbe, DebugProbeError, DebugProbeInfo,
+    DebugProbeSelector, DebugProbeType, Lister, Probe, ProbeCreationError, WireProtocol,
 };
 pub use crate::session::{Permissions, Session};
 
-pub use crate::probe::fake_probe::FakeProbe;
+// Exports only used in tests
+#[cfg(feature = "test")]
 pub use crate::probe::fake_probe::Operation as ProbeOperation;
+#[cfg(feature = "test")]
+pub use crate::probe::ProbeLister;

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -1,6 +1,6 @@
 use super::CmsisDapDevice;
 use crate::{
-    probe::{DebugProbeInfo, DebugProbeType, ProbeCreationError, ProbeLister},
+    probe::{DebugProbeInfo, DebugProbeType, ProbeCreationError},
     DebugProbeSelector,
 };
 use hidapi::HidApi;

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -1,6 +1,6 @@
 use super::CmsisDapDevice;
 use crate::{
-    probe::{AllProbesLister, DebugProbeInfo, DebugProbeType, ProbeCreationError, ProbeLister},
+    probe::{DebugProbeInfo, DebugProbeType, ProbeCreationError, ProbeLister},
     DebugProbeSelector,
 };
 use hidapi::HidApi;
@@ -13,7 +13,7 @@ use std::time::Duration;
 /// to permission or driver errors, so it falls back to listing only
 /// HID devices if it does not find any suitable devices.
 #[tracing::instrument(skip_all)]
-pub fn list_cmsisdap_devices<L: ProbeLister>() -> Vec<DebugProbeInfo<L>> {
+pub fn list_cmsisdap_devices() -> Vec<DebugProbeInfo> {
     tracing::debug!("Searching for CMSIS-DAP probes using libusb");
     let mut probes = match rusb::Context::new().and_then(|ctx| ctx.devices()) {
         Ok(devices) => devices
@@ -50,7 +50,7 @@ pub fn list_cmsisdap_devices<L: ProbeLister>() -> Vec<DebugProbeInfo<L>> {
 }
 
 /// Checks if a given Device is a CMSIS-DAP probe, returning Some(DebugProbeInfo) if so.
-fn get_cmsisdap_info<L: ProbeLister>(device: &Device<rusb::Context>) -> Option<DebugProbeInfo<L>> {
+fn get_cmsisdap_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
     // Open device handle and read basic information
     let timeout = Duration::from_millis(100);
     let d_desc = device.device_descriptor().ok()?;
@@ -125,7 +125,7 @@ fn get_cmsisdap_info<L: ProbeLister>(device: &Device<rusb::Context>) -> Option<D
 }
 
 /// Checks if a given HID device is a CMSIS-DAP v1 probe, returning Some(DebugProbeInfo) if so.
-fn get_cmsisdap_hid_info<L: ProbeLister>(device: &hidapi::DeviceInfo) -> Option<DebugProbeInfo<L>> {
+fn get_cmsisdap_hid_info(device: &hidapi::DeviceInfo) -> Option<DebugProbeInfo> {
     let prod_str = device.product_string().unwrap_or("");
     let path = device.path().to_str().unwrap_or("");
     if is_cmsis_dap(prod_str) || is_cmsis_dap(path) {
@@ -267,7 +267,7 @@ pub fn open_device_from_selector(
     //
     // If rusb cannot be used, we will just use the first HID interface and
     // try to open that.
-    let mut hid_device_info: Option<DebugProbeInfo<AllProbesLister>> = None;
+    let mut hid_device_info = None;
 
     // Try using rusb to open a v2 device. This might fail if
     // the device does not support v2 operation or due to driver

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -4,8 +4,7 @@ use bitvec::{prelude::*, slice::BitSlice, vec::BitVec};
 use rusb::{request_type, Context, Device, Direction, TransferType, UsbContext};
 
 use crate::{
-    probe::ProbeLister, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType,
-    ProbeCreationError,
+    DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType, ProbeCreationError,
 };
 
 const JTAG_PROTOCOL_CAPABILITIES_VERSION: u8 = 1;

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -4,7 +4,8 @@ use bitvec::{prelude::*, slice::BitSlice, vec::BitVec};
 use rusb::{request_type, Context, Device, Direction, TransferType, UsbContext};
 
 use crate::{
-    DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType, ProbeCreationError, probe::ProbeLister,
+    probe::ProbeLister, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType,
+    ProbeCreationError,
 };
 
 const JTAG_PROTOCOL_CAPABILITIES_VERSION: u8 = 1;
@@ -516,7 +517,7 @@ pub(super) fn is_espjtag_device<T: UsbContext>(device: &Device<T>) -> bool {
 }
 
 #[tracing::instrument(skip_all)]
-pub fn list_espjtag_devices<L: ProbeLister>() -> Vec<DebugProbeInfo<L>> {
+pub fn list_espjtag_devices() -> Vec<DebugProbeInfo> {
     rusb::Context::new()
         .and_then(|context| context.devices())
         .map_or(vec![], |devices| {

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -4,7 +4,7 @@ use bitvec::{prelude::*, slice::BitSlice, vec::BitVec};
 use rusb::{request_type, Context, Device, Direction, TransferType, UsbContext};
 
 use crate::{
-    DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType, ProbeCreationError,
+    DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType, ProbeCreationError, probe::ProbeLister,
 };
 
 const JTAG_PROTOCOL_CAPABILITIES_VERSION: u8 = 1;
@@ -516,7 +516,7 @@ pub(super) fn is_espjtag_device<T: UsbContext>(device: &Device<T>) -> bool {
 }
 
 #[tracing::instrument(skip_all)]
-pub fn list_espjtag_devices() -> Vec<DebugProbeInfo> {
+pub fn list_espjtag_devices<L: ProbeLister>() -> Vec<DebugProbeInfo<L>> {
     rusb::Context::new()
         .and_then(|context| context.devices())
         .map_or(vec![], |devices| {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -25,8 +25,6 @@ use crate::{
     DebugProbeSelector,
 };
 
-use super::ProbeLister;
-
 const SWO_BUFFER_SIZE: u16 = 128;
 
 #[derive(Debug)]
@@ -798,7 +796,7 @@ impl SwoAccess for JLink {
 }
 
 #[tracing::instrument(skip_all)]
-pub(crate) fn list_jlink_devices<L: ProbeLister>() -> Vec<DebugProbeInfo<L>> {
+pub(crate) fn list_jlink_devices() -> Vec<DebugProbeInfo> {
     match jaylink::scan_usb() {
         Ok(devices) => devices
             .map(|device_info| {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -25,6 +25,8 @@ use crate::{
     DebugProbeSelector,
 };
 
+use super::ProbeLister;
+
 const SWO_BUFFER_SIZE: u16 = 128;
 
 #[derive(Debug)]
@@ -796,7 +798,7 @@ impl SwoAccess for JLink {
 }
 
 #[tracing::instrument(skip_all)]
-pub(crate) fn list_jlink_devices() -> Vec<DebugProbeInfo> {
+pub(crate) fn list_jlink_devices<L: ProbeLister>() -> Vec<DebugProbeInfo<L>> {
     match jaylink::scan_usb() {
         Ok(devices) => devices
             .map(|device_info| {

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -1,7 +1,6 @@
 use rusb::Device;
 use rusb::UsbContext;
 
-use crate::probe::ProbeLister;
 use crate::probe::{DebugProbeInfo, DebugProbeType};
 
 use super::usb_interface::USB_PID_EP_MAP;

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -20,7 +20,7 @@ pub(super) fn is_stlink_device<T: UsbContext>(device: &Device<T>) -> bool {
 }
 
 #[tracing::instrument(skip_all)]
-pub fn list_stlink_devices<L: ProbeLister>() -> Vec<DebugProbeInfo<L>> {
+pub fn list_stlink_devices() -> Vec<DebugProbeInfo> {
     rusb::Context::new()
         .and_then(|context| context.devices())
         .map_or(vec![], |devices| {

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -1,6 +1,7 @@
 use rusb::Device;
 use rusb::UsbContext;
 
+use crate::probe::ProbeLister;
 use crate::probe::{DebugProbeInfo, DebugProbeType};
 
 use super::usb_interface::USB_PID_EP_MAP;
@@ -19,7 +20,7 @@ pub(super) fn is_stlink_device<T: UsbContext>(device: &Device<T>) -> bool {
 }
 
 #[tracing::instrument(skip_all)]
-pub fn list_stlink_devices() -> Vec<DebugProbeInfo> {
+pub fn list_stlink_devices<L: ProbeLister>() -> Vec<DebugProbeInfo<L>> {
     rusb::Context::new()
         .and_then(|context| context.devices())
         .map_or(vec![], |devices| {

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use self::{commands::Speed, usb_interface::WchLinkUsbDevice};
-use super::{JTAGAccess, ProbeLister};
+use super::JTAGAccess;
 
 mod commands;
 mod usb_interface;

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -469,7 +469,7 @@ impl JTAGAccess for WchLink {
     }
 }
 
-fn get_wlink_info<L: ProbeLister>(device: &Device<rusb::Context>) -> Option<DebugProbeInfo<L>> {
+fn get_wlink_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
     let timeout = Duration::from_millis(100);
 
     let d_desc = device.device_descriptor().ok()?;
@@ -498,7 +498,7 @@ fn get_wlink_info<L: ProbeLister>(device: &Device<rusb::Context>) -> Option<Debu
 }
 
 #[tracing::instrument(skip_all)]
-pub fn list_wlink_devices<L: ProbeLister>() -> Vec<DebugProbeInfo<L>> {
+pub fn list_wlink_devices() -> Vec<DebugProbeInfo> {
     tracing::debug!("Searching for WCH-Link(RV) probes using libusb");
     let probes = match rusb::Context::new().and_then(|ctx| ctx.devices()) {
         Ok(devices) => devices

--- a/probe-rs/src/probe/wlink/usb_interface.rs
+++ b/probe-rs/src/probe/wlink/usb_interface.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use rusb::{DeviceHandle, UsbContext};
 
-use crate::{DebugProbeError, DebugProbeSelector, ProbeCreationError};
+use crate::{probe::AllProbesLister, DebugProbeError, DebugProbeSelector, ProbeCreationError};
 
 use super::{commands::WchLinkCommand, get_wlink_info, WchLinkError};
 
@@ -38,7 +38,7 @@ impl WchLinkUsbDevice {
                     })
                     .unwrap_or(false)
             })
-            .find(|device| get_wlink_info(device).is_some())
+            .find(|device| get_wlink_info::<AllProbesLister>(device).is_some())
             .map_or(Err(ProbeCreationError::NotFound), Ok)?;
 
         let mut device_handle = device.open()?;

--- a/probe-rs/src/probe/wlink/usb_interface.rs
+++ b/probe-rs/src/probe/wlink/usb_interface.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use rusb::{DeviceHandle, UsbContext};
 
-use crate::{probe::AllProbesLister, DebugProbeError, DebugProbeSelector, ProbeCreationError};
+use crate::{DebugProbeError, DebugProbeSelector, ProbeCreationError};
 
 use super::{commands::WchLinkCommand, get_wlink_info, WchLinkError};
 
@@ -38,7 +38,7 @@ impl WchLinkUsbDevice {
                     })
                     .unwrap_or(false)
             })
-            .find(|device| get_wlink_info::<AllProbesLister>(device).is_some())
+            .find(|device| get_wlink_info(device).is_some())
             .map_or(Err(ProbeCreationError::NotFound), Ok)?;
 
         let mut device_handle = device.open()?;

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -12,11 +12,11 @@
 //!
 //! ```no_run
 //! use std::sync::{Arc, Mutex};
-//! use probe_rs::{Probe, Permissions, AllProbesLister, ProbeLister};
+//! use probe_rs::{Probe, Permissions, Lister};
 //! use probe_rs::rtt::Rtt;
 //!
 //! // First obtain a probe-rs session (see probe-rs documentation for details)
-//! let lister = AllProbesLister::new();
+//! let lister = Lister::new();
 //!
 //! let probes = lister.list_all();
 //!

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -12,11 +12,15 @@
 //!
 //! ```no_run
 //! use std::sync::{Arc, Mutex};
-//! use probe_rs::{Probe, Permissions};
+//! use probe_rs::{Probe, Permissions, AllProbesLister, ProbeLister};
 //! use probe_rs::rtt::Rtt;
 //!
 //! // First obtain a probe-rs session (see probe-rs documentation for details)
-//! let probe = Probe::list_all()[0].open()?;
+//! let lister = AllProbesLister::new();
+//!
+//! let probes = lister.list_all();
+//!
+//! let probe = probes[0].open(&lister)?;
 //! let mut session = probe.attach("somechip", Permissions::default())?;
 //! let memory_map = session.target().memory_map.clone();
 //! // Select a core.

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -4,8 +4,7 @@ use crate::architecture::arm::{ArmError, DpAddress};
 use crate::architecture::riscv::communication_interface::RiscvError;
 use crate::config::{ChipInfo, CoreExt, RegistryError, Target, TargetSelector};
 use crate::core::{Architecture, CombinedCoreState};
-use crate::probe::fake_probe::FakeProbe;
-use crate::probe::AllProbesLister;
+use crate::probe::{fake_probe::FakeProbe, Lister};
 use crate::{
     architecture::{
         arm::{
@@ -300,9 +299,9 @@ impl Session {
         permissions: Permissions,
     ) -> Result<Session, Error> {
         // Get a list of all available debug probes.
-        let lister = AllProbesLister {};
+        let lister = Lister::new();
 
-        let probes = AllProbesLister::list_all();
+        let probes = lister.list_all();
 
         // Use the first probe found.
         let probe = probes

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -4,6 +4,8 @@ use crate::architecture::arm::{ArmError, DpAddress};
 use crate::architecture::riscv::communication_interface::RiscvError;
 use crate::config::{ChipInfo, CoreExt, RegistryError, Target, TargetSelector};
 use crate::core::{Architecture, CombinedCoreState};
+use crate::probe::fake_probe::FakeProbe;
+use crate::probe::AllProbesLister;
 use crate::{
     architecture::{
         arm::{
@@ -14,7 +16,7 @@ use crate::{
     },
     config::DebugSequence,
 };
-use crate::{AttachMethod, Core, CoreType, Error, FakeProbe, Probe};
+use crate::{AttachMethod, Core, CoreType, Error, Probe};
 use std::ops::DerefMut;
 use std::{fmt, sync::Arc, time::Duration};
 
@@ -298,13 +300,15 @@ impl Session {
         permissions: Permissions,
     ) -> Result<Session, Error> {
         // Get a list of all available debug probes.
-        let probes = Probe::list_all();
+        let lister = AllProbesLister {};
+
+        let probes = AllProbesLister::list_all();
 
         // Use the first probe found.
         let probe = probes
             .get(0)
             .ok_or(Error::UnableToOpenProbe("No probe was found"))?
-            .open()?;
+            .open(&lister)?;
 
         // Attach to a chip.
         probe.attach(target, permissions)

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -4,7 +4,7 @@ use crate::architecture::arm::{ArmError, DpAddress};
 use crate::architecture::riscv::communication_interface::RiscvError;
 use crate::config::{ChipInfo, CoreExt, RegistryError, Target, TargetSelector};
 use crate::core::{Architecture, CombinedCoreState};
-use crate::probe::{fake_probe::FakeProbe, Lister};
+use crate::probe::fake_probe::FakeProbe;
 use crate::{
     architecture::{
         arm::{
@@ -15,7 +15,7 @@ use crate::{
     },
     config::DebugSequence,
 };
-use crate::{AttachMethod, Core, CoreType, Error, Probe};
+use crate::{AttachMethod, Core, CoreType, Error, Lister, Probe};
 use std::ops::DerefMut;
 use std::{fmt, sync::Arc, time::Duration};
 

--- a/rtthost/src/main.rs
+++ b/rtthost/src/main.rs
@@ -1,6 +1,6 @@
 use probe_rs::rtt::{Channels, Rtt, RttChannel, ScanRegion};
 use probe_rs::{config::TargetSelector, DebugProbeInfo};
-use probe_rs::{AllProbesLister, Permissions, ProbeLister};
+use probe_rs::{Lister, Permissions};
 
 use anyhow::{bail, Result};
 use clap::Parser;
@@ -109,7 +109,7 @@ fn main() -> Result<()> {
     pretty_env_logger::init();
     let opts = Opts::parse();
 
-    let lister = AllProbesLister::new();
+    let lister = Lister::new();
 
     let probes = lister.list_all();
 

--- a/rtthost/src/main.rs
+++ b/rtthost/src/main.rs
@@ -1,5 +1,5 @@
 use probe_rs::rtt::{Channels, Rtt, RttChannel, ScanRegion};
-use probe_rs::{config::TargetSelector, DebugProbeInfo, Probe};
+use probe_rs::{config::TargetSelector, DebugProbeInfo};
 use probe_rs::{AllProbesLister, Permissions, ProbeLister};
 
 use clap::Parser;
@@ -268,7 +268,7 @@ fn run() -> i32 {
     }
 }
 
-fn list_probes<L: ProbeLister>(mut stream: impl std::io::Write, probes: &[DebugProbeInfo<L>]) {
+fn list_probes(mut stream: impl std::io::Write, probes: &[DebugProbeInfo]) {
     writeln!(stream, "Available probes:").unwrap();
 
     for (i, probe) in probes.iter().enumerate() {

--- a/smoke-tester/src/dut_definition.rs
+++ b/smoke-tester/src/dut_definition.rs
@@ -6,7 +6,7 @@
 use anyhow::{bail, ensure, Context, Result};
 use probe_rs::{
     config::{get_target_by_name, search_chips},
-    AllProbesLister, DebugProbeSelector, Probe, ProbeLister, Target,
+    DebugProbeSelector, Lister, Probe, Target,
 };
 use serde::Deserialize;
 use std::{
@@ -143,7 +143,7 @@ impl DutDefinition {
     }
 
     pub fn open_probe(&self) -> Result<Probe> {
-        let lister = AllProbesLister::new();
+        let lister = Lister::new();
 
         match &self.probe_selector {
             Some(selector) => {

--- a/smoke-tester/src/dut_definition.rs
+++ b/smoke-tester/src/dut_definition.rs
@@ -148,7 +148,7 @@ impl DutDefinition {
         match &self.probe_selector {
             Some(selector) => {
                 let probe = lister
-                    .open(selector.clone())
+                    .open(selector)
                     .with_context(|| format!("Failed to open probe with selector {selector}"))?;
 
                 Ok(probe)

--- a/smoke-tester/src/dut_definition.rs
+++ b/smoke-tester/src/dut_definition.rs
@@ -6,7 +6,7 @@
 use anyhow::{bail, ensure, Context, Result};
 use probe_rs::{
     config::{get_target_by_name, search_chips},
-    DebugProbeSelector, Probe, Target,
+    AllProbesLister, DebugProbeSelector, Probe, ProbeLister, Target,
 };
 use serde::Deserialize;
 use std::{
@@ -143,15 +143,18 @@ impl DutDefinition {
     }
 
     pub fn open_probe(&self) -> Result<Probe> {
+        let lister = AllProbesLister::new();
+
         match &self.probe_selector {
             Some(selector) => {
-                let probe = Probe::open(selector.clone())
+                let probe = lister
+                    .open(selector.clone())
                     .with_context(|| format!("Failed to open probe with selector {selector}"))?;
 
                 Ok(probe)
             }
             None => {
-                let probes = Probe::list_all();
+                let probes = lister.list_all();
 
                 ensure!(!probes.is_empty(), "No probes detected!");
 
@@ -160,7 +163,7 @@ impl DutDefinition {
             "Multiple probes detected. Specify which probe to use using the '--probe' argument."
         );
 
-                let probe = probes[0].open()?;
+                let probe = probes[0].open(&lister)?;
 
                 Ok(probe)
             }


### PR DESCRIPTION
This adds a `Lister` struct, which replaces `Probe::list_all()` and `Probe::open`.  This helps with testing by making it easier to use Mocks instead of actual probes.

Some initial tests using the new `Lister` to test the debug adapter are added as well.