### PR TITLE
espusbjtag: use nusb `get_descriptor()` instead of doing a manual control request.

### DIFF
--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -1,6 +1,6 @@
 use bitvec::{prelude::*, slice::BitSlice, vec::BitVec};
 use nusb::{
-    transfer::{ControlIn, Direction, EndpointType},
+    transfer::{Direction, EndpointType},
     DeviceInfo,
 };
 use std::{fmt::Debug, time::Duration};
@@ -29,9 +29,8 @@ const USB_DEVICE_TRANSFER_TYPE: EndpointType = EndpointType::Bulk;
 const USB_VID: u16 = 0x303A;
 const USB_PID: u16 = 0x1001;
 
-const VENDOR_DESCRIPTOR_JTAG_CAPABILITIES: u16 = 0x2000;
-
-const USB_REQUEST_GET_DESCRIPTOR: u8 = 0x06;
+const DESCRIPTOR_JTAG_CAPABILITIES_TYPE: u8 = 0x20;
+const DESCRIPTOR_JTAG_CAPABILITIES_INDEX: u8 = 0x00;
 
 pub(super) struct ProtocolHandler {
     // The USB device handle.
@@ -159,16 +158,13 @@ impl ProtocolHandler {
             ));
         };
 
-        let control = ControlIn {
-            recipient: nusb::transfer::Recipient::Device,
-            control_type: nusb::transfer::ControlType::Standard,
-            request: USB_REQUEST_GET_DESCRIPTOR,
-            value: VENDOR_DESCRIPTOR_JTAG_CAPABILITIES,
-            index: 0,
-            length: 255,
-        };
-        let buffer = iface
-            .read_control(control, USB_TIMEOUT)
+        let buffer = device_handle
+            .get_descriptor(
+                DESCRIPTOR_JTAG_CAPABILITIES_TYPE,
+                DESCRIPTOR_JTAG_CAPABILITIES_INDEX,
+                0,
+                USB_TIMEOUT,
+            )
             .map_err(ProbeCreationError::Usb)?;
 
         let mut base_speed_khz = 1000;
@@ -176,7 +172,7 @@ impl ProtocolHandler {
         let mut div_max = 1;
 
         let protocol_version = buffer[0];
-        tracing::debug!("{:?}", &buffer[..20]);
+        tracing::debug!("{:02x?}", &buffer);
         tracing::debug!("Protocol version: {}", protocol_version);
         if protocol_version != JTAG_PROTOCOL_CAPABILITIES_VERSION {
             return Err(ProbeCreationError::ProbeSpecific(

--- a/probe-rs/src/probe/usb_util.rs
+++ b/probe-rs/src/probe/usb_util.rs
@@ -1,32 +1,14 @@
 use async_io::{block_on, Timer};
 use futures_lite::FutureExt;
-use nusb::{
-    transfer::{ControlIn, RequestBuffer},
-    Interface,
-};
+use nusb::{transfer::RequestBuffer, Interface};
 use std::{io, time::Duration};
 
 pub trait InterfaceExt {
-    fn read_control(&self, data: ControlIn, timeout: Duration) -> io::Result<Vec<u8>>;
     fn read_bulk(&self, endpoint: u8, buf: &mut [u8], timeout: Duration) -> io::Result<usize>;
     fn write_bulk(&self, endpoint: u8, buf: &[u8], timeout: Duration) -> io::Result<usize>;
 }
 
 impl InterfaceExt for Interface {
-    fn read_control(&self, data: ControlIn, timeout: Duration) -> io::Result<Vec<u8>> {
-        let fut = async {
-            let comp = self.control_in(data).await;
-            comp.status.map_err(io::Error::other)?;
-
-            Ok(comp.data)
-        };
-
-        block_on(fut.or(async {
-            Timer::after(timeout).await;
-            Err(std::io::ErrorKind::TimedOut.into())
-        }))
-    }
-
     fn write_bulk(&self, endpoint: u8, buf: &[u8], timeout: Duration) -> io::Result<usize> {
         let fut = async {
             let comp = self.bulk_out(endpoint, buf.to_vec()).await;


### PR DESCRIPTION
**WARNING**: I haven't tested it on real hardware, please test before merge! :pray:
