### PR TITLE
Don't panic if `current_local_offset` fails

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -53,18 +53,7 @@ struct Opt {
     cargo_options: CargoOptions,
 }
 
-pub fn main(args: Vec<OsString>) {
-    // Determine the local offset as early as possible to avoid potential
-    // issues with multiple threads and getting the offset.
-    let offset = match UtcOffset::current_local_offset() {
-        Ok(offset) => offset,
-        Err(e) => {
-            tracing::debug!("Error getting local offset: {e}");
-            tracing::warn!("Unable to determine local time. All timestamps will be in UTC.");
-            UtcOffset::UTC
-        }
-    };
-
+pub fn main(args: Vec<OsString>, offset: UtcOffset) {
     match main_try(args, offset) {
         Ok(_) => (),
         Err(e) => {


### PR DESCRIPTION
Just ran into `probe-rs run` panicking for some reason. I don't think we should consider timestamp issues critical.

I've also extracted the same code from cargo embed, and removed the - ineffectual - logging. If we really need to notify the user, we should maybe pass around an `Option` and handle the `None` case where we need to use the timestamp. I consider this out of scope for this PR.