### PR TITLE
Add configurable idle TDI level, add ESP32

### DIFF
--- a/changelog/added-idle-tdi.md
+++ b/changelog/added-idle-tdi.md
@@ -1,0 +1,1 @@
+Added option to specify level of TDI when in the IDLE state

--- a/changelog/added-jtag-access.md
+++ b/changelog/added-jtag-access.md
@@ -1,0 +1,1 @@
+`JTAGAccess` is now publicly available

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -73,6 +73,8 @@ pub struct Chip {
     pub scan_chain: Option<Vec<ScanChainElement>>,
     /// The default binary format for this chip
     pub default_binary_format: Option<BinaryFormat>,
+    /// Specifies the level of the TDI line while in the idle state.
+    pub idle_tdi: Option<bool>,
 }
 
 impl Chip {
@@ -94,6 +96,7 @@ impl Chip {
             rtt_scan_ranges: None,
             scan_chain: Some(vec![]),
             default_binary_format: Some(BinaryFormat::Raw),
+            idle_tdi: None,
         }
     }
 }

--- a/probe-rs/src/architecture/arm/traits.rs
+++ b/probe-rs/src/architecture/arm/traits.rs
@@ -67,7 +67,7 @@ impl ApAddress {
 ///
 /// Almost everything is the responsibility of the caller. For example, the caller must
 /// handle bank switching and AP selection.
-pub trait RawDapAccess {
+pub trait RawDapAccess: DebugProbe {
     /// Select the debug port to operate on.
     ///
     /// If the probe is connected to a system with multiple debug ports,

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -135,8 +135,6 @@ pub struct Xdm {
 
 impl Xdm {
     pub fn new(probe: Box<dyn JTAGAccess>) -> Result<Self, (Box<dyn JTAGAccess>, XtensaError)> {
-        // TODO implement openocd's esp32_queue_tdi_idle() to prevent potentially damaging flash ICs
-
         let mut x = Self {
             probe,
             device_id: 0,

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -112,6 +112,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
                 rtt_scan_ranges: None,
                 scan_chain: Some(vec![]),
                 default_binary_format: Some(BinaryFormat::Raw),
+                idle_tdi: None,
             }],
             flash_algorithms: vec![],
             source: TargetDescriptionSource::Generic,

--- a/probe-rs/src/config/sequences/esp32.rs
+++ b/probe-rs/src/config/sequences/esp32.rs
@@ -1,0 +1,72 @@
+//! Sequence for the ESP32.
+
+use std::sync::Arc;
+
+use probe_rs_target::Chip;
+
+use crate::{
+    architecture::xtensa::{
+        communication_interface::XtensaCommunicationInterface, sequences::XtensaDebugSequence,
+    },
+    config::sequences::esp::EspFlashSizeDetector,
+    MemoryInterface,
+};
+
+/// The debug sequence implementation for the ESP32.
+#[derive(Debug)]
+pub struct ESP32 {
+    inner: EspFlashSizeDetector,
+}
+
+impl ESP32 {
+    /// Creates a new debug sequence handle for the ESP32.
+    pub fn create(_chip: &Chip) -> Arc<dyn XtensaDebugSequence> {
+        Arc::new(Self {
+            inner: EspFlashSizeDetector {
+                stack_pointer: 0x3FFE_0000,
+                load_address: 0x400A_0000,
+                spiflash_peripheral: 0x3ff4_2000,
+                attach_fn: 0x4006_2a6c,
+            },
+        })
+    }
+}
+
+impl XtensaDebugSequence for ESP32 {
+    fn on_connect(&self, interface: &mut XtensaCommunicationInterface) -> Result<(), crate::Error> {
+        tracing::info!("Disabling ESP32 watchdogs...");
+
+        // tg0 wdg
+        const TIMG0_BASE: u64 = 0x3ff5f000;
+        const TIMG0_WRITE_PROT: u64 = TIMG0_BASE | 0x64;
+        const TIMG0_WDTCONFIG0: u64 = TIMG0_BASE | 0x48;
+        interface.write_word_32(TIMG0_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        interface.write_word_32(TIMG0_WDTCONFIG0, 0x0)?;
+        interface.write_word_32(TIMG0_WRITE_PROT, 0x0)?; // write protection on
+
+        // tg1 wdg
+        const TIMG1_BASE: u64 = 0x3ff60000;
+        const TIMG1_WRITE_PROT: u64 = TIMG1_BASE | 0x64;
+        const TIMG1_WDTCONFIG0: u64 = TIMG1_BASE | 0x48;
+        interface.write_word_32(TIMG1_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        interface.write_word_32(TIMG1_WDTCONFIG0, 0x0)?;
+        interface.write_word_32(TIMG1_WRITE_PROT, 0x0)?; // write protection on
+
+        // rtc wdg
+        const RTC_CNTL_BASE: u64 = 0x3ff48000;
+        const RTC_WRITE_PROT: u64 = RTC_CNTL_BASE | 0xa4;
+        const RTC_WDTCONFIG0: u64 = RTC_CNTL_BASE | 0x8c;
+        interface.write_word_32(RTC_WRITE_PROT, 0x50D83AA1)?; // write protection off
+        interface.write_word_32(RTC_WDTCONFIG0, 0x0)?;
+        interface.write_word_32(RTC_WRITE_PROT, 0x0)?; // write protection on
+
+        Ok(())
+    }
+
+    fn detect_flash_size(
+        &self,
+        interface: &mut XtensaCommunicationInterface,
+    ) -> Result<Option<usize>, crate::Error> {
+        self.inner.detect_flash_size_esp32(interface)
+    }
+}

--- a/probe-rs/src/config/sequences/mod.rs
+++ b/probe-rs/src/config/sequences/mod.rs
@@ -11,6 +11,7 @@ pub mod esp32c6;
 pub mod esp32h2;
 
 // Xtensa ESP32 devices
+pub mod esp32;
 pub mod esp32s3;
 
 // ARM devices

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -2,6 +2,7 @@ use super::{
     sequences::{
         atsam::AtSAM,
         efm32xg2::EFM32xG2,
+        esp32::ESP32,
         esp32c2::ESP32C2,
         esp32c3::ESP32C3,
         esp32c6::ESP32C6,
@@ -136,6 +137,8 @@ impl Target {
             || chip.name.starts_with("EFR32ZG2")
         {
             DebugSequence::Arm(EFM32xG2::create())
+        } else if chip.name.starts_with("esp32-") {
+            DebugSequence::Xtensa(ESP32::create(chip))
         } else if chip.name.eq_ignore_ascii_case("esp32s3") {
             DebugSequence::Xtensa(ESP32S3::create(chip))
         } else if chip.name.eq_ignore_ascii_case("esp32c2") {

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -62,6 +62,8 @@ pub struct Target {
     pub scan_chain: Option<Vec<ScanChainElement>>,
     /// The default executable format for the target.
     pub default_format: BinaryFormat,
+    /// Specifies the level of the TDI line while in the idle state.
+    pub idle_tdi: Option<bool>,
 }
 
 impl std::fmt::Debug for Target {
@@ -237,6 +239,7 @@ impl Target {
             rtt_scan_regions,
             scan_chain: chip.scan_chain.clone(),
             default_format: chip.default_binary_format.clone().unwrap_or_default(),
+            idle_tdi: chip.idle_tdi,
         })
     }
 

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -130,7 +130,12 @@ impl FlashLoader {
         options: IdfOptions,
     ) -> Result<(), FileDownloadError> {
         let target = session.target();
-        let chip = espflash::targets::Chip::from_str(&target.name)
+        let target_name = target
+            .name
+            .split_once('-')
+            .map(|(name, _)| name)
+            .unwrap_or(target.name.as_str());
+        let chip = espflash::targets::Chip::from_str(target_name)
             .map_err(|_| FileDownloadError::IdfUnsupported(target.name.clone()))?
             .into_target();
 

--- a/probe-rs/src/probe/arm_jtag.rs
+++ b/probe-rs/src/probe/arm_jtag.rs
@@ -1578,6 +1578,8 @@ mod test {
             todo!()
         }
 
+        fn set_idle_tdi(&mut self, _tdi: bool) {}
+
         fn write_register(
             &mut self,
             address: u32,

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -375,6 +375,10 @@ impl DebugProbe for WchLink {
     ) -> Result<(), DebugProbeError> {
         Ok(())
     }
+
+    fn as_jtag_probe(&mut self) -> Option<&mut dyn JTAGAccess> {
+        Some(self)
+    }
 }
 
 /// Wrap WCH-Link's USB based DMI access as a fake JTAGAccess
@@ -408,6 +412,10 @@ impl JTAGAccess for WchLink {
     }
 
     fn set_ir_len(&mut self, _len: u32) {}
+
+    fn set_idle_tdi(&mut self, _tdi: bool) {
+        // This isn't an actual JTAG interface
+    }
 
     fn write_register(
         &mut self,

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -173,6 +173,9 @@ impl Session {
         if let Some(scan_chain) = target.scan_chain.clone() {
             probe.set_scan_chain(scan_chain)?;
         }
+        if let Some(idle_tdi) = target.idle_tdi {
+            probe.set_jtag_idle_tdi(idle_tdi)?;
+        }
         probe.attach_to_unspecified()?;
 
         let interface = probe.try_into_arm_interface().map_err(|(_, err)| err)?;
@@ -273,6 +276,9 @@ impl Session {
         if let Some(scan_chain) = target.scan_chain.clone() {
             probe.set_scan_chain(scan_chain)?;
         }
+        if let Some(idle_tdi) = target.idle_tdi {
+            probe.set_jtag_idle_tdi(idle_tdi)?;
+        }
 
         probe.attach_to_unspecified()?;
 
@@ -313,6 +319,9 @@ impl Session {
 
         if let Some(scan_chain) = target.scan_chain.clone() {
             probe.set_scan_chain(scan_chain)?;
+        }
+        if let Some(idle_tdi) = target.idle_tdi {
+            probe.set_jtag_idle_tdi(idle_tdi)?;
         }
 
         probe.attach_to_unspecified()?;

--- a/probe-rs/targets/esp32.yaml
+++ b/probe-rs/targets/esp32.yaml
@@ -1,0 +1,132 @@
+name: esp32
+manufacturer:
+  cc: 0x0C
+  id: 0x12
+variants:
+  - name: esp32-1.8v
+    scan_chain:
+      - name: main
+        ir_len: 5
+      - name: app
+        ir_len: 5
+    default_binary_format: idf
+    idle_tdi: true
+    cores:
+      - name: main
+        type: xtensa
+        core_access_options: !Xtensa {}
+    memory_map:
+      - !Nvm
+        range:
+          start: 0x0
+          end: 0x4000000
+        is_boot_memory: true
+        cores:
+          - main
+      - !Ram # SRAM2, Data bus
+        range:
+          start: 0x3FFAE000
+          end: 0x3FFE0000
+        cores:
+          - main
+      - !Ram # SRAM1, Data bus
+        range:
+          start: 0x3FFE0000
+          end: 0x40000000
+        cores:
+          - main
+      - !Ram # SRAM0, Instruction bus, cache
+        range:
+          start: 0x40070000
+          end: 0x40080000
+        cores:
+          - main
+      - !Ram # SRAM0, Instruction bus, non-cache
+        range:
+          start: 0x40080000
+          end: 0x400A0000
+        cores:
+          - main
+      - !Ram # SRAM1, Instruction bus
+        range:
+          start: 0x400A0000
+          end: 0x400B0000
+        cores:
+          - main
+      - !Ram # SRAM1, Instruction bus, Remappable
+        range:
+          start: 0x400B0000
+          end: 0x400B8000
+        cores:
+          - main
+      - !Ram # Last part of SRAM1, Instruction bus
+        range:
+          start: 0x400B8000
+          end: 0x400C0000
+        cores:
+          - main
+    flash_algorithms:
+  - name: esp32-3.3v
+    scan_chain:
+      - name: main
+        ir_len: 5
+      - name: app
+        ir_len: 5
+    default_binary_format: idf
+    idle_tdi: false
+    cores:
+      - name: main
+        type: xtensa
+        core_access_options: !Xtensa {}
+    memory_map:
+      - !Nvm
+        range:
+          start: 0x0
+          end: 0x4000000
+        is_boot_memory: true
+        cores:
+          - main
+      - !Ram # SRAM2, Data bus
+        range:
+          start: 0x3FFAE000
+          end: 0x3FFE0000
+        cores:
+          - main
+      - !Ram # SRAM1, Data bus
+        range:
+          start: 0x3FFE0000
+          end: 0x40000000
+        cores:
+          - main
+      - !Ram # SRAM0, Instruction bus, cache
+        range:
+          start: 0x40070000
+          end: 0x40080000
+        cores:
+          - main
+      - !Ram # SRAM0, Instruction bus, non-cache
+        range:
+          start: 0x40080000
+          end: 0x400A0000
+        cores:
+          - main
+      - !Ram # SRAM1, Instruction bus
+        range:
+          start: 0x400A0000
+          end: 0x400B0000
+        cores:
+          - main
+      - !Ram # SRAM1, Instruction bus, Remappable
+        range:
+          start: 0x400B0000
+          end: 0x400B8000
+        cores:
+          - main
+      - !Ram # Last part of SRAM1, Instruction bus
+        range:
+          start: 0x400B8000
+          end: 0x400C0000
+        cores:
+          - main
+    flash_algorithms:
+flash_algorithms:

--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -108,6 +108,7 @@ pub fn cmd_elf(
                 rtt_scan_ranges: None,
                 scan_chain: None,
                 default_binary_format: None,
+                idle_tdi: None,
             }],
             flash_algorithms: vec![algorithm],
             source: BuiltIn,

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -166,6 +166,7 @@ where
             rtt_scan_ranges: None,
             scan_chain: None, // TODO, parse from sdf
             default_binary_format: None,
+            idle_tdi: None,
         });
     }
 


### PR DESCRIPTION
On the ESP32, the TDI pin is also used to select the VDD level of the external flash chip. If the target is reset with an indeterminate TDI, it can either operate incorrectly or be damaged. This PR should allow remedying that, by allowing to set a specific TDI level at the end of register accesses.