### PR TITLE
Allow specifying a chip via environment variable

### DIFF
--- a/changelog/added-specifying-a-chip-via-environment-variable.md
+++ b/changelog/added-specifying-a-chip-via-environment-variable.md
@@ -1,0 +1,1 @@
+Allow specifying a chip via environment variable

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -144,7 +144,7 @@ bytesize = { version = "1", optional = true }
 capstone = { version = "0.11.0", optional = true }
 cargo_metadata = { version = "0.18.1", optional = true }
 cargo_toml = { version = "0.17.2", optional = true }
-clap = { version = "4.4", features = ["derive"], optional = true }
+clap = { version = "4.4", features = ["derive", "env"], optional = true }
 colored = { version = "2.1.0", optional = true }
 crossterm = { version = "<= 0.27.0", optional = true }
 defmt-decoder = { version = "0.3.9", features = ["unstable"], optional = true }

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -123,7 +123,7 @@ pub struct ReadWriteOptions {
 /// Common options and logic when interfacing with a [Probe].
 #[derive(clap::Parser, Debug)]
 pub struct ProbeOptions {
-    #[arg(long)]
+    #[arg(long, env = "PROBE_RS_CHIP")]
     pub chip: Option<String>,
     #[arg(value_name = "chip description file path", long)]
     pub chip_description_path: Option<PathBuf>,


### PR DESCRIPTION
Pretty minor change, but this solves a problem for me when using in conjunction with `embedded-test` :)

Wasn't totally sure on the env var naming, considered `PROBERS_CHIP` as well, or maybe something else would be better. Regardless, happy to change it.

Also wasn't sure whether or not any other options would benefit from this, but I'm happy to add more if requested.