### PR TITLE
Move scan_chain under jtag, use for validation only

### DIFF
--- a/changelog/changed-jtag-description.md
+++ b/changelog/changed-jtag-description.md
@@ -1,0 +1,1 @@
+Moved `scan_chain` under `jtag` in target descriptions

--- a/changelog/changed-scan-chain.md
+++ b/changelog/changed-scan-chain.md
@@ -1,0 +1,1 @@
+The scan chain information in target descriptions is now always used to validate the measured JTAG chain.

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -148,16 +148,3 @@ pub struct RiscvCoreAccessOptions {}
 /// The data required to access an Xtensa core
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct XtensaCoreAccessOptions {}
-
-/// Helper function that iterates the scan chain and returns a vector of all of
-/// the ir_lengths of the scan chain elements.
-/// If an element does not contain an ir_length, the default value of 4 is used.
-/// The first element of the vector is the first element of the scan chain.
-pub fn get_ir_lengths(scan_chain: &Vec<ScanChainElement>) -> Vec<u8> {
-    let mut ir_lengths = Vec::new();
-    for element in scan_chain {
-        let ir_len = element.ir_len.unwrap_or(4);
-        ir_lengths.push(ir_len);
-    }
-    ir_lengths
-}

--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -22,6 +22,16 @@ pub enum BinaryFormat {
     Idf,
 }
 
+/// Configuration for JTAG probes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Jtag {
+    /// Describes the scan chain
+    ///
+    /// ref: `<https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain>`
+    #[serde(default)]
+    pub scan_chain: Option<Vec<ScanChainElement>>,
+}
+
 /// A single chip variant.
 ///
 /// This describes an exact chip variant, including the cores, flash and memory size. For example,
@@ -66,11 +76,9 @@ pub struct Chip {
     /// executable image that includes the `_SEGGER_RTT` symbol pointing
     /// to the exact address of the RTT header.
     pub rtt_scan_ranges: Option<Vec<std::ops::Range<u64>>>,
-    /// Describes the scan chain
-    ///
-    /// ref: `<https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain>`
+    /// JTAG-specific options
     #[serde(default)]
-    pub scan_chain: Option<Vec<ScanChainElement>>,
+    pub jtag: Option<Jtag>,
     /// The default binary format for this chip
     pub default_binary_format: Option<BinaryFormat>,
 }
