### PR TITLE
espusbjtag, ftdi: Fix JTAG IR measurement

### DIFF
--- a/changelog/fixed-jtag-measurement.md
+++ b/changelog/fixed-jtag-measurement.md
@@ -1,0 +1,1 @@
+espusbjtag, ftdi: fix IR length measurement

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -208,7 +208,7 @@ impl CmsisDap {
     fn jtag_scan(&mut self, ir_lengths: Option<&[usize]>) -> Result<JtagChain, CmsisDapError> {
         let (ir, dr) = self.jtag_reset_scan()?;
         let idcodes = extract_idcodes(&dr)?;
-        let irlens = extract_ir_lengths(&ir, &ir, idcodes.len(), ir_lengths)?;
+        let irlens = extract_ir_lengths(&ir, idcodes.len(), ir_lengths)?;
 
         let chain = JtagChain { irlens };
 

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -208,7 +208,7 @@ impl CmsisDap {
     fn jtag_scan(&mut self, ir_lengths: Option<&[usize]>) -> Result<JtagChain, CmsisDapError> {
         let (ir, dr) = self.jtag_reset_scan()?;
         let idcodes = extract_idcodes(&dr)?;
-        let irlens = extract_ir_lengths(&ir, idcodes.len(), ir_lengths)?;
+        let irlens = extract_ir_lengths(&ir, &ir, idcodes.len(), ir_lengths)?;
 
         let chain = JtagChain { irlens };
 

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -143,10 +143,19 @@ pub(crate) fn extract_idcodes(
 ///
 /// Returns Vec<usize>, with an entry for each TAP.
 pub(crate) fn extract_ir_lengths(
-    ir: &BitSlice<u8>,
+    ir_ones: &BitSlice<u8>,
+    ir_zeros: &BitSlice<u8>,
     n_taps: usize,
     expected: Option<&[usize]>,
 ) -> Result<Vec<usize>, ScanChainError> {
+    let common_length = ir_ones
+        .iter()
+        .zip(ir_zeros.iter())
+        .take_while(|(a, b)| *a == *b)
+        .count();
+
+    let ir = &ir_ones[..common_length];
+
     // Find all `10` patterns which indicate potential IR start positions.
     let starts = ir
         .windows(2)
@@ -245,7 +254,7 @@ mod tests {
         let n_taps = 1;
         let expected = None;
 
-        let ir_lengths = extract_ir_lengths(ir, n_taps, expected).unwrap();
+        let ir_lengths = extract_ir_lengths(ir, ir, n_taps, expected).unwrap();
 
         assert_eq!(ir_lengths, vec![4]);
     }
@@ -259,7 +268,7 @@ mod tests {
         let n_taps = 2;
         let expected = None;
 
-        let ir_lengths = extract_ir_lengths(ir, n_taps, expected).unwrap();
+        let ir_lengths = extract_ir_lengths(ir, ir, n_taps, expected).unwrap();
 
         assert_eq!(ir_lengths, vec![4, 5]);
     }

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -4,6 +4,7 @@ use crate::architecture::{
     arm::communication_interface::UninitializedArmProbe,
     riscv::communication_interface::RiscvCommunicationInterface,
 };
+use crate::probe::common::extract_ir_lengths;
 use crate::probe::{
     DeferredResultSet, JTAGAccess, JtagCommandQueue, ProbeCreationError, ScanChainElement,
 };
@@ -238,13 +239,12 @@ impl JtagAdapter {
 
         let cmd = vec![0xff; max_device_count * 4];
         let r = self.transfer_dr(&cmd, cmd.len() * 8)?;
-        let mut targets = vec![];
+        let mut idcodes = vec![];
         for i in 0..max_device_count {
             let idcode = u32::from_le_bytes(r[i * 4..(i + 1) * 4].try_into().unwrap());
             if idcode != 0xffffffff {
                 tracing::debug!("tap found: {:08x}", idcode);
-                let target = JtagChainItem { idcode, irlen: 0 };
-                targets.push(target);
+                idcodes.push(idcode);
             } else {
                 break;
             }
@@ -252,59 +252,21 @@ impl JtagAdapter {
 
         self.reset()?;
 
-        // Autodetect the targets' IR lengths.
-        //
-        // For many targets, reading the IR right after a reset yields 0b00..001. This allows
-        // autodetecting the IR lengths even when we have multiple targets. For example,
-        // if we read `0b1111111111110001000001` (LSB first) we know the first target in the
-        // chain has an irlen of 6 and the next one has an irlen of 4.
-        //
-        // However, not all targets satisfy this. For example, the esp32c3 shifts out a fixed value
-        // of `0b00101`. This makes the above algorithm to incorrectly detect the IR len as 2.
-        //
-        // Fortunately, we can use a different autodetection algorithm when we only have one target
-        // in the chain, that doesn't rely on the target to shift out a particular value. The key is
-        // the fact that whatever we shift in gets shifted back out, but delayed by the number of bits
-        // in the IR shfit register. So, we shift in lots of `1` bits to fill the shift register with `1`s.
-        // Then we shift in lots of `0` bytes. The output will be something like `0b00000111`, and the
-        // number of ones is the IR length.
-        if targets.len() == 1 {
-            let r = self.transfer_ir(&[0xFF, 0x00], 16)?;
+        let cmd = vec![0xff; max_device_count];
+        let r = self.transfer_ir(&cmd, cmd.len() * 8)?;
 
-            let irlen = r[1].count_ones() as usize;
-            targets[0].irlen = irlen;
-            tracing::debug!("tap irlen: {}", irlen);
-        } else {
-            let cmd = vec![0xff; max_device_count];
-            let mut r = self.transfer_ir(&cmd, cmd.len() * 8)?;
+        let response = BitSlice::<u8, Lsb0>::from_slice(&r);
 
-            let mut ir = 0;
-            let mut irbits = 0;
-            for (i, target) in targets.iter_mut().enumerate() {
-                if (!r.is_empty()) && irbits < 8 {
-                    let byte = r[0];
-                    r.remove(0);
-                    ir |= (byte as u32) << irbits;
-                    irbits += 8;
-                }
-                if ir & 0b11 == 0b01 {
-                    ir &= !1;
-                    let irlen = ir.trailing_zeros();
-                    ir >>= irlen;
-                    irbits -= irlen;
-                    tracing::debug!("tap {} irlen: {}", i, irlen);
-                    target.irlen = irlen as usize;
-                } else {
-                    tracing::debug!("invalid irlen for tap {}", i);
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "Invalid IR sequence during the chain scan",
-                    ));
-                }
-            }
-        }
+        tracing::debug!("IR scan: {:?}", response);
 
-        Ok(targets)
+        let lengths = extract_ir_lengths(response, idcodes.len(), None).unwrap();
+        tracing::debug!("Detected IR lens: {:?}", lengths);
+
+        Ok(idcodes
+            .into_iter()
+            .zip(lengths.into_iter())
+            .map(|(idcode, irlen)| JtagChainItem { idcode, irlen })
+            .collect())
     }
 
     pub fn select_target(&mut self, taps: &[JtagChainItem], idx: usize) -> io::Result<()> {

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -4,7 +4,7 @@ use crate::architecture::{
     arm::communication_interface::UninitializedArmProbe,
     riscv::communication_interface::RiscvCommunicationInterface,
 };
-use crate::probe::common::extract_ir_lengths;
+use crate::probe::common::{common_sequence, extract_ir_lengths};
 use crate::probe::{
     DeferredResultSet, JTAGAccess, JtagCommandQueue, ProbeCreationError, ScanChainElement,
 };
@@ -265,14 +265,15 @@ impl JtagAdapter {
         let response = BitSlice::<u8, Lsb0>::from_slice(&r);
         let response_zeros = BitSlice::<u8, Lsb0>::from_slice(&r_zeros);
 
+        let response = common_sequence(response, response_zeros);
         tracing::debug!("IR scan: {:?}", response);
 
-        let lengths = extract_ir_lengths(response, response_zeros, idcodes.len(), None).unwrap();
+        let lengths = extract_ir_lengths(response, idcodes.len(), None).unwrap();
         tracing::debug!("Detected IR lens: {:?}", lengths);
 
         Ok(idcodes
             .into_iter()
-            .zip(lengths.into_iter())
+            .zip(lengths)
             .map(|(idcode, irlen)| JtagChainItem { idcode, irlen })
             .collect())
     }


### PR DESCRIPTION
This PR removes the custom IR length measurement from FTDI, and implements (as it turns out, CMSIS-DAP's) a new strategy to measure IR length: first, shift out ones, then a sequence of zeroes-then-ones, and find the common sequence.