### PR TITLE
Introduce esp-specific debug sequence trait

### DIFF
--- a/probe-rs/src/architecture/esp32/mod.rs
+++ b/probe-rs/src/architecture/esp32/mod.rs
@@ -1,0 +1,19 @@
+//! Common code for ESP32 chips.
+
+use espflash::flasher::FlashSize;
+
+use crate::Error;
+
+/// Debug sequences for various ESP32 chips.
+pub trait EspDebugSequence {
+    /// The communication interface required by the chip.
+    type Interface;
+
+    /// Detects the flash size of the target.
+    fn detect_flash_size(
+        &self,
+        _interface: &mut Self::Interface,
+    ) -> Result<Option<FlashSize>, Error> {
+        Ok(None)
+    }
+}

--- a/probe-rs/src/architecture/mod.rs
+++ b/probe-rs/src/architecture/mod.rs
@@ -1,5 +1,4 @@
-#![warn(missing_docs)]
-
 pub mod arm;
+pub mod esp32;
 pub mod riscv;
 pub mod xtensa;

--- a/probe-rs/src/architecture/riscv/sequences.rs
+++ b/probe-rs/src/architecture/riscv/sequences.rs
@@ -1,5 +1,7 @@
 //! Debug sequences to operate special requirements RISC-V targets.
 
+use crate::architecture::esp32::EspDebugSequence;
+
 use super::communication_interface::RiscvCommunicationInterface;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -13,12 +15,11 @@ pub trait RiscvDebugSequence: Send + Sync + Debug {
         Ok(())
     }
 
-    /// Detects the flash size of the target.
-    fn detect_flash_size(
+    /// Returns the ESP-specific debug sequences if available.
+    fn as_esp_sequence(
         &self,
-        _interface: &mut RiscvCommunicationInterface,
-    ) -> Result<Option<usize>, crate::Error> {
-        Ok(None)
+    ) -> Option<&dyn EspDebugSequence<Interface = RiscvCommunicationInterface>> {
+        None
     }
 }
 

--- a/probe-rs/src/architecture/xtensa/sequences.rs
+++ b/probe-rs/src/architecture/xtensa/sequences.rs
@@ -1,6 +1,8 @@
 use std::{fmt::Debug, sync::Arc};
 
-use crate::architecture::xtensa::communication_interface::XtensaCommunicationInterface;
+use crate::architecture::{
+    esp32::EspDebugSequence, xtensa::communication_interface::XtensaCommunicationInterface,
+};
 
 /// A interface to operate debug sequences for Xtensa targets.
 ///
@@ -14,12 +16,11 @@ pub trait XtensaDebugSequence: Send + Sync + Debug {
         Ok(())
     }
 
-    /// Detects the flash size of the target.
-    fn detect_flash_size(
+    /// Returns the ESP-specific debug sequences if available.
+    fn as_esp_sequence(
         &self,
-        _interface: &mut XtensaCommunicationInterface,
-    ) -> Result<Option<usize>, crate::Error> {
-        Ok(None)
+    ) -> Option<&dyn EspDebugSequence<Interface = XtensaCommunicationInterface>> {
+        None
     }
 }
 

--- a/probe-rs/src/config/sequences/esp32c2.rs
+++ b/probe-rs/src/config/sequences/esp32c2.rs
@@ -2,14 +2,18 @@
 
 use std::sync::Arc;
 
+use espflash::flasher::FlashSize;
 use probe_rs_target::Chip;
 
 use crate::{
-    architecture::riscv::{
-        communication_interface::RiscvCommunicationInterface, sequences::RiscvDebugSequence,
+    architecture::{
+        esp32::EspDebugSequence,
+        riscv::{
+            communication_interface::RiscvCommunicationInterface, sequences::RiscvDebugSequence,
+        },
     },
     config::sequences::esp::EspFlashSizeDetector,
-    MemoryInterface,
+    Error, MemoryInterface,
 };
 
 /// The debug sequence implementation for the ESP32C2.
@@ -54,10 +58,20 @@ impl RiscvDebugSequence for ESP32C2 {
         Ok(())
     }
 
+    fn as_esp_sequence(
+        &self,
+    ) -> Option<&dyn EspDebugSequence<Interface = RiscvCommunicationInterface>> {
+        Some(self)
+    }
+}
+
+impl EspDebugSequence for ESP32C2 {
+    type Interface = RiscvCommunicationInterface;
+
     fn detect_flash_size(
         &self,
         interface: &mut RiscvCommunicationInterface,
-    ) -> Result<Option<usize>, crate::Error> {
+    ) -> Result<Option<FlashSize>, Error> {
         self.inner.detect_flash_size_riscv(interface)
     }
 }

