### PR TITLE
debugger: REPL 'dump' command, auto calculate required memory ranges for `CoreDump`

### DIFF
--- a/changelog/changed-coredump-auto-calculate-memory.md
+++ b/changelog/changed-coredump-auto-calculate-memory.md
@@ -1,0 +1,3 @@
+The `dump` command that is used by the VSCode REPL can now be used without specifying memory regions.
+
+The resulting coredump will include all the memory regions required to unwind the in-scope functions and variables.

--- a/probe-rs-target/src/memory.rs
+++ b/probe-rs-target/src/memory.rs
@@ -137,7 +137,10 @@ impl MemoryRange for Range<u64> {
             self.start -= self.start % 4;
         }
         if self.end % 4 != 0 {
-            self.end += 4 - self.end % 4;
+            // Try to align the end to 32 bits, but don't overflow.
+            if let Some(new_end) = self.end.checked_add(4 - self.end % 4) {
+                self.end = new_end;
+            }
         }
     }
 }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands.rs
@@ -13,7 +13,7 @@ use probe_rs::{
     debug::{ObjectRef, VariableName},
     CoreStatus, HaltReason,
 };
-use std::{fmt::Display, path::Path, str::FromStr, time::Duration};
+use std::{fmt::Display, ops::Range, path::Path, str::FromStr, time::Duration};
 
 /// The handler is a function that takes a reference to the target core, and a reference to the response body.
 /// The response body is used to populate the response to the client.
