### PR TITLE
Remove `log`, integrate tracing and progress bars better, make cargo-embed smarter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,9 +341,6 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitmatch"
@@ -571,16 +568,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "cargo_toml"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802b755090e39835a4b0440fb0bbee0df7495a8b337f63db21e616f7821c7e8c"
-dependencies = [
- "serde",
- "toml",
 ]
 
 [[package]]
@@ -2120,7 +2107,7 @@ dependencies = [
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "terminal_size 0.1.17",
+ "terminal_size",
  "textwrap 0.15.2",
  "thiserror",
  "unicode-width",
@@ -2549,7 +2536,6 @@ dependencies = [
  "bytesize",
  "capstone",
  "cargo_metadata",
- "cargo_toml",
  "clap",
  "colored",
  "crossterm",
@@ -2588,7 +2574,6 @@ dependencies = [
  "rand",
  "ratatui",
  "rmp-serde",
- "ron",
  "rustyline",
  "sanitize-filename",
  "schemafy",
@@ -2600,7 +2585,6 @@ dependencies = [
  "static_assertions",
  "svd-parser",
  "svg",
- "terminal_size 0.3.0",
  "termtree",
  "test-case",
  "textwrap 0.16.0",
@@ -3002,18 +2986,6 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
-]
-
-[[package]]
-name = "ron"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
-dependencies = [
- "base64",
- "bitflags 2.4.2",
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -3803,16 +3775,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
-dependencies = [
- "rustix",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2575,7 +2575,6 @@ dependencies = [
  "itm",
  "jep106",
  "kmp",
- "log",
  "miniz_oxide",
  "num-traits",
  "nusb",

--- a/changelog/fixed-cargo-embed.md
+++ b/changelog/fixed-cargo-embed.md
@@ -1,0 +1,1 @@
+Fixed cargo-embed not respecting the target's preferred image format.

--- a/changelog/fixed-logging-with-progress-bars.md
+++ b/changelog/fixed-logging-with-progress-bars.md
@@ -1,0 +1,1 @@
+Fixed logging causing multiple progress bars to appear in console output.

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -39,7 +39,6 @@ cli = [
     "dep:byte-unit",
     "dep:capstone",
     "dep:cargo_metadata",
-    "dep:cargo_toml",
     "dep:clap",
     "dep:colored",
     "dep:defmt-decoder",
@@ -49,12 +48,9 @@ cli = [
     "dep:is-terminal",
     "dep:itm",
     "dep:parse_int",
-    "dep:pretty_env_logger",
     "dep:rand",
-    "dep:ron",
     "dep:rustyline",
     "dep:sanitize-filename",
-    "dep:terminal_size",
     "dep:termtree",
     "dep:time",
     "dep:tracing-appender",
@@ -136,7 +132,6 @@ byte-unit = { version = "5", optional = true }
 bytesize = { version = "1", optional = true }
 capstone = { version = "0.11", optional = true }
 cargo_metadata = { version = "0.18", optional = true }
-cargo_toml = { version = "0.18", optional = true }
 clap = { version = "4", features = ["derive", "env"], optional = true }
 colored = { version = "2", optional = true }
 crossterm = { version = "<= 0.27", optional = true }
@@ -155,16 +150,13 @@ insta = { version = "1", features = ["yaml", "filters"] }
 is-terminal = { version = "0.4", optional = true }
 itm = { version = "0.9.0-rc.1", default-features = false, optional = true }
 parse_int = { version = "0.6", optional = true }
-pretty_env_logger = { workspace = true, optional = true }
 rand = { version = "0.8", optional = true }
-ron = { version = "0.8", optional = true }
 rustyline = { version = "13", optional = true }
 sanitize-filename = { version = "0.5", optional = true }
 schemafy = { version = "0.6", optional = true }
 serde_json = { version = "1", optional = true }
 signal-hook = "0.3"
 svd-parser = { version = "0.14", features = ["expand"], optional = true }
-terminal_size = { version = "0.3", optional = true }
 termtree = { version = "0.4", optional = true }
 textwrap = { version = "0.16", optional = true }
 time = { version = "0.3", default-features = false, features = [

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -36,7 +36,6 @@ rtt = ["dep:kmp"]
 cli = [
     "gdb-server",
 
-    "dep:log",
     "dep:byte-unit",
     "dep:capstone",
     "dep:cargo_metadata",
@@ -155,7 +154,6 @@ indicatif = { version = "0.17", optional = true }
 insta = { version = "1", features = ["yaml", "filters"] }
 is-terminal = { version = "0.4", optional = true }
 itm = { version = "0.9.0-rc.1", default-features = false, optional = true }
-log = { version = "0.4", optional = true }
 parse_int = { version = "0.6", optional = true }
 pretty_env_logger = { workspace = true, optional = true }
 rand = { version = "0.8", optional = true }

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -8,6 +8,8 @@ use probe_rs::WireProtocol;
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, time::Duration};
 
+use crate::util::logging::LevelFilter;
+
 use super::rttui::channel::ChannelConfig;
 
 /// A struct which holds all configs.
@@ -68,7 +70,7 @@ pub struct Reset {
 pub struct General {
     pub chip: Option<String>,
     pub chip_descriptions: Vec<String>,
-    pub log_level: log::LevelFilter,
+    pub log_level: Option<LevelFilter>,
     pub derives: Option<String>,
     /// Use this flag to assert the nreset & ntrst pins during attaching the probe to the chip.
     pub connect_under_reset: bool,

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -28,6 +28,7 @@ use time::{OffsetDateTime, UtcOffset};
 
 use self::rttui::channel::DataFormat;
 use crate::util::common_options::{OperationError, ProbeOptions};
+use crate::util::logging::setup_logging;
 use crate::util::{build_artifact, common_options::CargoOptions, logging};
 
 #[derive(Debug, clap::Parser)]
@@ -58,8 +59,8 @@ pub fn main(args: Vec<OsString>) {
     let offset = match UtcOffset::current_local_offset() {
         Ok(offset) => offset,
         Err(e) => {
-            log::debug!("Error getting local offset: {e}");
-            log::warn!("Unable to determine local time. All timestamps will be in UTC.");
+            tracing::debug!("Error getting local offset: {e}");
+            tracing::warn!("Unable to determine local time. All timestamps will be in UTC.");
             UtcOffset::UTC
         }
     };
@@ -125,9 +126,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
     let configs = config::Configs::new(work_dir.clone());
     let config = configs.select_defined(config_name)?;
 
-    if config.general.log_level != log::LevelFilter::Off {
-        logging::init(config.general.log_level.to_level());
-    }
+    let _log_guard = setup_logging(None, config.general.log_level);
 
     // Make sure we load the config given in the cli parameters.
     for cdp in &config.general.chip_descriptions {
@@ -179,10 +178,10 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
             }),
             (vid, pid) => {
                 if vid.is_some() {
-                    log::warn!("USB VID ignored, because PID is not specified.");
+                    tracing::warn!("USB VID ignored, because PID is not specified.");
                 }
                 if pid.is_some() {
-                    log::warn!("USB PID ignored, because VID is not specified.");
+                    tracing::warn!("USB PID ignored, because VID is not specified.");
                 }
                 None
             }
@@ -220,12 +219,12 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
             source,
             connect_under_reset,
         }) => {
-            log::info!("The target seems to be unable to be attached to.");
+            tracing::info!("The target seems to be unable to be attached to.");
             if !connect_under_reset {
-                log::info!(
+                tracing::info!(
                     "A hard reset during attaching might help. This will reset the entire chip."
                 );
-                log::info!("Set `general.connect_under_reset` in your cargo-embed configuration file to enable this feature.");
+                tracing::info!("Set `general.connect_under_reset` in your cargo-embed configuration file to enable this feature.");
             }
             return Err(source).context("failed attaching to target");
         }
@@ -291,7 +290,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
             .any(|elem| elem.format == DataFormat::Defmt);
 
         let defmt_state = if defmt_enable {
-            log::debug!(
+            tracing::debug!(
                 "Found RTT channels with format = defmt, trying to intialize defmt parsing."
             );
             DefmtInformation::try_read_from_elf(path)?
@@ -315,7 +314,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
         // Configure rtt channels according to configuration
         rtt_config(session.clone(), &config, &mut rtt)?;
 
-        log::info!("RTT initialized.");
+        tracing::info!("RTT initialized.");
 
         // Check if the terminal supports x
 
@@ -410,7 +409,7 @@ fn rtt_config(
         if let Some(mode) = specific_mode.or(default_up_mode) {
             // Only set the mode when the config file says to,
             // when not set explicitly, the firmware picks.
-            log::debug!("Setting RTT channel {} to {:?}", up_channel.number(), &mode);
+            tracing::debug!("Setting RTT channel {} to {:?}", up_channel.number(), &mode);
             up_channel.set_mode(&mut core, mode)?;
         }
     }
@@ -437,12 +436,14 @@ impl DefmtInformation {
                 let locs = table.get_locations(&elf)?;
 
                 if !table.is_empty() && locs.is_empty() {
-                    log::warn!("Insufficient DWARF info; compile your program with `debug = 2` to enable location info.");
+                    tracing::warn!("Insufficient DWARF info; compile your program with `debug = 2` to enable location info.");
                     None
                 } else if table.indices().all(|idx| locs.contains_key(&(idx as u64))) {
                     Some(locs)
                 } else {
-                    log::warn!("Location info is incomplete; it will be omitted from the output.");
+                    tracing::warn!(
+                        "Location info is incomplete; it will be omitted from the output."
+                    );
                     None
                 }
             };
@@ -451,7 +452,7 @@ impl DefmtInformation {
                 location_information: locs,
             })
         } else {
-            log::error!("Defmt enabled in rtt channel config, but defmt table couldn't be loaded from binary.");
+            tracing::error!("Defmt enabled in rtt channel config, but defmt table couldn't be loaded from binary.");
             None
         };
 
@@ -472,7 +473,7 @@ fn rtt_attach(
     let mut last_error = None;
 
     while t.elapsed() < timeout {
-        log::info!("Initializing RTT (attempt {})...", rtt_init_attempt);
+        tracing::info!("Initializing RTT (attempt {})...", rtt_init_attempt);
         rtt_init_attempt += 1;
 
         // Lock the session mutex in a block, so it gets dropped as soon as possible.
@@ -489,7 +490,7 @@ fn rtt_attach(
             }
         }
 
-        log::debug!("Failed to initialize RTT. Retrying until timeout.");
+        tracing::debug!("Failed to initialize RTT. Retrying until timeout.");
         std::thread::sleep(Duration::from_millis(10));
     }
 

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -188,8 +188,14 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
         }
     };
 
+    let chip = opt
+        .chip
+        .as_ref()
+        .or(config.general.chip.as_ref())
+        .map(|chip| chip.into());
+
     let probe_options = ProbeOptions {
-        chip: opt.chip,
+        chip,
         chip_description_path: None,
         protocol: Some(config.probe.protocol),
         probe_selector: selector,

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -528,7 +528,7 @@ fn flash(
         session,
         path,
         &download_options,
-        &probe_options,
+        probe_options,
         loader,
         config.flashing.do_chip_erase,
     )?;

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -138,7 +138,7 @@ impl<'defmt> App<'defmt> {
                 match std::fs::create_dir_all(&config.rtt.log_path) {
                     Ok(_) => Some(config.rtt.log_path.clone()),
                     Err(_) => {
-                        log::warn!("Could not create log directory");
+                        tracing::warn!("Could not create log directory");
                         None
                     }
                 }
@@ -169,7 +169,9 @@ impl<'defmt> App<'defmt> {
             }
         }
 
-        log::warn!("No RTT header info was present in the ELF file. Does your firmware run RTT?");
+        tracing::warn!(
+            "No RTT header info was present in the ELF file. Does your firmware run RTT?"
+        );
         None
     }
 
@@ -375,7 +377,9 @@ impl<'defmt> App<'defmt> {
                 _ => false,
             },
             Err(RecvTimeoutError::Disconnected) => {
-                log::warn!("Unable to receive anymore input events from terminal, shutting down.");
+                tracing::warn!(
+                    "Unable to receive anymore input events from terminal, shutting down."
+                );
                 true
             }
             // Timeout just means no input received.

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
@@ -192,7 +192,7 @@ impl<'defmt> ChannelState<'defmt> {
             match channel.read(core, self.rtt_buffer.0.as_mut()) {
                 Ok(count) => count,
                 Err(err) => {
-                    log::error!("\nError reading from RTT: {}", err);
+                    tracing::error!("\nError reading from RTT: {}", err);
                     return Ok(());
                 }
             }

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
@@ -289,7 +289,7 @@ fn generate_flash_error_hints(
                     // Check if the chip specification was unique
                     let matching_chips = probe_rs::config::search_chips(target_spec).unwrap();
 
-                    log::info!(
+                    tracing::info!(
                         "Searching for all chips for spec '{}', found {}",
                         target_spec,
                         matching_chips.len()

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -8,6 +8,7 @@ use std::{path::PathBuf, process};
 
 use crate::util::common_options::{CargoOptions, FlashOptions, OperationError};
 use crate::util::flash;
+use crate::util::logging::setup_logging;
 use clap::{CommandFactory, FromArgMatches};
 
 use crate::util::{build_artifact, logging};
@@ -51,7 +52,7 @@ fn main_try(mut args: Vec<OsString>, lister: &Lister) -> Result<(), OperationErr
     };
 
     // Initialize the logger with the loglevel given on the commandline.
-    logging::init(opt.log);
+    let _log_guard = setup_logging(None, opt.log);
 
     // Get the current working dir. Make sure we have a proper default if it cannot be determined.
     let work_dir = opt.work_dir.clone().unwrap_or_else(|| PathBuf::from("."));
@@ -63,7 +64,7 @@ fn main_try(mut args: Vec<OsString>, lister: &Lister) -> Result<(), OperationErr
             path: work_dir.clone(),
         }
     })?;
-    log::debug!("Changed working directory to {}", work_dir.display());
+    tracing::debug!("Changed working directory to {}", work_dir.display());
 
     // Get the path to the binary we want to flash.
     // This can either be give from the arguments or can be a cargo build artifact.

--- a/probe-rs/src/bin/probe-rs/cmd/info.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/info.rs
@@ -82,7 +82,7 @@ fn try_show_info(
     let mut probe = probe;
 
     if probe.has_arm_interface() {
-        log::debug!("Trying to show ARM chip information");
+        tracing::debug!("Trying to show ARM chip information");
         match probe.try_into_arm_interface() {
             Ok(interface) => {
                 match interface.initialize(DefaultArmSequence::create()) {
@@ -111,7 +111,7 @@ fn try_show_info(
     }
 
     if probe.has_riscv_interface() {
-        log::debug!("Trying to show RISC-V chip information");
+        tracing::debug!("Trying to show RISC-V chip information");
         match probe.try_into_riscv_interface() {
             Ok(mut interface) => {
                 if let Err(e) = show_riscv_info(&mut interface) {
@@ -132,7 +132,7 @@ fn try_show_info(
     }
 
     if probe.has_xtensa_interface() {
-        log::debug!("Trying to show Xtensa chip information");
+        tracing::debug!("Trying to show Xtensa chip information");
         match probe.try_into_xtensa_interface() {
             Ok(mut interface) => {
                 if let Err(e) = show_xtensa_info(&mut interface) {

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -231,7 +231,7 @@ fn run_loop(
 /// Prints the stacktrace of the current execution state.
 fn print_stacktrace(core: &mut impl CoreInterface, path: &Path) -> Result<(), anyhow::Error> {
     let Some(debug_info) = DebugInfo::from_file(path).ok() else {
-        log::error!("No debug info found.");
+        tracing::error!("No debug info found.");
         return Ok(());
     };
     let initial_registers = DebugRegisters::from_core(core);
@@ -326,10 +326,10 @@ fn attach_to_rtt(
             log_format,
         ) {
             Ok(target_rtt) => return target_rtt,
-            Err(error) => log::debug!("{:?} RTT attach error", error),
+            Err(error) => tracing::debug!("{:?} RTT attach error", error),
         }
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
-    log::error!("Failed to attach to RTT continuing...");
+    tracing::error!("Failed to attach to RTT continuing...");
     None
 }

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -284,7 +284,7 @@ fn main() -> Result<()> {
 
     let _logger_guard = setup_logging(log_path.as_deref(), None);
 
-    let result = match matches.subcommand {
+    match matches.subcommand {
         Subcommand::DapServer { .. } => unreachable!(), // handled above.
         Subcommand::List(cmd) => cmd.run(&lister),
         Subcommand::Info(cmd) => cmd.run(&lister),
@@ -302,7 +302,5 @@ fn main() -> Result<()> {
         Subcommand::Profile(cmd) => cmd.run(&lister),
         Subcommand::Read(cmd) => cmd.run(&lister),
         Subcommand::Write(cmd) => cmd.run(&lister),
-    };
-
-    result
+    }
 }

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -57,7 +57,7 @@ pub struct FlashOptions {
     pub reset_halt: bool,
     /// Use this flag to set the log level.
     ///
-    /// Default is `error`. Possible choices are [error, warning, info, debug, trace].
+    /// Default is `warn`. Possible choices are [error, warn, info, debug, trace].
     #[arg(value_name = "level", long)]
     pub log: Option<LevelFilter>,
     /// The path to the file to be flashed.

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -35,7 +35,10 @@ use super::ArtifactError;
 
 use std::{fs::File, path::Path, path::PathBuf};
 
-use crate::{cmd::dap_server::DebuggerError, util::parse_u64};
+use crate::{
+    cmd::dap_server::DebuggerError,
+    util::{logging::LevelFilter, parse_u64},
+};
 use clap;
 use probe_rs::{
     config::{RegistryError, TargetSelector},
@@ -54,9 +57,9 @@ pub struct FlashOptions {
     pub reset_halt: bool,
     /// Use this flag to set the log level.
     ///
-    /// Default is `warning`. Possible choices are [error, warning, info, debug, trace].
+    /// Default is `error`. Possible choices are [error, warning, info, debug, trace].
     #[arg(value_name = "level", long)]
-    pub log: Option<log::Level>,
+    pub log: Option<LevelFilter>,
     /// The path to the file to be flashed.
     #[arg(value_name = "path", long)]
     pub path: Option<PathBuf>,
@@ -281,7 +284,7 @@ impl LoadedProbeOptions {
             let protocol_speed = probe.speed_khz();
             if let Some(speed) = self.0.speed {
                 if protocol_speed < speed {
-                    log::warn!(
+                    tracing::warn!(
                         "Unable to use specified speed of {} kHz, actual speed used is {} kHz",
                         speed,
                         protocol_speed
@@ -289,7 +292,7 @@ impl LoadedProbeOptions {
                 }
             }
 
-            log::info!("Protocol speed {} kHz", protocol_speed);
+            tracing::info!("Protocol speed {} kHz", protocol_speed);
         }
 
         Ok(probe)

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -57,6 +57,7 @@ pub struct FlashOptions {
     pub reset_halt: bool,
     /// Use this flag to set the log level.
     ///
+    /// Configurable via the `RUST_LOG` environment variable.
     /// Default is `warn`. Possible choices are [error, warn, info, debug, trace].
     #[arg(value_name = "level", long)]
     pub log: Option<LevelFilter>,

--- a/probe-rs/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs/src/bin/probe-rs/util/flash.rs
@@ -5,7 +5,7 @@ use super::logging;
 
 use std::fs::File;
 use std::time::Duration;
-use std::{path::Path, sync::Arc, time::Instant};
+use std::{path::Path, time::Instant};
 
 use colored::Colorize;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
@@ -48,6 +48,8 @@ pub fn run_flash_download(
     if !download_options.disable_progressbars {
         // Create progress bars.
         let multi_progress = MultiProgress::new();
+        logging::set_progress_bar(multi_progress.clone());
+
         let style = ProgressStyle::default_bar()
                     .tick_chars("⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈✔")
                     .progress_chars("--")
@@ -64,10 +66,7 @@ pub fn run_flash_download(
         };
 
         // Create a new progress bar for the erase progress.
-        let erase_progress = Arc::new(multi_progress.add(ProgressBar::new(0)));
-        {
-            logging::set_progress_bar(erase_progress.clone());
-        }
+        let erase_progress = multi_progress.add(ProgressBar::new(0));
         erase_progress.set_style(style.clone());
         erase_progress.set_message("      Erasing");
 
@@ -153,6 +152,9 @@ pub fn run_flash_download(
             target_spec: probe_options.chip(),
             path: path.to_path_buf(),
         })?;
+
+    // If we don't do this, the progress bars disappear.
+    logging::clear_progress_bar();
 
     // Stop timer.
     let elapsed = instant.elapsed();

--- a/probe-rs/src/bin/probe-rs/util/logging.rs
+++ b/probe-rs/src/bin/probe-rs/util/logging.rs
@@ -1,18 +1,14 @@
-use indicatif::ProgressBar;
+use indicatif::MultiProgress;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::{
-    fs::File,
-    path::Path,
-    sync::{Arc, RwLock},
-};
+use std::{fs::File, path::Path, sync::RwLock};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
     fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
 };
 
 /// Stores the progress bar for the logging facility.
-static PROGRESS_BAR: Lazy<RwLock<Option<Arc<ProgressBar>>>> = Lazy::new(|| RwLock::new(None));
+static PROGRESS_BAR: Lazy<RwLock<Option<MultiProgress>>> = Lazy::new(|| RwLock::new(None));
 
 pub struct FileLoggerGuard<'a> {
     _append_guard: WorkerGuard,
@@ -62,14 +58,41 @@ impl LevelFilter {
     }
 }
 
+// A custom writer that delegates to indicatif's printing when available.
+struct ProgressBarWriter;
+
+impl std::io::Write for ProgressBarWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let out_str = String::from_utf8_lossy(buf);
+
+        // Extra line endings look wrong, so strip them. We can't just trim all, because that would
+        // also remove intentional newlines, too.
+        let out_str = if let Some(str) = out_str.strip_suffix("\r\n") {
+            str
+        } else if let Some(str) = out_str.strip_suffix("\n") {
+            str
+        } else {
+            out_str.as_ref()
+        };
+
+        eprintln(out_str);
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 pub fn setup_logging(
     log_path: Option<&Path>,
     default: Option<LevelFilter>,
 ) -> anyhow::Result<Option<FileLoggerGuard<'_>>> {
-    // TODO: we need out own layer to play nice with indicatif
     let stdout_subscriber = tracing_subscriber::fmt::layer()
         .compact()
         .without_time()
+        .with_writer(|| ProgressBarWriter)
         .with_filter(
             EnvFilter::builder()
                 .with_default_directive(default.unwrap_or(LevelFilter::Error).into_tracing().into())
@@ -107,7 +130,7 @@ pub fn setup_logging(
 }
 
 /// Sets the currently displayed progress bar of the CLI.
-pub fn set_progress_bar(progress: Arc<ProgressBar>) {
+pub fn set_progress_bar(progress: MultiProgress) {
     let mut guard = PROGRESS_BAR.write().unwrap();
     *guard = Some(progress);
 }
@@ -123,7 +146,9 @@ pub fn clear_progress_bar() {
 pub fn eprintln(message: impl AsRef<str>) {
     if let Ok(guard) = PROGRESS_BAR.try_write() {
         match guard.as_ref() {
-            Some(pb) if !pb.is_finished() => pb.println(message.as_ref()),
+            Some(pb) => {
+                let _ = pb.println(message.as_ref());
+            }
             _ => eprintln!("{}", message.as_ref()),
         }
     } else {
@@ -136,7 +161,9 @@ pub fn eprintln(message: impl AsRef<str>) {
 pub fn println(message: impl AsRef<str>) {
     if let Ok(guard) = PROGRESS_BAR.try_write() {
         match guard.as_ref() {
-            Some(pb) if !pb.is_finished() => pb.println(message.as_ref()),
+            Some(pb) => {
+                let _ = pb.println(message.as_ref());
+            }
             _ => println!("{}", message.as_ref()),
         }
     } else {

--- a/probe-rs/src/bin/probe-rs/util/logging.rs
+++ b/probe-rs/src/bin/probe-rs/util/logging.rs
@@ -69,7 +69,7 @@ impl std::io::Write for ProgressBarWriter {
         // also remove intentional newlines, too.
         let out_str = if let Some(str) = out_str.strip_suffix("\r\n") {
             str
-        } else if let Some(str) = out_str.strip_suffix("\n") {
+        } else if let Some(str) = out_str.strip_suffix('\n') {
             str
         } else {
             out_str.as_ref()

--- a/probe-rs/src/bin/probe-rs/util/mod.rs
+++ b/probe-rs/src/bin/probe-rs/util/mod.rs
@@ -73,7 +73,7 @@ pub fn build_artifact(work_dir: &Path, args: &[String]) -> Result<Artifact, Arti
 
     let cargo_executable = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
 
-    log::debug!(
+    tracing::debug!(
         "Running '{}' in directory {}",
         cargo_executable,
         work_dir.display()


### PR DESCRIPTION
This PR also fixes a regression introduced in #2083 that ignored the chip in `Embed.toml`