### PR TITLE
Speed up J-Link JTAG

### DIFF
--- a/probe-rs/src/probe/jlink/jaylink/mod.rs
+++ b/probe-rs/src/probe/jlink/jaylink/mod.rs
@@ -846,7 +846,7 @@ impl JayLink {
         self.write_cmd(&buf)?;
 
         // Round bit count up to multple of 8 to get the number of response bytes.
-        let num_resp_bytes = (tms_bit_count + 7) >> 3;
+        let num_resp_bytes = (tms_bit_count + 7) / 8;
         trace!(
             "{} TMS/TDI bits sent; reading {} response bytes",
             tms_bit_count,


### PR DESCRIPTION
This PR does fewer IO operations, speeding up JTAG considerably. Not quite up to the levels of FTDI/espusbjtag, but usable - I had a ~~36-37~~ 53-54 KiB/s flashing run while testing.