### PR TITLE
Transition to JTAG idle when calling flush

### DIFF
--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -439,6 +439,9 @@ impl ProtocolHandler {
     pub fn flush(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
         self.finalize_previous_command()?;
 
+        // Leave the state machine in the Idle state.
+        self.jtag_move_to_state(JtagState::Idle)?;
+
         // Only flush if we have anything to do.
         if !self.output_buffer.is_empty() || self.pending_in_bits != 0 {
             tracing::debug!("Flushing ...");


### PR DESCRIPTION
This ensures we don't leave the JTAG state machine in the DR/IR Update state, which may or may not be important.