### PR TITLE
JTAG command batching / espusbjtag: Transfer fewer bits

### DIFF
--- a/changelog/changed-espusbjtag-capture-less.md
+++ b/changelog/changed-espusbjtag-capture-less.md
@@ -1,0 +1,1 @@
+espusbjtag: capture fewer bits

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -13,7 +13,7 @@ use crate::{
     core::RegisterId,
     memory::valid_32bit_address,
     memory_mapped_bitfield_register,
-    probe::{CommandResult, DeferredResultIndex, JTAGAccess},
+    probe::{DeferredResultIndex, DeferredResultSet, JTAGAccess},
     DebugProbeError, Error as ProbeRsError, MemoryInterface, MemoryMappedRegister, Probe,
 };
 use std::{
@@ -670,7 +670,7 @@ impl RiscvCommunicationInterface {
 
         let data_len = data.len();
 
-        let mut read_results: Vec<usize> = vec![];
+        let mut read_results: Vec<DeferredResultIndex> = vec![];
         for _ in data[..data_len - 1].iter() {
             let idx = self.schedule_read_large_dtm_register::<V, Sbdata>()?;
             read_results.push(idx);
@@ -686,7 +686,7 @@ impl RiscvCommunicationInterface {
 
         let result = self.execute()?;
 
-        for (out_index, &idx) in read_results.iter().enumerate() {
+        for (out_index, idx) in read_results.into_iter().enumerate() {
             data[out_index] = V::from_register_value(result[idx].as_u32());
         }
 
@@ -1301,7 +1301,7 @@ impl RiscvCommunicationInterface {
         Probe::from_attached_probe(self.dtm.probe.into_probe())
     }
 
-    pub(super) fn execute(&mut self) -> Result<Vec<CommandResult>, RiscvError> {
+    pub(super) fn execute(&mut self) -> Result<DeferredResultSet, RiscvError> {
         self.dtm.execute()
     }
 

--- a/probe-rs/src/architecture/riscv/dtm.rs
+++ b/probe-rs/src/architecture/riscv/dtm.rs
@@ -12,7 +12,7 @@ use bitfield::bitfield;
 use super::communication_interface::RiscvError;
 use crate::{
     probe::{
-        BatchedJtagCommands, CommandResult, DeferredResultIndex, DeferredResultSet, JTAGAccess,
+        CommandResult, DeferredResultIndex, DeferredResultSet, JTAGAccess, JtagCommandQueue,
         JtagWriteCommand,
     },
     DebugProbeError,
@@ -24,7 +24,7 @@ use crate::{
 pub struct Dtm {
     pub probe: Box<dyn JTAGAccess>,
 
-    queued_commands: BatchedJtagCommands,
+    queued_commands: JtagCommandQueue,
 
     /// Number of address bits in the DMI register
     abits: u32,
@@ -66,7 +66,7 @@ impl Dtm {
         Ok(Self {
             probe,
             abits,
-            queued_commands: BatchedJtagCommands::new(),
+            queued_commands: JtagCommandQueue::new(),
         })
     }
 
@@ -162,7 +162,7 @@ impl Dtm {
 
         let bit_size = self.abits + DMI_ADDRESS_BIT_OFFSET;
 
-        Ok(self.queued_commands.push(JtagWriteCommand {
+        Ok(self.queued_commands.schedule(JtagWriteCommand {
             address: DMI_ADDRESS,
             data: bytes.to_vec(),
             transform: |result| {

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -822,9 +822,10 @@ pub trait JTAGAccess: DebugProbe {
         len: u32,
     ) -> Result<Vec<u8>, DebugProbeError>;
 
+    /// Executes a sequence of JTAG commands.
     fn write_register_batch(
         &mut self,
-        writes: &BatchedJtagCommands,
+        writes: &JtagCommandQueue,
     ) -> Result<DeferredResultSet, BatchExecutionError> {
         tracing::debug!("Using default `JTAGAccess::write_register_batch` this will hurt performance. Please implement proper batching for this probe.");
         let mut results = DeferredResultSet::new();
@@ -850,46 +851,6 @@ pub struct JtagWriteCommand {
     pub data: Vec<u8>,
     pub len: u32,
     pub transform: fn(Vec<u8>) -> Result<CommandResult, crate::Error>,
-}
-
-#[derive(Default, Debug)]
-pub struct BatchedJtagCommands {
-    pub(crate) commands: Vec<(DeferredResultIndex, JtagWriteCommand)>,
-}
-
-impl BatchedJtagCommands {
-    pub fn new() -> Self {
-        Self {
-            commands: Vec::new(),
-        }
-    }
-
-    pub fn push(&mut self, command: JtagWriteCommand) -> DeferredResultIndex {
-        let idx = Arc::new(());
-        let index = DeferredResultIndex(idx.clone());
-        self.commands.push((index, command));
-        DeferredResultIndex(idx)
-    }
-
-    pub fn len(&self) -> usize {
-        self.commands.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.commands.is_empty()
-    }
-
-    pub fn clear(&mut self) {
-        self.commands.clear();
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (&DeferredResultIndex, &JtagWriteCommand)> {
-        self.commands.iter().map(|(idx, cmd)| (idx, cmd))
-    }
-
-    pub fn consume(&mut self, len: usize) {
-        self.commands.drain(..len);
-    }
 }
 
 /// Represents a Jtag Tap within the chain.
@@ -952,6 +913,49 @@ impl CommandResult {
     }
 }
 
+/// A set of batched commands that will be executed all at once.
+///
+/// This list maintains which commands' results can be read by the issuing code, which then
+/// can be used to skip capturing or processing certain parts of the response.
+#[derive(Default, Debug)]
+pub struct JtagCommandQueue {
+    commands: Vec<(DeferredResultIndex, JtagWriteCommand)>,
+}
+
+impl JtagCommandQueue {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Schedules a command for later execution.
+    ///
+    /// Returns a token value that can be used to retrieve the result of the command.
+    pub fn schedule(&mut self, command: JtagWriteCommand) -> DeferredResultIndex {
+        let idx = Arc::new(());
+        let index = DeferredResultIndex(idx.clone());
+        self.commands.push((index, command));
+        DeferredResultIndex(idx)
+    }
+
+    pub fn len(&self) -> usize {
+        self.commands.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.commands.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(DeferredResultIndex, JtagWriteCommand)> {
+        self.commands.iter()
+    }
+
+    /// Removes the first `len` number of commands from the batch.
+    pub fn consume(&mut self, len: usize) {
+        self.commands.drain(..len);
+    }
+}
+
+/// The set of results returned by executing a batched command.
 #[derive(Debug, Default)]
 pub struct DeferredResultSet(HashMap<usize, CommandResult>);
 
@@ -965,7 +969,10 @@ impl DeferredResultSet {
     }
 
     pub fn push(&mut self, idx: &DeferredResultIndex, result: CommandResult) {
-        self.0.insert(idx.id(), result);
+        // Only store results if reading is possible.
+        if idx.should_capture() {
+            self.0.insert(idx.id(), result);
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -985,22 +992,17 @@ impl Index<DeferredResultIndex> for DeferredResultSet {
     }
 }
 
+/// An index type used to retrieve the result of a deferred command.
+///
+/// This type can detect if the result of a command is not used.
 #[derive(PartialEq, Eq, Debug)]
 pub struct DeferredResultIndex(Arc<()>);
 
 impl DeferredResultIndex {
-    pub fn id(&self) -> usize {
+    fn id(&self) -> usize {
         Arc::as_ptr(&self.0) as usize
     }
-}
 
-impl std::hash::Hash for DeferredResultIndex {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.id().hash(state);
-    }
-}
-
-impl DeferredResultIndex {
     pub fn should_capture(&self) -> bool {
         // Both the queue and the user code may hold on to at most one of the references. The queue
         // execution will be able to detect if the user dropped their read reference, meaning

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -952,12 +952,12 @@ impl CommandResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct DeferredResultSet(HashMap<usize, CommandResult>);
 
 impl DeferredResultSet {
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self::default()
     }
 
     pub fn with_capacity(capacity: usize) -> Self {

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     probe::{
         common::extract_ir_lengths,
         espusbjtag::protocol::{JtagState, RegisterState},
-        BatchedJtagCommands, DeferredResultSet,
+        DeferredResultSet, JtagCommandQueue,
     },
     DebugProbe, DebugProbeError, DebugProbeSelector, WireProtocol,
 };
@@ -373,7 +373,7 @@ impl JTAGAccess for EspUsbJtag {
 
     fn write_register_batch(
         &mut self,
-        writes: &BatchedJtagCommands,
+        writes: &JtagCommandQueue,
     ) -> Result<DeferredResultSet, BatchExecutionError> {
         let mut bits = Vec::with_capacity(writes.len());
         let t1 = std::time::Instant::now();

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -4,7 +4,7 @@ use crate::architecture::{
     riscv::communication_interface::RiscvCommunicationInterface,
 };
 use crate::probe::{
-    BatchedJtagCommands, DeferredResultSet, JTAGAccess, ProbeCreationError, ScanChainElement,
+    DeferredResultSet, JTAGAccess, JtagCommandQueue, ProbeCreationError, ScanChainElement,
 };
 use crate::{
     DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType, WireProtocol,
@@ -607,7 +607,7 @@ impl JTAGAccess for FtdiProbe {
 
     fn write_register_batch(
         &mut self,
-        writes: &BatchedJtagCommands,
+        writes: &JtagCommandQueue,
     ) -> Result<DeferredResultSet, BatchExecutionError> {
         // this value was determined by experimenting and doesn't match e.g
         // the libftdi read/write chunk size - it is hopefully useful for every setup


### PR DESCRIPTION
This PR implements a bunch of changes designed to transfer as few bits as possible. For one, a JTAG state machine should skip generating a few state transitions in some cases. Additionally, the batch command execution can now follow which results will definitely not be read, and the espusbjtag driver can now skip capturing data bits for those commands.