### PR TITLE
Update esp targets

### DIFF
--- a/changelog/changed-esp-target-update.md
+++ b/changelog/changed-esp-target-update.md
@@ -1,0 +1,1 @@
+Updated ESP32 targets to tune flashing speed

--- a/probe-rs/targets/esp32c2.yaml
+++ b/probe-rs/targets/esp32c2.yaml
@@ -50,24 +50,24 @@ flash_algorithms:
   - name: esp32c2-flashloader
     description: ""
     default: true
-    instructions: N8U4QANFhQYZwQFFgoBBEQbGgUWXQMf/54BAFpdAx//ngEASskBBARHBgoC3xThABUYjhMUGgoAxgRdDx/9nAGMPF0PH/2cA4wwTdzYAAccTBaAKgoCuhrKFNoYXQ8f/ZwDDDQFFgoAAAAAA
+    instructions: QREGxiLEN8Q4QANFpAcJ6YFFl0DH/+eAYBYFRSMNpAYBRbJAIkRBAYKAQYEXQ8f/ZwCDEBdDx/9nAMMNE3c2AAHHEwWgCoKAroayhTaGF0PH/2cAow5BEQbGBUUqxANFgQAFiQHJKACVRZdAx//ngGAOddWyQEEBgoAAAA==
     pc_init: 0x0
-    pc_uninit: 0x64
-    pc_program_page: 0x4a
-    pc_erase_sector: 0x38
-    pc_erase_all: 0x42
-    data_section_offset: 0x4038c06c
+    pc_uninit: 0x56
+    pc_program_page: 0x3c
+    pc_erase_sector: 0x2a
+    pc_erase_all: 0x34
+    data_section_offset: 0x4038C07C
     load_address: 0x4038C000
     flash_properties:
       address_range:
         start: 0x0
-        end: 0x4000000
-      page_size: 0x800
+        end: 0x1000000
+      page_size: 0x4000
       erased_byte_value: 0xff
       program_page_timeout: 1000
       erase_sector_timeout: 2000
       sectors:
-        - size: 0x1000
+        - size: 0x10000
           address: 0x0
     cores:
       - main

--- a/probe-rs/targets/esp32c3.yaml
+++ b/probe-rs/targets/esp32c3.yaml
@@ -1,4 +1,3 @@
----
 name: esp32c3
 manufacturer:
   cc: 0x0C
@@ -56,24 +55,24 @@ flash_algorithms:
   - name: esp32c3-flashloader
     description: A flash loader for the esp32c3.
     default: true
-    instructions: QREGxjcFOUADRQUHGcEBRS2glwDH/+eAoHCBRZcAx//ngIAUlwDH/+eAwBEZ5QFFtwU5QAVGI4jFBrJAQQGCgDGBFwPH/2cAYw4XA8f/ZwBjDRN3NgABxxMFoAqCgK6GsoU2hhcDx/9nAIMMAUWCgAAAAAA=
-    load_address: 0x40390000 # See discussion at https://github.com/probe-rs/probe-rs/pull/1209/#issuecomment-1218430338
-    pc_init: 0
-    pc_uninit: 108
-    pc_program_page: 82
-    pc_erase_sector: 64
-    pc_erase_all: 74
-    data_section_offset: 116
+    instructions: QREGxiLENwQ5QANFJAgJ7ZcAx//ngMBwgUWXAMf/54CgFAVFIwGkCAFFskAiREEBgoBBgRcDx/9nAAMPFwPH/2cAQw4TdzYAAccTBaAKgoCuhrKFNoYXA8f/ZwBjDUERBsYFRSrEA0WBAAWJAckoAJVFlwDH/+eAYAx11bJAQQGCgAAA
+    pc_init: 0x0
+    pc_uninit: 0x5e
+    pc_program_page: 0x44
+    pc_erase_sector: 0x32
+    pc_erase_all: 0x3c
+    data_section_offset: 0x40390084
+    load_address: 0x40390000
     flash_properties:
-      address_range: #16 Mb Max addressable Flash size
+      address_range:
         start: 0x0
         end: 0x1000000
-      page_size: 2048
-      erased_byte_value: 255
+      page_size: 0x4000
+      erased_byte_value: 0xff
       program_page_timeout: 1000
       erase_sector_timeout: 2000
       sectors:
