### PR TITLE
Cargo Embed: publish channel data over optional tcp socket

### DIFF
--- a/changelog/added-cargo-embed-rtt-channel-socket.md
+++ b/changelog/added-cargo-embed-rtt-channel-socket.md
@@ -1,1 +1,1 @@
-Added support to `Cargo Embed` for publishing raw RTT data for specific channels on a tcp socket.
+Added support to `cargo embed` for publishing raw RTT data for specific channels on a tcp socket.

--- a/changelog/added-cargo-embed-rtt-channel-socket.md
+++ b/changelog/added-cargo-embed-rtt-channel-socket.md
@@ -1,0 +1,1 @@
+Added support to `Cargo Embed` for publishing raw RTT data for specific channels on a tcp socket.

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -63,7 +63,7 @@ enabled = false
 #              String - Directly show output from the target
 #              Defmt  - Format output on the host, see https://defmt.ferrous-systems.com/
 #              BinaryLE - Display as raw hex
-# socket   (Optional) - Server socket address (for optional external frontend or endpoint).
+# socket   (Optional, up channel only) - Server socket address (for optional external frontend or endpoint).
 channels = [
     # { up = 0, down = 0, name = "name", up_mode = "BlockIfFull", format = "Defmt" },
     # { up = 1, down = 0, name = "name", up_mode = "BlockIfFull", format = "String", socket = "127.0.0.1:12345" },

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -60,11 +60,13 @@ enabled = false
 # name     (Optional) - String to be displayed in the RTTUI tab
 # up_mode  (Optional) - RTT channel specific as described above
 # format   (Required) - How to interpret data from target firmware.  One of:
-#              String - Directly show output from the target 
+#              String - Directly show output from the target
 #              Defmt  - Format output on the host, see https://defmt.ferrous-systems.com/
 #              BinaryLE - Display as raw hex
+# socket   (Optional) - Server socket address (for optional external frontend or endpoint).
 channels = [
     # { up = 0, down = 0, name = "name", up_mode = "BlockIfFull", format = "Defmt" },
+    # { up = 1, down = 0, name = "name", up_mode = "BlockIfFull", format = "String", socket = "127.0.0.1:12345" },
 ]
 # The duration in ms for which the logger should retry to attach to RTT.
 timeout = 3000

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -85,7 +85,7 @@ impl<'defmt> App<'defmt> {
                         .and_then(|down| pull_channel(&mut down_channels, down)),
                     channel.name.clone(),
                     data,
-                    channel.socket.clone(),
+                    channel.socket,
                 ))
             }
         } else {

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -85,6 +85,7 @@ impl<'defmt> App<'defmt> {
                         .and_then(|down| pull_channel(&mut down_channels, down)),
                     channel.name.clone(),
                     data,
+                    channel.socket.clone(),
                 ))
             }
         } else {
@@ -99,6 +100,7 @@ impl<'defmt> App<'defmt> {
                     pull_channel(&mut down_channels, number),
                     None,
                     ChannelData::new_string(config.rtt.show_timestamps),
+                    None,
                 ));
             }
 
@@ -108,6 +110,7 @@ impl<'defmt> App<'defmt> {
                     Some(channel),
                     None,
                     ChannelData::new_string(config.rtt.show_timestamps),
+                    None,
                 ));
             }
         }

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
@@ -133,11 +133,7 @@ impl<'defmt> ChannelState<'defmt> {
             })
             .unwrap_or_else(|| "Unnamed channel".to_owned());
 
