### PR TITLE
Use `extract_idcode` more

### DIFF
--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -15,6 +15,7 @@ use crate::architecture::arm::ArmError;
 use crate::architecture::riscv::communication_interface::RiscvError;
 use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
 use crate::error::Error;
+use crate::probe::common::IdCode;
 use crate::{
     architecture::arm::communication_interface::UninitializedArmProbe,
     config::{RegistryError, TargetSelector},
@@ -895,18 +896,41 @@ pub struct JtagWriteCommand {
 /// Represents a Jtag Tap within the chain.
 #[derive(Debug)]
 pub struct JtagChainItem {
-    pub idcode: u32,
+    pub idcode: Option<IdCode>,
     pub irlen: usize,
 }
 
 /// Chain parameters to select a target tap within the chain.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct ChainParams {
     pub irpre: usize,
     pub irpost: usize,
     pub drpre: usize,
     pub drpost: usize,
     pub irlen: usize,
+}
+
+impl ChainParams {
+    fn from_jtag_chain(chain: &[JtagChainItem], selected: usize) -> Option<Self> {
+        let mut params = Self::default();
+
+        let mut found = false;
+        for (index, tap) in chain.iter().enumerate() {
+            tracing::info!("{:?}", tap);
+            if index == selected {
+                params.irlen = tap.irlen;
+                found = true;
+            } else if found {
+                params.irpost += tap.irlen;
+                params.drpost += 1;
+            } else {
+                params.irpre += tap.irlen;
+                params.drpre += 1;
+            }
+        }
+
+        found.then_some(params)
+    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -15,7 +15,7 @@ use crate::{
             general::info::{CapabilitiesCommand, PacketCountCommand, SWOTraceBufferSizeCommand},
             CmsisDapError,
         },
-        BatchCommand, ProbeDriver,
+        BatchCommand, JtagChainItem, ProbeDriver,
     },
     CoreStatus, DebugProbe, DebugProbeError, DebugProbeSelector, WireProtocol,
 };
@@ -98,12 +98,6 @@ pub struct CmsisDap {
     scan_chain: Option<Vec<ScanChainElement>>,
 
     batch: Vec<BatchCommand>,
-}
-
-/// Stores information about a JTAG scan chain,
-/// including IR lengths.
-struct JtagChain {
-    pub irlens: Vec<usize>,
 }
 
 impl std::fmt::Debug for CmsisDap {
@@ -225,14 +219,19 @@ impl CmsisDap {
     /// If IR lengths for each TAP are known, provide them in `ir_lengths`.
     ///
     /// Returns a new JTAGChain.
-    fn jtag_scan(&mut self, ir_lengths: Option<&[usize]>) -> Result<JtagChain, CmsisDapError> {
+    fn jtag_scan(
+        &mut self,
+        ir_lengths: Option<&[usize]>,
+    ) -> Result<Vec<JtagChainItem>, CmsisDapError> {
         let (ir, dr) = self.jtag_reset_scan()?;
         let idcodes = extract_idcodes(&dr)?;
-        let irlens = extract_ir_lengths(&ir, idcodes.len(), ir_lengths)?;
+        let ir_lens = extract_ir_lengths(&ir, idcodes.len(), ir_lengths)?;
 
-        let chain = JtagChain { irlens };
-
-        Ok(chain)
+        Ok(idcodes
+            .into_iter()
+            .zip(ir_lens)
+            .map(|(idcode, irlen)| JtagChainItem { irlen, idcode })
+            .collect())
     }
 
     /// Capture the power-up scan chain values, including all IDCODEs.
@@ -1051,7 +1050,7 @@ impl RawDapAccess for CmsisDap {
         } else {
             tracing::info!("No scan chain provided, doing runtime detection");
             let chain = self.jtag_scan(None)?;
-            chain.irlens.iter().map(|len| *len as u8).collect()
+            chain.iter().map(|item| item.irlen as u8).collect()
         };
         tracing::info!("Configuring JTAG with ir lengths: {:?}", ir_lengths);
         self.send_jtag_configure(JtagConfigureRequest::new(ir_lengths)?)?;

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -94,6 +94,9 @@ fn starts_to_lengths(starts: &[usize], total: usize) -> Vec<usize> {
 /// We can therefore unambiguously scan through the DR capture to find
 /// all IDCODEs and TAPs in BYPASS.
 ///
+/// Because we don't know how many TAPs there are, we scan until we find
+/// a 32-bit IDCODE of all 1s, which comes after the last TAP in the chain.
+///
 /// Returns Vec<Option<IdCode>>, with None for TAPs in BYPASS.
 pub(crate) fn extract_idcodes(
     mut dr: &BitSlice<u8>,
@@ -108,6 +111,11 @@ pub(crate) fn extract_idcodes(
             }
 
             let idcode = dr[0..32].load_le::<u32>();
+
+            if idcode == u32::MAX {
+                break;
+            }
+
             let idcode = IdCode(idcode);
 
             if !idcode.valid() {

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -1,6 +1,6 @@
 mod protocol;
 
-use std::{convert::TryInto, iter};
+use std::iter;
 
 use crate::{
     architecture::{
@@ -12,7 +12,7 @@ use crate::{
         xtensa::communication_interface::XtensaCommunicationInterface,
     },
     probe::{
-        common::{common_sequence, extract_ir_lengths},
+        common::{common_sequence, extract_idcodes, extract_ir_lengths},
         espusbjtag::protocol::{JtagState, RegisterState},
         DeferredResultSet, JtagCommandQueue, ProbeDriver,
     },
@@ -47,13 +47,7 @@ impl ProbeDriver for EspUsbJtagSource {
             // default to 5, as most Espressif chips have an irlen of 5
             max_ir_address: 5,
             scan_chain: None,
-            chain_params: ChainParams {
-                irpre: 0,
-                irpost: 0,
-                drpre: 0,
-                drpost: 0,
-                irlen: 0,
-            },
+            chain_params: ChainParams::default(),
         }))
     }
 
@@ -86,29 +80,15 @@ impl EspUsbJtag {
 
         self.jtag_reset()?;
 
-        self.chain_params = ChainParams {
-            irpre: 0,
-            irpost: 0,
-            drpre: 0,
-            drpost: 0,
-            irlen: 0,
-        };
+        self.chain_params = ChainParams::default();
 
-        let input = Vec::from_iter(iter::repeat(0xFFu8).take(4 * max_chain));
-        let response = self.write_dr(&input, 4 * max_chain * 8).unwrap();
+        let input = vec![0xFF; 4 * max_chain];
+        let response = self.write_dr(&input, input.len() * 8).unwrap();
 
-        tracing::trace!("DR: {:?}", response);
+        tracing::debug!("DR: {:?}", response);
 
-        let mut idcodes = Vec::new();
-
-        for idcode in response.chunks(4) {
-            assert_eq!(idcode.len(), 4, "Bad length");
-
-            if idcode == [0xFF, 0xFF, 0xFF, 0xFF] {
-                break;
-            }
-            idcodes.push(u32::from_le_bytes((idcode).try_into().unwrap()));
-        }
+        let idcodes = extract_idcodes(BitSlice::<u8, Lsb0>::from_slice(&response))
+            .map_err(|e| DebugProbeError::Other(e.into()))?;
 
         tracing::info!(
             "JTAG DR scan complete, found {} TAPs. {:?}",
@@ -493,7 +473,7 @@ impl DebugProbe for EspUsbJtag {
         Ok(())
     }
 
-    fn attach(&mut self) -> Result<(), super::DebugProbeError> {
+    fn attach(&mut self) -> Result<(), DebugProbeError> {
         tracing::debug!("Attaching to ESP USB JTAG");
 
         let taps = self.scan()?;
@@ -501,31 +481,12 @@ impl DebugProbe for EspUsbJtag {
 
         let selected = 0;
         if taps.len() > 1 {
-            tracing::warn!("More than one TAP detected, defaulting to tap0")
+            tracing::warn!("More than one TAP detected, defaulting to tap0");
         }
 
-        let mut params = ChainParams {
-            irpre: 0,
-            irpost: 0,
-            drpre: 0,
-            drpost: 0,
-            irlen: 0,
+        let Some(params) = ChainParams::from_jtag_chain(&taps, selected) else {
+            return Err(DebugProbeError::TargetNotFound);
         };
-
-        let mut found = false;
-        for (index, tap) in taps.iter().enumerate() {
-            tracing::info!("{:?}", tap);
-            if index == selected {
-                params.irlen = tap.irlen;
-                found = true;
-            } else if found {
-                params.irpost += tap.irlen;
-                params.drpost += 1;
-            } else {
-                params.irpre += tap.irlen;
-                params.drpre += 1;
-            }
-        }
 
         tracing::info!("Setting chain params: {:?}", params);
 
@@ -541,8 +502,8 @@ impl DebugProbe for EspUsbJtag {
         Ok(())
     }
 
-    fn target_reset(&mut self) -> Result<(), super::DebugProbeError> {
-        Err(super::DebugProbeError::NotImplemented("target_reset"))
+    fn target_reset(&mut self) -> Result<(), DebugProbeError> {
+        Err(DebugProbeError::NotImplemented("target_reset"))
     }
 
     fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -4,15 +4,15 @@ use crate::architecture::{
     arm::communication_interface::UninitializedArmProbe,
     riscv::communication_interface::RiscvCommunicationInterface,
 };
-use crate::probe::common::{common_sequence, extract_ir_lengths};
+use crate::probe::common::{common_sequence, extract_idcodes, extract_ir_lengths};
 use crate::probe::{
     DebugProbe, DeferredResultSet, JTAGAccess, JtagCommandQueue, ProbeCreationError, ProbeDriver,
     ScanChainElement,
 };
 use crate::{DebugProbeError, DebugProbeInfo, DebugProbeSelector, WireProtocol};
+use anyhow::anyhow;
 use bitvec::{order::Lsb0, slice::BitSlice, vec::BitVec};
 use rusb::UsbContext;
-use std::convert::TryInto;
 use std::io::{self, Read, Write};
 use std::iter;
 use std::time::Duration;
@@ -67,30 +67,31 @@ impl JtagAdapter {
         Ok(())
     }
 
-    fn read_response(&mut self, size: usize) -> io::Result<Vec<u8>> {
+    fn read_response(&mut self, size: usize) -> Result<Vec<u8>, DebugProbeError> {
         let timeout = Duration::from_millis(10);
         let mut result = Vec::new();
 
         let t0 = std::time::Instant::now();
         while result.len() < size {
             if t0.elapsed() > timeout {
-                return Err(io::Error::from(io::ErrorKind::TimedOut));
+                return Err(DebugProbeError::Timeout);
             }
 
-            self.device.read_to_end(&mut result)?;
+            self.device
+                .read_to_end(&mut result)
+                .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
         }
 
         if result.len() > size {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Read more data than expected",
-            ));
+            return Err(DebugProbeError::Other(anyhow!(
+                "Read more data than expected"
+            )));
         }
 
         Ok(result)
     }
 
-    fn shift_tms(&mut self, mut data: &[u8], mut bits: usize) -> io::Result<()> {
+    fn shift_tms(&mut self, mut data: &[u8], mut bits: usize) -> Result<(), DebugProbeError> {
         assert!(bits > 0);
         assert!((bits + 7) / 8 <= data.len());
 
@@ -106,10 +107,12 @@ impl JtagAdapter {
                 bits = 0;
             }
         }
-        self.device.write_all(&command)
+        self.device
+            .write_all(&command)
+            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))
     }
 
-    fn shift_tdi(&mut self, mut data: &[u8], mut bits: usize) -> io::Result<()> {
+    fn shift_tdi(&mut self, mut data: &[u8], mut bits: usize) -> Result<(), DebugProbeError> {
         assert!(bits > 0);
         assert!((bits + 7) / 8 <= data.len());
 
@@ -141,10 +144,16 @@ impl JtagAdapter {
             command.extend_from_slice(&[0x4b, 0x00, tms_byte]);
         }
 
-        self.device.write_all(&command)
+        self.device
+            .write_all(&command)
+            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))
     }
 
-    fn tranfer_tdi(&mut self, mut data: &[u8], mut bits: usize) -> io::Result<Vec<u8>> {
+    fn tranfer_tdi(
+        &mut self,
+        mut data: &[u8],
+        mut bits: usize,
+    ) -> Result<Vec<u8>, DebugProbeError> {
         assert!(bits > 0);
         assert!((bits + 7) / 8 <= data.len());
 
@@ -174,7 +183,9 @@ impl JtagAdapter {
         let tms_byte = 0x01 | (last_bit << 7);
         command.extend_from_slice(&[0x6b, 0x00, tms_byte]);
 
-        self.device.write_all(&command)?;
+        self.device
+            .write_all(&command)
+            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
 
         let mut expect_bytes = full_bytes + 1;
         if bits > 1 {
@@ -195,12 +206,12 @@ impl JtagAdapter {
     }
 
     /// Reset and go to RUN-TEST/IDLE
-    pub fn reset(&mut self) -> io::Result<()> {
+    pub fn reset(&mut self) -> Result<(), DebugProbeError> {
         self.shift_tms(&[0xff, 0xff, 0xff, 0xff, 0x7f], 40)
     }
 
     /// Execute RUN-TEST/IDLE for a number of cycles
-    pub fn idle(&mut self, cycles: usize) -> io::Result<()> {
+    pub fn idle(&mut self, cycles: usize) -> Result<(), DebugProbeError> {
         if cycles == 0 {
             return Ok(());
         }
@@ -209,7 +220,7 @@ impl JtagAdapter {
     }
 
     /// Shift to IR and return to IDLE
-    pub fn shift_ir(&mut self, data: &[u8], bits: usize) -> io::Result<()> {
+    pub fn shift_ir(&mut self, data: &[u8], bits: usize) -> Result<(), DebugProbeError> {
         self.shift_tms(&[0b0011], 4)?;
         self.shift_tdi(data, bits)?;
         self.shift_tms(&[0b01], 2)?;
@@ -217,7 +228,7 @@ impl JtagAdapter {
     }
 
     /// Shift to IR and return to IDLE
-    pub fn transfer_ir(&mut self, data: &[u8], bits: usize) -> io::Result<Vec<u8>> {
+    pub fn transfer_ir(&mut self, data: &[u8], bits: usize) -> Result<Vec<u8>, DebugProbeError> {
         self.shift_tms(&[0b0011], 4)?;
         let r = self.tranfer_tdi(data, bits)?;
         self.shift_tms(&[0b01], 2)?;
@@ -225,30 +236,23 @@ impl JtagAdapter {
     }
 
     /// Shift to DR and return to IDLE
-    pub fn transfer_dr(&mut self, data: &[u8], bits: usize) -> io::Result<Vec<u8>> {
+    pub fn transfer_dr(&mut self, data: &[u8], bits: usize) -> Result<Vec<u8>, DebugProbeError> {
         self.shift_tms(&[0b001], 3)?;
         let r = self.tranfer_tdi(data, bits)?;
         self.shift_tms(&[0b01], 2)?;
         Ok(r)
     }
 
-    fn scan(&mut self) -> io::Result<Vec<JtagChainItem>> {
+    fn scan(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
         let max_device_count = 8;
 
         self.reset()?;
 
         let cmd = vec![0xff; max_device_count * 4];
         let r = self.transfer_dr(&cmd, cmd.len() * 8)?;
-        let mut idcodes = vec![];
-        for i in 0..max_device_count {
-            let idcode = u32::from_le_bytes(r[i * 4..(i + 1) * 4].try_into().unwrap());
-            if idcode != 0xffffffff {
-                tracing::debug!("tap found: {:08x}", idcode);
-                idcodes.push(idcode);
-            } else {
-                break;
-            }
-        }
+
+        let idcodes = extract_idcodes(BitSlice::<u8, Lsb0>::from_slice(&r))
+            .map_err(|e| DebugProbeError::Other(e.into()))?;
 
         self.reset()?;
 
@@ -277,44 +281,24 @@ impl JtagAdapter {
             .collect())
     }
 
-    pub fn select_target(&mut self, taps: &[JtagChainItem], idx: usize) -> io::Result<()> {
-        let mut found = false;
-        let mut params = ChainParams {
-            irpre: 0,
-            irpost: 0,
-            drpre: 0,
-            drpost: 0,
-            irlen: 0,
+    fn select_target(
+        &mut self,
+        chain: &[JtagChainItem],
+        selected: usize,
+    ) -> Result<(), DebugProbeError> {
+        let Some(params) = ChainParams::from_jtag_chain(chain, selected) else {
+            return Err(DebugProbeError::TargetNotFound);
         };
-        for (i, tap) in taps.iter().enumerate() {
-            if i == idx {
-                params.irlen = tap.irlen;
-                found = true;
-            } else if found {
-                params.irpost += tap.irlen;
-                params.drpost += 1;
-            } else {
-                params.irpre += tap.irlen;
-                params.drpre += 1;
-            }
-        }
 
-        if found {
-            tracing::debug!("Target chain params: {:?}", params);
-            self.chain_params = Some(params);
-            Ok(())
-        } else {
-            Err(io::Error::new(io::ErrorKind::NotFound, "target not found"))
-        }
+        tracing::debug!("Target chain params: {:?}", params);
+        self.chain_params = Some(params);
+        Ok(())
     }
 
-    fn get_chain_params(&self) -> io::Result<ChainParams> {
+    fn get_chain_params(&self) -> Result<ChainParams, DebugProbeError> {
         match &self.chain_params {
             Some(params) => Ok(*params),
-            None => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "target is not selected",
-            )),
+            None => Err(DebugProbeError::Other(anyhow!("target is not selected"))),
         }
     }
 
@@ -323,14 +307,11 @@ impl JtagAdapter {
         address: u32,
         data: Option<&[u8]>,
         len_bits: usize,
-    ) -> io::Result<Vec<u8>> {
+    ) -> Result<Vec<u8>, DebugProbeError> {
         let params = self.get_chain_params()?;
         let max_address = (1 << params.irlen) - 1;
         if address > max_address {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "invalid register address",
-            ));
+            return Err(DebugProbeError::Other(anyhow!("invalid register address")));
         }
 
         // Write IR register
@@ -442,10 +423,7 @@ impl DebugProbe for FtdiProbe {
             .attach()
             .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
 
-        let taps = self
-            .adapter
-            .scan()
-            .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
+        let taps = self.adapter.scan()?;
         if taps.is_empty() {
             tracing::warn!("no JTAG taps detected");
             return Err(DebugProbeError::TargetNotFound);
@@ -460,7 +438,11 @@ impl DebugProbe for FtdiProbe {
                 0x120034e5, // Little endian Xtensa core
             ];
             let idcode = taps.iter().map(|tap| tap.idcode).position(|idcode| {
-                let found = KNOWN_IDCODES.contains(&idcode);
+                let Some(idcode) = idcode else {
+                    return false;
+                };
+
+                let found = KNOWN_IDCODES.contains(&idcode.0);
                 if !found {
                     tracing::warn!("Unknown IDCODEs: {:x?}", idcode);
                 }


### PR DESCRIPTION
This PR extends `extract_idcode` to stop and not die at 0xFFFF_FFFF, and replaces the manual reimplementations with calls to `extract_idcode`. The PR includes related changes to JtagChainItem, and also FTDI driver error types because one place complained and this is here that particular rabbit hole led.