### PR TITLE
espusbjtag: don't reset the chip on attach

### DIFF
--- a/changelog/changed-espusbjtag-avoid-por-on-attach.md
+++ b/changelog/changed-espusbjtag-avoid-por-on-attach.md
@@ -1,0 +1,1 @@
+espusbjtag: don't reset the chip on attach

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -59,11 +59,6 @@ impl EspUsbJtag {
     fn reset_scan(&mut self) -> Result<(Vec<u32>, Vec<usize>), super::DebugProbeError> {
         let max_chain = 8;
 
-        tracing::debug!("Resetting JTAG chain using trst");
-        // TODO this isn't actually needed, we should only do this when AttachUnderReset it supplied
-        // self.protocol.set_reset(true, true)?;
-        // self.protocol.set_reset(false, false)?;
-
         self.jtag_reset()?;
 
         let input = Vec::from_iter(iter::repeat(0xFFu8).take(4 * max_chain));

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -61,8 +61,8 @@ impl EspUsbJtag {
 
         tracing::debug!("Resetting JTAG chain using trst");
         // TODO this isn't actually needed, we should only do this when AttachUnderReset it supplied
-        self.protocol.set_reset(true, true)?;
-        self.protocol.set_reset(false, false)?;
+        // self.protocol.set_reset(true, true)?;
+        // self.protocol.set_reset(false, false)?;
 
         self.jtag_reset()?;
 


### PR DESCRIPTION
There isn't currently a generic way to handle attach under reset, so in this case I'm changing the behavior of the espusbjtag driver to _not_ attach under reset by default.