### PR TITLE
Respect timeouts, add `erase_chip_timeout`

### DIFF
--- a/changelog/added-erase-chip-timeout.md
+++ b/changelog/added-erase-chip-timeout.md
@@ -1,0 +1,1 @@
+New target configuration: flasher.erase_chip_timeout

--- a/probe-rs-target/src/flash_properties.rs
+++ b/probe-rs-target/src/flash_properties.rs
@@ -3,6 +3,11 @@ use crate::serialize::{hex_range, hex_u_int};
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
 
+/// The default chip erase timeout in milliseconds.
+pub const fn default_chip_erase_timeout() -> u32 {
+    30000
+}
+
 /// Properties of flash memory, which
 /// are used when programming Flash memory.
 ///
@@ -19,10 +24,13 @@ pub struct FlashProperties {
     /// The value of a byte in flash that was just erased.
     #[serde(serialize_with = "hex_u_int")]
     pub erased_byte_value: u8,
-    /// The approximative time it takes to program a page.
+    /// The approximate time it takes to program a page.
     pub program_page_timeout: u32,
-    /// The approximative time it takes to erase a sector.
+    /// The approximate time it takes to erase a sector.
     pub erase_sector_timeout: u32,
+    /// The approximate time it takes to erase a sector.
+    #[serde(default = "default_chip_erase_timeout")]
+    pub erase_chip_timeout: u32,
     /// The available sectors of the device flash.
     #[serde(default)]
     pub sectors: Vec<SectorDescription>,
@@ -37,6 +45,7 @@ impl Default for FlashProperties {
             erased_byte_value: 0,
             program_page_timeout: 0,
             erase_sector_timeout: 0,
+            erase_chip_timeout: 0,
             sectors: vec![],
         }
     }

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -26,7 +26,7 @@ pub use chip_family::{
     Architecture, ChipFamily, CoreType, InstructionSet, TargetDescriptionSource,
 };
 pub use flash_algorithm::RawFlashAlgorithm;
-pub use flash_properties::FlashProperties;
+pub use flash_properties::{default_chip_erase_timeout, FlashProperties};
 pub use memory::{
     GenericRegion, MemoryRange, MemoryRegion, NvmRegion, PageInfo, RamRegion, SectorDescription,
     SectorInfo,

--- a/probe-rs/src/config/mod.rs
+++ b/probe-rs/src/config/mod.rs
@@ -27,9 +27,9 @@ mod registry;
 mod target;
 
 pub use probe_rs_target::{
-    Chip, ChipFamily, Core, CoreType, FlashProperties, GenericRegion, InstructionSet, MemoryRange,
-    MemoryRegion, NvmRegion, PageInfo, RamRegion, RawFlashAlgorithm, ScanChainElement,
-    SectorDescription, SectorInfo, TargetDescriptionSource,
+    default_chip_erase_timeout, Chip, ChipFamily, Core, CoreType, FlashProperties, GenericRegion,
+    InstructionSet, MemoryRange, MemoryRegion, NvmRegion, PageInfo, RamRegion, RawFlashAlgorithm,
+    ScanChainElement, SectorDescription, SectorInfo, TargetDescriptionSource,
 };
 
 pub use registry::{

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -389,6 +389,7 @@ mod tests {
                 erased_byte_value: 255,
                 program_page_timeout: 200,
                 erase_sector_timeout: 200,
+                erase_chip_timeout: 2000,
                 sectors: vec![sd],
             },
             ..Default::default()
@@ -417,6 +418,7 @@ mod tests {
                 erased_byte_value: 255,
                 program_page_timeout: 200,
                 erase_sector_timeout: 200,
+                erase_chip_timeout: 2000,
                 sectors: vec![sd],
             },
             ..Default::default()

--- a/target-gen/src/parser.rs
+++ b/target-gen/src/parser.rs
@@ -1,6 +1,8 @@
 use crate::flash_device::FlashDevice;
 use anyhow::{anyhow, Context, Result};
-use probe_rs::config::{FlashProperties, RawFlashAlgorithm, SectorDescription};
+use probe_rs::config::{
+    default_chip_erase_timeout, FlashProperties, RawFlashAlgorithm, SectorDescription,
+};
 
 /// Extract a chunk of data from an ELF binary.
 ///
@@ -144,6 +146,7 @@ pub fn extract_flash_algo(
 
         program_page_timeout: flash_device.program_page_timeout,
         erase_sector_timeout: flash_device.erase_sector_timeout,
+        erase_chip_timeout: default_chip_erase_timeout(),
 
         sectors,
     };


### PR DESCRIPTION
I found out that no matter what value I set for `program_page_timeout`, it always times out after 2 seconds. This PR changes the flasher to respect the target configuration. I've also replaced the hard-coded chip erase timeout with a configurable one.

This isn't the nicest thing in the world, though 🙃