--- a/probe-rs/src/config/sequences/esp32c3.rs
+++ b/probe-rs/src/config/sequences/esp32c3.rs
@@ -2,14 +2,18 @@
 
 use std::sync::Arc;
 
+use espflash::flasher::FlashSize;
 use probe_rs_target::Chip;
 
 use crate::{
-    architecture::riscv::{
-        communication_interface::RiscvCommunicationInterface, sequences::RiscvDebugSequence,
+    architecture::{
+        esp32::EspDebugSequence,
+        riscv::{
+            communication_interface::RiscvCommunicationInterface, sequences::RiscvDebugSequence,
+        },
     },
     config::sequences::esp::EspFlashSizeDetector,
-    MemoryInterface,
+    Error, MemoryInterface,
 };
 
 /// The debug sequence implementation for the ESP32C3.
@@ -59,10 +63,20 @@ impl RiscvDebugSequence for ESP32C3 {
         Ok(())
     }
 
+    fn as_esp_sequence(
+        &self,
+    ) -> Option<&dyn EspDebugSequence<Interface = RiscvCommunicationInterface>> {
+        Some(self)
+    }
+}
+
+impl EspDebugSequence for ESP32C3 {
+    type Interface = RiscvCommunicationInterface;
+
     fn detect_flash_size(
         &self,
         interface: &mut RiscvCommunicationInterface,
-    ) -> Result<Option<usize>, crate::Error> {
+    ) -> Result<Option<FlashSize>, Error> {
         self.inner.detect_flash_size_riscv(interface)
     }
 }

--- a/probe-rs/src/config/sequences/esp32c6.rs
+++ b/probe-rs/src/config/sequences/esp32c6.rs
@@ -2,14 +2,18 @@
 
 use std::sync::Arc;
 
+use espflash::flasher::FlashSize;
 use probe_rs_target::Chip;
 
 use crate::{
-    architecture::riscv::{
-        communication_interface::RiscvCommunicationInterface, sequences::RiscvDebugSequence,
+    architecture::{
+        esp32::EspDebugSequence,
+        riscv::{
+            communication_interface::RiscvCommunicationInterface, sequences::RiscvDebugSequence,
+        },
     },
     config::sequences::esp::EspFlashSizeDetector,
-    MemoryInterface,
+    Error, MemoryInterface,
 };
 
 /// The debug sequence implementation for the ESP32C6.
@@ -59,10 +63,20 @@ impl RiscvDebugSequence for ESP32C6 {
         Ok(())
     }
 
+    fn as_esp_sequence(
+        &self,
+    ) -> Option<&dyn EspDebugSequence<Interface = RiscvCommunicationInterface>> {
+        Some(self)
+    }
+}
+
+impl EspDebugSequence for ESP32C6 {
+    type Interface = RiscvCommunicationInterface;
+
     fn detect_flash_size(
         &self,
         interface: &mut RiscvCommunicationInterface,
-    ) -> Result<Option<usize>, crate::Error> {
+    ) -> Result<Option<FlashSize>, Error> {
         self.inner.detect_flash_size_riscv(interface)
     }
 }

--- a/probe-rs/src/config/sequences/esp32h2.rs
+++ b/probe-rs/src/config/sequences/esp32h2.rs
@@ -2,14 +2,18 @@
 
 use std::sync::Arc;
 
