### PR TITLE
cmsisdap: don't do i/o for the iface string when listing devices.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,9 +2381,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nusb"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed578456ade6b3642c40fad8aa25cd7584725f5170628619f21b24e8fb8d125f"
+checksum = "e4a78c02d64455ced38cfadc3cfb1ecc45a2874a8accbda59ee74ecf2168e18a"
 dependencies = [
  "atomic-waker",
  "core-foundation",

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -106,7 +106,7 @@ object = { version = "0.32.2", default-features = false, features = [
     "std",
 ] }
 paste = "1.0.14"
-nusb = { version = "0.1.3" }
+nusb = { version = "0.1.4" }
 futures-lite = "2.2.0"
 async-io = "2.1.0"
 scroll = "0.12.0"

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -5,11 +5,9 @@ use crate::{
 };
 use hidapi::HidApi;
 use nusb::{
-    descriptors::{language_id::US_ENGLISH, InterfaceAltSetting},
     transfer::{Direction, EndpointType},
     DeviceInfo,
 };
-use std::{io, time::Duration};
 
 const USB_CLASS_HID: u8 = 0x03;
 
@@ -58,19 +56,6 @@ pub fn list_cmsisdap_devices() -> Vec<DebugProbeInfo> {
     probes
 }
 
-fn read_interface_string(
-    device: &nusb::Device,
-    iface_info: &InterfaceAltSetting,
-) -> std::io::Result<String> {
-    let timeout = Duration::from_millis(1000);
-
-    let index = iface_info
-        .string_index()
-        .ok_or_else(|| io::Error::other("No description string index in iface"))?;
-
-    device.get_string_descriptor(index, US_ENGLISH, timeout)
-}
-
 /// Checks if a given Device is a CMSIS-DAP probe, returning Some(DebugProbeInfo) if so.
 fn get_cmsisdap_info(device: &DeviceInfo) -> Option<DebugProbeInfo> {
     // Open device handle and read basic information
@@ -80,48 +65,30 @@ fn get_cmsisdap_info(device: &DeviceInfo) -> Option<DebugProbeInfo> {
     // Most CMSIS-DAP probes say something like "CMSIS-DAP"
     let cmsis_dap_product = is_cmsis_dap(prod_str) || is_known_cmsis_dap_dev(device);
 
-    let dev = match device.open() {
-        Ok(dev) => dev,
-        Err(e) => {
-            tracing::debug!(
-                "failed to open usb device to check for cmsisdap interfaces: {:?} {:?}",
-                e,
-                device
-            );
-            return None;
-        }
-    };
-
     // Iterate all interfaces, looking for:
     // 1. Any with CMSIS-DAP in their interface string
     // 2. Any that are HID, if the product string says CMSIS-DAP,
     //    to save for potential HID-only operation.
-    let config_descriptor = dev.configurations().next()?;
     let mut cmsis_dap_interface = false;
     let mut hid_interface = None;
-    for interface in config_descriptor.interfaces() {
-        for descriptor in interface.alt_settings() {
-            let interface_desc = match read_interface_string(&dev, &descriptor) {
-                Ok(desc) => desc,
-                Err(_) => {
-                    tracing::trace!(
-                        "Could not read string for interface {}, skipping",
-                        interface.interface_number()
-                    );
-                    continue;
-                }
-            };
-            if is_cmsis_dap(&interface_desc) {
-                tracing::trace!(
-                    "  Interface {}: {}",
-                    interface.interface_number(),
-                    interface_desc
-                );
-                cmsis_dap_interface = true;
-                if descriptor.class() == USB_CLASS_HID {
-                    tracing::trace!("    HID interface found");
-                    hid_interface = Some(interface.interface_number());
-                }
+    for interface in device.interfaces() {
+        let Some(interface_desc) = interface.interface_string() else {
+            tracing::trace!(
+                "interface {} has no string, skipping",
+                interface.interface_number()
+            );
+            continue;
+        };
+        if is_cmsis_dap(interface_desc) {
+            tracing::trace!(
+                "  Interface {}: {}",
+                interface.interface_number(),
+                interface_desc
+            );
+            cmsis_dap_interface = true;
+            if interface.class() == USB_CLASS_HID {
+                tracing::trace!("    HID interface found");
+                hid_interface = Some(interface.interface_number());
             }
         }
     }
@@ -130,7 +97,7 @@ fn get_cmsisdap_info(device: &DeviceInfo) -> Option<DebugProbeInfo> {
         tracing::trace!(
             "{}: CMSIS-DAP device with {} interfaces",
             prod_str,
-            config_descriptor.num_interfaces()
+            device.interfaces().count()
         );
 
         if let Some(interface) = hid_interface {
@@ -178,12 +145,12 @@ fn get_cmsisdap_hid_info(device: &hidapi::DeviceInfo) -> Option<DebugProbeInfo> 
 }
 
 /// Attempt to open the given device in CMSIS-DAP v2 mode
-pub fn open_v2_device(device: &DeviceInfo) -> Option<CmsisDapDevice> {
+pub fn open_v2_device(device_info: &DeviceInfo) -> Option<CmsisDapDevice> {
     // Open device handle and read basic information
-    let vid = device.vendor_id();
-    let pid = device.product_id();
+    let vid = device_info.vendor_id();
+    let pid = device_info.product_id();
 
-    let device = device.open().ok()?;
+    let device = device_info.open().ok()?;
 
     // Go through interfaces to try and find a v2 interface.
     // The CMSIS-DAPv2 spec says that v2 interfaces should use a specific
@@ -195,10 +162,15 @@ pub fn open_v2_device(device: &DeviceInfo) -> Option<CmsisDapDevice> {
     for interface in c_desc.interfaces() {
         for i_desc in interface.alt_settings() {
             // Skip interfaces without "CMSIS-DAP" like pattern in their string
-            match read_interface_string(&device, &i_desc) {
-                Ok(i_str) if !is_cmsis_dap(&i_str) => continue,
-                Err(_) => continue,
-                Ok(_) => (),
+            let Some(interface_str) = device_info
+                .interfaces()
+                .find(|i| i.interface_number() == interface.interface_number())
+                .and_then(|i| i.interface_string())
+            else {
+                continue;
+            };
+            if !is_cmsis_dap(interface_str) {
+                continue;
             }
 
             // Skip interfaces without 2 or 3 endpoints


### PR DESCRIPTION
nusb added an API to list basic interface info from DeviceInfo which does no
actual USB I/O to the device (info is cached by the OS when plugging in the device).
This includes the interface string, which we use to detect CMSIS-DAP interfaces.

This takes `probe-rs list` in the Embassy CI machine (52 USB devices, 32 probes) from 900ms to 60ms.

see https://github.com/kevinmehall/nusb/issues/28