### PR TITLE
Enable ftdi when using ftdi-vendored

### DIFF
--- a/changelog/changed-vendored-ftdi.md
+++ b/changelog/changed-vendored-ftdi.md
@@ -1,0 +1,1 @@
+The `ftdi-vendored` feature now enabled `ftdi` automatically

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -78,7 +78,7 @@ vendored-libusb = ["rusb/vendored"]
 builtin-targets = []
 
 ftdi = ["libftdi1-sys"]
-ftdi-vendored = ["libftdi1-sys/vendored", "libftdi1-sys/libusb1-sys"]
+ftdi-vendored = ["ftdi", "libftdi1-sys/vendored", "libftdi1-sys/libusb1-sys"]
 
 # Enable helpers for testing
 test = []


### PR DESCRIPTION
Previously enabling `ftdi-vendored` still did not include the ftdi probe driver, which honestly made no sense to me.