### PR TITLE
Transfer words while single-buffer flashing

### DIFF
--- a/changelog/fixed-single-buffer-transfer-speed.md
+++ b/changelog/fixed-single-buffer-transfer-speed.md
@@ -1,0 +1,1 @@
+Flasher: single buffer transfers are now done with u32 writes


### PR DESCRIPTION
This change has a pretty sizeable effect (3-4KB/s -> 20+ KB/s) while flashing an ESP32-C6 with `--disable-double-buffering`