### PR TITLE
Fix GITHUB_TOKEN env var name

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -61,7 +61,7 @@ jobs:
           cargo xtask assemble-changelog --commit ${{ inputs.version }}
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Bump versions
         run: |
@@ -94,4 +94,4 @@ jobs:
           - target-gen
           - rtthost"
         env:
-            GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+            GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -128,7 +128,7 @@ impl FragmentList {
 
 fn get_changelog_fragments(fragments_dir: &Path) -> Result<FragmentList> {
     let mut list = FragmentList::new();
-    let github_token = std::env::var("GITHUB_TOKEN").context("GITHUB_TOKEN not set")?;
+    let github_token = std::env::var("GH_TOKEN").context("GH_TOKEN not set")?;
 
     let fragment_files = std::fs::read_dir(fragments_dir)
         .with_context(|| format!("Unable to read fragments from {}", fragments_dir.display()))?;


### PR DESCRIPTION
Github tools seem to tolerate both GH_TOKEN and GITHUB_TOKEN, but the release workflow gets mad at me if I try to change it to GITHUB_TOKEN, so let's go the other direction.