### PR TITLE
Xtensa: Implement cache flushing

### DIFF
--- a/probe-rs/src/architecture/xtensa/arch/mod.rs
+++ b/probe-rs/src/architecture/xtensa/arch/mod.rs
@@ -139,3 +139,36 @@ impl SpecialRegister {
         self as u8
     }
 }
+
+pub struct CacheConfig {
+    pub line_size: u32,
+    pub size: u32,
+    pub way_count: u8,
+    pub regions: Vec<Range<u32>>,
+}
+
+impl CacheConfig {
+    /// Returns if the given address is covered by the cache.
+    pub fn contains(&self, address: u32) -> bool {
+        self.regions.iter().any(|r| r.contains(&address))
+    }
+}
+
+pub struct ChipConfig {
+    /// IRAM, IROM, SRAM, SROM
+    pub icache: CacheConfig,
+
+    /// DRAM, DROM, SRAM, SROM
+    pub dcache: CacheConfig,
+}
+
+impl CacheConfig {
+    pub const fn not_present() -> Self {
+        Self {
+            line_size: 0,
+            size: 0,
+            way_count: 1,
+            regions: vec![],
+        }
+    }
+}


### PR DESCRIPTION
Just putting it here so I won't forget what this branch is for...

ESP32 Xtensas don't use the Xtensa cache but others do, e.g. https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/i-mx-rt-crossover-mcus/i-mx-rt600-crossover-mcu-with-arm-cortex-m33-and-dsp-cores:i.MX-RT600 and we may or may not want to support that in probe-rs in the future.