### PR TITLE
Fill last word with empty bytes

### DIFF
--- a/changelog/fixed-flash-loader-not-loading-last-word.md
+++ b/changelog/fixed-flash-loader-not-loading-last-word.md
@@ -1,0 +1,1 @@
+Flash loader will now properly flash all bytes


### PR DESCRIPTION
This isn't a bug... yet, but the miniz encoder introduced in #1947 does not pad it's output. Instead of requiring this for each future algorithm, I thought we might simply pad the last word right before download if we need to.