### PR TITLE
Xtensa: fixes

### DIFF
--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -230,10 +230,7 @@ impl XtensaCommunicationInterface {
         // Force a low INTLEVEL to allow halting on debug exceptions
         // TODO: do this only if we set a breakpoint or watchpoint or single step
         let mut ps = self.read_register::<ProgramStatus>()?;
-
-        ps.set_excm(false);
-        ps.set_intlevel(0);
-
+        ps.set_intlevel(1);
         self.write_register(ps)?;
 
         Ok(())
@@ -856,25 +853,25 @@ bitfield::bitfield! {
     impl Debug;
 
     /// Interrupt level disable
-    pub intlevel,  set_intlevel : 4, 0;
+    pub intlevel,  set_intlevel : 3, 0;
 
     /// Exception mode
-    pub excm,      set_excm     : 5;
+    pub excm,      set_excm     : 4;
 
     /// User mode
-    pub user_mode, set_user_mode: 6;
+    pub user_mode, set_user_mode: 5;
 
     /// Privilege level (when using the MMU option)
-    pub ring,      set_ring     : 8, 7;
+    pub ring,      set_ring     : 7, 6;
 
     /// Old window base
-    pub owb,       set_owb      : 12, 9;
+    pub owb,       set_owb      : 11, 8;
 
     /// Call increment
-    pub callinc,   set_callinc  : 14, 13;
+    pub callinc,   set_callinc  : 17, 16;
 
     /// Window overflow-detection enable
-    pub woe,       set_woe      : 15;
+    pub woe,       set_woe      : 18;
 }
 u32_register!(ProgramStatus, Register::CurrentPs);
 


### PR DESCRIPTION
 - Make sure the core is halted when accessing memory. Trying to execute instructions while running means the instructions get ignored.
 - Fix the bitfields of PS.