### PR TITLE
Make logging to file opt-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,6 +2502,7 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "typed-path",
  "uf2-decode",
@@ -3909,6 +3920,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/changelog/changed-log-to-file-opt-in.md
+++ b/changelog/changed-log-to-file-opt-in.md
@@ -1,0 +1,1 @@
+Logging to file is now off by default. Use `--log-to-folder` or `--log-file` to enable.

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -58,6 +58,7 @@ cli = [
     "dep:terminal_size",
     "dep:termtree",
     "dep:time",
+    "dep:tracing-appender",
     "dep:tracing-subscriber",
     "dep:git-version",
     "dep:serde_json",
@@ -184,6 +185,7 @@ tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",
     "json",
 ], optional = true }
+tracing-appender = { version = "0.2.3", optional = true }
 ratatui = { version = "0.24.0", default-features = false, features = [
     "crossterm",
 ], optional = true }

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -237,10 +237,15 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         // write 1 to the haltreq register, which is part
         // of the dmcontrol register
 
-        tracing::debug!(
-            "Before requesting halt, the Dmcontrol register value was: {:?}",
-            self.interface.read_dm_register::<Dmcontrol>()?
-        );
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            // For some reason inlining this read into the log macro causes it to be printed
+            // even if debug prints are disabled.
+            let dmc = self.interface.read_dm_register::<Dmcontrol>()?;
+            tracing::debug!(
+                "Before requesting halt, the Dmcontrol register value was: {:?}",
+                dmc
+            );
+        }
 
         let mut dmcontrol = Dmcontrol(0);
 

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -40,9 +40,12 @@ const MAX_LOG_FILES: usize = 20;
 struct Cli {
     /// Location for log file
     ///
-    /// If no location is specified, the log file will be stored in a default directory.
+    /// If no location is specified, the behaviour depends on `--log-to-folder`.
     #[clap(long, global = true)]
     log_file: Option<PathBuf>,
+    /// Enable logging to the default folder. This option is ignored if `--log-file` is specified.
+    #[clap(long, global = true)]
+    log_to_folder: bool,
     #[clap(subcommand)]
     subcommand: Subcommand,
 }
@@ -269,8 +272,8 @@ fn main() -> Result<()> {
     }
 
     let log_path = if let Some(location) = matches.log_file {
-        location
-    } else {
+        Some(location)
+    } else if matches.log_to_folder {
         let location =
             default_logfile_location().context("Unable to determine default log file location.")?;
         prune_logs(
@@ -278,21 +281,10 @@ fn main() -> Result<()> {
                 .parent()
                 .expect("A file parent directory. Please report this as a bug."),
         )?;
-        location
+        Some(location)
+    } else {
+        None
     };
-
-    let log_file = File::create(&log_path)?;
-    let (file_appender, _guard) = tracing_appender::non_blocking::NonBlockingBuilder::default()
-        .lossy(false)
-        .buffered_lines_limit(128 * 1024)
-        .finish(log_file);
-
-    let file_subscriber = tracing_subscriber::fmt::layer()
-        .json()
-        .with_file(true)
-        .with_line_number(true)
-        .with_span_events(FmtSpan::FULL)
-        .with_writer(file_appender);
 
     let stdout_subscriber = tracing_subscriber::fmt::layer()
         .compact()
@@ -303,12 +295,38 @@ fn main() -> Result<()> {
                 .from_env_lossy(),
         );
 
-    tracing_subscriber::registry()
-        .with(stdout_subscriber)
-        .with(file_subscriber)
-        .init();
+    let _append_guard = if let Some(ref log_path) = log_path {
+        let log_file = File::create(log_path)?;
 
-    tracing::info!("Writing log to {:?}", log_path);
+        let (file_appender, guard) = tracing_appender::non_blocking::NonBlockingBuilder::default()
+            .lossy(false)
+            .buffered_lines_limit(128 * 1024)
+            .finish(log_file);
+
+        let file_subscriber = tracing_subscriber::fmt::layer()
+            .json()
+            .with_file(true)
+            .with_line_number(true)
+            .with_span_events(FmtSpan::FULL)
+            .with_writer(file_appender);
+
+        tracing_subscriber::registry()
+            .with(stdout_subscriber)
+            .with(file_subscriber)
+            .init();
+
+        Some(guard)
+    } else {
+        tracing_subscriber::registry()
+            .with(stdout_subscriber)
+            .init();
+
+        None
+    };
+
+    if let Some(ref log_path) = log_path {
+        tracing::info!("Writing log to {:?}", log_path);
+    }
 
     let result = match matches.subcommand {
         Subcommand::DapServer { .. } => unreachable!(), // handled above.
@@ -330,7 +348,9 @@ fn main() -> Result<()> {
         Subcommand::Write(cmd) => cmd.run(&lister),
     };
 
-    tracing::info!("Wrote log to {:?}", log_path);
+    if let Some(ref log_path) = log_path {
+        tracing::info!("Wrote log to {:?}", log_path);
+    }
 
     result
 }

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -282,13 +282,17 @@ fn main() -> Result<()> {
     };
 
     let log_file = File::create(&log_path)?;
+    let (file_appender, _guard) = tracing_appender::non_blocking::NonBlockingBuilder::default()
+        .lossy(false)
+        .buffered_lines_limit(128 * 1024)
+        .finish(log_file);
 
     let file_subscriber = tracing_subscriber::fmt::layer()
         .json()
         .with_file(true)
         .with_line_number(true)
         .with_span_events(FmtSpan::FULL)
-        .with_writer(log_file);
+        .with_writer(file_appender);
 
     let stdout_subscriber = tracing_subscriber::fmt::layer()
         .compact()


### PR DESCRIPTION
This PR turns of file logging by default. It is slow, generates extreme amounts of data and apparently rarely used. Logging to file can now be enabled by two ways:
 - by providing the `--log-file <some path>` switch
 - or by setting `--log-to-folder` (name pending, feel free to suggest a better one!) in which case the logs are generated into the previously default folder.

If logging to file is used, probe-rs now uses [`tracing_appender::non_blocking`](https://docs.rs/tracing-appender/latest/tracing_appender/non_blocking/struct.NonBlocking.html) to avoid waiting on file IO if possible.