### PR TITLE
Clean up some places

### DIFF
--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -777,7 +777,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
             self.memory.flush()?;
         }
 
-        // Exit halt state ..
+        // Exit halt state...
         dhcsr.set_c_step(false);
         dhcsr.set_c_halt(false);
         dhcsr.enable_write();
@@ -927,7 +927,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
         { 0..num_hw_breakpoints }.try_for_each(|bp_unit_index| {
             let raw_val = self.memory.read_word_32(FpCtrl::get_mmio_address())?;
             let ctrl_reg = FpCtrl::from(raw_val);
-            // FpRev1 and FpRev2 needs different decoding of the register value, but the location where we read from is the same ...
+            // FpRev1 and FpRev2 needs different decoding of the register value, but the location where we read from is the same...
             let reg_addr = FpRev1CompX::get_mmio_address() + (bp_unit_index * size_of::<u32>()) as u64;
             // The raw breakpoint address as read from memory.
             let register_value = self.memory.read_word_32(reg_addr)?;

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -23,11 +23,13 @@ pub enum DebugPortError {
         /// The version of the operated debug port.
         version: DebugPortVersion,
     },
+
     /// Error parsing a register value.
-    #[error("Error parsing register value.")]
+    #[error("Error parsing register value: {0}")]
     RegisterParse(#[from] RegisterParseError),
+
     /// An error with operating the debug probe occurred.
-    #[error("A Debug Probe Error occurred")]
+    #[error("A Debug Probe Error: {0}")]
     DebugProbe(#[from] DebugProbeError),
 
     /// A timeout occurred.
@@ -43,9 +45,10 @@ pub enum DebugPortError {
     Unsupported(String),
 
     /// An error occurred in the communication with an access port or debug port.
-    #[error("An error occurred in the communication with an access port or debug port.")]
+    #[error("An error occurred in the communication with an access port or debug port: {0}")]
     Dap(#[from] DapError),
 }
+
 /// A typed interface to be implemented on drivers that can control a debug port.
 pub trait DpAccess {
     /// Reads a debug port register.

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -1,8 +1,7 @@
 //! Debug Module Communication
 //!
-//! This module implements communication with a
-//! Debug Module, as described in the RISC-V debug
-//! specification v0.13.2 .
+//! This module implements communication with a Debug Module, as described in the RISC-V debug
+//! specification v0.13.2.
 
 use super::{
     dtm::{DmiOperation, DmiOperationStatus, Dtm},
@@ -28,7 +27,7 @@ pub enum RiscvError {
     #[error("Error during read/write to the DMI register: {0:?}")]
     DmiTransfer(DmiOperationStatus),
     /// An error with operating the debug probe occurred.
-    #[error("Debug Probe Error")]
+    #[error("Debug Probe Error: {0}")]
     DebugProbe(#[from] DebugProbeError),
     /// A timeout occurred during JTAG register access.
     #[error("Timeout during JTAG register access.")]

--- a/probe-rs/src/bin/probe-rs/util/mod.rs
+++ b/probe-rs/src/bin/probe-rs/util/mod.rs
@@ -31,7 +31,7 @@ pub enum ArtifactError {
     },
     #[error("An IO error occurred during the execution of 'cargo build'.")]
     Io(#[source] std::io::Error),
-    #[error("Failed to run cargo build: exit code = {0:?}.")]
+    #[error("Failed to run cargo build: exit code = {0:?}")]
     CargoBuild(Option<i32>),
     #[error("Multiple binary artifacts were found.")]
     MultipleArtifacts,

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -70,20 +70,24 @@ pub enum DebugError {
     #[error(transparent)]
     IntConversion(#[from] std::num::TryFromIntError),
     /// Errors encountered while determining valid halt locations for breakpoints and stepping.
-    /// These are distinct from other errors because they terminate the current step, and result in a user message, but they do not interrupt the rest of the debug session.
-    #[error("{message}  @program_counter={:#010X}.", pc_at_error)]
+    /// These are distinct from other errors because they terminate the current step, and result in
+    /// a user message, but they do not interrupt the rest of the debug session.
+    #[error("{message}  @program_counter={:#010X}", pc_at_error)]
     NoValidHaltLocation {
         /// A message that can be displayed to the user to help them make an informed recovery choice.
         message: String,
         /// The value of the program counter for which a halt was requested.
         pc_at_error: u64,
     },
-    /// Non-terminal Errors encountered while unwinding the stack, e.g. Could not resolve the value of a variable in the stack.
+    /// Non-terminal Errors encountered while unwinding the stack, e.g. Could not resolve the value
+    /// of a variable in the stack.
     /// These are distinct from other errors because they do not interrupt processing.
-    /// Instead, the cause of incomplete results are reported back/explained to the user, and the stack continues to unwind.
+    /// Instead, the cause of incomplete results are reported back/explained to the user, and the
+    /// stack continues to unwind.
     #[error("{message}")]
     UnwindIncompleteResults {
-        /// A message that can be displayed to the user to help them understand the reason for the incomplete results.
+        /// A message that can be displayed to the user to help them understand the reason for the
+        /// incomplete results.
         message: String,
     },
     /// Some other error occurred.

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -1881,7 +1881,7 @@ fn provide_register(
         }
         None => {
             return Err(DebugError::UnwindIncompleteResults {
-                    message: format!("Error while calculating `Variable::memory_location`. No value for register #:{}.",
+                    message: format!("Error while calculating `Variable::memory_location`. No value for register #: {}.",
                     register.0
                 )});
         }
@@ -1906,7 +1906,7 @@ fn provide_frame_base(
         Ok(evaluation_result) => evaluation_result,
         Err(error) => {
             return Err(DebugError::UnwindIncompleteResults {
-                message: format!("Error while calculating `Variable::memory_location`:{error}."),
+                message: format!("Error while calculating `Variable::memory_location`: {error}"),
             })
         }
     })

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -10,16 +10,16 @@ use crate::DebugProbeError;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     /// An error in the probe driver occurred.
-    #[error("An error with the usage of the probe occurred")]
+    #[error("An error with the usage of the probe occurred: {0}")]
     Probe(#[from] DebugProbeError),
     /// An ARM specific error occurred.
-    #[error("An ARM specific error occurred.")]
+    #[error("An ARM specific error occurred: {0}")]
     Arm(#[source] ArmError),
     /// A RISC-V specific error occurred.
-    #[error("A RISC-V specific error occurred.")]
+    #[error("A RISC-V specific error occurred: {0}")]
     Riscv(#[source] RiscvError),
     /// An Xtensa specific error occurred.
-    #[error("An Xtensa specific error occurred.")]
+    #[error("An Xtensa specific error occurred: {0}")]
     Xtensa(#[source] XtensaError),
     /// The probe could not be opened.
     #[error("Probe could not be opened: {0}")]
@@ -28,7 +28,7 @@ pub enum Error {
     #[error("Core {0} does not exist")]
     CoreNotFound(usize),
     /// The given chip does not exist.
-    #[error("Unable to load specification for chip")]
+    #[error("Unable to load specification for chip: {0}")]
     ChipNotFound(#[from] RegistryError),
     /// An operation was not performed because the required permissions were not given.
     ///
@@ -37,9 +37,9 @@ pub enum Error {
     #[error("An operation could not be performed because it lacked the permission to do so: {0}")]
     MissingPermissions(String),
     /// An error that is not architecture specific occurred.
-    #[error("A generic core (not architecture specific) error occurred.")]
+    #[error("A generic core (not architecture specific) error occurred: {0}")]
     GenericCoreError(String),
-    /// Errors related to the handling of core registers inside probe-rs .
+    /// Errors related to the handling of core registers inside probe-rs.
     #[error("Register error: {0}")]
     Register(String),
     /// The variant of the function you called is not yet implemented.

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -73,25 +73,25 @@ pub enum FileDownloadError {
     /// An error with the actual flashing procedure has occurred.
     ///
     /// This is mostly an error in the communication with the target inflicted by a bad hardware connection or a probe-rs bug.
-    #[error("Error while flashing")]
+    #[error("Error while flashing: {0}")]
     Flash(#[from] FlashError),
     /// Reading and decoding the IHEX file has failed due to the given error.
-    #[error("Could not read ihex format")]
+    #[error("Could not read ihex format: {0}")]
     IhexRead(#[from] ihex::ReaderError),
     /// An IO error has occurred while reading the firmware file.
-    #[error("I/O error")]
+    #[error("I/O error: {0}")]
     IO(#[from] std::io::Error),
     /// The given error has occurred while reading the object file.
-    #[error("Object Error: {0}.")]
+    #[error("Object Error: {0}")]
     Object(&'static str),
     /// Reading and decoding the given ELF file has resulted in the given error.
-    #[error("Could not read ELF file")]
+    #[error("Could not read ELF file: {0}")]
     Elf(#[from] object::read::Error),
     /// Espflash format error
-    #[error("Failed to format as esp-idf binary")]
+    #[error("Failed to format as esp-idf binary: {0}")]
     Idf(#[from] espflash::error::Error),
     /// The target doesn't support the esp-idf format
-    #[error("Target {0} does not support the esp-idf format")]
+    #[error("Target {0} does not support the esp-idf format.")]
     IdfUnsupported(String),
     /// No loadable segments were found in the ELF file.
     ///

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 pub enum FlashError {
     /// No flash memory contains the entire requested memory range.
     #[error(
-        "No flash memory contains the entire requested memory range {start:#010x}..{end:#010x}."
+        "No flash memory contains the entire requested memory range {start:#010x}..{end:#010x}"
     )]
     NoSuitableNvm {
         /// The start of the requested memory range.
@@ -24,7 +24,7 @@ pub enum FlashError {
         source: Box<dyn std::error::Error + 'static + Send + Sync>,
     },
     /// Erasing the given flash sector failed.
-    #[error("Failed to erase flash sector at address {sector_address:#010x}.")]
+    #[error("Failed to erase flash sector at address {sector_address:#010x}")]
     EraseFailed {
         /// The address of the sector that should have been erased.
         sector_address: u64,
@@ -59,7 +59,7 @@ pub enum FlashError {
         error_code: u32,
     },
     /// The core entered an unexpected status while executing a flashing operation.
-    #[error("The core entered an unexpected status: {status:?}.")]
+    #[error("The core entered an unexpected status: {status:?}")]
     UnexpectedCoreStatus {
         /// The status that the core entered.
         status: crate::CoreStatus,
@@ -100,19 +100,19 @@ pub enum FlashError {
     // TODO: 1 Add information about flash (name, address)
     // TODO: 2 Add source of target definition (built-in, yaml)
     /// No flash algorithm was linked to this target.
-    #[error("Trying to write flash, but no suitable (default) flash loader algorithm is linked to the given target: {name} .")]
+    #[error("Trying to write flash, but no suitable (default) flash loader algorithm is linked to the given target: {name}")]
     NoFlashLoaderAlgorithmAttached {
         /// The name of the chip.
         name: String,
     },
     /// More than one matching flash algorithm was found for the given memory range and all of them is marked as default.
-    #[error("Trying to write flash, but found more than one suitable flash loader algorithim marked as default for {region:?}.")]
+    #[error("Trying to write flash, but found more than one suitable flash loader algorithim marked as default for {region:?}")]
     MultipleDefaultFlashLoaderAlgorithms {
         /// The region which matched more than one flash algorithm.
         region: NvmRegion,
     },
     /// More than one matching flash algorithm was found for the given memory range and none of them is marked as default.
-    #[error("Trying to write flash, but found more than one suitable flash algorithims but none marked as default for {region:?}.")]
+    #[error("Trying to write flash, but found more than one suitable flash algorithims but none marked as default for {region:?}")]
     MultipleFlashLoaderAlgorithmsNoDefault {
         /// The region which matched more than one flash algorithm.
         region: NvmRegion,
@@ -141,7 +141,7 @@ pub enum FlashError {
     /// Two blocks of data overlap each other which means the loaded binary is broken.
     ///
     /// Please check your data and try again.
-    #[error("Adding data for addresses {added_addresses:08X?} overlaps previously added data for addresses {existing_addresses:08X?}.")]
+    #[error("Adding data for addresses {added_addresses:08X?} overlaps previously added data for addresses {existing_addresses:08X?}")]
     DataOverlaps {
         /// The address range that was tried to be added.
         added_addresses: Range<u64>,
@@ -149,10 +149,10 @@ pub enum FlashError {
         existing_addresses: Range<u64>,
     },
     /// No core can access this NVM region.
-    #[error("No core can access the NVM region {0:?}.")]
+    #[error("No core can access the NVM region {0:?}")]
     NoNvmCoreAccess(NvmRegion),
     /// No core can access this RAM region.
-    #[error("No core can access the ram region {0:?}.")]
+    #[error("No core can access the ram region {0:?}")]
     NoRamCoreAccess(RamRegion),
     /// The register value supplied for this flash algorithm is out of the supported range.
     #[error("The register value {0:08X?} is out of the supported range.")]

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -75,7 +75,7 @@ use std::ops::Range;
 ///
 /// 2. **Scenario: Failure to detect RTT Control Block** The target has been configured correctly, BUT the host creates this interface BEFORE
 /// the target program has initialized RTT.
-///     * This most commonly occurs when the target halts processing before initializing RTT. For example, this could happen ...
+///     * This most commonly occurs when the target halts processing before initializing RTT. For example, this could happen...
 ///         * During debugging, if the user sets a breakpoint in the code before the RTT initialization.
 ///         * After flashing, if the user has configured `probe-rs` to `reset_after_flashing` AND `halt_after_reset`. On most targets, this
 /// will result in the target halting with reason `Exception` and will delay the subsequent RTT initialization.


### PR DESCRIPTION
The main motivator of this PR is removing the periods from the end of nested error messages: if the inner error already ends with a period, the result currently includes a bunch of periods which may look weird(er than just omitting).