### PR TITLE
Improve usability of `chips list`

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/chip.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/chip.rs
@@ -7,7 +7,7 @@ pub struct Cmd {
 }
 
 #[derive(clap::Subcommand)]
-/// Inspect internal registry of supported chips
+/// List supported chips and their properties.
 enum Subcommand {
     /// Lists all the available families and their chips with their full.
     #[clap(name = "list")]

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -15,7 +15,7 @@ static REGISTRY: Lazy<Arc<Mutex<Registry>>> =
 #[derive(Debug, thiserror::Error)]
 pub enum RegistryError {
     /// The requested chip was not found in the registry.
-    #[error("The requested chip '{0}' was not found in the list of known targets.")]
+    #[error("The requested chip '{0}' was not found in the list of known targets. Run `probe-rs chip list` to see which chips are supported.")]
     ChipNotFound(String),
     /// Multiple chips found which match the given string, unable to return a single chip.
     #[error("Found multiple chips matching '{0}', unable to select a single chip. ({1})")]


### PR DESCRIPTION
Make it easier for users to figure out where they went wrong when they've specified an unrecognized target with their `run` command.

I'm not sure if such a miniscule change warrants a changelog entry so I didn't include one, but will be happy to do so if needed!