### PR TITLE
cmsisdap: fix probes not being found on windows.

### DIFF
--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -109,7 +109,7 @@ fn read_interface_string(
 /// Checks if a given Device is a CMSIS-DAP probe, returning Some(DebugProbeInfo) if so.
 fn get_cmsisdap_info(device: &DeviceInfo) -> Option<DebugProbeInfo> {
     // Open device handle and read basic information
-    let prod_str = device.product_string()?;
+    let prod_str = device.product_string().unwrap_or("");
     let sn_str = device.serial_number();
 
     // Most CMSIS-DAP probes say something like "CMSIS-DAP"


### PR DESCRIPTION
Do not ignore devices without product string, still try to check whether they have an
interface with "CMSIS-DAP" in the name.

It seems the root cause is a `nusb` issue (https://github.com/kevinmehall/nusb/issues/24), which makes
`product_string()` always return None on Windows. Even when that's fixed, I
still think it's good to not bail out if there's no product string, it can help with compatibility
with weird probes.
