### PR TITLE
Delete duplicate JTAG logic

### DIFF
--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -837,9 +837,6 @@ impl fmt::Display for DebugProbeSelector {
 /// This trait should be implemented by all probes which offer low-level access to
 /// the JTAG protocol, i.e. direction control over the bytes sent and received.
 pub trait JTAGAccess: DebugProbe {
-    /// Resets the JTAG state machine by shifting out a number of high TMS bits.
-    fn reset_jtag_state_machine(&mut self) -> Result<(), DebugProbeError>;
-
     /// Returns `IDCODE` and `IR` length information about the devices on the JTAG chain.
     ///
     /// If configured, this will use the data from [`DebugProbe::set_scan_chain`]. Otherwise, it

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -837,7 +837,13 @@ impl fmt::Display for DebugProbeSelector {
 /// This trait should be implemented by all probes which offer low-level access to
 /// the JTAG protocol, i.e. direction control over the bytes sent and received.
 pub trait JTAGAccess: DebugProbe {
+    /// Resets the JTAG state machine by shifting out a number of high TMS bits.
     fn reset_jtag_state_machine(&mut self) -> Result<(), DebugProbeError>;
+
+    /// Returns `IDCODE` and `IR` length information about the devices on the JTAG chain.
+    ///
+    /// If configured, this will use the data from [`DebugProbe::set_scan_chain`]. Otherwise, it
+    /// will try to measure and extract `IR` lengths by driving the JTAG interface.
     fn scan_chain(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError>;
 
     /// Read a JTAG register.

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -837,6 +837,9 @@ impl fmt::Display for DebugProbeSelector {
 /// This trait should be implemented by all probes which offer low-level access to
 /// the JTAG protocol, i.e. direction control over the bytes sent and received.
 pub trait JTAGAccess: DebugProbe {
+    fn reset_jtag_state_machine(&mut self) -> Result<(), DebugProbeError>;
+    fn scan_chain(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError>;
+
     /// Read a JTAG register.
     ///
     /// This function emulates a read by performing a write with all zeros to the DR.

--- a/probe-rs/src/probe/arm_jtag.rs
+++ b/probe-rs/src/probe/arm_jtag.rs
@@ -1528,10 +1528,6 @@ mod test {
     }
 
     impl JTAGAccess for MockJaylink {
-        fn reset_jtag_state_machine(&mut self) -> Result<(), DebugProbeError> {
-            todo!()
-        }
-
         fn scan_chain(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
             todo!()
         }

--- a/probe-rs/src/probe/arm_jtag.rs
+++ b/probe-rs/src/probe/arm_jtag.rs
@@ -1321,8 +1321,7 @@ mod test {
     use crate::{
         architecture::arm::{PortType, RawDapAccess},
         probe::{JTAGAccess, JtagChainItem, ScanChainElement},
-        probe::{JTAGAccess, ScanChainElement},
-        DebugProbe, DebugProbe, DebugProbeError, DebugProbeError, WireProtocol,
+        DebugProbe, DebugProbeError, WireProtocol,
     };
 
     use super::{
@@ -1534,10 +1533,6 @@ mod test {
         }
 
         fn scan_chain(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
-            todo!()
-        }
-
-        fn set_ir_len(&mut self, _len: u32) {
             todo!()
         }
 

--- a/probe-rs/src/probe/arm_jtag.rs
+++ b/probe-rs/src/probe/arm_jtag.rs
@@ -1320,8 +1320,9 @@ mod test {
 
     use crate::{
         architecture::arm::{PortType, RawDapAccess},
+        probe::{JTAGAccess, JtagChainItem, ScanChainElement},
         probe::{JTAGAccess, ScanChainElement},
-        DebugProbe, DebugProbeError, WireProtocol,
+        DebugProbe, DebugProbe, DebugProbeError, DebugProbeError, WireProtocol,
     };
 
     use super::{
@@ -1528,6 +1529,18 @@ mod test {
     }
 
     impl JTAGAccess for MockJaylink {
+        fn reset_jtag_state_machine(&mut self) -> Result<(), DebugProbeError> {
+            todo!()
+        }
+
+        fn scan_chain(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
+            todo!()
+        }
+
+        fn set_ir_len(&mut self, _len: u32) {
+            todo!()
+        }
+
         fn read_register(&mut self, _address: u32, _len: u32) -> Result<Vec<u8>, DebugProbeError> {
             todo!()
         }

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -653,44 +653,47 @@ impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
             idcodes
         );
 
-        // First shift out all ones
-        let input = vec![0xff; idcodes.len()];
-        shift_ir(self, &input, input.len() * 8, true)?;
-        let response = self.read_captured_bits()?;
-
-        tracing::debug!("IR scan: {}", response);
-
-        self.reset_jtag_state_machine()?;
-
-        // Next, shift out same amount of zeros, then ones to make sure the IRs contain BYPASS.
-        let input = iter::repeat(0)
-            .take(idcodes.len())
-            .chain(input.iter().copied())
-            .collect::<Vec<_>>();
-        shift_ir(self, &input, input.len() * 8, true)?;
-        let response_zeros = self.read_captured_bits()?;
-
-        tracing::debug!("IR scan: {}", response_zeros);
-
-        let expected = if let Some(ref chain) = self.state().expected_scan_chain {
-            let expected = chain
+        let ir_lens = if let Some(ref chain) = self.state().expected_scan_chain {
+            tracing::debug!("Using configured scan chain: {:?}", chain);
+            chain
                 .iter()
                 .filter_map(|s| s.ir_len)
                 .map(|s| s as usize)
-                .collect::<Vec<usize>>();
-            Some(expected)
+                .collect::<Vec<usize>>()
         } else {
-            None
+            tracing::debug!("Measuing IR lengths");
+
+            // First shift out all ones
+            let input = vec![0xff; idcodes.len()];
+            shift_ir(self, &input, input.len() * 8, true)?;
+            let response = self.read_captured_bits()?;
+
+            tracing::debug!("IR scan: {}", response);
+
+            self.reset_jtag_state_machine()?;
+
+            // Next, shift out same amount of zeros, then ones to make sure the IRs contain BYPASS.
+            let input = iter::repeat(0)
+                .take(idcodes.len())
+                .chain(input.iter().copied())
+                .collect::<Vec<_>>();
+            shift_ir(self, &input, input.len() * 8, true)?;
+            let response_zeros = self.read_captured_bits()?;
+
+            tracing::debug!("IR scan: {}", response_zeros);
+
+            let response = response.as_bitslice();
+            let response = common_sequence(response, response_zeros.as_bitslice());
+
+            tracing::debug!("IR scan: {}", response);
+
+            let ir_lens = extract_ir_lengths(response, idcodes.len(), None)
+                .map_err(|e| DebugProbeError::Other(e.into()))?;
+
+            tracing::debug!("Detected IR lens: {:?}", ir_lens);
+
+            ir_lens
         };
-
-        let response = response.as_bitslice();
-        let response = common_sequence(response, response_zeros.as_bitslice());
-
-        tracing::debug!("IR scan: {}", response);
-
-        let ir_lens = extract_ir_lengths(response, idcodes.len(), expected.as_deref())
-            .map_err(|e| DebugProbeError::Other(e.into()))?;
-        tracing::debug!("Detected IR lens: {:?}", ir_lens);
 
         Ok(idcodes
             .into_iter()

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -1,7 +1,19 @@
 //! Crate-public structures and utilities to be shared between probes.
 
+use std::iter;
+
+use anyhow::anyhow;
 use bitfield::bitfield;
 use bitvec::prelude::*;
+use probe_rs_target::ScanChainElement;
+
+use crate::{
+    probe::{
+        BatchExecutionError, ChainParams, DeferredResultSet, JTAGAccess, JtagChainItem,
+        JtagCommandQueue,
+    },
+    DebugProbe, DebugProbeError,
+};
 
 pub(crate) fn bits_to_byte(bits: impl IntoIterator<Item = bool>) -> u32 {
     let mut bit_val = 0u32;
@@ -290,6 +302,7 @@ impl RegisterState {
     }
 }
 
+/// JTAG State Machine representation.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub(crate) enum JtagState {
     Reset,
@@ -359,6 +372,412 @@ impl JtagState {
             Self::Dr(state) => Self::Dr(state.update(tms)),
             Self::Ir(state) => Self::Ir(state.update(tms)),
         };
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct JtagDriverState {
+    pub state: JtagState,
+    pub current_ir_reg: u32,
+    // The maximum IR address
+    pub max_ir_address: u32,
+    pub expected_scan_chain: Option<Vec<ScanChainElement>>,
+    pub chain_params: ChainParams,
+    /// Idle cycles necessary between consecutive
+    /// accesses to the DMI register
+    pub jtag_idle_cycles: usize,
+}
+
+impl Default for JtagDriverState {
+    fn default() -> Self {
+        Self {
+            state: JtagState::Reset,
+            current_ir_reg: 1,
+            max_ir_address: 0x0F,
+            expected_scan_chain: None,
+            chain_params: ChainParams::default(),
+            jtag_idle_cycles: 0,
+        }
+    }
+}
+
+/// A trait for implementing low-level JTAG interface operations.
+pub(crate) trait RawJtagIo {
+    /// Returns a mutable reference to the current state.
+    fn state_mut(&mut self) -> &mut JtagDriverState;
+
+    /// Returns the current state.
+    fn state(&self) -> &JtagDriverState;
+
+    /// Shifts a number of bits through the TAP.
+    fn shift_bits(
+        &mut self,
+        tms: impl IntoIterator<Item = bool>,
+        tdi: impl IntoIterator<Item = bool>,
+        cap: impl IntoIterator<Item = bool>,
+    ) -> Result<(), DebugProbeError> {
+        for ((tms, tdi), cap) in tms.into_iter().zip(tdi.into_iter()).zip(cap.into_iter()) {
+            self.shift_bit(tms, tdi, cap)?;
+        }
+
+        Ok(())
+    }
+
+    /// Shifts a single bit through the TAP.
+    ///
+    /// Drivers may choose, and are encouraged, to buffer bits and flush them
+    /// in batches for performance reasons.
+    fn shift_bit(&mut self, tms: bool, tdi: bool, capture: bool) -> Result<(), DebugProbeError>;
+
+    /// Ensures internal buffers are flushed.
+    fn flush(&mut self) -> Result<(), DebugProbeError>;
+
+    /// Returns the bits captured from TDO and clears the capture buffer.
+    fn read_captured_bits(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError>;
+
+    /// Set the IR register length
+    fn set_ir_len(&mut self, len: usize) {
+        self.state_mut().chain_params.irlen = len;
+    }
+
+    fn select_target(
+        &mut self,
+        chain: &[JtagChainItem],
+        target: usize,
+    ) -> Result<(), DebugProbeError> {
+        let Some(params) = ChainParams::from_jtag_chain(chain, target) else {
+            return Err(DebugProbeError::TargetNotFound);
+        };
+
+        let max_ir_address = (1 << params.irlen) - 1;
+
+        tracing::debug!("Setting chain params: {:?}", params);
+        tracing::debug!("Setting max_ir_address to {}", max_ir_address);
+
+        let state = self.state_mut();
+        state.max_ir_address = max_ir_address;
+        state.chain_params = params;
+
+        Ok(())
+    }
+}
+
+fn jtag_move_to_state(
+    protocol: &mut impl RawJtagIo,
+    target: JtagState,
+) -> Result<(), DebugProbeError> {
+    tracing::trace!(
+        "Changing state: {:?} -> {:?}",
+        protocol.state_mut().state,
+        target
+    );
+
+    while let Some(tms) = protocol.state().state.step_toward(target) {
+        protocol.shift_bit(tms, false, false)?;
+    }
+
+    tracing::trace!("In state: {:?}", protocol.state_mut().state);
+    Ok(())
+}
+
+fn shift_ir(
+    protocol: &mut impl RawJtagIo,
+    data: &[u8],
+    len: usize,
+    capture_data: bool,
+) -> Result<(), DebugProbeError> {
+    tracing::debug!("Write IR: {:?}, len={}", data, len);
+
+    // Check the bit length, enough data has to be available
+    if data.len() * 8 < len || len == 0 {
+        return Err(DebugProbeError::Other(anyhow!("Invalid data length")));
+    }
+
+    // BYPASS commands before and after shifting out data where required
+    let pre_bits = protocol.state().chain_params.irpre;
+    let post_bits = protocol.state().chain_params.irpost;
+
+    // The last bit will be transmitted when exiting the shift state,
+    // so we need to stay in the shift state for one period less than
+    // we have bits to transmit.
+    let tms_data = iter::repeat(false).take(len - 1);
+
+    // Enter IR shift
+    jtag_move_to_state(protocol, JtagState::Ir(RegisterState::Shift))?;
+
+    let tms = iter::repeat(false)
+        .take(pre_bits)
+        .chain(tms_data)
+        .chain(iter::repeat(false).take(post_bits))
+        .chain(iter::once(true));
+
+    let tdi = iter::repeat(true)
+        .take(pre_bits)
+        .chain(data.as_bits::<Lsb0>()[..len].iter().map(|b| *b))
+        .chain(iter::repeat(true).take(post_bits));
+
+    let capture = iter::repeat(false)
+        .take(pre_bits)
+        .chain(iter::repeat(capture_data).take(len))
+        .chain(iter::repeat(false));
+
+    tracing::trace!("tms: {:?}", tms.clone());
+    tracing::trace!("tdi: {:?}", tdi.clone());
+
+    protocol.shift_bits(tms, tdi, capture)?;
+    jtag_move_to_state(protocol, JtagState::Ir(RegisterState::Update))?;
+
+    Ok(())
+}
+
+fn shift_dr(
+    protocol: &mut impl RawJtagIo,
+    data: &[u8],
+    register_bits: usize,
+    capture_data: bool,
+) -> Result<usize, DebugProbeError> {
+    tracing::debug!("Write DR: {:?}, len={}", data, register_bits);
+
+    // Check the bit length, enough data has to be available
+    if data.len() * 8 < register_bits || register_bits == 0 {
+        return Err(DebugProbeError::Other(anyhow!("Invalid data length")));
+    }
+
+    // Last bit of data is shifted out when we exit the SHIFT-DR State
+    let tms_shift_out_value = iter::repeat(false).take(register_bits - 1);
+
+    // Enter DR shift
+    jtag_move_to_state(protocol, JtagState::Dr(RegisterState::Shift))?;
+
+    // dummy bits to account for bypasses
+    let pre_bits = protocol.state().chain_params.drpre;
+    let post_bits = protocol.state().chain_params.drpost;
+
+    let tms = iter::repeat(false)
+        .take(pre_bits)
+        .chain(tms_shift_out_value)
+        .chain(iter::repeat(false).take(post_bits))
+        .chain(iter::once(true));
+
+    let tdi = iter::repeat(false)
+        .take(pre_bits)
+        .chain(data.as_bits::<Lsb0>()[..register_bits].iter().map(|b| *b))
+        .chain(iter::repeat(false).take(post_bits));
+
+    let capture = iter::repeat(false)
+        .take(pre_bits)
+        .chain(iter::repeat(capture_data).take(register_bits))
+        .chain(iter::repeat(false));
+
+    protocol.shift_bits(tms, tdi, capture)?;
+
+    jtag_move_to_state(protocol, JtagState::Dr(RegisterState::Update))?;
+
+    let idle_cycles = protocol.state().jtag_idle_cycles;
+    if idle_cycles > 0 {
+        jtag_move_to_state(protocol, JtagState::Idle)?;
+
+        // We need to stay in the idle cycle a bit
+        let tms = iter::repeat(false).take(idle_cycles);
+        let tdi = iter::repeat(false).take(idle_cycles);
+
+        protocol.shift_bits(tms, tdi, iter::repeat(false))?;
+    }
+
+    if capture_data {
+        Ok(register_bits)
+    } else {
+        Ok(0)
+    }
+}
+
+fn prepare_write_register(
+    protocol: &mut impl RawJtagIo,
+    address: u32,
+    data: &[u8],
+    len: u32,
+    capture: bool,
+) -> Result<usize, DebugProbeError> {
+    if protocol.state().current_ir_reg != address {
+        if address > protocol.state().max_ir_address {
+            return Err(DebugProbeError::Other(anyhow!(
+                "Invalid instruction register access: {}",
+                address
+            )));
+        }
+
+        let ir_len = protocol.state().chain_params.irlen;
+        shift_ir(protocol, &address.to_le_bytes(), ir_len, false)?;
+        protocol.state_mut().current_ir_reg = address;
+    }
+
+    // read DR register by transfering len bits to the chain
+    shift_dr(protocol, data, len as usize, capture)
+}
+
+impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
+    fn reset_jtag_state_machine(&mut self) -> Result<(), DebugProbeError> {
+        tracing::debug!("Resetting JTAG chain by setting tms high for 5 bits");
+
+        // Reset JTAG chain (5 times TMS high), and enter idle state afterwards
+        let tms = [true, true, true, true, true, false];
+        let tdi = iter::repeat(true);
+
+        self.shift_bits(tms, tdi, iter::repeat(false))?;
+        let response = self.read_captured_bits()?;
+
+        tracing::debug!("Response to reset: {}", response);
+
+        Ok(())
+    }
+
+    fn scan_chain(&mut self) -> Result<Vec<super::JtagChainItem>, DebugProbeError> {
+        const MAX_CHAIN: usize = 8;
+
+        self.reset_jtag_state_machine()?;
+
+        self.state_mut().chain_params = ChainParams::default();
+
+        let input = vec![0xFF; 4 * MAX_CHAIN];
+
+        shift_dr(self, &input, input.len() * 8, true)?;
+        let response = self.read_captured_bits()?;
+
+        tracing::debug!("DR: {:?}", response);
+
+        let idcodes = extract_idcodes(&response).map_err(|e| DebugProbeError::Other(e.into()))?;
+
+        tracing::info!(
+            "JTAG DR scan complete, found {} TAPs. {:?}",
+            idcodes.len(),
+            idcodes
+        );
+
+        // First shift out all ones
+        let input = vec![0xff; idcodes.len()];
+        shift_ir(self, &input, input.len() * 8, true)?;
+        let response = self.read_captured_bits()?;
+
+        tracing::debug!("IR scan: {}", response);
+
+        self.reset_jtag_state_machine()?;
+
+        // Next, shift out same amount of zeros, then ones to make sure the IRs contain BYPASS.
+        let input = iter::repeat(0)
+            .take(idcodes.len())
+            .chain(input.iter().copied())
+            .collect::<Vec<_>>();
+        shift_ir(self, &input, input.len() * 8, true)?;
+        let response_zeros = self.read_captured_bits()?;
+
+        tracing::debug!("IR scan: {}", response_zeros);
+
+        let expected = if let Some(ref chain) = self.state().expected_scan_chain {
+            let expected = chain
+                .iter()
+                .filter_map(|s| s.ir_len)
+                .map(|s| s as usize)
+                .collect::<Vec<usize>>();
+            Some(expected)
+        } else {
+            None
+        };
+
+        let response = response.as_bitslice();
+        let response = common_sequence(response, response_zeros.as_bitslice());
+
+        tracing::debug!("IR scan: {}", response);
+
+        let ir_lens = extract_ir_lengths(response, idcodes.len(), expected.as_deref())
+            .map_err(|e| DebugProbeError::Other(e.into()))?;
+        tracing::debug!("Detected IR lens: {:?}", ir_lens);
+
+        Ok(idcodes
+            .into_iter()
+            .zip(ir_lens)
+            .map(|(idcode, irlen)| JtagChainItem { irlen, idcode })
+            .collect())
+    }
+
+    fn set_idle_cycles(&mut self, idle_cycles: u8) {
+        self.state_mut().jtag_idle_cycles = idle_cycles as usize;
+    }
+
+    fn idle_cycles(&self) -> u8 {
+        self.state().jtag_idle_cycles as u8
+    }
+
+    fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {
+        let data = vec![0u8; (len as usize + 7) / 8];
+
+        self.write_register(address, &data, len)
+    }
+
+    fn write_register(
+        &mut self,
+        address: u32,
+        data: &[u8],
+        len: u32,
+    ) -> Result<Vec<u8>, DebugProbeError> {
+        prepare_write_register(self, address, data, len, true)?;
+
+        let mut response = self.read_captured_bits()?;
+
+        // Implementations don't need to align to keep the code simple
+        response.force_align();
+        let result = response.into_vec();
+
+        tracing::trace!("recieve_write_dr result: {:?}", result);
+        Ok(result)
+    }
+
+    fn write_register_batch(
+        &mut self,
+        writes: &JtagCommandQueue,
+    ) -> Result<DeferredResultSet, BatchExecutionError> {
+        let mut bits = Vec::with_capacity(writes.len());
+        let t1 = std::time::Instant::now();
+        tracing::debug!("Preparing {} writes...", writes.len());
+        for (idx, write) in writes.iter() {
+            // If an error happens during prep, return no results as chip will be in an inconsistent state
+            let op = prepare_write_register(
+                self,
+                write.address,
+                &write.data,
+                write.len,
+                idx.should_capture(),
+            )
+            .map_err(|e| BatchExecutionError::new(e.into(), DeferredResultSet::new()))?;
+
+            bits.push((idx, write.transform, op));
+        }
+
+        tracing::debug!("Sending to chip...");
+        // If an error happens during the final flush, also retry whole operation
+        let bitstream = self
+            .read_captured_bits()
+            .map_err(|e| BatchExecutionError::new(e.into(), DeferredResultSet::new()))?;
+
+        tracing::debug!("Got responses! Took {:?}! Processing...", t1.elapsed());
+        let mut responses = DeferredResultSet::with_capacity(bits.len());
+
+        let mut bitstream = bitstream.as_bitslice();
+        for (idx, transform, bits) in bits.into_iter() {
+            if idx.should_capture() {
+                // TODO: this back-and-forth between BitVec and Vec is probably unnecessary
+                let mut reg_bits = bitstream[..bits].to_bitvec();
+                reg_bits.force_align();
+                let response = reg_bits.into_vec();
+                match transform(response) {
+                    Ok(response) => responses.push(idx, response),
+                    Err(e) => return Err(BatchExecutionError::new(e, responses)),
+                }
+            }
+
+            bitstream = &bitstream[bits..];
+        }
+
+        Ok(responses)
     }
 }
 

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -1,7 +1,5 @@
 mod protocol;
 
-use std::iter;
-
 use crate::{
     architecture::{
         arm::{
@@ -11,18 +9,14 @@ use crate::{
         riscv::communication_interface::{RiscvCommunicationInterface, RiscvError},
         xtensa::communication_interface::XtensaCommunicationInterface,
     },
-    probe::{
-        common::{common_sequence, extract_idcodes, extract_ir_lengths, JtagState, RegisterState},
-        DeferredResultSet, JtagCommandQueue, ProbeDriver,
-    },
+    probe::{common::RawJtagIo, ProbeDriver},
     DebugProbe, DebugProbeError, DebugProbeSelector, WireProtocol,
 };
-use anyhow::anyhow;
 use bitvec::prelude::*;
 
 use self::protocol::ProtocolHandler;
 
-use super::{BatchExecutionError, ChainParams, JTAGAccess, JtagChainItem};
+use super::{common::JtagDriverState, JTAGAccess};
 
 use probe_rs_target::ScanChainElement;
 
@@ -40,12 +34,7 @@ impl ProbeDriver for EspUsbJtagSource {
 
         Ok(Box::new(EspUsbJtag {
             protocol,
-            jtag_idle_cycles: 0,
-            current_ir_reg: 1,
-            // default to 5 bits, as most Espressif chips have an irlen of 5
-            max_ir_address: 0x1F,
-            scan_chain: None,
-            chain_params: ChainParams::default(),
+            jtag_state: JtagDriverState::default(),
         }))
     }
 
@@ -58,351 +47,35 @@ impl ProbeDriver for EspUsbJtagSource {
 pub(crate) struct EspUsbJtag {
     protocol: ProtocolHandler,
 
-    /// Idle cycles necessary between consecutive
-    /// accesses to the DMI register
-    jtag_idle_cycles: u8,
-
-    current_ir_reg: u32,
-    max_ir_address: u32,
-    scan_chain: Option<Vec<ScanChainElement>>,
-    chain_params: ChainParams,
+    jtag_state: JtagDriverState,
 }
 
-impl EspUsbJtag {
-    fn scan(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
-        self.reset_scan()
-    }
-
-    fn reset_scan(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
-        const MAX_CHAIN: usize = 8;
-
-        self.jtag_reset()?;
-
-        self.chain_params = ChainParams::default();
-
-        let input = vec![0xFF; 4 * MAX_CHAIN];
-        let response = self.write_dr(&input, input.len() * 8)?;
-
-        tracing::debug!("DR: {:?}", response);
-
-        let idcodes = extract_idcodes(BitSlice::<u8, Lsb0>::from_slice(&response))
-            .map_err(|e| DebugProbeError::Other(e.into()))?;
-
-        tracing::info!(
-            "JTAG DR scan complete, found {} TAPs. {:?}",
-            idcodes.len(),
-            idcodes
-        );
-
-        // First shift out all ones
-        let input = vec![0xff; idcodes.len()];
-        self.prepare_write_ir(&input, input.len() * 8, true)?;
-        let response = self.protocol.flush()?;
-
-        tracing::debug!("IR scan: {}", response);
-
-        self.jtag_reset()?;
-
-        // Next, shift out same amount of zeros, then ones to make sure the IRs contain BYPASS.
-        let input = iter::repeat(0)
-            .take(idcodes.len())
-            .chain(input.iter().copied())
-            .collect::<Vec<_>>();
-        self.prepare_write_ir(&input, input.len() * 8, true)?;
-        let response_zeros = self.protocol.flush()?;
-
-        tracing::debug!("IR scan: {}", response_zeros);
-
-        let expected = if let Some(ref chain) = self.scan_chain {
-            let expected = chain
-                .iter()
-                .filter_map(|s| s.ir_len)
-                .map(|s| s as usize)
-                .collect::<Vec<usize>>();
-            Some(expected)
-        } else {
-            None
-        };
-
-        let response = response.as_bitslice();
-        let response = common_sequence(response, response_zeros.as_bitslice());
-
-        tracing::debug!("IR scan: {}", response);
-
-        let ir_lens = extract_ir_lengths(response, idcodes.len(), expected.as_deref())
-            .map_err(|e| DebugProbeError::Other(e.into()))?;
-        tracing::debug!("Detected IR lens: {:?}", ir_lens);
-
-        Ok(idcodes
-            .into_iter()
-            .zip(ir_lens)
-            .map(|(idcode, irlen)| JtagChainItem { irlen, idcode })
-            .collect())
-    }
-
-    /// Write IR register with the specified data. The
-    /// IR register might have an odd length, so the data
-    /// will be truncated to `len` bits. If data has less
-    /// than `len` bits, an error will be returned.
-    fn prepare_write_ir(
+impl RawJtagIo for EspUsbJtag {
+    fn shift_bit(
         &mut self,
-        data: &[u8],
-        len: usize,
-        capture_data: bool,
+        tms: bool,
+        tdi: bool,
+        capture_tdo: bool,
     ) -> Result<(), DebugProbeError> {
-        tracing::debug!("Write IR: {:?}, len={}", data, len);
-
-        // Check the bit length, enough data has to be available
-        if data.len() * 8 < len || len == 0 {
-            return Err(DebugProbeError::Other(anyhow!("Invalid data length")));
-        }
-
-        // BYPASS commands before and after shifting out data where required
-        let pre_bits = self.chain_params.irpre;
-        let post_bits = self.chain_params.irpost;
-
-        // The last bit will be transmitted when exiting the shift state,
-        // so we need to stay in the shift state for one period less than
-        // we have bits to transmit.
-        let tms_data = iter::repeat(false).take(len - 1);
-
-        // Enter IR shift
-        self.protocol
-            .jtag_move_to_state(JtagState::Ir(RegisterState::Shift))?;
-
-        let tms = iter::repeat(false)
-            .take(pre_bits)
-            .chain(tms_data)
-            .chain(iter::repeat(false).take(post_bits))
-            .chain(iter::once(true));
-
-        let tdi = iter::repeat(true)
-            .take(pre_bits)
-            .chain(data.as_bits::<Lsb0>()[..len].iter().map(|b| *b))
-            .chain(iter::repeat(true).take(post_bits));
-
-        let capture = iter::repeat(false)
-            .take(pre_bits)
-            .chain(iter::repeat(capture_data).take(len))
-            .chain(iter::repeat(false));
-
-        tracing::trace!("tms: {:?}", tms.clone());
-        tracing::trace!("tdi: {:?}", tdi.clone());
-
-        self.protocol.schedule_jtag_scan(tms, tdi, capture)?;
-
-        self.protocol
-            .jtag_move_to_state(JtagState::Ir(RegisterState::Update))?;
-
+        self.jtag_state.state.update(tms);
+        self.protocol.shift_bit(tms, tdi, capture_tdo)?;
         Ok(())
     }
 
-    fn write_dr(&mut self, data: &[u8], register_bits: usize) -> Result<Vec<u8>, DebugProbeError> {
-        self.prepare_write_dr(data, register_bits, true)?;
-        let response = self.protocol.flush()?;
-        self.recieve_write_dr(response)
+    fn read_captured_bits(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
+        self.protocol.read_captured_bits()
     }
 
-    fn recieve_write_dr(
-        &mut self,
-        mut response: BitVec<u8, Lsb0>,
-    ) -> Result<Vec<u8>, DebugProbeError> {
-        response.force_align();
-        let result = response.into_vec();
-        tracing::trace!("recieve_write_dr result: {:?}", result);
-        Ok(result)
+    fn state_mut(&mut self) -> &mut JtagDriverState {
+        &mut self.jtag_state
     }
 
-    fn prepare_write_dr(
-        &mut self,
-        data: &[u8],
-        register_bits: usize,
-        capture_data: bool,
-    ) -> Result<usize, DebugProbeError> {
-        tracing::debug!("Write DR: {:?}, len={}", data, register_bits);
-
-        // Check the bit length, enough data has to be available
-        if data.len() * 8 < register_bits || register_bits == 0 {
-            return Err(DebugProbeError::Other(anyhow!("Invalid data length")));
-        }
-
-        // Last bit of data is shifted out when we exit the SHIFT-DR State
-        let tms_shift_out_value = iter::repeat(false).take(register_bits - 1);
-
-        // Enter DR shift
-        self.protocol
-            .jtag_move_to_state(JtagState::Dr(RegisterState::Shift))?;
-
-        // dummy bits to account for bypasses
-        let pre_bits = self.chain_params.drpre;
-        let post_bits = self.chain_params.drpost;
-
-        let tms = iter::repeat(false)
-            .take(pre_bits)
-            .chain(tms_shift_out_value)
-            .chain(iter::repeat(false).take(post_bits))
-            .chain(iter::once(true));
-
-        let tdi = iter::repeat(false)
-            .take(pre_bits)
-            .chain(data.as_bits::<Lsb0>()[..register_bits].iter().map(|b| *b))
-            .chain(iter::repeat(false).take(post_bits));
-
-        let capture = iter::repeat(false)
-            .take(pre_bits)
-            .chain(iter::repeat(capture_data).take(register_bits))
-            .chain(iter::repeat(false));
-
-        self.protocol.schedule_jtag_scan(tms, tdi, capture)?;
-
-        self.protocol
-            .jtag_move_to_state(JtagState::Dr(RegisterState::Update))?;
-
-        if self.idle_cycles() > 0 {
-            self.protocol.jtag_move_to_state(JtagState::Idle)?;
-
-            // We need to stay in the idle cycle a bit
-            let tms = iter::repeat(false).take(self.idle_cycles() as usize);
-            let tdi = iter::repeat(false).take(self.idle_cycles() as usize);
-
-            self.protocol
-                .schedule_jtag_scan(tms, tdi, iter::repeat(false))?;
-        }
-
-        if capture_data {
-            Ok(register_bits)
-        } else {
-            Ok(0)
-        }
+    fn state(&self) -> &JtagDriverState {
+        &self.jtag_state
     }
 
-    /// Write the data register
-    fn prepare_write_register(
-        &mut self,
-        address: u32,
-        data: &[u8],
-        len: u32,
-        capture_data: bool,
-    ) -> Result<DeferredRegisterWrite, DebugProbeError> {
-        if address > self.max_ir_address {
-            return Err(DebugProbeError::Other(anyhow!(
-                "Invalid instruction register access: {}",
-                address
-            )));
-        }
-        let address_bytes = address.to_le_bytes();
-
-        if self.current_ir_reg != address {
-            // Write IR register
-            self.prepare_write_ir(&address_bytes, self.chain_params.irlen, false)?;
-            self.current_ir_reg = address;
-        }
-
-        // write DR register
-        let len = self.prepare_write_dr(data, len as usize, capture_data)?;
-
-        Ok(DeferredRegisterWrite { len })
-    }
-
-    fn jtag_reset(&mut self) -> Result<(), DebugProbeError> {
-        tracing::debug!("Resetting JTAG chain by setting tms high for 5 bits");
-
-        // Reset JTAG chain (5 times TMS high), and enter idle state afterwards
-        let tms = [true, true, true, true, true, false];
-        let tdi = iter::repeat(true);
-
-        self.protocol
-            .schedule_jtag_scan(tms, tdi, iter::repeat(false))?;
-        let response = self.protocol.flush()?;
-
-        tracing::debug!("Response to reset: {}", response);
-
-        Ok(())
-    }
-}
-
-struct DeferredRegisterWrite {
-    len: usize,
-}
-
-impl JTAGAccess for EspUsbJtag {
-    /// Write the data register
-    fn write_register(
-        &mut self,
-        address: u32,
-        data: &[u8],
-        len: u32,
-    ) -> Result<Vec<u8>, DebugProbeError> {
-        if address > self.max_ir_address {
-            return Err(DebugProbeError::Other(anyhow!(
-                "Invalid instruction register access: {}",
-                address
-            )));
-        }
-        let address_bytes = address.to_le_bytes();
-
-        if self.current_ir_reg != address {
-            // Write IR register
-            self.prepare_write_ir(&address_bytes, self.chain_params.irlen, false)?;
-            self.current_ir_reg = address;
-        }
-
-        // write DR register
-        self.write_dr(data, len as usize)
-    }
-
-    fn set_idle_cycles(&mut self, idle_cycles: u8) {
-        self.jtag_idle_cycles = idle_cycles;
-    }
-
-    fn idle_cycles(&self) -> u8 {
-        self.jtag_idle_cycles
-    }
-
-    fn write_register_batch(
-        &mut self,
-        writes: &JtagCommandQueue,
-    ) -> Result<DeferredResultSet, BatchExecutionError> {
-        let mut bits = Vec::with_capacity(writes.len());
-        let t1 = std::time::Instant::now();
-        tracing::debug!("Preparing {} writes...", writes.len());
-        for (idx, write) in writes.iter() {
-            // If an error happens during prep, return no results as chip will be in an inconsistent state
-            let op = self
-                .prepare_write_register(write.address, &write.data, write.len, idx.should_capture())
-                .map_err(|e| BatchExecutionError::new(e.into(), DeferredResultSet::new()))?;
-
-            bits.push((idx, write.transform, op));
-        }
-
-        tracing::debug!("Sending to chip...");
-        // If an error happens during the final flush, also retry whole operation
-        let bitstream = self
-            .protocol
-            .flush()
-            .map_err(|e| BatchExecutionError::new(e.into(), DeferredResultSet::new()))?;
-
-        tracing::debug!("Got responses! Took {:?}! Processing...", t1.elapsed());
-        let mut responses = DeferredResultSet::with_capacity(bits.len());
-
-        let mut bitstream = bitstream.as_bitslice();
-        for (idx, transform, bit) in bits.into_iter() {
-            if idx.should_capture() {
-                let write_response = match self.recieve_write_dr(bitstream[..bit.len].to_bitvec()) {
-                    Ok(response_bits) => transform(response_bits),
-                    Err(e) => Err(e.into()),
-                };
-
-                match write_response {
-                    Ok(response) => responses.push(idx, response),
-                    Err(e) => return Err(BatchExecutionError::new(e, responses)),
-                }
-            }
-
-            bitstream = &bitstream[bit.len..];
-        }
-
-        Ok(responses)
+    fn flush(&mut self) -> Result<(), DebugProbeError> {
+        self.protocol.flush()
     }
 }
 
@@ -436,33 +109,21 @@ impl DebugProbe for EspUsbJtag {
 
     fn set_scan_chain(&mut self, scan_chain: Vec<ScanChainElement>) -> Result<(), DebugProbeError> {
         tracing::info!("Setting scan chain to {:?}", scan_chain);
-        self.scan_chain = Some(scan_chain);
+        self.jtag_state.expected_scan_chain = Some(scan_chain);
         Ok(())
     }
 
     fn attach(&mut self) -> Result<(), DebugProbeError> {
         tracing::debug!("Attaching to ESP USB JTAG");
 
-        let taps = self.scan()?;
-        tracing::info!("Found {} TAPs on reset scan", taps.len());
+        let chain = self.scan_chain()?;
+        tracing::info!("Found {} TAPs on reset scan", chain.len());
 
-        let selected = 0;
-        if taps.len() > 1 {
+        if chain.len() > 1 {
             tracing::warn!("More than one TAP detected, defaulting to tap0");
         }
 
-        let Some(params) = ChainParams::from_jtag_chain(&taps, selected) else {
-            return Err(DebugProbeError::TargetNotFound);
-        };
-
-        tracing::info!("Setting chain params: {:?}", params);
-
-        // set the max address to the max number of bits irlen can represent
-        self.max_ir_address = (1 << params.irlen) - 1;
-        tracing::debug!("Setting max_ir_address to {}", self.max_ir_address);
-        self.chain_params = params;
-
-        Ok(())
+        self.select_target(&chain, 0)
     }
 
     fn detach(&mut self) -> Result<(), crate::Error> {

--- a/probe-rs/src/probe/espusbjtag/protocol.rs
+++ b/probe-rs/src/probe/espusbjtag/protocol.rs
@@ -272,8 +272,10 @@ impl ProtocolHandler {
         Ok(())
     }
 
-    /// Flushes all the pending commands to the JTAG adapter.
-    pub fn flush(&mut self) -> Result<(), DebugProbeError> {
+    /// Flushes pending commands and reads the captured bits from the target.
+    ///
+    /// The captured bits will be stored in the response buffer.
+    pub(super) fn flush(&mut self) -> Result<(), DebugProbeError> {
         self.finalize_previous_command()?;
 
         // Only flush if we have anything to do.
@@ -291,8 +293,11 @@ impl ProtocolHandler {
         Ok(())
     }
 
-    /// Flushes all the pending commands to the JTAG adapter.
-    pub fn read_captured_bits(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
+    /// Flushes pending commands and reads the captured bits from the target.
+    ///
+    /// This method returns the response buffer and clears it. The returned buffer will contain
+    /// all bits captured since the last call to `read_captured_bits`.
+    pub(super) fn read_captured_bits(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
         self.flush()?;
 
         Ok(std::mem::take(&mut self.response))

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -4,20 +4,15 @@ use crate::architecture::{
     arm::communication_interface::UninitializedArmProbe,
     riscv::communication_interface::RiscvCommunicationInterface,
 };
-use crate::probe::common::{JtagState, RegisterState};
-use crate::probe::{BatchExecutionError, DeferredResultSet, JtagCommandQueue};
+use crate::probe::common::{JtagDriverState, RawJtagIo};
 use crate::{
-    probe::{
-        common::{common_sequence, extract_idcodes, extract_ir_lengths},
-        DebugProbe, JTAGAccess, ProbeCreationError, ProbeDriver, ScanChainElement,
-    },
+    probe::{DebugProbe, JTAGAccess, ProbeCreationError, ProbeDriver, ScanChainElement},
     DebugProbeError, DebugProbeInfo, DebugProbeSelector, WireProtocol,
 };
 use anyhow::anyhow;
 use bitvec::prelude::*;
 use nusb::DeviceInfo;
 use std::io::{Read, Write};
-use std::iter;
 use std::time::Duration;
 
 mod ftdi_impl;
@@ -25,29 +20,18 @@ use ftdi_impl as ftdi;
 
 mod command_compacter;
 
-use super::{ChainParams, JtagChainItem};
-
 use command_compacter::Command;
 
 #[derive(Debug)]
 struct JtagAdapter {
     device: ftdi::Device,
 
-    chain_params: ChainParams,
-    jtag_idle_cycles: u8,
-
-    current_ir_reg: u32,
-    max_ir_address: u32,
-
     buffer_size: usize,
-    jtag_state: JtagState,
 
     command: Command,
     commands: Vec<u8>,
     in_bit_counts: Vec<usize>,
     in_bits: BitVec<u8, Lsb0>,
-
-    scan_chain: Option<Vec<ScanChainElement>>,
 }
 
 impl JtagAdapter {
@@ -58,17 +42,11 @@ impl JtagAdapter {
 
         Ok(Self {
             device,
-            chain_params: ChainParams::default(),
-            jtag_idle_cycles: 0,
             buffer_size: ftdi.buffer_size,
-            jtag_state: JtagState::Reset,
-            current_ir_reg: 1,
-            max_ir_address: 0x1F,
             command: Command::default(),
             commands: vec![],
             in_bit_counts: vec![],
             in_bits: BitVec::new(),
-            scan_chain: None,
         })
     }
 
@@ -141,31 +119,8 @@ impl JtagAdapter {
         Ok(())
     }
 
-    /// Reset and go to RUN-TEST/IDLE
-    pub fn reset(&mut self) -> Result<(), DebugProbeError> {
-        tracing::debug!("Resetting JTAG chain by setting tms high for 5 bits");
-
-        // Reset JTAG chain (5 times TMS high), and enter idle state afterwards
-        let tms = [true, true, true, true, true, false];
-        let tdi = iter::repeat(false);
-
-        let response = self.jtag_scan(tms, tdi, iter::repeat(true))?;
-
-        tracing::debug!("Response to reset: {:?}", response);
-
-        Ok(())
-    }
-
-    fn jtag_move_to_state(&mut self, target: JtagState) -> Result<(), DebugProbeError> {
-        tracing::trace!("Changing state: {:?} -> {:?}", self.jtag_state, target);
-        while let Some(tms) = self.jtag_state.step_toward(target) {
-            self.schedule_jtag_scan([tms], [false], [false])?;
-        }
-        tracing::trace!("In state: {:?}", self.jtag_state);
-        Ok(())
-    }
-
-    fn do_io(&mut self) -> Result<(), DebugProbeError> {
+    fn flush(&mut self) -> Result<(), DebugProbeError> {
+        self.finalize_command()?;
         self.send_buffer()?;
         self.read_response()
             .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
@@ -177,7 +132,9 @@ impl JtagAdapter {
         tracing::debug!("Appending {:?}", command);
         // 1 byte is reserved for the send immediate command
         if self.commands.len() + command.len() + 1 >= self.buffer_size {
-            self.do_io()?;
+            self.send_buffer()?;
+            self.read_response()
+                .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
         }
 
         command.add_captured_bits(&mut self.in_bit_counts);
@@ -194,23 +151,9 @@ impl JtagAdapter {
         Ok(())
     }
 
-    fn schedule_bit(&mut self, tms: bool, tdi: bool, capture: bool) -> Result<(), DebugProbeError> {
+    fn shift_bit(&mut self, tms: bool, tdi: bool, capture: bool) -> Result<(), DebugProbeError> {
         if let Some(command) = self.command.append_jtag_bit(tms, tdi, capture) {
             self.append_command(command)?;
-        }
-
-        Ok(())
-    }
-
-    fn schedule_jtag_scan(
-        &mut self,
-        tms: impl IntoIterator<Item = bool>,
-        tdi: impl IntoIterator<Item = bool>,
-        cap: impl IntoIterator<Item = bool>,
-    ) -> Result<(), DebugProbeError> {
-        for ((tms, tdi), cap) in tms.into_iter().zip(tdi.into_iter()).zip(cap.into_iter()) {
-            self.schedule_bit(tms, tdi, cap)?;
-            self.jtag_state.update(tms);
         }
 
         Ok(())
@@ -237,284 +180,11 @@ impl JtagAdapter {
         Ok(())
     }
 
-    fn flush(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
-        self.finalize_command()?;
-        self.do_io()?;
+    fn read_captured_bits(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
+        self.flush()?;
 
         Ok(std::mem::take(&mut self.in_bits))
     }
-
-    fn jtag_scan(
-        &mut self,
-        tms: impl IntoIterator<Item = bool>,
-        tdi: impl IntoIterator<Item = bool>,
-        capture: impl IntoIterator<Item = bool>,
-    ) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
-        self.schedule_jtag_scan(tms, tdi, capture)?;
-        self.flush()
-    }
-
-    fn idle_cycles(&self) -> u8 {
-        self.jtag_idle_cycles
-    }
-
-    /// Write IR register with the specified data. The
-    /// IR register might have an odd length, so the data
-    /// will be truncated to `len` bits. If data has less
-    /// than `len` bits, an error will be returned.
-    fn scan_ir(
-        &mut self,
-        data: &[u8],
-        len: usize,
-        capture_response: bool,
-    ) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
-        self.schedule_ir_scan(data, len, capture_response)?;
-        let response = self.flush()?;
-        tracing::trace!("Response: {:?}", response);
-
-        Ok(response)
-    }
-
-    fn schedule_ir_scan(
-        &mut self,
-        data: &[u8],
-        len: usize,
-        capture_data: bool,
-    ) -> Result<(), DebugProbeError> {
-        tracing::debug!("Write IR: {:?}, len={}", data, len);
-
-        // Check the bit length, enough data has to be available
-        if data.len() * 8 < len || len == 0 {
-            return Err(DebugProbeError::Other(anyhow!("Invalid data length")));
-        }
-
-        // BYPASS commands before and after shifting out data where required
-        let pre_bits = self.chain_params.irpre;
-        let post_bits = self.chain_params.irpost;
-
-        // The last bit will be transmitted when exiting the shift state,
-        // so we need to stay in the shift state for one period less than
-        // we have bits to transmit.
-        let tms_data = iter::repeat(false).take(len - 1);
-
-        // Enter IR shift
-        self.jtag_move_to_state(JtagState::Ir(RegisterState::Shift))?;
-
-        let tms = iter::repeat(false)
-            .take(pre_bits)
-            .chain(tms_data)
-            .chain(iter::repeat(false).take(post_bits))
-            .chain(iter::once(true));
-
-        let tdi = iter::repeat(true)
-            .take(pre_bits)
-            .chain(data.as_bits::<Lsb0>()[..len].iter().map(|b| *b))
-            .chain(iter::repeat(true).take(post_bits));
-
-        let capture = iter::repeat(false)
-            .take(pre_bits)
-            .chain(iter::repeat(capture_data).take(len))
-            .chain(iter::repeat(false));
-
-        self.schedule_jtag_scan(tms, tdi, capture)?;
-
-        self.jtag_move_to_state(JtagState::Ir(RegisterState::Update))?;
-
-        Ok(())
-    }
-
-    fn scan_dr(&mut self, data: &[u8], register_bits: usize) -> Result<Vec<u8>, DebugProbeError> {
-        self.schedule_dr_scan(data, register_bits, true)?;
-        let response = self.flush()?;
-        self.recieve_dr_scan(response)
-    }
-
-    fn recieve_dr_scan(
-        &mut self,
-        mut response: BitVec<u8, Lsb0>,
-    ) -> Result<Vec<u8>, DebugProbeError> {
-        response.force_align();
-        let result = response.into_vec();
-        tracing::trace!("recieve_write_dr result: {:?}", result);
-        Ok(result)
-    }
-
-    fn schedule_dr_scan(
-        &mut self,
-        data: &[u8],
-        register_bits: usize,
-        capture_data: bool,
-    ) -> Result<usize, DebugProbeError> {
-        tracing::debug!("Write DR: {:?}, len={}", data, register_bits);
-
-        // Check the bit length, enough data has to be available
-        if data.len() * 8 < register_bits || register_bits == 0 {
-            return Err(DebugProbeError::Other(anyhow!("Invalid data length")));
-        }
-
-        // Last bit of data is shifted out when we exit the SHIFT-DR State
-        let tms_shift_out_value = iter::repeat(false).take(register_bits - 1);
-
-        // Enter DR shift
-        self.jtag_move_to_state(JtagState::Dr(RegisterState::Shift))?;
-
-        // dummy bits to account for bypasses
-        let pre_bits = self.chain_params.drpre;
-        let post_bits = self.chain_params.drpost;
-
-        let tms = iter::repeat(false)
-            .take(pre_bits)
-            .chain(tms_shift_out_value)
-            .chain(iter::repeat(false).take(post_bits))
-            .chain(iter::once(true));
-
-        let tdi = iter::repeat(false)
-            .take(pre_bits)
-            .chain(data.as_bits::<Lsb0>()[..register_bits].iter().map(|b| *b))
-            .chain(iter::repeat(false).take(post_bits));
-
-        let capture = iter::repeat(false)
-            .take(pre_bits)
-            .chain(iter::repeat(capture_data).take(register_bits))
-            .chain(iter::repeat(false));
-
-        self.schedule_jtag_scan(tms, tdi, capture)?;
-
-        self.jtag_move_to_state(JtagState::Dr(RegisterState::Update))?;
-
-        if self.idle_cycles() > 0 {
-            self.jtag_move_to_state(JtagState::Idle)?;
-
-            // We need to stay in the idle cycle a bit
-            let tms = iter::repeat(false).take(self.idle_cycles() as usize);
-            let tdi = iter::repeat(false).take(self.idle_cycles() as usize);
-
-            self.schedule_jtag_scan(tms, tdi, iter::repeat(false))?;
-        }
-
-        if capture_data {
-            Ok(register_bits)
-        } else {
-            Ok(0)
-        }
-    }
-
-    fn scan(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
-        const MAX_CHAIN: usize = 8;
-
-        self.reset()?;
-
-        self.chain_params = ChainParams::default();
-
-        let input = vec![0xFF; 4 * MAX_CHAIN];
-        let response = self.scan_dr(&input, input.len() * 8)?;
-
-        tracing::debug!("DR: {:?}", response);
-
-        let idcodes = extract_idcodes(BitSlice::<u8, Lsb0>::from_slice(&response))
-            .map_err(|e| DebugProbeError::Other(e.into()))?;
-
-        tracing::info!(
-            "JTAG DR scan complete, found {} TAPs. {:?}",
-            idcodes.len(),
-            idcodes
-        );
-
-        self.reset()?;
-
-        // First shift out all ones
-        let input = vec![0xff; idcodes.len()];
-        let response = self.scan_ir(&input, input.len() * 8, true)?;
-
-        tracing::debug!("IR scan: {}", response);
-
-        self.reset()?;
-
-        // Next, shift out same amount of zeros, then ones to make sure the IRs contain BYPASS.
-        let input = iter::repeat(0)
-            .take(idcodes.len())
-            .chain(input.iter().copied())
-            .collect::<Vec<_>>();
-        let response_zeros = self.scan_ir(&input, input.len() * 8, true)?;
-
-        tracing::debug!("IR scan: {}", response_zeros);
-
-        let expected = if let Some(ref chain) = self.scan_chain {
-            let expected = chain
-                .iter()
-                .filter_map(|s| s.ir_len)
-                .map(|s| s as usize)
-                .collect::<Vec<usize>>();
-            Some(expected)
-        } else {
-            None
-        };
-
-        let response = response.as_bitslice();
-        let response = common_sequence(response, response_zeros.as_bitslice());
-
-        tracing::debug!("IR scan: {}", response);
-
-        let ir_lens = extract_ir_lengths(response, idcodes.len(), expected.as_deref())
-            .map_err(|e| DebugProbeError::Other(e.into()))?;
-        tracing::debug!("Detected IR lens: {:?}", ir_lens);
-
-        Ok(idcodes
-            .into_iter()
-            .zip(ir_lens)
-            .map(|(idcode, irlen)| JtagChainItem { irlen, idcode })
-            .collect())
-    }
-
-    fn select_target(
-        &mut self,
-        chain: &[JtagChainItem],
-        selected: usize,
-    ) -> Result<(), DebugProbeError> {
-        let Some(params) = ChainParams::from_jtag_chain(chain, selected) else {
-            return Err(DebugProbeError::TargetNotFound);
-        };
-
-        tracing::debug!("Target chain params: {:?}", params);
-        self.chain_params = params;
-
-        self.max_ir_address = (1 << params.irlen) - 1;
-        tracing::debug!("Setting max_ir_address to {}", self.max_ir_address);
-
-        Ok(())
-    }
-
-    /// Write the data register
-    fn prepare_write_register(
-        &mut self,
-        address: u32,
-        data: &[u8],
-        len: u32,
-        capture_data: bool,
-    ) -> Result<DeferredRegisterWrite, DebugProbeError> {
-        if address > self.max_ir_address {
-            return Err(DebugProbeError::Other(anyhow!(
-                "Invalid instruction register access: {}",
-                address
-            )));
-        }
-        let address_bytes = address.to_le_bytes();
-
-        if self.current_ir_reg != address {
-            // Write IR register
-            self.schedule_ir_scan(&address_bytes, self.chain_params.irlen, false)?;
-            self.current_ir_reg = address;
-        }
-
-        // write DR register
-        let len = self.schedule_dr_scan(data, len as usize, capture_data)?;
-
-        Ok(DeferredRegisterWrite { len })
-    }
-}
-
-struct DeferredRegisterWrite {
-    len: usize,
 }
 
 pub struct FtdiProbeSource;
@@ -570,6 +240,7 @@ impl ProbeDriver for FtdiProbeSource {
         let probe = FtdiProbe {
             adapter,
             speed_khz: 0,
+            jtag_state: JtagDriverState::default(),
         };
         tracing::debug!("opened probe: {:?}", probe);
         Ok(Box::new(probe))
@@ -583,6 +254,7 @@ impl ProbeDriver for FtdiProbeSource {
 #[derive(Debug)]
 pub struct FtdiProbe {
     adapter: JtagAdapter,
+    jtag_state: JtagDriverState,
     speed_khz: u32,
 }
 
@@ -603,51 +275,25 @@ impl DebugProbe for FtdiProbe {
 
     fn set_scan_chain(&mut self, scan_chain: Vec<ScanChainElement>) -> Result<(), DebugProbeError> {
         tracing::info!("Setting scan chain to {:?}", scan_chain);
-        self.adapter.scan_chain = Some(scan_chain);
+        self.jtag_state.expected_scan_chain = Some(scan_chain);
         Ok(())
     }
 
     fn attach(&mut self) -> Result<(), DebugProbeError> {
-        tracing::debug!("attaching...");
+        tracing::debug!("Attaching...");
 
         self.adapter
             .attach()
             .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
 
-        let taps = self.adapter.scan()?;
-        if taps.is_empty() {
-            tracing::warn!("no JTAG taps detected");
-            return Err(DebugProbeError::TargetNotFound);
-        }
-        if taps.len() == 1 {
-            self.adapter
-                .select_target(&taps, 0)
-                .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
-        } else {
-            const KNOWN_IDCODES: [u32; 2] = [
-                0x1000563d, // GD32VF103
-                0x120034e5, // Little endian Xtensa core
-            ];
-            let idcode = taps.iter().map(|tap| tap.idcode).position(|idcode| {
-                let Some(idcode) = idcode else {
-                    return false;
-                };
+        let chain = self.scan_chain()?;
+        tracing::info!("Found {} TAPs on reset scan", chain.len());
 
-                let found = KNOWN_IDCODES.contains(&idcode.0);
-                if !found {
-                    tracing::warn!("Unknown IDCODEs: {:x?}", idcode);
-                }
-                found
-            });
-            if let Some(pos) = idcode {
-                self.adapter
-                    .select_target(&taps, pos)
-                    .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
-            } else {
-                return Err(DebugProbeError::TargetNotFound);
-            }
+        if chain.len() > 1 {
+            tracing::warn!("More than one TAP detected, defaulting to tap0");
         }
-        Ok(())
+
+        self.select_target(&chain, 0)
     }
 
     fn detach(&mut self) -> Result<(), crate::Error> {
@@ -721,93 +367,32 @@ impl DebugProbe for FtdiProbe {
     }
 }
 
-impl JTAGAccess for FtdiProbe {
-    fn set_idle_cycles(&mut self, idle_cycles: u8) {
-        tracing::debug!("set_idle_cycles({})", idle_cycles);
-        self.adapter.jtag_idle_cycles = idle_cycles;
-    }
-
-    fn idle_cycles(&self) -> u8 {
-        self.adapter.jtag_idle_cycles
-    }
-
-    /// Write the data register
-    fn write_register(
+impl RawJtagIo for FtdiProbe {
+    fn shift_bit(
         &mut self,
-        address: u32,
-        data: &[u8],
-        len: u32,
-    ) -> Result<Vec<u8>, DebugProbeError> {
-        if address > self.adapter.max_ir_address {
-            return Err(DebugProbeError::Other(anyhow!(
-                "JTAG Register addresses are fixed to {} bits",
-                self.adapter.chain_params.irlen
-            )));
-        }
-        let address_bytes = address.to_le_bytes();
-
-        if self.adapter.current_ir_reg != address {
-            // Write IR register
-            self.adapter.schedule_ir_scan(
-                &address_bytes,
-                self.adapter.chain_params.irlen,
-                false,
-            )?;
-            self.adapter.current_ir_reg = address;
-        }
-
-        // write DR register
-        self.adapter.scan_dr(data, len as usize)
+        tms: bool,
+        tdi: bool,
+        capture_tdo: bool,
+    ) -> Result<(), DebugProbeError> {
+        self.jtag_state.state.update(tms);
+        self.adapter.shift_bit(tms, tdi, capture_tdo)?;
+        Ok(())
     }
 
-    fn write_register_batch(
-        &mut self,
-        writes: &JtagCommandQueue,
-    ) -> Result<DeferredResultSet, BatchExecutionError> {
-        let mut bits = Vec::with_capacity(writes.len());
-        let t1 = std::time::Instant::now();
-        tracing::debug!("Preparing {} writes...", writes.len());
-        for (idx, write) in writes.iter() {
-            // If an error happens during prep, return no results as chip will be in an inconsistent state
-            let op = self
-                .adapter
-                .prepare_write_register(write.address, &write.data, write.len, idx.should_capture())
-                .map_err(|e| BatchExecutionError::new(e.into(), DeferredResultSet::new()))?;
+    fn read_captured_bits(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
+        self.adapter.read_captured_bits()
+    }
 
-            bits.push((idx, write.transform, op));
-        }
+    fn state_mut(&mut self) -> &mut JtagDriverState {
+        &mut self.jtag_state
+    }
 
-        tracing::debug!("Sending to chip...");
-        // If an error happens during the final flush, also retry whole operation
-        let bitstream = self
-            .adapter
-            .flush()
-            .map_err(|e| BatchExecutionError::new(e.into(), DeferredResultSet::new()))?;
+    fn state(&self) -> &JtagDriverState {
+        &self.jtag_state
+    }
 
-        tracing::debug!("Got response! Took {:?}! Processing...", t1.elapsed(),);
-        let mut responses = DeferredResultSet::with_capacity(bits.len());
-
-        let mut bitstream = bitstream.as_bitslice();
-        for (idx, transform, bit) in bits.into_iter() {
-            if idx.should_capture() {
-                let write_response = match self
-                    .adapter
-                    .recieve_dr_scan(bitstream[..bit.len].to_bitvec())
-                {
-                    Ok(response_bits) => transform(response_bits),
-                    Err(e) => Err(e.into()),
-                };
-
-                match write_response {
-                    Ok(response) => responses.push(idx, response),
-                    Err(e) => return Err(BatchExecutionError::new(e, responses)),
-                }
-            }
-
-            bitstream = &bitstream[bit.len..];
-        }
-
-        Ok(responses)
+    fn flush(&mut self) -> Result<(), DebugProbeError> {
+        self.adapter.flush()
     }
 }
 

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -11,7 +11,7 @@ use probe_rs_target::ScanChainElement;
 
 use crate::{
     architecture::riscv::communication_interface::{RiscvCommunicationInterface, RiscvError},
-    probe::ProbeDriver,
+    probe::{JtagChainItem, ProbeDriver},
     DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, ProbeCreationError,
     WireProtocol,
 };
@@ -379,6 +379,14 @@ impl DebugProbe for WchLink {
 
 /// Wrap WCH-Link's USB based DMI access as a fake JTAGAccess
 impl JTAGAccess for WchLink {
+    fn reset_jtag_state_machine(&mut self) -> Result<(), DebugProbeError> {
+        Ok(())
+    }
+
+    fn scan_chain(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
+        Ok(vec![])
+    }
+
     fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {
         tracing::debug!("read register 0x{:08x}", address);
         assert_eq!(len, 32);

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -379,10 +379,6 @@ impl DebugProbe for WchLink {
 
 /// Wrap WCH-Link's USB based DMI access as a fake JTAGAccess
 impl JTAGAccess for WchLink {
-    fn reset_jtag_state_machine(&mut self) -> Result<(), DebugProbeError> {
-        Ok(())
-    }
-
     fn scan_chain(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
         Ok(vec![])
     }


### PR DESCRIPTION
FTDI, JLink and espusbjtag are essentially the same high level JTAG code. This PR removes the duplication from them, getting rid of a considerable amount of code.

This PR also skips IR detection if the configuration contains a scan chain specification. This is now consistent with the CMSIS-DAP implementation. On the other hand, there exists #1796 ... This PR is big enough and blocks enough others so that I would vote for resolving 1796 later.

I'm willing to say this closes #1181