### PR TITLE
Make erase before flashing optional (opt-out) and allow hiding the progress bar

### DIFF
--- a/changelog/added-disable-erase.md
+++ b/changelog/added-disable-erase.md
@@ -1,0 +1,1 @@
+Added option to skip erasing flash before flashing

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -86,6 +86,10 @@ pub struct BinaryDownloadOptions {
     /// download fails during programming with timeout errors, try this option.
     #[arg(long)]
     pub disable_double_buffering: bool,
+    /// Use this flag to disable erasing before flashing. Only use this option if you know
+    /// that the target memory is already erased.
+    #[arg(long)]
+    pub disable_erase: bool,
     /// Enable this flag to restore all bytes erased in the sector erase but not overwritten by any page.
     #[arg(long)]
     pub restore_unwritten: bool,


### PR DESCRIPTION
I'm not sure if this wasn't done because factory programming is usually not done with probe-rs, but hiding the progress bar may not be a terrible idea for download-time interleaved erases :)