### PR TITLE
Fix a few typos

### DIFF
--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -57,9 +57,9 @@ STLINKv1, v2 and v2-1. Written in C.
 ### CMSIS-DAP
 [CMSIS-DAP Spec](https://arm-software.github.io/CMSIS_5/DAP/html/index.html)
 
-## RISCV
+## RISC-V
 
-[RISCV Debug Specification](https://github.com/riscv/riscv-debug-spec/blob/release/riscv-debug-release.pdf)
+[RISC-V Debug Specification](https://github.com/riscv/riscv-debug-spec/blob/release/riscv-debug-release.pdf)
 
 
 ## ELF

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! For debugging and flashing different chips, called *target* in probe-rs, some
 //! target specific configuration is required. This includes the architecture of
-//! the chip, e.g. RISCV or ARM, and information about the memory map of the target,
+//! the chip, e.g. RISC-V or ARM, and information about the memory map of the target,
 //! which can be used together with a flash algorithm to program the flash memory
 //! of a target.
 //!

--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -12,7 +12,7 @@ define_ap!(
     /// Memory AP
     ///
     /// The memory AP can be used to access a memory-mapped
-    /// set of debug resouces of the attached system.
+    /// set of debug resources of the attached system.
     MemoryAp
 );
 
@@ -337,7 +337,7 @@ impl CSW {
     /// Creates a new CSW content with default values and a configurable [`DataSize`].
     /// See in code documentation for more info.
     ///
-    /// The CSW Register is set for an AMBA AHB Acccess, according to
+    /// The CSW Register is set for an AMBA AHB Access, according to
     /// the ARM Debug Interface Architecture Specification.
     ///
     /// The PROT bits are set as follows:
@@ -441,7 +441,7 @@ define_ap_register!(
     name: TAR2,
     address: 0x08,
     fields: [
-        /// The uppper 32-bits of the register address to be used for the next access to DRW.
+        /// The upper 32-bits of the register address to be used for the next access to DRW.
         address: u32,
     ],
     from: value => Ok(TAR2 { address: value }),

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -206,7 +206,7 @@ impl<T: DapAccess> ApAccess for T {
 ///
 /// The test is performed by reading the IDR register, and checking if the register is non-zero.
 ///
-/// Can fail silently under the hood testing an ap that doesnt exist and would require cleanup.
+/// Can fail silently under the hood testing an ap that doesn't exist and would require cleanup.
 pub fn access_port_is_valid<AP>(debug_port: &mut AP, access_port: GenericAp) -> bool
 where
     AP: ApAccess,
@@ -227,7 +227,7 @@ where
 }
 
 /// Return a Vec of all valid access ports found that the target connected to the debug_probe.
-/// Can fail silently under the hood testing an ap that doesnt exist and would require cleanup.
+/// Can fail silently under the hood testing an ap that doesn't exist and would require cleanup.
 #[tracing::instrument(skip(debug_port))]
 pub(crate) fn valid_access_ports<AP>(debug_port: &mut AP, dp: DpAddress) -> Vec<GenericAp>
 where

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -741,7 +741,7 @@ impl DapAccess for ArmCommunicationInterface<Initialized> {
 pub struct ArmChipInfo {
     /// The JEP106 code of the manufacturer of this chip target.
     pub manufacturer: JEP106Code,
-    /// The unique part numer of the chip target. Unfortunately this only unique in the spec.
+    /// The unique part number of the chip target. Unfortunately this only unique in the spec.
     /// In practice some manufacturers violate the spec and assign a part number to an entire family.
     ///
     /// Consider this not unique when working with targets!

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -109,7 +109,7 @@ bitfield! {
     ///
     /// The effect of setting this bit to `1` is UNPREDICTABLE unless the DHCSR write also sets
     /// C_DEBUGEN and C_HALT to 1. This means that if the processor is not already in Debug
-    /// stateit enters Debug state when the stalled instruction completes.
+    /// state it enters Debug state when the stalled instruction completes.
     ///
     /// Writing `1` to this bit makes the state of the memory system UNPREDICTABLE. Therefore, if a
     /// debugger writes `1` to this bit it must reset the processor before leaving Debug state.

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -1012,7 +1012,7 @@ bitfield! {
     /// Global enable for DWT, PMU and ITM features
     pub trcena, set_trcena: 24;
     /// Monitor pending request key. Writes to the mon_pend and mon_en fields
-    /// request are ignorend unless monprkey is set to zero concurrently.
+    /// request are ignored unless `monprkey` is set to zero concurrently.
     pub monprkey, set_monprkey: 23;
     /// Unprivileged monitor enable.
     pub umon_en, set_umon_en: 21;

--- a/probe-rs/src/architecture/arm/core/exception_handling.rs
+++ b/probe-rs/src/architecture/arm/core/exception_handling.rs
@@ -6,7 +6,7 @@ use crate::{
     Error, MemoryInterface,
 };
 pub(crate) mod armv6m;
-/// Where applicable, this defines shared logic for implementing exception handling accross the various ARMv6-m and ARMv7-m [`crate::CoreType`]'s.
+/// Where applicable, this defines shared logic for implementing exception handling across the various ARMv6-m and ARMv7-m [`crate::CoreType`]'s.
 pub(crate) mod armv6m_armv7m_shared;
 // NOTE: There is also a [`CoreType::Armv7em`] variant, but it is not currently used/implemented in probe-rs.
 pub(crate) mod armv7m;

--- a/probe-rs/src/architecture/arm/core/exception_handling/armv6m_armv7m_shared.rs
+++ b/probe-rs/src/architecture/arm/core/exception_handling/armv6m_armv7m_shared.rs
@@ -26,7 +26,7 @@ bitfield! {
     pub struct ExcReturn(u32);
     /// If the value is 0xF, then this is a valid EXC_RETURN value.
     pub is_exception_flag, _: 31, 28;
-    /// Defines whether the stack frame for this exception has space allocated for FPU state information. Bit [4] is 0 if stack space is the exended frame that includes FPU registes.
+    /// Defines whether the stack frame for this exception has space allocated for FPU state information. Bit [4] is 0 if stack space is the extended frame that includes FPU registers.
     pub use_standard_stackframe, _: 4;
     /// Identifies one of the following 3 behaviours.
     /// - 0x1: Return to Handler mode(always uses the Main SP).

--- a/probe-rs/src/architecture/arm/core/exception_handling/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/exception_handling/armv7m.rs
@@ -17,7 +17,7 @@ memory_mapped_bitfield_register! {
 }
 
 memory_mapped_bitfield_register! {
-    /// CFSR - Configuratble Status Register (UFSR[31:16], BFSR[15:8], MMFSR[7:0])
+    /// CFSR - Configurable Status Register (UFSR[31:16], BFSR[15:8], MMFSR[7:0])
     pub struct Cfsr(u32);
     0xE000ED28, "CFSR",
     impl From;

--- a/probe-rs/src/architecture/arm/core/exception_handling/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/exception_handling/armv8m.rs
@@ -16,9 +16,9 @@ bitfield! {
     is_exception_flag, _: 31, 24;
     /// Indicates whether to restore registers from the secure stack or the unsecure stack
     use_secure_stack, _:6;
-    /// Indicates wheteher the default stacking rules apply or the callee registers are already on the stack
+    /// Indicates whether the default stacking rules apply or the callee registers are already on the stack
     use_default_register_stacking, _:5;
-    /// Defines whether the stack frame for this exception has space allocated for FPU state information. Bit [4] is 0 if stack space is the exended frame that includes FPU registes.
+    /// Defines whether the stack frame for this exception has space allocated for FPU state information. Bit [4] is 0 if stack space is the extended frame that includes FPU registers.
     use_standard_stackframe, _: 4;
     /// Indicates whether the return mode is Handler (0) or Thread (1)
     mode, _: 3;

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -163,7 +163,7 @@ where
     ap_information: MemoryApInformation,
     memory_ap: MemoryAp,
 
-    /// Cached value of the CSW register, to avoid unecessary writes.
+    /// Cached value of the CSW register, to avoid unnecessary writes.
     //
     /// TODO: This is the wrong location for this, it should actually be
     /// cached on a lower level, where the other Memory AP information is

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -257,7 +257,7 @@ impl ComponentId {
     }
 }
 
-/// A reader to extract infromation from a CoreSight component table.
+/// A reader to extract information from a CoreSight component table.
 ///
 /// This reader is meant for internal use only.
 pub struct ComponentInformationReader<'probe: 'memory, 'memory> {
@@ -669,7 +669,7 @@ impl PeripheralID {
         self.dev_type
     }
 
-    /// Uses the available data to match it againts a table of known components.
+    /// Uses the available data to match it against a table of known components.
     /// If the component is known, some info about it is returned.
     /// If it is not known, None is returned.
     #[rustfmt::skip]

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -85,7 +85,7 @@ pub enum ArmError {
         /// The required alignment in bytes (address increments).
         alignment: usize,
     },
-    /// A region ouside of the AP address space was accessed.
+    /// A region outside of the AP address space was accessed.
     #[error("Out of bounds access")]
     OutOfBounds,
     /// The requested memory transfer width is not supported on the current core.
@@ -103,10 +103,10 @@ pub enum ArmError {
     #[error("Unable to create a breakpoint at address {0:#010X}. Hardware breakpoints are only supported at addresses < 0x2000'0000.")]
     UnsupportedBreakpointAddress(u32),
 
-    /// ARMv8a specifc erorr occurred.
+    /// ARMv8a specific error occurred.
     Armv8a(#[from] Armv8aError),
 
-    /// ARMv7a specifc erorr occurred.
+    /// ARMv7a specific error occurred.
     Armv7a(#[from] Armv7aError),
 
     /// Error occurred in a debug sequence.

--- a/probe-rs/src/architecture/arm/sequences/atsam.rs
+++ b/probe-rs/src/architecture/arm/sequences/atsam.rs
@@ -226,7 +226,7 @@ impl AtSAM {
     ///
     /// # Errors
     /// This operation can fail due to insufficient permissions, or if Chip-Erase Lock is
-    /// enabled (this lock can only be released from within the device firmare).
+    /// enabled (this lock can only be released from within the device firmware).
     /// After a successful Chip-Erase a `DebugProbeError::ReAttachRequired` is returned
     /// to signal that a re-connect is needed for the DSU to start operating in unlocked mode.
     pub fn erase_all(

--- a/probe-rs/src/architecture/riscv/assembly.rs
+++ b/probe-rs/src/architecture/riscv/assembly.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unusual_byte_groupings)]
 
-/// RISCV breakpoint instruction
+/// RISC-V breakpoint instruction
 pub const EBREAK: u32 = 0b000000000001_00000_000_00000_1110011;
 
 /// Assemble a `lw` instruction.
@@ -58,7 +58,7 @@ pub fn csrrw(rd: u8, rs1: u8, csr: u16) -> u32 {
     i_type_instruction(opcode, rs1, funct3, rd, csr)
 }
 
-/// Assemble an I-type instruction, as specified in the RISCV ISA
+/// Assemble an I-type instruction, as specified in the RISC-V ISA
 ///
 /// This function panics if any of the values would have to be truncated.
 fn i_type_instruction(opcode: u8, rs1: u8, funct3: u8, rd: u8, imm: u16) -> u32 {

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -1,7 +1,7 @@
 //! Debug Module Communication
 //!
 //! This module implements communication with a
-//! Debug Module, as described in the RISCV debug
+//! Debug Module, as described in the RISC-V debug
 //! specification v0.13.2 .
 
 use super::{
@@ -21,7 +21,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-/// Some error occurered when working with the RISC-V core.
+/// Some error occurred when working with the RISC-V core.
 #[derive(thiserror::Error, Debug)]
 pub enum RiscvError {
     /// An error during read/write of the DMI register happened.
@@ -63,8 +63,8 @@ pub enum RiscvError {
     /// The given trigger type is not available for the address breakpoint.
     #[error("Unexpected trigger type {0} for address breakpoint.")]
     UnexpectedTriggerType(u32),
-    /// The connected target is not a RISCV device.
-    #[error("Connected target is not a RISCV device.")]
+    /// The connected target is not a RISC-V device.
+    #[error("Connected target is not a RISC-V device.")]
     NoRiscvTarget,
     /// The target does not support halt after reset.
     #[error("The target does not support halt after reset.")]
@@ -87,10 +87,10 @@ pub enum AbstractCommandErrorKind {
     /// No error happened.
     None = 0,
     /// An abstract command was executing
-    /// while command, abstractcs, or abstractauto
-    /// was written, or when one of the data or progbuf
+    /// while command, `abstractcs`, or `abstractauto`
+    /// was written, or when one of the `data` or `progbuf`
     /// registers was read or written. This status is only
-    /// written if cmderr contains 0.
+    /// written if `cmderr` contains 0.
     Busy = 1,
     /// The requested command is not supported, reg
     NotSupported = 2,
@@ -135,11 +135,11 @@ impl AbstractCommandErrorKind {
 pub enum DebugModuleVersion {
     /// There is no debug module present.
     NoModule,
-    /// The debug module conforms to the version 0.11 of the RISCV Debug Specification.
+    /// The debug module conforms to the version 0.11 of the RISC-V Debug Specification.
     Version0_11,
-    /// The debug module conforms to the version 0.13 of the RISCV Debug Specification.
+    /// The debug module conforms to the version 0.13 of the RISC-V Debug Specification.
     Version0_13,
-    /// The debug module is present, but does not conform to any available version of the RISCV Debug Specification.
+    /// The debug module is present, but does not conform to any available version of the RISC-V Debug Specification.
     NonConforming,
     /// Unknown debug module version.
     Unknown(u8),
@@ -213,7 +213,7 @@ pub struct RiscvCommunicationInterfaceState {
     abstract_cmd_register_info: HashMap<RegisterId, CoreRegisterAbstractCmdSupport>,
 }
 
-/// Timeout for RISCV operations.
+/// Timeout for RISC-V operations.
 const RISCV_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// RiscV only supports 12bit CSRs. See
@@ -307,7 +307,7 @@ impl RiscvCommunicationInterface {
     fn enter_debug_mode(&mut self) -> Result<(), RiscvError> {
         // We need a jtag interface
 
-        tracing::debug!("Building RISCV interface");
+        tracing::debug!("Building RISC-V interface");
 
         // Reset error bits from previous connections
         self.dtm.reset()?;
@@ -1158,7 +1158,7 @@ impl RiscvCommunicationInterface {
         }
     }
 
-    /// Read the CSR progbuf register.
+    /// Read the CSR `progbuf` register.
     pub fn read_csr_progbuf(&mut self, address: u16) -> Result<u32, RiscvError> {
         tracing::debug!("Reading CSR {:#04x}", address);
 
@@ -1189,7 +1189,7 @@ impl RiscvCommunicationInterface {
         Ok(reg_value)
     }
 
-    /// Write the CSR progbuf register.
+    /// Write the CSR `progbuf` register.
     pub fn write_csr_progbuf(&mut self, address: u16, value: u32) -> Result<(), RiscvError> {
         tracing::debug!("Writing CSR {:#04x}={}", address, value);
 
@@ -1907,25 +1907,25 @@ memory_mapped_bitfield_register! {
     /// 3: Access the lowest 64 bits of the register.\
     /// 4: Access the lowest 128 bits of the register.
     ///
-    /// If aarsize specifies a size larger than the register’s
-    /// actual size, then the access must fail. If a register is accessible, then reads of aarsize less than
+    /// If `aarsize` specifies a size larger than the register’s
+    /// actual size, then the access must fail. If a register is accessible, then reads of `aarsize` less than
     /// or equal to the register’s actual size must be supported.
     ///
     /// This field controls the Argument Width as referenced in Table 3.1.
     pub u8, from into RiscvBusAccess, _, set_aarsize: 22, 20;
     /// 0: No effect. This variant must be supported.\
-    /// 1: After a successful register access, regno is incremented (wrapping around to 0). Supporting
+    /// 1: After a successful register access, `regno` is incremented (wrapping around to 0). Supporting
     /// this variant is optional.
     pub _, set_aarpostincrement: 19;
     /// 0: No effect. This variant must be supported, and
-    /// is the only supported one if progbufsize is 0.\
+    /// is the only supported one if `progbufsize` is 0.\
     /// 1: Execute the program in the Program Buffer
     /// exactly once after performing the transfer, if any.
     /// Supporting this variant is optional.
     pub _, set_postexec: 18;
     /// 0: Don’t do the operation specified by write.\
     /// 1: Do the operation specified by write.
-    /// This bit can be used to just execute the Program Buffer without having to worry about placing valid values into aarsize or regno
+    /// This bit can be used to just execute the Program Buffer without having to worry about placing valid values into `aarsize` or `regno`
     pub _, set_transfer: 17;
     /// When transfer is set: 0: Copy data from the specified register into arg0 portion of data.
     /// 1: Copy data from arg0 portion of data into the
@@ -1950,7 +1950,7 @@ memory_mapped_bitfield_register! {
     sbversion, _: 31, 29;
     /// Set when the debugger attempts to read data
     /// while a read is in progress, or when the debugger initiates a new access while one is already in
-    /// progress (while sbbusy is set). It remains set until
+    /// progress (while `sbbusy` is set). It remains set until
     /// it’s explicitly cleared by the debugger.
     /// While this field is set, no more system bus accesses
     /// can be initiated by the Debug Module.
@@ -1961,10 +1961,10 @@ memory_mapped_bitfield_register! {
     /// any reason, and does not go low until the access
     /// is fully completed.
     ///
-    /// Writes to sbcs while sbbusy is high result in undefined behavior. A debugger must not write to
-    /// sbcs until it reads sbbusy as 0.
+    /// Writes to `sbcs` while `sbbusy` is high result in undefined behavior. A debugger must not write to
+    /// sbcs until it reads `sbbusy` as 0.
     sbbusy, _: 21;
-    /// When 1, every write to sbaddress0 automatically
+    /// When 1, every write to `sbaddress0` automatically
     /// triggers a system bus read at the new address.
     sbreadonaddr, set_sbreadonaddr: 20;
     /// Select the access size to use for system bus accesses.
@@ -1975,13 +1975,13 @@ memory_mapped_bitfield_register! {
     /// 3: 64-bit\
     /// 4: 128-bit
     ///
-    /// If sbaccess has an unsupported value when the
-    /// DM starts a bus access, the access is not performed and sberror is set to 4.
+    /// If `sbaccess` has an unsupported value when the
+    /// DM starts a bus access, the access is not performed and `sberror` is set to 4.
     sbaccess, set_sbaccess: 19, 17;
-    /// When 1, sbaddress is incremented by the access
-    /// size (in bytes) selected in sbaccess after every system bus access.
+    /// When 1, `sbaddress` is incremented by the access
+    /// size (in bytes) selected in `sbaccess` after every system bus access.
     sbautoincrement, set_sbautoincrement: 16;
-    /// When 1, every read from sbdata0 automatically
+    /// When 1, every read from `sbdata0` automatically
     /// triggers a system bus read at the (possibly autoincremented) address.
     sbreadondata, set_sbreadondata: 15;
     /// When the Debug Module’s system bus master encounters an error, this field gets set. The bits in
@@ -2017,7 +2017,7 @@ memory_mapped_bitfield_register! {
     pub struct Abstractauto(u32);
     0x18, "abstractauto",
     impl From;
-    /// When a bit in this field is 1, read or write accesses to the corresponding progbuf word cause
+    /// When a bit in this field is 1, read or write accesses to the corresponding `progbuf` word cause
     /// the command in command to be executed again.
     autoexecprogbuf, set_autoexecprogbuf: 31, 16;
     /// When a bit in this field is 1, read or write accesses to the corresponding data word cause the
@@ -2040,7 +2040,7 @@ memory_mapped_bitfield_register! {
     /// 0: Addresses are physical (to the hart they are
     /// performed on).\
     /// 1: Addresses are virtual, and translated the way
-    /// they would be from M-mode, with MPRV set.
+    /// they would be from M-mode, with `MPRV` set.
     pub _, set_aamvirtual: 23;
     /// 0: Access the lowest 8 bits of the memory location.\
     /// 1: Access the lowest 16 bits of the memory location.\
@@ -2050,7 +2050,7 @@ memory_mapped_bitfield_register! {
     pub _, set_aamsize: 22,20;
     /// After a memory access has completed, if this bit
     /// is 1, increment arg1 (which contains the address
-    /// used) by the number of bytes encoded in aamsize.
+    /// used) by the number of bytes encoded in `aamsize`.
     pub _, set_aampostincrement: 19;
     /// 0: Copy data from the memory location specified
     /// in arg1 into arg0 portion of data.\

--- a/probe-rs/src/architecture/riscv/dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 /// Access to the Debug Transport Module (DTM),
-/// which is used to communicate with the RISCV debug module.
+/// which is used to communicate with the RISC-V debug module.
 #[derive(Debug)]
 pub struct Dtm {
     pub probe: Box<dyn JTAGAccess>,
@@ -201,8 +201,8 @@ impl Dtm {
         Ok(Ok(value))
     }
 
-    /// Read or write the `dmi` register. If a busy value is rerurned, the access is
-    /// retried until the transfer either succeeds, or the tiemout expires.
+    /// Read or write the `dmi` register. If a busy value is returned, the access is
+    /// retried until the transfer either succeeds, or the timeout expires.
     pub fn dmi_register_access_with_timeout(
         &mut self,
         address: u64,

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -875,14 +875,14 @@ memory_mapped_bitfield_register! {
 impl Dmcontrol {
     /// Currently selected harts
     ///
-    /// Combination of the hartselhi and hartsello registers.
+    /// Combination of the `hartselhi` and `hartsello` registers.
     fn hartsel(&self) -> u32 {
         self.hartselhi() << 10 | self.hartsello()
     }
 
     /// Set the currently selected harts
     ///
-    /// This sets the hartselhi and hartsello registers.
+    /// This sets the `hartselhi` and `hartsello` registers.
     /// This is a 20 bit register, larger values will be truncated.
     fn set_hartsel(&mut self, value: u32) {
         self.set_hartsello(value & 0x3ff);

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -170,9 +170,9 @@ impl Configs {
             .collect()
     }
 
-    /// Extract the requested config, but only if the profile has been explicity defined in the
+    /// Extract the requested config, but only if the profile has been explicitly defined in the
     /// configuration files etc. (selecting an arbitrary undefined profile with Figment will coerce
-    /// it into existance - inheriting from the default config).
+    /// it into existence - inheriting from the default config).
     pub fn select_defined(self: Configs, name: &str) -> anyhow::Result<Config> {
         let defined_profiles = self.prof_names();
         let requested_profile_defined: bool = defined_profiles

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/event.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/event.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use crossterm::event::{self, Event as CEvent, KeyEvent};
 
-/// A small event handler that wrap termion input and tick events. Each event
+/// A small event handler that wrap `termion` input and tick events. Each event
 /// type is handled in its own thread and returned to a common `Receiver`
 pub struct Events {
     rx: mpsc::Receiver<KeyEvent>,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_types.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_types.rs
@@ -141,7 +141,7 @@ impl GdbNuf {
     }
 }
 
-/// TODO: gdb changes the default `format_specifier` everytime x or p is used. For now we will use a static default of `x`.
+/// TODO: gdb changes the default `format_specifier` every time x or p is used. For now we will use a static default of `x`.
 impl Default for GdbNuf {
     fn default() -> Self {
         Self {

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
@@ -267,7 +267,7 @@ pub(crate) fn get_capstone(target_core: &mut CoreHandle) -> Result<Capstone, Deb
     Ok(cs)
 }
 
-/// A helper function to greate a [`Source`] struct from a [`SourceLocation`]
+/// A helper function to create a [`Source`] struct from a [`SourceLocation`]
 pub(crate) fn get_dap_source(source_location: &SourceLocation) -> Option<Source> {
     // Attempt to construct the path for the source code
     let directory = source_location.directory.as_ref()?;

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_variables.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_variables.rs
@@ -20,7 +20,8 @@ use svd_parser::{
 pub struct SvdCache {
     /// The SVD contents and structure will be stored as variables, down to the Field level.
     /// Unlike other VariableCache instances, it will only be built once per DebugSession.
-    /// After that, only the SVD fields values change values, and the data for these will be re-read everytime they are queried by the debugger.
+    /// After that, only the SVD fields values change values, and the data for these will be re-read
+    /// every time they are queried by the debugger.
     pub(crate) svd_variable_cache: VariableCache,
 }
 

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -46,7 +46,7 @@ pub struct CoreData {
 
 /// [CoreHandle] provides handles to various data structures required to debug a single instance of a core. The actual state is stored in [session_data::SessionData].
 ///
-/// Usage: To get access to this structure please use the [session_data::SessionData::attach_core] method. Please keep access/locks to this to a minumum duration.
+/// Usage: To get access to this structure please use the [session_data::SessionData::attach_core] method. Please keep access/locks to this to a minimum duration.
 pub struct CoreHandle<'p> {
     pub(crate) core: Core<'p>,
     pub(crate) core_data: &'p mut CoreData,
@@ -66,7 +66,7 @@ impl<'p> CoreHandle<'p> {
     }
 
     /// - Whenever we check the status, we compare it against `last_known_status` and send the appropriate event to the client.
-    /// - If we cannot determine the core status, then there is no sense in continuing the debug session, so please propogate the error.
+    /// - If we cannot determine the core status, then there is no sense in continuing the debug session, so please propagate the error.
     /// - If the core status has changed, then we update `last_known_status` to the new value, and return `true` as part of the Result<>.
     pub(crate) fn poll_core<P: ProtocolAdapter>(
         &mut self,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -36,7 +36,7 @@ use time::UtcOffset;
 
 #[derive(Clone, Debug, PartialEq)]
 /// The `DebuggerStatus` is used to control how the Debugger::debug_session() decides if it should respond to
-/// DAP Client requests such as `Terminate`, `Disconnect`, and `Reset`, as well as how to repond to unrecoverable errors
+/// DAP Client requests such as `Terminate`, `Disconnect`, and `Reset`, as well as how to respond to unrecoverable errors
 /// during a debug session interacting with a target session.
 pub(crate) enum DebugSessionStatus {
     Continue,
@@ -77,7 +77,7 @@ impl Debugger {
 
     /// The logic of this function is as follows:
     /// - While we are waiting for DAP-Client, we have to continuously check in on the status of the probe.
-    /// - Initally, while [`DebugAdapter::configuration_done`] = `false`, we do nothing.
+    /// - Initially, while [`DebugAdapter::configuration_done`] = `false`, we do nothing.
     /// - Once [`DebugAdapter::configuration_done`] = `true`, we can start polling the probe for status, as follows:
     ///   - If the [`super::core_data::CoreData::last_known_status`] is `Halted(_)`, then we stop polling the Probe until the next DAP-Client request attempts an action
     ///   - If the `new_status` is an Err, then the probe is no longer available, and we  end the debugging session
@@ -848,7 +848,7 @@ impl Debugger {
 
 /// Wait for the next request with the given command.
 ///
-/// If the next request doesn *not* have the given command,
+/// If the next request does *not* have the given command,
 /// the function returns an error.
 fn expect_request<P: ProtocolAdapter>(
     debug_adapter: &mut DebugAdapter<P>,
@@ -938,9 +938,9 @@ mod test {
         test::TestLister,
     };
 
-    /// Helper function to get the expected capabilites for the debugger
+    /// Helper function to get the expected capabilities for the debugger
     ///
-    /// `Capabilites::default()` is not const, so this can't just be a constant.
+    /// `Capabilities::default()` is not const, so this can't just be a constant.
     fn expected_capabilites() -> Capabilities {
         Capabilities {
             support_suspend_debuggee: Some(true),

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/session_data.rs
@@ -31,7 +31,7 @@ pub(crate) enum BreakpointType {
     },
 }
 
-/// Breakpoint requests will either be refer to a specific SourceLcoation, or unspecified, in which case it will refer to
+/// Breakpoint requests will either be refer to a specific `SourceLocation`, or unspecified, in which case it will refer to
 /// all breakpoints for the Source.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum SourceLocationScope {

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
@@ -101,7 +101,9 @@ pub fn debug(
     Ok(())
 }
 
-/// All eprintln! messages are picked up by the VSCode extension and displayed in the debug console. We send these to stderr, in addition to logging them, so that they will show up, irrespective of the RUST_LOG level filters.
+/// All eprintln! messages are picked up by the VSCode extension and displayed in the debug console.
+/// We send these to stderr, in addition to logging them, so that they will show up, irrespective of
+/// the RUST_LOG level filters.
 fn log_to_console_and_tracing(message: &str) {
     eprintln!("probe-rs-debug: {}", &message);
     tracing::info!("{}", &message);

--- a/probe-rs/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/info.rs
@@ -116,7 +116,7 @@ fn try_show_info(
             match probe.try_into_riscv_interface() {
                 Ok(mut interface) => {
                     if let Err(e) = show_riscv_info(&mut interface) {
-                        log::warn!("Error showing RISCV chip information: {}", e);
+                        log::warn!("Error showing RISC-V chip information: {}", e);
                     }
 
                     probe = interface.close();
@@ -138,7 +138,7 @@ fn try_show_info(
         );
         }
     } else {
-        tracing::info!("Debugging RISCV-Targets over SWD is not supported.");
+        tracing::info!("Debugging RISC-V-Targets over SWD is not supported.");
     }
 
     (probe, Ok(()))
@@ -375,7 +375,7 @@ fn show_riscv_info(interface: &mut RiscvCommunicationInterface) -> Result<()> {
 
     let jep_id = jep106::JEP106Code::new(jep_cc as u8, jep_id as u8);
 
-    println!("RISCV Chip:");
+    println!("RISC-V Chip:");
     println!("\tIDCODE: {idcode:010x}");
     println!("\t Version:      {version}");
     println!("\t Part:         {part_number}");

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -147,7 +147,7 @@ impl Cmd {
     }
 }
 
-/// Print all RTT messsages and a stacktrace when the core stops due to an
+/// Print all RTT messages and a stacktrace when the core stops due to an
 /// exception or when ctrl + c is pressed.
 ///
 /// Returns `Ok(())` if the core gracefully halted, or an error.

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -189,7 +189,7 @@ impl LoadedProbeOptions {
     }
 
     /// Add targets contained in file given by --chip-description-path
-    /// to probe-rs registery.
+    /// to probe-rs registry.
     ///
     /// Note: should be called before [FlashOptions::early_exit] and any other functions in [ProbeOptions].
     fn maybe_load_chip_desc(&self) -> Result<(), OperationError> {

--- a/probe-rs/src/bin/probe-rs/util/logging.rs
+++ b/probe-rs/src/bin/probe-rs/util/logging.rs
@@ -53,7 +53,7 @@ fn colored_level(level: Level) -> ColoredString {
     }
 }
 
-/// Logger wrapper that can coexist peacefully with indicatif progressbars.
+/// Logger wrapper that can coexist peacefully with indicative progress bars.
 struct CliLogger {
     env_logger: Logger,
     output_is_terminal: bool,

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -101,7 +101,9 @@ pub struct RttConfig {
     pub channels: Vec<RttChannelConfig>,
 }
 
-/// The User specified configuration for each active RTT Channel. The configuration is passed via a DAP Client configuration (`launch.json`). If no configuration is specified, the defaults will be `Dataformat::String` and `show_timestamps=false`.
+/// The User specified configuration for each active RTT Channel. The configuration is passed via a
+/// DAP Client configuration (`launch.json`). If no configuration is specified, the defaults will be
+/// `Dataformat::String` and `show_timestamps=false`.
 #[derive(clap::Parser, Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RttChannelConfig {
@@ -119,7 +121,8 @@ pub struct RttChannelConfig {
     pub show_location: bool,
 }
 
-/// This is the primary interface through which RTT channel data is read and written. Every actual RTT channel has a configuration and buffer that is used for this purpose.
+/// This is the primary interface through which RTT channel data is read and written. Every actual
+/// RTT channel has a configuration and buffer that is used for this purpose.
 #[derive(Debug)]
 pub struct RttActiveChannel {
     pub up_channel: Option<UpChannel>,
@@ -139,7 +142,10 @@ pub struct RttActiveChannel {
     timestamp_offset: UtcOffset,
 }
 
-/// A fully configured RttActiveChannel. The configuration will always try to 'default' based on information read from the RTT control block in the binary. Where insufficient information is available, it will use the supplied configuration, with final hardcoded defaults where no other information was available.
+/// A fully configured RttActiveChannel. The configuration will always try to 'default' based on
+/// information read from the RTT control block in the binary. Where insufficient information is
+/// available, it will use the supplied configuration, with final hardcoded defaults where no other
+/// information was available.
 impl RttActiveChannel {
     pub fn new(
         up_channel: Option<UpChannel>,
@@ -368,7 +374,8 @@ impl RttActiveChannel {
     }
 }
 
-/// Once an active connection with the Target RTT control block has been established, we configure each of the active channels, and hold essential state information for successfull communication.
+/// Once an active connection with the Target RTT control block has been established, we configure
+/// each of the active channels, and hold essential state information for successful communication.
 #[derive(Debug)]
 pub struct RttActiveTarget {
     pub active_channels: Vec<RttActiveChannel>,

--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! For debugging and flashing different chips, called *target* in probe-rs, some
 //! target specific configuration is required. This includes the architecture of
-//! the chip, e.g. RISCV or ARM, and information about the memory map of the target,
+//! the chip, e.g. RISC-V or ARM, and information about the memory map of the target,
 //! which can be used together with a flash algorithm to program the flash memory
 //! of a target.
 //!

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -130,7 +130,7 @@ pub trait CoreInterface: MemoryInterface {
     /// Returns the return address register, a.k.a. link register.
     fn return_address(&self) -> &'static CoreRegister;
 
-    /// Returns `true` if hwardware breakpoints are enabled, `false` otherwise.
+    /// Returns `true` if hardware breakpoints are enabled, `false` otherwise.
     fn hw_breakpoints_enabled(&self) -> bool;
 
     /// Configure the target to ensure software breakpoints will enter Debug Mode.
@@ -733,7 +733,7 @@ impl<'probe> Core<'probe> {
     ///
     /// # Remarks
     ///
-    /// `T` can be an unsigned interger type, such as [u32] or [u64], or
+    /// `T` can be an unsigned integer type, such as [u32] or [u64], or
     /// it can be [RegisterValue] to allow the caller to support arbitrary
     /// length registers.
     ///

--- a/probe-rs/src/core/core_status.rs
+++ b/probe-rs/src/core/core_status.rs
@@ -5,7 +5,7 @@ pub enum CoreStatus {
     Running,
     /// The core is currently halted. This also specifies the reason as a payload.
     Halted(HaltReason),
-    /// This is a Cortex-M specific status, and will not be set or handled by RISCV code.
+    /// This is a Cortex-M specific status, and will not be set or handled by RISC-V code.
     LockedUp,
     /// The core is currently sleeping.
     Sleeping,

--- a/probe-rs/src/core/registers.rs
+++ b/probe-rs/src/core/registers.rs
@@ -70,7 +70,7 @@ impl Display for RegisterRole {
     }
 }
 
-/// The rule used to preserve the value of a register between function calls duing unwinding,
+/// The rule used to preserve the value of a register between function calls during unwinding,
 /// when DWARF unwind information is not available.
 ///
 /// The rules for these are based on the 'Procedure Calling Standard' for each of the supported architectures:

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -96,7 +96,7 @@ impl DebugInfo {
 
     /// Get the name of the function at the given address.
     ///
-    /// If no function is found, `None` will be returend.
+    /// If no function is found, `None` will be returned.
     ///
     /// ## Inlined functions
     /// Multiple nested inline functions could exist at the given address.
@@ -946,7 +946,7 @@ impl DebugInfo {
             };
 
             // PART 2-c: Unwind registers for the "previous/calling" frame.
-            // We sometimes need to keep a copy of the LR value to calculate the PC. For both ARM, and RISCV, The LR will be unwound before the PC, so we can reference it safely.
+            // We sometimes need to keep a copy of the LR value to calculate the PC. For both ARM, and RISC-V, The LR will be unwound before the PC, so we can reference it safely.
             let mut unwound_return_address: Option<RegisterValue> = None;
             for debug_register in unwind_registers.0.iter_mut() {
                 if unwind_register(
@@ -1337,7 +1337,7 @@ fn unwind_register(
                     .register_has_role(RegisterRole::StackPointer) =>
                 {
                     // NOTE: [ARMv7-M Architecture Reference Manual](https://developer.arm.com/documentation/ddi0403/ee), Section B.1.4.1: Treat bits [1:0] as `Should be Zero or Preserved`
-                    // - Applying this logic to RISCV has no adverse effects, since all incoming addresses are already 32-bit aligned.
+                    // - Applying this logic to RISC-V has no adverse effects, since all incoming addresses are already 32-bit aligned.
                     register_rule_string = "SP=CFA (dwarf Undefined)".to_string();
                     unwind_cfa.map(|unwind_cfa| {
                         if sp.is_u32() {

--- a/probe-rs/src/debug/debug_step.rs
+++ b/probe-rs/src/debug/debug_step.rs
@@ -34,7 +34,9 @@ impl SteppingMode {
     /// - If no hardware breakpoints are available, we will do repeated instruction steps until we reach the desired location.
     ///
     /// Usage Note:
-    /// - Currently, no special provision is made for the effect of interrupts that get triggered during stepping. The user must ensure that interrupts are disabled during stepping, or accept that stepping may be diverted by the interrupt processing on the core.
+    /// - Currently, no special provision is made for the effect of interrupts that get triggered
+    ///   during stepping. The user must ensure that interrupts are disabled during stepping, or
+    ///   accept that stepping may be diverted by the interrupt processing on the core.
     pub fn step(
         &self,
         core: &mut impl CoreInterface,
@@ -153,7 +155,7 @@ impl SteppingMode {
     /// - Everything is calculated from a given machine instruction address, usually the current program counter.
     /// - To calculate where the user might step to (step-over, step-into, step-out), we start from the given instruction address/program counter, and work our way through all the rows in the sequence of instructions it is part of.
     ///   - A sequence of instructions represents a series of contiguous target machine instructions, and does not necessarily represent the whole of a function.
-    ///   - Similarly, the instructions belonging to a source statement are not necessarily contiquous inside the sequence of instructions (e.g. conditional branching inside the sequence).
+    ///   - Similarly, the instructions belonging to a source statement are not necessarily contiguous inside the sequence of instructions (e.g. conditional branching inside the sequence).
     ///
     ///
     /// - The next row address in the target processor's instruction sequence may qualify as (one, or more) of the following:
@@ -168,7 +170,9 @@ impl SteppingMode {
     ///   - The beginning of a statement that is neither inside the prologue, nor inside the epilogue.
     /// - Based on this, we will attempt to return the "most appropriate" address for the [`SteppingMode`], given the available information in the instruction sequence.
     /// All data is calculated using the [`gimli::read::CompleteLineProgram`] as well as, function call data from the debug info frame section.
-    /// NOTE about errors returned: Sometimes the target program_counter is at a location where the debug_info program row data does not contain valid statements for halt points, and we will return a DebugError::NoValidHaltLocation . In this case, we recommend the consumer of this API step the core to the next instruction and try again, with a resasonable retry limit. All other error kinds are should be treated as non recoverable errors.
+    /// NOTE about errors returned: Sometimes the target program_counter is at a location where the debug_info program row data does not contain valid statements
+    /// for halt points, and we will return a `DebugError::NoValidHaltLocation`. In this case, we recommend the consumer of this API step the core to the next instruction
+    /// and try again, with a reasonable retry limit. All other error kinds are should be treated as non recoverable errors.
     pub(crate) fn get_halt_location(
         &self,
         core: &mut impl CoreInterface,

--- a/probe-rs/src/debug/function_die.rs
+++ b/probe-rs/src/debug/function_die.rs
@@ -21,7 +21,7 @@ pub(crate) struct FunctionDie<'abbrev, 'unit, 'unit_info, 'debug_info> {
     pub(crate) abstract_die: Option<Die<'abbrev, 'unit>>,
     /// The address of the first instruction in this function.
     pub(crate) low_pc: u64,
-    /// The address of the first instruction after this funciton.
+    /// The address of the first instruction after this function.
     pub(crate) high_pc: u64,
 }
 

--- a/probe-rs/src/debug/registers.rs
+++ b/probe-rs/src/debug/registers.rs
@@ -173,7 +173,7 @@ impl DebugRegisters {
             .unwrap_or_else(|| "unknown register".to_string())
     }
 
-    /// Retrieve a refererence to a register by searching against an exact match of the [`RegisterRole`].
+    /// Retrieve a reference to a register by searching against an exact match of the [`RegisterRole`].
     pub fn get_register_by_role(
         &self,
         register_role: &RegisterRole,
@@ -218,7 +218,7 @@ impl DebugRegisters {
             .try_into()
     }
 
-    /// Retrieve a mutable refererence to a register by searching against an exact match of the [`RegisterRole`].
+    /// Retrieve a mutable reference to a register by searching against an exact match of the [`RegisterRole`].
     pub fn get_register_mut_by_role(
         &mut self,
         register_role: &RegisterRole,

--- a/probe-rs/src/debug/source_statement.rs
+++ b/probe-rs/src/debug/source_statement.rs
@@ -156,7 +156,7 @@ impl SourceStatements {
 /// - The [`gimli::LineRow`] entries for a source statement does not have to be contiguous where they appear in a [`gimli::LineSequence`]
 /// - A `sequence`( [`gimli::LineSequence`] ) is a series of contiguous `rows`/`instructions`(may contain multiple `source_statement`'s).
 pub(crate) struct SourceStatement {
-    /// The first addresss of the statement where row.is_stmt() is true.
+    /// The first address of the statement where row.is_stmt() is true.
     pub(crate) is_stmt: bool,
     pub(crate) file_index: u64,
     pub(crate) line: Option<NonZeroU64>,

--- a/probe-rs/src/debug/stack_frame.rs
+++ b/probe-rs/src/debug/stack_frame.rs
@@ -21,7 +21,7 @@ pub struct StackFrame {
     pub pc: RegisterValue,
     /// The DWARF debug info defines a `DW_AT_frame_base` attribute which can be used to calculate the memory location of variables in a stack frame.
     /// The rustc compiler, has a compile flag, `-C force-frame-pointers`, which when set to `on`, will usually result in this being a pointer to the register value of the platform frame pointer.
-    /// However, some isa's (e.g. RISCV) uses a default of `-C force-frame-pointers off` and will then use the stack pointer as the frame base address.
+    /// However, some isa's (e.g. RISC-V) uses a default of `-C force-frame-pointers off` and will then use the stack pointer as the frame base address.
     /// We store the frame_base of the relevant non-inlined parent function, to ensure correct calculation of the [`Variable::memory_location`] values.
     pub frame_base: Option<u64>,
     /// Indicate if this stack frame belongs to an inlined function.

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -1418,7 +1418,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
 
     /// - Find the location using either DW_AT_location, DW_AT_data_member_location, or DW_AT_frame_base attribute.
     /// Return values are implemented as follows:
-    /// - Result<_, DebugError>: This happens when we encounter an error we did not expect, and will propogate upwards until the debugger request is failed. NOT GRACEFUL, and should be avoided.
+    /// - Result<_, DebugError>: This happens when we encounter an error we did not expect, and will propagate upwards until the debugger request is failed. NOT GRACEFUL, and should be avoided.
     /// - Result<ExpressionResult::Value(),_>:  The value is statically stored in the binary, and can be returned, and has no relevant memory location.
     /// - Result<ExpressionResult::Location(),_>:  One of the variants of VariableLocation, and needs to be interpreted for handling the 'expected' errors we encounter during evaluation.
     pub(crate) fn extract_location(
@@ -1562,7 +1562,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
 
     /// Evaluate a gimli::Expression as a valid memory location.
     /// Return values are implemented as follows:
-    /// - Result<_, DebugError>: This happens when we encounter an error we did not expect, and will propogate upwards until the debugger request is failed. NOT GRACEFUL, and should be avoided.
+    /// - Result<_, DebugError>: This happens when we encounter an error we did not expect, and will propagate upwards until the debugger request is failed. NOT GRACEFUL, and should be avoided.
     /// - Result<ExpressionResult::Value(),_>:  The value is statically stored in the binary, and can be returned, and has no relevant memory location.
     /// - Result<ExpressionResult::Location(),_>:  One of the variants of VariableLocation, and needs to be interpreted for handling the 'expected' errors we encounter during evaluation.
     pub(crate) fn evaluate_expression(

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -17,7 +17,7 @@ pub enum VariantRole {
 
 /// A [Variable] will have either a valid value, or some reason why a value could not be constructed.
 /// - If we encounter expected errors, they will be displayed to the user as defined below.
-/// - If we encounter unexpected errors, they will be treated as proper errors and will propogated to the calling process as an `Err()`
+/// - If we encounter unexpected errors, they will be treated as proper errors and will propagated to the calling process as an `Err()`
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub enum VariableValue {
     /// A valid value of this variable
@@ -158,7 +158,7 @@ pub enum VariableType {
     Struct(String),
     /// A Rust enum.
     Enum(String),
-    /// Namespace refers to the path that qualifies a variable. e.g. "std::string" is the namespace for the strucct "String"
+    /// Namespace refers to the path that qualifies a variable. e.g. "std::string" is the namespace for the struct "String"
     Namespace,
     /// A Pointer is a variable that contains a reference to another variable, and the type of the referenced variable may not be known until the reference has been resolved.
     Pointer(Option<String>),
@@ -172,7 +172,7 @@ pub enum VariableType {
     /// When we are unable to determine the name of a variable.
     #[default]
     Unknown,
-    /// For infrequently used categories of variables that does not fall into any of the other VriableType variants.
+    /// For infrequently used categories of variables that does not fall into any of the other `VariableType` variants.
     Other(String),
 }
 
@@ -355,7 +355,8 @@ impl Variable {
     }
 
     /// Convert the [String] value into the appropriate memory format and update the target memory with the new value.
-    /// Currently this only works for base data types. There is no provision in the MS DAP API to catch this client side, so we can only respond with a 'gentle' error message if the user attemtps unsupported data types.
+    /// Currently this only works for base data types. There is no provision in the MS DAP API to catch
+    /// this client side, so we can only respond with a 'gentle' error message if the user attempts unsupported data types.
     pub fn update_value(
         &self,
         memory: &mut impl MemoryInterface,

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -14,8 +14,8 @@ pub enum Error {
     /// An ARM specific error occurred.
     #[error("An ARM specific error occurred.")]
     Arm(#[source] ArmError),
-    /// A RISCV specific error occurred.
-    #[error("A RISCV specific error occurred.")]
+    /// A RISC-V specific error occurred.
+    #[error("A RISC-V specific error occurred.")]
     Riscv(#[source] RiscvError),
     /// The probe could not be opened.
     #[error("Probe could not be opened: {0}")]

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -149,7 +149,7 @@ impl DownloadOptions {
 
 /// Downloads a file of given `format` at `path` to the flash of the target given in `session`.
 ///
-/// This will ensure that memory bounderies are honored and does unlocking, erasing and programming of the flash for you.
+/// This will ensure that memory boundaries are honored and does unlocking, erasing and programming of the flash for you.
 ///
 /// If you are looking for more options, have a look at [download_file_with_options].
 pub fn download_file<P: AsRef<Path>>(
@@ -162,7 +162,7 @@ pub fn download_file<P: AsRef<Path>>(
 
 /// Downloads a file of given `format` at `path` to the flash of the target given in `session`.
 ///
-/// This will ensure that memory bounderies are honored and does unlocking, erasing and programming of the flash for you.
+/// This will ensure that memory boundaries are honored and does unlocking, erasing and programming of the flash for you.
 ///
 /// If you are looking for a simple version without many options, have a look at [download_file].
 pub fn download_file_with_options<P: AsRef<Path>>(
@@ -191,7 +191,7 @@ pub fn download_file_with_options<P: AsRef<Path>>(
         .map_err(FileDownloadError::Flash)
 }
 
-/// Flash data which was extraced from an ELF file.
+/// Flash data which was extracted from an ELF file.
 pub(super) struct ExtractedFlashData<'data> {
     pub(super) section_names: Vec<String>,
     pub(super) address: u32,

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -128,7 +128,7 @@ pub enum FlashError {
         /// The name of the chip.
         name: String,
     },
-    /// The given flash algorithm did not have a leng multiple of 4 bytes.
+    /// The given flash algorithm did not have a length multiple of 4 bytes.
     ///
     /// This means that the flash algorithm that was loaded is broken.
     #[error("Flash algorithm {name} does not have a length that is 4 byte aligned.")]

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -160,7 +160,7 @@ impl FlashAlgorithm {
     const FLASH_ALGO_STACK_SIZE: u32 = 512;
     const FLASH_ALGO_STACK_DECREMENT: u32 = 64;
 
-    // Header for RISCV Flash Algorithms
+    // Header for RISC-V Flash Algorithms
     const RISCV_FLASH_BLOB_HEADER: [u32; 2] = [riscv::assembly::EBREAK, riscv::assembly::EBREAK];
 
     const ARM_FLASH_BLOB_HEADER: [u32; 8] = [

--- a/probe-rs/src/flashing/mod.rs
+++ b/probe-rs/src/flashing/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This modules provides a means to do flash unlocking, erasing and programming.
 //!
-//! It provides a convenient highlevel interface that can flash an ELF, IHEX or BIN file
+//! It provides a convenient high level interface that can flash an ELF, IHEX or BIN file
 //! as well as a lower level block based interface.
 //!
 //!

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, time::Duration};
 
 /// A structure to manage the flashing procedure progress reporting.
 ///
-/// This struct stores a handler closure which will be called everytime an event happens during the flashing process.
+/// This struct stores a handler closure which will be called every time an event happens during the flashing process.
 /// Such an event can be start or finish of the flashing procedure or a progress report, as well as some more events.
 ///
 /// # Example
@@ -47,7 +47,7 @@ impl FlashProgress {
         self.emit(ProgressEvent::StartedFilling);
     }
 
-    /// Signalize that the programing procedure started.
+    /// Signalize that the programming procedure started.
     pub(super) fn started_programming(&self) {
         self.emit(ProgressEvent::StartedProgramming);
     }
@@ -119,7 +119,7 @@ impl FlashProgress {
 /// * `PageProgrammed` for every page
 /// * `FinishedProgramming`
 ///
-/// If an erorr occurs in any stage, one of the `Failed*` event will be returned,
+/// If an error occurs in any stage, one of the `Failed*` event will be returned,
 /// and no further events will be returned.
 #[derive(Debug)]
 pub enum ProgressEvent {

--- a/probe-rs/src/flashing/visualizer.rs
+++ b/probe-rs/src/flashing/visualizer.rs
@@ -115,7 +115,7 @@ impl<'layout> FlashVisualizer<'layout> {
     /// Generates an SVG which visualizes the given flash contents
     /// and writes the SVG into the file at the given `path`.
     ///
-    /// This is aequivalent to [FlashVisualizer::generate_svg] with the difference of operating on a file instead of a string.
+    /// This is equivalent to [FlashVisualizer::generate_svg] with the difference of operating on a file instead of a string.
     pub fn write_svg(&self, path: impl AsRef<std::path::Path>) -> std::io::Result<()> {
         use std::fs::OpenOptions;
         use std::io::Write;

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -90,7 +90,7 @@ pub trait MemoryInterface {
     /// guarantee which kind of memory access is used. The function might also read more
     /// data than requested, e.g. when the start address is not aligned to a 32-bit boundary.
     ///
-    /// For more control, the `read_x` functiongs, e.g. [`MemoryInterface::read_32()`], can be
+    /// For more control, the `read_x` functions, e.g. [`MemoryInterface::read_32()`], can be
     /// used.
     ///
     ///  Generally faster than `read_8`.

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -34,7 +34,7 @@ use probe_rs_target::ScanChainElement;
 use std::{convert::TryFrom, fmt};
 
 /// Used to log warnings when the measured target voltage is
-/// lower than 1.4V, if at all measureable.
+/// lower than 1.4V, if at all measurable.
 const LOW_TARGET_VOLTAGE_WARNING_THRESHOLD: f32 = 1.4;
 
 /// The protocol that is to be used by the probe when communicating with the target.
@@ -133,7 +133,7 @@ pub enum DebugProbeError {
     #[error("You need to be attached to the target to perform this action")]
     NotAttached,
     /// The debug probe already performed the init sequence.
-    /// Try runnoing the failing command before [`DebugProbe::attach`].
+    /// Try running the failing command before [`DebugProbe::attach`].
     #[error("You need to be detached from the target to perform this action")]
     Attached,
     /// Performing the init sequence on the target failed.
@@ -165,7 +165,7 @@ pub enum DebugProbeError {
     Timeout,
 }
 
-/// An error during probe creation accured.
+/// An error during probe creation occurred.
 /// This is almost always a sign of a bad USB setup.
 /// Check UDEV rules if you are on Linux and try installing Zadig
 /// (This will disable vendor specific drivers for your probe!) if you are on Windows.
@@ -413,13 +413,13 @@ impl Probe {
     }
 
     /// Check if the probe has an interface to
-    /// debug RISCV chips.
+    /// debug RISC-V chips.
     pub fn has_riscv_interface(&self) -> bool {
         self.inner.has_riscv_interface()
     }
 
     /// Try to get a [`RiscvCommunicationInterface`], which can
-    /// can be used to communicate with chips using the RISCV
+    /// can be used to communicate with chips using the RISC-V
     /// architecture.
     ///
     /// If an error occurs while trying to connect, the probe is returned.
@@ -456,7 +456,7 @@ impl Probe {
         self.inner.try_as_dap_probe()
     }
 
-    /// Try reading the target voltage of via the connected volgate pin.
+    /// Try reading the target voltage of via the connected voltage pin.
     ///
     /// This does not work on all probes.
     pub fn get_target_voltage(&mut self) -> Result<Option<f32>, DebugProbeError> {
@@ -470,7 +470,7 @@ impl Probe {
 pub trait DebugProbe: Send + fmt::Debug {
     /// Creates a new boxed [`DebugProbe`] from a given [`DebugProbeSelector`].
     /// This will be called for all available debug drivers when discovering probes.
-    /// When opening, it will open the first probe which succeds during this call.
+    /// When opening, it will open the first probe which succeeds during this call.
     fn new_from_selector(
         selector: impl Into<DebugProbeSelector>,
     ) -> Result<Box<Self>, DebugProbeError>
@@ -507,13 +507,13 @@ pub trait DebugProbe: Send + fmt::Debug {
     ///
     /// If the scan chain is provided, and the selected protocol is JTAG, the
     /// probe will automatically configure the JTAG interface to match the
-    /// scan chain configuration without trying to deteremine the chain at
+    /// scan chain configuration without trying to determine the chain at
     /// runtime.
     ///
     /// This is called by the `Session` when attaching to a target.
     /// So this does not need to be called manually, unless you want to
     /// modify the scan chain. You must be attached to a target to set the
-    /// scan_chain since the scan chain only applys to the attached target.
+    /// scan_chain since the scan chain only applies to the attached target.
     ///
     fn set_scan_chain(&mut self, scan_chain: Vec<ScanChainElement>) -> Result<(), DebugProbeError>;
 
@@ -546,7 +546,7 @@ pub trait DebugProbe: Send + fmt::Debug {
     /// Get the transport protocol currently in active use by the debug probe.
     fn active_protocol(&self) -> Option<WireProtocol>;
 
-    /// Check if the proble offers an interface to debug ARM chips.
+    /// Check if the probe offers an interface to debug ARM chips.
     fn has_arm_interface(&self) -> bool {
         false
     }
@@ -563,18 +563,18 @@ pub trait DebugProbe: Send + fmt::Debug {
         ))
     }
 
-    /// Get the dedicated interface to debug RISCV chips. Ensure that the
+    /// Get the dedicated interface to debug RISC-V chips. Ensure that the
     /// probe actually supports this by calling [DebugProbe::has_riscv_interface] first.
     fn try_get_riscv_interface(
         self: Box<Self>,
     ) -> Result<RiscvCommunicationInterface, (Box<dyn DebugProbe>, RiscvError)> {
         Err((
             self.into_probe(),
-            DebugProbeError::InterfaceNotAvailable("RISCV").into(),
+            DebugProbeError::InterfaceNotAvailable("RISC-V").into(),
         ))
     }
 
-    /// Check if the probe offers an interface to debug RISCV chips.
+    /// Check if the probe offers an interface to debug RISC-V chips.
     fn has_riscv_interface(&self) -> bool {
         false
     }
@@ -700,7 +700,7 @@ pub enum DebugProbeSelectorParseError {
 ///
 /// Construct this from a set of info or from a string. The
 /// string has to be in the format "VID:PID:SERIALNUMBER",
-/// where the serialnumber is optional, and VID and PID are
+/// where the serial number is optional, and VID and PID are
 /// parsed as hexadecimal numbers.
 ///
 /// ## Example:
@@ -799,11 +799,11 @@ impl fmt::Display for DebugProbeSelector {
 /// Low-Level Access to the JTAG protocol
 ///
 /// This trait should be implemented by all probes which offer low-level access to
-/// the JTAG protocol, i.e. directo control over the bytes sent and received.
+/// the JTAG protocol, i.e. direction control over the bytes sent and received.
 pub trait JTAGAccess: DebugProbe {
     fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError>;
 
-    /// For Riscv, and possibly other interfaces, the JTAG interface has to remain in
+    /// For RISC-V, and possibly other interfaces, the JTAG interface has to remain in
     /// the idle state for several cycles between consecutive accesses to the DR register.
     ///
     /// This function configures the number of idle cycles which are inserted after each access.

--- a/probe-rs/src/probe/arm_jtag.rs
+++ b/probe-rs/src/probe/arm_jtag.rs
@@ -36,7 +36,7 @@ pub struct SwdSettings {
     ///
     /// When performing a write operation, the write can
     /// be buffered, meaning that completing the transfer
-    /// does not mean that the write was performed succesfully.
+    /// does not mean that the write was performed successfully.
     ///
     /// To check that all writes have been executed, the
     /// `RDBUFF` register can be read from the DP.
@@ -70,7 +70,7 @@ pub struct ProbeStatistics {
     /// Number of protocol transfers performed.
     ///
     /// This includes repeated transfers, and transfers
-    /// which are automatically added to fullfill
+    /// which are automatically added to fulfill
     /// protocol requirements, e.g. a read from a
     /// DP register will result in two transfers,
     /// because the read value is returned in the
@@ -173,7 +173,7 @@ fn parse_jtag_response(data: &[u8]) -> u64 {
     received
 }
 
-/// Perform a single JTAG tranfer and parse the results
+/// Perform a single JTAG transfer and parse the results
 ///
 /// Return is (value, status)
 fn perform_jtag_transfer<P: JTAGAccess + RawProtocolIo>(
@@ -305,7 +305,7 @@ fn perform_jtag_transfers<P: JTAGAccess + RawProtocolIo>(
 /// Perform a batch of SWD transfers.
 ///
 /// For each transfer, the corresponding bit sequence is
-/// created and the resulting sequences are concatened
+/// created and the resulting sequences are concatenated
 /// to a single sequence, so that it can be sent to
 /// to the probe.
 fn perform_swd_transfers<P: RawProtocolIo>(

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -386,7 +386,7 @@ impl CmsisDap {
     /// According to the ARM specification, this *should* never fail.
     /// In practice, it can unfortunately happen.
     ///
-    /// To avoid an endeless recursion in this cases, this function is provided
+    /// To avoid an endless recursion in this cases, this function is provided
     /// as an alternative to [`Self::process_batch()`]. This function will return any errors,
     /// and not retry any transfers.
     fn read_ctrl_register(&mut self) -> Result<Ctrl, ArmError> {

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -385,8 +385,8 @@ pub fn open_device_from_selector(
     }
 }
 
-/// We recognise cmis dap interfaces if they have string like "CMSIS-DAP"
-/// in them. As devices spell CMIS DAP differently we go through known
+/// We recognise cmsis dap interfaces if they have string like "CMSIS-DAP"
+/// in them. As devices spell CMSIS DAP differently we go through known
 /// spellings/patterns looking for a match
 fn is_cmsis_dap(id: &str) -> bool {
     id.contains("CMSIS-DAP") || id.contains("CMSIS_DAP")

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -1,4 +1,4 @@
-//! Crate-public stuctures and utilites to be shared between probes.
+//! Crate-public structures and utilities to be shared between probes.
 
 use bitfield::bitfield;
 use bitvec::prelude::*;

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -234,7 +234,7 @@ impl ProtocolHandler {
     }
 
     /// Put a bit on TDI and possibly read one from TDO.
-    /// to recieve the bytes from this operations call [`ProtocolHandler::flush`]
+    /// to receive the bytes from this operations call [`ProtocolHandler::flush`]
     ///
     /// Note that if the internal buffer is exceeded bytes will be automatically flushed to usb device
     pub fn jtag_io_async(
@@ -254,7 +254,7 @@ impl ProtocolHandler {
     }
 
     /// Sets the two different resets on the target.
-    /// NOTE: Only srst can be set for now. Setting trst is not implemented yet.
+    /// NOTE: Only `srst` can be set for now. Setting `trst` is not implemented yet.
     pub fn set_reset(&mut self, _trst: bool, srst: bool) -> Result<(), DebugProbeError> {
         // TODO: Handle trst using setup commands. This is not necessarily required and can be left as is for the moiment..
         self.push_command(Command::Reset(srst))?;

--- a/probe-rs/src/probe/stlink/usb_interface.rs
+++ b/probe-rs/src/probe/stlink/usb_interface.rs
@@ -35,7 +35,7 @@ pub static USB_PID_EP_MAP: Lazy<HashMap<u16, StLinkInfo>> = Lazy::new(|| {
     m
 });
 
-/// A helper struct to match STLink deviceinfo.
+/// A helper struct to match STLink device info.
 #[derive(Clone, Debug, Default)]
 pub struct StLinkInfo {
     pub version_name: &'static str,

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -103,7 +103,7 @@ pub enum RiscvChip {
     CH59X = 0x0B, // 11
     /// CH643 Qingke-V4C series, RGB Display Driver MCU
     CH643 = 0x0C, // 12
-    /// CH32X035 Qingke-V4C USB-PD series, fallbak as CH643
+    /// CH32X035 Qingke-V4C USB-PD series, fallback as CH643
     CH32X035 = 0x0D, // 13
     /// CH32L103 Qingke-V4C low power series, USB-PD
     CH32L103 = 0x0E, // 14

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -74,18 +74,18 @@ use std::ops::Range;
 /// this RTT interface can be expected to work as expected.  
 ///
 /// 2. **Scenario: Failure to detect RTT Control Block** The target has been configured correctly, BUT the host creates this interface BEFORE
-/// the target program has initalized RTT.
-///     * This most commonly occurs when the target halts processing before intializing RTT. For example, this could happen ...
-///         * During debugging, if the user sets a breakpoint in the code before the RTT initalization.
+/// the target program has initialized RTT.
+///     * This most commonly occurs when the target halts processing before initializing RTT. For example, this could happen ...
+///         * During debugging, if the user sets a breakpoint in the code before the RTT initialization.
 ///         * After flashing, if the user has configured `probe-rs` to `reset_after_flashing` AND `halt_after_reset`. On most targets, this
-/// will result in the target halting with reason `Exception` and will delay the subsequent RTT intialization.
+/// will result in the target halting with reason `Exception` and will delay the subsequent RTT initialization.
 ///         * If RTT initialization on the target is delayed because of time consuming processing or excessive interrupt handling. This can
-/// usually be prevented by moving the RTT intialization code to the very beginning of the target program logic.
-///     * The result of such a timing issue is that `probe-rs` will fail to intialize RTT with an [`probe-rs-rtt::Error::ControlBlockNotFound`]
+/// usually be prevented by moving the RTT initialization code to the very beginning of the target program logic.
+///     * The result of such a timing issue is that `probe-rs` will fail to initialize RTT with an [`probe-rs-rtt::Error::ControlBlockNotFound`]
 ///
-/// 3. **Scenario: Incorrect Channel names and incorrect Channel buffer sizes** This scenario usually occurs when two conditions co-incide. Firstly, the same timing mismatch as described in point #2 above, and secondly, the target memory has NOT been cleared since a previous version of the binary program has been flashed to the target.
+/// 3. **Scenario: Incorrect Channel names and incorrect Channel buffer sizes** This scenario usually occurs when two conditions coincide. Firstly, the same timing mismatch as described in point #2 above, and secondly, the target memory has NOT been cleared since a previous version of the binary program has been flashed to the target.
 ///     * What happens here is that the RTT Control Block is validated by reading a previously initialized RTT ID from the target memory. The next step in the logic is then to read the Channel configuration from the RTT Control block which is usually contains unreliable data
-/// at this point. The symptomps will appear as:
+/// at this point. The symptoms will appear as:
 ///         * RTT Channel names are incorrect and/or contain unprintable characters.
 ///         * RTT Channel names are correct, but no data, or corrupted data, will be reported from RTT, because the buffer sizes are incorrect.
 #[derive(Debug)]

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -321,7 +321,7 @@ impl Session {
     /// Attaches to the core with the given number.
     ///
     /// ## Usage
-    /// Everytime you want to perform an operation on the chip, you need to get the Core handle with the [Session::core()] method. This [Core] handle is merely a view into the core and provides a convenient API surface.
+    /// Every time you want to perform an operation on the chip, you need to get the Core handle with the [Session::core()] method. This [Core] handle is merely a view into the core and provides a convenient API surface.
     ///
     /// All the state is stored in the [Session] handle.
     ///
@@ -687,12 +687,12 @@ fn get_target_from_selector(
                         probe = interface.close();
                     }
                     Err((returned_probe, err)) => {
-                        tracing::debug!("Error during autodetection of RISCV chips: {}", err);
+                        tracing::debug!("Error during autodetection of RISC-V chips: {}", err);
                         probe = returned_probe;
                     }
                 }
             } else {
-                tracing::debug!("No RISCV interface was present. Skipping Riscv autodetect.");
+                tracing::debug!("No RISC-V interface was present. Skipping Riscv autodetect.");
             }
 
             // Now we can deassert reset in case we asserted it before. This is always okay.
@@ -710,7 +710,7 @@ fn get_target_from_selector(
 }
 
 /// The `Permissions` struct represents what a [Session] is allowed to do with a target.
-/// Some operations can be irreversable, so need to be explicitly allowed by the user.
+/// Some operations can be irreversible, so need to be explicitly allowed by the user.
 ///
 /// # Example
 ///

--- a/smoke-tester/src/tests.rs
+++ b/smoke-tester/src/tests.rs
@@ -42,7 +42,7 @@ pub fn test_register_write(tracker: &TestTracker, core: &mut Core) -> Result<()>
     let mut test_value = 1;
 
     for register in register.core_registers() {
-        // Skip register x0 on RISCV chips, it's hardwired to zero.
+        // Skip register x0 on RISC-V chips, it's hardwired to zero.
         if core.architecture() == Architecture::Riscv && register.name() == "x0" {
             continue;
         }

--- a/smoke-tester/src/tests/stepping.rs
+++ b/smoke-tester/src/tests/stepping.rs
@@ -12,7 +12,7 @@ pub fn test_stepping(core: &mut Core, memory_regions: &[MemoryRegion]) -> Result
     println!("Testing stepping...");
 
     if core.architecture() == Architecture::Riscv {
-        // Not implemented for RISCV yet
+        // Not implemented for RISC-V yet
         return Ok(());
     }
 


### PR DESCRIPTION
I've also changed RISCV -> RISC-V as it's officially written, and wrapped a few lines that didn't fit my 32" monitor 👀

I deliberately didn't convert british <-> US spelling differences, but there's a few.

I'm not sure if this warrants a changelog entry. Let me know if I should add one.