### PR TITLE
Add target file for OpenTitan Earl Grey

### DIFF
--- a/changelog/added-opentitan-target.md
+++ b/changelog/added-opentitan-target.md
@@ -1,0 +1,1 @@
+Add OpenTitan target file with description of the Earl Grey chip.

--- a/probe-rs/targets/OpenTitan.yaml
+++ b/probe-rs/targets/OpenTitan.yaml
@@ -1,0 +1,44 @@
+name: OpenTitan
+manufacturer: null
+variants:
+  - name: earlgrey
+    cores:
+      - name: ibex
+        type: riscv
+        core_access_options:
+          !Riscv {}
+    memory_map:
+      - !Nvm
+          name: ROM
+          range:
+            start: 0x00008000
+            end: 0x00010000
+          is_boot_memory: true
+          cores:
+            - ibex
+      - !Nvm
+          name: Flash
+          range:
+            start: 0x20000000
+            end: 0x20100000
+          is_boot_memory: false
+          cores:
+            - ibex
+      - !Ram
+          name: AON Retention SRAM
+          range:
+            start: 0x40600000
+            end: 0x40601000
+          is_boot_memory: false
+          cores:
+            - ibex
+      - !Ram
+          name: Main SRAM
+          range:
+            start: 0x10000000
+            end: 0x10020000
+          is_boot_memory: false
+          cores:
+            - ibex
+    flash_algorithms: []
+flash_algorithms: []


### PR DESCRIPTION
OpenTitan is an open source root of trust project. The discrete chip (Earl Grey) is now frozen and has a RISC-V debug module. 

This commit does not include a flash algorithm which will need writing from scratch.

The memory map addresses and sizes of the four memory regions can be found [this design doc](https://opentitan.org/book/hw/top_earlgrey/doc/design/index.html#memory-map) and [in the datasheet](https://opentitan.org/book/hw/top_earlgrey/doc/specification.html) respectively:

|                   memory | size    | start        |
|-------------------------:|---------|--------------|
|                      ROM | 32kiB   | `0x00008000` |
|                    Flash | 1024kiB | `0x20000000` |
|                Main SRAM | 128kiB  | `0x10000000` |
| Always-on retention SRAM | 4kiB    | `0x40600000` |

The fifth memory mentioned (OTP) is one-time programmable fuses that aren't memory mapped.

I've tested halting and resuming on an FPGA, and also checked reading from the ROM and the flash. I didn't check reading from the SRAMs because it was a little hard to check the data was correct - I couldn't get GDB started with the debug probe I'm using.

I also haven't assigned a JEDEC manufacturer ID - lowRISC has ID `0xEF` in bank 13 ([from the RTL here](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/rtl/jtag_id_pkg.sv#L8)) that we use for open source builds of the chip, but anybody could manufacture the chip and change this value so I haven't used it.