### PR TITLE
WIP towards more flexible jtag debug module chain handling.

### DIFF
--- a/probe-rs-target/src/chip.rs
+++ b/probe-rs-target/src/chip.rs
@@ -153,7 +153,8 @@ pub struct ArmCoreAccessOptions {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RiscvCoreAccessOptions {
     /// The hart id
-    pub hart_id: Option<u32>,
+    #[serde(default)]
+    pub hart_id: u32,
 }
 
 /// The data required to access an Xtensa core

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -106,7 +106,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
                     name: "core".to_owned(),
                     core_type: CoreType::Riscv,
                     core_access_options: CoreAccessOptions::Riscv(RiscvCoreAccessOptions {
-                        hart_id: None,
+                        hart_id: 0,
                     }),
                 }],
                 memory_map: vec![],

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -165,11 +165,7 @@ impl CombinedCoreState {
                 self.id,
                 name,
                 memory_regions,
-                crate::architecture::riscv::Riscv32::new(
-                    options.hart_id.unwrap_or_default(),
-                    interface,
-                    s,
-                )?,
+                crate::architecture::riscv::Riscv32::new(options.clone(), interface, s)?,
             ),
             _ => {
                 return Err(Error::UnableToOpenProbe(

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -855,9 +855,13 @@ impl fmt::Display for DebugProbeSelector {
 pub trait JTAGAccess: DebugProbe {
     /// Returns `IDCODE` and `IR` length information about the devices on the JTAG chain.
     ///
-    /// If configured, this will use the data from [`DebugProbe::set_scan_chain`]. Otherwise, it
-    /// will try to measure and extract `IR` lengths by driving the JTAG interface.
-    fn scan_chain(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError>;
+    /// This function will measure the length of the instruction registers of all devices on the
+    /// JTAG chain. If configured, the it will use the data from [`DebugProbe::set_scan_chain`] to
+    /// check that the IR lengths are as expected.
+    fn scan_chain(&mut self) -> Result<&'_ [JtagChainItem], DebugProbeError>;
+
+    /// Selects a TAP on the JTAG chain.
+    fn select_target(&mut self, target: usize) -> Result<(), DebugProbeError>;
 
     /// Read a JTAG register.
     ///

--- a/probe-rs/src/probe/arm_debug_interface.rs
+++ b/probe-rs/src/probe/arm_debug_interface.rs
@@ -1527,7 +1527,11 @@ mod test {
     }
 
     impl JTAGAccess for MockJaylink {
-        fn scan_chain(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
+        fn scan_chain(&mut self) -> Result<&[JtagChainItem], DebugProbeError> {
+            todo!()
+        }
+
+        fn select_target(&mut self, _target: usize) -> Result<(), DebugProbeError> {
             todo!()
         }
 

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -379,7 +379,9 @@ pub(crate) struct JtagDriverState {
     // The maximum IR address
     pub max_ir_address: u32,
     pub expected_scan_chain: Option<Vec<ScanChainElement>>,
+    pub chain: Vec<JtagChainItem>,
     pub chain_params: ChainParams,
+    pub target_tap: usize,
     /// Idle cycles necessary between consecutive
     /// accesses to the DMI register
     pub jtag_idle_cycles: usize,
@@ -392,6 +394,8 @@ impl Default for JtagDriverState {
             current_ir_reg: 1,
             max_ir_address: 0x0F,
             expected_scan_chain: None,
+            chain: vec![],
+            target_tap: 0,
             chain_params: ChainParams::default(),
             jtag_idle_cycles: 0,
         }
@@ -449,28 +453,6 @@ pub(crate) trait RawJtagIo {
         let response = self.read_captured_bits()?;
 
         tracing::debug!("Response to reset: {}", response);
-
-        Ok(())
-    }
-
-    /// Configures the probe to address the given target.
-    fn select_target(
-        &mut self,
-        chain: &[JtagChainItem],
-        target: usize,
-    ) -> Result<(), DebugProbeError> {
-        let Some(params) = ChainParams::from_jtag_chain(chain, target) else {
-            return Err(DebugProbeError::TargetNotFound);
-        };
-
-        let max_ir_address = (1 << params.irlen) - 1;
-
-        tracing::debug!("Setting chain params: {:?}", params);
-        tracing::debug!("Setting max_ir_address to {}", max_ir_address);
-
-        let state = self.state_mut();
-        state.max_ir_address = max_ir_address;
-        state.chain_params = params;
 
         Ok(())
     }
@@ -630,7 +612,7 @@ fn prepare_write_register(
 }
 
 impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
-    fn scan_chain(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
+    fn scan_chain(&mut self) -> Result<&[JtagChainItem], DebugProbeError> {
         const MAX_CHAIN: usize = 8;
 
         self.reset_jtag_state_machine()?;
@@ -697,11 +679,18 @@ impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
 
         tracing::debug!("Detected IR lens: {:?}", ir_lens);
 
-        Ok(idcodes
+        self.state_mut().chain = idcodes
             .into_iter()
             .zip(ir_lens)
             .map(|(idcode, irlen)| JtagChainItem { irlen, idcode })
-            .collect())
+            .collect::<Vec<_>>();
+
+        let target_tap = self.state().target_tap;
+        // Force a reconfigure
+        self.state_mut().target_tap = target_tap + 1;
+        self.select_target(target_tap)?;
+
+        Ok(&self.state().chain)
     }
 
     fn set_idle_cycles(&mut self, idle_cycles: u8) {
@@ -783,6 +772,30 @@ impl<Probe: DebugProbe + RawJtagIo + 'static> JTAGAccess for Probe {
         }
 
         Ok(responses)
+    }
+
+    /// Configures the probe to address the given target.
+    fn select_target(&mut self, target: usize) -> Result<(), DebugProbeError> {
+        if target == self.state().target_tap {
+            return Ok(());
+        }
+
+        let Some(params) = ChainParams::from_jtag_chain(&self.state().chain, target) else {
+            return Err(DebugProbeError::TargetNotFound);
+        };
+
+        let max_ir_address = (1 << params.irlen) - 1;
+
+        tracing::debug!("Setting chain params: {:?}", params);
+        tracing::debug!("Setting max_ir_address to {}", max_ir_address);
+
+        let state = self.state_mut();
+        state.max_ir_address = max_ir_address;
+        state.chain_params = params;
+
+        state.target_tap = target;
+
+        Ok(())
     }
 }
 

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -122,14 +122,9 @@ impl DebugProbe for EspUsbJtag {
     fn attach(&mut self) -> Result<(), DebugProbeError> {
         tracing::debug!("Attaching to ESP USB JTAG");
 
-        let chain = self.scan_chain()?;
-        tracing::info!("Found {} TAPs on reset scan", chain.len());
+        self.scan_chain()?;
 
-        if chain.len() > 1 {
-            tracing::warn!("More than one TAP detected, defaulting to tap0");
-        }
-
-        self.select_target(&chain, 0)
+        Ok(())
     }
 
     fn detach(&mut self) -> Result<(), crate::Error> {

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -327,14 +327,9 @@ impl DebugProbe for FtdiProbe {
             .attach()
             .map_err(|e| DebugProbeError::ProbeSpecific(Box::new(e)))?;
 
-        let chain = self.scan_chain()?;
-        tracing::info!("Found {} TAPs on reset scan", chain.len());
+        self.scan_chain()?;
 
-        if chain.len() > 1 {
-            tracing::warn!("More than one TAP detected, defaulting to tap0");
-        }
-
-        self.select_target(&chain, 0)
+        Ok(())
     }
 
     fn detach(&mut self) -> Result<(), crate::Error> {

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -776,14 +776,7 @@ impl DebugProbe for JLink {
                 tracing::debug!("Resetting JTAG chain using trst");
                 self.reset_trst()?;
 
-                let chain = self.scan_chain()?;
-                tracing::info!("Found {} TAPs on reset scan", chain.len());
-
-                if chain.len() > 1 {
-                    tracing::warn!("More than one TAP detected, defaulting to tap0");
-                }
-
-                self.select_target(&chain, 0)?;
+                self.scan_chain()?;
             }
             WireProtocol::Swd => {
                 // Attaching is handled in sequence

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -385,8 +385,12 @@ impl DebugProbe for WchLink {
 
 /// Wrap WCH-Link's USB based DMI access as a fake JTAGAccess
 impl JTAGAccess for WchLink {
-    fn scan_chain(&mut self) -> Result<Vec<JtagChainItem>, DebugProbeError> {
-        Ok(vec![])
+    fn scan_chain(&mut self) -> Result<&[JtagChainItem], DebugProbeError> {
+        Ok(&[])
+    }
+
+    fn select_target(&mut self, _target: usize) -> Result<(), DebugProbeError> {
+        Ok(())
     }
 
     fn read_register(&mut self, address: u32, len: u32) -> Result<Vec<u8>, DebugProbeError> {

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -188,9 +188,7 @@ fn create_core(processor: &Processor) -> Result<ProbeCore> {
                 debug_base: None,
                 cti_base: None,
             }),
-            Architecture::Riscv => {
-                CoreAccessOptions::Riscv(RiscvCoreAccessOptions { hart_id: None })
-            }
+            Architecture::Riscv => CoreAccessOptions::Riscv(RiscvCoreAccessOptions { hart_id: 0 }),
             Architecture::Xtensa => CoreAccessOptions::Xtensa(XtensaCoreAccessOptions {}),
         },
     })


### PR DESCRIPTION
This PR currently does not come with functional changes, it just moves selection of tap 0 from probes to the common JTAG code, and extracts RISC-V hart selection into a single function. I'm planning on extending this select function to eventually select between JTAG TAPs but that is a hard enough task for me to want to postpone and wait for #2103 to land first.

What I think needs to be solved to push this forward:

Both the Xtensa and RISC-V comm interface does initialization on the implicitly selected first TAP/debug module. This is bad. Right now, the ESP32-P4's "main" debug module lives on the first TAP and we have no way to select that before initializing the comm interface. We would need to set up the interface when we know which core (and so, which debug module) we want to connect to, and select that as our target first.

Currently I believe we have a limitation where we can only work with a single architecture's interface at a time (i.e. I see no easy way to string an ARM and a RISC-V to the same chain and work with both in the same session), as that would need the probe object to be either available for multiple interfaces, or it would need to be re-attached similar to how `Session::core` attaches the interface to a core state on lookup. Not sure how this will turn out, to be honest. Not sure if I'm on the wrong track here or not.