+use espflash::flasher::FlashSize;
 use probe_rs_target::Chip;
 
 use crate::{
-    architecture::riscv::{
-        communication_interface::RiscvCommunicationInterface, sequences::RiscvDebugSequence,
+    architecture::{
+        esp32::EspDebugSequence,
+        riscv::{
+            communication_interface::RiscvCommunicationInterface, sequences::RiscvDebugSequence,
+        },
     },
     config::sequences::esp::EspFlashSizeDetector,
-    MemoryInterface,
+    Error, MemoryInterface,
 };
 
 /// The debug sequence implementation for the ESP32H2.
@@ -59,10 +63,20 @@ impl RiscvDebugSequence for ESP32H2 {
         Ok(())
     }
 
+    fn as_esp_sequence(
+        &self,
+    ) -> Option<&dyn EspDebugSequence<Interface = RiscvCommunicationInterface>> {
+        Some(self)
+    }
+}
+
+impl EspDebugSequence for ESP32H2 {
+    type Interface = RiscvCommunicationInterface;
+
     fn detect_flash_size(
         &self,
         interface: &mut RiscvCommunicationInterface,
-    ) -> Result<Option<usize>, crate::Error> {
+    ) -> Result<Option<FlashSize>, Error> {
         self.inner.detect_flash_size_riscv(interface)
     }
 }

--- a/probe-rs/src/config/sequences/esp32s2.rs
+++ b/probe-rs/src/config/sequences/esp32s2.rs
@@ -2,14 +2,18 @@
 
 use std::sync::Arc;
 
+use espflash::flasher::FlashSize;
 use probe_rs_target::Chip;
 
 use crate::{
-    architecture::xtensa::{
-        communication_interface::XtensaCommunicationInterface, sequences::XtensaDebugSequence,
+    architecture::{
+        esp32::EspDebugSequence,
+        xtensa::{
+            communication_interface::XtensaCommunicationInterface, sequences::XtensaDebugSequence,
+        },
     },
     config::sequences::esp::EspFlashSizeDetector,
-    MemoryInterface,
+    Error, MemoryInterface,
 };
 
 /// The debug sequence implementation for the ESP32-S2.
@@ -63,10 +67,20 @@ impl XtensaDebugSequence for ESP32S2 {
         Ok(())
     }
 
+    fn as_esp_sequence(
+        &self,
+    ) -> Option<&dyn EspDebugSequence<Interface = XtensaCommunicationInterface>> {
+        Some(self)
+    }
+}
+
+impl EspDebugSequence for ESP32S2 {
+    type Interface = XtensaCommunicationInterface;
+
     fn detect_flash_size(
         &self,
         interface: &mut XtensaCommunicationInterface,
-    ) -> Result<Option<usize>, crate::Error> {
+    ) -> Result<Option<FlashSize>, Error> {
         self.inner.detect_flash_size_xtensa(interface)
     }
 }

--- a/probe-rs/src/config/sequences/esp32s3.rs
+++ b/probe-rs/src/config/sequences/esp32s3.rs
@@ -2,14 +2,18 @@
 
 use std::sync::Arc;
 
+use espflash::flasher::FlashSize;
 use probe_rs_target::Chip;
 
 use crate::{
-    architecture::xtensa::{
-        communication_interface::XtensaCommunicationInterface, sequences::XtensaDebugSequence,
+    architecture::{
+        esp32::EspDebugSequence,
+        xtensa::{
+            communication_interface::XtensaCommunicationInterface, sequences::XtensaDebugSequence,
+        },
     },
     config::sequences::esp::EspFlashSizeDetector,
-    MemoryInterface,
+    Error, MemoryInterface,
 };
 
 /// The debug sequence implementation for the ESP32-S3.
@@ -63,10 +67,20 @@ impl XtensaDebugSequence for ESP32S3 {
         Ok(())
     }
 
+    fn as_esp_sequence(
+        &self,
+    ) -> Option<&dyn EspDebugSequence<Interface = XtensaCommunicationInterface>> {
+        Some(self)
+    }
+}
+
+impl EspDebugSequence for ESP32S3 {
+    type Interface = XtensaCommunicationInterface;
+
     fn detect_flash_size(
         &self,
         interface: &mut XtensaCommunicationInterface,
-    ) -> Result<Option<usize>, crate::Error> {
+    ) -> Result<Option<FlashSize>, Error> {
         self.inner.detect_flash_size_xtensa(interface)
     }
 }


### PR DESCRIPTION
This PR extracts the ESP32-specific `detect_flash_size` operation of architecture-specific DebugSequence traits. Because we now know the sequence is ESP-specific, we can simplify the loader and avoid roundtrip conversion (after updating espflash).

This PR allows us adding [new debug sequences](https://github.com/probe-rs/probe-rs/pull/2115/commits/1feeb1d3823e93959c58b8d5572ee43064c410f3) without bloating the API surface of the other traits.