### PR TITLE
Make probe-rs info work with Xtensa

### DIFF
--- a/changelog/added-xtensa-info.md
+++ b/changelog/added-xtensa-info.md
@@ -1,0 +1,1 @@
+probe-rs info now supports Xtensa devices

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -10,7 +10,7 @@ use crate::{
         instruction::Instruction, CpuRegister, Register, SpecialRegister,
     },
     probe::{DeferredResultIndex, JTAGAccess},
-    BreakpointCause, DebugProbeError, Error as ProbeRsError, HaltReason, MemoryInterface,
+    BreakpointCause, DebugProbeError, Error as ProbeRsError, HaltReason, MemoryInterface, Probe,
 };
 
 use super::xdm::{Error as XdmError, Xdm};
@@ -128,6 +128,16 @@ impl XtensaCommunicationInterface {
 
             Err(e) => Err((s.xdm.free(), e.into())),
         }
+    }
+
+    /// Destruct the interface and return the stored probe driver.
+    pub fn close(self) -> Probe {
+        Probe::from_attached_probe(self.xdm.probe.into_probe())
+    }
+
+    /// Read the targets IDCODE.
+    pub fn read_idcode(&mut self) -> Result<u32, DebugProbeError> {
+        Ok(self.xdm.read_idcode()?)
     }
 
     fn init(&mut self) -> Result<(), XtensaError> {

--- a/probe-rs/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/info.rs
@@ -387,20 +387,7 @@ fn cpu_info_tree(scs: &mut Scs) -> Result<Tree<String>> {
 fn show_riscv_info(interface: &mut RiscvCommunicationInterface) -> Result<()> {
     let idcode = interface.read_idcode()?;
 
-    let version = (idcode >> 28) & 0xf;
-    let part_number = (idcode >> 12) & 0xffff;
-    let manufacturer_id = (idcode >> 1) & 0x7ff;
-
-    let jep_cc = (manufacturer_id >> 7) & 0xf;
-    let jep_id = manufacturer_id & 0x3f;
-
-    let jep_id = jep106::JEP106Code::new(jep_cc as u8, jep_id as u8);
-
-    println!("RISC-V Chip:");
-    println!("\tIDCODE: {idcode:010x}");
-    println!("\t Version:      {version}");
-    println!("\t Part:         {part_number}");
-    println!("\t Manufacturer: {manufacturer_id} ({jep_id})");
+    print_idcode_info("RISC-V", idcode);
 
     Ok(())
 }
@@ -408,6 +395,12 @@ fn show_riscv_info(interface: &mut RiscvCommunicationInterface) -> Result<()> {
 fn show_xtensa_info(interface: &mut XtensaCommunicationInterface) -> Result<()> {
     let idcode = interface.read_idcode()?;
 
+    print_idcode_info("Xtensa", idcode);
+
+    Ok(())
+}
+
+fn print_idcode_info(architecture: &str, idcode: u32) {
     let version = (idcode >> 28) & 0xf;
     let part_number = (idcode >> 12) & 0xffff;
     let manufacturer_id = (idcode >> 1) & 0x7ff;
@@ -417,11 +410,9 @@ fn show_xtensa_info(interface: &mut XtensaCommunicationInterface) -> Result<()> 
 
     let jep_id = jep106::JEP106Code::new(jep_cc as u8, jep_id as u8);
 
-    println!("Xtensa Chip:");
-    println!("\tIDCODE: {idcode:010x}");
-    println!("\t Version:      {version}");
-    println!("\t Part:         {part_number}");
-    println!("\t Manufacturer: {manufacturer_id} ({jep_id})");
-
-    Ok(())
+    println!("{architecture} Chip:");
+    println!("  IDCODE: {idcode:010x}");
+    println!("    Version:      {version}");
+    println!("    Part:         {part_number}");
+    println!("    Manufacturer: {manufacturer_id} ({jep_id})");
 }

--- a/probe-rs/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/info.rs
@@ -406,7 +406,7 @@ fn print_idcode_info(architecture: &str, idcode: u32) {
     let manufacturer_id = (idcode >> 1) & 0x7ff;
 
     let jep_cc = (manufacturer_id >> 7) & 0xf;
-    let jep_id = manufacturer_id & 0x3f;
+    let jep_id = manufacturer_id & 0x7f;
 
     let jep_id = jep106::JEP106Code::new(jep_cc as u8, jep_id as u8);
 


### PR DESCRIPTION
WIP, as automatic IR detection reports ambiguous on xtensa, i.e. the algorithm likely treats trailing ones incorrectly.