### PR TITLE
JTAG state machine fixes

### DIFF
--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -296,7 +296,7 @@ impl JtagState {
     pub fn step_toward(self, target: Self) -> Option<bool> {
         let tms = match self {
             state if target == state => return None,
-            Self::Reset => true,
+            Self::Reset => false,
             Self::Idle => true,
             Self::Dr(RegisterState::Select) => !matches!(target, Self::Dr(_)),
             Self::Ir(RegisterState::Select) => !matches!(target, Self::Ir(_)),
@@ -434,5 +434,20 @@ mod tests {
         let mut state = JtagState::Reset;
         state.update(false);
         assert_eq!(state, JtagState::Idle);
+    }
+
+    #[test]
+    fn generated_bits_lead_to_correct_state() {
+        for (start, goal) in [(JtagState::Reset, JtagState::Idle)] {
+            let mut state = start;
+            let mut transitions = 0;
+            while state != goal && transitions < 10 {
+                let tms = state.step_toward(goal).unwrap();
+                state.update(tms);
+                transitions += 1;
+            }
+
+            assert!(transitions < 10);
+        }
     }
 }

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -325,8 +325,8 @@ impl JtagState {
 
     pub fn update(&mut self, tms: bool) {
         *self = match *self {
-            Self::Reset if tms => Self::Idle,
-            Self::Reset => Self::Reset,
+            Self::Reset if tms => Self::Reset,
+            Self::Reset => Self::Idle,
             Self::Idle if tms => Self::Dr(RegisterState::Select),
             Self::Idle => Self::Idle,
             Self::Dr(RegisterState::Select) if tms => Self::Ir(RegisterState::Select),
@@ -416,5 +416,23 @@ mod tests {
         let idcodes = extract_idcodes(&dr).unwrap();
 
         assert_eq!(idcodes, vec![Some(ARM_TAP), None, Some(STM_BS_TAP)]);
+    }
+
+    #[test]
+    fn reset_from_ir_shift() {
+        let mut state = JtagState::Ir(RegisterState::Shift);
+        state.update(true);
+        state.update(true);
+        state.update(true);
+        state.update(true);
+        state.update(true);
+        assert_eq!(state, JtagState::Reset);
+    }
+
+    #[test]
+    fn idle_from_reset() {
+        let mut state = JtagState::Reset;
+        state.update(false);
+        assert_eq!(state, JtagState::Idle);
     }
 }

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -258,7 +258,9 @@ impl RegisterState {
             Self::Capture if target == Self::Shift => false,
             Self::Exit1 if target == Self::Pause => false,
             Self::Exit2 if target == Self::Shift => false,
-            Self::Update => unreachable!(),
+            Self::Update => {
+                unreachable!("This is a bug, this case should have been handled by JtagState.")
+            }
             _ => true,
         }
     }
@@ -269,8 +271,9 @@ impl RegisterState {
                 Self::Capture | Self::Shift => Self::Exit1,
                 Self::Exit1 | Self::Exit2 => Self::Update,
                 Self::Pause => Self::Exit2,
-                Self::Select => unreachable!(),
-                Self::Update => unreachable!(),
+                Self::Select | Self::Update => {
+                    unreachable!("This is a bug, this case should have been handled by JtagState.")
+                }
             }
         } else {
             match self {
@@ -278,7 +281,9 @@ impl RegisterState {
                 Self::Capture | Self::Shift => Self::Shift,
                 Self::Exit1 | Self::Pause => Self::Pause,
                 Self::Exit2 => Self::Shift,
-                Self::Update => unreachable!(),
+                Self::Update => {
+                    unreachable!("This is a bug, this case should have been handled by JtagState.")
+                }
             }
         }
     }

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -98,12 +98,18 @@ impl EspUsbJtag {
         let input = vec![0xff; idcodes.len()];
         let response = self.write_ir(&input, input.len() * 8, true)?;
 
+        tracing::debug!("IR scan: {}", response);
+
+        self.jtag_reset()?;
+
         // Next, shift out same amount of zeros, then ones to make sure the IRs contain BYPASS.
         let input = iter::repeat(0)
             .take(idcodes.len())
             .chain(input.iter().copied())
             .collect::<Vec<_>>();
         let response_zeros = self.write_ir(&input, input.len() * 8, true)?;
+
+        tracing::debug!("IR scan: {}", response_zeros);
 
         let expected = if let Some(ref chain) = self.scan_chain {
             let expected = chain


### PR DESCRIPTION
 - Fix JTAG state tracking (exit from Reset was previously incorrectly detected)
 - Fix JTAG state traversal (Idle -> Reset is TMS = 0, not TMS = 1)
 - Reset, just in case