### PR TITLE
Split out `ProbeDriver`

### DIFF
--- a/changelog/changed-debug-probe-traits.md
+++ b/changelog/changed-debug-probe-traits.md
@@ -1,1 +1,1 @@
-Extract DebugProbeSource from DebugProbe
+Extract ProbeDriver from DebugProbe

--- a/changelog/changed-debug-probe-traits.md
+++ b/changelog/changed-debug-probe-traits.md
@@ -1,0 +1,1 @@
+Extract DebugProbeSource from DebugProbe

--- a/changelog/removed-debugprobetype.md
+++ b/changelog/removed-debugprobetype.md
@@ -1,0 +1,1 @@
+Removed `DebugProbeType`

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -916,11 +916,11 @@ mod test {
     use std::path::PathBuf;
 
     use probe_rs::architecture::arm::ApAddress;
-    use probe_rs::DebugProbeInfo;
     use probe_rs::{
         integration::{FakeProbe, Operation},
         Lister,
     };
+    use probe_rs::{DebugProbeInfo, DebugProbeSource};
     use serde_json::json;
     use time::UtcOffset;
 
@@ -939,6 +939,22 @@ mod test {
         server::{configuration::SessionConfig, debugger::DebugSessionStatus},
         test::TestLister,
     };
+
+    #[derive(Debug)]
+    struct MockProbeSource;
+
+    impl DebugProbeSource for MockProbeSource {
+        fn new_from_selector(
+            &self,
+            _selector: &probe_rs::DebugProbeSelector,
+        ) -> Result<Box<dyn probe_rs::DebugProbe>, probe_rs::DebugProbeError> {
+            todo!()
+        }
+
+        fn list_probes(&self) -> Vec<DebugProbeInfo> {
+            todo!()
+        }
+    }
 
     /// Helper function to get the expected capabilities for the debugger
     ///
@@ -1344,7 +1360,7 @@ mod test {
             0x12,
             0x23,
             Some("mock_serial".to_owned()),
-            probe_rs::DebugProbeType::CmsisDap,
+            &MockProbeSource,
             None,
         );
 
@@ -1422,7 +1438,7 @@ mod test {
             0x12,
             0x23,
             Some("mock_serial".to_owned()),
-            probe_rs::DebugProbeType::CmsisDap,
+            &MockProbeSource,
             None,
         );
 
@@ -1478,7 +1494,7 @@ mod test {
             0x12,
             0x23,
             Some("mock_serial".to_owned()),
-            probe_rs::DebugProbeType::CmsisDap,
+            &MockProbeSource,
             None,
         );
 
@@ -1552,7 +1568,7 @@ mod test {
             0x12,
             0x23,
             Some("mock_serial".to_owned()),
-            probe_rs::DebugProbeType::CmsisDap,
+            &MockProbeSource,
             None,
         );
 
@@ -1626,7 +1642,7 @@ mod test {
             0x12,
             0x23,
             Some("mock_serial".to_owned()),
-            probe_rs::DebugProbeType::CmsisDap,
+            &MockProbeSource,
             None,
         );
 
@@ -1718,7 +1734,7 @@ mod test {
             0x12,
             0x23,
             Some("mock_serial".to_owned()),
-            probe_rs::DebugProbeType::CmsisDap,
+            &MockProbeSource,
             None,
         );
 

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -920,31 +920,34 @@ mod test {
         integration::{FakeProbe, Operation},
         Lister,
     };
-    use probe_rs::{DebugProbeInfo, DebugProbeSource};
+    use probe_rs::{DebugProbeInfo, ProbeDriver};
     use serde_json::json;
     use time::UtcOffset;
 
-    use crate::cmd::dap_server::debug_adapter::dap::dap_types::{
-        DisconnectArguments, ErrorResponseBody, Message, Response, Thread, ThreadsResponseBody,
-    };
-    use crate::cmd::dap_server::server::configuration::{ConsoleLog, CoreConfig, FlashingConfig};
     use crate::cmd::dap_server::{
         debug_adapter::{
             dap::{
                 adapter::DebugAdapter,
-                dap_types::{Capabilities, InitializeRequestArguments, Request},
+                dap_types::{
+                    Capabilities, DisconnectArguments, ErrorResponseBody,
+                    InitializeRequestArguments, Message, Request, Response, Thread,
+                    ThreadsResponseBody,
+                },
             },
             protocol::ProtocolAdapter,
         },
-        server::{configuration::SessionConfig, debugger::DebugSessionStatus},
+        server::{
+            configuration::{ConsoleLog, CoreConfig, FlashingConfig, SessionConfig},
+            debugger::DebugSessionStatus,
+        },
         test::TestLister,
     };
 
     #[derive(Debug)]
     struct MockProbeSource;
 
-    impl DebugProbeSource for MockProbeSource {
-        fn new_from_selector(
+    impl ProbeDriver for MockProbeSource {
+        fn open(
             &self,
             _selector: &probe_rs::DebugProbeSelector,
         ) -> Result<Box<dyn probe_rs::DebugProbe>, probe_rs::DebugProbeError> {

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -104,6 +104,6 @@ pub use crate::error::Error;
 pub use crate::memory::MemoryInterface;
 pub use crate::probe::{
     list::Lister, AttachMethod, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
-    DebugProbeType, Probe, ProbeCreationError, WireProtocol,
+    DebugProbeSource, Probe, ProbeCreationError, WireProtocol,
 };
 pub use crate::session::{Permissions, Session};

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -104,6 +104,6 @@ pub use crate::error::Error;
 pub use crate::memory::MemoryInterface;
 pub use crate::probe::{
     list::Lister, AttachMethod, DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
-    DebugProbeSource, Probe, ProbeCreationError, WireProtocol,
+    Probe, ProbeCreationError, ProbeDriver, WireProtocol,
 };
 pub use crate::session::{Permissions, Session};

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -482,19 +482,26 @@ impl Probe {
     }
 }
 
-/// An abstraction over general debug probe functionality.
+/// An abstraction over a probe driver type.
 ///
 /// This trait has to be implemented by ever debug probe driver.
-pub trait DebugProbe: Send + fmt::Debug {
+pub trait DebugProbeSource {
     /// Creates a new boxed [`DebugProbe`] from a given [`DebugProbeSelector`].
     /// This will be called for all available debug drivers when discovering probes.
     /// When opening, it will open the first probe which succeeds during this call.
     fn new_from_selector(
+        &self,
         selector: &DebugProbeSelector,
-    ) -> Result<Box<dyn DebugProbe>, DebugProbeError>
-    where
-        Self: Sized;
+    ) -> Result<Box<dyn DebugProbe>, DebugProbeError>;
 
+    /// Returns a list of all available debug probes of the current type.
+    fn list_probes(&self) -> Vec<DebugProbeInfo>;
+}
+
+/// An abstraction over general debug probe.
+///
+/// This trait has to be implemented by ever debug probe driver.
+pub trait DebugProbe: Send + fmt::Debug {
     /// Get human readable name for the probe.
     fn get_name(&self) -> &str;
 

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -696,7 +696,7 @@ impl std::fmt::Debug for DebugProbeInfo {
             self.vendor_id,
             self.product_id,
             self.serial_number
-                .clone()
+                .as_ref()
                 .map_or("".to_owned(), |v| format!("Serial: {v}, ")),
             self.probe_type
         )

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -489,7 +489,9 @@ pub trait DebugProbe: Send + fmt::Debug {
     /// Creates a new boxed [`DebugProbe`] from a given [`DebugProbeSelector`].
     /// This will be called for all available debug drivers when discovering probes.
     /// When opening, it will open the first probe which succeeds during this call.
-    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError>
+    fn new_from_selector(
+        selector: &DebugProbeSelector,
+    ) -> Result<Box<dyn DebugProbe>, DebugProbeError>
     where
         Self: Sized;
 

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -489,9 +489,7 @@ pub trait DebugProbe: Send + fmt::Debug {
     /// Creates a new boxed [`DebugProbe`] from a given [`DebugProbeSelector`].
     /// This will be called for all available debug drivers when discovering probes.
     /// When opening, it will open the first probe which succeeds during this call.
-    fn new_from_selector(
-        selector: impl Into<DebugProbeSelector>,
-    ) -> Result<Box<Self>, DebugProbeError>
+    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError>
     where
         Self: Sized;
 

--- a/probe-rs/src/probe/arm_jtag.rs
+++ b/probe-rs/src/probe/arm_jtag.rs
@@ -1671,15 +1671,6 @@ mod test {
     /// This is just a blanket impl that will crash if used (only relevant in tests,
     /// so no problem as we do not use it) to fulfill the marker requirement.
     impl DebugProbe for MockJaylink {
-        fn new_from_selector(
-            _selector: &crate::DebugProbeSelector,
-        ) -> Result<Box<dyn DebugProbe>, crate::DebugProbeError>
-        where
-            Self: Sized,
-        {
-            todo!()
-        }
-
         fn get_name(&self) -> &str {
             todo!()
         }

--- a/probe-rs/src/probe/arm_jtag.rs
+++ b/probe-rs/src/probe/arm_jtag.rs
@@ -1672,7 +1672,7 @@ mod test {
     /// so no problem as we do not use it) to fulfill the marker requirement.
     impl DebugProbe for MockJaylink {
         fn new_from_selector(
-            _selector: impl Into<crate::DebugProbeSelector>,
+            _selector: &crate::DebugProbeSelector,
         ) -> Result<Box<Self>, crate::DebugProbeError>
         where
             Self: Sized,

--- a/probe-rs/src/probe/arm_jtag.rs
+++ b/probe-rs/src/probe/arm_jtag.rs
@@ -1673,7 +1673,7 @@ mod test {
     impl DebugProbe for MockJaylink {
         fn new_from_selector(
             _selector: &crate::DebugProbeSelector,
-        ) -> Result<Box<Self>, crate::DebugProbeError>
+        ) -> Result<Box<dyn DebugProbe>, crate::DebugProbeError>
         where
             Self: Sized,
         {

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -15,7 +15,7 @@ use crate::{
             general::info::{CapabilitiesCommand, PacketCountCommand, SWOTraceBufferSizeCommand},
             CmsisDapError,
         },
-        BatchCommand, DebugProbeSource,
+        BatchCommand, ProbeDriver,
     },
     CoreStatus, DebugProbe, DebugProbeError, DebugProbeSelector, WireProtocol,
 };
@@ -67,11 +67,8 @@ impl std::fmt::Debug for CmsisDapSource {
     }
 }
 
-impl DebugProbeSource for CmsisDapSource {
-    fn new_from_selector(
-        &self,
-        selector: &DebugProbeSelector,
-    ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+impl ProbeDriver for CmsisDapSource {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
         Ok(Box::new(CmsisDap::new_from_device(
             tools::open_device_from_selector(selector)?,
         )?))

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -15,7 +15,7 @@ use crate::{
             general::info::{CapabilitiesCommand, PacketCountCommand, SWOTraceBufferSizeCommand},
             CmsisDapError,
         },
-        BatchCommand,
+        BatchCommand, DebugProbeSource,
     },
     CoreStatus, DebugProbe, DebugProbeError, DebugProbeSelector, WireProtocol,
 };
@@ -58,6 +58,23 @@ use std::{result::Result, time::Duration};
 use bitvec::prelude::*;
 
 use super::common::{extract_idcodes, extract_ir_lengths, ScanChainError};
+
+pub struct CmsisDapSource;
+
+impl DebugProbeSource for CmsisDapSource {
+    fn new_from_selector(
+        &self,
+        selector: &DebugProbeSelector,
+    ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+        Ok(Box::new(CmsisDap::new_from_device(
+            tools::open_device_from_selector(selector)?,
+        )?))
+    }
+
+    fn list_probes(&self) -> Vec<crate::DebugProbeInfo> {
+        tools::list_cmsisdap_devices()
+    }
+}
 
 pub struct CmsisDap {
     pub device: CmsisDapDevice,
@@ -700,17 +717,6 @@ impl CmsisDap {
 }
 
 impl DebugProbe for CmsisDap {
-    fn new_from_selector(
-        selector: &DebugProbeSelector,
-    ) -> Result<Box<dyn DebugProbe>, DebugProbeError>
-    where
-        Self: Sized,
-    {
-        Ok(Box::new(Self::new_from_device(
-            tools::open_device_from_selector(selector)?,
-        )?))
-    }
-
     fn get_name(&self) -> &str {
         "CMSIS-DAP"
     }

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -61,6 +61,12 @@ use super::common::{extract_idcodes, extract_ir_lengths, ScanChainError};
 
 pub struct CmsisDapSource;
 
+impl std::fmt::Debug for CmsisDapSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CmsisDap").finish()
+    }
+}
+
 impl DebugProbeSource for CmsisDapSource {
     fn new_from_selector(
         &self,

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -700,7 +700,9 @@ impl CmsisDap {
 }
 
 impl DebugProbe for CmsisDap {
-    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError>
+    fn new_from_selector(
+        selector: &DebugProbeSelector,
+    ) -> Result<Box<dyn DebugProbe>, DebugProbeError>
     where
         Self: Sized,
     {

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -700,9 +700,7 @@ impl CmsisDap {
 }
 
 impl DebugProbe for CmsisDap {
-    fn new_from_selector(
-        selector: impl Into<DebugProbeSelector>,
-    ) -> Result<Box<Self>, DebugProbeError>
+    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError>
     where
         Self: Sized,
     {

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -256,8 +256,6 @@ fn device_matches(
 pub fn open_device_from_selector(
     selector: &DebugProbeSelector,
 ) -> Result<CmsisDapDevice, ProbeCreationError> {
-    let selector = selector.into();
-
     tracing::trace!("Attempting to open device matching {}", selector);
 
     // We need to use rusb to detect the proper HID interface to use

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -1,6 +1,6 @@
 use super::CmsisDapDevice;
 use crate::{
-    probe::{DebugProbeInfo, DebugProbeType, ProbeCreationError},
+    probe::{cmsisdap::CmsisDapSource, DebugProbeInfo, ProbeCreationError},
     DebugProbeSelector,
 };
 use hidapi::HidApi;
@@ -116,7 +116,7 @@ fn get_cmsisdap_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
             d_desc.vendor_id(),
             d_desc.product_id(),
             sn_str,
-            DebugProbeType::CmsisDap,
+            &CmsisDapSource,
             hid_interface,
         ))
     } else {
@@ -141,7 +141,7 @@ fn get_cmsisdap_hid_info(device: &hidapi::DeviceInfo) -> Option<DebugProbeInfo> 
             device.vendor_id(),
             device.product_id(),
             device.serial_number().map(|s| s.to_owned()),
-            DebugProbeType::CmsisDap,
+            &CmsisDapSource,
             Some(device.interface_number() as u8),
         ))
     } else {

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -427,7 +427,9 @@ impl JTAGAccess for EspUsbJtag {
 }
 
 impl DebugProbe for EspUsbJtag {
-    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError> {
+    fn new_from_selector(
+        selector: &DebugProbeSelector,
+    ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
         let protocol = ProtocolHandler::new_from_selector(selector)?;
 
         Ok(Box::new(EspUsbJtag {

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -427,9 +427,7 @@ impl JTAGAccess for EspUsbJtag {
 }
 
 impl DebugProbe for EspUsbJtag {
-    fn new_from_selector(
-        selector: impl Into<DebugProbeSelector>,
-    ) -> Result<Box<Self>, DebugProbeError> {
+    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError> {
         let protocol = ProtocolHandler::new_from_selector(selector)?;
 
         Ok(Box::new(EspUsbJtag {

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     probe::{
         common::{common_sequence, extract_ir_lengths},
         espusbjtag::protocol::{JtagState, RegisterState},
-        DebugProbeSource, DeferredResultSet, JtagCommandQueue,
+        DeferredResultSet, JtagCommandQueue, ProbeDriver,
     },
     DebugProbe, DebugProbeError, DebugProbeSelector, WireProtocol,
 };
@@ -36,11 +36,8 @@ impl std::fmt::Debug for EspUsbJtagSource {
     }
 }
 
-impl DebugProbeSource for EspUsbJtagSource {
-    fn new_from_selector(
-        &self,
-        selector: &DebugProbeSelector,
-    ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+impl ProbeDriver for EspUsbJtagSource {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
         let protocol = ProtocolHandler::new_from_selector(selector)?;
 
         Ok(Box::new(EspUsbJtag {

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -30,6 +30,12 @@ use probe_rs_target::ScanChainElement;
 
 pub struct EspUsbJtagSource;
 
+impl std::fmt::Debug for EspUsbJtagSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EspJtag").finish()
+    }
+}
+
 impl DebugProbeSource for EspUsbJtagSource {
     fn new_from_selector(
         &self,

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -336,41 +336,17 @@ impl ProtocolHandler {
 
     pub(super) fn jtag_move_to_state(&mut self, target: JtagState) -> Result<(), DebugProbeError> {
         while let Some(tms) = self.jtag_state.step_toward(target) {
-            self.jtag_io_async([tms], [false], false)?;
+            self.schedule_jtag_scan([tms], [false], [false])?;
         }
         tracing::debug!("In state: {:?}", self.jtag_state);
         Ok(())
     }
 
     /// Put a bit on TDI and possibly read one from TDO.
-    pub fn jtag_io(
-        &mut self,
-        tms: impl IntoIterator<Item = bool>,
-        tdi: impl IntoIterator<Item = bool>,
-        cap: bool,
-    ) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
-        self.jtag_io_async(tms, tdi, cap)?;
-        self.flush()
-    }
-
-    /// Put a bit on TDI and possibly read one from TDO.
     /// to receive the bytes from this operations call [`ProtocolHandler::flush`]
     ///
     /// Note that if the internal buffer is exceeded bytes will be automatically flushed to usb device
-    pub fn jtag_io_async(
-        &mut self,
-        tms: impl IntoIterator<Item = bool>,
-        tdi: impl IntoIterator<Item = bool>,
-        cap: bool,
-    ) -> Result<(), DebugProbeError> {
-        self.jtag_io_async2(tms, tdi, std::iter::repeat(cap))
-    }
-
-    /// Put a bit on TDI and possibly read one from TDO.
-    /// to receive the bytes from this operations call [`ProtocolHandler::flush`]
-    ///
-    /// Note that if the internal buffer is exceeded bytes will be automatically flushed to usb device
-    pub fn jtag_io_async2(
+    pub fn schedule_jtag_scan(
         &mut self,
         tms: impl IntoIterator<Item = bool>,
         tdi: impl IntoIterator<Item = bool>,

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -176,11 +176,7 @@ impl Debug for ProtocolHandler {
 }
 
 impl ProtocolHandler {
-    pub fn new_from_selector(
-        selector: impl Into<DebugProbeSelector>,
-    ) -> Result<Self, ProbeCreationError> {
-        let selector = selector.into();
-
+    pub fn new_from_selector(selector: &DebugProbeSelector) -> Result<Self, ProbeCreationError> {
         let context = Context::new()?;
 
         tracing::debug!("Acquired libusb context.");
@@ -196,7 +192,7 @@ impl ProtocolHandler {
                     && selector.product_id == descriptor.product_id()
                 {
                     // If the VID & PID match, match the serial if one was given.
-                    if let Some(serial) = &selector.serial_number {
+                    if let Some(serial) = selector.serial_number.as_ref() {
                         let sn_str = read_serial_number(&device, &descriptor).ok();
                         if sn_str.as_ref() == Some(serial) {
                             Some(device)

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -614,7 +614,7 @@ pub(super) fn is_espjtag_device<T: UsbContext>(device: &Device<T>) -> bool {
 }
 
 #[tracing::instrument(skip_all)]
-pub fn list_espjtag_devices() -> Vec<DebugProbeInfo> {
+pub(super) fn list_espjtag_devices() -> Vec<DebugProbeInfo> {
     rusb::Context::new()
         .and_then(|context| context.devices())
         .map_or(vec![], |devices| {

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -4,7 +4,8 @@ use bitvec::{prelude::*, slice::BitSlice, vec::BitVec};
 use rusb::{request_type, Context, Device, Direction, TransferType, UsbContext};
 
 use crate::{
-    DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType, ProbeCreationError,
+    probe::espusbjtag::EspUsbJtagSource, DebugProbeError, DebugProbeInfo, DebugProbeSelector,
+    ProbeCreationError,
 };
 
 const JTAG_PROTOCOL_CAPABILITIES_VERSION: u8 = 1;
@@ -646,7 +647,7 @@ pub(super) fn list_espjtag_devices() -> Vec<DebugProbeInfo> {
                         descriptor.vendor_id(),
                         descriptor.product_id(),
                         sn_str,
-                        DebugProbeType::EspJtag,
+                        &EspUsbJtagSource,
                         None,
                     ))
                 })

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -295,9 +295,7 @@ impl Default for FakeProbe {
 }
 
 impl DebugProbe for FakeProbe {
-    fn new_from_selector(
-        _selector: impl Into<DebugProbeSelector>,
-    ) -> Result<Box<Self>, DebugProbeError>
+    fn new_from_selector(_selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError>
     where
         Self: Sized,
     {

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -295,7 +295,9 @@ impl Default for FakeProbe {
 }
 
 impl DebugProbe for FakeProbe {
-    fn new_from_selector(_selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError>
+    fn new_from_selector(
+        _selector: &DebugProbeSelector,
+    ) -> Result<Box<dyn DebugProbe>, DebugProbeError>
     where
         Self: Sized,
     {

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -16,8 +16,7 @@ use crate::{
         ApAddress, ArmError, ArmProbeInterface, DapAccess, DpAddress, MemoryApInformation,
         PortType, RawDapAccess, SwoAccess,
     },
-    DebugProbe, DebugProbeError, DebugProbeSelector, Error, MemoryMappedRegister, Probe,
-    WireProtocol,
+    DebugProbe, DebugProbeError, Error, MemoryMappedRegister, Probe, WireProtocol,
 };
 
 /// This is a mock probe which can be used for mocking things in tests or for dry runs.
@@ -295,15 +294,6 @@ impl Default for FakeProbe {
 }
 
 impl DebugProbe for FakeProbe {
-    fn new_from_selector(
-        _selector: &DebugProbeSelector,
-    ) -> Result<Box<dyn DebugProbe>, DebugProbeError>
-    where
-        Self: Sized,
-    {
-        Ok(Box::new(FakeProbe::new()))
-    }
-
     /// Get human readable name for the probe
     fn get_name(&self) -> &str {
         "Mock probe for testing"

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -6,8 +6,8 @@ use crate::architecture::{
 };
 use crate::probe::common::{common_sequence, extract_ir_lengths};
 use crate::probe::{
-    DebugProbe, DebugProbeSource, DeferredResultSet, JTAGAccess, JtagCommandQueue,
-    ProbeCreationError, ScanChainElement,
+    DebugProbe, DeferredResultSet, JTAGAccess, JtagCommandQueue, ProbeCreationError, ProbeDriver,
+    ScanChainElement,
 };
 use crate::{DebugProbeError, DebugProbeInfo, DebugProbeSelector, WireProtocol};
 use bitvec::{order::Lsb0, slice::BitSlice, vec::BitVec};
@@ -379,11 +379,8 @@ impl std::fmt::Debug for FtdiProbeSource {
     }
 }
 
-impl DebugProbeSource for FtdiProbeSource {
-    fn new_from_selector(
-        &self,
-        selector: &DebugProbeSelector,
-    ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+impl ProbeDriver for FtdiProbeSource {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
         // Only open FTDI-compatible probes
         if !FTDI_COMPAT_DEVICE_IDS.contains(&(selector.vendor_id, selector.product_id)) {
             return Err(DebugProbeError::ProbeCouldNotBeCreated(

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -9,7 +9,7 @@ use crate::probe::{
     DebugProbe, DebugProbeSource, DeferredResultSet, JTAGAccess, JtagCommandQueue,
     ProbeCreationError, ScanChainElement,
 };
-use crate::{DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType, WireProtocol};
+use crate::{DebugProbeError, DebugProbeInfo, DebugProbeSelector, WireProtocol};
 use bitvec::{order::Lsb0, slice::BitSlice, vec::BitVec};
 use rusb::UsbContext;
 use std::convert::TryInto;
@@ -372,6 +372,12 @@ impl JtagAdapter {
 }
 
 pub struct FtdiProbeSource;
+
+impl std::fmt::Debug for FtdiProbeSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FTDI").finish()
+    }
+}
 
 impl DebugProbeSource for FtdiProbeSource {
     fn new_from_selector(
@@ -768,7 +774,7 @@ fn get_device_info(device: &rusb::Device<rusb::Context>) -> Option<DebugProbeInf
         vendor_id: d_desc.vendor_id(),
         product_id: d_desc.product_id(),
         serial_number: sn_str,
-        probe_type: DebugProbeType::Ftdi,
+        probe_type: &FtdiProbeSource,
         hid_interface: None,
     })
 }

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -381,7 +381,9 @@ pub struct FtdiProbe {
 }
 
 impl DebugProbe for FtdiProbe {
-    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError>
+    fn new_from_selector(
+        selector: &DebugProbeSelector,
+    ) -> Result<Box<dyn DebugProbe>, DebugProbeError>
     where
         Self: Sized,
     {

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -381,9 +381,7 @@ pub struct FtdiProbe {
 }
 
 impl DebugProbe for FtdiProbe {
-    fn new_from_selector(
-        selector: impl Into<DebugProbeSelector>,
-    ) -> Result<Box<Self>, DebugProbeError>
+    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError>
     where
         Self: Sized,
     {
@@ -391,7 +389,7 @@ impl DebugProbe for FtdiProbe {
             vendor_id,
             product_id,
             ..
-        } = selector.into();
+        } = selector;
 
         // Only open FTDI-compatible probes
         if !FTDI_COMPAT_DEVICE_IDS.contains(&(vendor_id, product_id)) {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -11,7 +11,7 @@ use crate::architecture::arm::{ArmError, RawDapAccess};
 use crate::architecture::riscv::communication_interface::RiscvError;
 use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
 use crate::probe::common::bits_to_byte;
-use crate::probe::DebugProbeSource;
+use crate::probe::ProbeDriver;
 use crate::{
     architecture::{
         arm::{
@@ -37,11 +37,8 @@ impl std::fmt::Debug for JLinkSource {
     }
 }
 
-impl DebugProbeSource for JLinkSource {
-    fn new_from_selector(
-        &self,
-        selector: &DebugProbeSelector,
-    ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+impl ProbeDriver for JLinkSource {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
         let mut jlinks = jaylink::scan_usb()?
             .filter_map(|usb_info| {
                 if usb_info.vid() == selector.vendor_id && usb_info.pid() == selector.product_id {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -315,7 +315,9 @@ impl JLink {
 }
 
 impl DebugProbe for JLink {
-    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError> {
+    fn new_from_selector(
+        selector: &DebugProbeSelector,
+    ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
         let mut jlinks = jaylink::scan_usb()?
             .filter_map(|usb_info| {
                 if usb_info.vid() == selector.vendor_id && usb_info.pid() == selector.product_id {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -315,10 +315,7 @@ impl JLink {
 }
 
 impl DebugProbe for JLink {
-    fn new_from_selector(
-        selector: impl Into<DebugProbeSelector>,
-    ) -> Result<Box<Self>, DebugProbeError> {
-        let selector = selector.into();
+    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError> {
         let mut jlinks = jaylink::scan_usb()?
             .filter_map(|usb_info| {
                 if usb_info.vid() == selector.vendor_id && usb_info.pid() == selector.product_id {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     probe::{
         arm_jtag::{ProbeStatistics, RawProtocolIo, SwdSettings},
-        DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeType, JTAGAccess, WireProtocol,
+        DebugProbe, DebugProbeError, DebugProbeInfo, JTAGAccess, WireProtocol,
     },
     DebugProbeSelector,
 };
@@ -30,6 +30,12 @@ use crate::{
 const SWO_BUFFER_SIZE: u16 = 128;
 
 pub struct JLinkSource;
+
+impl std::fmt::Debug for JLinkSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JLink").finish()
+    }
+}
 
 impl DebugProbeSource for JLinkSource {
     fn new_from_selector(
@@ -847,7 +853,7 @@ fn list_jlink_devices() -> Vec<DebugProbeInfo> {
                     vid,
                     pid,
                     serial,
-                    DebugProbeType::JLink,
+                    &JLinkSource,
                     None,
                 )
             })

--- a/probe-rs/src/probe/list.rs
+++ b/probe-rs/src/probe/list.rs
@@ -85,33 +85,33 @@ impl AllProbesLister {
 
     fn open(selector: impl Into<DebugProbeSelector>) -> Result<Probe, DebugProbeError> {
         let selector = selector.into();
-        match cmsisdap::CmsisDap::new_from_selector(selector.clone()) {
+        match cmsisdap::CmsisDap::new_from_selector(&selector) {
             Ok(link) => return Ok(Probe::from_specific_probe(link)),
             Err(DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::NotFound)) => {}
             Err(e) => return Err(e),
         };
         #[cfg(feature = "ftdi")]
-        match ftdi::FtdiProbe::new_from_selector(selector.clone()) {
+        match ftdi::FtdiProbe::new_from_selector(&selector) {
             Ok(link) => return Ok(Probe::from_specific_probe(link)),
             Err(DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::NotFound)) => {}
             Err(e) => return Err(e),
         };
-        match stlink::StLink::new_from_selector(selector.clone()) {
+        match stlink::StLink::new_from_selector(&selector) {
             Ok(link) => return Ok(Probe::from_specific_probe(link)),
             Err(DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::NotFound)) => {}
             Err(e) => return Err(e),
         };
-        match jlink::JLink::new_from_selector(selector.clone()) {
+        match jlink::JLink::new_from_selector(&selector) {
             Ok(link) => return Ok(Probe::from_specific_probe(link)),
             Err(DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::NotFound)) => {}
             Err(e) => return Err(e),
         };
-        match espusbjtag::EspUsbJtag::new_from_selector(selector.clone()) {
+        match espusbjtag::EspUsbJtag::new_from_selector(&selector) {
             Ok(link) => return Ok(Probe::from_specific_probe(link)),
             Err(DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::NotFound)) => {}
             Err(e) => return Err(e),
         };
-        match wlink::WchLink::new_from_selector(selector) {
+        match wlink::WchLink::new_from_selector(&selector) {
             Ok(link) => return Ok(Probe::from_specific_probe(link)),
             Err(DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::NotFound)) => {}
             Err(e) => return Err(e),

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -55,7 +55,9 @@ pub(crate) struct StLink<D: StLinkUsb> {
 }
 
 impl DebugProbe for StLink<StLinkUsbDevice> {
-    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError> {
+    fn new_from_selector(
+        selector: &DebugProbeSelector,
+    ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
         let device = StLinkUsbDevice::new_from_selector(selector)?;
         let mut stlink = Self {
             name: format!("ST-Link {}", &device.info.version_name),

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -41,6 +41,12 @@ const DP_PORT: u16 = 0xFFFF;
 
 pub struct StLinkSource;
 
+impl std::fmt::Debug for StLinkSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StLink").finish()
+    }
+}
+
 impl DebugProbeSource for StLinkSource {
     fn new_from_selector(
         &self,

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -6,7 +6,7 @@ use self::usb_interface::{StLinkUsb, StLinkUsbDevice};
 use super::{DebugProbe, DebugProbeError, ProbeCreationError, WireProtocol};
 use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
 use crate::architecture::arm::{valid_32bit_arm_address, ArmError};
-use crate::probe::DebugProbeSource;
+use crate::probe::ProbeDriver;
 use crate::{
     architecture::arm::{
         ap::{valid_access_ports, AccessPort, ApAccess, ApClass, MemoryAp, IDR},
@@ -47,11 +47,8 @@ impl std::fmt::Debug for StLinkSource {
     }
 }
 
-impl DebugProbeSource for StLinkSource {
-    fn new_from_selector(
-        &self,
-        selector: &DebugProbeSelector,
-    ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+impl ProbeDriver for StLinkSource {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
         let device = StLinkUsbDevice::new_from_selector(selector)?;
         let mut stlink = StLink {
             name: format!("ST-Link {}", &device.info.version_name),

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -6,6 +6,7 @@ use self::usb_interface::{StLinkUsb, StLinkUsbDevice};
 use super::{DebugProbe, DebugProbeError, ProbeCreationError, WireProtocol};
 use crate::architecture::arm::memory::adi_v5_memory_interface::ArmProbe;
 use crate::architecture::arm::{valid_32bit_arm_address, ArmError};
+use crate::probe::DebugProbeSource;
 use crate::{
     architecture::arm::{
         ap::{valid_access_ports, AccessPort, ApAccess, ApClass, MemoryAp, IDR},
@@ -38,28 +39,15 @@ const STLINK_MAX_WRITE_LEN: usize = 0xFFFC;
 
 const DP_PORT: u16 = 0xFFFF;
 
-#[derive(Debug)]
-pub(crate) struct StLink<D: StLinkUsb> {
-    device: D,
-    name: String,
-    hw_version: u8,
-    jtag_version: u8,
-    protocol: WireProtocol,
-    swd_speed_khz: u32,
-    jtag_speed_khz: u32,
-    swo_enabled: bool,
-    scan_chain: Option<Vec<ScanChainElement>>,
+pub struct StLinkSource;
 
-    /// List of opened APs
-    opened_aps: Vec<u8>,
-}
-
-impl DebugProbe for StLink<StLinkUsbDevice> {
+impl DebugProbeSource for StLinkSource {
     fn new_from_selector(
+        &self,
         selector: &DebugProbeSelector,
     ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
         let device = StLinkUsbDevice::new_from_selector(selector)?;
-        let mut stlink = Self {
+        let mut stlink = StLink {
             name: format!("ST-Link {}", &device.info.version_name),
             device,
             hw_version: 0,
@@ -78,6 +66,28 @@ impl DebugProbe for StLink<StLinkUsbDevice> {
         Ok(Box::new(stlink))
     }
 
+    fn list_probes(&self) -> Vec<crate::DebugProbeInfo> {
+        tools::list_stlink_devices()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct StLink<D: StLinkUsb> {
+    device: D,
+    name: String,
+    hw_version: u8,
+    jtag_version: u8,
+    protocol: WireProtocol,
+    swd_speed_khz: u32,
+    jtag_speed_khz: u32,
+    swo_enabled: bool,
+    scan_chain: Option<Vec<ScanChainElement>>,
+
+    /// List of opened APs
+    opened_aps: Vec<u8>,
+}
+
+impl DebugProbe for StLink<StLinkUsbDevice> {
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -55,9 +55,7 @@ pub(crate) struct StLink<D: StLinkUsb> {
 }
 
 impl DebugProbe for StLink<StLinkUsbDevice> {
-    fn new_from_selector(
-        selector: impl Into<DebugProbeSelector>,
-    ) -> Result<Box<Self>, DebugProbeError> {
+    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError> {
         let device = StLinkUsbDevice::new_from_selector(selector)?;
         let mut stlink = Self {
             name: format!("ST-Link {}", &device.info.version_name),

--- a/probe-rs/src/probe/stlink/tools.rs
+++ b/probe-rs/src/probe/stlink/tools.rs
@@ -1,7 +1,8 @@
 use rusb::Device;
 use rusb::UsbContext;
 
-use crate::probe::{DebugProbeInfo, DebugProbeType};
+use crate::probe::stlink::StLinkSource;
+use crate::probe::DebugProbeInfo;
 
 use super::usb_interface::USB_PID_EP_MAP;
 use super::usb_interface::USB_VID;
@@ -54,7 +55,7 @@ pub fn list_stlink_devices() -> Vec<DebugProbeInfo> {
                         descriptor.vendor_id(),
                         descriptor.product_id(),
                         sn_str,
-                        DebugProbeType::StLink,
+                        &StLinkSource,
                         None,
                     ))
                 })

--- a/probe-rs/src/probe/stlink/usb_interface.rs
+++ b/probe-rs/src/probe/stlink/usb_interface.rs
@@ -99,11 +99,7 @@ pub(crate) trait StLinkUsb: std::fmt::Debug {
 
 impl StLinkUsbDevice {
     /// Creates and initializes a new USB device.
-    pub fn new_from_selector(
-        selector: impl Into<DebugProbeSelector>,
-    ) -> Result<Self, ProbeCreationError> {
-        let selector = selector.into();
-
+    pub fn new_from_selector(selector: &DebugProbeSelector) -> Result<Self, ProbeCreationError> {
         let context = Context::new()?;
 
         tracing::debug!("Acquired libusb context.");
@@ -119,7 +115,7 @@ impl StLinkUsbDevice {
                     && selector.product_id == descriptor.product_id()
                 {
                     // If the VID & PID match, match the serial if one was given.
-                    if let Some(serial) = &selector.serial_number {
+                    if let Some(serial) = selector.serial_number.as_ref() {
                         let sn_str = read_serial_number(&device, &descriptor).ok();
                         if sn_str.as_ref() == Some(serial) {
                             Some(device)

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -226,7 +226,9 @@ impl WchLink {
 }
 
 impl DebugProbe for WchLink {
-    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError>
+    fn new_from_selector(
+        selector: &DebugProbeSelector,
+    ) -> Result<Box<dyn DebugProbe>, DebugProbeError>
     where
         Self: Sized,
     {

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -11,6 +11,7 @@ use rusb::{Device, UsbContext};
 
 use crate::{
     architecture::riscv::communication_interface::{RiscvCommunicationInterface, RiscvError},
+    probe::DebugProbeSource,
     DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType,
     ProbeCreationError, WireProtocol,
 };
@@ -146,6 +147,37 @@ impl RiscvChip {
     }
 }
 
+pub struct WchLinkSource;
+
+impl DebugProbeSource for WchLinkSource {
+    fn new_from_selector(
+        &self,
+        selector: &DebugProbeSelector,
+    ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+        let device = WchLinkUsbDevice::new_from_selector(selector)?;
+        let mut wlink = WchLink {
+            device,
+            name: "WCH-Link".into(),
+            variant: WchLinkVariant::Ch549,
+            v_major: 0,
+            v_minor: 0,
+            chip_id: 0,
+            chip_family: RiscvChip::CH32V103,
+            last_dmi_read: None,
+            speed: Speed::default(),
+            idle_cycles: 0,
+        };
+
+        wlink.init()?;
+
+        Ok(Box::new(wlink))
+    }
+
+    fn list_probes(&self) -> Vec<DebugProbeInfo> {
+        list_wlink_devices()
+    }
+}
+
 /// WCH-Link device (mod:RV)
 #[derive(Debug)]
 pub(crate) struct WchLink {
@@ -226,31 +258,6 @@ impl WchLink {
 }
 
 impl DebugProbe for WchLink {
-    fn new_from_selector(
-        selector: &DebugProbeSelector,
-    ) -> Result<Box<dyn DebugProbe>, DebugProbeError>
-    where
-        Self: Sized,
-    {
-        let device = WchLinkUsbDevice::new_from_selector(selector)?;
-        let mut wlink = Self {
-            device,
-            name: "WCH-Link".into(),
-            variant: WchLinkVariant::Ch549,
-            v_major: 0,
-            v_minor: 0,
-            chip_id: 0,
-            chip_family: RiscvChip::CH32V103,
-            last_dmi_read: None,
-            speed: Speed::default(),
-            idle_cycles: 0,
-        };
-
-        wlink.init()?;
-
-        Ok(Box::new(wlink))
-    }
-
     fn get_name(&self) -> &str {
         &self.name
     }
@@ -498,7 +505,7 @@ fn get_wlink_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
 }
 
 #[tracing::instrument(skip_all)]
-pub fn list_wlink_devices() -> Vec<DebugProbeInfo> {
+fn list_wlink_devices() -> Vec<DebugProbeInfo> {
     tracing::debug!("Searching for WCH-Link(RV) probes using libusb");
     let probes = match rusb::Context::new().and_then(|ctx| ctx.devices()) {
         Ok(devices) => devices

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -226,9 +226,7 @@ impl WchLink {
 }
 
 impl DebugProbe for WchLink {
-    fn new_from_selector(
-        selector: impl Into<DebugProbeSelector>,
-    ) -> Result<Box<Self>, DebugProbeError>
+    fn new_from_selector(selector: &DebugProbeSelector) -> Result<Box<Self>, DebugProbeError>
     where
         Self: Sized,
     {

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -12,8 +12,8 @@ use rusb::{Device, UsbContext};
 use crate::{
     architecture::riscv::communication_interface::{RiscvCommunicationInterface, RiscvError},
     probe::DebugProbeSource,
-    DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, DebugProbeType,
-    ProbeCreationError, WireProtocol,
+    DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeCreationError,
+    WireProtocol,
 };
 
 use self::{commands::Speed, usb_interface::WchLinkUsbDevice};
@@ -148,6 +148,12 @@ impl RiscvChip {
 }
 
 pub struct WchLinkSource;
+
+impl std::fmt::Debug for WchLinkSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WchLink").finish()
+    }
+}
 
 impl DebugProbeSource for WchLinkSource {
     fn new_from_selector(
@@ -496,7 +502,7 @@ fn get_wlink_info(device: &Device<rusb::Context>) -> Option<DebugProbeInfo> {
             VENDOR_ID,
             PRODUCT_ID,
             sn_str,
-            DebugProbeType::WchLink,
+            &WchLinkSource,
             None,
         ))
     } else {

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -11,7 +11,7 @@ use rusb::{Device, UsbContext};
 
 use crate::{
     architecture::riscv::communication_interface::{RiscvCommunicationInterface, RiscvError},
-    probe::DebugProbeSource,
+    probe::ProbeDriver,
     DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeCreationError,
     WireProtocol,
 };
@@ -155,11 +155,8 @@ impl std::fmt::Debug for WchLinkSource {
     }
 }
 
-impl DebugProbeSource for WchLinkSource {
-    fn new_from_selector(
-        &self,
-        selector: &DebugProbeSelector,
-    ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
+impl ProbeDriver for WchLinkSource {
+    fn open(&self, selector: &DebugProbeSelector) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
         let device = WchLinkUsbDevice::new_from_selector(selector)?;
         let mut wlink = WchLink {
             device,

--- a/probe-rs/src/probe/wlink/usb_interface.rs
+++ b/probe-rs/src/probe/wlink/usb_interface.rs
@@ -18,11 +18,7 @@ pub struct WchLinkUsbDevice {
 }
 
 impl WchLinkUsbDevice {
-    pub fn new_from_selector(
-        selector: impl Into<DebugProbeSelector>,
-    ) -> Result<Self, ProbeCreationError> {
-        let selector = selector.into();
-
+    pub fn new_from_selector(selector: &DebugProbeSelector) -> Result<Self, ProbeCreationError> {
         let context = rusb::Context::new()?;
 
         tracing::trace!("Acquired libusb context.");


### PR DESCRIPTION
This PR makes some slight cleanups in espusbjtag, and separates ProbeDriver from DebugProbe. This change allows reducing hard coding or probe types, cleaning up the probe driver lists, streamlining the open and probe lister code.

This PR also removes the `DebugProbeType` enum, which is only used to print the probe type internally, and requires the set of probe types to be hard coded into probe-rs.