### PR TITLE
fix: increase timeout for S_RESET_ST

### DIFF
--- a/probe-rs/src/config/sequences/infineon.rs
+++ b/probe-rs/src/config/sequences/infineon.rs
@@ -314,7 +314,7 @@ impl ArmDebugSequence for XMC4000 {
             if !dhcsr.s_reset_st() {
                 tracing::debug!("Detected reset via S_RESET_ST");
                 break;
-            } else if start.elapsed() > Duration::from_millis(500) {
+            } else if start.elapsed() > Duration::from_millis(5000) {
                 tracing::error!("XMC4000 did not reset as commanded");
                 return Err(ArmError::Timeout);
             }


### PR DESCRIPTION
Trying to flash to a XMC4700, I had to increase the timeout for `S_RESET_ST`.
Probably the timeout could be lowered, but I wanted to be on the safe side.

I am not sure why I had to increase this timeout, but maybe my USB cable is slower?