### PR TITLE
Remove `FlashAlgorithm::begin_data`

### DIFF
--- a/changelog/removed-flash-algorithm-begin-data.md
+++ b/changelog/removed-flash-algorithm-begin-data.md
@@ -1,0 +1,1 @@
+Removed the redundant `begin_data` field of `FlashAlgorithm`

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -36,9 +36,7 @@ pub struct FlashAlgorithm {
     pub static_base: u64,
     /// Initial value of the stack pointer when calling any flash algo API.
     pub begin_stack: u64,
-    /// Base address of the page buffer. Used if `page_buffers` is not provided.
-    pub begin_data: u64,
-    /// An optional list of base addresses for page buffers. The buffers must be at
+    /// A list of base addresses for page buffers. The buffers must be at
     /// least as large as the region's `page_size` attribute. If at least 2 buffers are included in
     /// the list, then double buffered programming will be enabled.
     pub page_buffers: Vec<u64>,
@@ -321,8 +319,7 @@ impl FlashAlgorithm {
             pc_erase_all: raw.pc_erase_all.map(|v| code_start + v),
             static_base: code_start + raw.data_section_offset,
             begin_stack: addr_stack,
-            begin_data: page_buffers[0],
-            page_buffers: page_buffers.clone(),
+            page_buffers,
             rtt_control_block: raw.rtt_location,
             flash_properties: raw.flash_properties.clone(),
             transfer_encoding: raw.transfer_encoding.unwrap_or_default(),

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -911,7 +911,8 @@ impl<'p> ActiveFlasher<'p, Program> {
         );
 
         // Transfer the bytes to RAM.
-        self.load_data(self.flash_algorithm.begin_data, bytes)?;
+        let begin_data = self.buffer_address(0);
+        self.load_data(begin_data, bytes)?;
 
         let result = self
             .call_function_and_wait(
@@ -919,7 +920,7 @@ impl<'p> ActiveFlasher<'p, Program> {
                     pc: into_reg(self.flash_algorithm.pc_program_page)?,
                     r0: Some(into_reg(address)?),
                     r1: Some(bytes.len() as u32),
-                    r2: Some(into_reg(self.flash_algorithm.begin_data)?),
+                    r2: Some(into_reg(begin_data)?),
                     r3: None,
                 },
                 false,


### PR DESCRIPTION
This is a breaking change but it's very simple to migrate and I don't see the need to maintain the redundancy