### PR TITLE
Fix smoke-tester being unable to target rp2040

### DIFF
--- a/smoke-tester/src/dut_definition.rs
+++ b/smoke-tester/src/dut_definition.rs
@@ -199,16 +199,23 @@ fn lookup_unique_target(chip: &str) -> Result<Target> {
     );
 
     if targets.len() > 1 {
-        eprintln!(
-            "For tests, chip definition must be exact. Chip name {} matches multiple chips:",
-            &chip
-        );
+        let target_string = String::from(chip).to_ascii_uppercase();
+        if targets.contains(&target_string) {
+            // Multiple chips returned, but one was an exact match so we're using it
+            let target = get_target_by_name(target_string)?;
+            return Ok(target);
+        } else {
+            eprintln!(
+                "For tests, chip definition must be exact. Chip name {} matches multiple chips:",
+                &chip
+            );
 
-        for target in &targets {
-            eprintln!("\t{target}");
+            for target in &targets {
+                eprintln!("\t{target}");
+            }
+
+            bail!("Chip definition does not match exactly.");
         }
-
-        bail!("Chip definition does not match exactly.");
     }
 
     let target = get_target_by_name(&targets[0])?;


### PR DESCRIPTION
Before:
```console
$ /target/release/smoke_tester --chip RP2040
For tests, chip definition must be exact. Chip name RP2040 matches multiple chips:
        RP2040
        RP2040_SELFDEBUG
Error: Chip definition does not match exactly.
```
After:
```console
$ ./target/release/smoke_tester --chip not_a_chip
Error: Unable to find any chip matching not_a_chip

$ ./target/release/smoke_tester --chip rp204
For tests, chip definition must be exact. Chip name rp204 matches multiple chips:
        RP2040
        RP2040_SELFDEBUG
Error: Chip definition does not match exactly.

$ ./target/release/smoke_tester --chip rp2040
[1/1](RP2040) - Starting Test
[1/1](RP2040) - Error message: No probes detected!
[1/1](RP2040) - Tests Failed
[DONE] - Some DUTs failed some tests.

Test summary:
 [RP2040] failed
1 out of 1 tests failed.

$ ./target/release/smoke_tester --chip rp2040_selfdebug
[1/1](RP2040_SELFDEBUG) - Starting Test
[1/1](RP2040_SELFDEBUG) - Error message: No probes detected!
[1/1](RP2040_SELFDEBUG) - Tests Failed
[DONE] - Some DUTs failed some tests.

Test summary:
 [RP2040_SELFDEBUG] failed
1 out of 1 tests failed.
```