### PR TITLE
Don't serialize the default transfer encoding

### DIFF
--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -149,7 +149,7 @@ pub struct RiscvCoreAccessOptions {}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct XtensaCoreAccessOptions {}
 
-/// Helper function that interates the scan chain and returns a vector of all of
+/// Helper function that iterates the scan chain and returns a vector of all of
 /// the ir_lengths of the scan chain elements.
 /// If an element does not contain an ir_length, the default value of 4 is used.
 /// The first element of the vector is the first element of the scan chain.

--- a/probe-rs-target/src/flash_algorithm.rs
+++ b/probe-rs-target/src/flash_algorithm.rs
@@ -79,7 +79,7 @@ pub struct RawFlashAlgorithm {
 
     /// The encoding format accepted by the flash algorithm.
     #[serde(default)]
-    pub transfer_encoding: TransferEncoding,
+    pub transfer_encoding: Option<TransferEncoding>,
 }
 
 pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -325,7 +325,7 @@ impl FlashAlgorithm {
             page_buffers: page_buffers.clone(),
             rtt_control_block: raw.rtt_location,
             flash_properties: raw.flash_properties.clone(),
-            transfer_encoding: raw.transfer_encoding,
+            transfer_encoding: raw.transfer_encoding.unwrap_or_default(),
         })
     }
 }


### PR DESCRIPTION
This PR removed `transfer_encoding: raw` from newly generated yamls