### PR TITLE
Introcude `displaydoc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "git+https://github.com/bugadani/displaydoc.git?branch=core#f9dc8d05bc50f7dc26696a0f44c602cf1105c116"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "dissimilar"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2541,6 +2551,7 @@ dependencies = [
  "crossterm",
  "defmt-decoder",
  "directories",
+ "displaydoc",
  "dunce",
  "enum-primitive-derive",
  "esp-idf-part",

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -79,6 +79,7 @@ base64 = "0.21"
 bincode = "1.3"
 bitfield = "0.14"
 bitvec = "1"
+displaydoc = { version ="0.2", git = "https://github.com/bugadani/displaydoc.git", branch = "core" }
 enum-primitive-derive = "0.3"
 gimli = { version = "0.28", default-features = false, features = [
     "endian-reader",

--- a/probe-rs/src/architecture/arm/ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/mod.rs
@@ -19,39 +19,35 @@ use super::{
 };
 
 /// Some error during AP handling occurred.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, displaydoc::Display, thiserror::Error)]
 pub enum AccessPortError {
-    /// An error occurred when trying to read a register.
-    #[error("Failed to read register {name} at address 0x{address:08x}")]
+    /// Failed to read register {name} at address 0x{address:08x}.
     RegisterRead {
         /// The address of the register.
         address: u8,
         /// The name if the register.
         name: &'static str,
         /// The underlying root error of this access error.
-        #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
-    /// An error occurred when trying to write a register.
-    #[error("Failed to write register {name} at address 0x{address:08x}")]
+
+    /// Failed to write register {name} at address 0x{address:08x}.
     RegisterWrite {
         /// The address of the register.
         address: u8,
         /// The name if the register.
         name: &'static str,
         /// The underlying root error of this access error.
-        #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
-    /// Some error with the operation of the APs DP occurred.
-    #[error("Error while communicating with debug port")]
+
+    /// Error while communicating with debug port.
     DebugPort(#[from] DebugPortError),
-    /// An error occurred when trying to flush batched writes of to the AP.
-    #[error("Failed to flush batched writes")]
+
+    /// Failed to flush batched writes.
     Flush(#[from] DebugProbeError),
 
-    /// Error while parsing a register
-    #[error("Error parsing a register")]
+    /// Error parsing a register.
     RegisterParse(#[from] RegisterParseError),
 }
 

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -27,22 +27,17 @@ use std::{
 
 /// An error in the communication with an access port or
 /// debug port.
-#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq, Copy)]
+#[derive(Debug, displaydoc::Display, thiserror::Error, Clone, PartialEq, Eq, Copy)]
 pub enum DapError {
-    /// An error occurred during SWD communication.
-    #[error("An error occurred in the SWD communication between probe and device.")]
+    /// "An error occurred in the SWD communication between probe and device.
     SwdProtocol,
-    /// The target device did not respond to the request.
-    #[error("Target device did not respond to request.")]
+    /// "Target device did not respond to request.
     NoAcknowledge,
-    /// The target device responded with a FAULT response to the request.
-    #[error("Target device responded with a FAULT response to the request.")]
+    /// "Target device responded with a FAULT response to the request.
     FaultResponse,
-    /// Target device responded with a WAIT response to the request.
-    #[error("Target device responded with a WAIT response to the request.")]
+    /// "Target device responded with a WAIT response to the request.
     WaitResponse,
-    /// The parity bit on the read request was incorrect.
-    #[error("Incorrect parity on READ request.")]
+    /// "Incorrect parity on READ request.
     IncorrectParity,
 }
 

--- a/probe-rs/src/architecture/arm/component/mod.rs
+++ b/probe-rs/src/architecture/arm/component/mod.rs
@@ -41,14 +41,6 @@ pub enum TraceSink {
     TraceMemory,
 }
 
-/// An error when operating a core ROM table component occurred.
-#[derive(thiserror::Error, Debug)]
-pub enum ComponentError {
-    /// Nordic chips do not support setting all TPIU clocks. Try choosing another clock speed.
-    #[error("Nordic does not support TPIU CLK value of {0}")]
-    NordicUnsupportedTPUICLKValue(u32),
-}
-
 /// A trait to be implemented on memory mapped register types for debug component interfaces.
 pub trait DebugComponentInterface:
     MemoryMappedRegister<u32> + Clone + From<u32> + Into<u32> + Sized + std::fmt::Debug

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -34,18 +34,15 @@ use std::{
 };
 
 /// Errors for the ARMv7-A state machine
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, displaydoc::Display, Debug)]
 pub enum Armv7aError {
-    /// Invalid register number
-    #[error("Register number {0} is not valid for ARMv7-A")]
+    /// Register number {0} is not valid for ARMv7-A.
     InvalidRegisterNumber(u16),
 
-    /// Not halted
-    #[error("Core is running but operation requires it to be halted")]
+    /// Core is running but operation requires it to be halted.
     NotHalted,
 
-    /// Data Abort occurred
-    #[error("A data abort occurred")]
+    /// A data abort occurred.
     DataAbort,
 }
 

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -28,18 +28,15 @@ use std::{
 };
 
 /// Errors for the ARMv8-A state machine
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, displaydoc::Display, Debug)]
 pub enum Armv8aError {
-    /// Invalid register number
-    #[error("Register number {0} is not valid for ARMv8-A in {1}-bit mode")]
+    /// Register number {0} is not valid for ARMv8-A in {1}-bit mode.
     InvalidRegisterNumber(u16, u16),
 
-    /// Not halted
-    #[error("Core is running but operation requires it to be halted")]
+    /// Core is running but operation requires it to be halted.
     NotHalted,
 
-    /// Data Abort occurred
-    #[error("A data abort occurred")]
+    /// A data abort occurred.
     DataAbort,
 }
 

--- a/probe-rs/src/architecture/arm/dp/mod.rs
+++ b/probe-rs/src/architecture/arm/dp/mod.rs
@@ -13,37 +13,32 @@ use crate::probe::DebugProbeError;
 use std::fmt::Display;
 
 /// An error occurred when interacting with the debug port.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, displaydoc::Display, Debug)]
 pub enum DebugPortError {
-    /// The accessed register is not supported on this debug port.
-    #[error("Register {register} not supported by debug port version {version}")]
+    /// Register {register} is not supported by debug port version {version}.
     UnsupportedRegister {
         /// The name of the register that was accessed.
         register: &'static str,
         /// The version of the operated debug port.
         version: DebugPortVersion,
     },
-    /// Error parsing a register value.
-    #[error("Error parsing register value.")]
+
+    /// Error parsing register value.
     RegisterParse(#[from] RegisterParseError),
-    /// An error with operating the debug probe occurred.
-    #[error("A Debug Probe Error occurred")]
+
+    /// A Debug Probe Error occurred
     DebugProbe(#[from] DebugProbeError),
 
-    /// A timeout occurred.
-    #[error("Timeout occurred")]
+    /// Timeout occurred
     Timeout,
 
-    /// Powerup of the target device failed.
-    #[error("Target power-up failed.")]
+    /// Target power-up failed.
     TargetPowerUpFailed,
 
-    /// The debug port is not supported.
-    #[error("Debug port not supported: {0}")]
+    /// Debug port not supported: {0}
     Unsupported(String),
 
     /// An error occurred in the communication with an access port or debug port.
-    #[error("An error occurred in the communication with an access port or debug port.")]
     Dap(#[from] DapError),
 }
 /// A typed interface to be implemented on drivers that can control a debug port.

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -6,23 +6,28 @@ use enum_primitive_derive::Primitive;
 use num_traits::cast::FromPrimitive;
 
 /// An error to report any errors that are romtable discovery specific.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, displaydoc::Display, Debug)]
 pub enum RomTableError {
-    #[error("Component is not a valid romtable")]
+    /// Component is not a valid romtable.
     NotARomtable,
-    #[error("An error with the access port occurred during runtime")]
+
+    /// An error with the access port occurred during runtime.
     AccessPort(
         #[from]
         #[source]
         AccessPortError,
     ),
-    #[error("The CoreSight Component could not be identified")]
+
+    /// The CoreSight Component could not be identified.
     CSComponentIdentification,
-    #[error("Could not access romtable")]
+
+    /// Could not access romtable.
     Memory(#[source] Box<ArmError>),
-    #[error("The requested component '{0}' was not found")]
+
+    /// The requested component '{0}' was not found.
     ComponentNotFound(PeripheralType),
-    #[error("There are no components to operate on")]
+
+    /// There are no components to operate on.
     NoComponents,
 }
 

--- a/probe-rs/src/architecture/arm/mod.rs
+++ b/probe-rs/src/architecture/arm/mod.rs
@@ -28,23 +28,18 @@ pub use swo::{SwoAccess, SwoConfig, SwoMode, SwoReader};
 pub use traits::*;
 
 /// ARM-specific errors
-#[derive(Debug, thiserror::Error)]
-#[error("An ARM specific error occurred.")]
+#[derive(Debug, displaydoc::Display, thiserror::Error)]
+#[ignore_extra_doc_attributes]
 pub enum ArmError {
-    /// The operation requires a specific architecture.
-    #[error("The operation requires one of the following architectures: {0:?}")]
+    /// The operation requires one of the following architectures: {0:?}
     ArchitectureRequired(&'static [&'static str]),
     /// A timeout occurred during an operation
-    #[error("Timeout occurred during operation.")]
     Timeout,
     /// The address is too large for the 32 bit address space.
-    #[error("Address is not in 32 bit address space.")]
     AddressOutOf32BitAddressSpace,
     /// The current target device is not an ARM device.
-    #[error("Target device is not an ARM device.")]
     NoArmTarget,
-    /// Error using a specific AP.
-    #[error("Error using access port")]
+    /// Error using access port {address:?}.
     AccessPort {
         /// Address of the access port
         address: ApAddress,
@@ -52,33 +47,27 @@ pub enum ArmError {
         source: AccessPortError,
     },
     /// An error occurred while using a debug port.
-    #[error("Error using a debug port.")]
     DebugPort(#[from] DebugPortError),
-    /// The core has to be halted for the operation, but was not.
-    #[error("The core needs to be halted for this operation but was not.")]
+    /// The core needs to be halted for this operation but was not.
     CoreNotHalted,
-    /// Performing certain operations (e.g device unlock or Chip-Erase) can leave the device in a state
-    /// that requires a probe re-attach to resolve.
-    #[error("Probe and device internal state mismatch. A probe re-attach is required")]
+    /// Probe and device internal state mismatch. A probe re-attach is required
     ReAttachRequired,
-    /// An operation was not performed because the required permissions were not given.
+    /// An operation could not be performed because it lacked the permission to do so: {0}
     ///
     /// This can for example happen when the core is locked and needs to be erased to be unlocked.
     /// Then the correct permission needs to be given to automatically unlock the core to prevent accidental erases.
-    #[error("An operation could not be performed because it lacked the permission to do so: {0}")]
     MissingPermissions(String),
 
     /// An error occurred in the communication with an access port or debug port.
-    #[error("An error occurred in the communication with an access port or debug port.")]
     Dap(#[from] DapError),
 
     /// The debug probe encountered an error.
-    #[error("The debug probe encountered an error.")]
     Probe(#[from] DebugProbeError),
 
+    /// Failed to access address 0x{address:08x} as it is not aligned to the requirement of {alignment} bytes for this platform and API call.
+    ///
     /// The given register address to perform an access on was not memory aligned.
     /// Make sure it is aligned to the size of the access (`address & access_size == 0`).
-    #[error("Failed to access address 0x{address:08x} as it is not aligned to the requirement of {alignment} bytes for this platform and API call.")]
     MemoryNotAligned {
         /// The address of the register.
         address: u64,
@@ -86,27 +75,24 @@ pub enum ArmError {
         alignment: usize,
     },
     /// A region outside of the AP address space was accessed.
-    #[error("Out of bounds access")]
     OutOfBounds,
-    /// The requested memory transfer width is not supported on the current core.
-    #[error("{0} bit is not a supported memory transfer width on the current core")]
+
+    /// {0} bit is not a supported memory transfer width on the current core.
     UnsupportedTransferWidth(usize),
 
-    /// The AP with the specified address does not exist.
-    #[error("The AP with address {0:?} does not exist.")]
+    /// The AP with address {0:?} does not exist.
     ApDoesNotExist(ApAddress),
 
     /// The AP has the wrong type for the operation.
     WrongApType,
 
-    /// It is not possible to create a breakpoint a the given address.
-    #[error("Unable to create a breakpoint at address {0:#010X}. Hardware breakpoints are only supported at addresses < 0x2000'0000.")]
+    /// Unable to create a breakpoint at address {0:#010X}. Hardware breakpoints are only supported at addresses < 0x2000'0000.
     UnsupportedBreakpointAddress(u32),
 
-    /// ARMv8a specific error occurred.
+    /// An ARMv8a specific error occurred.
     Armv8a(#[from] Armv8aError),
 
-    /// ARMv7a specific error occurred.
+    /// An ARMv7a specific error occurred.
     Armv7a(#[from] Armv7aError),
 
     /// Error occurred in a debug sequence.
@@ -124,8 +110,7 @@ pub enum ArmError {
     /// Failed to erase chip
     ChipEraseFailed,
 
-    /// The operation requires a specific extension.
-    #[error("The operation requires the following extension(s): {0:?}")]
+    /// The operation requires the following extension(s): {0:?}
     ExtensionRequired(&'static [&'static str]),
 
     /// Any other error occurred.

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -31,18 +31,15 @@ use super::{
 };
 
 /// An error occurred when executing an ARM debug sequence
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, displaydoc::Display, Debug)]
 pub enum ArmDebugSequenceError {
-    /// Debug base address is required but not specified
-    #[error("Core access requries debug_base to be specified, but it is not")]
+    /// Core access requries debug_base to be specified, but it is not.
     DebugBaseNotSpecified,
 
-    /// CTI base address is required but not specified
-    #[error("Core access requries cti_base to be specified, but it is not")]
+    /// Core access requries cti_base to be specified, but it is not.
     CtiBaseNotSpecified,
 
-    /// An error occurred in a debug sequence.
-    #[error("An error occurred in a debug sequnce: {0}")]
+    /// An error occurred in a debug sequnce.
     SequenceSpecific(#[from] Box<dyn Error + Send + Sync + 'static>),
 }
 

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -18,61 +18,43 @@ use std::{
 };
 
 /// Some error occurred when working with the RISC-V core.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, displaydoc::Display, Debug)]
 pub enum RiscvError {
     /// An error occurred during transport
-    #[error("Error during transport")]
     DtmOperationFailed,
-    /// DMI operation is in progress
-    #[error("Transport operation in progress")]
+    /// Transport operation in progress
     DtmOperationInProcess,
     /// An error with operating the debug probe occurred.
-    #[error("Debug Probe Error")]
     DebugProbe(#[from] DebugProbeError),
     /// A timeout occurred during DMI access.
-    #[error("Timeout during DMI access.")]
     Timeout,
-    /// An error occurred during the execution of an abstract command.
-    #[error("Error occurred during execution of an abstract command: {0:?}")]
+    /// Error occurred during execution of an abstract command: {0:?}.
     AbstractCommand(AbstractCommandErrorKind),
-    /// The request for reset, resume or halt was not acknowledged.
-    #[error("The core did not acknowledge a request for reset, resume or halt")]
+    /// The core did not acknowledge a request for reset, resume or halt.
     RequestNotAcknowledged,
-    /// This debug transport module (DTM) version is currently not supported.
-    #[error("The version '{0}' of the debug transport module (DTM) is currently not supported.")]
+    /// The version '{0}' of the debug transport module (DTM) is currently not supported.
     UnsupportedDebugTransportModuleVersion(u8),
-    /// This version of the debug module is not supported.
-    #[error("The version '{0:?}' of the debug module is currently not supported.")]
+    /// The version '{0:?}' of the debug module is currently not supported.
     UnsupportedDebugModuleVersion(DebugModuleVersion),
-    /// The provided csr address was invalid/unsupported
-    #[error("CSR at address '{0:x}' is unsupported.")]
+    /// CSR at address '{0:x}' is unsupported.
     UnsupportedCsrAddress(u16),
-    /// The given program buffer register is not supported.
-    #[error("Program buffer register '{0}' is currently not supported.")]
+    /// Program buffer register '{0}' is currently not supported.
     UnsupportedProgramBufferRegister(usize),
     /// The program buffer is too small for the supplied program.
-    #[error("Program buffer is too small for supplied program.")]
     ProgramBufferTooSmall,
     /// Memory width larger than 32 bits is not supported yet.
-    #[error("Memory width larger than 32 bits is not supported yet.")]
     UnsupportedBusAccessWidth(RiscvBusAccess),
-    /// An error during system bus access occurred.
-    #[error("Error using system bus")]
+    /// An error occurred during accessing the system bus.
     SystemBusAccess,
-    /// The given trigger type is not available for the address breakpoint.
-    #[error("Unexpected trigger type {0} for address breakpoint.")]
+    /// Unexpected trigger type {0} for address breakpoint.
     UnexpectedTriggerType(u32),
     /// The connected target is not a RISC-V device.
-    #[error("Connected target is not a RISC-V device.")]
     NoRiscvTarget,
     /// The target does not support halt after reset.
-    #[error("The target does not support halt after reset.")]
     ResetHaltRequestNotSupported,
-    /// The result index of a batched command is not available.
-    #[error("The requested data is not available due to a previous error.")]
+    /// The requested data is not available due to a previous error.
     BatchedResultNotAvailable,
-    /// The hart is unavailable
-    #[error("The requested hart is unavailable.")]
+    /// The requested hart is unavailable.
     HartUnavailable,
 }
 
@@ -115,17 +97,15 @@ pub enum AbstractCommandErrorKind {
 
 impl AbstractCommandErrorKind {
     fn parse(value: u8) -> Self {
-        use AbstractCommandErrorKind::*;
-
         match value {
-            0 => None,
-            1 => Busy,
-            2 => NotSupported,
-            3 => Exception,
-            4 => HaltResume,
-            5 => Bus,
-            6 => _Reserved,
-            7 => Other,
+            0 => Self::None,
+            1 => Self::Busy,
+            2 => Self::NotSupported,
+            3 => Self::Exception,
+            4 => Self::HaltResume,
+            5 => Self::Bus,
+            6 => Self::_Reserved,
+            7 => Self::Other,
             _ => panic!("cmderr is a 3 bit value, values higher than 7 should not occur."),
         }
     }

--- a/probe-rs/src/architecture/xtensa/communication_interface.rs
+++ b/probe-rs/src/architecture/xtensa/communication_interface.rs
@@ -16,26 +16,19 @@ use crate::{
 use super::xdm::{Error as XdmError, Xdm};
 
 /// Possible Xtensa errors
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, displaydoc::Display, Debug)]
 pub enum XtensaError {
-    /// An error originating from the DebugProbe
-    #[error("Debug Probe Error")]
+    /// An error with operating the debug probe occurred.
     DebugProbe(#[from] DebugProbeError),
     /// Xtensa debug module error
-    #[error("Xtensa debug module error")]
     XdmError(#[from] XdmError),
-    /// A timeout occurred
-    // TODO: maybe we could be a bit more specific
-    #[error("The operation has timed out")]
+    /// The operation has timed out.
     Timeout,
     /// The connected target is not an Xtensa device.
-    #[error("Connected target is not an Xtensa device.")]
     NoXtensaTarget,
     /// The requested register is not available.
-    #[error("The requested register is not available.")]
     RegisterNotAvailable,
-    /// The result index of a batched command is not available.
-    #[error("The requested data is not available due to a previous error.")]
+    /// The requested data is not available due to a previous error.
     BatchedResultNotAvailable,
 }
 

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -85,36 +85,36 @@ impl From<PowerDevice> for TapInstruction {
     }
 }
 
-#[derive(thiserror::Error, Debug, Copy, Clone)]
+#[derive(thiserror::Error, displaydoc::Display, Debug, Copy, Clone)]
 pub enum DebugRegisterError {
-    #[error("Register is busy")]
+    /// Register is busy.
     Busy,
 
-    #[error("Register-specific error")]
+    /// Register-specific error.
     Error,
 
-    #[error("Unexpected value")]
+    /// Read a register status that is neither Ok, Busy or Error. Maybe your device restarted unexpectedly?
     Unexpected,
 }
 
-#[derive(thiserror::Error, Debug, Clone, Copy)]
+#[derive(thiserror::Error, displaydoc::Display, Debug, Clone, Copy)]
 pub enum Error {
-    #[error("Error while accessing register")]
+    /// Error while accessing register.
     Xdm(#[from] DebugRegisterError),
 
-    #[error("ExecExeception")]
+    /// Instruction execution exeception.
     ExecExeception,
 
-    #[error("ExecBusy")]
+    /// Instruction execution busy.
     ExecBusy,
 
-    #[error("ExecOverrun")]
+    /// Instruction execution overrun.
     ExecOverrun,
 
-    #[error("Instruction ignored")]
+    /// Instruction ignored.
     InstructionIgnored,
 
-    #[error("XdmPoweredOff")]
+    /// The Xtensa Debug Module is powered off.
     XdmPoweredOff,
 }
 

--- a/probe-rs/src/bin/probe-rs/util/mod.rs
+++ b/probe-rs/src/bin/probe-rs/util/mod.rs
@@ -21,21 +21,24 @@ pub fn parse_u64(input: &str) -> Result<u64, ParseIntError> {
     parse_int::parse(input)
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, displaydoc::Display, Error)]
 pub enum ArtifactError {
-    #[error("Failed to canonicalize path '{work_dir}'.")]
+    /// Failed to canonicalize path '{work_dir}'.
     Canonicalize {
-        #[source]
         source: std::io::Error,
         work_dir: String,
     },
-    #[error("An IO error occurred during the execution of 'cargo build'.")]
+
+    /// An IO error occurred during the execution of 'cargo build'.
     Io(#[source] std::io::Error),
-    #[error("Failed to run cargo build: exit code = {0:?}.")]
+
+    /// Failed to run cargo build: exit code = {0:?}.
     CargoBuild(Option<i32>),
-    #[error("Multiple binary artifacts were found.")]
+
+    /// Multiple binary artifacts were found.
     MultipleArtifacts,
-    #[error("No binary artifacts were found.")]
+
+    /// No binary artifacts were found.
     NoArtifacts,
 }
 

--- a/probe-rs/src/config/sequences/nrf52.rs
+++ b/probe-rs/src/config/sequences/nrf52.rs
@@ -12,14 +12,12 @@ use crate::architecture::arm::{
 use crate::session::MissingPermissions;
 
 /// An error when operating a core ROM table component occurred.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, displaydoc::Display, Debug)]
 pub enum ComponentError {
-    /// Nordic chips do not support setting all TPIU clocks. Try choosing another clock speed.
-    #[error("Nordic does not support TPIU CLK value of {0}")]
+    /// Nordic chips do not support TPIU CLK value of {0}. Try choosing another clock speed.
     NordicUnsupportedTPUICLKValue(u32),
 
-    /// Nordic chips do not have an embedded trace buffer.
-    #[error("nRF52 devices do not have a trace buffer")]
+    /// nRF52 devices do not have a trace buffer.
     NordicNoTraceMem,
 }
 

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -448,19 +448,15 @@ impl MemoryInterface for CoreDump {
 }
 
 /// The overarching error type which contains all possible errors as variants.
-#[derive(thiserror::Error, Debug)]
+#[derive(displaydoc::Display, thiserror::Error, Debug)]
 pub enum CoreDumpError {
-    /// Opening the file for writing the core dump failed.
-    #[error("Opening {1} for writing the core dump failed.")]
+    /// Opening {1} for writing the core dump failed.
     CoreDumpFileWrite(std::io::Error, PathBuf),
-    /// Opening the file for reading the core dump failed.
-    #[error("Opening {1} for reading the core dump failed.")]
+    /// Opening {1} for reading the core dump failed.
     CoreDumpFileRead(std::io::Error, PathBuf),
     /// Encoding the coredump MessagePack failed.
-    #[error("Encoding the coredump MessagePack failed.")]
     EncodingCoreDump(rmp_serde::encode::Error),
     /// Decoding the coredump MessagePack failed.
-    #[error("Decoding the coredump MessagePack failed.")]
     DecodingCoreDump(rmp_serde::decode::Error),
 }
 

--- a/probe-rs/src/error.rs
+++ b/probe-rs/src/error.rs
@@ -7,57 +7,45 @@ use crate::config::RegistryError;
 use crate::probe::DebugProbeError;
 
 /// The overarching error type which contains all possible errors as variants.
-#[derive(thiserror::Error, Debug)]
+#[derive(displaydoc::Display, thiserror::Error, Debug)]
+#[ignore_extra_doc_attributes]
 pub enum Error {
-    /// An error in the probe driver occurred.
-    #[error("An error with the usage of the probe occurred")]
+    /// An error with the usage of the probe occurred.
     Probe(#[from] DebugProbeError),
     /// An ARM specific error occurred.
-    #[error("An ARM specific error occurred.")]
     Arm(#[source] ArmError),
     /// A RISC-V specific error occurred.
-    #[error("A RISC-V specific error occurred.")]
     Riscv(#[source] RiscvError),
     /// An Xtensa specific error occurred.
-    #[error("An Xtensa specific error occurred.")]
     Xtensa(#[source] XtensaError),
-    /// The probe could not be opened.
-    #[error("Probe could not be opened: {0}")]
+    /// Probe could not be opened: {0}.
     UnableToOpenProbe(&'static str),
-    /// The core with given ID does not exist.
-    #[error("Core {0} does not exist")]
+    /// Core {0} does not exist.
     CoreNotFound(usize),
-    /// The given chip does not exist.
-    #[error("Unable to load specification for chip")]
+    /// Unable to load specification for chip.
     ChipNotFound(#[from] RegistryError),
-    /// An operation was not performed because the required permissions were not given.
+    /// An operation could not be performed because it lacked the permission to do so: {0}
     ///
     /// This can for example happen when the core is locked and needs to be erased to be unlocked.
     /// Then the correct permission needs to be given to automatically unlock the core to prevent accidental erases.
-    #[error("An operation could not be performed because it lacked the permission to do so: {0}")]
     MissingPermissions(String),
-    /// An error that is not architecture specific occurred.
-    #[error("A generic core (not architecture specific) error occurred.")]
+    /// A generic core (not architecture specific) error occurred.
     GenericCoreError(String),
-    /// Errors related to the handling of core registers inside probe-rs .
-    #[error("Register error: {0}")]
+    /// Error during core register operation: {0}.
     Register(String),
-    /// The variant of the function you called is not yet implemented.
+    /// This capability has not yet been implemented for this architecture: {0}
+    ///
     /// Because of the large varieties of supported architectures, it is not always possible for
     /// a contributor to implement functionality for all of them. This allows us to
     /// implement new functionality on selected architectures first, and then add support for
     /// the other architectures later.
-    #[error("This capability has not yet been implemented for this architecture: {0}")]
     NotImplemented(&'static str),
-    /// Any other error occurred.
-    #[error(transparent)]
+    /// {0}
     Other(#[from] anyhow::Error),
     // TODO: Errors below should be core specific
-    /// A timeout occurred during an operation
-    #[error("A timeout occurred.")]
+    /// A timeout occurred during an operation.
     Timeout,
-    /// Unaligned memory access
-    #[error("Alignment error")]
+    /// Attempted to access memory at address {address:X?} with improper alignment. (Required alignment: {alignment})
     MemoryNotAligned {
         /// The address of the register.
         address: u64,

--- a/probe-rs/src/flashing/download.rs
+++ b/probe-rs/src/flashing/download.rs
@@ -68,38 +68,38 @@ impl FromStr for Format {
 ///
 /// This includes corrupt file issues,
 /// OS permission issues as well as chip connectivity and memory boundary issues.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, displaydoc::Display, thiserror::Error)]
+#[ignore_extra_doc_attributes]
 pub enum FileDownloadError {
-    /// An error with the actual flashing procedure has occurred.
+    /// An error occurred with the actual flashing procedure.
     ///
     /// This is mostly an error in the communication with the target inflicted by a bad hardware connection or a probe-rs bug.
-    #[error("Error while flashing")]
     Flash(#[from] FlashError),
-    /// Reading and decoding the IHEX file has failed due to the given error.
-    #[error("Could not read ihex format")]
+
+    /// Could not read ihex format.
     IhexRead(#[from] ihex::ReaderError),
+
     /// An IO error has occurred while reading the firmware file.
-    #[error("I/O error")]
     IO(#[from] std::io::Error),
-    /// The given error has occurred while reading the object file.
-    #[error("Object Error: {0}.")]
+
+    /// Error reading the object file: {0}.
     Object(&'static str),
-    /// Reading and decoding the given ELF file has resulted in the given error.
-    #[error("Could not read ELF file")]
+
+    /// Could not read ELF file.
     Elf(#[from] object::read::Error),
-    /// Espflash format error
-    #[error("Failed to format as esp-idf binary")]
+
+    /// Failed to format as esp-idf binary.
     Idf(#[from] espflash::error::Error),
-    /// The target doesn't support the esp-idf format
-    #[error("Target {0} does not support the esp-idf format")]
+
+    /// Target {0} does not support the esp-idf format.
     IdfUnsupported(String),
+
     /// No loadable segments were found in the ELF file.
     ///
     /// This is most likely because of a bad linker script.
-    #[error("No loadable ELF sections were found.")]
     NoLoadableSegments,
-    /// Some error returned by the flash size detection.
-    #[error("Could not determine flash size.")]
+
+    /// Could not determine flash size.
     FlashSizeDetection(#[from] crate::Error),
 }
 

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -3,12 +3,9 @@ use crate::error;
 use std::ops::Range;
 
 /// Describes any error that happened during the or in preparation for the flashing procedure.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, displaydoc::Display, Debug)]
 pub enum FlashError {
-    /// No flash memory contains the entire requested memory range.
-    #[error(
-        "No flash memory contains the entire requested memory range {start:#010x}..{end:#010x}."
-    )]
+    /// "No flash memory contains the entire requested memory range: {start:#010x}..{end:#010x}.
     NoSuitableNvm {
         /// The start of the requested memory range.
         start: u64,
@@ -17,14 +14,12 @@ pub enum FlashError {
         /// The source of this target description (was it a built in target or one loaded externally and from what file path?).
         description_source: TargetDescriptionSource,
     },
-    /// Erasing the full chip flash failed.
-    #[error("Failed to erase the whole chip.")]
+    /// Failed to erase the whole chip.
     ChipEraseFailed {
         /// The source error of this error.
         source: Box<dyn std::error::Error + 'static + Send + Sync>,
     },
-    /// Erasing the given flash sector failed.
-    #[error("Failed to erase flash sector at address {sector_address:#010x}.")]
+    /// Failed to erase flash sector at address {sector_address:#010x}.
     EraseFailed {
         /// The address of the sector that should have been erased.
         sector_address: u64,
@@ -32,8 +27,7 @@ pub enum FlashError {
         #[source]
         source: Box<dyn std::error::Error + 'static + Send + Sync>,
     },
-    /// Writing the given page failed.
-    #[error("The page write of the page at address {page_address:#010x} failed.")]
+    /// The page write of the page at address {page_address:#010x} failed.
     PageWrite {
         /// The address of the page that should have been written.
         page_address: u64,
@@ -41,57 +35,45 @@ pub enum FlashError {
         #[source]
         source: Box<dyn std::error::Error + 'static + Send + Sync>,
     },
-    /// Initializing the flash algorithm failed.
-    #[error("The initialization of the flash algorithm failed.")]
+    /// The initialization of the flash algorithm failed.
     Init(#[source] Box<dyn std::error::Error + 'static + Send + Sync>),
-    /// Uninizializing the flash algorithm failed.
-    #[error("The uninitialization of the flash algorithm failed.")]
+    /// The uninitialization of the flash algorithm failed.
     Uninit(#[source] Box<dyn std::error::Error + 'static + Send + Sync>),
-    /// This target does not support full chip flash erases.
-    #[error("The chip erase routine is not supported with the given flash algorithm.")]
+    /// The chip erase routine is not supported with the given flash algorithm.
     ChipEraseNotSupported,
-    /// Calling the given routine returned the given error code.
-    #[error("The execution of '{name}' failed with code {error_code}. This might indicate a problem with the flash algorithm.")]
+    /// The execution of '{name}' failed with code {error_code}. This might indicate a problem with the flash algorithm.
     RoutineCallFailed {
         /// The name of the routine that was called.
         name: &'static str,
         /// The error code the called routine returned.
         error_code: u32,
     },
-    /// The core entered an unexpected status while executing a flashing operation.
-    #[error("The core entered an unexpected status: {status:?}.")]
+    /// The core entered an unexpected status: {status:?}.
     UnexpectedCoreStatus {
         /// The status that the core entered.
         status: crate::CoreStatus,
     },
-    /// The given address was not contained in the given NVM region.
-    #[error("{address:#010x} is not contained in {region:?}")]
+    /// {address:#010x} is not contained in {region:?}.
     AddressNotInRegion {
         /// The address which was not contained in `region`.
         address: u32,
         /// The region which did not contain `address`.
         region: NvmRegion,
     },
-    /// An error occurred during the interaction with the core.
-    #[error("Something during the interaction with the core went wrong")]
+    /// Something during the interaction with the core went wrong.
     Core(#[from] error::Error),
-    /// The RAM contents did not match the flash algorithm.
-    #[error(
-        "The RAM contents did not match the expected contents after loading the flash algorithm."
-    )]
+    /// The RAM contents did not match the expected contents after loading the flash algorithm.
     FlashAlgorithmNotLoaded,
-    /// Failed to load the flash algorithm into RAM at given address. This can happen if there is not enough space.
-    ///
-    /// Check the algorithm code and settings before you try again.
-    #[error(
-        "Failed to load flash algorithm into RAM at address {address:08X?}. Is there space for the algorithm header?"
-    )]
+    /**
+     * Failed to load the flash algorithm into RAM at given address. This can happen if there is not enough space.
+     *
+     * Check the algorithm code and settings before you try again.
+     */
     InvalidFlashAlgorithmLoadAddress {
         /// The address where the algorithm was supposed to be loaded to.
         address: u64,
     },
-    /// The given page size is not valid. Only page sizes multiples of 4 bytes are allowed.
-    #[error("Invalid page size {size:08X?}. Must be a multiple of 4 bytes.")]
+    /// Invalid page size {size:08X?}. Must be a multiple of 4 bytes.
     InvalidPageSize {
         /// The size of the page in bytes.
         size: u32,
@@ -99,62 +81,56 @@ pub enum FlashError {
     // TODO: Warn at YAML parsing stage.
     // TODO: 1 Add information about flash (name, address)
     // TODO: 2 Add source of target definition (built-in, yaml)
-    /// No flash algorithm was linked to this target.
-    #[error("Trying to write flash, but no suitable (default) flash loader algorithm is linked to the given target: {name} .")]
+    /// Trying to write flash, but no suitable (default) flash loader algorithm is linked to the given target: {name}.
     NoFlashLoaderAlgorithmAttached {
         /// The name of the chip.
         name: String,
     },
-    /// More than one matching flash algorithm was found for the given memory range and all of them is marked as default.
-    #[error("Trying to write flash, but found more than one suitable flash loader algorithim marked as default for {region:?}.")]
+    /// Trying to write flash, but found more than one suitable flash loader algorithm marked as default for {region:?}.
     MultipleDefaultFlashLoaderAlgorithms {
         /// The region which matched more than one flash algorithm.
         region: NvmRegion,
     },
-    /// More than one matching flash algorithm was found for the given memory range and none of them is marked as default.
-    #[error("Trying to write flash, but found more than one suitable flash algorithims but none marked as default for {region:?}.")]
+    /// Trying to write flash, but found more than one suitable flash algorithms but none marked as default for {region:?}.
     MultipleFlashLoaderAlgorithmsNoDefault {
         /// The region which matched more than one flash algorithm.
         region: NvmRegion,
     },
     /// Flash content verification failed.
-    #[error("Flash content verification failed.")]
     Verify,
     // TODO: 1 Add source of target definition
     // TOOD: 2 Do this at target load time.
-    /// The given chip has no RAM defined.
-    #[error("No RAM defined for target: {name}.")]
+    /// No RAM defined for target: {name}.
     NoRamDefined {
         /// The name of the chip.
         name: String,
     },
-    /// The given flash algorithm did not have a length multiple of 4 bytes.
-    ///
-    /// This means that the flash algorithm that was loaded is broken.
-    #[error("Flash algorithm {name} does not have a length that is 4 byte aligned.")]
+    /**
+     * Flash algorithm {name} does not have a length that is 4 byte aligned.
+     *
+     * This means that the flash algorithm that was loaded is broken.
+     */
     InvalidFlashAlgorithmLength {
         /// The name of the flash algorithm.
         name: String,
         /// The source of the flash algorithm (was it a built in target or one loaded externally and from what file path?).
         algorithm_source: Option<TargetDescriptionSource>,
     },
-    /// Two blocks of data overlap each other which means the loaded binary is broken.
-    ///
-    /// Please check your data and try again.
-    #[error("Adding data for addresses {added_addresses:08X?} overlaps previously added data for addresses {existing_addresses:08X?}.")]
+    /**
+     * Adding data for addresses {added_addresses:08X?} overlaps previously added data for addresses {existing_addresses:08X?}.
+     *
+     * This means the loaded binary is broken. Please check your data and try again.
+     */
     DataOverlaps {
         /// The address range that was tried to be added.
         added_addresses: Range<u64>,
         /// The address range that was already present.
         existing_addresses: Range<u64>,
     },
-    /// No core can access this NVM region.
-    #[error("No core can access the NVM region {0:?}.")]
+    /// No core can access the NVM region {0:?}.
     NoNvmCoreAccess(NvmRegion),
-    /// No core can access this RAM region.
-    #[error("No core can access the ram region {0:?}.")]
+    /// No core can access the ram region {0:?}.
     NoRamCoreAccess(RamRegion),
-    /// The register value supplied for this flash algorithm is out of the supported range.
-    #[error("The register value {0:08X?} is out of the supported range.")]
+    /// The register value {0:08X?} is out of the supported range.
     RegisterValueNotSupported(u64),
 }

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -100,73 +100,66 @@ impl fmt::Display for BatchCommand {
 }
 
 /// This error occurs whenever the debug probe logic encounters an error while operating the relevant debug probe.
-#[derive(thiserror::Error, Debug)]
+#[derive(displaydoc::Display, thiserror::Error, Debug)]
+#[ignore_extra_doc_attributes]
 pub enum DebugProbeError {
-    /// Something with the USB communication went wrong.
-    #[error("USB Communication Error")]
+    /// USB communication error.
     Usb(#[source] std::io::Error),
-    /// The firmware of the probe is outdated. This error is especially prominent with ST-Links.
+    /// The firmware on the probe is outdated, and not supported by probe-rs.
+    ///
+    /// This error is especially prominent with ST-Links.
     /// You can use their official updater utility to update your probe firmware.
-    #[error("The firmware on the probe is outdated, and not supported by probe-rs.")]
     ProbeFirmwareOutdated,
-    /// An error which is specific to the debug probe in use occurred.
-    #[error("An error specific to a probe type occurred")]
+    /// An error specific to the probe occurred.
     ProbeSpecific(#[source] Box<dyn std::error::Error + Send + Sync>),
-    /// The debug probe handle could not be created as specified.
-    #[error("Probe could not be created")]
+    /// Probe could not be created.
     ProbeCouldNotBeCreated(#[from] ProbeCreationError),
-    /// The selected wire protocol is not supported with given probe.
-    #[error("Probe does not support {0}")]
+    /// Probe does not support {0}.
     UnsupportedProtocol(WireProtocol),
-    /// The selected probe does not support the selected interface.
+    /// The connected probe does not support the {0} interface.
+    ///
     /// This happens if a probe does not support certain functionality, such as:
     /// - ARM debugging
     /// - RISC-V debugging
     /// - SWO
-    #[error("The connected probe does not support the interface '{0}'")]
     InterfaceNotAvailable(&'static str),
-    /// Some interaction with the target registry failed.
+    /// An error occurred while working with the registry.
+    ///
     /// This happens when an invalid chip name is given for example.
-    #[error("An error occurred while working with the registry")]
     Registry(#[from] RegistryError),
-    /// The debug probe does not support the speed that was chosen.
-    /// Try to alter the selected speed.
-    #[error("The requested speed setting ({0} kHz) is not supported by the probe")]
+    /// The requested speed setting ({0} kHz) is not supported by the probe. Try to lower the selected speed.
     UnsupportedSpeed(u32),
+    /// You need to be attached to the target to perform this action.
+    ///
     /// The debug probe did not yet perform the init sequence.
     /// Try calling [`DebugProbe::attach`] before trying again.
-    #[error("You need to be attached to the target to perform this action")]
     NotAttached,
+    /// You need to be detached from the target to perform this action.
+    ///
     /// The debug probe already performed the init sequence.
     /// Try running the failing command before [`DebugProbe::attach`].
-    #[error("You need to be detached from the target to perform this action")]
     Attached,
-    /// Performing the init sequence on the target failed.
-    /// Check the wiring before continuing.
-    #[error("Failed to find the target or attach to the target")]
+    /// Failed to find the target or attach to the target. Check the wiring before continuing.
     TargetNotFound,
-    /// The variant of the function you called is not yet implemented.
+    /// Some functionality was not implemented yet: {0}.
+    ///
     /// This can happen if some debug probe has some unimplemented functionality for a specific protocol or architecture.
-    #[error("Some functionality was not implemented yet: {0}")]
     NotImplemented(&'static str),
-    /// The called debug sequence is not supported on given probe.
+    /// This debug sequence is not supported on the used probe: {0}.
+    ///
     /// This is most likely happening because you are using an ST-Link, which are severely limited in functionality.
     /// If possible, try using another probe.
-    #[error("This debug sequence is not supported on the used probe: {0}")]
     DebugSequenceNotSupported(&'static str),
-    /// An error occurred during the previously batched command.
-    #[error("Error in previous batched command")]
+    /// An error occurred during a previously batched command.
     BatchError(BatchCommand),
+    /// Command not supported by probe: {0}.
+    ///
     /// The used functionality is not supported by the selected probe.
     /// This can happen when a probe does not allow for setting speed manually for example.
-    #[error("Command not supported by probe: {0}")]
     CommandNotSupportedByProbe(&'static str),
-    /// Some other error occurred.
-    #[error(transparent)]
+    /// An uncategorized error occurred.
     Other(#[from] anyhow::Error),
-
     /// A timeout occurred during probe operation.
-    #[error("Timeout occurred during probe operation.")]
     Timeout,
 }
 
@@ -174,27 +167,22 @@ pub enum DebugProbeError {
 /// This is almost always a sign of a bad USB setup.
 /// Check UDEV rules if you are on Linux and try installing Zadig
 /// (This will disable vendor specific drivers for your probe!) if you are on Windows.
-#[derive(thiserror::Error, Debug)]
+#[derive(displaydoc::Display, thiserror::Error, Debug)]
+#[ignore_extra_doc_attributes]
 pub enum ProbeCreationError {
     /// The selected debug probe was not found.
+    ///
     /// This can be due to permissions.
-    #[error("Probe was not found.")]
     NotFound,
-    /// The selected probe USB device could not be opened.
-    /// Make sure you have all necessary permissions.
-    #[error("USB device could not be opened. Please check the permissions.")]
+    /// The selected probe USB device could not be opened. Make sure you have all necessary permissions.
     CouldNotOpen,
     /// Some error with HID API occurred.
-    #[error("{0}")]
     HidApi(#[from] hidapi::HidError),
     /// Some USB error occurred.
-    #[error("{0}")]
     Usb(std::io::Error),
     /// An error specific with the selected probe occurred.
-    #[error("An error specific to a probe type occurred: {0}")]
     ProbeSpecific(#[source] Box<dyn std::error::Error + Send + Sync>),
-    /// Something else happened.
-    #[error("{0}")]
+    /// An uncategorized error occurred: {0}.
     Other(&'static str),
 }
 
@@ -725,14 +713,12 @@ impl DebugProbeInfo {
 }
 
 /// An error which can occur while parsing a [`DebugProbeSelector`].
-#[derive(thiserror::Error, Debug)]
+#[derive(displaydoc::Display, thiserror::Error, Debug)]
 pub enum DebugProbeSelectorParseError {
-    /// The VID or PID is not a valid number.
-    #[error("The VID or PID could not be parsed: {0}")]
+    /// The VID or PID could not be parsed: {0}
     ParseInt(#[from] std::num::ParseIntError),
 
-    /// The format of the selector is invalid.
-    #[error("Please use a string in the form `VID:PID:<Serial>` where Serial is optional.")]
+    /// Please use a string in the form `VID:PID:<Serial>` where Serial is optional.
     Format,
 }
 

--- a/probe-rs/src/probe/cmsisdap/commands/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/mod.rs
@@ -12,56 +12,72 @@ use std::io::ErrorKind;
 use std::str::Utf8Error;
 use std::time::Duration;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, displaydoc::Display, thiserror::Error)]
 pub enum CmsisDapError {
-    #[error("Error handling CMSIS-DAP command {command_id:?}")]
+    /// Error handling CMSIS-DAP command {command_id:?}.
     Send {
         command_id: CommandId,
         source: SendError,
     },
-    #[error("CMSIS-DAP responded with an error")]
+
+    /// CMSIS-DAP responded with an error.
     ErrorResponse,
-    #[error("Too much data provided for SWJ Sequence command")]
+
+    /// Too much data provided for SWJ Sequence command.
     TooMuchData,
-    #[error("Requested SWO baud rate could not be configured")]
+
+    /// Requested SWO baud rate could not be configured.
     SwoBaudrateNotConfigured,
-    #[error("Probe reported an error while streaming SWO")]
+
+    /// Probe reported an error while streaming SWO.
     SwoTraceStreamError,
-    #[error("Requested SWO mode is not available on this probe")]
+
+    /// Requested SWO mode is not available on this probe.
     SwoModeNotAvailable,
-    #[error("USB Error reading SWO data.")]
+
+    /// USB Error reading SWO data.
     SwoReadError(#[source] std::io::Error),
-    #[error("Could not determine a suitable packet size for this probe")]
+
+    /// Could not determine a suitable packet size for this probe.
     NoPacketSize,
-    #[error("Invalid IDCODE detected")]
+
+    /// Invalid IDCODE detected.
     InvalidIdCode,
-    #[error("Error scanning IR lengths")]
+
+    /// Error scanning IR lengths.
     InvalidIR,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, displaydoc::Display, thiserror::Error)]
+#[ignore_extra_doc_attributes]
 pub enum SendError {
-    #[error("Error in the USB HID access")]
+    /// Error in the USB HID access
     HidApi(#[from] hidapi::HidError),
-    #[error("Error in the USB access")]
+
+    /// Error in the USB access
     UsbError(std::io::Error),
-    #[error("Not enough data in response from probe")]
+
+    /// Not enough data in response from probe
     NotEnoughData,
-    #[error("Status can only be 0x00 or 0xFF")]
+
+    /// Status can only be 0x00 or 0xFF
     InvalidResponseStatus,
-    #[error("Connecting to target failed, received: {0:x}")]
+
+    /// Connecting to target failed, received: {0:x}
     ConnectResponseError(u8),
-    #[error("Command ID in response (:#02x) does not match sent command ID")]
+
+    /// Command ID in response (:#02x) does not match sent command ID
     CommandIdMismatch(u8),
+
     /// String in response is not valid UTF-8.
     ///
-    /// Strings are required to be UTF-8 encoded by the
-    /// CMSIS-DAP specification.
-    #[error("String in response is not valid UTF-8.")]
+    /// Strings are required to be UTF-8 encoded by the CMSIS-DAP specification.
     InvalidString(#[from] Utf8Error),
-    #[error("Unexpected answer to command")]
+
+    /// Unexpected answer to command
     UnexpectedAnswer,
-    #[error("Timeout in USB communication.")]
+
+    /// Timeout in USB communication.
     Timeout,
 }
 

--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -80,11 +80,12 @@ impl IdCode {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, displaydoc::Display, thiserror::Error)]
 pub enum ScanChainError {
-    #[error("Invalid IDCODE")]
+    /// Invalid IDCODE.
     InvalidIdCode,
-    #[error("Invalid IR scan chain")]
+
+    /// Invalid IR scan chain.
     InvalidIR,
 }
 

--- a/probe-rs/src/probe/ftdi/ftdaye/error.rs
+++ b/probe-rs/src/probe/ftdi/ftdaye/error.rs
@@ -2,9 +2,10 @@ use nusb::descriptors::ActiveConfigurationError;
 
 use crate::probe::{ftdi::ftdaye::ChipType, DebugProbeError};
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, displaydoc::Display, thiserror::Error)]
+#[ignore_extra_doc_attributes]
 pub enum FtdiError {
-    #[error("A USB transport error occurred.")]
+    /// A USB transport error occurred.
     ///
     /// This variant is used for all errors reported by the operating system when performing a USB
     /// operation. It may indicate that the USB device was unplugged, that another application or an
@@ -12,15 +13,14 @@ pub enum FtdiError {
     /// permission to access it.
     Usb(#[from] nusb::Error),
 
-    #[error("Unsupported chip type: {0:?}")]
+    /// Unsupported chip type: {0:?}.
     /// The connected device is not supported by the driver.
     UnsupportedChipType(ChipType),
 
-    #[error("Failed to get active configuration")]
+    /// Failed to get active configuration.
     ActiveConfigurationError(#[source] ActiveConfigurationError),
 
-    #[error("{0}")]
-    /// An unspecified error occurred.
+    /// An uncategorized error occurred: {0}
     Other(String),
 }
 

--- a/probe-rs/src/probe/jlink/error.rs
+++ b/probe-rs/src/probe/jlink/error.rs
@@ -2,12 +2,13 @@ use crate::probe::DebugProbeError;
 
 use super::{capabilities::Capability, interface::Interface};
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, displaydoc::Display, thiserror::Error)]
+#[ignore_extra_doc_attributes]
 pub enum JlinkError {
-    #[error("Unknown interface reported by J-Link: {0:?}")]
+    /// Unknown interface reported by J-Link: {0:?}.
     UnknownInterface(Interface),
 
-    #[error("A USB transport error occurred.")]
+    /// A USB transport error occurred.
     ///
     /// This variant is used for all errors reported by the operating system when performing a USB
     /// operation. It may indicate that the USB device was unplugged, that another application or an
@@ -15,8 +16,7 @@ pub enum JlinkError {
     /// permission to access it.
     Usb(#[from] nusb::Error),
 
-    #[error("device is missing capabilities ({0:?}) for operation")]
-    /// An operation was attempted that is not supported by the probe.
+    /// An operation was attempted that is not supported by the probe. Device is missing capabilities ({0:?}) for operation
     ///
     /// Some operations are not supported by all firmware/hardware versions, and are instead
     /// advertised as optional *capability* bits. This error occurs when the capability bit for an
@@ -26,16 +26,16 @@ pub enum JlinkError {
     /// [`Capabilities`] bitflags struct.
     MissingCapability(Capability),
 
-    #[error("probe does not support target interface {0:?}")]
+    /// The probe does not support target interface {0:?}.
     InterfaceNotSupported(Interface),
 
-    #[error("interface {needed:?} must be selected for this operation (currently using interface {selected:?})")]
+    /// Interface {needed:?} must be selected for this operation (currently using interface {selected:?}.
     WrongInterfaceSelected {
         selected: Interface,
         needed: Interface,
     },
 
-    #[error("{0}")]
+    /// {0}
     Other(String),
 }
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -1249,25 +1249,21 @@ impl<D: StLinkUsb> SwoAccess for StLink<D> {
 }
 
 /// ST-Link specific errors.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, displaydoc::Display, Debug)]
 pub enum StlinkError {
     /// Invalid voltage values returned by probe.
-    #[error("Invalid voltage values returned by probe.")]
     VoltageDivisionByZero,
 
     /// Probe is in an unknown mode.
-    #[error("Probe is in an unknown mode.")]
     UnknownMode,
 
-    /// Banks not allowed on DP register.
-    #[error(
-        "Current version of the STLink firmware does not support accessing banked DP registers. \
-         Upgrading the firmware to the newest version might fix this."
-    )]
+    /**
+     * Current version of the STLink firmware does not support accessing banked DP registers.
+     * Upgrading the firmware to the newest version might fix this.
+     */
     BanksNotAllowedOnDPRegister,
 
     /// Not enough bytes were written.
-    #[error("Not enough bytes written.")]
     NotEnoughBytesWritten {
         /// The number of bytes actually written
         is: usize,
@@ -1276,32 +1272,25 @@ pub enum StlinkError {
     },
 
     /// USB endpoint not found.
-    #[error("Usb endpoint not found.")]
     EndpointNotFound,
 
-    /// Command failed.
-    #[error("Command failed with status {0:?}")]
+    /// Command failed with status {0:?}.
     CommandFailed(Status),
 
     /// The probe does not support JTAG.
-    #[error("JTAG not supported on Probe")]
     JTAGNotSupportedOnProbe,
 
     /// The probe does not support SWO with Manchester encoding.
-    #[error("Manchester-coded SWO mode not supported")]
     ManchesterSwoNotSupported,
 
     /// The probe does not support multidrop SWD.
-    #[error("Multidrop SWD not supported")]
     MultidropNotSupported,
 
     /// Attempted unaligned access.
-    #[error("Unaligned")]
     UnalignedAddress,
 
     /// USB error.
-    #[error("USB")]
-    Usb(Box<dyn std::error::Error + Sync + Send>),
+    Usb(#[source] Box<dyn std::error::Error + Sync + Send>),
 }
 
 impl From<nusb::Error> for StlinkError {

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -532,25 +532,33 @@ fn list_wlink_devices() -> Vec<DebugProbeInfo> {
     probes
 }
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, displaydoc::Display, Debug)]
 pub(crate) enum WchLinkError {
-    #[error("Unknown WCH-Link device(new variant?)")]
+    /// Unknown WCH-Link device (new variant?)
     UnknownDevice,
-    #[error("Firmware version is not supported.")]
+
+    /// Firmware version is not supported.
     UnsupportedFirmwareVersion,
-    #[error("Not enough bytes written.")]
+
+    /// Only wrote {is} bytes instead of {should}.
     NotEnoughBytesWritten { is: usize, should: usize },
-    #[error("Not enough bytes read.")]
+
+    /// Only read {is} bytes instead of {should}.
     NotEnoughBytesRead { is: usize, should: usize },
-    #[error("Usb endpoint not found.")]
+
+    /// Usb endpoint not found.
     EndpointNotFound,
-    #[error("Invalid payload.")]
+
+    /// Invalid payload.
     InvalidPayload,
-    #[error("Protocol error.")]
+
+    /// Protocol error.
     Protocol(u8, Vec<u8>),
-    #[error("Unknown chip 0x{0:02x}")]
+
+    /// Unknown chip 0x{0:02x}.
     UnknownChip(u8),
-    #[error("Unsupported operation.")]
+
+    /// Unsupported operation.
     UnsupportedOperation,
 }
 

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -375,35 +375,29 @@ pub enum ScanRegion {
 }
 
 /// Error type for RTT operations.
-#[derive(thiserror::Error, Debug)]
+#[derive(displaydoc::Display, thiserror::Error, Debug)]
 pub enum Error {
-    /// RTT control block not found in target memory. Make sure RTT is initialized on the target.
-    #[error(
-        "RTT control block not found in target memory.\n\
-        - Make sure RTT is initialized on the target, AND that there are NO target breakpoints before RTT initalization.\n\
-        - For VSCode and probe-rs-debugger users, using `halt_after_reset:true` in your `launch.json` file will prevent RTT \n\
-        \tinitialization from happening on time.\n\
-        - Depending on the target, sleep modes can interfere with RTT."
-    )]
+    /**
+     * Could not find RTT control block in target memory.
+     *
+     * - Make sure RTT is initialized on the target, AND that there are NO target breakpoints before RTT initalization.
+     * - For VSCode and probe-rs-debugger users, using `halt_after_reset:true` in your `launch.json` file will prevent RTT initialization from happening on time.
+     * - Depending on the target, sleep modes can interfere with RTT.
+     */
     ControlBlockNotFound,
 
-    /// Multiple control blocks found in target memory. The data contains the control block addresses (up to 5).
-    #[error("Multiple control blocks found in target memory.")]
+    /// Multiple control blocks found in target memory: {0:X?}
     MultipleControlBlocksFound(Vec<u32>),
 
-    /// The control block has been corrupted. The data contains a detailed error.
-    #[error("Control block corrupted: {0}")]
+    /// Control block corrupted: {0}
     ControlBlockCorrupted(String),
 
-    /// Attempted an RTT read/write operation against a Core number that is different from the Core number against which RTT was initialized
-    #[error("Incorrect Core number specified for this operation. Expected {0}, and found {1}")]
+    /// Incorrect Core number specified for this operation. Expected {0}, and found {1}
     IncorrectCoreSpecified(usize, usize),
 
-    /// Wraps errors propagated up from probe-rs.
-    #[error("Error communicating with probe: {0}")]
+    /// Error communicating with probe
     Probe(#[from] crate::Error),
 
-    /// Wraps errors propagated up from reading memory on the target.
-    #[error("Unexpected error while reading {0} from target memory. Please report this as a bug.")]
+    /// Unexpected error while reading {0} from target memory. Please report this as a bug.
     MemoryRead(String),
 }


### PR DESCRIPTION
[As requested](https://github.com/probe-rs/probe-rs/pull/2027#discussion_r1468917140)

displaydoc doesn't support everything that thiserror does, so I couldn't make use of it everywhere, which is a bit unfortunate.

PR is blocked on https://github.com/yaahc/displaydoc/pull/45 as we have a module named `core` :(