### PR TITLE
Fix j-link speed config

### DIFF
--- a/changelog/fixed-jlink-speed.md
+++ b/changelog/fixed-jlink-speed.md
@@ -1,0 +1,1 @@
+Fixed `--speed` being ignored by J-Links


### PR DESCRIPTION
J-Links like to reset speed when their interface changes. This PR a) reduces the number of interface changes and b) restores speed on interface change.