### PR TITLE
Add support for 16bit reads/writes.

### DIFF
--- a/changelog/added-16bit.md
+++ b/changelog/added-16bit.md
@@ -1,0 +1,1 @@
+Added support for 16bit reads and writes.

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -817,11 +817,11 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
         Ok(InstructionSet::Thumb2)
     }
 
-    fn fpu_support(&mut self) -> Result<bool, crate::error::Error> {
+    fn fpu_support(&mut self) -> Result<bool, Error> {
         Ok(false)
     }
 
-    fn floating_point_register_count(&mut self) -> Result<usize, crate::error::Error> {
+    fn floating_point_register_count(&mut self) -> Result<usize, Error> {
         Ok(0)
     }
 
@@ -899,7 +899,7 @@ impl<'probe> MemoryInterface for Armv6m<'probe> {
     fn supports_native_64bit_access(&mut self) -> bool {
         self.memory.supports_native_64bit_access()
     }
-    fn read_word_64(&mut self, address: u64) -> Result<u64, crate::error::Error> {
+    fn read_word_64(&mut self, address: u64) -> Result<u64, Error> {
         let value = self.memory.read_word_64(address)?;
         Ok(value)
     }
@@ -907,12 +907,16 @@ impl<'probe> MemoryInterface for Armv6m<'probe> {
         let value = self.memory.read_word_32(address)?;
         Ok(value)
     }
+    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
+        let value = self.memory.read_word_16(address)?;
+        Ok(value)
+    }
     fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
         let value = self.memory.read_word_8(address)?;
         Ok(value)
     }
 
-    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), crate::error::Error> {
+    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error> {
         self.memory.read_64(address, data)?;
         Ok(())
     }
@@ -922,12 +926,17 @@ impl<'probe> MemoryInterface for Armv6m<'probe> {
         Ok(())
     }
 
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
+        self.memory.read_16(address, data)?;
+        Ok(())
+    }
+
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
         self.memory.read_8(address, data)?;
         Ok(())
     }
 
-    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), crate::error::Error> {
+    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
         self.memory.write_word_64(address, data)?;
         Ok(())
     }
@@ -937,18 +946,28 @@ impl<'probe> MemoryInterface for Armv6m<'probe> {
         Ok(())
     }
 
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
+        self.memory.write_word_16(address, data)?;
+        Ok(())
+    }
+
     fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
         self.memory.write_word_8(address, data)?;
         Ok(())
     }
 
-    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), crate::error::Error> {
+    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
         self.memory.write_64(address, data)?;
         Ok(())
     }
 
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
         self.memory.write_32(address, data)?;
+        Ok(())
+    }
+
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
+        self.memory.write_16(address, data)?;
         Ok(())
     }
 

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -936,7 +936,7 @@ impl<'probe> MemoryInterface for Armv7a<'probe> {
 
     fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
         for (i, byte) in data.iter().enumerate() {
-            self.write_word_8(address + ((i as u64) * 4), *byte)?;
+            self.write_word_8(address + (i as u64), *byte)?;
         }
 
         Ok(())

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -845,6 +845,18 @@ impl<'probe> MemoryInterface for Armv7a<'probe> {
         self.execute_instruction_with_result(instr)
     }
 
+    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
+        // Find the word this is in and its byte offset
+        let byte_offset = address % 4;
+        let word_start = address - byte_offset;
+
+        // Read the word
+        let data = self.read_word_32(word_start)?;
+
+        // Return the byte
+        Ok((data >> (byte_offset * 8)) as u16)
+    }
+
     fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
         // Find the word this is in and its byte offset
         let byte_offset = address % 4;
@@ -868,6 +880,14 @@ impl<'probe> MemoryInterface for Armv7a<'probe> {
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
         for (i, word) in data.iter_mut().enumerate() {
             *word = self.read_word_32(address + ((i as u64) * 4))?;
+        }
+
+        Ok(())
+    }
+
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
+        for (i, word) in data.iter_mut().enumerate() {
+            *word = self.read_word_16(address + ((i as u64) * 2))?;
         }
 
         Ok(())
@@ -918,6 +938,21 @@ impl<'probe> MemoryInterface for Armv7a<'probe> {
         self.write_word_32(word_start, u32::from_le_bytes(word_bytes))
     }
 
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
+        // Find the word this is in and its byte offset
+        let byte_offset = address % 4;
+        let word_start = address - byte_offset;
+
+        // Get the current word value
+        let mut word = self.read_word_32(word_start)?;
+
+        // patch the word into it
+        word &= !(0xFFFFu32 << (byte_offset * 8));
+        word |= (data as u32) << (byte_offset * 8);
+
+        self.write_word_32(word_start, word)
+    }
+
     fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), crate::error::Error> {
         for (i, word) in data.iter().enumerate() {
             self.write_word_64(address + ((i as u64) * 8), *word)?;
@@ -929,6 +964,14 @@ impl<'probe> MemoryInterface for Armv7a<'probe> {
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
         for (i, word) in data.iter().enumerate() {
             self.write_word_32(address + ((i as u64) * 4), *word)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
+        for (i, word) in data.iter().enumerate() {
+            self.write_word_16(address + ((i as u64) * 2), *word)?;
         }
 
         Ok(())
@@ -1011,6 +1054,10 @@ mod test {
             todo!()
         }
 
+        fn read_16(&mut self, _address: u64, _data: &mut [u16]) -> Result<(), ArmError> {
+            todo!()
+        }
+
         fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), ArmError> {
             if self.expected_ops.is_empty() {
                 panic!(
@@ -1047,6 +1094,10 @@ mod test {
         }
 
         fn write_8(&mut self, _address: u64, _data: &[u8]) -> Result<(), ArmError> {
+            todo!()
+        }
+
+        fn write_16(&mut self, _address: u64, _data: &[u16]) -> Result<(), ArmError> {
             todo!()
         }
 

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -1047,11 +1047,11 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
         Ok(InstructionSet::Thumb2)
     }
 
-    fn fpu_support(&mut self) -> Result<bool, crate::error::Error> {
+    fn fpu_support(&mut self) -> Result<bool, Error> {
         Ok(self.state.fp_present)
     }
 
-    fn floating_point_register_count(&mut self) -> Result<usize, crate::error::Error> {
+    fn floating_point_register_count(&mut self) -> Result<usize, Error> {
         Ok(32)
     }
 
@@ -1128,7 +1128,7 @@ impl<'probe> MemoryInterface for Armv7m<'probe> {
         self.memory.supports_native_64bit_access()
     }
 
-    fn read_word_64(&mut self, address: u64) -> Result<u64, crate::error::Error> {
+    fn read_word_64(&mut self, address: u64) -> Result<u64, Error> {
         self.memory
             .read_word_64(address)
             .map_err(From::<ArmError>::from)
@@ -1140,13 +1140,19 @@ impl<'probe> MemoryInterface for Armv7m<'probe> {
             .map_err(From::<ArmError>::from)
     }
 
+    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
+        self.memory
+            .read_word_16(address)
+            .map_err(From::<ArmError>::from)
+    }
+
     fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
         self.memory
             .read_word_8(address)
             .map_err(From::<ArmError>::from)
     }
 
-    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), crate::error::Error> {
+    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error> {
         self.memory
             .read_64(address, data)
             .map_err(From::<ArmError>::from)
@@ -1158,13 +1164,19 @@ impl<'probe> MemoryInterface for Armv7m<'probe> {
             .map_err(From::<ArmError>::from)
     }
 
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
+        self.memory
+            .read_16(address, data)
+            .map_err(From::<ArmError>::from)
+    }
+
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
         self.memory
             .read_8(address, data)
             .map_err(From::<ArmError>::from)
     }
 
-    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), crate::error::Error> {
+    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
         self.memory
             .write_word_64(address, data)
             .map_err(From::<ArmError>::from)
@@ -1176,13 +1188,19 @@ impl<'probe> MemoryInterface for Armv7m<'probe> {
             .map_err(From::<ArmError>::from)
     }
 
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
+        self.memory
+            .write_word_16(address, data)
+            .map_err(From::<ArmError>::from)
+    }
+
     fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
         self.memory
             .write_word_8(address, data)
             .map_err(From::<ArmError>::from)
     }
 
-    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), crate::error::Error> {
+    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
         self.memory
             .write_64(address, data)
             .map_err(From::<ArmError>::from)
@@ -1191,6 +1209,12 @@ impl<'probe> MemoryInterface for Armv7m<'probe> {
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
         self.memory
             .write_32(address, data)
+            .map_err(From::<ArmError>::from)
+    }
+
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
+        self.memory
+            .write_16(address, data)
             .map_err(From::<ArmError>::from)
     }
 

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -1187,6 +1187,18 @@ impl<'probe> MemoryInterface for Armv8a<'probe> {
         }
     }
 
+    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
+        // Find the word this is in and its byte offset
+        let byte_offset = address % 4;
+        let word_start = address - byte_offset;
+
+        // Read the word
+        let data = self.read_word_32(word_start)?;
+
+        // Return the byte
+        Ok((data >> (byte_offset * 8)) as u16)
+    }
+
     fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
         // Find the word this is in and its byte offset
         let byte_offset = address % 4;
@@ -1210,6 +1222,14 @@ impl<'probe> MemoryInterface for Armv8a<'probe> {
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
         for (i, word) in data.iter_mut().enumerate() {
             *word = self.read_word_32(address + ((i as u64) * 4))?;
+        }
+
+        Ok(())
+    }
+
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
+        for (i, word) in data.iter_mut().enumerate() {
+            *word = self.read_word_16(address + ((i as u64) * 2))?;
         }
 
         Ok(())
@@ -1243,6 +1263,21 @@ impl<'probe> MemoryInterface for Armv8a<'probe> {
         }
     }
 
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
+        // Find the word this is in and its byte offset
+        let byte_offset = address % 4;
+        let word_start = address - byte_offset;
+
+        // Get the current word value
+        let mut word = self.read_word_32(word_start)?;
+
+        // patch the word into it
+        word &= !(0xFFFFu32 << (byte_offset * 8));
+        word |= (data as u32) << (byte_offset * 8);
+
+        self.write_word_32(word_start, word)
+    }
+
     fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
         // Find the word this is in and its byte offset
         let byte_offset = address % 4;
