### PR TITLE
Use WARN as the default log level

### DIFF
--- a/probe-rs/src/bin/probe-rs/util/logging.rs
+++ b/probe-rs/src/bin/probe-rs/util/logging.rs
@@ -107,9 +107,9 @@ pub fn setup_logging(
                     .parse_lossy("")
             }
             None => {
-                // No default, use RUST_LOG or fall back to ERROR.
+                // No default, use RUST_LOG or fall back to WARN.
                 EnvFilter::builder()
-                    .with_default_directive(tracing::level_filters::LevelFilter::ERROR.into())
+                    .with_default_directive(tracing::level_filters::LevelFilter::WARN.into())
                     .from_env_lossy()
             }
         });


### PR DESCRIPTION
I hope this time `cargo flash` really does default to WARN. `None`-ing missing clap arguments has its downsides...

I'm still not happy with it. `cargo embed` defines its default in `default.toml` even though the config type is `Option<LevelFilter>`. If we would remove the option, however, it would hurt discoverability as I believe that file is the template for the documentation.