### PR TITLE
Initial Xtensa support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,28 @@
     {
       "type": "lldb",
       "request": "launch",
+      "name": "Debug example 'xtensa'",
+      "cargo": {
+        "args": [
+          "build",
+          "--example=xtensa",
+          "--package=probe-rs",
+          "--features=ftdi"
+        ],
+        "filter": {
+          "name": "xtensa",
+          "kind": "example"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "RUST_LOG": "info"
+      }
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
       "name": "Launch smoke tester",
       "cargo": {
         "args": ["build", "--package=smoke_tester"]

--- a/changelog/added-initial-xtensa-support.md
+++ b/changelog/added-initial-xtensa-support.md
@@ -1,0 +1,1 @@
+Added initial xtensa support.

--- a/probe-rs/examples/xtensa.rs
+++ b/probe-rs/examples/xtensa.rs
@@ -41,7 +41,7 @@ fn main() -> Result<()> {
     const TEST_MEMORY_REGION_START: u64 = 0x600F_E000;
     const TEST_MEMORY_LEN: usize = 100;
 
-    let mut saved_memory = vec![0; TEST_MEMORY_LEN];
+    let mut saved_memory = [0; TEST_MEMORY_LEN];
     iface.read(TEST_MEMORY_REGION_START, &mut saved_memory[..])?;
 
     // Zero the memory

--- a/probe-rs/examples/xtensa.rs
+++ b/probe-rs/examples/xtensa.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use probe_rs::config::ScanChainElement;
 use probe_rs::Probe;
 
 fn main() -> Result<()> {
@@ -12,6 +13,17 @@ fn main() -> Result<()> {
 
     probe.set_speed(100)?;
     probe.select_protocol(probe_rs::WireProtocol::Jtag)?;
+    // scan chain for an esp32s3
+    probe.set_scan_chain(vec![
+        ScanChainElement {
+            ir_len: Some(5),
+            name: Some("main".to_owned()),
+        },
+        ScanChainElement {
+            ir_len: Some(5),
+            name: Some("second".to_owned()),
+        },
+    ])?;
     probe.attach_to_unspecified()?;
     let _iface = probe
         .try_into_xtensa_interface()

--- a/probe-rs/examples/xtensa.rs
+++ b/probe-rs/examples/xtensa.rs
@@ -1,3 +1,5 @@
+//! This example demonstrates how to use the implemented parts of the Xtensa interface.
+
 use anyhow::Result;
 use probe_rs::config::ScanChainElement;
 use probe_rs::{Lister, MemoryInterface, Probe};
@@ -15,7 +17,8 @@ fn main() -> Result<()> {
 
     probe.set_speed(100)?;
     probe.select_protocol(probe_rs::WireProtocol::Jtag)?;
-    // scan chain for an esp32s3
+
+    // Scan the chain for an esp32s3.
     probe.set_scan_chain(vec![
         ScanChainElement {
             ir_len: Some(5),

--- a/probe-rs/examples/xtensa.rs
+++ b/probe-rs/examples/xtensa.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use probe_rs::Probe;
+
+fn main() -> Result<()> {
+    pretty_env_logger::init();
+
+    // Get a list of all available debug probes.
+    let probes = Probe::list_all();
+
+    // Use the first probe found.
+    let mut probe: Probe = probes[0].open()?;
+
+    probe.set_speed(100)?;
+    probe.select_protocol(probe_rs::WireProtocol::Jtag)?;
+    probe.attach_to_unspecified()?;
+    let _iface = probe
+        .try_into_xtensa_interface()
+        .unwrap();
+
+    Ok(())
+}

--- a/probe-rs/examples/xtensa.rs
+++ b/probe-rs/examples/xtensa.rs
@@ -44,14 +44,20 @@ fn main() -> Result<()> {
     // Zero the memory
     iface.write(TEST_MEMORY_REGION_START, &[0; TEST_MEMORY_LEN])?;
 
+    // Write a test word into memory, unaligned
     iface.write_word_32(TEST_MEMORY_REGION_START + 1, 0xDECAFBAD)?;
     let coffee_opinion = iface.read_word_32(TEST_MEMORY_REGION_START + 1)?;
 
-    let mut readback = [0; 8];
+    // Write a test word into memory, aligned
+    iface.write_word_32(TEST_MEMORY_REGION_START + 8, 0xFEEDC0DE)?;
+    let aligned_word = iface.read_word_32(TEST_MEMORY_REGION_START + 8)?;
+
+    let mut readback = [0; 12];
     iface.read(TEST_MEMORY_REGION_START, &mut readback[..])?;
 
     tracing::info!("coffee_opinion: {:08X}", coffee_opinion);
-    tracing::info!("readback: {:#X?}", readback);
+    tracing::info!("aligned_word: {:08X}", aligned_word);
+    tracing::info!("readback: {:X?}", readback);
 
     // Restore memory we just overwrote
     iface.write(TEST_MEMORY_REGION_START, &saved_memory[..])?;

--- a/probe-rs/examples/xtensa.rs
+++ b/probe-rs/examples/xtensa.rs
@@ -1,15 +1,17 @@
 use anyhow::Result;
 use probe_rs::config::ScanChainElement;
-use probe_rs::{MemoryInterface, Probe};
+use probe_rs::{Lister, MemoryInterface, Probe};
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
 
     // Get a list of all available debug probes.
-    let probes = Probe::list_all();
+    let probe_lister = Lister::new();
+
+    let probes = probe_lister.list_all();
 
     // Use the first probe found.
-    let mut probe: Probe = probes[0].open()?;
+    let mut probe: Probe = probes[0].open(&probe_lister)?;
 
     probe.set_speed(100)?;
     probe.select_protocol(probe_rs::WireProtocol::Jtag)?;

--- a/probe-rs/src/architecture/mod.rs
+++ b/probe-rs/src/architecture/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod arm;
 pub mod riscv;
+pub mod xtensa;

--- a/probe-rs/src/architecture/xtensa/arch/instruction/format.rs
+++ b/probe-rs/src/architecture/xtensa/arch/instruction/format.rs
@@ -1,7 +1,17 @@
+//! Instruction formats implemented as functions.
+//!
+//! Instruction formats are common bytecode formats used to simplify instruction implementation.
+//! They are implemented with an opcode and a set of more-or-less standardised slots where
+//! instructions may define their operands.
+//!
+//! For more information, see the Xtensa ISA documentation.
+
+/// Implements the RSR instruction format.
 pub const fn rsr(opcode: u32, rs: u8, t: u8) -> u32 {
     opcode | (rs as u32) << 8 | (t as u32 & 0x0F) << 4
 }
 
+/// Implements the RRI8 instruction format.
 pub const fn rri8(opcode: u32, at: u8, _as: u8, off: u8) -> u32 {
     opcode | ((off as u32) << 16) | (_as as u32 & 0x0F) << 8 | (at as u32 & 0x0F) << 4
 }

--- a/probe-rs/src/architecture/xtensa/arch/instruction/format.rs
+++ b/probe-rs/src/architecture/xtensa/arch/instruction/format.rs
@@ -1,0 +1,3 @@
+pub const fn rsr(opcode: u32, rs: u8, t: u8) -> u32 {
+    opcode | (rs as u32) << 8 | (t as u32 & 0x0F) << 4
+}

--- a/probe-rs/src/architecture/xtensa/arch/instruction/format.rs
+++ b/probe-rs/src/architecture/xtensa/arch/instruction/format.rs
@@ -1,3 +1,7 @@
 pub const fn rsr(opcode: u32, rs: u8, t: u8) -> u32 {
     opcode | (rs as u32) << 8 | (t as u32 & 0x0F) << 4
 }
+
+pub const fn rri8(opcode: u32, at: u8, _as: u8, off: u8) -> u32 {
+    opcode | ((off as u32) << 16) | (_as as u32 & 0x0F) << 8 | (at as u32 & 0x0F) << 4
+}

--- a/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
@@ -1,0 +1,22 @@
+pub mod format;
+
+/// Loads a 32-bit word from the address in `src` into `DDR`
+/// Note: this is an illegal instruction when the processor is not in On-Chip Debug Mode
+pub const fn lddr32_p(src: u8) -> u32 {
+    0x0070E0 | (src as u32 & 0x0F) << 8
+}
+
+/// Reads special register `sr` into `t`
+pub const fn rsr(sr: u8, t: u8) -> u32 {
+    format::rsr(0x030000, sr, t)
+}
+
+/// Writes `t` into special register `sr`
+pub const fn wsr(sr: u8, t: u8) -> u32 {
+    format::rsr(0x130000, sr, t)
+}
+
+/// Returns the Core to the Running state
+pub const fn rfdo(_i: u8) -> u32 {
+    0xF1E000
+}

--- a/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
@@ -2,23 +2,38 @@ use crate::architecture::xtensa::arch::{CpuRegister, SpecialRegister};
 
 pub mod format;
 
-/// Loads a 32-bit word from the address in `src` into `DDR`
-/// Note: this is an illegal instruction when the processor is not in On-Chip Debug Mode
-pub const fn lddr32_p(src: CpuRegister) -> u32 {
-    0x0070E0 | (src.address() as u32 & 0x0F) << 8
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum Instruction {
+    /// Loads a 32-bit word from the address in `src` into `DDR`
+    /// Note: this is an illegal instruction when the processor is not in On-Chip Debug Mode
+    Lddr32P(CpuRegister),
+
+    /// Reads special register `sr` into `t`
+    Rsr(SpecialRegister, CpuRegister),
+
+    /// Writes `t` into special register `sr`
+    Wsr(SpecialRegister, CpuRegister),
+
+    /// Returns the Core to the Running state
+    Rfdo(u8),
 }
 
-/// Reads special register `sr` into `t`
-pub const fn rsr(sr: SpecialRegister, t: CpuRegister) -> u32 {
-    format::rsr(0x030000, sr.address(), t.address())
+/// The architecture supports multi-word instructions. This enum represents the different encodings
+// ... but we only support narrow ones for now
+pub enum InstructionEncoding {
+    /// Instruction encoding is narrow enough to fit into DIR0/DIR0EXEC
+    Narrow(u32),
 }
 
-/// Writes `t` into special register `sr`
-pub const fn wsr(sr: SpecialRegister, t: CpuRegister) -> u32 {
-    format::rsr(0x130000, sr.address(), t.address())
-}
+impl Instruction {
+    pub fn encode(self) -> InstructionEncoding {
+        let narrow = match self {
+            Instruction::Lddr32P(src) => 0x0070E0 | (src.address() as u32 & 0x0F) << 8,
+            Instruction::Rsr(sr, t) => format::rsr(0x030000, sr.address(), t.address()),
+            Instruction::Wsr(sr, t) => format::rsr(0x130000, sr.address(), t.address()),
+            Instruction::Rfdo(_) => 0xF1E000,
+        };
 
-/// Returns the Core to the Running state
-pub const fn rfdo(_i: u8) -> u32 {
-    0xF1E000
+        InstructionEncoding::Narrow(narrow)
+    }
 }

--- a/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
@@ -8,11 +8,30 @@ pub enum Instruction {
     /// Note: this is an illegal instruction when the processor is not in On-Chip Debug Mode
     Lddr32P(CpuRegister),
 
+    /// Stores a 32-bit word from `DDR` to the address in `src`
+    /// Note: this is an illegal instruction when the processor is not in On-Chip Debug Mode
+    Sddr32P(CpuRegister),
+
+    /// Stores 8 bits from `at` to the address in `as` offset by a constant.
+    ///
+    /// This instruction can not access InstrRAM.
+    S8i(CpuRegister, CpuRegister, u8),
+
     /// Reads `SpecialRegister` into `CpuRegister`
     Rsr(SpecialRegister, CpuRegister),
 
     /// Writes `CpuRegister` into `SpecialRegister`
     Wsr(SpecialRegister, CpuRegister),
+
+    /// Invalidates the I-Cache at the address in `CpuRegister` + offset.
+    ///
+    /// The offset will be divided by 4 and has a maximum value of 1020.
+    Ihi(CpuRegister, u32),
+
+    /// Writes back and Invalidates the D-Cache at the address in `CpuRegister` + offset.
+    ///
+    /// The offset will be divided by 4 and has a maximum value of 1020.
+    Dhwbi(CpuRegister, u32),
 
     /// Returns the Core to the Running state
     Rfdo(u8),
@@ -29,8 +48,18 @@ impl Instruction {
     pub fn encode(self) -> InstructionEncoding {
         let narrow = match self {
             Instruction::Lddr32P(src) => 0x0070E0 | (src.address() as u32 & 0x0F) << 8,
+            Instruction::Sddr32P(src) => 0x0070F0 | (src.address() as u32 & 0x0F) << 8,
             Instruction::Rsr(sr, t) => format::rsr(0x030000, sr.address(), t.address()),
             Instruction::Wsr(sr, t) => format::rsr(0x130000, sr.address(), t.address()),
+            Instruction::S8i(at, as_, offset) => {
+                format::rri8(0x004002, at.address(), as_.address(), offset)
+            }
+            Instruction::Ihi(src, offset) => {
+                format::rri8(0x0070E2, 0, src.address(), (offset / 4) as u8)
+            }
+            Instruction::Dhwbi(src, offset) => {
+                format::rri8(0x007052, 0, src.address(), (offset / 4) as u8)
+            }
             Instruction::Rfdo(_) => 0xF1E000,
         };
 

--- a/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
@@ -8,10 +8,10 @@ pub enum Instruction {
     /// Note: this is an illegal instruction when the processor is not in On-Chip Debug Mode
     Lddr32P(CpuRegister),
 
-    /// Reads special register `sr` into `t`
+    /// Reads `SpecialRegister` into `CpuRegister`
     Rsr(SpecialRegister, CpuRegister),
 
-    /// Writes `t` into special register `sr`
+    /// Writes `CpuRegister` into `SpecialRegister`
     Wsr(SpecialRegister, CpuRegister),
 
     /// Returns the Core to the Running state

--- a/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/instruction/mod.rs
@@ -1,19 +1,21 @@
+use crate::architecture::xtensa::arch::{CpuRegister, SpecialRegister};
+
 pub mod format;
 
 /// Loads a 32-bit word from the address in `src` into `DDR`
 /// Note: this is an illegal instruction when the processor is not in On-Chip Debug Mode
-pub const fn lddr32_p(src: u8) -> u32 {
-    0x0070E0 | (src as u32 & 0x0F) << 8
+pub const fn lddr32_p(src: CpuRegister) -> u32 {
+    0x0070E0 | (src.address() as u32 & 0x0F) << 8
 }
 
 /// Reads special register `sr` into `t`
-pub const fn rsr(sr: u8, t: u8) -> u32 {
-    format::rsr(0x030000, sr, t)
+pub const fn rsr(sr: SpecialRegister, t: CpuRegister) -> u32 {
+    format::rsr(0x030000, sr.address(), t.address())
 }
 
 /// Writes `t` into special register `sr`
-pub const fn wsr(sr: u8, t: u8) -> u32 {
-    format::rsr(0x130000, sr, t)
+pub const fn wsr(sr: SpecialRegister, t: CpuRegister) -> u32 {
+    format::rsr(0x130000, sr.address(), t.address())
 }
 
 /// Returns the Core to the Running state

--- a/probe-rs/src/architecture/xtensa/arch/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/mod.rs
@@ -1,0 +1,1 @@
+pub mod instruction;

--- a/probe-rs/src/architecture/xtensa/arch/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/mod.rs
@@ -1,1 +1,12 @@
 pub mod instruction;
+
+// Register addresses
+
+// Processor registers
+pub const A3: u8 = 3;
+
+// Special registers
+pub const SR_DDR: u8 = 104;
+pub const SR_EXCCAUSE: u8 = 232;
+pub const SR_DEBUGCAUSE: u8 = 233;
+pub const SR_EXCVADDR: u8 = 238;

--- a/probe-rs/src/architecture/xtensa/arch/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/mod.rs
@@ -1,5 +1,7 @@
 #![allow(unused)] // TODO remove
 
+use std::ops::Range;
+
 pub mod instruction;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]

--- a/probe-rs/src/architecture/xtensa/arch/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/mod.rs
@@ -12,6 +12,10 @@ pub enum CpuRegister {
 }
 
 impl CpuRegister {
+    pub const fn scratch() -> Self {
+        Self::A3
+    }
+
     pub const fn address(self) -> u8 {
         self as u8
     }

--- a/probe-rs/src/architecture/xtensa/arch/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/mod.rs
@@ -2,13 +2,13 @@
 
 pub mod instruction;
 
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum Register {
     Cpu(CpuRegister),
     Special(SpecialRegister),
 }
 
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum CpuRegister {
     A0 = 0,
     A1 = 1,
@@ -38,7 +38,7 @@ impl CpuRegister {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum SpecialRegister {
     Lbeg = 0,
     Lend = 1,

--- a/probe-rs/src/architecture/xtensa/arch/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/mod.rs
@@ -1,12 +1,32 @@
 pub mod instruction;
 
-// Register addresses
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum Register {
+    Cpu(CpuRegister),
+    Special(SpecialRegister),
+}
 
-// Processor registers
-pub const A3: u8 = 3;
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum CpuRegister {
+    A3 = 3,
+}
 
-// Special registers
-pub const SR_DDR: u8 = 104;
-pub const SR_EXCCAUSE: u8 = 232;
-pub const SR_DEBUGCAUSE: u8 = 233;
-pub const SR_EXCVADDR: u8 = 238;
+impl CpuRegister {
+    pub const fn address(self) -> u8 {
+        self as u8
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum SpecialRegister {
+    Ddr = 104,
+    ExcCause = 232,
+    DebugCause = 233,
+    ExcVaddr = 238,
+}
+
+impl SpecialRegister {
+    pub const fn address(self) -> u8 {
+        self as u8
+    }
+}

--- a/probe-rs/src/architecture/xtensa/arch/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unused)] // TODO remove
+
 pub mod instruction;
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -8,7 +10,22 @@ pub enum Register {
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum CpuRegister {
+    A0 = 0,
+    A1 = 1,
+    A2 = 2,
     A3 = 3,
+    A4 = 4,
+    A5 = 5,
+    A6 = 6,
+    A7 = 7,
+    A8 = 8,
+    A9 = 9,
+    A10 = 10,
+    A11 = 11,
+    A12 = 12,
+    A13 = 13,
+    A14 = 14,
+    A15 = 15,
 }
 
 impl CpuRegister {
@@ -23,13 +40,99 @@ impl CpuRegister {
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum SpecialRegister {
+    Lbeg = 0,
+    Lend = 1,
+    Lcount = 2,
+    Sar = 3,
+    Br = 4,
+    Litbase = 5,
+    Scompare1 = 12,
+    AccLo = 16,
+    AccHi = 17,
+    M0 = 32,
+    M1 = 33,
+    M2 = 34,
+    M3 = 35,
+    Windowbase = 72,
+    Windowstart = 73,
+    PteVAddr = 83,
+    RAsid = 90,
+    // MpuEnB = 90,
+    ITlbCfg = 91,
+    DTlbCfg = 92,
+    // MpuCfg = 92,
+    ERAccess = 95,
+    IBreakEnable = 96,
+    Memctl = 97,
+    CacheAdrDis = 98,
+    AtomCtl = 99,
     Ddr = 104,
+    Mepc = 106,
+    Meps = 107,
+    Mesave = 108,
+    Mesr = 109,
+    Mecr = 110,
+    MeVAddr = 111,
+    IBreakA0 = 128,
+    IBreakA1 = 129,
+    DBreakA0 = 144,
+    DBreakA1 = 145,
+    DBreakC0 = 160,
+    DBreakC1 = 161,
+    Epc1 = 177,
+    Epc2 = 178,
+    Epc3 = 179,
+    Epc4 = 180,
+    Epc5 = 181,
+    Epc6 = 182,
+    Epc7 = 183,
+    IBreakC0 = 192,
+    IBreakC1 = 193,
+    // Depc = 192,
+    Eps2 = 194,
+    Eps3 = 195,
+    Eps4 = 196,
+    Eps5 = 197,
+    Eps6 = 198,
+    Eps7 = 199,
+    ExcSave1 = 209,
+    ExcSave2 = 210,
+    ExcSave3 = 211,
+    ExcSave4 = 212,
+    ExcSave5 = 213,
+    ExcSave6 = 214,
+    ExcSave7 = 215,
+    CpEnable = 224,
+    // Interrupt = 226,
+    IntSet = 226,
+    IntClear = 227,
+    IntEnable = 228,
+    Ps = 230,
+    VecBase = 231,
     ExcCause = 232,
     DebugCause = 233,
+    CCount = 234,
+    Prid = 235,
+    ICount = 236,
+    ICountLevel = 237,
     ExcVaddr = 238,
+    CCompare0 = 240,
+    CCompare1 = 241,
+    CCompare2 = 242,
+    Misc0 = 244,
+    Misc1 = 245,
+    Misc2 = 246,
+    Misc3 = 247,
 }
 
+#[allow(non_upper_case_globals)] // Aliasses have same style as other register names
 impl SpecialRegister {
+    // Aliasses
+    pub const MpuEnB: Self = Self::RAsid;
+    pub const MpuCfg: Self = Self::DTlbCfg;
+    pub const Depc: Self = Self::IBreakC0;
+    pub const Interrupt: Self = Self::IntSet;
+
     pub const fn address(self) -> u8 {
         self as u8
     }

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -222,23 +222,40 @@ impl MemoryInterface for XtensaCommunicationInterface {
     }
 
     fn read_word_64(&mut self, address: u64) -> anyhow::Result<u64, crate::Error> {
-        todo!()
+        let mut out = [0; 8];
+        self.read(address, &mut out)?;
+
+        Ok(u64::from_le_bytes(out))
     }
 
     fn read_word_8(&mut self, address: u64) -> anyhow::Result<u8, crate::Error> {
-        todo!()
+        let mut out = 0;
+        self.read(address, std::slice::from_mut(&mut out))?;
+        Ok(out)
     }
 
     fn read_64(&mut self, address: u64, data: &mut [u64]) -> anyhow::Result<(), crate::Error> {
-        todo!()
+        let data_8 = unsafe {
+            std::slice::from_raw_parts_mut(
+                data.as_mut_ptr() as *mut u8,
+                data.len() * std::mem::size_of::<u64>(),
+            )
+        };
+        self.read_8(address, data_8)
     }
 
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> anyhow::Result<(), crate::Error> {
-        todo!()
+        let data_8 = unsafe {
+            std::slice::from_raw_parts_mut(
+                data.as_mut_ptr() as *mut u8,
+                data.len() * std::mem::size_of::<u32>(),
+            )
+        };
+        self.read_8(address, data_8)
     }
 
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> anyhow::Result<(), crate::Error> {
-        todo!()
+        self.read(address, data)
     }
 
     fn write_word_64(&mut self, address: u64, data: u64) -> anyhow::Result<(), crate::Error> {

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -297,6 +297,10 @@ impl XtensaCommunicationInterface {
     }
 }
 
+/// DataType
+///
+/// # Safety
+/// Don't implement this trait
 unsafe trait DataType: Sized {}
 unsafe impl DataType for u8 {}
 unsafe impl DataType for u32 {}
@@ -419,7 +423,7 @@ impl MemoryInterface for XtensaCommunicationInterface {
 
         if buffer.len() > 4 {
             // Prepare store instruction
-            self.write_cpu_register(CpuRegister::A3, addr as u32)?;
+            self.write_cpu_register(CpuRegister::A3, addr)?;
             self.xdm
                 .write_instruction(Instruction::Sddr32P(CpuRegister::A3))?;
 

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -1,6 +1,11 @@
 //! Xtensa Debug Module Communication
 
-use crate::{probe::JTAGAccess, DebugProbeError};
+// TODO: remove
+#![allow(missing_docs)]
+
+use crate::{
+    architecture::xtensa::arch::instruction, probe::JTAGAccess, DebugProbeError, MemoryInterface,
+};
 
 use super::xdm::{Error as XdmError, Xdm};
 
@@ -11,7 +16,7 @@ pub enum XtensaError {
     #[error("Debug Probe Error")]
     DebugProbe(#[from] DebugProbeError),
     /// Xtensa debug module error
-    #[error("Xtensa debug module error")]
+    #[error("Xtensa debug module error: {0}")]
     XdmError(XdmError),
 }
 
@@ -34,5 +39,145 @@ impl XtensaCommunicationInterface {
         let s = Self { xdm };
 
         Ok(s)
+    }
+
+    pub fn enter_ocd_mode(&mut self) -> Result<(), XtensaError> {
+        self.xdm.enter_ocd_mode()?;
+        tracing::info!("Entered OCD mode");
+        Ok(())
+    }
+
+    pub fn is_in_ocd_mode(&mut self) -> Result<bool, XtensaError> {
+        self.xdm.is_in_ocd_mode()
+    }
+
+    pub fn leave_ocd_mode(&mut self) -> Result<(), XtensaError> {
+        self.xdm.leave_ocd_mode()?;
+        tracing::info!("Left OCD mode");
+        Ok(())
+    }
+
+    pub fn halt(&mut self) -> Result<(), XtensaError> {
+        self.xdm.halt()?;
+        Ok(())
+    }
+
+    pub fn resume(&mut self) -> Result<(), XtensaError> {
+        self.xdm.resume()?;
+        Ok(())
+    }
+}
+
+impl MemoryInterface for XtensaCommunicationInterface {
+    fn read(&mut self, address: u64, dst: &mut [u8]) -> Result<(), crate::Error> {
+        if dst.is_empty() {
+            return Ok(());
+        }
+
+        let read_words = if dst.len() % 4 == 0 {
+            dst.len() / 4
+        } else {
+            dst.len() / 4 + 1
+        };
+
+        const SR_DDR: u8 = 104;
+        const A3: u8 = 3;
+
+        const MOVE_A3_TO_DDR: u32 = instruction::rsr(SR_DDR, A3);
+        const MOVE_DDR_TO_A3: u32 = instruction::wsr(A3, SR_DDR);
+        const READ_DATA_FROM: u32 = instruction::lddr32_p(A3);
+
+        // Save A3
+        // TODO: mark in restore context
+        self.xdm.execute_instruction(MOVE_A3_TO_DDR)?;
+        let old_a3 = self.xdm.read_ddr()?;
+
+        // Write address to A3
+        self.xdm.write_ddr(address as u32)?;
+        self.xdm.execute_instruction(MOVE_DDR_TO_A3)?;
+
+        // Read from address in A3
+        self.xdm.execute_instruction(READ_DATA_FROM)?;
+
+        for i in 0..read_words - 1 {
+            let word = self.xdm.read_ddr_and_execute()?.to_le_bytes();
+            dst[4 * i..][..4].copy_from_slice(&word);
+        }
+
+        let remaining_bytes = if dst.len() % 4 == 0 { 4 } else { dst.len() % 4 };
+
+        let word = self.xdm.read_ddr()?;
+        dst[4 * (read_words - 1)..][..remaining_bytes]
+            .copy_from_slice(&word.to_le_bytes()[..remaining_bytes]);
+
+        // Restore A3
+        // TODO: only do this when restoring program context
+        self.xdm.write_ddr(old_a3)?;
+        self.xdm.execute_instruction(MOVE_DDR_TO_A3)?;
+
+        Ok(())
+    }
+
+    fn read_word_32(&mut self, address: u64) -> Result<u32, crate::Error> {
+        let mut out = [0; 4];
+        self.read(address, &mut out)?;
+
+        Ok(u32::from_le_bytes(out))
+    }
+
+    fn supports_native_64bit_access(&mut self) -> bool {
+        false
+    }
+
+    fn read_word_64(&mut self, address: u64) -> anyhow::Result<u64, crate::Error> {
+        todo!()
+    }
+
+    fn read_word_8(&mut self, address: u64) -> anyhow::Result<u8, crate::Error> {
+        todo!()
+    }
+
+    fn read_64(&mut self, address: u64, data: &mut [u64]) -> anyhow::Result<(), crate::Error> {
+        todo!()
+    }
+
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> anyhow::Result<(), crate::Error> {
+        todo!()
+    }
+
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> anyhow::Result<(), crate::Error> {
+        todo!()
+    }
+
+    fn write_word_64(&mut self, address: u64, data: u64) -> anyhow::Result<(), crate::Error> {
+        todo!()
+    }
+
+    fn write_word_32(&mut self, address: u64, data: u32) -> anyhow::Result<(), crate::Error> {
+        todo!()
+    }
+
+    fn write_word_8(&mut self, address: u64, data: u8) -> anyhow::Result<(), crate::Error> {
+        todo!()
+    }
+
+    fn write_64(&mut self, address: u64, data: &[u64]) -> anyhow::Result<(), crate::Error> {
+        todo!()
+    }
+
+    fn write_32(&mut self, address: u64, data: &[u32]) -> anyhow::Result<(), crate::Error> {
+        todo!()
+    }
+
+    fn write_8(&mut self, address: u64, data: &[u8]) -> anyhow::Result<(), crate::Error> {
+        todo!()
+    }
+
+    fn supports_8bit_transfers(&self) -> anyhow::Result<bool, crate::Error> {
+        todo!()
+    }
+
+    fn flush(&mut self) -> anyhow::Result<(), crate::Error> {
+        todo!()
     }
 }

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -30,7 +30,7 @@ impl XtensaCommunicationInterface {
             XtensaError::DebugProbe(err) => (probe, err),
             other_error => (
                 probe,
-                DebugProbeError::ArchitectureSpecific(Box::new(other_error)),
+                DebugProbeError::Other(other_error.into()),
             ),
         })?;
 

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -1,8 +1,8 @@
 //! Xtensa Debug Module Communication
 
-use crate::{DebugProbeError, probe::JTAGAccess};
+use crate::{probe::JTAGAccess, DebugProbeError};
 
-use super::xdm::{Xdm, Error as XdmError};
+use super::xdm::{Error as XdmError, Xdm};
 
 /// Possible Xtensa errors
 #[derive(thiserror::Error, Debug)]
@@ -15,12 +15,12 @@ pub enum XtensaError {
     XdmError(XdmError),
 }
 
-/// A interface that implements controls for RISC-V cores.
+/// A interface that implements controls for Xtensa cores.
 #[derive(Debug)]
 pub struct XtensaCommunicationInterface {
     /// The Xtensa debug module
     xdm: Xdm,
-    // state: RiscvCommunicationInterfaceState,
+    // state: XtensaCommunicationInterfaceState,
 }
 
 impl XtensaCommunicationInterface {
@@ -28,10 +28,7 @@ impl XtensaCommunicationInterface {
     pub fn new(probe: Box<dyn JTAGAccess>) -> Result<Self, (Box<dyn JTAGAccess>, DebugProbeError)> {
         let xdm = Xdm::new(probe).map_err(|(probe, e)| match e {
             XtensaError::DebugProbe(err) => (probe, err),
-            other_error => (
-                probe,
-                DebugProbeError::Other(other_error.into()),
-            ),
+            other_error => (probe, DebugProbeError::Other(other_error.into())),
         })?;
 
         let s = Self { xdm };

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -105,6 +105,8 @@ impl XtensaCommunicationInterface {
         self.save_register(Register::Cpu(CpuRegister::scratch()))?;
         self.save_register(Register::Special(register))?;
 
+        tracing::debug!("Writing special register: {:?}", register);
+
         self.xdm.write_ddr(value)?;
 
         // DDR -> scratch
@@ -122,6 +124,8 @@ impl XtensaCommunicationInterface {
 
     fn write_cpu_register(&mut self, register: CpuRegister, value: u32) -> Result<(), XtensaError> {
         self.save_register(Register::Cpu(register))?;
+
+        tracing::debug!("Writing register: {:?}", register);
 
         self.xdm.write_ddr(value)?;
         self.xdm
@@ -200,6 +204,7 @@ impl XtensaCommunicationInterface {
 
     fn save_register(&mut self, register: Register) -> Result<(), XtensaError> {
         if !self.is_register_saved(register) {
+            tracing::debug!("Saving register: {:?}", register);
             let value = self.read_register(register)?;
             self.state.saved_registers.push((register, value));
         }
@@ -208,6 +213,8 @@ impl XtensaCommunicationInterface {
     }
 
     fn restore_registers(&mut self) -> Result<(), XtensaError> {
+        tracing::debug!("Restoring registers");
+
         // Clone the list of saved registers so we can iterate over it, but code may still save
         // new registers. We can't take it otherwise the restore loop would unnecessarily save
         // registers.

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -171,7 +171,6 @@ impl XtensaCommunicationInterface {
     }
 
     fn execute_instruction(&mut self, inst: Instruction) -> Result<(), XtensaError> {
-        tracing::debug!("Executing instruction: {:?}", inst);
         let status = self.xdm.execute_instruction(inst);
         if let Err(XtensaError::XdmError(err)) = status {
             self.debug_execution_error(err)?

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -2,7 +2,7 @@
 
 use crate::{DebugProbeError, probe::JTAGAccess};
 
-use super::xdm::Xdm;
+use super::xdm::{Xdm, Error as XdmError};
 
 /// Possible Xtensa errors
 #[derive(thiserror::Error, Debug)]
@@ -10,6 +10,9 @@ pub enum XtensaError {
     /// An error originating from the DebugProbe
     #[error("Debug Probe Error")]
     DebugProbe(#[from] DebugProbeError),
+    /// Xtensa debug module error
+    #[error("Xtensa debug module error")]
+    XdmError(XdmError),
 }
 
 /// A interface that implements controls for RISC-V cores.

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -1,0 +1,38 @@
+//! Xtensa Debug Module Communication
+
+use crate::{DebugProbeError, probe::JTAGAccess};
+
+use super::xdm::Xdm;
+
+/// Possible Xtensa errors
+#[derive(thiserror::Error, Debug)]
+pub enum XtensaError {
+    /// An error originating from the DebugProbe
+    #[error("Debug Probe Error")]
+    DebugProbe(#[from] DebugProbeError),
+}
+
+/// A interface that implements controls for RISC-V cores.
+#[derive(Debug)]
+pub struct XtensaCommunicationInterface {
+    /// The Xtensa debug module
+    xdm: Xdm,
+    // state: RiscvCommunicationInterfaceState,
+}
+
+impl XtensaCommunicationInterface {
+    /// Create the Xtensa communication interface using the underlying probe driver
+    pub fn new(probe: Box<dyn JTAGAccess>) -> Result<Self, (Box<dyn JTAGAccess>, DebugProbeError)> {
+        let xdm = Xdm::new(probe).map_err(|(probe, e)| match e {
+            XtensaError::DebugProbe(err) => (probe, err),
+            other_error => (
+                probe,
+                DebugProbeError::ArchitectureSpecific(Box::new(other_error)),
+            ),
+        })?;
+
+        let s = Self { xdm };
+
+        Ok(s)
+    }
+}

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -2,6 +2,7 @@
 
 // TODO: remove
 #![allow(missing_docs)]
+#![allow(unused_variables)]
 
 use std::collections::HashMap;
 
@@ -341,7 +342,7 @@ impl MemoryInterface for XtensaCommunicationInterface {
         let data_8 = unsafe {
             std::slice::from_raw_parts_mut(
                 data.as_mut_ptr() as *mut u8,
-                data.len() * std::mem::size_of::<u64>(),
+                std::mem::size_of_val(data),
             )
         };
         self.read_8(address, data_8)
@@ -351,7 +352,7 @@ impl MemoryInterface for XtensaCommunicationInterface {
         let data_8 = unsafe {
             std::slice::from_raw_parts_mut(
                 data.as_mut_ptr() as *mut u8,
-                data.len() * std::mem::size_of::<u32>(),
+                std::mem::size_of_val(data),
             )
         };
         self.read_8(address, data_8)

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -1,0 +1,20 @@
+//! All the interface bits for Xtensa.
+
+use self::communication_interface::XtensaCommunicationInterface;
+
+mod xdm;
+
+pub mod communication_interface;
+
+
+/// A interface to operate Xtensa cores.
+pub struct Xtensa<'probe> {
+    interface: &'probe mut XtensaCommunicationInterface,
+}
+
+impl<'probe> Xtensa<'probe> {
+    /// Create a new Xtensa interface.
+    pub fn new(interface: &'probe mut XtensaCommunicationInterface) -> Self {
+        Self { interface }
+    }
+}

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -2,10 +2,10 @@
 
 use self::communication_interface::XtensaCommunicationInterface;
 
+mod arch;
 mod xdm;
 
 pub mod communication_interface;
-
 
 /// A interface to operate Xtensa cores.
 pub struct Xtensa<'probe> {

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -9,7 +9,7 @@ mod xdm;
 
 pub mod communication_interface;
 
-/// A interface to operate Xtensa cores.
+/// An interface to operate Xtensa cores.
 pub struct Xtensa<'probe> {
     interface: &'probe mut XtensaCommunicationInterface,
 }

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -1,5 +1,7 @@
 //! All the interface bits for Xtensa.
 
+#![allow(unused)] // FIXME remove after testing
+
 use self::communication_interface::XtensaCommunicationInterface;
 
 mod arch;

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -1,6 +1,6 @@
 //! All the interface bits for Xtensa.
 
-#![allow(unused)] // FIXME remove after testing
+use crate::{Error, MemoryInterface};
 
 use self::communication_interface::XtensaCommunicationInterface;
 
@@ -18,5 +18,71 @@ impl<'probe> Xtensa<'probe> {
     /// Create a new Xtensa interface.
     pub fn new(interface: &'probe mut XtensaCommunicationInterface) -> Self {
         Self { interface }
+    }
+}
+
+impl<'probe> MemoryInterface for Xtensa<'probe> {
+    fn supports_native_64bit_access(&mut self) -> bool {
+        self.interface.supports_native_64bit_access()
+    }
+
+    fn read_word_64(&mut self, address: u64) -> Result<u64, Error> {
+        self.interface.read_word_64(address)
+    }
+
+    fn read_word_32(&mut self, address: u64) -> Result<u32, Error> {
+        self.interface.read_word_32(address)
+    }
+
+    fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
+        self.interface.read_word_8(address)
+    }
+
+    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error> {
+        self.interface.read_64(address, data)
+    }
+
+    fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
+        self.interface.read_32(address, data)
+    }
+
+    fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
+        self.interface.read_8(address, data)
+    }
+
+    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
+        self.interface.write_word_64(address, data)
+    }
+
+    fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), Error> {
+        self.interface.write_word_32(address, data)
+    }
+
+    fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
+        self.interface.write_word_8(address, data)
+    }
+
+    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
+        self.interface.write_64(address, data)
+    }
+
+    fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
+        self.interface.write_32(address, data)
+    }
+
+    fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
+        self.interface.write_8(address, data)
+    }
+
+    fn write(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
+        self.interface.write(address, data)
+    }
+
+    fn supports_8bit_transfers(&self) -> Result<bool, Error> {
+        self.interface.supports_8bit_transfers()
+    }
+
+    fn flush(&mut self) -> Result<(), Error> {
+        self.interface.flush()
     }
 }

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -102,7 +102,7 @@ fn parse_register_status(byte: u8) -> Result<DebugRegisterStatus, DebugRegisterE
     }
 }
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone, Copy)]
 pub enum Error {
     #[error("Error while accessing register: {0}")]
     XdmError(DebugRegisterError),
@@ -205,6 +205,18 @@ impl Xdm {
 
         tracing::info!("Found Xtensa device with OCDID: 0x{:08X}", device_id);
         self.device_id = device_id;
+
+        Ok(())
+    }
+
+    pub fn clear_exec_exception(&mut self) -> Result<(), XtensaError> {
+        self.write_nexus_register({
+            let mut status = DebugStatus(0);
+
+            status.set_exec_exception(true);
+
+            status
+        })?;
 
         Ok(())
     }

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -314,11 +314,11 @@ impl DebugStatus {
     }
 
     pub fn is_ok(&self) -> Result<(), Error> {
-        Err(if self.0 & Self::OCDDSR_EXECEXCEPTION == 1 {
+        Err(if self.0 & Self::OCDDSR_EXECEXCEPTION != 0 {
             Error::ExecExeception
-        } else if self.0 & Self::OCDDSR_EXECBUSY == 1 {
+        } else if self.0 & Self::OCDDSR_EXECBUSY != 0 {
             Error::ExecBusy
-        } else if self.0 & Self::OCDDSR_EXECOVERRUN == 1 {
+        } else if self.0 & Self::OCDDSR_EXECOVERRUN != 0 {
             Error::ExecOverrun
         } else if self.0 & Self::OCDDSR_DBGMODPOWERON == 0 {
             // should always be set to one

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -381,8 +381,6 @@ impl Xdm {
     }
 
     pub(super) fn leave_ocd_mode(&mut self) -> Result<(), XtensaError> {
-        self.resume()?;
-
         self.write_nexus_register(DebugControlClear({
             let mut control = DebugControlBits(0);
 

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -132,11 +132,7 @@ pub struct Xdm {
 
 impl Xdm {
     pub fn new(mut probe: Box<dyn JTAGAccess>) -> Result<Self, (Box<dyn JTAGAccess>, XtensaError)> {
-        // TODO calculate idle cycles? see esp32_queue_tdi_idle() in openocd
-        let idle_cycles = 100;
-
-        // Setup the number of idle cycles between JTAG accesses
-        probe.set_idle_cycles(idle_cycles);
+        // TODO implement openocd's esp32_queue_tdi_idle() to prevent potentially damaging flash ICs
 
         // fixed to 5 bits for now
         probe.set_ir_len(5);
@@ -145,7 +141,7 @@ impl Xdm {
             probe,
             queued_commands: Vec::new(),
             device_id: 0,
-            idle_cycles,
+            idle_cycles: 0,
         };
 
         if let Err(e) = x.init() {

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -165,6 +165,14 @@ impl Xdm {
         // Wakeup and enable the JTAG
         self.pwr_write(PowerDevice::PowerControl, pwr_control.0)?;
 
+        tracing::trace!("Waiting for power domain to turn on");
+        loop {
+            let bits = self.pwr_read(PowerDevice::PowerStat)?;
+            if PowerStatus(bits).debug_domain_on() {
+                break;
+            }
+        }
+
         // Set JTAG_DEBUG_USE separately to ensure it doesn't get reset by a previous write.
         // We don't reset anything but this is a good practice to avoid sneaky issues.
         pwr_control.set_jtag_debug_use(true);

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -152,11 +152,11 @@ impl Xdm {
         }
 
         let status = x.status().unwrap();
-        log::info!("DSR: {:?}", status);
+        tracing::info!("DSR: {:?}", status);
         status.is_ok().unwrap();
         // TODO check status and clear bits if required
 
-        log::info!("Found Xtensa device with OCDID: 0x{:08X}", device_id);
+        tracing::info!("Found Xtensa device with OCDID: 0x{:08X}", device_id);
         x.device_id = device_id;
 
         Ok(x)
@@ -172,7 +172,7 @@ impl Xdm {
         )?.is_ok()?;
 
         let res = self.probe.read_register(DEBUG_ADDR, XDM_REGISTER_WIDTH)?;
-        log::trace!("dbg_read response: {:?}", res);
+        tracing::trace!("dbg_read response: {:?}", res);
 
         Ok(u32::from_le_bytes((&res[..]).try_into().unwrap()))
     }
@@ -190,7 +190,7 @@ impl Xdm {
             self.probe
                 .write_register(DEBUG_ADDR, &value.to_le_bytes()[..], XDM_REGISTER_WIDTH)?;
 
-        log::trace!("dbg_write response: {:?}", res);
+        tracing::trace!("dbg_write response: {:?}", res);
 
         Ok(u32::from_le_bytes((&res[..]).try_into().unwrap()))
     }
@@ -200,7 +200,7 @@ impl Xdm {
             self.probe
                 .write_register(dev as u32, &[value], XDM_ADDRESS_REGISTER_WIDTH)?[0],
         )?;
-        log::trace!("pwr_write response: {:?}", res);
+        tracing::trace!("pwr_write response: {:?}", res);
 
         Ok(res)
     }
@@ -210,7 +210,7 @@ impl Xdm {
             self.probe
                 .read_register(dev as u32, XDM_ADDRESS_REGISTER_WIDTH)?[0],
         )?;
-        log::trace!("pwr_read response: {:?}", res);
+        tracing::trace!("pwr_read response: {:?}", res);
 
         Ok(res)
     }
@@ -226,10 +226,7 @@ impl Xdm {
 
 impl From<XtensaError> for crate::Error {
     fn from(err: XtensaError) -> Self {
-        match err {
-            XtensaError::DebugProbe(e) => e.into(),
-            other => crate::Error::ArchitectureSpecific(Box::new(other)),
-        }
+        crate::Error::Xtensa(err)
     }
 }
 

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -326,22 +326,36 @@ bitfield::bitfield! {
     #[derive(Copy, Clone)]
     pub struct DebugStatus(u32);
 
-    pub exec_done,         _: 0;
-    pub exec_exception,    _: 1;
+    // Cleared by writing 1
+    pub exec_done,         set_exec_done: 0;
+    // Cleared by writing 1
+    pub exec_exception,    set_exec_exception: 1;
     pub exec_busy,         _: 2;
-    pub exec_overrun,      _: 3;
+    // Cleared by writing 1
+    pub exec_overrun,      set_exec_overrun: 3;
     pub stopped,           _: 4;
-    pub core_wrote_ddr,    _: 10;
-    pub core_read_ddr,     _: 11;
-    pub host_wrote_ddr,    _: 14;
-    pub host_read_ddr,     _: 15;
-    pub debug_pend_break,  _: 16;
-    pub debug_pend_host,   _: 17;
-    pub debug_pend_trax,   _: 18;
-    pub debug_int_break,   _: 20;
-    pub debug_int_host,    _: 21;
-    pub debug_int_trax,    _: 22;
-    pub run_stall_toggle,  _: 23;
+    // Cleared by writing 1
+    pub core_wrote_ddr,    set_core_wrote_ddr: 10;
+    // Cleared by writing 1
+    pub core_read_ddr,     set_core_read_ddr: 11;
+    // Cleared by writing 1
+    pub host_wrote_ddr,    set_host_wrote_ddr: 14;
+    // Cleared by writing 1
+    pub host_read_ddr,     set_host_read_ddr: 15;
+    // Cleared by writing 1
+    pub debug_pend_break,  set_debug_pend_break: 16;
+    // Cleared by writing 1
+    pub debug_pend_host,   set_debug_pend_host: 17;
+    // Cleared by writing 1
+    pub debug_pend_trax,   set_debug_pend_trax: 18;
+    // Cleared by writing 1
+    pub debug_int_break,   set_debug_int_break: 20;
+    // Cleared by writing 1
+    pub debug_int_host,    set_debug_int_host: 21;
+    // Cleared by writing 1
+    pub debug_int_trax,    set_debug_int_trax: 22;
+    // Cleared by writing 1
+    pub run_stall_toggle,  set_run_stall_toggle: 23;
     pub run_stall_sample,  _: 24;
     pub break_out_ack_iti, _: 25;
     pub break_in_iti,      _: 26;
@@ -388,5 +402,11 @@ impl NexusRegister for DebugStatus {
 
     fn from_bits(bits: u32) -> Result<Self, XtensaError> {
         Ok(Self(bits))
+    }
+}
+
+impl WritableNexusRegister for DebugStatus {
+    fn bits(&self) -> u32 {
+        self.0
     }
 }

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -1,0 +1,173 @@
+#![allow(unused)] // FIXME remove after testing
+
+use crate::{
+    probe::{JTAGAccess, JtagWriteCommand},
+    DebugProbeError,
+};
+
+use super::communication_interface::XtensaError;
+
+const NARADR_OCDID: u8 = 0x40;
+const NARADR_DCRSET: u8 = 0x43;
+const NARADR_DCRCLR: u8 = 0x42;
+const NARADR_DSR: u8 = 0x44;
+const NARADR_DDR: u8 = 0x45;
+const NARADR_DDREXEC: u8 = 0x46;
+const NARADR_DIR0EXEC: u8 = 0x47;
+
+const XDM_REGISTER_WIDTH: u32 = 32;
+
+const PWRCTL_JTAGDEBUGUSE: u8 = 1 << 7;
+const PWRCTL_DEBUGRESET: u8 = 1 << 6;
+const PWRCTL_CORERESET: u8 = 1 << 4;
+const PWRCTL_DEBUGWAKEUP: u8 = 1 << 2;
+const PWRCTL_MEMWAKEUP: u8 = 1 << 1;
+const PWRCTL_COREWAKEUP: u8 = 1 << 0;
+
+const PWRSTAT_DEBUGWASRESET: u8 = 1 << 6;
+const PWRSTAT_COREWASRESET: u8 = 1 << 4;
+const PWRSTAT_CORESTILLNEEDED: u8 = 1 << 3;
+const PWRSTAT_DEBUGDOMAINON: u8 = 1 << 2;
+const PWRSTAT_MEMDOMAINON: u8 = 1 << 1;
+const PWRSTAT_COREDOMAINON: u8 = 1 << 0;
+
+// The debug module is accesible through NARSEL JTAG register (NAR for IR, NDR for DR)
+const DEBUG_ADDR: u32 = 0x1C;
+
+#[repr(u32)]
+enum PowerDevice {
+    /// Power Control
+    PowerControl = 0x08,
+    /// Power status
+    PowerStat = 0x09,
+}
+
+#[derive(Debug)]
+pub struct Xdm {
+    pub probe: Box<dyn JTAGAccess>,
+
+    queued_commands: Vec<JtagWriteCommand>,
+
+    device_id: u32,
+    idle_cycles: u8,
+}
+
+impl Xdm {
+    pub fn new(mut probe: Box<dyn JTAGAccess>) -> Result<Self, (Box<dyn JTAGAccess>, XtensaError)> {
+        // TODO calculate idle cycles? see esp32_queue_tdi_idle() in openocd
+        let idle_cycles = 100;
+
+        // Setup the number of idle cycles between JTAG accesses
+        probe.set_idle_cycles(idle_cycles);
+
+        // fixed to 5 bits for now
+        probe.set_ir_len(5);
+
+        let mut x = Self {
+            probe,
+            queued_commands: Vec::new(),
+            device_id: 0,
+            idle_cycles,
+        };
+
+        // Wakeup and enable the JTAG
+        if let Err(e) = x.pwr_write(
+            PowerDevice::PowerControl,
+            PWRCTL_DEBUGWAKEUP | PWRCTL_MEMWAKEUP | PWRCTL_COREWAKEUP,
+        ) {
+            return Err((x.free(), e.into()));
+        }
+        if let Err(e) = x.pwr_write(
+            PowerDevice::PowerControl,
+            PWRCTL_DEBUGWAKEUP | PWRCTL_MEMWAKEUP | PWRCTL_COREWAKEUP | PWRCTL_JTAGDEBUGUSE,
+        ) {
+            return Err((x.free(), e.into()));
+        }
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        // enable the debug module
+        if let Err(e) = x.dbg_write(NARADR_DCRSET, 1) {
+            return Err((x.free(), e.into()));
+        }
+
+        // read the device_id
+        let device_id = match x.dbg_read(NARADR_OCDID) {
+            Ok(value) => value,
+            Err(e) => return Err((x.free(), e.into())),
+        };
+
+        let status = x.status().unwrap();
+        log::info!("DSR: {:032b}", status);
+
+        log::info!("Found Xtensa device with OCDID: 0x{:08X}", device_id);
+        x.device_id = device_id;
+
+        Ok(x)
+    }
+
+    /// Perform an access to a register
+    fn dbg_read(&mut self, address: u8) -> Result<u32, DebugProbeError> {
+        let regdata = (address << 1) | 0;
+
+        // TODO check response for error
+        let res = self.probe.write_register(DEBUG_ADDR, &[regdata], 8)?;
+        log::info!("dbg_read setup response: {:?}", res);
+
+        let res = self.probe.read_register(DEBUG_ADDR, XDM_REGISTER_WIDTH)?;
+
+        log::info!("dbg_read response: {:?}", res);
+
+        Ok(u32::from_le_bytes((&res[..]).try_into().unwrap()))
+    }
+
+    /// Perform an access to a register
+    fn dbg_write(&mut self, address: u8, value: u32) -> Result<u32, DebugProbeError> {
+        let regdata = (address << 1) | 1;
+
+        // TODO check error in response
+        let res = self.probe.write_register(DEBUG_ADDR, &[regdata], 8)?;
+        log::info!("write setup response: {:?}", res);
+
+        let res =
+            self.probe
+                .write_register(DEBUG_ADDR, &value.to_le_bytes()[..], XDM_REGISTER_WIDTH)?;
+
+        log::info!("dbg_write response: {:?}", res);
+
+        Ok(u32::from_le_bytes((&res[..]).try_into().unwrap()))
+    }
+
+    fn pwr_write(&mut self, dev: PowerDevice, value: u8) -> Result<u8, DebugProbeError> {
+        let res = self.probe.write_register(dev as u32, &[value], 8)?;
+
+        log::info!("pwr_write response: {:?}", res);
+
+        Ok(res[0])
+    }
+
+    fn pwr_read(&mut self, dev: PowerDevice) -> Result<u8, DebugProbeError> {
+        let res = self.probe.read_register(dev as u32, 8)?;
+
+        log::info!("pwr_write response: {:?}", res);
+
+        Ok(res[0])
+    }
+
+    fn status(&mut self) -> Result<u32, DebugProbeError> {
+        self.dbg_read(NARADR_DSR)
+    }
+
+    fn free(self) -> Box<dyn JTAGAccess> {
+        self.probe
+    }
+}
+
+impl From<XtensaError> for crate::Error {
+    fn from(err: XtensaError) -> Self {
+        match err {
+            XtensaError::DebugProbe(e) => e.into(),
+            other => crate::Error::ArchitectureSpecific(Box::new(other)),
+        }
+    }
+}

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -56,7 +56,7 @@ impl XdmStatus {
     pub fn is_ok(&self) -> Result<(), Error> {
         match self {
             XdmStatus::Ok => Ok(()),
-            other => Err(Error::XdmError(Some(*self)))
+            other => Err(Error::XdmError(Some(*self))),
         }
     }
 }
@@ -67,7 +67,7 @@ pub enum Error {
     ExecExeception,
     ExecBusy,
     ExecOverrun,
-    XdmPoweredOff
+    XdmPoweredOff,
 }
 
 impl XdmStatus {
@@ -152,7 +152,7 @@ impl Xdm {
         }
 
         let status = x.status().unwrap();
-        tracing::info!("DSR: {:?}", status);
+        tracing::info!("{:?}", status);
         status.is_ok().unwrap();
         // TODO check status and clear bits if required
 
@@ -169,7 +169,8 @@ impl Xdm {
         XdmStatus::parse(
             self.probe
                 .write_register(DEBUG_ADDR, &[regdata], XDM_ADDRESS_REGISTER_WIDTH)?[0],
-        )?.is_ok()?;
+        )?
+        .is_ok()?;
 
         let res = self.probe.read_register(DEBUG_ADDR, XDM_REGISTER_WIDTH)?;
         tracing::trace!("dbg_read response: {:?}", res);
@@ -184,7 +185,8 @@ impl Xdm {
         XdmStatus::parse(
             self.probe
                 .write_register(DEBUG_ADDR, &[regdata], XDM_ADDRESS_REGISTER_WIDTH)?[0],
-        )?.is_ok()?;
+        )?
+        .is_ok()?;
 
         let res =
             self.probe
@@ -272,10 +274,11 @@ impl DebugStatus {
             Error::ExecBusy
         } else if self.0 & Self::OCDDSR_EXECOVERRUN == 1 {
             Error::ExecOverrun
-        } else if self.0 & Self::OCDDSR_DBGMODPOWERON == 0 { // should always be set to one
+        } else if self.0 & Self::OCDDSR_DBGMODPOWERON == 0 {
+            // should always be set to one
             Error::XdmPoweredOff
         } else {
-            return Ok(())
+            return Ok(());
         })
     }
 }

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -188,10 +188,22 @@ impl Xdm {
             return Err(DebugProbeError::TargetNotFound.into());
         }
 
-        // TODO: we might find that an old instruction execution left the core with an exception
         let status = self.status()?;
         tracing::info!("{:?}", status);
-        status.is_ok()?;
+
+        // we might find that an old instruction execution left the core with an exception
+        // try to clear problematic bits
+        self.write_nexus_register({
+            let mut status = DebugStatus(0);
+
+            status.set_exec_exception(true);
+            status.set_exec_done(true);
+            status.set_exec_overrun(true);
+            status.set_debug_pend_break(true);
+            status.set_debug_pend_host(true);
+
+            status
+        })?;
 
         // TODO check status and clear bits if required
 

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -410,3 +410,59 @@ impl WritableNexusRegister for DebugStatus {
         self.0
     }
 }
+
+bitfield::bitfield! {
+    #[derive(Copy, Clone)]
+    pub struct DebugControlBits(u32);
+
+    pub enable_ocd,          set_enable_ocd         : 0;
+    // R/set
+    pub debug_interrupt,     set_debug_interrupt    : 1;
+    pub interrupt_all_conds, set_interrupt_all_conds: 2;
+
+    pub break_in_en,         set_break_in_en        : 16;
+    pub break_out_en,        set_break_out_en       : 17;
+
+    pub debug_sw_active,     set_debug_sw_active    : 20;
+    pub run_stall_in_en,     set_run_stall_in_en    : 21;
+    pub debug_mode_out_en,   set_debug_mode_out_en  : 22;
+
+    pub break_out_ito,       set_break_out_ito      : 24;
+    pub break_in_ack_ito,    set_break_in_ack_ito   : 25;
+}
+
+#[derive(Copy, Clone)]
+/// Bits written as 1 are set to 1 in hardware.
+struct DebugControlSet(DebugControlBits);
+
+impl NexusRegister for DebugControlSet {
+    const ADDRESS: u8 = NARADR_DCRSET;
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(DebugControlBits(bits)))
+    }
+}
+
+impl WritableNexusRegister for DebugControlSet {
+    fn bits(&self) -> u32 {
+        self.0 .0
+    }
+}
+
+#[derive(Copy, Clone)]
+/// Bits written as 1 are set to 0 in hardware.
+struct DebugControlClear(DebugControlBits);
+
+impl NexusRegister for DebugControlClear {
+    const ADDRESS: u8 = NARADR_DCRCLR;
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(DebugControlBits(bits)))
+    }
+}
+
+impl WritableNexusRegister for DebugControlClear {
+    fn bits(&self) -> u32 {
+        self.0 .0
+    }
+}

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -15,7 +15,10 @@ const NARADR_DCRCLR: u8 = 0x42;
 const NARADR_DSR: u8 = 0x44;
 const NARADR_DDR: u8 = 0x45;
 const NARADR_DDREXEC: u8 = 0x46;
+// DIR0 that also executes when written
 const NARADR_DIR0EXEC: u8 = 0x47;
+// Assume we only support 16-24b instructions for now
+const NARADR_DIR0: u8 = 0x48;
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum TapInstruction {
@@ -464,5 +467,79 @@ impl NexusRegister for DebugControlClear {
 impl WritableNexusRegister for DebugControlClear {
     fn bits(&self) -> u32 {
         self.0 .0
+    }
+}
+
+/// Writes DDR.
+#[derive(Copy, Clone)]
+struct DebugDataRegister(u32);
+
+impl NexusRegister for DebugDataRegister {
+    const ADDRESS: u8 = NARADR_DDR;
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(bits))
+    }
+}
+
+impl WritableNexusRegister for DebugDataRegister {
+    fn bits(&self) -> u32 {
+        self.0
+    }
+}
+
+/// Writes DDR and executes DIR on write AND READ.
+#[derive(Copy, Clone)]
+struct DebugDataAndExecRegister(u32);
+
+impl NexusRegister for DebugDataAndExecRegister {
+    const ADDRESS: u8 = NARADR_DDREXEC;
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(bits))
+    }
+}
+
+impl WritableNexusRegister for DebugDataAndExecRegister {
+    fn bits(&self) -> u32 {
+        self.0
+    }
+}
+
+/// Writes DIR.
+// TODO: type for instructions?
+#[derive(Copy, Clone)]
+struct DebugInstructionRegister(u32);
+
+impl NexusRegister for DebugInstructionRegister {
+    const ADDRESS: u8 = NARADR_DIR0;
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(bits))
+    }
+}
+
+impl WritableNexusRegister for DebugInstructionRegister {
+    fn bits(&self) -> u32 {
+        self.0
+    }
+}
+
+/// Writes and executes DIR.
+// TODO: type for instructions?
+#[derive(Copy, Clone)]
+struct DebugInstructionAndExecRegister(u32);
+
+impl NexusRegister for DebugInstructionAndExecRegister {
+    const ADDRESS: u8 = NARADR_DIR0EXEC;
+
+    fn from_bits(bits: u32) -> Result<Self, XtensaError> {
+        Ok(Self(bits))
+    }
+}
+
+impl WritableNexusRegister for DebugInstructionAndExecRegister {
+    fn bits(&self) -> u32 {
+        self.0
     }
 }

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -18,8 +18,8 @@ pub enum Error {
     /// A RISC-V specific error occurred.
     #[error("A RISC-V specific error occurred.")]
     Riscv(#[source] RiscvError),
-    /// A Xtensa specific error occurred.
-    #[error("A RISCV specific error occurred.")]
+    /// An Xtensa specific error occurred.
+    #[error("An Xtensa specific error occurred.")]
     Xtensa(#[source] XtensaError),
     /// The probe could not be opened.
     #[error("Probe could not be opened: {0}")]

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -2,6 +2,7 @@
 
 use crate::architecture::arm::ArmError;
 use crate::architecture::riscv::communication_interface::RiscvError;
+use crate::architecture::xtensa::communication_interface::XtensaError;
 use crate::config::RegistryError;
 use crate::DebugProbeError;
 
@@ -17,6 +18,9 @@ pub enum Error {
     /// A RISC-V specific error occurred.
     #[error("A RISC-V specific error occurred.")]
     Riscv(#[source] RiscvError),
+    /// A Xtensa specific error occurred.
+    #[error("A RISCV specific error occurred.")]
+    Xtensa(#[source] XtensaError),
     /// The probe could not be opened.
     #[error("Probe could not be opened: {0}")]
     UnableToOpenProbe(&'static str),

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -598,7 +598,7 @@ pub trait DebugProbe: Send + fmt::Debug {
         false
     }
 
-    /// Get the dedicated interface to debug RISCV chips. Ensure that the
+    /// Get the dedicated interface to debug Xtensa chips. Ensure that the
     /// probe actually supports this by calling [DebugProbe::has_xtensa_interface] first.
     fn try_get_xtensa_interface(
         self: Box<Self>,
@@ -609,7 +609,7 @@ pub trait DebugProbe: Send + fmt::Debug {
         ))
     }
 
-    /// Check if the probe offers an interface to debug RISCV chips.
+    /// Check if the probe offers an interface to debug Xtensa chips.
     fn has_xtensa_interface(&self) -> bool {
         false
     }

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -9,6 +9,7 @@ use crate::{
             SwoAccess,
         },
         riscv::communication_interface::{RiscvCommunicationInterface, RiscvError},
+        xtensa::communication_interface::XtensaCommunicationInterface,
     },
     probe::{
         common::extract_ir_lengths,
@@ -588,5 +589,19 @@ impl DebugProbe for EspUsbJtag {
     fn get_target_voltage(&mut self) -> Result<Option<f32>, DebugProbeError> {
         // We cannot read the voltage on this probe, unfortunately.
         Ok(None)
+    }
+
+    fn try_get_xtensa_interface(
+        self: Box<Self>,
+    ) -> Result<XtensaCommunicationInterface, (Box<dyn DebugProbe>, DebugProbeError)> {
+        // This probe is intended for Xtensa.
+        match XtensaCommunicationInterface::new(self) {
+            Ok(interface) => Ok(interface),
+            Err((probe, err)) => Err((probe.into_probe(), err)),
+        }
+    }
+
+    fn has_xtensa_interface(&self) -> bool {
+        true
     }
 }

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -1,4 +1,5 @@
 use crate::architecture::riscv::communication_interface::RiscvError;
+use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
 use crate::architecture::{
     arm::communication_interface::UninitializedArmProbe,
     riscv::communication_interface::RiscvCommunicationInterface,
@@ -555,6 +556,20 @@ impl DebugProbe for FtdiProbe {
     ) -> Result<Box<dyn UninitializedArmProbe + 'probe>, (Box<dyn DebugProbe>, DebugProbeError)>
     {
         todo!()
+    }
+
+    fn try_get_xtensa_interface(
+        self: Box<Self>,
+    ) -> Result<XtensaCommunicationInterface, (Box<dyn DebugProbe>, DebugProbeError)> {
+        // This probe is intended for Xtensa.
+        match XtensaCommunicationInterface::new(self) {
+            Ok(interface) => Ok(interface),
+            Err((probe, err)) => Err((probe.into_probe(), err)),
+        }
+    }
+
+    fn has_xtensa_interface(&self) -> bool {
+        true
     }
 }
 

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use crate::architecture::arm::{ArmError, RawDapAccess};
 use crate::architecture::riscv::communication_interface::RiscvError;
 use crate::probe::common::bits_to_byte;
+use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
 use crate::{
     architecture::{
         arm::{
@@ -620,6 +621,20 @@ impl DebugProbe for JLink {
     fn get_target_voltage(&mut self) -> Result<Option<f32>, DebugProbeError> {
         // Convert the integer millivolts value from self.handle to volts as an f32.
         Ok(Some((self.handle.read_target_voltage()? as f32) / 1000f32))
+    }
+
+    fn try_get_xtensa_interface(
+        self: Box<Self>,
+    ) -> Result<XtensaCommunicationInterface, (Box<dyn DebugProbe>, DebugProbeError)> {
+        // This probe is intended for Xtensa.
+        match XtensaCommunicationInterface::new(self) {
+            Ok(interface) => Ok(interface),
+            Err((probe, err)) => Err((probe.into_probe(), err)),
+        }
+    }
+
+    fn has_xtensa_interface(&self) -> bool {
+        true
     }
 }
 

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -9,8 +9,8 @@ use std::time::{Duration, Instant};
 
 use crate::architecture::arm::{ArmError, RawDapAccess};
 use crate::architecture::riscv::communication_interface::RiscvError;
-use crate::probe::common::bits_to_byte;
 use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
+use crate::probe::common::bits_to_byte;
 use crate::{
     architecture::{
         arm::{


### PR DESCRIPTION
I'm opening this up early, to get initial feedback, but also to ensure that this PR and subsequent PRs are reviewable.

With much help from @bugadani, this PR implements the following:

* Support for communicating with the Xtensa Debug Module (Xdm)
* Support for powering up the xdm, and reading back the status
* Support for entering and exiting debug mode
* Support for halt & resume
* Support for random access memory reads, write is not yet implemented
* Adds `try_get_xtensa_interface` & `has_xtensa_interface` to probes, and implements it for espusbjtag
* Finally, an example which can be ran on the esp32s3 to read back a timestamp register. If you have an esp32s3 board, you can run it with `RUST_LOG="info" cargo run --example xtensa`