### PR TITLE
Xtensa: Batch up some transfers

### DIFF
--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -950,6 +950,13 @@ impl CommandResult {
             _ => panic!("CommandResult is not a u32"),
         }
     }
+
+    pub fn as_u8(&self) -> u8 {
+        match self {
+            CommandResult::U8(val) => *val,
+            _ => panic!("CommandResult is not a u8"),
+        }
+    }
 }
 
 /// A set of batched commands that will be executed all at once.


### PR DESCRIPTION
The current interface is very slow as it doesn't use any batching. This probably won't change until we actually have something working, but this change at least does the register reads/writes in one step. I see a more than 2x speedup which is helpful even in this early stage.