@@ -408,12 +408,12 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
     },
     ReplCommand {
         command: "dump",
-        help_text: "Create a core dump at a target location",
+        help_text: "Create a core dump at a target location. Specify memory ranges to dump, or leave blank to dump in-scope memory regions.",
         sub_commands: None,
         args: Some(&[
             ReplCommandArgs::Optional("memory start address"),
             ReplCommandArgs::Optional("memory size in bytes"),
-            ReplCommandArgs::Optional("path"),
+            ReplCommandArgs::Optional("path (default: ./coredump)"),
         ]),
         handler: |target_core, command_arguments, _request_arguments| {
             let mut args = command_arguments.split_whitespace().collect_vec();
@@ -429,7 +429,13 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
                 .unwrap_or("./coredump"),
             );
 
-            let ranges = args
+            let ranges = if args.is_empty() {
+                // No specific memory ranges were requested, so we will dump the
+                // memory ranges we know are specifically referenced by the variables
+                // in the current scope.
+                target_core.get_memory_ranges()
+            } else {
+                args
                 .chunks(2)
                 .map(|c| {
                     let start = if let Some(start) = c.first() {
@@ -446,16 +452,31 @@ pub(crate) static REPL_COMMANDS: &[ReplCommand<ReplHandler>] = &[
                         unreachable!("This should never be reached as there cannot be an odd number of arguments. Please report this as a bug.")
                     };
 
-                    Ok::<_, DebuggerError>(start..start + size)
+                    Ok::<_, DebuggerError>(Range {start,end: start + size})
                 })
-                .collect::<Result<Vec<_>, _>>()?;
-
+                .collect::<Result<Vec<Range<u64>>, _>>()?
+            };
+            let mut range_string = String::new();
+            for memory_range in &ranges {
+                range_string.push_str(&format!(
+                    "{:#x}..{:#x}, ",
+                    &memory_range.start, &memory_range.end
+                ));
+            }
+            if range_string.is_empty() {
+                range_string = "(No memory ranges specified)".to_string();
+            } else {
+                range_string = range_string.trim_end_matches(", ").to_string();
+                range_string = format!("(Includes memory ranges: {range_string})");
+            }
             target_core.core.dump(ranges)?.store(location)?;
 
             Ok(Response {
                 command: "dump".to_string(),
                 success: true,
-                message: Some(format!("Core dump successfully stored at {location:?}",)),
+                message: Some(format!(
+                    "Core dump {range_string} successfully stored at {location:?}.",
+                )),
                 type_: "response".to_string(),
                 request_seq: 0,
                 seq: 0,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -419,7 +419,7 @@ impl<'p> CoreHandle<'p> {
             }
         }
         // Consolidating all memory ranges that are withing 0x400 bytes of each other.
-        consolidate_memory_ranges(&mut all_discrete_memory_ranges, 0x400)
+        consolidate_memory_ranges(all_discrete_memory_ranges, 0x400)
     }
 }
 
@@ -427,7 +427,7 @@ impl<'p> CoreHandle<'p> {
 /// Note: The concept of "adjacent" is calculated to include a gap of up to specicied number of bytes between ranges.
 /// This serves to consolidate memory ranges that are separated by a small gap, but are still close enough for the purpose of the caller.
 fn consolidate_memory_ranges(
-    discrete_memory_ranges: &mut Vec<Range<u64>>,
+    mut discrete_memory_ranges: Vec<Range<u64>>,
     include_bytes_between_ranges: u64,
 ) -> Vec<Range<u64>> {
     discrete_memory_ranges.sort_by_cached_key(|range| (range.start, range.end));
@@ -464,7 +464,7 @@ fn consolidate_memory_ranges(
 fn test_single_range() {
     let mut input = vec![Range { start: 0, end: 5 }];
     let expected = vec![Range { start: 0, end: 5 }];
-    let result = consolidate_memory_ranges(&mut input, 0);
+    let result = consolidate_memory_ranges(input, 0);
     assert_eq!(result, expected);
 }
 
@@ -477,7 +477,7 @@ fn test_three_adjacent_ranges() {
         Range { start: 11, end: 15 },
     ];
     let expected = vec![Range { start: 0, end: 15 }];
-    let result = consolidate_memory_ranges(&mut input, 0);
+    let result = consolidate_memory_ranges(input, 0);
     assert_eq!(result, expected);
 }
 
@@ -486,7 +486,7 @@ fn test_three_adjacent_ranges() {
 fn test_distinct_ranges() {
     let mut input = vec![Range { start: 0, end: 5 }, Range { start: 7, end: 10 }];
     let expected = vec![Range { start: 0, end: 5 }, Range { start: 7, end: 10 }];
-    let result = consolidate_memory_ranges(&mut input, 0);
+    let result = consolidate_memory_ranges(input, 0);
     assert_eq!(result, expected);
 }
 
@@ -495,7 +495,7 @@ fn test_distinct_ranges() {
 fn test_contiguous_ranges() {
     let mut input = vec![Range { start: 0, end: 5 }, Range { start: 5, end: 10 }];
     let expected = vec![Range { start: 0, end: 10 }];
-    let result = consolidate_memory_ranges(&mut input, 0);
+    let result = consolidate_memory_ranges(input, 0);
     assert_eq!(result, expected);
 }
 
@@ -508,7 +508,7 @@ fn test_adjacent_and_distinct_ranges() {
         Range { start: 12, end: 15 },
     ];
     let expected = vec![Range { start: 0, end: 10 }, Range { start: 12, end: 15 }];
-    let result = consolidate_memory_ranges(&mut input, 0);
+    let result = consolidate_memory_ranges(input, 0);
     assert_eq!(result, expected);
 }
 
@@ -517,7 +517,7 @@ fn test_adjacent_and_distinct_ranges() {
 fn test_non_overlapping_ranges() {
     let mut input = vec![Range { start: 10, end: 20 }, Range { start: 0, end: 5 }];
     let expected = vec![Range { start: 0, end: 5 }, Range { start: 10, end: 20 }];
-    let result = consolidate_memory_ranges(&mut input, 0);
+    let result = consolidate_memory_ranges(input, 0);
     assert_eq!(result, expected);
 }
 
@@ -526,7 +526,7 @@ fn test_non_overlapping_ranges() {
 fn test_non_overlapping_ranges_with_extra_bytes() {
     let mut input = vec![Range { start: 10, end: 20 }, Range { start: 0, end: 5 }];
     let expected = vec![Range { start: 0, end: 20 }];
-    let result = consolidate_memory_ranges(&mut input, 5);
+    let result = consolidate_memory_ranges(input, 5);
     assert_eq!(result, expected);
 }
 
@@ -535,6 +535,6 @@ fn test_non_overlapping_ranges_with_extra_bytes() {
 fn test_reversed_intersecting_ranges() {
     let mut input = vec![Range { start: 10, end: 20 }, Range { start: 5, end: 15 }];
     let expected = vec![Range { start: 5, end: 20 }];
-    let result = consolidate_memory_ranges(&mut input, 0);
+    let result = consolidate_memory_ranges(input, 0);
     assert_eq!(result, expected);
 }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -426,7 +426,7 @@ impl<'p> CoreHandle<'p> {
 /// Return a Vec of memory ranges that consolidate the adjacent memory ranges of the input ranges.
 /// Note: The concept of "adjacent" is calculated to include a gap of up to specicied number of bytes between ranges.
 /// This serves to consolidate memory ranges that are separated by a small gap, but are still close enough for the purpose of the caller.
-pub(crate) fn consolidate_memory_ranges(
+fn consolidate_memory_ranges(
     discrete_memory_ranges: &mut Vec<Range<u64>>,
     include_bytes_between_ranges: u64,
 ) -> Vec<Range<u64>> {

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -411,6 +411,12 @@ impl<'p> CoreHandle<'p> {
                 );
                 all_discrete_memory_ranges.append(&mut variable_cache.get_discrete_memory_ranges());
             }
+            // Also capture memory addresses for essential registers.
+            for register in frame.registers.0.iter() {
+                if let Ok(Some(memory_range)) = register.memory_range() {
+                    all_discrete_memory_ranges.push(memory_range);
+                }
+            }
         }
         // Consolidating all memory ranges that are withing 0x400 bytes of each other.
         consolidate_memory_ranges(&mut all_discrete_memory_ranges, 0x400)

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -458,7 +458,6 @@ fn consolidate_memory_ranges(
 
     consolidated_memory_ranges
 }
-#[cfg(test)]
 
 /// A single range should remain the same after consolidation.
 #[test]

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use anyhow::anyhow;
 pub use probe_rs_target::{Architecture, CoreAccessOptions};
-use probe_rs_target::{ArmCoreAccessOptions, RiscvCoreAccessOptions};
+use probe_rs_target::{ArmCoreAccessOptions, MemoryRange, RiscvCoreAccessOptions};
 use scroll::Pread;
 use std::{
     collections::HashMap,
@@ -321,7 +321,7 @@ impl CoreDump {
         size_in_bytes: u64,
     ) -> Result<(u64, &Vec<u8>), crate::Error> {
         for (range, memory) in &self.data {
-            if range.contains(&address) && range.contains(&(address + size_in_bytes)) {
+            if range.contains_range(&(address..(address + size_in_bytes))) {
                 return Ok((range.start, memory));
             }
         }

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040__full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040__full_unwind.snap
@@ -8248,4 +8248,393 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: Unknown
+- function_name: "<unknown function @ 0x100001e6>"
+  source_location: ~
+  registers:
+    - core_register:
+        id: 0
+        roles:
+          - Core: R0
+          - Argument: a1
+          - Return: r1
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 0
+      value: ~
+    - core_register:
+        id: 1
+        roles:
+          - Core: R1
+          - Argument: a2
+          - Return: r2
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 1
+      value: ~
+    - core_register:
+        id: 2
+        roles:
+          - Core: R2
+          - Argument: a3
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 2
+      value: ~
+    - core_register:
+        id: 3
+        roles:
+          - Core: R3
+          - Argument: a4
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 3
+      value: ~
+    - core_register:
+        id: 4
+        roles:
+          - Core: R4
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 4
+      value:
+        U32: 0
+    - core_register:
+        id: 5
+        roles:
+          - Core: R5
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 5
+      value:
+        U32: 537140993
+    - core_register:
+        id: 6
+        roles:
+          - Core: R6
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 6
+      value:
+        U32: 402653184
+    - core_register:
+        id: 7
+        roles:
+          - Core: R7
+          - FramePointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 7
+      value:
+        U32: 0
+    - core_register:
+        id: 8
+        roles:
+          - Core: R8
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 8
+      value:
+        U32: 4294967295
+    - core_register:
+        id: 9
+        roles:
+          - Core: R9
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 9
+      value: ~
+    - core_register:
+        id: 10
+        roles:
+          - Core: R10
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 10
+      value:
+        U32: 4294967295
+    - core_register:
+        id: 11
+        roles:
+          - Core: R11
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 11
+      value:
+        U32: 4294967295
+    - core_register:
+        id: 12
+        roles:
+          - Core: R12
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 12
+      value:
+        U32: 536871449
+    - core_register:
+        id: 13
+        roles:
+          - Core: R13
+          - StackPointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 13
+      value:
+        U32: 536887296
+    - core_register:
+        id: 14
+        roles:
+          - Core: R14
+          - ReturnAddress
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 14
+      value:
+        U32: 268435943
+    - core_register:
+        id: 15
+        roles:
+          - Core: R15
+          - ProgramCounter
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 15
+      value:
+        U32: 268435942
+    - core_register:
+        id: 17
+        roles:
+          - Core: MSP
+          - MainStackPointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 16
+      value: ~
+    - core_register:
+        id: 18
+        roles:
+          - Core: PSP
+          - ProcessStackPointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
+    - core_register:
+        id: 16
+        roles:
+          - Core: XPSR
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 18
+      value:
+        U32: 1627389952
+    - core_register:
+        id: 20
+        roles:
+          - Core: EXTRA
+          - Other: EXTRA
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 19
+      value: ~
+  pc:
+    U32: 268435942
+  frame_base: ~
+  is_inlined: false
+  static_variables: ~
+  local_variables: ~
+- function_name: "<unknown function @ 0x100001e6>"
+  source_location: ~
+  registers:
+    - core_register:
+        id: 0
+        roles:
+          - Core: R0
+          - Argument: a1
+          - Return: r1
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 0
+      value: ~
+    - core_register:
+        id: 1
+        roles:
+          - Core: R1
+          - Argument: a2
+          - Return: r2
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 1
+      value: ~
+    - core_register:
+        id: 2
+        roles:
+          - Core: R2
+          - Argument: a3
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 2
+      value: ~
+    - core_register:
+        id: 3
+        roles:
+          - Core: R3
+          - Argument: a4
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 3
+      value: ~
+    - core_register:
+        id: 4
+        roles:
+          - Core: R4
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 4
+      value:
+        U32: 0
+    - core_register:
+        id: 5
+        roles:
+          - Core: R5
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 5
+      value:
+        U32: 537140993
+    - core_register:
+        id: 6
+        roles:
+          - Core: R6
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 6
+      value:
+        U32: 402653184
+    - core_register:
+        id: 7
+        roles:
+          - Core: R7
+          - FramePointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 7
+      value:
+        U32: 0
+    - core_register:
+        id: 8
+        roles:
+          - Core: R8
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 8
+      value:
+        U32: 4294967295
+    - core_register:
+        id: 9
+        roles:
+          - Core: R9
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 9
+      value: ~
+    - core_register:
+        id: 10
+        roles:
+          - Core: R10
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 10
+      value:
+        U32: 4294967295
+    - core_register:
+        id: 11
+        roles:
+          - Core: R11
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 11
+      value:
+        U32: 4294967295
+    - core_register:
+        id: 12
+        roles:
+          - Core: R12
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 12
+      value:
+        U32: 536871449
+    - core_register:
+        id: 13
+        roles:
+          - Core: R13
+          - StackPointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 13
+      value:
+        U32: 536887296
+    - core_register:
+        id: 14
+        roles:
+          - Core: R14
+          - ReturnAddress
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 14
+      value: ~
+    - core_register:
+        id: 15
+        roles:
+          - Core: R15
+          - ProgramCounter
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 15
+      value:
+        U32: 268435942
+    - core_register:
+        id: 17
+        roles:
+          - Core: MSP
+          - MainStackPointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 16
+      value: ~
+    - core_register:
+        id: 18
+        roles:
+          - Core: PSP
+          - ProcessStackPointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
+    - core_register:
+        id: 16
+        roles:
+          - Core: XPSR
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 18
+      value:
+        U32: 1627389952
+    - core_register:
+        id: 20
+        roles:
+          - Core: EXTRA
+          - Other: EXTRA
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 19
+      value: ~
+  pc:
+    U32: 268435942
+  frame_base: ~
+  is_inlined: false
+  static_variables: ~
+  local_variables: ~
 

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__full_unwind.snap
@@ -8281,4 +8281,267 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: Unknown
+- function_name: "<unknown function @ 0x0000013c>"
+  source_location: ~
+  registers:
+    - core_register:
+        id: 0
+        roles:
+          - Core: R0
+          - Argument: a1
+          - Return: r1
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 0
+      value: ~
+    - core_register:
+        id: 1
+        roles:
+          - Core: R1
+          - Argument: a2
+          - Return: r2
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 1
+      value: ~
+    - core_register:
+        id: 2
+        roles:
+          - Core: R2
+          - Argument: a3
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 2
+      value: ~
+    - core_register:
+        id: 3
+        roles:
+          - Core: R3
+          - Argument: a4
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 3
+      value: ~
+    - core_register:
+        id: 4
+        roles:
+          - Core: R4
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 4
+      value:
+        U32: 0
+    - core_register:
+        id: 5
+        roles:
+          - Core: R5
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 5
+      value:
+        U32: 0
+    - core_register:
+        id: 6
+        roles:
+          - Core: R6
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 6
+      value:
+        U32: 0
+    - core_register:
+        id: 7
+        roles:
+          - Core: R7
+          - FramePointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 7
+      value:
+        U32: 0
+    - core_register:
+        id: 8
+        roles:
+          - Core: R8
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 8
+      value:
+        U32: 0
+    - core_register:
+        id: 9
+        roles:
+          - Core: R9
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 9
+      value: ~
+    - core_register:
+        id: 10
+        roles:
+          - Core: R10
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 10
+      value:
+        U32: 0
+    - core_register:
+        id: 11
+        roles:
+          - Core: R11
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 11
+      value:
+        U32: 0
+    - core_register:
+        id: 12
+        roles:
+          - Core: R12
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 12
+      value:
+        U32: 536871464
+    - core_register:
+        id: 13
+        roles:
+          - Core: R13
+          - StackPointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 13
+      value:
+        U32: 536887296
+    - core_register:
+        id: 14
+        roles:
+          - Core: R14
+          - ReturnAddress
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 14
+      value:
+        U32: 317
+    - core_register:
+        id: 15
+        roles:
+          - Core: R15
+          - ProgramCounter
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 15
+      value:
+        U32: 316
+    - core_register:
+        id: 17
+        roles:
+          - Core: MSP
+          - MainStackPointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 16
+      value: ~
+    - core_register:
+        id: 18
+        roles:
+          - Core: PSP
+          - ProcessStackPointer
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 17
+      value: ~
+    - core_register:
+        id: 16
+        roles:
+          - Core: XPSR
+          - ProcessorStatus
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 18
+      value:
+        U32: 1627389952
+    - core_register:
+        id: 20
+        roles:
+          - Core: EXTRA
+          - Other: EXTRA
+        data_type:
+          UnsignedInteger: 32
+      dwarf_id: 19
+      value: ~
+  pc:
+    U32: 316
+  frame_base: 0
+  is_inlined: false
+  static_variables:
+    Child Variables:
+      name: StaticScopeRoot
+      type_name: Unknown
+      value: ", <unknown> {\n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&nrf_hal_common::pwm::Seq as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >}"
+      children:
+        - name:
+            Namespace: nrf_hal_common
+          type_name: Namespace
+          value: ""
+          children:
+            - name:
+                Namespace: "nrf_hal_common::pwm"
+              type_name: Namespace
+              value: ""
+              children:
+                - name:
+                    Named: BUF0
+                  type_name: Unknown
+                  value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                - name:
+                    Named: BUF1
+                  type_name: Unknown
+                  value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                - name:
+                    Named: BUF2
+                  type_name: Unknown
+                  value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+                - name:
+                    Named: BUF3
+                  type_name: Unknown
+                  value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+        - name:
+            Named: "<&u16 as core::fmt::Debug>::{vtable}"
+          type_name: Unknown
+          value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+        - name:
+            Named: "<&nrf_hal_common::pwm::Seq as core::fmt::Debug>::{vtable}"
+          type_name: Unknown
+          value: "< The value of this variable may have been optimized out of the debug info, by the compiler. >"
+  local_variables:
+    Child Variables:
+      name: LocalScopeRoot
+      type_name: Unknown
+      value: "<unknown> {\n\tself: &mut nrf_hal_common::ecb::Ecb = &mut nrf_hal_common::ecb::Ecb @ 0x200040C8, \n\tblock: <unknown> = < <value optimized away by compiler, out of scope, or dropped> >, \n\tkey: <unknown> = < <value optimized away by compiler, out of scope, or dropped> >}"
+      children:
+        - name:
+            Named: self
+          type_name:
+            Pointer: "&mut nrf_hal_common::ecb::Ecb"
+          value: "&mut nrf_hal_common::ecb::Ecb @ 0x200040C8"
+          children:
+            - name:
+                Named: "*self"
+              type_name:
+                Struct: Ecb
+              value: "Ecb {\n\tregs: <unknown> = < Failed to read referenced variable address from memory location 0x200040C8 : The coredump does not include the memory for address 0x200040c8 of size 0x4. >}"
+              children:
+                - name:
+                    Named: regs
+                  type_name: Unknown
+                  value: "< Failed to read referenced variable address from memory location 0x200040C8 : The coredump does not include the memory for address 0x200040c8 of size 0x4. >"
+        - name:
+            Named: block
+          type_name: Unknown
+          value: "< <value optimized away by compiler, out of scope, or dropped> >"
+        - name:
+            Named: key
+          type_name: Unknown
+          value: "< <value optimized away by compiler, out of scope, or dropped> >"
 

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__print_stacktrace.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__print_stacktrace.snap
@@ -74,4 +74,9 @@ Frame:
   line: Some(10)
   column: Some(Column(1))
  frame_base:      Some(20003ff8)
+Frame:
+ function:        fold<usize, u32, core::iter::adapters::map::map_fold::{closure_env#0}<&usize, u32, u32, microbit_common::display::nonblocking::control::{impl#0}::initialise_for_display::{closure#2}::{closure_env#0}, core::iter::traits::accum::{impl#36}::sum::{closure_env#0}<core::iter::adapters::map::Map<core::slice::iter::Iter<usize>, microbit_common::display::nonblocking::control::{impl#0}::initialise_for_display::{closure#2}::{closure_env#0}>>>> : ERROR: UNWIND: Failed to read value for register R7/FP from address 0x0000000000000000 (4 bytes): The coredump does not include the memory for address 0x0 of size 0x4
+ source_location:
+None
+ frame_base:      None
 

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -173,7 +173,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
         tree_node: &mut gimli::EntriesTreeNode<GimliReader>,
         parent_variable: &mut Variable,
         mut child_variable: Variable,
-        memory: &mut impl MemoryInterface,
+        memory: &mut dyn MemoryInterface,
         stack_frame_registers: &registers::DebugRegisters,
         frame_base: Option<u64>,
         cache: &mut VariableCache,
@@ -496,7 +496,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
         &self,
         parent_node: gimli::EntriesTreeNode<GimliReader>,
         mut parent_variable: Variable,
-        memory: &mut impl MemoryInterface,
+        memory: &mut dyn MemoryInterface,
         stack_frame_registers: &registers::DebugRegisters,
         frame_base: Option<u64>,
         cache: &mut VariableCache,
@@ -814,7 +814,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
         node: gimli::EntriesTreeNode<GimliReader>,
         parent_variable: &Variable,
         mut child_variable: Variable,
-        memory: &mut impl MemoryInterface,
+        memory: &mut dyn MemoryInterface,
         stack_frame_registers: &registers::DebugRegisters,
         frame_base: Option<u64>,
         cache: &mut VariableCache,
@@ -1255,7 +1255,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
         unit_ref: UnitOffset,
         cache: &mut VariableCache,
         child_variable: &mut Variable,
-        memory: &mut impl MemoryInterface,
+        memory: &mut dyn MemoryInterface,
         array_member_index: i64,
         stack_frame_registers: &DebugRegisters,
         frame_base: Option<u64>,
@@ -1328,7 +1328,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
         node_die: &gimli::DebuggingInformationEntry<GimliReader>,
         parent_variable: &Variable,
         child_variable: &mut Variable,
-        memory: &mut impl MemoryInterface,
+        memory: &mut dyn MemoryInterface,
         stack_frame_registers: &registers::DebugRegisters,
         frame_base: Option<u64>,
     ) -> Result<(), DebugError> {
@@ -1417,7 +1417,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
         &self,
         node_die: &gimli::DebuggingInformationEntry<GimliReader>,
         parent_location: &VariableLocation,
-        memory: &mut impl MemoryInterface,
+        memory: &mut dyn MemoryInterface,
         stack_frame_registers: &registers::DebugRegisters,
         frame_base: Option<u64>,
     ) -> Result<ExpressionResult, DebugError> {
@@ -1559,7 +1559,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
     /// - Result<ExpressionResult::Location(),_>:  One of the variants of VariableLocation, and needs to be interpreted for handling the 'expected' errors we encounter during evaluation.
     pub(crate) fn evaluate_expression(
         &self,
-        memory: &mut impl MemoryInterface,
+        memory: &mut dyn MemoryInterface,
         expression: gimli::Expression<GimliReader>,
         stack_frame_registers: &registers::DebugRegisters,
         frame_base: Option<u64>,
@@ -1678,7 +1678,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
     /// Tries to get the result of a DWARF expression in the form of a Piece.
     pub(crate) fn expression_to_piece(
         &self,
-        memory: &mut impl MemoryInterface,
+        memory: &mut dyn MemoryInterface,
         expression: gimli::Expression<GimliReader>,
         stack_frame_registers: &registers::DebugRegisters,
         frame_base: Option<u64>,
@@ -1723,7 +1723,7 @@ impl<'debuginfo> UnitInfo<'debuginfo> {
         unit_ref: UnitOffset,
         child_variable: &mut Variable,
         parent_variable: &Variable,
-        memory: &mut impl MemoryInterface,
+        memory: &mut dyn MemoryInterface,
     ) {
         if let Some(child_member_index) = child_variable.member_index {
             // If this variable is a member of an array type, and needs special handling to calculate the `memory_location`.
@@ -1885,7 +1885,7 @@ fn provide_frame_base(
 /// Reads memory requested by the DWARF resolver.
 fn read_memory(
     size: u8,
-    memory: &mut impl MemoryInterface,
+    memory: &mut dyn MemoryInterface,
     address: u64,
     evaluation: &mut gimli::Evaluation<EndianReader>,
 ) -> Result<EvaluationResult<EndianReader>, DebugError> {

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -491,7 +491,7 @@ impl VariableCache {
     }
 
     /// Traverse the `VariableCache` and return a Vec of all the memory ranges that are referenced by the variables.
-    /// This is used to determine which memory ranges to read from the target when creating a 'default' [`core::CoreDump`].
+    /// This is used to determine which memory ranges to read from the target when creating a 'default' [`crate::core::CoreDump`].
     pub fn get_discrete_memory_ranges(&self) -> Vec<Range<u64>> {
         let mut memory_ranges: Vec<Range<u64>> = Vec::new();
         for variable in self.variable_hash_map.values() {

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -461,7 +461,7 @@ impl VariableCache {
                 return;
             }
             .clone();
-            debug_info
+            if debug_info
                 .cache_deferred_variables(
                     self,
                     memory,
@@ -469,7 +469,10 @@ impl VariableCache {
                     registers,
                     frame_base,
                 )
-                .unwrap();
+                .is_err()
+            {
+                return;
+            };
             for mut child in self.get_children(variable_to_recurse.variable_key).unwrap() {
                 self.recurse_deferred_variables(
                     debug_info,

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -2,9 +2,10 @@ use super::*;
 use crate::Error;
 use anyhow::anyhow;
 use gimli::{DebugInfoOffset, UnitOffset, UnitSectionOffset};
+use num_traits::Zero;
+use probe_rs_target::MemoryRange;
 use serde::{Serialize, Serializer};
-use std::collections::{btree_map::Entry, BTreeMap};
-
+use std::{collections::BTreeMap, ops::Range};
 /// VariableCache stores available `Variable`s, and provides methods to create and navigate the parent-child relationships of the Variables.
 #[derive(Debug, Clone, PartialEq)]
 pub struct VariableCache {
@@ -129,6 +130,11 @@ impl VariableCache {
     /// Get the root variable of the cache
     pub fn root_variable(&self) -> Variable {
         self.variable_hash_map[&self.root_variable_key].clone()
+    }
+
+    /// Get a mutable reference to the root variable of the cache
+    pub fn root_variable_mut(&mut self) -> Option<&mut Variable> {
+        self.variable_hash_map.get_mut(&self.root_variable_key)
     }
 
     /// Returns the number of `Variable`s in the cache.
@@ -428,6 +434,129 @@ impl VariableCache {
             return Err(anyhow!("Failed to remove a `VariableCache` entry with key: {:?}. Please report this as a bug.", variable_key).into());
         };
         Ok(())
+    }
+    /// Recursively process the deferred variables in the variable cache,
+    /// and add their children to the cache.
+    /// Enforce a max level, so that we don't recurse infinitely on circular references.
+    #[allow(clippy::too_many_arguments)]
+    pub fn recurse_deferred_variables(
+        &mut self,
+        debug_info: &DebugInfo,
+        memory: &mut dyn MemoryInterface,
+        parent_variable: Option<&mut Variable>,
+        registers: &DebugRegisters,
+        frame_base: Option<u64>,
+        _max_recursion_depth: usize,
+        current_recursion_depth: usize,
+    ) {
+        if current_recursion_depth < 10 {
+            let children_depth = current_recursion_depth + 1;
+            let mut variable_to_recurse = if let Some(parent_variable) = parent_variable {
+                parent_variable
+            } else if let Some(parent_variable) = self.root_variable_mut() {
+                // This is the top-level variable, which has no parent.
+                parent_variable
+            } else {
+                // If the variable cache is empty, we have nothing to do.
+                return;
+            }
+            .clone();
+            debug_info
+                .cache_deferred_variables(
+                    self,
+                    memory,
+                    &mut variable_to_recurse,
+                    registers,
+                    frame_base,
+                )
+                .unwrap();
+            for mut child in self.get_children(variable_to_recurse.variable_key).unwrap() {
+                self.recurse_deferred_variables(
+                    debug_info,
+                    memory,
+                    Some(&mut child),
+                    registers,
+                    frame_base,
+                    _max_recursion_depth,
+                    children_depth,
+                );
+            }
+        }
+    }
+
+    /// Traverse the `VariableCache` and return a Vec of all the memory ranges that are referenced by the variables.
+    /// This is used to determine which memory ranges to read from the target when creating a 'default' [`core::CoreDump`].
+    pub fn get_discrete_memory_ranges(&self) -> Vec<Range<u64>> {
+        let mut memory_ranges: Vec<Range<u64>> = Vec::new();
+        for variable in self.variable_hash_map.values() {
+            if let Some(mut memory_range) = variable.memory_range() {
+                // This memory might need to be read by 32-bit aligned words, so make sure
+                // the range is aligned to 32 bits.
+                memory_range.align_to_32_bits();
+                if !memory_ranges.contains(&memory_range) {
+                    memory_ranges.push(memory_range);
+                }
+            }
+            // The datatype &str is a special case, because it is stores a pointer to the string data,
+            // and the length of the string.
+            if variable.type_name == VariableType::Struct("&str".to_string()) {
+                if let Ok(children) = self.get_children(variable.variable_key) {
+                    if !children.is_empty() {
+                        let string_length = match children.iter().find(|child_variable| {
+                            child_variable.name == VariableName::Named("length".to_string())
+                        }) {
+                            Some(string_length) => {
+                                if string_length.is_valid() {
+                                    string_length.get_value(self).parse().unwrap_or(0_usize)
+                                } else {
+                                    0_usize
+                                }
+                            }
+                            None => 0_usize,
+                        };
+                        let string_location = match children.iter().find(|child_variable| {
+                            child_variable.name == VariableName::Named("data_ptr".to_string())
+                        }) {
+                            Some(location_value) => {
+                                if let Ok(child_variables) =
+                                    self.get_children(location_value.variable_key)
+                                {
+                                    if let Some(first_child) = child_variables.first() {
+                                        first_child
+                                            .memory_location
+                                            .memory_address()
+                                            .unwrap_or(0_u64)
+                                    } else {
+                                        0_u64
+                                    }
+                                } else {
+                                    0_u64
+                                }
+                            }
+                            None => 0_u64,
+                        };
+                        if string_location.is_zero() || string_length.is_zero() {
+                            // We don't have enough information to read the string from memory.
+                            // I've never seen an instance of this, but it is theoretically possible.
+                            tracing::warn!(
+                                "Failed to find string location or length for variable: {:?}",
+                                variable
+                            );
+                        } else {
+                            let mut memory_range =
+                                string_location..(string_location + string_length as u64);
+                            // This memory might need to be read by 32-bit aligned words, so make sure
+                            // the range is aligned to 32 bits.
+                            memory_range.align_to_32_bits();
+                            if !memory_ranges.contains(&memory_range) {
+                                memory_ranges.push(memory_range);
+                            }
+                        }
+                    }
+                };
+            }
+        }
+        memory_ranges
     }
 }
 

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -5,7 +5,10 @@ use gimli::{DebugInfoOffset, UnitOffset, UnitSectionOffset};
 use num_traits::Zero;
 use probe_rs_target::MemoryRange;
 use serde::{Serialize, Serializer};
-use std::{collections::BTreeMap, ops::Range};
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    ops::Range,
+};
 /// VariableCache stores available `Variable`s, and provides methods to create and navigate the parent-child relationships of the Variables.
 #[derive(Debug, Clone, PartialEq)]
 pub struct VariableCache {

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -490,7 +490,7 @@ impl VariableCache {
         let mut memory_ranges: Vec<Range<u64>> = Vec::new();
         for variable in self.variable_hash_map.values() {
             if let Some(mut memory_range) = variable.memory_range() {
-                // This memory might need to be read by 32-bit aligned words, so make sure
+                // This memory may need to be read by 32-bit aligned words, so make sure
                 // the range is aligned to 32 bits.
                 memory_range.align_to_32_bits();
                 if !memory_ranges.contains(&memory_range) {


### PR DESCRIPTION
- As part of the journey to complete high quality unwind testing in the debugger (see #1916), this PR updates the debugger's REPL `dump` command, to auto calculate the memory ranges required in the `CoreDump`.  e.g.:
  - Previously required something like `dump 0x20000000 0x4000 0x4cf0 0x1070 target/NRF52833_xxAA.coredump`
  - Now the user can use `dump target/NRF52833_xxAA.coredump` to automatically dump all "in-scope" memory ranges, i.e. memory ranges required to reproduce the full stack unwind at the current target halt point (program counter).
  - For the test case in `debug::debug_info::test::full_unwind::armv7_m_using_nrf52833_xxaa`, this reduced the coredump file from ~24Kb to ~10Kb. Note: The updated coredump for these tests are not included in this PR, because I wanted to isolate changes required to the updates in the `insta` snapshots (see next bullet point).

- This PR also updates the `insta` snapshots for unwind tests, by adding frames that were previously missing in the unwind from the coredumps.
  - These frames are frames that precede the `fn main() ->!` functions and should be ignored for now, as they are not correctly identifying/unwinding the target `Reset` handler that invoked the `main()`. 
  - Fixing this problem with the `Reset` is also being tracked by #1916. 

- In addition to the contextual testing of the unwind tests, I've also added new unit tests where I thought it was necessary/valuable.
