### PR TITLE
Ftdi: do not discard devices without product string

### DIFF
--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -729,7 +729,7 @@ fn get_device_info(device: &DeviceInfo) -> Option<DebugProbeInfo> {
     }
 
     Some(DebugProbeInfo {
-        identifier: device.product_string()?.to_string(),
+        identifier: device.product_string().unwrap_or("FTDI").to_string(),
         vendor_id: device.vendor_id(),
         product_id: device.product_id(),
         serial_number: device.serial_number().map(|s| s.to_string()),


### PR DESCRIPTION
Looks like windows might have some trouble reading the product string (nusb tries to read DEVPKEY_Device_FriendlyName which may be missing) for whatever reason. Probe-rs discarded previously working FTDI chips due to this.

cc @Dirbaio in case you know something better, and since this is likely a nusb regression