@@ -1267,6 +1302,14 @@ impl<'probe> MemoryInterface for Armv8a<'probe> {
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
         for (i, word) in data.iter().enumerate() {
             self.write_word_32(address + ((i as u64) * 4), *word)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
+        for (i, word) in data.iter().enumerate() {
+            self.write_word_16(address + ((i as u64) * 2), *word)?;
         }
 
         Ok(())
@@ -1352,6 +1395,10 @@ mod test {
             todo!()
         }
 
+        fn read_16(&mut self, _address: u64, _data: &mut [u16]) -> Result<(), ArmError> {
+            todo!()
+        }
+
         fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), ArmError> {
             if self.expected_ops.is_empty() {
                 panic!(
@@ -1384,6 +1431,10 @@ mod test {
         }
 
         fn write_8(&mut self, _address: u64, _data: &[u8]) -> Result<(), ArmError> {
+            todo!()
+        }
+
+        fn write_16(&mut self, _address: u64, _data: &[u16]) -> Result<(), ArmError> {
             todo!()
         }
 

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -1274,7 +1274,7 @@ impl<'probe> MemoryInterface for Armv8a<'probe> {
 
     fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {
         for (i, byte) in data.iter().enumerate() {
-            self.write_word_8(address + ((i as u64) * 4), *byte)?;
+            self.write_word_8(address + (i as u64), *byte)?;
         }
 
         Ok(())

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -436,11 +436,11 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         Ok(InstructionSet::Thumb2)
     }
 
-    fn fpu_support(&mut self) -> Result<bool, crate::error::Error> {
+    fn fpu_support(&mut self) -> Result<bool, Error> {
         Ok(self.state.fp_present)
     }
 
-    fn floating_point_register_count(&mut self) -> Result<usize, crate::error::Error> {
+    fn floating_point_register_count(&mut self) -> Result<usize, Error> {
         Ok(32)
     }
 
@@ -531,18 +531,32 @@ impl<'probe> MemoryInterface for Armv8m<'probe> {
     fn supports_native_64bit_access(&mut self) -> bool {
         self.memory.supports_native_64bit_access()
     }
+
+    fn read_word_64(&mut self, address: u64) -> Result<u64, Error> {
+        self.memory
+            .read_word_64(address)
+            .map_err(From::<ArmError>::from)
+    }
+
     fn read_word_32(&mut self, address: u64) -> Result<u32, Error> {
         self.memory
             .read_word_32(address)
             .map_err(From::<ArmError>::from)
     }
+
+    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
+        self.memory
+            .read_word_16(address)
+            .map_err(From::<ArmError>::from)
+    }
+
     fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
         self.memory
             .read_word_8(address)
             .map_err(From::<ArmError>::from)
     }
 
-    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), crate::error::Error> {
+    fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error> {
         self.memory
             .read_64(address, data)
             .map_err(From::<ArmError>::from)
@@ -554,19 +568,19 @@ impl<'probe> MemoryInterface for Armv8m<'probe> {
             .map_err(From::<ArmError>::from)
     }
 
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
+        self.memory
+            .read_16(address, data)
+            .map_err(From::<ArmError>::from)
+    }
+
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
         self.memory
             .read_8(address, data)
             .map_err(From::<ArmError>::from)
     }
 
-    fn read_word_64(&mut self, address: u64) -> Result<u64, crate::error::Error> {
-        self.memory
-            .read_word_64(address)
-            .map_err(From::<ArmError>::from)
-    }
-
-    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), crate::error::Error> {
+    fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error> {
         self.memory
             .write_word_64(address, data)
             .map_err(From::<ArmError>::from)
@@ -578,13 +592,19 @@ impl<'probe> MemoryInterface for Armv8m<'probe> {
             .map_err(From::<ArmError>::from)
     }
 
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
+        self.memory
+            .write_word_16(address, data)
+            .map_err(From::<ArmError>::from)
+    }
+
     fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
         self.memory
             .write_word_8(address, data)
             .map_err(From::<ArmError>::from)
     }
 
-    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), crate::error::Error> {
+    fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error> {
         self.memory
             .write_64(address, data)
             .map_err(From::<ArmError>::from)
@@ -593,6 +613,12 @@ impl<'probe> MemoryInterface for Armv8m<'probe> {
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
         self.memory
             .write_32(address, data)
+            .map_err(From::<ArmError>::from)
+    }
+
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
+        self.memory
+            .write_16(address, data)
             .map_err(From::<ArmError>::from)
     }
 

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -347,7 +347,7 @@ where
 
     /// Read a 64bit word at `address`.
     ///
-    /// The address where the read should be performed at has to be word aligned.
+    /// The address where the read should be performed at has to be a multiple of 8.
     /// Returns `ArmError::MemoryNotAligned` if this does not hold true.
     pub fn read_word_64(&mut self, access_port: MemoryAp, address: u64) -> Result<u64, ArmError> {
         if (address % 8) != 0 {
@@ -377,7 +377,7 @@ where
 
     /// Read a 32bit word at `addr`.
     ///
-    /// The address where the read should be performed at has to be word aligned.
+    /// The address where the read should be performed at has to be a multiple of 4.
     /// Returns `ArmError::MemoryNotAligned` if this does not hold true.
     pub fn read_word_32(&mut self, access_port: MemoryAp, address: u64) -> Result<u32, ArmError> {
         if (address % 4) != 0 {
@@ -395,7 +395,7 @@ where
 
     /// Read an 16 bit word at `address`.
     ///
-    /// The address where the read should be performed at has to be word aligned.
+    /// The address where the read should be performed at has to be a multiple of 2.
     /// Returns `ArmError::MemoryNotAligned` if this does not hold true.
     pub fn read_word_16(&mut self, access_port: MemoryAp, address: u64) -> Result<u16, ArmError> {
         if self.ap_information.supports_only_32bit_data_size {
@@ -439,7 +439,7 @@ where
     /// Read a block of 32 bit words at `address`.
     ///
     /// The number of words read is `data.len()`.
-    /// The address where the read should be performed at has to be word aligned.
+    /// The address where the read should be performed at has to be a multiple of 4.
     /// Returns `ArmError::MemoryNotAligned` if this does not hold true.
     pub fn read_32(
         &mut self,
@@ -485,7 +485,7 @@ where
     /// Read a block of 16 bit words at `address`.
     ///
     /// The number of words read is `data.len()`.
-    /// The address where the read should be performed at has to be word aligned.
+    /// The address where the read should be performed at has to be a multiple of 2.
     /// Returns `ArmError::MemoryNotAligned` if this does not hold true.
     pub fn read_16(
         &mut self,
@@ -600,7 +600,7 @@ where
 
     /// Write a 64bit word at `addr`.
     ///
-    /// The address where the write should be performed at has to be word aligned.
+    /// The address where the write should be performed at has to be a multiple of 8.
     /// Returns `ArmError::MemoryNotAligned` if this does not hold true.
     pub fn write_word_64(
         &mut self,
@@ -636,7 +636,7 @@ where
 
     /// Write a 32bit word at `address`.
     ///
-    /// The address where the write should be performed at has to be word aligned.
+    /// The address where the write should be performed at has to be a multiple of 4.
     /// Returns `ArmError::MemoryNotAligned` if this does not hold true.
     pub fn write_word_32(
         &mut self,
@@ -661,7 +661,7 @@ where
 
     /// Write a 16bit word at `address`.
     ///
-    /// The address where the write should be performed at has to be word aligned.
+    /// The address where the write should be performed at has to be a multiple of 2.
     /// Returns `ArmError::MemoryNotAligned` if this does not hold true.
     pub fn write_word_16(
         &mut self,
@@ -719,7 +719,7 @@ where
     /// Write a block of 32 bit words at `address`.
     ///
     /// The number of words written is `data.len()`.
-    /// The address where the write should be performed at has to be word aligned.
+    /// The address where the write should be performed at has to be a multiple of 4.
     /// Returns `ArmError::MemoryNotAligned` if this does not hold true.
     pub fn write_32(
         &mut self,
@@ -771,7 +771,7 @@ where
     /// Write a block of 16 bit words at `address`.
     ///
     /// The number of words written is `data.len()`.
-    /// The address where the write should be performed at has to be word aligned.
+    /// The address where the write should be performed at has to be a multiple of 2.
     /// Returns `ArmError::MemoryNotAligned` if this does not hold true.
     pub fn write_16(
         &mut self,

--- a/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
+++ b/probe-rs/src/architecture/arm/memory/adi_v5_memory_interface.rs
@@ -151,6 +151,14 @@ pub trait ArmProbe: SwdSequence {
     }
 }
 
+/// Calculate the maximum number of bytes we can write starting at address
+/// before we run into the 10-bit TAR autoincrement limit.
+fn autoincr_max_bytes(address: u64) -> usize {
+    const AUTOINCR_LIMIT: usize = 0x400;
+
+    ((address + 1).next_multiple_of(AUTOINCR_LIMIT as _) - address) as usize
+}
+
 /// A struct to give access to a targets memory using a certain DAP.
 pub(crate) struct ADIMemoryInterface<'interface, AP>
 where
@@ -396,8 +404,8 @@ where
     pub fn read_32(
         &mut self,
         access_port: MemoryAp,
-        address: u64,
-        data: &mut [u32],
+        mut address: u64,
+        mut data: &mut [u32],
     ) -> Result<(), ArmError> {
         if data.is_empty() {
             return Ok(());
@@ -407,70 +415,26 @@ where
             return Err(ArmError::alignment_error(address, 4));
         }
 
-        // Second we read in 32 bit reads until we have less than 32 bits left to read.
         let csw = self.build_csw_register(DataSize::U32);
         self.write_csw_register(access_port, csw)?;
-        self.write_tar_register(access_port, address)?;
 
-        // The maximum chunk size we can read before data overflows.
-        // This is the size of the internal counter that is used for the address increment in the ARM spec.
-        let max_chunk_size_bytes = 0x400;
-
-        let mut remaining_data_len = data.len();
-
-        let first_chunk_size_bytes = std::cmp::min(
-            max_chunk_size_bytes - (address as usize % max_chunk_size_bytes),
-            data.len() * 4,
-        );
-
-        let mut data_offset = 0;
-
-        tracing::debug!(
-            "Read first block with len {} at address {:#08x}",
-            first_chunk_size_bytes,
-            address
-        );
-
-        let first_chunk_size_transfer_unit = first_chunk_size_bytes / 4;
-
-        self.read_ap_register_repeated(
-            access_port,
-            DRW { data: 0 },
-            &mut data[data_offset..first_chunk_size_transfer_unit],
-        )?;
-
-        remaining_data_len -= first_chunk_size_transfer_unit;
-        let mut address = address
-            .checked_add((4 * first_chunk_size_transfer_unit) as u64)
-            .ok_or(ArmError::OutOfBounds)?;
-        data_offset += first_chunk_size_transfer_unit;
-
-        while remaining_data_len > 0 {
-            // the autoincrement is limited to the 10 lowest bits so we need to write the address
-            // every time it overflows
-            self.write_tar_register(access_port, address)?;
-
-            let next_chunk_size_bytes = std::cmp::min(max_chunk_size_bytes, remaining_data_len * 4);
+        while !data.is_empty() {
+            let chunk_size = data.len().min(autoincr_max_bytes(address) / 4);
 
             tracing::debug!(
                 "Reading chunk with len {} at address {:#08x}",
-                next_chunk_size_bytes,
+                chunk_size,
                 address
             );
 
-            let next_chunk_size_transfer_unit = next_chunk_size_bytes / 4;
+            // autoincrement is limited to the 10 lowest bits, so write TAR every time.
+            self.write_tar_register(access_port, address)?;
+            self.read_ap_register_repeated(access_port, DRW { data: 0 }, &mut data[..chunk_size])?;
 
-            self.read_ap_register_repeated(
-                access_port,
-                DRW { data: 0 },
-                &mut data[data_offset..(data_offset + next_chunk_size_transfer_unit)],
-            )?;
-
-            remaining_data_len -= next_chunk_size_transfer_unit;
             address = address
-                .checked_add((4 * next_chunk_size_transfer_unit) as u64)
+                .checked_add(chunk_size as u64 * 4)
                 .ok_or(ArmError::OutOfBounds)?;
-            data_offset += next_chunk_size_transfer_unit;
+            data = &mut data[chunk_size..];
         }
 
         tracing::debug!("Finished reading block");
@@ -484,8 +448,8 @@ where
     pub fn read_8(
         &mut self,
         access_port: MemoryAp,
-        address: u64,
-        data: &mut [u8],
+        mut address: u64,
+        mut data: &mut [u8],
     ) -> Result<(), ArmError> {
         if self.ap_information.supports_only_32bit_data_size {
             return Err(ArmError::UnsupportedTransferWidth(8));
@@ -495,81 +459,37 @@ where
             return Ok(());
         }
 
-        let start_address = address;
-        let mut data_u32 = vec![0u32; data.len()];
-
         let csw = self.build_csw_register(DataSize::U8);
         self.write_csw_register(access_port, csw)?;
 
-        let mut address = address;
-        self.write_tar_register(access_port, address)?;
-
-        // The maximum chunk size we can read before data overflows.
-        // This is the size of the internal counter that is used for the address increment in the ARM spec.
-        let max_chunk_size_bytes = 0x400;
-
-        let mut remaining_data_len = data.len();
-
-        let first_chunk_size_bytes = std::cmp::min(
-            max_chunk_size_bytes - (address as usize % max_chunk_size_bytes),
-            data.len(),
-        );
-
-        let mut data_offset = 0;
-
-        tracing::debug!(
-            "Read first block with len {} at address {:#08x}",
-            first_chunk_size_bytes,
-            address
-        );
-
-        let first_chunk_size_transfer_unit = first_chunk_size_bytes;
-
-        self.read_ap_register_repeated(
-            access_port,
-            DRW { data: 0 },
-            &mut data_u32[data_offset..first_chunk_size_transfer_unit],
-        )?;
-
-        remaining_data_len -= first_chunk_size_transfer_unit;
-        address = address
-            .checked_add((first_chunk_size_transfer_unit) as u64)
-            .ok_or(ArmError::OutOfBounds)?;
-        data_offset += first_chunk_size_transfer_unit;
-
-        while remaining_data_len > 0 {
-            // The autoincrement is limited to the 10 lowest bits so we need to write the address
-            // every time it overflows.
-            self.write_tar_register(access_port, address)?;
-
-            let next_chunk_size_bytes = std::cmp::min(max_chunk_size_bytes, remaining_data_len);
+        while !data.is_empty() {
+            let chunk_size = data.len().min(autoincr_max_bytes(address));
 
             tracing::debug!(
                 "Reading chunk with len {} at address {:#08x}",
-                next_chunk_size_bytes,
+                chunk_size,
                 address
             );
 
-            let next_chunk_size_transfer_unit = next_chunk_size_bytes;
+            let mut values = vec![0; chunk_size];
 
-            self.read_ap_register_repeated(
-                access_port,
-                DRW { data: 0 },
-                &mut data_u32[data_offset..(data_offset + next_chunk_size_transfer_unit)],
-            )?;
+            // autoincrement is limited to the 10 lowest bits, so write TAR every time.
+            self.write_tar_register(access_port, address)?;
+            self.read_ap_register_repeated(access_port, DRW { data: 0 }, &mut values)?;
 
-            remaining_data_len -= next_chunk_size_transfer_unit;
+            // The required shifting logic here is described in C2.2.6 Byte lanes of the ADI v5.2 specification.
+            // All bytes are transfered in their lane, so when we do an access at an address that is not divisible by 4,
+            // we have to shift the word (one or two bytes) to it's correct position.
+            for (target, (i, source)) in
+                data[..chunk_size].iter_mut().zip(values.iter().enumerate())
+            {
+                *target = ((*source >> (((address + i as u64) % 4) * 8)) & 0xFF) as u8;
+            }
+
             address = address
-                .checked_add((next_chunk_size_transfer_unit) as u64)
+                .checked_add(chunk_size as u64)
                 .ok_or(ArmError::OutOfBounds)?;
-            data_offset += next_chunk_size_transfer_unit;
-        }
-
-        // The required shifting logic here is described in C2.2.6 Byte lanes of the ADI v5.2 specification.
-        // All bytes are transfered in their lane, so when we do an access at an address that is not divisible by 4,
-        // we have to shift the word (one or two bytes) to it's correct position.
-        for (target, (i, source)) in data.iter_mut().zip(data_u32.iter().enumerate()) {
-            *target = ((*source >> (((start_address + i as u64) % 4) * 8)) & 0xFF) as u8;
+            data = &mut data[chunk_size..];
         }
 
         tracing::debug!("Finished reading block");
@@ -672,8 +592,8 @@ where
     pub fn write_32(
         &mut self,
         access_port: MemoryAp,
-        address: u64,
-        data: &[u32],
+        mut address: u64,
+        mut data: &[u32],
     ) -> Result<(), ArmError> {
         if (address % 4) != 0 {
             return Err(ArmError::alignment_error(address, 4));
@@ -689,71 +609,26 @@ where
             address
         );
 
-        // Second we write in 32 bit reads until we have less than 32 bits left to write.
         let csw = self.build_csw_register(DataSize::U32);
-
         self.write_csw_register(access_port, csw)?;
 
-        self.write_tar_register(access_port, address)?;
-
-        // maximum chunk size
-        let max_chunk_size_bytes = 0x400_usize;
-
-        let mut remaining_data_len = data.len();
-
-        let first_chunk_size_bytes = std::cmp::min(
-            max_chunk_size_bytes - (address as usize % max_chunk_size_bytes),
-            data.len() * 4,
-        );
-
-        let mut data_offset = 0;
-
-        tracing::debug!(
-            "Write first block with len {} at address {:#08x}",
-            first_chunk_size_bytes,
-            address
-        );
-
-        let first_chunk_size_transfer_unit = first_chunk_size_bytes / 4;
-
-        self.write_ap_register_repeated(
-            access_port,
-            DRW { data: 0 },
-            &data[data_offset..first_chunk_size_transfer_unit],
-        )?;
-
-        remaining_data_len -= first_chunk_size_transfer_unit;
-        let mut address = address
-            .checked_add((first_chunk_size_transfer_unit * 4) as u64)
-            .ok_or(ArmError::OutOfBounds)?;
-        data_offset += first_chunk_size_transfer_unit;
-
-        while remaining_data_len > 0 {
-            // the autoincrement is limited to the 10 lowest bits so we need to write the address
-            // every time it overflows
-            self.write_tar_register(access_port, address)?;
-
-            let next_chunk_size_bytes = std::cmp::min(max_chunk_size_bytes, remaining_data_len * 4);
+        while !data.is_empty() {
+            let chunk_size = data.len().min(autoincr_max_bytes(address) / 4);
 
             tracing::debug!(
                 "Writing chunk with len {} at address {:#08x}",
-                next_chunk_size_bytes,
+                chunk_size,
                 address
             );
 
-            let next_chunk_size_transfer_unit = next_chunk_size_bytes / 4;
+            // autoincrement is limited to the 10 lowest bits, so write TAR every time.
+            self.write_tar_register(access_port, address)?;
+            self.write_ap_register_repeated(access_port, DRW { data: 0 }, &data[..chunk_size])?;
 
-            self.write_ap_register_repeated(
-                access_port,
-                DRW { data: 0 },
-                &data[data_offset..(data_offset + next_chunk_size_transfer_unit)],
-            )?;
-
-            remaining_data_len -= next_chunk_size_transfer_unit;
             address = address
-                .checked_add((next_chunk_size_transfer_unit * 4) as u64)
+                .checked_add(chunk_size as u64 * 4)
                 .ok_or(ArmError::OutOfBounds)?;
-            data_offset += next_chunk_size_transfer_unit;
+            data = &data[chunk_size..];
         }
 
         tracing::debug!("Finished writing block");
@@ -767,8 +642,8 @@ where
     pub fn write_8(
         &mut self,
         access_port: MemoryAp,
-        address: u64,
-        data: &[u8],
+        mut address: u64,
+        mut data: &[u8],
     ) -> Result<(), ArmError> {
         if self.ap_information.supports_only_32bit_data_size {
             return Err(ArmError::UnsupportedTransferWidth(8));
@@ -778,88 +653,41 @@ where
             return Ok(());
         }
 
-        // The required shifting logic here is described in C2.2.6 Byte lanes of the ADI v5.2 specification.
-        // All bytes are transfered in their lane, so when we do an access at an address that is not divisible by 4,
-        // we have to shift the word (one or two bytes) to it's correct position.
-        let data = data
-            .iter()
-            .enumerate()
-            .map(|(i, v)| (*v as u32) << (((address as usize + i) % 4) * 8))
-            .collect::<Vec<_>>();
-
         tracing::debug!(
             "Write block with total size {} bytes to address {:#08x}",
             data.len(),
             address
         );
 
-        // Second we write in 8 bit writes until we have less than 8 bits left to write.
         let csw = self.build_csw_register(DataSize::U8);
-
         self.write_csw_register(access_port, csw)?;
-        self.write_tar_register(access_port, address)?;
 
-        // figure out how many words we can write before the
-        // data overflows
-
-        // maximum chunk size
-        let max_chunk_size_bytes = 0x400_usize;
-
-        let mut remaining_data_len = data.len();
-
-        let first_chunk_size_bytes = std::cmp::min(
-            max_chunk_size_bytes - (address as usize % max_chunk_size_bytes),
-            data.len(),
-        );
-
-        let mut data_offset = 0;
-
-        tracing::debug!(
-            "Write first block with len {} at address {:#08x}",
-            first_chunk_size_bytes,
-            address
-        );
-
-        let first_chunk_size_transfer_unit = first_chunk_size_bytes;
-
-        self.write_ap_register_repeated(
-            access_port,
-            DRW { data: 0 },
-            &data[data_offset..first_chunk_size_transfer_unit],
-        )?;
-
-        remaining_data_len -= first_chunk_size_transfer_unit;
-        let mut address = address
-            .checked_add((first_chunk_size_transfer_unit) as u64)
-            .ok_or(ArmError::OutOfBounds)?;
-        data_offset += first_chunk_size_transfer_unit;
-
-        while remaining_data_len > 0 {
-            // the autoincrement is limited to the 10 lowest bits so we need to write the address
-            // every time it overflows
-            self.write_tar_register(access_port, address)?;
-
-            let next_chunk_size_bytes = std::cmp::min(max_chunk_size_bytes, remaining_data_len);
+        while !data.is_empty() {
+            let chunk_size = data.len().min(autoincr_max_bytes(address));
 
             tracing::debug!(
                 "Writing chunk with len {} at address {:#08x}",
-                next_chunk_size_bytes,
+                chunk_size,
                 address
             );
 
-            let next_chunk_size_transfer_unit = next_chunk_size_bytes;
+            // The required shifting logic here is described in C2.2.6 Byte lanes of the ADI v5.2 specification.
+            // All bytes are transfered in their lane, so when we do an access at an address that is not divisible by 4,
+            // we have to shift the word (one or two bytes) to it's correct position.
+            let values = data[..chunk_size]
+                .iter()
+                .enumerate()
+                .map(|(i, v)| (*v as u32) << (((address as usize + i) % 4) * 8))
+                .collect::<Vec<_>>();
 
-            self.write_ap_register_repeated(
-                access_port,
-                DRW { data: 0 },
-                &data[data_offset..(data_offset + next_chunk_size_transfer_unit)],
-            )?;
+            // autoincrement is limited to the 10 lowest bits, so write TAR every time.
+            self.write_tar_register(access_port, address)?;
+            self.write_ap_register_repeated(access_port, DRW { data: 0 }, &values)?;
 
-            remaining_data_len -= next_chunk_size_transfer_unit;
             address = address
-                .checked_add((next_chunk_size_transfer_unit) as u64)
+                .checked_add(chunk_size as u64)
                 .ok_or(ArmError::OutOfBounds)?;
-            data_offset += next_chunk_size_transfer_unit;
+            data = &data[chunk_size..];
         }
 
         tracing::debug!("Finished writing block");

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -1791,6 +1791,13 @@ impl MemoryInterface for RiscvCommunicationInterface {
 
     fn read_word_32(&mut self, address: u64) -> Result<u32, crate::Error> {
         let address = valid_32bit_address(address)?;
+        tracing::debug!("read_word_32 from {:#08x}", address);
+        self.read_word(address)
+    }
+
+    fn read_word_16(&mut self, address: u64) -> Result<u16, crate::Error> {
+        let address = valid_32bit_address(address)?;
+        tracing::debug!("read_word_16 from {:#08x}", address);
         self.read_word(address)
     }
 
@@ -1814,6 +1821,12 @@ impl MemoryInterface for RiscvCommunicationInterface {
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), crate::Error> {
         let address = valid_32bit_address(address)?;
         tracing::debug!("read_32 from {:#08x}", address);
+        self.read_multiple(address, data)
+    }
+
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), crate::Error> {
+        let address = valid_32bit_address(address)?;
+        tracing::debug!("read_16 from {:#08x}", address);
         self.read_multiple(address, data)
     }
 
@@ -1843,6 +1856,11 @@ impl MemoryInterface for RiscvCommunicationInterface {
         self.write_word(address, data)
     }
 
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), crate::Error> {
+        let address = valid_32bit_address(address)?;
+        self.write_word(address, data)
+    }
+
     fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), crate::Error> {
         let address = valid_32bit_address(address)?;
         self.write_word(address, data)
@@ -1862,6 +1880,13 @@ impl MemoryInterface for RiscvCommunicationInterface {
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), crate::Error> {
         let address = valid_32bit_address(address)?;
         tracing::debug!("write_32 to {:#08x}", address);
+
+        self.write_multiple(address, data)
+    }
+
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), crate::Error> {
+        let address = valid_32bit_address(address)?;
+        tracing::debug!("write_16 to {:#08x}", address);
 
         self.write_multiple(address, data)
     }

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -770,6 +770,10 @@ impl<'probe> MemoryInterface for Riscv32<'probe> {
         self.interface.read_word_32(address)
     }
 
+    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
+        self.interface.read_word_16(address)
+    }
+
     fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
         self.interface.read_word_8(address)
     }
@@ -780,6 +784,10 @@ impl<'probe> MemoryInterface for Riscv32<'probe> {
 
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
         self.interface.read_32(address, data)
+    }
+
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
+        self.interface.read_16(address, data)
     }
 
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
@@ -794,6 +802,10 @@ impl<'probe> MemoryInterface for Riscv32<'probe> {
         self.interface.write_word_32(address, data)
     }
 
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
+        self.interface.write_word_16(address, data)
+    }
+
     fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
         self.interface.write_word_8(address, data)
     }
@@ -804,6 +816,10 @@ impl<'probe> MemoryInterface for Riscv32<'probe> {
 
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
         self.interface.write_32(address, data)
+    }
+
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
+        self.interface.write_16(address, data)
     }
 
     fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -704,6 +704,7 @@ impl XtensaCommunicationInterface {
 /// Don't implement this trait
 unsafe trait DataType: Sized {}
 unsafe impl DataType for u8 {}
+unsafe impl DataType for u16 {}
 unsafe impl DataType for u32 {}
 unsafe impl DataType for u64 {}
 
@@ -724,13 +725,6 @@ impl MemoryInterface for XtensaCommunicationInterface {
         Ok(())
     }
 
-    fn read_word_32(&mut self, address: u64) -> Result<u32, crate::Error> {
-        let mut out = [0; 4];
-        self.read(address, &mut out)?;
-
-        Ok(u32::from_le_bytes(out))
-    }
-
     fn supports_native_64bit_access(&mut self) -> bool {
         false
     }
@@ -740,6 +734,20 @@ impl MemoryInterface for XtensaCommunicationInterface {
         self.read(address, &mut out)?;
 
         Ok(u64::from_le_bytes(out))
+    }
+
+    fn read_word_32(&mut self, address: u64) -> Result<u32, crate::Error> {
+        let mut out = [0; 4];
+        self.read(address, &mut out)?;
+
+        Ok(u32::from_le_bytes(out))
+    }
+
+    fn read_word_16(&mut self, address: u64) -> Result<u16, crate::Error> {
+        let mut out = [0; 2];
+        self.read(address, &mut out)?;
+
+        Ok(u16::from_le_bytes(out))
     }
 
     fn read_word_8(&mut self, address: u64) -> anyhow::Result<u8, crate::Error> {
@@ -753,6 +761,10 @@ impl MemoryInterface for XtensaCommunicationInterface {
     }
 
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> anyhow::Result<(), crate::Error> {
+        self.read_8(address, as_bytes_mut(data))
+    }
+
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> anyhow::Result<(), crate::Error> {
         self.read_8(address, as_bytes_mut(data))
     }
 
@@ -774,6 +786,10 @@ impl MemoryInterface for XtensaCommunicationInterface {
         self.write(address, &data.to_le_bytes())
     }
 
+    fn write_word_16(&mut self, address: u64, data: u16) -> anyhow::Result<(), crate::Error> {
+        self.write(address, &data.to_le_bytes())
+    }
+
     fn write_word_8(&mut self, address: u64, data: u8) -> anyhow::Result<(), crate::Error> {
         self.write(address, &[data])
     }
@@ -783,6 +799,10 @@ impl MemoryInterface for XtensaCommunicationInterface {
     }
 
     fn write_32(&mut self, address: u64, data: &[u32]) -> anyhow::Result<(), crate::Error> {
+        self.write_8(address, as_bytes(data))
+    }
+
+    fn write_16(&mut self, address: u64, data: &[u16]) -> anyhow::Result<(), crate::Error> {
         self.write_8(address, as_bytes(data))
     }
 

--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -116,6 +116,10 @@ impl<'probe> MemoryInterface for Xtensa<'probe> {
         self.interface.read_word_32(address)
     }
 
+    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
+        self.interface.read_word_16(address)
+    }
+
     fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
         self.interface.read_word_8(address)
     }
@@ -126,6 +130,10 @@ impl<'probe> MemoryInterface for Xtensa<'probe> {
 
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
         self.interface.read_32(address, data)
+    }
+
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
+        self.interface.read_16(address, data)
     }
 
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
@@ -140,6 +148,10 @@ impl<'probe> MemoryInterface for Xtensa<'probe> {
         self.interface.write_word_32(address, data)
     }
 
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
+        self.interface.write_word_16(address, data)
+    }
+
     fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
         self.interface.write_word_8(address, data)
     }
@@ -150,6 +162,10 @@ impl<'probe> MemoryInterface for Xtensa<'probe> {
 
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
         self.interface.write_32(address, data)
+    }
+
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
+        self.interface.write_16(address, data)
     }
 
     fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {

--- a/probe-rs/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/debug.rs
@@ -343,36 +343,7 @@ impl DebugCli {
         });
 
         cli.add_command(Command {
-            name: "read",
-            help_text: "Read 32bit value from memory",
-
-            function: |cli_data, args| {
-                let address = get_int_argument(args, 0)?;
-
-                let num_words = if args.len() > 1 {
-                    get_int_argument(args, 1)?
-                } else {
-                    1
-                };
-
-                let mut buff = vec![0u32; num_words];
-
-                if num_words > 1 {
-                    cli_data.core.read_32(address, &mut buff)?;
-                } else {
-                    buff[0] = cli_data.core.read_word_32(address)?;
-                }
-
-                for (offset, word) in buff.iter().enumerate() {
-                    println!("0x{:08x} = 0x{:08x}", address + (offset * 4) as u64, word);
-                }
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "read_byte",
+            name: "read8",
             help_text: "Read 8bit value from memory",
 
             function: |cli_data, args| {
@@ -401,7 +372,65 @@ impl DebugCli {
         });
 
         cli.add_command(Command {
-            name: "read_64",
+            name: "read16",
+            help_text: "Read 16bit value from memory",
+
+            function: |cli_data, args| {
+                let address = get_int_argument(args, 0)?;
+
+                let num_words = if args.len() > 1 {
+                    get_int_argument(args, 1)?
+                } else {
+                    1
+                };
+
+                let mut buff = vec![0u16; num_words];
+
+                if num_words > 1 {
+                    cli_data.core.read_16(address, &mut buff)?;
+                } else {
+                    buff[0] = cli_data.core.read_word_16(address)?;
+                }
+
+                for (offset, word) in buff.iter().enumerate() {
+                    println!("0x{:08x} = 0x{:04x}", address + (offset * 2) as u64, word);
+                }
+
+                Ok(CliState::Continue)
+            },
+        });
+
+        cli.add_command(Command {
+            name: "read32",
+            help_text: "Read 32bit value from memory",
+
+            function: |cli_data, args| {
+                let address = get_int_argument(args, 0)?;
+
+                let num_words = if args.len() > 1 {
+                    get_int_argument(args, 1)?
+                } else {
+                    1
+                };
+
+                let mut buff = vec![0u32; num_words];
+
+                if num_words > 1 {
+                    cli_data.core.read_32(address, &mut buff)?;
+                } else {
+                    buff[0] = cli_data.core.read_word_32(address)?;
+                }
+
+                for (offset, word) in buff.iter().enumerate() {
+                    println!("0x{:08x} = 0x{:08x}", address + (offset * 4) as u64, word);
+                }
+
+                Ok(CliState::Continue)
+            },
+        });
+
+        cli.add_command(Command {
+            name: "read64",
             help_text: "Read 64bit value from memory",
 
             function: |cli_data, args| {
@@ -430,21 +459,7 @@ impl DebugCli {
         });
 
         cli.add_command(Command {
-            name: "write",
-            help_text: "Write a 32bit value to memory",
-
-            function: |cli_data, args| {
-                let address = get_int_argument(args, 0)?;
-                let data = get_int_argument(args, 1)?;
-
-                cli_data.core.write_word_32(address, data)?;
-
-                Ok(CliState::Continue)
-            },
-        });
-
-        cli.add_command(Command {
-            name: "write_byte",
+            name: "write8",
             help_text: "Write a 8bit value to memory",
 
             function: |cli_data, args| {
@@ -458,7 +473,35 @@ impl DebugCli {
         });
 
         cli.add_command(Command {
-            name: "write_64",
+            name: "write16",
+            help_text: "Write a 16bit value to memory",
+
+            function: |cli_data, args| {
+                let address = get_int_argument(args, 0)?;
+                let data = get_int_argument(args, 1)?;
+
+                cli_data.core.write_word_16(address, data)?;
+
+                Ok(CliState::Continue)
+            },
+        });
+
+        cli.add_command(Command {
+            name: "write32",
+            help_text: "Write a 32bit value to memory",
+
+            function: |cli_data, args| {
+                let address = get_int_argument(args, 0)?;
+                let data = get_int_argument(args, 1)?;
+
+                cli_data.core.write_word_32(address, data)?;
+
+                Ok(CliState::Continue)
+            },
+        });
+
+        cli.add_command(Command {
+            name: "write64",
             help_text: "Write a 64bit value to memory",
 
             function: |cli_data, args| {

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -373,6 +373,12 @@ impl MemoryInterface for CoreDump {
         Ok(data[0])
     }
 
+    fn read_word_16(&mut self, address: u64) -> Result<u16, crate::Error> {
+        let mut data = [0u16; 1];
+        self.read_memory_range(address, &mut data)?;
+        Ok(data[0])
+    }
+
     fn read_word_8(&mut self, address: u64) -> Result<u8, crate::Error> {
         let mut data = [0u8; 1];
         self.read_memory_range(address, &mut data)?;
@@ -385,6 +391,11 @@ impl MemoryInterface for CoreDump {
     }
 
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), crate::Error> {
+        self.read_memory_range(address, data)?;
+        Ok(())
+    }
+
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), crate::Error> {
         self.read_memory_range(address, data)?;
         Ok(())
     }
@@ -402,6 +413,10 @@ impl MemoryInterface for CoreDump {
         todo!()
     }
 
+    fn write_word_16(&mut self, _address: u64, _data: u16) -> Result<(), crate::Error> {
+        todo!()
+    }
+
     fn write_word_8(&mut self, _address: u64, _data: u8) -> Result<(), crate::Error> {
         todo!()
     }
@@ -411,6 +426,10 @@ impl MemoryInterface for CoreDump {
     }
 
     fn write_32(&mut self, _address: u64, _data: &[u32]) -> Result<(), crate::Error> {
+        todo!()
+    }
+
+    fn write_16(&mut self, _address: u64, _data: &[u16]) -> Result<(), crate::Error> {
         todo!()
     }
 
@@ -457,6 +476,10 @@ impl<'probe> MemoryInterface for Core<'probe> {
         self.inner.read_word_32(address)
     }
 
+    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
+        self.inner.read_word_16(address)
+    }
+
     fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
         self.inner.read_word_8(address)
     }
@@ -467,6 +490,10 @@ impl<'probe> MemoryInterface for Core<'probe> {
 
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
         self.inner.read_32(address, data)
+    }
+
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
+        self.inner.read_16(address, data)
     }
 
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
@@ -485,6 +512,10 @@ impl<'probe> MemoryInterface for Core<'probe> {
         self.inner.write_word_32(addr, data)
     }
 
+    fn write_word_16(&mut self, addr: u64, data: u16) -> Result<(), Error> {
+        self.inner.write_word_16(addr, data)
+    }
+
     fn write_word_8(&mut self, addr: u64, data: u8) -> Result<(), Error> {
         self.inner.write_word_8(addr, data)
     }
@@ -495,6 +526,10 @@ impl<'probe> MemoryInterface for Core<'probe> {
 
     fn write_32(&mut self, addr: u64, data: &[u32]) -> Result<(), Error> {
         self.inner.write_32(addr, data)
+    }
+
+    fn write_16(&mut self, addr: u64, data: &[u16]) -> Result<(), Error> {
+        self.inner.write_16(addr, data)
     }
 
     fn write_8(&mut self, addr: u64, data: &[u8]) -> Result<(), Error> {

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -24,6 +24,12 @@ pub trait MemoryInterface {
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn read_word_32(&mut self, address: u64) -> Result<u32, Error>;
 
+    /// Read a 16bit word of at `address`.
+    ///
+    /// The address where the read should be performed at has to be word aligned.
+    /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
+    fn read_word_16(&mut self, address: u64) -> Result<u16, Error>;
+
     /// Read an 8bit word of at `address`.
     fn read_word_8(&mut self, address: u64) -> Result<u8, Error>;
 
@@ -40,6 +46,13 @@ pub trait MemoryInterface {
     /// The address where the read should be performed at has to be word aligned.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error>;
+
+    /// Read a block of 16bit words at `address`.
+    ///
+    /// The number of words read is `data.len()`.
+    /// The address where the read should be performed at has to be word aligned.
+    /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error>;
 
     /// Read a block of 8bit words at `address`.
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error>;
@@ -122,6 +135,12 @@ pub trait MemoryInterface {
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), Error>;
 
+    /// Write a 16bit word at `address`.
+    ///
+    /// The address where the write should be performed at has to be word aligned.
+    /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error>;
+
     /// Write an 8bit word at `address`.
     fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error>;
 
@@ -138,6 +157,13 @@ pub trait MemoryInterface {
     /// The address where the write should be performed at has to be word aligned.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error>;
+
+    /// Write a block of 16bit words at `address`.
+    ///
+    /// The number of words written is `data.len()`.
+    /// The address where the write should be performed at has to be word aligned.
+    /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error>;
 
     /// Write a block of 8bit words at `address`.
     fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error>;
@@ -261,6 +287,10 @@ where
         (*self).read_word_32(address)
     }
 
+    fn read_word_16(&mut self, address: u64) -> Result<u16, Error> {
+        (*self).read_word_16(address)
+    }
+
     fn read_word_8(&mut self, address: u64) -> Result<u8, Error> {
         (*self).read_word_8(address)
     }
@@ -271,6 +301,10 @@ where
 
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error> {
         (*self).read_32(address, data)
+    }
+
+    fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error> {
+        (*self).read_16(address, data)
     }
 
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
@@ -289,6 +323,10 @@ where
         (*self).write_word_32(address, data)
     }
 
+    fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error> {
+        (*self).write_word_16(address, data)
+    }
+
     fn write_word_8(&mut self, address: u64, data: u8) -> Result<(), Error> {
         (*self).write_word_8(address, data)
     }
@@ -299,6 +337,10 @@ where
 
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error> {
         (*self).write_32(address, data)
+    }
+
+    fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error> {
+        (*self).write_16(address, data)
     }
 
     fn write_8(&mut self, address: u64, data: &[u8]) -> Result<(), Error> {

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -14,19 +14,19 @@ pub trait MemoryInterface {
 
     /// Read a 64bit word of at `address`.
     ///
-    /// The address where the read should be performed at has to be word aligned.
+    /// The address where the read should be performed at has to be a multiple of 8.
     /// Returns `AccessPortError::MemoryNotAligned` if this does not hold true.
     fn read_word_64(&mut self, address: u64) -> Result<u64, Error>;
 
     /// Read a 32bit word of at `address`.
     ///
-    /// The address where the read should be performed at has to be word aligned.
+    /// The address where the read should be performed at has to be a multiple of 4.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn read_word_32(&mut self, address: u64) -> Result<u32, Error>;
 
     /// Read a 16bit word of at `address`.
     ///
-    /// The address where the read should be performed at has to be word aligned.
+    /// The address where the read should be performed at has to be a multiple of 2.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn read_word_16(&mut self, address: u64) -> Result<u16, Error>;
 
@@ -36,29 +36,31 @@ pub trait MemoryInterface {
     /// Read a block of 64bit words at `address`.
     ///
     /// The number of words read is `data.len()`.
-    /// The address where the read should be performed at has to be word aligned.
+    /// The address where the read should be performed at has to be a multiple of 8.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn read_64(&mut self, address: u64, data: &mut [u64]) -> Result<(), Error>;
 
     /// Read a block of 32bit words at `address`.
     ///
     /// The number of words read is `data.len()`.
-    /// The address where the read should be performed at has to be word aligned.
+    /// The address where the read should be performed at has to be a multiple of 4.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), Error>;
 
     /// Read a block of 16bit words at `address`.
     ///
     /// The number of words read is `data.len()`.
-    /// The address where the read should be performed at has to be word aligned.
+    /// The address where the read should be performed at has to be a multiple of 2.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn read_16(&mut self, address: u64, data: &mut [u16]) -> Result<(), Error>;
 
     /// Read a block of 8bit words at `address`.
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error>;
 
-    /// Reads bytes using 64 bit memory access. Address must be 64 bit aligned
-    /// and data must be an exact multiple of 8.
+    /// Reads bytes using 64 bit memory access.
+    ///
+    /// The address where the read should be performed at has to be a multiple of 8.
+    /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn read_mem_64bit(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
         // Default implementation uses `read_64`, then converts u64 values back
         // to bytes. Assumes target is little endian. May be overridden to
@@ -77,8 +79,10 @@ pub trait MemoryInterface {
         Ok(())
     }
 
-    /// Reads bytes using 32 bit memory access. Address must be 32 bit aligned
-    /// and data must be an exact multiple of 4.
+    /// Reads bytes using 32 bit memory access.
+    ///
+    /// The address where the read should be performed at has to be a multiple of 4.
+    /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn read_mem_32bit(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
         // Default implementation uses `read_32`, then converts u32 values back
         // to bytes. Assumes target is little endian. May be overridden to
@@ -125,19 +129,19 @@ pub trait MemoryInterface {
 
     /// Write a 64bit word at `address`.
     ///
-    /// The address where the write should be performed at has to be word aligned.
+    /// The address where the write should be performed at has to be a multiple of 8.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn write_word_64(&mut self, address: u64, data: u64) -> Result<(), Error>;
 
     /// Write a 32bit word at `address`.
     ///
-    /// The address where the write should be performed at has to be word aligned.
+    /// The address where the write should be performed at has to be a multiple of 4.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn write_word_32(&mut self, address: u64, data: u32) -> Result<(), Error>;
 
     /// Write a 16bit word at `address`.
     ///
-    /// The address where the write should be performed at has to be word aligned.
+    /// The address where the write should be performed at has to be a multiple of 2.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn write_word_16(&mut self, address: u64, data: u16) -> Result<(), Error>;
 
@@ -147,21 +151,21 @@ pub trait MemoryInterface {
     /// Write a block of 64bit words at `address`.
     ///
     /// The number of words written is `data.len()`.
-    /// The address where the write should be performed at has to be word aligned.
+    /// The address where the write should be performed at has to be a multiple of 8.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn write_64(&mut self, address: u64, data: &[u64]) -> Result<(), Error>;
 
     /// Write a block of 32bit words at `address`.
     ///
     /// The number of words written is `data.len()`.
-    /// The address where the write should be performed at has to be word aligned.
+    /// The address where the write should be performed at has to be a multiple of 4.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn write_32(&mut self, address: u64, data: &[u32]) -> Result<(), Error>;
 
     /// Write a block of 16bit words at `address`.
     ///
     /// The number of words written is `data.len()`.
-    /// The address where the write should be performed at has to be word aligned.
+    /// The address where the write should be performed at has to be a multiple of 2.
     /// Returns [`Error::MemoryNotAligned`] if this does not hold true.
     fn write_16(&mut self, address: u64, data: &[u16]) -> Result<(), Error>;
 

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -79,6 +79,10 @@ impl ArmProbe for &mut MockCore {
         todo!()
     }
 
+    fn read_16(&mut self, _address: u64, _data: &mut [u16]) -> Result<(), ArmError> {
+        todo!()
+    }
+
     fn read_32(&mut self, address: u64, data: &mut [u32]) -> Result<(), ArmError> {
         for (i, val) in data.iter_mut().enumerate() {
             let address = address + (i as u64 * 4);
@@ -115,6 +119,10 @@ impl ArmProbe for &mut MockCore {
     }
 
     fn write_8(&mut self, _address: u64, _data: &[u8]) -> Result<(), ArmError> {
+        todo!()
+    }
+
+    fn write_16(&mut self, _address: u64, _data: &[u16]) -> Result<(), ArmError> {
         todo!()
     }
 

--- a/probe-rs/src/test.rs
+++ b/probe-rs/src/test.rs
@@ -93,6 +93,10 @@ impl MemoryInterface for MockMemory {
         todo!()
     }
 
+    fn read_word_16(&mut self, _address: u64) -> anyhow::Result<u16, crate::Error> {
+        todo!()
+    }
+
     fn read_64(&mut self, _address: u64, _data: &mut [u64]) -> anyhow::Result<(), crate::Error> {
         todo!()
     }
@@ -107,6 +111,10 @@ impl MemoryInterface for MockMemory {
         }
 
         Ok(())
+    }
+
+    fn read_16(&mut self, _address: u64, _data: &mut [u16]) -> anyhow::Result<(), crate::Error> {
+        todo!()
     }
 
     fn read_8(&mut self, address: u64, data: &mut [u8]) -> anyhow::Result<(), crate::Error> {
@@ -164,6 +172,10 @@ impl MemoryInterface for MockMemory {
         todo!()
     }
 
+    fn write_word_16(&mut self, _address: u64, _data: u16) -> anyhow::Result<(), crate::Error> {
+        todo!()
+    }
+
     fn write_word_8(&mut self, _address: u64, _data: u8) -> anyhow::Result<(), crate::Error> {
         todo!()
     }
@@ -173,6 +185,10 @@ impl MemoryInterface for MockMemory {
     }
 
     fn write_32(&mut self, _address: u64, _data: &[u32]) -> anyhow::Result<(), crate::Error> {
+        todo!()
+    }
+
+    fn write_16(&mut self, _address: u64, _data: &[u16]) -> anyhow::Result<(), crate::Error> {
         todo!()
     }
 


### PR DESCRIPTION
- arch/arm: simplify removing aligned_range.
- arch/arm: simplify block transfer chunking.
- Add support for 16bit reads/writes.

Tested working with STLink and cmsisdap.

TODO: 
- [x] Add support in adi_v5_memory_interface.rs, needed for cmsisdap, link, etc.
