### PR TITLE
Deduplicate FlashLoader data loading

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/download.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/download.rs
@@ -1,13 +1,10 @@
-use std::fs::File;
 use std::path::Path;
 
-use anyhow::Context;
-use probe_rs::flashing::FileDownloadError;
-use probe_rs::flashing::Format;
 use probe_rs::Lister;
 
 use crate::util::common_options::BinaryDownloadOptions;
 use crate::util::common_options::ProbeOptions;
+use crate::util::flash::build_loader;
 use crate::util::flash::run_flash_download;
 use crate::FormatOptions;
 
@@ -34,22 +31,7 @@ impl Cmd {
     pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, probe_options) = self.probe_options.simple_attach(lister)?;
 
-        let mut file = match File::open(&self.path) {
-            Ok(file) => file,
-            Err(e) => return Err(FileDownloadError::IO(e)).context("Failed to open binary file."),
-        };
-
-        let mut loader = session.target().flash_loader();
-
-        let format = self.format_options.into_format(session.target())?;
-        match format {
-            Format::Bin(options) => loader.load_bin_data(&mut file, options),
-            Format::Elf => loader.load_elf_data(&mut file),
-            Format::Hex => loader.load_hex_data(&mut file),
-            Format::Idf(options) => loader.load_idf_data(&mut session, &mut file, options),
-            Format::Uf2 => loader.load_uf2_data(&mut file),
-        }?;
-
+        let loader = build_loader(&mut session, &self.path, self.format_options)?;
         run_flash_download(
             &mut session,
             Path::new(&self.path),

--- a/probe-rs/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs/src/bin/probe-rs/util/flash.rs
@@ -170,7 +170,7 @@ pub fn run_flash_download(
 /// flashed etc.
 pub fn build_loader(
     session: &mut Session,
-    path: &Path,
+    path: impl AsRef<Path>,
     format_options: FormatOptions,
 ) -> anyhow::Result<FlashLoader> {
     // Create the flash loader

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -102,7 +102,6 @@ pub enum FileDownloadError {
 
 /// Options for downloading a file onto a target chip.
 ///
-///
 /// This struct should be created using the [`DownloadOptions::default()`] function, and can be configured by setting
 /// the fields directly:
 ///
@@ -171,10 +170,7 @@ pub fn download_file_with_options<P: AsRef<Path>>(
     format: Format,
     options: DownloadOptions,
 ) -> Result<(), FileDownloadError> {
-    let mut file = match File::open(path.as_ref()) {
-        Ok(file) => file,
-        Err(e) => return Err(FileDownloadError::IO(e)),
-    };
+    let mut file = File::open(path.as_ref()).map_err(FileDownloadError::IO)?;
 
     let mut loader = session.target().flash_loader();
 


### PR DESCRIPTION
This PR cleans up a bunch of duplicate flash data loading. Not everything - cargo-embed and libraries using `download_file_with_options` aren't affected because `FlashOptions` is internal to the probe-rs binary crate.