-        - size: 4096
-          address: 0
+        - size: 0x10000
+          address: 0x0
     cores:
       - main

--- a/probe-rs/targets/esp32c6.yaml
+++ b/probe-rs/targets/esp32c6.yaml
@@ -1,4 +1,3 @@
----
 name: esp32c6
 manufacturer:
   cc: 0x0C
@@ -44,22 +43,22 @@ flash_algorithms:
     default: true
     cores:
       - main
-    instructions: QREGxjcFgUCDRUUGAUWF4QFFlwB//+eAoByXAH//54CgExHltwWBQAVGI4LFBrJAQQGCgDGBFwN//2cA4xAXA3//ZwBjDhN3NgABxxMFoAqCgK6GsoU2hhcDf/9nAEMPAUWCgAAAAAA=
-    load_address: 0x40810000
+    instructions: QREGxiLENwSBQANFpAcJ6YFFlwB//+eAoBwFRSMNpAYBRbJAIkRBAYKAQYEXA3//ZwDDERcDf/9nAAMPE3c2AAHHEwWgCoKAroayhTaGFwN//2cA4w9BEQbGBUUqxANFgQAFiQHJKACVRZcAf//ngKAPddWyQEEBgoAAAA==
     pc_init: 0x0
-    pc_uninit: 0x60
-    pc_program_page: 0x46
-    pc_erase_sector: 0x34
-    pc_erase_all: 0x3e
-    data_section_offset: 0x40810068
+    pc_uninit: 0x56
+    pc_program_page: 0x3c
+    pc_erase_sector: 0x2a
+    pc_erase_all: 0x34
+    data_section_offset: 0x4081007C
+    load_address: 0x40810000
     flash_properties:
       address_range:
         start: 0x0
-        end: 0x4000000
-      page_size: 0x800
+        end: 0x1000000
+      page_size: 0x4000
       erased_byte_value: 0xff
       program_page_timeout: 1000
       erase_sector_timeout: 2000
       sectors:
-        - size: 0x1000
+        - size: 0x10000
           address: 0x0

--- a/probe-rs/targets/esp32h2.yaml
+++ b/probe-rs/targets/esp32h2.yaml
@@ -38,26 +38,26 @@ variants:
       - esp32h2-flashloader
 flash_algorithms:
   - name: esp32h2-flashloader
-    description: "A flasher loader for the esp32h2."
+    description: A flasher loader for the esp32h2.
     default: true
-    instructions: QREGxjcFgUADRWUGGcEBRQWggUWXAH//54AAHJcAf//ngAATEeW3BYFABUYjg8UGskBBAYKAMYEXA3//ZwBDEBcDf/9nAMMNE3c2AAHHEwWgCoKAroayhTaGFwN//2cAow4BRYKAAAA=
+    instructions: QREGxiLENwSBQANFpAcJ6YFFlwB//+eAIBwFRSMNpAYBRbJAIkRBAYKAQYEXA3//ZwBDERcDf/9nAIMOE3c2AAHHEwWgCoKAroayhTaGFwN//2cAYw9BEQbGBUUqxANFgQAFiQHJKACVRZcAf//ngCAPddWyQEEBgoAAAA==
     pc_init: 0x0
-    pc_uninit: 0x62
-    pc_program_page: 0x48
-    pc_erase_sector: 0x36
-    pc_erase_all: 0x40
-    data_section_offset: 0x40810068
+    pc_uninit: 0x56
+    pc_program_page: 0x3c
+    pc_erase_sector: 0x2a
+    pc_erase_all: 0x34
+    data_section_offset: 0x4081007C
     load_address: 0x40810000
     flash_properties:
       address_range:
         start: 0x0
-        end: 0x4000000
-      page_size: 0x800
+        end: 0x1000000
+      page_size: 0x4000
       erased_byte_value: 0xff
       program_page_timeout: 1000
       erase_sector_timeout: 2000
       sectors:
-        - size: 0x1000
+        - size: 0x10000
           address: 0x0
     cores:
       - main


### PR DESCRIPTION
Tune flashing algos to use faster block erase and increase the write page size for some gains.

[flash loader changes](https://github.com/esp-rs/esp-flash-loader/pull/7) and [flash size changes](https://github.com/esp-rs/esp-flash-loader/pull/10)