### PR TITLE
Do not overwrite detected IR length

### DIFF
--- a/changelog/fixed-info-ir.md
+++ b/changelog/fixed-info-ir.md
@@ -1,0 +1,1 @@
+Fixed `probe-rs info` not recognising Xtensa chips if probe supports SWD

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -855,9 +855,6 @@ pub trait JTAGAccess: DebugProbe {
     /// Return the currently configured idle cycles.
     fn idle_cycles(&self) -> u8;
 
-    /// Set the IR register length
-    fn set_ir_len(&mut self, len: u32);
-
     /// Write to a JTAG register
     ///
     /// This function will perform a write to the IR register, if necessary,

--- a/probe-rs/src/probe/arm_jtag.rs
+++ b/probe-rs/src/probe/arm_jtag.rs
@@ -1325,9 +1325,6 @@ impl<Probe: DebugProbe + RawProtocolIo + JTAGAccess + 'static> RawDapAccess for 
             bits >>= 1;
         }
 
-        // ARM / SWJ uses 4 bit IR length
-        self.set_ir_len(4);
-
         match protocol {
             Some(crate::WireProtocol::Jtag) => {
                 // Swj sequences should be shifted out to tms, since that is the pin

--- a/probe-rs/src/probe/arm_jtag.rs
+++ b/probe-rs/src/probe/arm_jtag.rs
@@ -1559,10 +1559,6 @@ mod test {
     }
 
     impl JTAGAccess for MockJaylink {
-        fn set_ir_len(&mut self, _len: u32) {
-            todo!()
-        }
-
         fn read_register(&mut self, _address: u32, _len: u32) -> Result<Vec<u8>, DebugProbeError> {
             todo!()
         }

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -326,12 +326,6 @@ struct DeferredRegisterWrite {
 }
 
 impl JTAGAccess for EspUsbJtag {
-    fn set_ir_len(&mut self, len: u32) {
-        if len != 5 {
-            panic!("Only IR Length of 5 is currently supported");
-        }
-    }
-
     /// Write the data register
     fn write_register(
         &mut self,

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -760,10 +760,6 @@ impl JTAGAccess for FtdiProbe {
         self.adapter.scan_dr(data, len as usize)
     }
 
-    fn set_ir_len(&mut self, _len: u32) {
-        // The FTDI implementation automatically sets this, so no need to act on this data
-    }
-
     fn write_register_batch(
         &mut self,
         writes: &JtagCommandQueue,

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -785,10 +785,6 @@ impl DebugProbe for JLink {
 }
 
 impl JTAGAccess for JLink {
-    fn set_ir_len(&mut self, len: u32) {
-        self.chain_params.irlen = len as usize;
-    }
-
     /// Read the data register
     fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {
         let data = vec![0u8; (len as usize + 7) / 8];

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -407,8 +407,6 @@ impl JTAGAccess for WchLink {
         self.idle_cycles
     }
 
-    fn set_ir_len(&mut self, _len: u32) {}
-
     fn write_register(
         &mut self,
         address: u32,


### PR DESCRIPTION
Closes #2067

Xtensas and some other MCUs use 5 IR bits. `swj_sequence` overwriting this causes problems in `probe-rs info` where the code forces 4 bits, no matter the detected length. In general, we either measure the IR lengths on attach, or use the value configured by target descriptions, so forcing 4 bits in code should not be necessary. Similarly, we configure IR lengths by setting the scan chain, so a method that sets the length after attach *should* not be necessary.