### PR TITLE
Rename `JTAGAccess::get_idle_cycles`

### DIFF
--- a/changelog/changed-jtagaccess-idle-cycles.md
+++ b/changelog/changed-jtagaccess-idle-cycles.md
@@ -1,0 +1,1 @@
+Renamed `JTAGAccess::get_idle_cycles` to `idle_cycles` and removed redundant inherent fns

--- a/probe-rs/src/architecture/riscv/dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm.rs
@@ -109,7 +109,7 @@ impl Dtm {
                             self.queued_commands
                                 .extend_from_slice(&cmds[e.results.len()..]);
 
-                            self.probe.set_idle_cycles(self.probe.get_idle_cycles() + 1);
+                            self.probe.set_idle_cycles(self.probe.idle_cycles() + 1);
 
                             self.execute()
                         }
@@ -219,7 +219,7 @@ impl Dtm {
                     // Operation still in progress, reset dmi status and try again.
                     self.reset()?;
                     self.probe
-                        .set_idle_cycles(self.probe.get_idle_cycles().saturating_add(1));
+                        .set_idle_cycles(self.probe.idle_cycles().saturating_add(1));
                 }
                 Err(e) => return Err(RiscvError::DmiTransfer(e)),
             }

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -810,7 +810,7 @@ pub trait JTAGAccess: DebugProbe {
     fn set_idle_cycles(&mut self, idle_cycles: u8);
 
     /// Return the currently configured idle cycles.
-    fn get_idle_cycles(&self) -> u8;
+    fn idle_cycles(&self) -> u8;
 
     /// Set the IR register length
     fn set_ir_len(&mut self, len: u32);

--- a/probe-rs/src/probe/arm_jtag.rs
+++ b/probe-rs/src/probe/arm_jtag.rs
@@ -1574,7 +1574,7 @@ mod test {
             todo!()
         }
 
-        fn get_idle_cycles(&self) -> u8 {
+        fn idle_cycles(&self) -> u8 {
             todo!()
         }
 

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -39,10 +39,6 @@ pub(crate) struct EspUsbJtag {
 }
 
 impl EspUsbJtag {
-    fn idle_cycles(&self) -> u8 {
-        self.jtag_idle_cycles
-    }
-
     fn scan(&mut self) -> Result<Vec<super::JtagChainItem>, DebugProbeError> {
         let chain = self.reset_scan()?;
         Ok(chain
@@ -391,7 +387,7 @@ impl JTAGAccess for EspUsbJtag {
         self.jtag_idle_cycles = idle_cycles;
     }
 
-    fn get_idle_cycles(&self) -> u8 {
+    fn idle_cycles(&self) -> u8 {
         self.jtag_idle_cycles
     }
 

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -599,7 +599,7 @@ impl JTAGAccess for FtdiProbe {
         Ok(r)
     }
 
-    fn get_idle_cycles(&self) -> u8 {
+    fn idle_cycles(&self) -> u8 {
         self.idle_cycles
     }
 

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -56,10 +56,6 @@ pub(crate) struct JLink {
 }
 
 impl JLink {
-    fn idle_cycles(&self) -> u8 {
-        self.jtag_idle_cycles
-    }
-
     fn select_interface(
         &mut self,
         protocol: Option<WireProtocol>,
@@ -681,7 +677,7 @@ impl JTAGAccess for JLink {
         self.jtag_idle_cycles = idle_cycles;
     }
 
-    fn get_idle_cycles(&self) -> u8 {
+    fn idle_cycles(&self) -> u8 {
         self.jtag_idle_cycles
     }
 }

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -378,7 +378,7 @@ impl JTAGAccess for WchLink {
         self.idle_cycles = idle_cycles;
     }
 
-    fn get_idle_cycles(&self) -> u8 {
+    fn idle_cycles(&self) -> u8 {
         self.idle_cycles
     }
 


### PR DESCRIPTION
This PR renames the accessor to remove the [`get_` prefix](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter) and removes two duplicate inherent implementations.