### PR TITLE
Simplify `FlashAlgorithm::assemble_from_raw`

### DIFF
--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -90,6 +90,9 @@ pub enum FlashError {
         /// The address where the algorithm was supposed to be loaded to.
         address: u64,
     },
+    /// Failed to configure a valid stack size for the flash algorithm.
+    #[error("Failed to configure a stack for the flash algorithm.")]
+    InvalidFlashAlgorithmStackSize,
     /// The given page size is not valid. Only page sizes multiples of 4 bytes are allowed.
     #[error("Invalid page size {size:08X?}. Must be a multiple of 4 bytes.")]
     InvalidPageSize {

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -292,8 +292,7 @@ impl FlashAlgorithm {
 
             // Data buffer 1
             addr_data = addr_stack;
-            offset =
-                addr_load + header_size + code_size_words + raw.flash_properties.page_size as u64;
+            offset = code_end + raw.flash_properties.page_size as u64;
 
             if offset <= ram_region.range.end {
                 break;

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -235,7 +235,6 @@ impl FlashAlgorithm {
         let header_size = size_of_val(header) as u64;
 
         let mut addr_stack = 0;
-        let mut addr_data = 0;
 
         // Try to find a stack size that fits with at least one page of data.
         let stack_size = {
@@ -291,9 +290,6 @@ impl FlashAlgorithm {
             // Stack start address
             addr_stack = code_end + actual_stack_size;
 
-            // Data buffer 1
-            addr_data = addr_stack;
-
             // Stack + data buffer fits, we're done
             if buffer_page_size + actual_stack_size <= remaining_ram {
                 break;
@@ -310,6 +306,9 @@ impl FlashAlgorithm {
         tracing::debug!(
             "The flash algorithm will be configured with {actual_stack_size} bytes of stack"
         );
+
+        // Data buffer 1
+        let addr_data = addr_stack;
 
         // Data buffer 2
         let second_buffer_start = addr_data + buffer_page_size;

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -237,7 +237,6 @@ impl FlashAlgorithm {
         let mut offset = 0;
         let mut addr_stack = 0;
         let mut addr_data = 0;
-        let mut code_start = 0;
 
         // Try to find a stack size that fits with at least one page of data.
         let stack_size = {
@@ -279,9 +278,10 @@ impl FlashAlgorithm {
             return Err(FlashError::InvalidFlashAlgorithmLoadAddress { address: addr_load });
         }
 
+        let code_start = addr_load + header_size;
+
         for i in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
             offset = header_size;
-            code_start = addr_load + offset;
             offset += (instructions.len() * size_of::<u32>()) as u64;
 
             // Stack start address (desc)

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -283,7 +283,7 @@ impl FlashAlgorithm {
 
         let remaining_ram = ram_region.range.end - code_end;
 
-        // Place data after stack, reduce stack size until it fits.
+        // Reduce stack size until it fits.
         while buffer_page_size + actual_stack_size > remaining_ram {
             // Stack does not fit, decrement stack size and try again
             actual_stack_size = (actual_stack_size

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -308,7 +308,7 @@ impl FlashAlgorithm {
 
         // Data buffer 2
         let addr_data2 = addr_data + raw.flash_properties.page_size as u64;
-        let offset = addr_data + 2 * raw.flash_properties.page_size as u64;
+        let offset = addr_data2 + raw.flash_properties.page_size as u64;
 
         // Determine whether we can use double buffering or not by the remaining RAM region size.
         let page_buffers = if offset <= ram_region.range.end {

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -283,6 +283,8 @@ impl FlashAlgorithm {
         let buffer_page_size = raw.flash_properties.page_size as u64;
 
         let mut actual_stack_size = stack_size as u64;
+
+        // Place data after stack, reduce stack size until it fits.
         for _ in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
             // Stack start address
             addr_stack = code_end + actual_stack_size;

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -273,20 +273,20 @@ impl FlashAlgorithm {
 
         tracing::debug!("The flash algorithm will be configured with {stack_size} bytes of stack");
 
-        let addr_stack = code_end + stack_size;
+        let stack_top_addr = code_end + stack_size;
 
         // Data buffer 1
-        let addr_data = addr_stack;
+        let first_buffer_start = stack_top_addr;
 
         // Data buffer 2
-        let second_buffer_start = addr_data + buffer_page_size;
+        let second_buffer_start = first_buffer_start + buffer_page_size;
         let second_buffer_end = second_buffer_start + buffer_page_size;
 
         // Determine whether we can use double buffering or not by the remaining RAM region size.
         let page_buffers = if second_buffer_end <= ram_region.range.end {
-            vec![addr_data, second_buffer_start]
+            vec![first_buffer_start, second_buffer_start]
         } else {
-            vec![addr_data]
+            vec![first_buffer_start]
         };
 
         let name = raw.name.clone();
@@ -302,7 +302,7 @@ impl FlashAlgorithm {
             pc_erase_sector: code_start + raw.pc_erase_sector,
             pc_erase_all: raw.pc_erase_all.map(|v| code_start + v),
             static_base: code_start + raw.data_section_offset,
-            begin_stack: addr_stack,
+            begin_stack: stack_top_addr,
             page_buffers,
             rtt_control_block: raw.rtt_location,
             flash_properties: raw.flash_properties.clone(),

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -279,10 +279,11 @@ impl FlashAlgorithm {
         }
 
         let code_start = addr_load + header_size;
+        let code_size_bytes = (instructions.len() * size_of::<u32>()) as u64;
 
         for i in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
             offset = header_size;
-            offset += (instructions.len() * size_of::<u32>()) as u64;
+            offset += code_size_bytes;
 
             // Stack start address (desc)
             addr_stack = addr_load

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -279,23 +279,21 @@ impl FlashAlgorithm {
 
         let buffer_page_size = raw.flash_properties.page_size as u64;
 
-        let mut actual_stack_size = stack_size;
-
         let remaining_ram = ram_region.range.end - code_end;
 
         // Reduce stack size if it does not fit.
-        if buffer_page_size + actual_stack_size > remaining_ram {
+        let stack_size = if buffer_page_size + stack_size > remaining_ram {
             if buffer_page_size >= remaining_ram {
                 return Err(FlashError::InvalidFlashAlgorithmLoadAddress { address: addr_load });
             }
-            actual_stack_size = remaining_ram - buffer_page_size;
-        }
+            remaining_ram - buffer_page_size
+        } else {
+            stack_size
+        };
 
-        tracing::debug!(
-            "The flash algorithm will be configured with {actual_stack_size} bytes of stack"
-        );
+        tracing::debug!("The flash algorithm will be configured with {stack_size} bytes of stack");
 
-        let addr_stack = code_end + actual_stack_size;
+        let addr_stack = code_end + stack_size;
 
         // Data buffer 1
         let addr_data = addr_stack;

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -284,6 +284,8 @@ impl FlashAlgorithm {
 
         let mut actual_stack_size = stack_size as u64;
 
+        let remaining_ram = ram_region.range.end - code_end;
+
         // Place data after stack, reduce stack size until it fits.
         for _ in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
             // Stack start address
@@ -291,10 +293,9 @@ impl FlashAlgorithm {
 
             // Data buffer 1
             addr_data = addr_stack;
-            let data_end = addr_data + buffer_page_size;
 
-            // Stack fits, we're done
-            if data_end <= ram_region.range.end {
+            // Stack + data buffer fits, we're done
+            if buffer_page_size + actual_stack_size <= remaining_ram {
                 break;
             }
 

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -234,8 +234,6 @@ impl FlashAlgorithm {
 
         let header_size = size_of_val(header) as u64;
 
-        let mut addr_stack = 0;
-
         // Try to find a stack size that fits with at least one page of data.
         let stack_size = {
             let stack_size = raw.stack_size.unwrap_or(Self::FLASH_ALGO_STACK_SIZE);
@@ -287,9 +285,6 @@ impl FlashAlgorithm {
 
         // Place data after stack, reduce stack size until it fits.
         for _ in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
-            // Stack start address
-            addr_stack = code_end + actual_stack_size;
-
             // Stack + data buffer fits, we're done
             if buffer_page_size + actual_stack_size <= remaining_ram {
                 break;
@@ -306,6 +301,8 @@ impl FlashAlgorithm {
         tracing::debug!(
             "The flash algorithm will be configured with {actual_stack_size} bytes of stack"
         );
+
+        let addr_stack = code_end + actual_stack_size;
 
         // Data buffer 1
         let addr_data = addr_stack;

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -288,10 +288,11 @@ impl FlashAlgorithm {
 
             // Data buffer 1
             addr_data = addr_stack;
-            offset = addr_data + raw.flash_properties.page_size as u64;
+            let data_end = addr_data + raw.flash_properties.page_size as u64;
+            offset = data_end;
 
             // Stack fits, we're done
-            if offset <= ram_region.range.end {
+            if data_end <= ram_region.range.end {
                 break;
             }
 

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -267,7 +267,7 @@ impl FlashAlgorithm {
                 .load_address
                 .map(|a| {
                     a.checked_sub(header_size) // adjust the raw load address to account for the algo header
-                        .ok_or(FlashError::InvalidFlashAlgorithmLoadAddress { address: addr_load })
+                        .ok_or(FlashError::InvalidFlashAlgorithmLoadAddress { address: a })
                 })
                 .unwrap_or(Ok(ram_region.range.start))?;
             if addr_load < ram_region.range.start {

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -234,7 +234,6 @@ impl FlashAlgorithm {
 
         let header_size = size_of_val(header) as u64;
 
-        let mut offset = 0;
         let mut addr_stack = 0;
         let mut addr_data = 0;
 
@@ -289,7 +288,6 @@ impl FlashAlgorithm {
             // Data buffer 1
             addr_data = addr_stack;
             let data_end = addr_data + raw.flash_properties.page_size as u64;
-            offset = data_end;
 
             // Stack fits, we're done
             if data_end <= ram_region.range.end {
@@ -310,7 +308,7 @@ impl FlashAlgorithm {
 
         // Data buffer 2
         let addr_data2 = addr_data + raw.flash_properties.page_size as u64;
-        offset += raw.flash_properties.page_size as u64;
+        let offset = addr_data + 2 * raw.flash_properties.page_size as u64;
 
         // Determine whether we can use double buffering or not by the remaining RAM region size.
         let page_buffers = if offset <= ram_region.range.end {

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -282,14 +282,8 @@ impl FlashAlgorithm {
         let code_end = code_start + code_size_bytes;
 
         let mut actual_stack_size = stack_size as u64;
-        for i in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
-            actual_stack_size = (stack_size
-                .checked_sub(Self::FLASH_ALGO_STACK_DECREMENT * i)
-                .expect(
-                    "Overflow never happens; decrement multiples are always less than stack size.",
-                )) as u64;
-
-            // Stack start address (desc)
+        for _ in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
+            // Stack start address
             addr_stack = code_end + actual_stack_size;
 
             // Data buffer 1
@@ -300,6 +294,13 @@ impl FlashAlgorithm {
             if offset <= ram_region.range.end {
                 break;
             }
+
+            // Stack does not fit, decrement stack size and try again
+            actual_stack_size = (actual_stack_size
+                .checked_sub(Self::FLASH_ALGO_STACK_DECREMENT as u64)
+                .expect(
+                    "Overflow never happens; decrement multiples are always less than stack size.",
+                )) as u64;
         }
 
         tracing::debug!(

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -280,13 +280,13 @@ impl FlashAlgorithm {
 
         let code_start = addr_load + header_size;
         let code_size_bytes = (instructions.len() * size_of::<u32>()) as u64;
+        let code_end = code_start + code_size_bytes;
 
         for i in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
             offset = header_size + code_size_bytes;
 
             // Stack start address (desc)
-            addr_stack = addr_load
-                + offset
+            addr_stack = code_end
                 + (stack_size
                     .checked_sub(Self::FLASH_ALGO_STACK_DECREMENT * i)
                     .expect("Overflow never happens; decrement multiples are always less than stack size."))

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -283,17 +283,20 @@ impl FlashAlgorithm {
         let code_end = code_start + code_size_bytes;
 
         for i in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
+            let actual_stack_size = (stack_size
+                .checked_sub(Self::FLASH_ALGO_STACK_DECREMENT * i)
+                .expect(
+                    "Overflow never happens; decrement multiples are always less than stack size.",
+                )) as u64;
+
             // Stack start address (desc)
-            addr_stack = code_end
-                + (stack_size
-                    .checked_sub(Self::FLASH_ALGO_STACK_DECREMENT * i)
-                    .expect("Overflow never happens; decrement multiples are always less than stack size."))
-                    as u64;
+            addr_stack = code_end + actual_stack_size;
 
             // Data buffer 1
             addr_data = addr_stack;
             offset = addr_data + raw.flash_properties.page_size as u64;
 
+            // Stack fits, we're done
             if offset <= ram_region.range.end {
                 break;
             }

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -257,7 +257,6 @@ impl FlashAlgorithm {
                 stack_size
             }
         };
-        tracing::debug!("The flash algorithm will be configured with {stack_size} bytes of stack");
 
         // Load address
         let addr_load = match raw.load_address {
@@ -282,8 +281,9 @@ impl FlashAlgorithm {
         let code_size_bytes = (instructions.len() * size_of::<u32>()) as u64;
         let code_end = code_start + code_size_bytes;
 
+        let mut actual_stack_size = stack_size as u64;
         for i in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
-            let actual_stack_size = (stack_size
+            actual_stack_size = (stack_size
                 .checked_sub(Self::FLASH_ALGO_STACK_DECREMENT * i)
                 .expect(
                     "Overflow never happens; decrement multiples are always less than stack size.",
@@ -301,6 +301,10 @@ impl FlashAlgorithm {
                 break;
             }
         }
+
+        tracing::debug!(
+            "The flash algorithm will be configured with {actual_stack_size} bytes of stack"
+        );
 
         // Data buffer 2
         let addr_data2 = addr_data + raw.flash_properties.page_size as u64;

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -282,8 +282,7 @@ impl FlashAlgorithm {
         let code_size_bytes = (instructions.len() * size_of::<u32>()) as u64;
 
         for i in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
-            offset = header_size;
-            offset += code_size_bytes;
+            offset = header_size + code_size_bytes;
 
             // Stack start address (desc)
             addr_stack = addr_load

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -292,9 +292,10 @@ impl FlashAlgorithm {
 
             // Data buffer 1
             addr_data = addr_stack;
-            offset = header_size + code_size_words + raw.flash_properties.page_size as u64;
+            offset =
+                addr_load + header_size + code_size_words + raw.flash_properties.page_size as u64;
 
-            if offset <= ram_region.range.end - addr_load {
+            if offset <= ram_region.range.end {
                 break;
             }
         }
@@ -304,7 +305,7 @@ impl FlashAlgorithm {
         offset += raw.flash_properties.page_size as u64;
 
         // Determine whether we can use double buffering or not by the remaining RAM region size.
-        let page_buffers = if offset <= ram_region.range.end - addr_load {
+        let page_buffers = if offset <= ram_region.range.end {
             vec![addr_data, addr_data2]
         } else {
             vec![addr_data]

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -248,9 +248,9 @@ impl FlashAlgorithm {
                     stack_size,
                     Self::FLASH_ALGO_STACK_DECREMENT
                 );
-                Self::FLASH_ALGO_STACK_DECREMENT
+                Self::FLASH_ALGO_STACK_DECREMENT as u64
             } else {
-                stack_size
+                stack_size as u64
             }
         };
 
@@ -279,7 +279,7 @@ impl FlashAlgorithm {
 
         let buffer_page_size = raw.flash_properties.page_size as u64;
 
-        let mut actual_stack_size = stack_size as u64;
+        let mut actual_stack_size = stack_size;
 
         let remaining_ram = ram_region.range.end - code_end;
 

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -280,6 +280,8 @@ impl FlashAlgorithm {
         let code_size_bytes = (instructions.len() * size_of::<u32>()) as u64;
         let code_end = code_start + code_size_bytes;
 
+        let buffer_page_size = raw.flash_properties.page_size as u64;
+
         let mut actual_stack_size = stack_size as u64;
         for _ in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
             // Stack start address
@@ -287,7 +289,7 @@ impl FlashAlgorithm {
 
             // Data buffer 1
             addr_data = addr_stack;
-            let data_end = addr_data + raw.flash_properties.page_size as u64;
+            let data_end = addr_data + buffer_page_size;
 
             // Stack fits, we're done
             if data_end <= ram_region.range.end {
@@ -307,12 +309,12 @@ impl FlashAlgorithm {
         );
 
         // Data buffer 2
-        let dual_buffer_start = addr_data + raw.flash_properties.page_size as u64;
-        let dual_buffer_data_end = dual_buffer_start + raw.flash_properties.page_size as u64;
+        let second_buffer_start = addr_data + buffer_page_size;
+        let second_buffer_end = second_buffer_start + buffer_page_size;
 
         // Determine whether we can use double buffering or not by the remaining RAM region size.
-        let page_buffers = if dual_buffer_data_end <= ram_region.range.end {
-            vec![addr_data, dual_buffer_start]
+        let page_buffers = if second_buffer_end <= ram_region.range.end {
+            vec![addr_data, second_buffer_start]
         } else {
             vec![addr_data]
         };

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -280,7 +280,7 @@ impl FlashAlgorithm {
         }
 
         for i in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
-            offset += header_size;
+            offset = header_size;
             code_start = addr_load + offset;
             offset += (instructions.len() * size_of::<u32>()) as u64;
 

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -267,7 +267,7 @@ impl FlashAlgorithm {
             // Make sure at least one data page fits into RAM.
             if buffer_page_size + stack_size > remaining_ram {
                 // The configured stack size is too large. Let's not try to be too clever about it.
-                return Err(FlashError::InvalidFlashAlgorithmLoadAddress { address: addr_load });
+                return Err(FlashError::InvalidFlashAlgorithmStackSize);
             }
             stack_size
         } else {
@@ -275,7 +275,7 @@ impl FlashAlgorithm {
             // avoid a panic if the RAM region is too small.
             if buffer_page_size >= remaining_ram {
                 // We don't have any space for a stack
-                return Err(FlashError::InvalidFlashAlgorithmLoadAddress { address: addr_load });
+                return Err(FlashError::InvalidFlashAlgorithmStackSize);
             }
 
             // Use up to 512 bytes of RAM out of the remaining for stack.

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -161,7 +161,6 @@ impl FlashAlgorithm {
     }
 
     const FLASH_ALGO_STACK_SIZE: u32 = 512;
-    const FLASH_ALGO_STACK_DECREMENT: u32 = 64;
 
     // Header for RISC-V Flash Algorithms
     const RISCV_FLASH_BLOB_HEADER: [u32; 2] = [riscv::assembly::EBREAK, riscv::assembly::EBREAK];
@@ -235,24 +234,7 @@ impl FlashAlgorithm {
         let header_size = size_of_val(header) as u64;
 
         // Try to find a stack size that fits with at least one page of data.
-        let stack_size = {
-            let stack_size = raw.stack_size.unwrap_or(Self::FLASH_ALGO_STACK_SIZE);
-            if stack_size < Self::FLASH_ALGO_STACK_DECREMENT {
-                // If the stack size is less than one decrement, we
-                // won't enter the loop (below), and we'll produce a variety
-                // of addresses that all start at zero (above).
-                // Let's make sure we have a chance to compute other addresses
-                // by using a reasonable minimum stack size.
-                tracing::warn!(
-                    "Stack size of {} bytes is too small; overriding to {} bytes",
-                    stack_size,
-                    Self::FLASH_ALGO_STACK_DECREMENT
-                );
-                Self::FLASH_ALGO_STACK_DECREMENT as u64
-            } else {
-                stack_size as u64
-            }
-        };
+        let stack_size = raw.stack_size.unwrap_or(Self::FLASH_ALGO_STACK_SIZE) as u64;
 
         // Load address
         let addr_load = match raw.load_address {

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -233,9 +233,6 @@ impl FlashAlgorithm {
 
         let header_size = size_of_val(header) as u64;
 
-        // Try to find a stack size that fits with at least one page of data.
-        let stack_size = raw.stack_size.unwrap_or(Self::FLASH_ALGO_STACK_SIZE) as u64;
-
         // Load address
         let addr_load = match raw.load_address {
             Some(address) => {
@@ -263,7 +260,8 @@ impl FlashAlgorithm {
 
         let remaining_ram = ram_region.range.end - code_end;
 
-        // Reduce stack size if it does not fit.
+        // Try to find a stack size that fits with at least one page of data.
+        let stack_size = raw.stack_size.unwrap_or(Self::FLASH_ALGO_STACK_SIZE) as u64;
         let stack_size = if buffer_page_size + stack_size > remaining_ram {
             if buffer_page_size >= remaining_ram {
                 return Err(FlashError::InvalidFlashAlgorithmLoadAddress { address: addr_load });

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -307,12 +307,12 @@ impl FlashAlgorithm {
         );
 
         // Data buffer 2
-        let addr_data2 = addr_data + raw.flash_properties.page_size as u64;
-        let offset = addr_data2 + raw.flash_properties.page_size as u64;
+        let dual_buffer_start = addr_data + raw.flash_properties.page_size as u64;
+        let dual_buffer_data_end = dual_buffer_start + raw.flash_properties.page_size as u64;
 
         // Determine whether we can use double buffering or not by the remaining RAM region size.
-        let page_buffers = if offset <= ram_region.range.end {
-            vec![addr_data, addr_data2]
+        let page_buffers = if dual_buffer_data_end <= ram_region.range.end {
+            vec![addr_data, dual_buffer_start]
         } else {
             vec![addr_data]
         };

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -283,8 +283,6 @@ impl FlashAlgorithm {
         let code_end = code_start + code_size_bytes;
 
         for i in 0..stack_size / Self::FLASH_ALGO_STACK_DECREMENT {
-            offset = header_size + code_size_bytes;
-
             // Stack start address (desc)
             addr_stack = code_end
                 + (stack_size
@@ -294,7 +292,7 @@ impl FlashAlgorithm {
 
             // Data buffer 1
             addr_data = addr_stack;
-            offset += raw.flash_properties.page_size as u64;
+            offset = header_size + code_size_words + raw.flash_properties.page_size as u64;
 
             if offset <= ram_region.range.end - addr_load {
                 break;

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -292,7 +292,7 @@ impl FlashAlgorithm {
 
             // Data buffer 1
             addr_data = addr_stack;
-            offset = code_end + raw.flash_properties.page_size as u64;
+            offset = addr_data + raw.flash_properties.page_size as u64;
 
             if offset <= ram_region.range.end {
                 break;

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -233,7 +233,7 @@ impl FlashAlgorithm {
 
         let header_size = size_of_val(header) as u64;
 
-        // Load address
+        // The start address where we try to load the flash algorithm.
         let addr_load = match raw.load_address {
             Some(address) => {
                 // adjust the raw load address to account for the algo header


### PR DESCRIPTION
This PR - step-by-step - gets rid of the very cryptic loop in `assemble_from_raw`. This code was very confusing so I've included every single step I made in a different commit so you can catch any mistakes I made.

This PR also fixes a suspected issue where the stack may overlap with the data pages