### PR TITLE
esp-usbjtag: correct reset assert/deassert levels

### DIFF
--- a/changelog/fixed-espusbjtag-reset-levels.md
+++ b/changelog/fixed-espusbjtag-reset-levels.md
@@ -1,0 +1,1 @@
+Correct esp-usbjtag reset assert/deassert levels.

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -552,13 +552,13 @@ impl DebugProbe for EspUsbJtag {
 
     fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {
         tracing::info!("reset_assert!");
-        self.protocol.set_reset(false, false)?;
+        self.protocol.set_reset(true, true)?;
         Ok(())
     }
 
     fn target_reset_deassert(&mut self) -> Result<(), DebugProbeError> {
         tracing::info!("reset_deassert!");
-        self.protocol.set_reset(true, true)?;
+        self.protocol.set_reset(false, false)?;
         Ok(())
     }
 


### PR DESCRIPTION
According to the ESP32-S3 technical reference manual, SRST is high-active. This PR will

 - trigger a JTAG reset when asserting reset (instead of while deasserting)
 - correct the SRST levels so deasserting now pulls the MCU out of reset instead of triggering it

> SRST is connected to the reset logic of the digital circuitry in the SoC and a high level on this line
will cause a digital system reset. Note that the USB Serial/JTAG Controller itself is not affected by SRST.

I'm not sure if attach under reset was used for ESP32-Cx devices or if it worked, but the current esp-usbjtag implementation doesn't seem to be correct in this regard.