@@ -92,7 +100,7 @@ impl Chip {
             memory_map: vec![],
             flash_algorithms: vec![],
             rtt_scan_ranges: None,
-            scan_chain: None,
+            jtag: None,
             default_binary_format: Some(BinaryFormat::Raw),
         }
     }

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -19,8 +19,8 @@ mod memory;
 pub(crate) mod serialize;
 
 pub use chip::{
-    get_ir_lengths, ArmCoreAccessOptions, BinaryFormat, Chip, Core, CoreAccessOptions,
-    RiscvCoreAccessOptions, ScanChainElement, XtensaCoreAccessOptions,
+    ArmCoreAccessOptions, BinaryFormat, Chip, Core, CoreAccessOptions, RiscvCoreAccessOptions,
+    ScanChainElement, XtensaCoreAccessOptions,
 };
 pub use chip_family::{
     Architecture, ChipFamily, CoreType, InstructionSet, TargetDescriptionSource,

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -19,8 +19,8 @@ mod memory;
 pub(crate) mod serialize;
 
 pub use chip::{
-    ArmCoreAccessOptions, BinaryFormat, Chip, Core, CoreAccessOptions, RiscvCoreAccessOptions,
-    ScanChainElement, XtensaCoreAccessOptions,
+    ArmCoreAccessOptions, BinaryFormat, Chip, Core, CoreAccessOptions, Jtag,
+    RiscvCoreAccessOptions, ScanChainElement, XtensaCoreAccessOptions,
 };
 pub use chip_family::{
     Architecture, ChipFamily, CoreType, InstructionSet, TargetDescriptionSource,

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -445,7 +445,6 @@ fn match_name_prefix(pattern: &str, name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use probe_rs_target::get_ir_lengths;
     use std::fs::File;
     type TestResult = Result<(), RegistryError>;
 
@@ -541,20 +540,6 @@ mod tests {
         let scan_chain = target.scan_chain.unwrap();
         assert_eq!(scan_chain[0].ir_len, Some(FIRST_IR_LENGTH));
         assert_eq!(scan_chain[1].ir_len, Some(SECOND_IR_LENGTH));
-
-        Ok(())
-    }
-
-    #[test]
-    fn check_get_ir_lengths_helper() -> TestResult {
-        let file = File::open("tests/scan_chain_test.yaml")?;
-        add_target_from_yaml(file)?;
-
-        // Check that the scan chain can read from a target correctly
-        let target = get_target_by_name("FULL_SCAN_CHAIN").unwrap();
-        let scan_chain = target.scan_chain.unwrap();
-        let ir_lengths = get_ir_lengths(&scan_chain);
-        assert_eq!(ir_lengths, vec![FIRST_IR_LENGTH, SECOND_IR_LENGTH]);
 
         Ok(())
     }

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -110,7 +110,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
                 memory_map: vec![],
                 flash_algorithms: vec![],
                 rtt_scan_ranges: None,
-                scan_chain: None,
+                jtag: None,
                 default_binary_format: Some(BinaryFormat::Raw),
             }],
             flash_algorithms: vec![],
@@ -522,7 +522,7 @@ mod tests {
 
         // Check that the scan chain can read from a target correctly
         let mut target = get_target_by_name("FULL_SCAN_CHAIN").unwrap();
-        let scan_chain = target.scan_chain.unwrap();
+        let scan_chain = target.jtag.unwrap().scan_chain.unwrap();
         for device in scan_chain {
             if device.name == Some("core0".to_string()) {
                 assert_eq!(device.ir_len, Some(FIRST_IR_LENGTH));
@@ -532,12 +532,16 @@ mod tests {
         }
 
         // Now check that a device without a scan chain is read correctly
+        target = get_target_by_name("NO_JTAG_INFO").unwrap();
+        assert_eq!(target.jtag, None);
+
+        // Now check that a device without a scan chain is read correctly
         target = get_target_by_name("NO_SCAN_CHAIN").unwrap();
-        assert_eq!(target.scan_chain, None);
+        assert_eq!(target.jtag.unwrap().scan_chain, None);
 
         // Check a device with a minimal scan chain
         target = get_target_by_name("PARTIAL_SCAN_CHAIN").unwrap();
-        let scan_chain = target.scan_chain.unwrap();
+        let scan_chain = target.jtag.unwrap().scan_chain.unwrap();
         assert_eq!(scan_chain[0].ir_len, Some(FIRST_IR_LENGTH));
         assert_eq!(scan_chain[1].ir_len, Some(SECOND_IR_LENGTH));
 

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -18,8 +18,7 @@ use super::{
         stm32_armv7::Stm32Armv7,
         stm32h7::Stm32h7,
     },
-    Core, MemoryRegion, RawFlashAlgorithm, RegistryError, ScanChainElement,
-    TargetDescriptionSource,
+    Core, MemoryRegion, RawFlashAlgorithm, RegistryError, TargetDescriptionSource,
 };
 use crate::architecture::{
     arm::{
@@ -31,7 +30,7 @@ use crate::architecture::{
     xtensa::sequences::{DefaultXtensaSequence, XtensaDebugSequence},
 };
 use crate::flashing::FlashLoader;
-use probe_rs_target::{Architecture, BinaryFormat, ChipFamily, MemoryRange};
+use probe_rs_target::{Architecture, BinaryFormat, ChipFamily, Jtag, MemoryRange};
 use std::sync::Arc;
 
 /// This describes a complete target with a fixed chip model and variant.
@@ -59,7 +58,7 @@ pub struct Target {
     /// The scan chain can be parsed from the CMSIS-SDF file, or specified
     /// manually in the target.yaml file. It is used by some probes to determine
     /// the number devices in the scan chain and their ir lengths.
-    pub scan_chain: Option<Vec<ScanChainElement>>,
+    pub jtag: Option<Jtag>,
     /// The default executable format for the target.
     pub default_format: BinaryFormat,
 }
@@ -235,7 +234,7 @@ impl Target {
             memory_map: chip.memory_map.clone(),
             debug_sequence,
             rtt_scan_regions,
-            scan_chain: chip.scan_chain.clone(),
+            jtag: chip.jtag.clone(),
             default_format: chip.default_binary_format.clone().unwrap_or_default(),
         })
     }

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -51,7 +51,7 @@ use commands::{
     },
     CmsisDapDevice, Status,
 };
-use probe_rs_target::{get_ir_lengths, ScanChainElement};
+use probe_rs_target::ScanChainElement;
 
 use std::{result::Result, time::Duration};
 
@@ -1041,17 +1041,20 @@ impl RawDapAccess for CmsisDap {
     }
 
     fn configure_jtag(&mut self) -> Result<(), DebugProbeError> {
-        // If the scan chain is populated, use that and skip runtime detection.
-        // We trust the user here and assume the scan chain is right. If its not,
-        // the use of the probe will fail later.
-        // If the scan chain is not populated, we need to do runtime detection.
-        let ir_lengths = if self.scan_chain.is_some() {
-            get_ir_lengths(self.scan_chain.as_ref().unwrap())
-        } else {
-            tracing::info!("No scan chain provided, doing runtime detection");
-            let chain = self.jtag_scan(None)?;
-            chain.iter().map(|item| item.irlen as u8).collect()
-        };
+        let chain = self.jtag_scan(
+            self.scan_chain
+                .as_ref()
+                .map(|chain| {
+                    chain
+                        .iter()
+                        .filter_map(|s| s.ir_len)
+                        .map(|s| s as usize)
+                        .collect::<Vec<usize>>()
+                })
+                .as_deref(),
+        )?;
+        let ir_lengths = chain.iter().map(|item| item.irlen as u8).collect();
+
         tracing::info!("Configuring JTAG with ir lengths: {:?}", ir_lengths);
         self.send_jtag_configure(JtagConfigureRequest::new(ir_lengths)?)?;
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -171,8 +171,10 @@ impl Session {
             }
         }
 
-        if let Some(scan_chain) = target.scan_chain.clone() {
-            probe.set_scan_chain(scan_chain)?;
+        if let Some(jtag) = target.jtag.as_ref() {
+            if let Some(scan_chain) = jtag.scan_chain.clone() {
+                probe.set_scan_chain(scan_chain)?;
+            }
         }
         probe.attach_to_unspecified()?;
 
@@ -271,8 +273,10 @@ impl Session {
             _ => unreachable!("Mismatch between architecture and sequence type!"),
         };
 
-        if let Some(scan_chain) = target.scan_chain.clone() {
-            probe.set_scan_chain(scan_chain)?;
+        if let Some(jtag) = target.jtag.as_ref() {
+            if let Some(scan_chain) = jtag.scan_chain.clone() {
+                probe.set_scan_chain(scan_chain)?;
+            }
         }
 
         probe.attach_to_unspecified()?;
@@ -312,8 +316,10 @@ impl Session {
             _ => unreachable!("Mismatch between architecture and sequence type!"),
         };
 
-        if let Some(scan_chain) = target.scan_chain.clone() {
-            probe.set_scan_chain(scan_chain)?;
+        if let Some(jtag) = target.jtag.as_ref() {
+            if let Some(scan_chain) = jtag.scan_chain.clone() {
+                probe.set_scan_chain(scan_chain)?;
+            }
         }
 
         probe.attach_to_unspecified()?;

--- a/probe-rs/targets/esp32c2.yaml
+++ b/probe-rs/targets/esp32c2.yaml
@@ -4,9 +4,10 @@ manufacturer:
   id: 0x12
 variants:
   - name: esp32c2
-    scan_chain:
-      - name: main
-        ir_len: 5
+    jtag:
+      scan_chain:
+        - name: main
+          ir_len: 5
     default_binary_format: idf
     cores:
       - name: main

--- a/probe-rs/targets/esp32c3.yaml
+++ b/probe-rs/targets/esp32c3.yaml
@@ -4,10 +4,10 @@ manufacturer:
   id: 0x12
 variants:
   - name: esp32c3
-    part: ~
-    scan_chain:
-      - name: main
-        ir_len: 5
+    jtag:
+      scan_chain:
+        - name: main
+          ir_len: 5
     default_binary_format: idf
     cores:
       - name: main

--- a/probe-rs/targets/esp32c6.yaml
+++ b/probe-rs/targets/esp32c6.yaml
@@ -4,10 +4,10 @@ manufacturer:
   id: 0x12
 variants:
   - name: esp32c6
-    part: null
-    scan_chain:
-      - name: main
-        ir_len: 5
+    jtag:
+      scan_chain:
+        - name: main
+          ir_len: 5
     default_binary_format: idf
     cores:
       - name: main

--- a/probe-rs/targets/esp32h2.yaml
+++ b/probe-rs/targets/esp32h2.yaml
@@ -4,9 +4,10 @@ manufacturer:
   id: 0x12
 variants:
   - name: esp32h2
-    scan_chain:
-    - name: main
-      ir_len: 5
+    jtag:
+      scan_chain:
+      - name: main
+        ir_len: 5
     default_binary_format: idf
     cores:
     - name: main

--- a/probe-rs/targets/esp32s2.yaml
+++ b/probe-rs/targets/esp32s2.yaml
@@ -4,9 +4,10 @@ manufacturer:
   id: 0x12
 variants:
   - name: esp32s2
-    scan_chain:
-      - name: main
-        ir_len: 5
+    jtag:
+      scan_chain:
+        - name: main
+          ir_len: 5
     default_binary_format: idf
     cores:
       - name: main

--- a/probe-rs/targets/esp32s3.yaml
+++ b/probe-rs/targets/esp32s3.yaml
@@ -4,11 +4,12 @@ manufacturer:
   id: 0x12
 variants:
   - name: esp32s3
-    scan_chain:
-      - name: cpu0
-        ir_len: 5
-      - name: cpu1
-        ir_len: 5
+    jtag:
+      scan_chain:
+        - name: cpu0
+          ir_len: 5
+        - name: cpu1
+          ir_len: 5
     default_binary_format: idf
     cores:
       - name: cpu0

--- a/probe-rs/tests/scan_chain_test.yaml
+++ b/probe-rs/tests/scan_chain_test.yaml
@@ -48,7 +48,7 @@ variants:
           !Arm
             ap: 0x0
             psel: 0x0
-    jtag:
+    jtag: {}
     memory_map:
       - !Ram
           range:

--- a/probe-rs/tests/scan_chain_test.yaml
+++ b/probe-rs/tests/scan_chain_test.yaml
@@ -2,12 +2,13 @@
 name: TEMP_FAM
 variants:
   - name: FULL_SCAN_CHAIN
-    # https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain
-    scan_chain:
-      - name: core0
-        ir_len: 4
-      - name: ICEPICK
-        ir_len: 6
+    jtag:
+      # https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain
+      scan_chain:
+        - name: core0
+          ir_len: 4
+        - name: ICEPICK
+          ir_len: 6
     cores:
       - name: core0
         type: armv6m
@@ -23,7 +24,7 @@ variants:
           is_boot_memory: false
           cores:
             - core0
-  - name: NO_SCAN_CHAIN
+  - name: NO_JTAG_INFO
     cores:
       - name: core0
         type: armv6m
@@ -39,11 +40,29 @@ variants:
           is_boot_memory: true
           cores:
             - core0
+  - name: NO_SCAN_CHAIN
+    cores:
+      - name: core0
+        type: armv6m
+        core_access_options:
+          !Arm
+            ap: 0x0
+            psel: 0x0
+    jtag:
+    memory_map:
+      - !Ram
+          range:
+            start: 0x20000000
+            end: 0x20040000
+          is_boot_memory: true
+          cores:
+            - core0
   - name: PARTIAL_SCAN_CHAIN
-    # https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain
-    scan_chain:
-      - ir_len: 4
-      - ir_len: 6
+    jtag:
+      # https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/sdf_pg.html#sdf_element_scanchain
+      scan_chain:
+        - ir_len: 4
+        - ir_len: 6
     cores:
       - name: core0
         type: armv6m

--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -106,7 +106,7 @@ pub fn cmd_elf(
                 ],
                 flash_algorithms: vec![algorithm_name],
                 rtt_scan_ranges: None,
-                scan_chain: None,
+                jtag: None,
                 default_binary_format: None,
             }],
             flash_algorithms: vec![algorithm],

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -164,7 +164,7 @@ where
             memory_map,
             flash_algorithms: flash_algorithm_names,
             rtt_scan_ranges: None,
-            scan_chain: None, // TODO, parse from sdf
+            jtag: None, // TODO, parse scan chain from sdf
             default_binary_format: None,
         });
     }


### PR DESCRIPTION
- scan chain info in target yamls are now for validation only
- scan_chain is now located under jtag
  This is done to prepare for introducing more configuration, like default TAP index, default probe speed, etc.

Closes #1796