### PR TITLE
Gate scanning memory for RTT control block behind a flag

### DIFF
--- a/changelog/changed-scan-memory-behavior.md
+++ b/changelog/changed-scan-memory-behavior.md
@@ -1,0 +1,1 @@
+By default, `probe-rs run` and `probe-rs attach` will only scan the memory for the RTT control block if the `--rtt-scan-memory` flag is provided. It will still always look for a `_SEGGER_RTT` symbol in the ELF file and use that first in all circumstances.

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -52,12 +52,17 @@ pub struct Cmd {
 
     #[clap(long)]
     pub(crate) log_format: Option<String>,
+
     /// Enable reset vector catch if its supported on the target.
     #[arg(long)]
     pub catch_reset: bool,
     /// Enable hardfault vector catch if its supported on the target.
     #[arg(long)]
     pub catch_hardfault: bool,
+
+    /// Scan the memory to find the RTT control block
+    #[clap(long)]
+    pub(crate) rtt_scan_memory: bool,
 }
 
 impl Cmd {
@@ -104,7 +109,10 @@ impl Cmd {
         }
 
         let memory_map = session.target().memory_map.clone();
-        let rtt_scan_regions = session.target().rtt_scan_regions.clone();
+        let rtt_scan_regions = match self.rtt_scan_memory {
+            true => session.target().rtt_scan_regions.clone(),
+            false => Vec::new(),
+        };
         let mut core = session.core(0)?;
 
         if self.catch_hardfault || self.catch_reset {


### PR DESCRIPTION
This changes the default of scanning to not scanning. This should hopefully not impact many users since most tools define a `_SEGGER_RTT` symbol in the ELF, in which case only that particular address is checked.

Fixes #1865