### PR TITLE
esp-usbjtag: implement TAP reset

### DIFF
--- a/changelog/added-espusbjtag-trst.md
+++ b/changelog/added-espusbjtag-trst.md
@@ -1,0 +1,1 @@
+Add TRST implementation for esp-usbjtag

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -257,10 +257,20 @@ impl ProtocolHandler {
     }
 
     /// Sets the two different resets on the target.
-    /// NOTE: Only `srst` can be set for now. Setting `trst` is not implemented yet.
-    pub fn set_reset(&mut self, _trst: bool, srst: bool) -> Result<(), DebugProbeError> {
-        // TODO: Handle trst using setup commands. This is not necessarily required and can be left as is for the moiment..
+    pub fn set_reset(&mut self, trst: bool, srst: bool) -> Result<(), DebugProbeError> {
+        if trst {
+            // We send 5 TMS bits as TAP reset
+            for _ in 0..5 {
+                self.push_command(RepeatableCommand::Clock {
+                    cap: false,
+                    tdi: false,
+                    tms: true,
+                })?;
+            }
+        }
+
         self.add_raw_command(Command::Reset(srst))?;
+
         self.flush()?;
         Ok(())
     }


### PR DESCRIPTION
To the best of my (not very comprehensive) knowledge, 5 TMS=1 cycles should always push the state machine into the reset state. We could use the `VEND_JTAG_SETIO` control request instead but this seemed much simpler.