### PR TITLE
ESP32-S3: Add missing changelog entry

### DIFF
--- a/changelog/added-esp32s3-support.md
+++ b/changelog/added-esp32s3-support.md
@@ -1,0 +1,1 @@
+Add support for the esp32s3 target


### PR DESCRIPTION
Somewhere along the line it started to make sense to advertise esp32-s3 support, but I forgot to do so :)