### PR TITLE
Don't eagerly send out IR scan, clean up register access

### DIFF
--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -837,7 +837,14 @@ impl fmt::Display for DebugProbeSelector {
 /// This trait should be implemented by all probes which offer low-level access to
 /// the JTAG protocol, i.e. direction control over the bytes sent and received.
 pub trait JTAGAccess: DebugProbe {
-    fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError>;
+    /// Read a JTAG register.
+    ///
+    /// This function emulates a read by performing a write with all zeros to the DR.
+    fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {
+        let data = vec![0u8; (len as usize + 7) / 8];
+
+        self.write_register(address, &data, len)
+    }
 
     /// For RISC-V, and possibly other interfaces, the JTAG interface has to remain in
     /// the idle state for several cycles between consecutive accesses to the DR register.

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -332,13 +332,6 @@ impl JTAGAccess for EspUsbJtag {
         }
     }
 
-    /// Read the data register
-    fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {
-        let data = vec![0u8; (len as usize + 7) / 8];
-
-        self.write_register(address, &data, len)
-    }
-
     /// Write the data register
     fn write_register(
         &mut self,

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -334,23 +334,9 @@ impl JTAGAccess for EspUsbJtag {
 
     /// Read the data register
     fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {
-        if address > self.max_ir_address {
-            return Err(DebugProbeError::Other(anyhow!(
-                "Invalid instruction register access: {}",
-                address
-            )));
-        }
-        let address_bytes = address.to_le_bytes();
+        let data = vec![0u8; (len as usize + 7) / 8];
 
-        if self.current_ir_reg != address {
-            // Write IR register
-            self.prepare_write_ir(&address_bytes, self.chain_params.irlen, false)?;
-            self.current_ir_reg = address;
-        }
-
-        // read DR register by transfering len bits to the chain
-        let data: Vec<u8> = iter::repeat(0).take((len as usize + 7) / 8).collect();
-        self.write_dr(&data, len as usize)
+        self.write_register(address, &data, len)
     }
 
     /// Write the data register


### PR DESCRIPTION
Similar pattern was added and then fixed in #2016 - it should be a tiny free perf increase.

Previously, `write_ir` immediately flushed the internal buffers, causing an IO operation. This was followed by another IO operation for the DR scan shortly after. This change allows batching these.