### PR TITLE
Flatten the RP2040 memory map.

### DIFF
--- a/changelog/changed-rp2040-flatten.md
+++ b/changelog/changed-rp2040-flatten.md
@@ -1,0 +1,1 @@
+RP2040 memory map changed from three blocks (256K + 4K + 4K) to one block (264K). Allows ELF files to contain sections that go over the boundaries.

--- a/probe-rs/targets/RP2040.yaml
+++ b/probe-rs/targets/RP2040.yaml
@@ -21,22 +21,6 @@ variants:
       - !Ram
           range:
             start: 0x20000000
-            end: 0x20040000
-          is_boot_memory: false
-          cores:
-            - core0
-            - core1
-      - !Ram
-          range:
-            start: 0x20040000
-            end: 0x20041000
-          is_boot_memory: false
-          cores:
-            - core0
-            - core1
-      - !Ram
-          range:
-            start: 0x20041000
             end: 0x20042000
           is_boot_memory: false
           cores:
@@ -96,20 +80,6 @@ variants:
       - !Ram
           range:
             start: 0x20000000
-            end: 0x20040000
-          is_boot_memory: false
-          cores:
-            - core0
-      - !Ram
-          range:
-            start: 0x20040000
-            end: 0x20041000
-          is_boot_memory: false
-          cores:
-            - core0
-      - !Ram
-          range:
-            start: 0x20041000
             end: 0x20042000
           is_boot_memory: false
           cores:


### PR DESCRIPTION
There is absolutely no issue writing from 0x2003FFFF to 0x20040000, so there's no need to arbitrarily divide up the memory and block the use of ELF regions that span across 'blocks'.