### PR TITLE
Rename the arm_jtag module to arm_debug_interface

### DIFF
--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -68,6 +68,7 @@ pub trait DpAccess {
 }
 
 impl<T: DapAccess> DpAccess for T {
+    #[tracing::instrument(skip(self))]
     fn read_dp_register<R: DpRegister>(&mut self, dp: DpAddress) -> Result<R, ArmError> {
         tracing::debug!("Reading DP register {}", R::NAME);
         let result = self.read_raw_dp_register(dp, R::ADDRESS)?;
@@ -75,6 +76,7 @@ impl<T: DapAccess> DpAccess for T {
         Ok(result.try_into()?)
     }
 
+    #[tracing::instrument(skip(self))]
     fn write_dp_register<R: DpRegister>(
         &mut self,
         dp: DpAddress,

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -1,5 +1,5 @@
 //! Probe drivers
-pub(crate) mod arm_jtag;
+pub(crate) mod arm_debug_interface;
 pub(crate) mod common;
 pub(crate) mod usb_util;
 

--- a/probe-rs/src/probe/arm_debug_interface.rs
+++ b/probe-rs/src/probe/arm_debug_interface.rs
@@ -1,4 +1,8 @@
-//! Generic implementation of the SWD and JTAG protocols.
+//! Implementation of the ARM Debug Interface
+//!
+//! This module implements functions to work with chips implementing the ARM Debug version v5.
+//!
+//! See <https://developer.arm.com/documentation/ihi0031/f/?lang=en> for the ADIv5 specification.
 
 use bitvec::{prelude::*, view::BitView};
 

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         xtensa::communication_interface::XtensaCommunicationInterface,
     },
     probe::{
-        arm_jtag::{ProbeStatistics, RawProtocolIo, SwdSettings},
+        arm_debug_interface::{ProbeStatistics, RawProtocolIo, SwdSettings},
         common::{JtagDriverState, RawJtagIo},
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, JTAGAccess,
         ProbeCreationError, ProbeFactory, ScanChainElement, WireProtocol,

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -46,7 +46,7 @@ use crate::{
         riscv::communication_interface::RiscvCommunicationInterface,
     },
     probe::{
-        arm_jtag::{ProbeStatistics, RawProtocolIo, SwdSettings},
+        arm_debug_interface::{ProbeStatistics, RawProtocolIo, SwdSettings},
         DebugProbe, DebugProbeError, DebugProbeInfo, DebugProbeSelector, WireProtocol,
     },
 };


### PR DESCRIPTION
The module is not JTAG specific, it also contains SWD related functions.

The log is really confusing when it always talks about arm_jtag, even though you're using SWD...