### PR TITLE
Use a timeout while waiting for debug module to power on, recognise X…

### DIFF
--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -166,10 +166,15 @@ impl Xdm {
         self.pwr_write(PowerDevice::PowerControl, pwr_control.0)?;
 
         tracing::trace!("Waiting for power domain to turn on");
+        let now = std::time::Instant::now();
         loop {
             let bits = self.pwr_read(PowerDevice::PowerStat)?;
             if PowerStatus(bits).debug_domain_on() {
                 break;
+            }
+
+            if now.elapsed().as_millis() > 500 {
+                return Err(XtensaError::Timeout);
             }
         }
 

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -484,13 +484,17 @@ impl DebugProbe for FtdiProbe {
                 .select_target(taps[0].idcode)
                 .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
         } else {
-            let known_idcodes = [
+            const KNOWN_IDCODES: [u32; 2] = [
                 0x1000563d, // GD32VF103
+                0x120034e5, // Little endian Xtensa core
             ];
-            let idcode = taps
-                .iter()
-                .map(|tap| tap.idcode)
-                .find(|idcode| known_idcodes.iter().any(|v| v == idcode));
+            let idcode = taps.iter().map(|tap| tap.idcode).find(|idcode| {
+                let found = KNOWN_IDCODES.contains(idcode);
+                if !found {
+                    tracing::warn!("Unknown IDCODEs: {:x?}", idcode);
+                }
+                found
+            });
             if let Some(idcode) = idcode {
                 self.adapter
                     .select_target(idcode)


### PR DESCRIPTION
…tensa cores

This PR allows using the FTDI probe driver with Xtensa MCUs. The timeout handles my next issue: trying to connect to an ESP32 just loops there, so we shouldn't wait forever.