### PR TITLE
Add ARM interface to FTDI

### DIFF
--- a/changelog/added-ftdi-arm.md
+++ b/changelog/added-ftdi-arm.md
@@ -1,0 +1,1 @@
+Added ARM interface support (JTAG only) to FTDI probes.


### PR DESCRIPTION
Closes #1716

Not a lot was missing in theory but all I get at this moment is an IR scan, an IDCODE and a timeout.

I'm not entirely sure what I have to see for `probe-rs info` but the current output is the following, matching my J-Link over JTAG:

```
❯ probe-rs  info
Probing target via JTAG

ARM Chip:
Debug Port: Version 0, DP Designer: <unknown>
└── 0 MemoryAP
    └── Generic
```