### PR TITLE
Don't error if there is no candidate region for the RTT control block

### DIFF
--- a/changelog/fixed-no-rtt-no-error.md
+++ b/changelog/fixed-no-rtt-no-error.md
@@ -1,0 +1,1 @@
+Do not print RTT error if there is nowhere to look for the control block

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -325,10 +325,8 @@ fn attach_to_rtt(
             timestamp_offset,
             log_format,
         ) {
-            Ok(target_rtt) => return Some(target_rtt),
-            Err(error) => {
-                log::debug!("{:?} RTT attach error", error);
-            }
+            Ok(target_rtt) => return target_rtt,
+            Err(error) => log::debug!("{:?} RTT attach error", error),
         }
         std::thread::sleep(std::time::Duration::from_millis(100));
     }


### PR DESCRIPTION
At least partially addresses #2072 at least in theory

If the .elf has no `_SEGGER_RTT` symbol defined and no scan regions are set, probe-rs should not print an error.