### PR TITLE
Don't match partial chipname if we have an exact one

### DIFF
--- a/changelog/fixed-chipname-when-substring.md
+++ b/changelog/fixed-chipname-when-substring.md
@@ -1,0 +1,1 @@
+Fixed a regression that made it impossible to select a chip target that was a substring of another chip (eg cortex-m3 is a substring of cortex-m33)

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -197,7 +197,7 @@ impl Registry {
                     }
                 }
             }
-            if partial_matches.len() > 1 {
+            if exact_matches == 0 && partial_matches.len() > 1 {
                 tracing::warn!(
                     "Ignoring ambiguous matches for specified chip name {}",
                     name,


### PR DESCRIPTION
#1671 removed checking if we had an exact match for chip name before looking for partial chip names.
This broke all chips that are a substring of another chip.
It also removed a check for multiple exact matches, but I think that case is probably impossible as long as the registry doesn't have any duplicates.

Example:
```system
$ probe-rs read b32 0x0 1 --chip Cortex-M3
Error: The chip 'Cortex-M3' was not found in the database.

Caused by:
    Found multiple chips matching 'Cortex-M3', unable to select a single chip. (Cortex-M33, Cortex-M35P)
```

This doesn't need a changelog entry IMO.