### PR TITLE
RISCV ESP Reset sequences and `--connect-under-reset` support

### DIFF
--- a/changelog/changed-ensure-core-halted-during-setup.md
+++ b/changelog/changed-ensure-core-halted-during-setup.md
@@ -1,0 +1,1 @@
+Ensure then when executing setup commands and sequences that the core is halted.

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -1008,7 +1008,7 @@ impl RiscvCommunicationInterface {
     }
 
     /// Memory write using system bus
-    fn perform_memory_write_sysbus<V: RiscvValue>(
+    pub (crate) fn perform_memory_write_sysbus<V: RiscvValue>(
         &mut self,
         address: u32,
         data: &[V],

--- a/probe-rs/src/architecture/riscv/sequences.rs
+++ b/probe-rs/src/architecture/riscv/sequences.rs
@@ -13,6 +13,10 @@ pub trait RiscvDebugSequence: Send + Sync + Debug {
         Ok(())
     }
 
+    fn reset(&self, _interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+        Ok(())
+    }
+
     /// Detects the flash size of the target.
     fn detect_flash_size(
         &self,

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -239,7 +239,7 @@ impl LoadedProbeOptions {
     /// Attaches to specified probe and configures it.
     pub fn attach_probe(&self, lister: &Lister) -> Result<Probe, OperationError> {
         let mut probe = if self.0.dry_run {
-            Probe::from_specific_probe(Box::new(FakeProbe::new()))
+            Probe::from_specific_probe(Box::new(FakeProbe::with_mocked_core()))
         } else {
             // If we got a probe selector as an argument, open the probe
             // matching the selector if possible.

--- a/probe-rs/src/config/sequences/esp32c3.rs
+++ b/probe-rs/src/config/sequences/esp32c3.rs
@@ -65,4 +65,13 @@ impl RiscvDebugSequence for ESP32C3 {
     ) -> Result<Option<usize>, crate::Error> {
         self.inner.detect_flash_size_riscv(interface)
     }
+
+    fn reset(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+        tracing::info!("SoC Reset...");
+        // trigger a full SoC reset which resets all domains execept the RTC domain
+        interface.write_word_32(0x60008000, 0x9c00a000)?;
+        interface.write_word_32(0x6001F068, 0)?;
+        Ok(())
+    }
+    
 }

--- a/probe-rs/src/config/sequences/esp32c6.rs
+++ b/probe-rs/src/config/sequences/esp32c6.rs
@@ -72,14 +72,14 @@ impl RiscvDebugSequence for ESP32C6 {
         // interface.write_word_32(0x600b1034, 0x80000000)?;
         // interface.write_word_32(0x600b1038, 0x10000000)?;
 
-        interface.perform_memory_write_sysbus(0x600b1034, &[0x80000000u32])?;
-        interface.perform_memory_write_sysbus(0x600b1038, &[0x10000000u32])?;
+        // interface.perform_memory_write_sysbus(0x600b1034, &[0x80000000u32])?;
+        // interface.perform_memory_write_sysbus(0x600b1038, &[0x10000000u32])?;
 
-        use crate::architecture::riscv::Dmcontrol;
+        // use crate::architecture::riscv::Dmcontrol;
 
-        let mut dmcontrol = Dmcontrol(0);
-        dmcontrol.set_dmactive(false);
-        interface.write_dm_register(dmcontrol)?;
+        // let mut dmcontrol = Dmcontrol(0);
+        // dmcontrol.set_dmactive(false);
+        // interface.write_dm_register(dmcontrol)?;
 
         Ok(())
     }

--- a/probe-rs/src/config/sequences/esp32c6.rs
+++ b/probe-rs/src/config/sequences/esp32c6.rs
@@ -65,4 +65,22 @@ impl RiscvDebugSequence for ESP32C6 {
     ) -> Result<Option<usize>, crate::Error> {
         self.inner.detect_flash_size_riscv(interface)
     }
+
+    fn reset(&self, interface: &mut RiscvCommunicationInterface) -> Result<(), crate::Error> {
+        tracing::info!("SoC Reset...");
+        // trigger a full SoC reset which resets all domains execept the RTC domain
+        // interface.write_word_32(0x600b1034, 0x80000000)?;
+        // interface.write_word_32(0x600b1038, 0x10000000)?;
+
+        interface.perform_memory_write_sysbus(0x600b1034, &[0x80000000u32])?;
+        interface.perform_memory_write_sysbus(0x600b1038, &[0x10000000u32])?;
+
+        use crate::architecture::riscv::Dmcontrol;
+
+        let mut dmcontrol = Dmcontrol(0);
+        dmcontrol.set_dmactive(false);
+        interface.write_dm_register(dmcontrol)?;
+
+        Ok(())
+    }
 }

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -716,6 +716,10 @@ impl<'probe> Core<'probe> {
         self.inner.reset_catch_clear()
     }
 
+    pub(crate) fn reset_catch_set(&mut self) -> Result<(), Error> {
+        self.inner.reset_catch_set()
+    }
+
     pub(crate) fn debug_core_stop(&mut self) -> Result<(), Error> {
         self.inner.debug_core_stop()
     }
@@ -880,7 +884,7 @@ impl<'probe> CoreInterface for Core<'probe> {
     }
 
     fn reset_catch_set(&mut self) -> Result<(), Error> {
-        todo!()
+        self.reset_catch_set()
     }
 
     fn reset_catch_clear(&mut self) -> Result<(), Error> {

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -614,7 +614,7 @@ mod test {
 
     #[test]
     fn create_session_with_fake_probe() {
-        let fake_probe = FakeProbe::new();
+        let fake_probe = FakeProbe::with_mocked_core();
 
         let probe = fake_probe.into_probe();
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -336,14 +336,9 @@ impl Session {
             configured_trace_sink: None,
         };
 
-        {
-            // Todo: Add multicore support. How to deal with any cores that are not active and won't respond?
-            let mut core = session.core(0)?;
-
-            core.halt(Duration::from_millis(100))?;
-        }
-
-        sequence_handle.on_connect(session.get_xtensa_interface()?)?;
+        session.halted_access(|sess| {
+            sequence_handle.on_connect(sess.get_xtensa_interface()?)
+        })?;
 
         Ok(session)
     }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -688,10 +688,7 @@ static_assertions::assert_impl_all!(Session: Send);
 impl Drop for Session {
     #[tracing::instrument(name = "session_drop", skip(self))]
     fn drop(&mut self) {
-        if let Err(err) = { 0..self.cores.len() }.try_for_each(|i| {
-            self.core(i)
-                .and_then(|mut core| core.clear_all_hw_breakpoints())
-        }) {
+        if let Err(err) = self.clear_all_hw_breakpoints() {
             tracing::warn!(
                 "Could not clear all hardware breakpoints: {:?}",
                 anyhow!(err)

--- a/probe-rs/tests/flash_dry_run.rs
+++ b/probe-rs/tests/flash_dry_run.rs
@@ -3,7 +3,7 @@ use probe_rs::{flashing::DownloadOptions, integration::FakeProbe, probe::Probe, 
 /// A chip where the flash algorithm's range is greater than the NVM range.
 #[test]
 fn flash_dry_run_stm32wb55ccux() {
-    let probe = Probe::from_specific_probe(Box::new(FakeProbe::new()));
+    let probe = Probe::from_specific_probe(Box::new(FakeProbe::with_mocked_core()));
 
     let mut session = probe
         .attach("stm32wb55ccux", Permissions::default())
@@ -27,7 +27,7 @@ fn flash_dry_run_stm32wb55ccux() {
 /// A chip where the flash algorithm's range could be less than the NVM range.
 #[test]
 fn flash_dry_run_mimxrt1010() {
-    let probe = Probe::from_specific_probe(Box::new(FakeProbe::new()));
+    let probe = Probe::from_specific_probe(Box::new(FakeProbe::with_mocked_core()));
 
     let mut session = probe
         .attach("mimxrt1010", Permissions::default())


### PR DESCRIPTION
A different attempt to solve #1963 and other related issues, mainly https://github.com/esp-rs/esp-wifi/issues/380 on my end. The idea is based on this openocd config file: https://github.com/espressif/openocd-esp32/blob/ce96f2fa3e495a6734fa809fa8fc9d8d70c6ef19/tcl/target/esp32c3.cfg#L53.

Doesn't currently work. For some reason, this breaks the flashing process (at some point during stub upload the USB device times outs), but attach works correctly.