### PR TITLE
Update svd-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,6 +2469,7 @@ dependencies = [
  "signal-hook",
  "static_assertions",
  "svd-parser",
+ "svd-rs",
  "svg",
  "terminal_size 0.3.0",
  "termtree",
@@ -3433,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "svd-parser"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2081d77e28f5144c3af0774dcbfd0b170b6bce37d238b2e5d7bc3d7a7d6b775"
+checksum = "d9c0521573455cce71aa930fd500d25d8f8be4f6a857d3dafe1963d9e14fffbb"
 dependencies = [
  "anyhow",
  "roxmltree",
@@ -3445,9 +3446,9 @@ dependencies = [
 
 [[package]]
 name = "svd-rs"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08273bc4ca66b632299903960efa8a306aac61dc6381bcf07450c20b1a5443c"
+checksum = "35830f227d0ee528eb674429091ba11781fbf141e72a87a9bc9c732522798b33"
 dependencies = [
  "once_cell",
  "regex",

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -69,6 +69,10 @@ cli = [
     "dep:bytesize",
     "dep:textwrap",
     "dep:addr2line",
+
+    # Temporary fix for https://github.com/rust-embedded/svd/issues/249,
+    # svd-parser does not compile with svd-rs 0.14.2 or 0.14.3.
+    "dep:svd-rs"
 ]
 
 vendored-libusb = ["rusb/vendored"]
@@ -165,7 +169,12 @@ sanitize-filename = { version = "0.5", optional = true }
 schemafy = { version = "0.6", optional = true }
 serde_json = { version = "1", optional = true }
 signal-hook = "0.3"
-svd-parser = { version = "0.14.2", features = ["expand"], optional = true }
+svd-parser = { version = "0.14.3", features = ["expand"], optional = true }
+
+# Temporary fix for https://github.com/rust-embedded/svd/issues/249,
+# svd-parser does not compile with svd-rs 0.14.2 or 0.14.3.
+svd-rs = { version = "0.14.4", optional = true }
+
 terminal_size = { version = "0.3.0", optional = true }
 termtree = { version = "0.4.1", optional = true }
 textwrap = { version = "0.16.0", optional = true }


### PR DESCRIPTION
With a workaround for https://github.com/rust-embedded/svd/issues/249