-        let tcp_socket = if let Some(tcp_address) = tcp_socket {
-            Some(TcpPublisher::new(tcp_address))
-        } else {
-            None
-        };
+        let tcp_socket = tcp_socket.map(TcpPublisher::new);
 
         Self {
             up_channel,

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::net::SocketAddr;
 
 use defmt_decoder::StreamDecoder;
 use probe_rs::rtt::{ChannelMode, DownChannel, UpChannel};
@@ -23,7 +24,7 @@ pub struct ChannelConfig {
     pub name: Option<String>,
     pub up_mode: Option<ChannelMode>,
     pub format: DataFormat,
-    pub socket: Option<String>,
+    pub socket: Option<SocketAddr>,
 }
 
 pub enum ChannelData<'defmt> {
@@ -122,7 +123,7 @@ impl<'defmt> ChannelState<'defmt> {
         down_channel: Option<DownChannel>,
         name: Option<String>,
         data: ChannelData<'defmt>,
-        tcp_socket: Option<String>,
+        tcp_socket: Option<SocketAddr>,
     ) -> Self {
         let name = name
             .or_else(|| up_channel.as_ref().and_then(|up| up.name().map(Into::into)))

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
@@ -6,6 +6,7 @@ use probe_rs::Core;
 use time::UtcOffset;
 use time::{macros::format_description, OffsetDateTime};
 
+use crate::cmd::cargo_embed::rttui::tcp::TcpPublisher;
 use crate::cmd::cargo_embed::DefmtInformation;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -22,6 +23,7 @@ pub struct ChannelConfig {
     pub name: Option<String>,
     pub up_mode: Option<ChannelMode>,
     pub format: DataFormat,
+    pub socket: Option<String>,
 }
 
 pub enum ChannelData<'defmt> {
@@ -111,6 +113,7 @@ pub struct ChannelState<'defmt> {
     input: String,
     scroll_offset: usize,
     rtt_buffer: RttBuffer,
+    tcp_socket: Option<TcpPublisher>,
 }
 
 impl<'defmt> ChannelState<'defmt> {
@@ -119,6 +122,7 @@ impl<'defmt> ChannelState<'defmt> {
         down_channel: Option<DownChannel>,
         name: Option<String>,
         data: ChannelData<'defmt>,
+        tcp_socket: Option<String>,
     ) -> Self {
         let name = name
             .or_else(|| up_channel.as_ref().and_then(|up| up.name().map(Into::into)))
@@ -129,6 +133,12 @@ impl<'defmt> ChannelState<'defmt> {
             })
             .unwrap_or_else(|| "Unnamed channel".to_owned());
 
+        let tcp_socket = if let Some(tcp_address) = tcp_socket {
+            Some(TcpPublisher::new(tcp_address))
+        } else {
+            None
+        };
+
         Self {
             up_channel,
             down_channel,
@@ -137,6 +147,7 @@ impl<'defmt> ChannelState<'defmt> {
             scroll_offset: 0,
             rtt_buffer: RttBuffer([0u8; 1024]),
             data,
+            tcp_socket,
         }
     }
 
@@ -214,6 +225,11 @@ impl<'defmt> ChannelState<'defmt> {
 
                 // First, convert the incoming bytes to UTF8.
                 let mut incoming = String::from_utf8_lossy(&self.rtt_buffer.0[..count]).to_string();
+
+                // Send incoming data over the TCP stream if we have one.
+                if let Some(stream) = &mut self.tcp_socket {
+                    stream.send(incoming.as_bytes());
+                }
 
                 // Then pop the last stored line from our line buffer if possible and append our new line.
                 if !*last_line_done {

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/mod.rs
@@ -1,3 +1,4 @@
 pub mod app;
 pub mod channel;
 pub mod event;
+pub mod tcp;

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tcp.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tcp.rs
@@ -1,14 +1,14 @@
 use std::io::Write;
-use std::net::TcpStream;
+use std::net::{SocketAddr, TcpStream};
 
 #[derive(Debug)]
 pub struct TcpPublisher {
-    pub address: String,
+    pub address: SocketAddr,
     pub socket: Option<TcpStream>,
 }
 
 impl TcpPublisher {
-    pub fn new(address: impl Into<String>) -> Self {
+    pub fn new(address: SocketAddr) -> Self {
         Self {
             address: address.into(),
             socket: None,

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tcp.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tcp.rs
@@ -1,0 +1,33 @@
+use std::io::Write;
+use std::net::TcpStream;
+
+#[derive(Debug)]
+pub struct TcpPublisher {
+    pub address: String,
+    pub socket: Option<TcpStream>,
+}
+
+impl TcpPublisher {
+    pub fn new(address: impl Into<String>) -> Self {
+        Self {
+            address: address.into(),
+            socket: None,
+        }
+    }
+
+    pub fn send(&mut self, bytes: &[u8]) {
+        if self.socket.is_none() {
+            // Try to connect if there is no socket
+            if let Ok(stream) = TcpStream::connect(self.address.clone()) {
+                self.socket = Some(stream);
+            }
+        }
+
+        if let Some(socket) = self.socket.as_mut() {
+            if socket.write(bytes).is_err() {
+                // Discard socket on error. Try reconnect next time.
+                self.socket = None;
+            }
+        }
+    }
+}

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tcp.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tcp.rs
@@ -10,7 +10,7 @@ pub struct TcpPublisher {
 impl TcpPublisher {
     pub fn new(address: SocketAddr) -> Self {
         Self {
-            address: address.into(),
+            address,
             socket: None,
         }
     }
@@ -18,7 +18,7 @@ impl TcpPublisher {
     pub fn send(&mut self, bytes: &[u8]) {
         if self.socket.is_none() {
             // Try to connect if there is no socket
-            if let Ok(stream) = TcpStream::connect(self.address.clone()) {
+            if let Ok(stream) = TcpStream::connect(self.address) {
                 self.socket = Some(stream);
             }
         }


### PR DESCRIPTION
This PR adds the option to send raw RTT data over a TCP Socket. This enables you to receive the data in some external frontend for e.g. plotting or specific processing.

This can be configured via a new 'socket' option in the `ChannelConfig` of Cargo Embed. 

The socket automatically connects if a listener (server) is available on the configured address. It also tries to reconnect automatically after an error. This means the transmission can be lossy.

Let me know if I put everything in the right location / use the correct naming.