### PR TITLE
Fix potential endless recursion in arm_jtag

### DIFF
--- a/changelog/fixed-recursion-in-arm_jtag.md
+++ b/changelog/fixed-recursion-in-arm_jtag.md
@@ -1,0 +1,1 @@
+Fixed potential endless recusion in arm_jtag

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -95,7 +95,7 @@ pub trait DpRegister: Register {
 
 bitfield! {
     /// ABORT, Abort register (see ADI v5.2 B2.2.1)
-    #[derive(Clone, Default)]
+    #[derive(Clone, Copy, Default)]
     pub struct Abort(u32);
     impl Debug;
     /// To clear the CTRL/STAT.STICKYORUN overrun error bit to `0b0`, write `0b1` to this bit.


### PR DESCRIPTION
Closes #531 (at least I think) as the calls are no longer recursive.

There's still a possibility to encounter endless recursion if the errors end up alternating between `DapError::FaultResponse` and `DapError::WaitResponse` but that doesn't seem like a practically possible case.