### PR TITLE
fix: only read pc if breakpoint was reached for armvXm

### DIFF
--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -636,15 +636,15 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
         // First check if we stopped on a breakpoint, because this requires special handling before we can continue.
-        let pc_before_step = self.read_core_reg(self.program_counter().into())?;
-        let was_breakpoint = if matches!(
+        let (was_breakpoint, pc_before_step) = if matches!(
             self.state.current_state,
             CoreStatus::Halted(HaltReason::Breakpoint(_))
         ) {
+            let pc_before_step = self.read_core_reg(self.program_counter().into())?;
             self.enable_breakpoints(false)?;
-            true
+            (true, pc_before_step)
         } else {
-            false
+            (false, RegisterValue::U32(0)) // Dummy register value that won't be used
         };
 
         let mut value = Dhcsr(0);

--- a/probe-rs/src/architecture/arm/core/armv6m.rs
+++ b/probe-rs/src/architecture/arm/core/armv6m.rs
@@ -636,15 +636,15 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
         // First check if we stopped on a breakpoint, because this requires special handling before we can continue.
-        let (was_breakpoint, pc_before_step) = if matches!(
+        let breakpoint_at_pc = if matches!(
             self.state.current_state,
             CoreStatus::Halted(HaltReason::Breakpoint(_))
         ) {
             let pc_before_step = self.read_core_reg(self.program_counter().into())?;
             self.enable_breakpoints(false)?;
-            (true, pc_before_step)
+            Some(pc_before_step)
         } else {
-            (false, RegisterValue::U32(0)) // Dummy register value that won't be used
+            None
         };
 
         let mut value = Dhcsr(0);
@@ -666,7 +666,7 @@ impl<'probe> CoreInterface for Armv6m<'probe> {
         let mut pc_after_step = self.read_core_reg(self.program_counter().into())?;
 
         // Re-enable breakpoints before we continue.
-        if was_breakpoint {
+        if let Some(pc_before_step) = breakpoint_at_pc {
             // If we were stopped on a software breakpoint, then we need to manually advance the PC, or else we will be stuck here forever.
             if pc_before_step == pc_after_step
                 && !self

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -828,15 +828,15 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
         // First check if we stopped on a breakpoint, because this requires special handling before we can continue.
-        let pc_before_step = self.read_core_reg(self.program_counter().into())?;
-        let was_breakpoint = if matches!(
+        let (was_breakpoint, pc_before_step) = if matches!(
             self.state.current_state,
             CoreStatus::Halted(HaltReason::Breakpoint(_))
         ) {
+            let pc_before_step = self.read_core_reg(self.program_counter().into())?;
             self.enable_breakpoints(false)?;
-            true
+            (true, pc_before_step)
         } else {
-            false
+            (false, RegisterValue::U32(0)) // Dummy register value that won't be used
         };
 
         let mut dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::get_mmio_address())?);

--- a/probe-rs/src/architecture/arm/core/armv7m.rs
+++ b/probe-rs/src/architecture/arm/core/armv7m.rs
@@ -828,15 +828,15 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
         // First check if we stopped on a breakpoint, because this requires special handling before we can continue.
-        let (was_breakpoint, pc_before_step) = if matches!(
+        let breakpoint_at_pc = if matches!(
             self.state.current_state,
             CoreStatus::Halted(HaltReason::Breakpoint(_))
         ) {
             let pc_before_step = self.read_core_reg(self.program_counter().into())?;
             self.enable_breakpoints(false)?;
-            (true, pc_before_step)
+            Some(pc_before_step)
         } else {
-            (false, RegisterValue::U32(0)) // Dummy register value that won't be used
+            None
         };
 
         let mut dhcsr = Dhcsr(self.memory.read_word_32(Dhcsr::get_mmio_address())?);
@@ -868,7 +868,7 @@ impl<'probe> CoreInterface for Armv7m<'probe> {
         let mut pc_after_step = self.read_core_reg(self.program_counter().into())?;
 
         // Re-enable breakpoints before we continue.
-        if was_breakpoint {
+        if let Some(pc_before_step) = breakpoint_at_pc {
             // If we were stopped on a software breakpoint, then we need to manually advance the PC, or else we will be stuck here forever.
             if pc_before_step == pc_after_step
                 && !self

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -262,15 +262,15 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
         // First check if we stopped on a breakpoint, because this requires special handling before we can continue.
-        let (was_breakpoint, pc_before_step) = if matches!(
+        let breakpoint_at_pc = if matches!(
             self.state.current_state,
             CoreStatus::Halted(HaltReason::Breakpoint(_))
         ) {
             let pc_before_step = self.read_core_reg(self.program_counter().into())?;
             self.enable_breakpoints(false)?;
-            (true, pc_before_step)
+            Some(pc_before_step)
         } else {
-            (false, RegisterValue::U32(0)) // Dummy register value that won't be used
+            None
         };
 
         let mut value = Dhcsr(0);
@@ -292,7 +292,7 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
         let mut pc_after_step = self.read_core_reg(self.program_counter().into())?;
 
         // Re-enable breakpoints before we continue.
-        if was_breakpoint {
+        if let Some(pc_before_step) = breakpoint_at_pc {
             // If we were stopped on a software breakpoint, then we need to manually advance the PC, or else we will be stuck here forever.
             if pc_before_step == pc_after_step
                 && !self

--- a/probe-rs/src/architecture/arm/core/armv8m.rs
+++ b/probe-rs/src/architecture/arm/core/armv8m.rs
@@ -262,15 +262,15 @@ impl<'probe> CoreInterface for Armv8m<'probe> {
 
     fn step(&mut self) -> Result<CoreInformation, Error> {
         // First check if we stopped on a breakpoint, because this requires special handling before we can continue.
-        let pc_before_step = self.read_core_reg(self.program_counter().into())?;
-        let was_breakpoint = if matches!(
+        let (was_breakpoint, pc_before_step) = if matches!(
             self.state.current_state,
             CoreStatus::Halted(HaltReason::Breakpoint(_))
         ) {
+            let pc_before_step = self.read_core_reg(self.program_counter().into())?;
             self.enable_breakpoints(false)?;
-            true
+            (true, pc_before_step)
         } else {
-            false
+            (false, RegisterValue::U32(0)) // Dummy register value that won't be used
         };
 
         let mut value = Dhcsr(0);


### PR DESCRIPTION
This change makes it possible to attach to running cores using `probe-rs attach`.

Before, I got an error trying to attach to a running app, because `read_core_reg()` requires the core to be *halted*, but the core might not be *halted*.

With the changes in this PR, `read_core_reg()` is only executed in case core stopped at a breakpoint.
This is fine, because `pc_before_step` is only used if core stopped at a breakpoint.
I decided to use a dummy register in the *else* branch, because it won't be accessed anyways.

**Note:** I only tested this on *armv7m*, but *armv6m* and *armv8m* should behave similar.