### PR TITLE
Try to improve C debugging experience

### DIFF
--- a/changelog/added-cfa.md
+++ b/changelog/added-cfa.md
@@ -1,0 +1,1 @@
+debug: Added `StackFrame::canonical_frame_address` and `StackFrameInfo`

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -17,7 +17,10 @@ use crate::cmd::dap_server::{
 use crate::util::rtt::{self, ChannelMode, DataFormat, RttActiveTarget};
 use anyhow::{anyhow, Result};
 use probe_rs::{
-    debug::{debug_info::DebugInfo, ColumnType, ObjectRef, VerifiedBreakpoint},
+    debug::{
+        debug_info::DebugInfo, stack_frame::StackFrameInfo, ColumnType, ObjectRef,
+        VerifiedBreakpoint,
+    },
     rtt::{Rtt, ScanRegion},
     Core, CoreStatus, Error, HaltReason,
 };
@@ -404,11 +407,13 @@ impl<'p> CoreHandle<'p> {
                     &self.core_data.debug_info,
                     &mut self.core,
                     None,
-                    &frame.registers,
-                    frame.frame_base,
                     10,
                     0,
-                    frame.canonical_frame_address,
+                    StackFrameInfo {
+                        registers: &frame.registers,
+                        frame_base: frame.frame_base,
+                        canonical_frame_address: frame.canonical_frame_address,
+                    },
                 );
                 all_discrete_memory_ranges.append(&mut variable_cache.get_discrete_memory_ranges());
             }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -408,6 +408,7 @@ impl<'p> CoreHandle<'p> {
                     frame.frame_base,
                     10,
                     0,
+                    frame.canonical_frame_address,
                 );
                 all_discrete_memory_ranges.append(&mut variable_cache.get_discrete_memory_ranges());
             }

--- a/probe-rs/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/debug.rs
@@ -10,6 +10,7 @@ use capstone::{
 use num_traits::Num;
 use parse_int::parse;
 use probe_rs::architecture::arm::ap::AccessPortError;
+use probe_rs::debug::stack_frame::StackFrameInfo;
 use probe_rs::exception_handler_for_core;
 use probe_rs::flashing::FileDownloadError;
 use probe_rs::probe::list::Lister;
@@ -754,9 +755,12 @@ impl DebugCli {
                                     local_variable_cache,
                                     &mut cli_data.core,
                                     &mut locals,
-                                    &current_frame.registers,
-                                    current_frame.frame_base,
-                                    current_frame.canonical_frame_address,
+                                    StackFrameInfo {
+                                        registers: &current_frame.registers,
+                                        frame_base: current_frame.frame_base,
+                                        canonical_frame_address: current_frame
+                                            .canonical_frame_address,
+                                    },
                                 )
                             {
                                 println!("Failed to cache local variables: {error}");

--- a/probe-rs/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/debug.rs
@@ -756,6 +756,7 @@ impl DebugCli {
                                     &mut locals,
                                     &current_frame.registers,
                                     current_frame.frame_base,
+                                    current_frame.canonical_frame_address,
                                 )
                             {
                                 println!("Failed to cache local variables: {error}");

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -425,11 +425,13 @@ impl DebugInfo {
     ) -> Result<Vec<StackFrame>, DebugError> {
         // When reporting the address, we format it as a hex string, with the width matching
         // the configured size of the datatype used in the `RegisterValue` address.
-        let unknown_function = format!(
-            "<unknown function @ {:#0width$x}>",
-            address,
-            width = (unwind_registers.get_address_size_bytes() * 2 + 2)
-        );
+        let unknown_function = || {
+            format!(
+                "<unknown function @ {:#0width$x}>",
+                address,
+                width = (unwind_registers.get_address_size_bytes() * 2 + 2)
+            )
+        };
 
         let mut frames = Vec::new();
 
@@ -457,7 +459,7 @@ impl DebugInfo {
             for (index, function_die) in functions[0..functions.len() - 1].iter().enumerate() {
                 let function_name = function_die
                     .function_name(self)
-                    .unwrap_or_else(|| unknown_function.clone());
+                    .unwrap_or_else(unknown_function);
 
                 tracing::debug!("UNWIND: Function name: {}", function_name);
 
@@ -535,7 +537,7 @@ impl DebugInfo {
 
             let function_name = last_function
                 .function_name(self)
-                .unwrap_or_else(|| unknown_function.clone());
+                .unwrap_or_else(unknown_function);
 
             let function_location = self.get_source_location(address);
 

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -511,6 +511,7 @@ impl DebugInfo {
                         is_inlined: function_die.is_inline(),
                         static_variables,
                         local_variables,
+                        canonical_frame_address: None,
                     });
                 } else {
                     tracing::warn!(
@@ -572,6 +573,7 @@ impl DebugInfo {
                 is_inlined: last_function.is_inline(),
                 static_variables,
                 local_variables,
+                canonical_frame_address: None,
             });
 
             break;
@@ -707,6 +709,7 @@ impl DebugInfo {
                             is_inlined: false,
                             static_variables: None,
                             local_variables: None,
+                            canonical_frame_address: None,
                         }
                     } else {
                         let address = frame_pc;
@@ -733,6 +736,7 @@ impl DebugInfo {
                             is_inlined: false,
                             static_variables: None,
                             local_variables: None,
+                            canonical_frame_address: None,
                         }
                     }
                 }
@@ -877,6 +881,8 @@ impl DebugInfo {
                 gimli::CfaRule::Expression(_) => unimplemented!(),
             };
 
+            return_frame.canonical_frame_address = unwind_cfa;
+
             // PART 2-c: Unwind registers for the "previous/calling" frame.
             // We sometimes need to keep a copy of the LR value to calculate the PC. For both ARM, and RISC-V, The LR will be unwound before the PC, so we can reference it safely.
             let mut unwound_return_address: Option<RegisterValue> = None;
@@ -931,6 +937,7 @@ impl DebugInfo {
                             is_inlined: false,
                             static_variables: None,
                             local_variables: None,
+                            canonical_frame_address: None,
                         };
 
                         stack_frames.push(exception_frame);

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -119,9 +119,9 @@ impl DebugInfo {
     /// ## Inlined functions
     /// Multiple nested inline functions could exist at the given address.
     /// This function will currently return the innermost function in that case.
-    // TODO: This function takes a memory interface. This seems odd, but gimly sometimes needs to read memory to resolve.
-    // Maybe this can be factored out if we can be sure that memory is never read for this usecase.
-    // Until we have more tests we cannot be sure tho and it should stay like this.
+    // TODO: This function takes a memory interface. This seems odd, but gimli sometimes needs to read memory to resolve.
+    // Maybe this can be factored out if we can be sure that memory is never read for this use case.
+    // Until we have more tests we cannot be sure though and it should stay like this.
     pub fn function_name(
         &self,
         address: u64,

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -835,7 +835,7 @@ impl DebugInfo {
                             calling_pc,
                             &callee_frame_registers,
                             None,
-                            None,
+                            return_frame.canonical_frame_address,
                             &mut unwound_return_address,
                             memory,
                             instruction_set,

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -1172,7 +1172,7 @@ fn get_unwind_info<'a>(
     let frame_descriptor_entry = match frame_section.fde_for_address(
         &unwind_bases,
         frame_program_counter,
-        gimli::DebugFrame::cie_from_offset,
+        DebugFrame::cie_from_offset,
     ) {
         Ok(frame_descriptor_entry) => frame_descriptor_entry,
         Err(error) => {

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -442,7 +442,15 @@ impl DebugInfo {
 
             // The first function is the non-inlined function, and the rest are inlined functions.
             // The frame base only exists for the non-inlined function, so we can reuse it for all the inlined functions.
-            let frame_base = functions[0].frame_base(self, memory, unwind_registers)?;
+            let frame_base = functions[0].frame_base(
+                self,
+                memory,
+                StackFrameInfo {
+                    registers: unwind_registers,
+                    frame_base: None,
+                    canonical_frame_address: None,
+                },
+            )?;
 
             // Handle all functions which contain further inlined functions. For
             // these functions, the location is the call site of the inlined function.

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -621,8 +621,7 @@ impl DebugInfo {
     ) -> Result<Vec<StackFrame>, crate::Error> {
         let mut stack_frames = Vec::<StackFrame>::new();
 
-        let mut unwind_context: Box<UnwindContext<DwarfReader>> =
-            Box::new(gimli::UnwindContext::new());
+        let mut unwind_context = Box::new(gimli::UnwindContext::new());
 
         let mut unwind_registers = initial_registers;
 
@@ -1146,7 +1145,7 @@ pub(crate) fn canonical_path_eq(
 
 /// Get a handle to the [`gimli::UnwindTableRow`] for this call frame, so that we can reference it to unwind register values.
 fn get_unwind_info<'a>(
-    unwind_context: &'a mut Box<UnwindContext<DwarfReader>>,
+    unwind_context: &'a mut UnwindContext<DwarfReader>,
     frame_section: &'a DebugFrame<DwarfReader>,
     frame_program_counter: u64,
 ) -> Result<&'a gimli::UnwindTableRow<DwarfReader, gimli::StoreOnHeap>, DebugError> {

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -298,6 +298,7 @@ impl DebugInfo {
         parent_variable: &mut Variable,
         stack_frame_registers: &DebugRegisters,
         frame_base: Option<u64>,
+        cfa: Option<u64>,
     ) -> Result<(), DebugError> {
         if !parent_variable.is_valid() {
             // Do nothing. The parent_variable.get_value() will already report back the debug_error value.
@@ -347,6 +348,7 @@ impl DebugInfo {
                     stack_frame_registers,
                     frame_base,
                     cache,
+                    cfa,
                 )?;
 
                 if referenced_variable.type_name == VariableType::Base("()".to_owned()) {
@@ -377,6 +379,7 @@ impl DebugInfo {
                     stack_frame_registers,
                     frame_base,
                     cache,
+                    cfa,
                 )?;
 
                 cache.adopt_grand_children(parent_variable, &temporary_variable)?;
@@ -405,6 +408,7 @@ impl DebugInfo {
                     stack_frame_registers,
                     frame_base,
                     cache,
+                    cfa,
                 )?;
 
                 cache.adopt_grand_children(parent_variable, &temporary_variable)?;
@@ -2030,6 +2034,7 @@ mod test {
                     frame.frame_base,
                     10,
                     0,
+                    frame.canonical_frame_address,
                 );
             }
         }

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -83,7 +83,7 @@ impl DebugInfo {
         let dwarf_cow = gimli::Dwarf::load(&load_section)?;
 
         use gimli::Section;
-        let frame_section = gimli::DebugFrame::load(load_section)?;
+        let mut frame_section = gimli::DebugFrame::load(load_section)?;
         let address_section = gimli::DebugAddr::load(load_section)?;
         let debug_loc = gimli::DebugLoc::load(load_section)?;
         let debug_loc_lists = gimli::DebugLocLists::load(load_section)?;
@@ -96,6 +96,8 @@ impl DebugInfo {
 
         while let Ok(Some(header)) = iter.next() {
             if let Ok(unit) = dwarf_cow.unit(header) {
+                // TODO: maybe it's not correct to read from arbitrary units
+                frame_section.set_address_size(unit.encoding().address_size);
                 unit_infos.push(UnitInfo::new(unit));
             };
         }

--- a/probe-rs/src/debug/function_die.rs
+++ b/probe-rs/src/debug/function_die.rs
@@ -3,7 +3,7 @@ use crate::{debug::stack_frame::StackFrameInfo, MemoryInterface};
 use super::{
     debug_info, extract_file,
     unit_info::{ExpressionResult, UnitInfo},
-    ColumnType, DebugError, DebugRegisters, SourceLocation, VariableLocation,
+    ColumnType, DebugError, SourceLocation, VariableLocation,
 };
 
 pub(crate) type Die<'abbrev, 'unit> =
@@ -180,18 +180,14 @@ impl<'debugunit, 'abbrev, 'unit: 'debugunit, 'unit_info> FunctionDie<'abbrev, 'u
         &self,
         debug_info: &super::DebugInfo,
         memory: &mut impl MemoryInterface,
-        stackframe_registers: &DebugRegisters,
+        frame_info: StackFrameInfo,
     ) -> Result<Option<u64>, DebugError> {
         match self.unit_info.extract_location(
             debug_info,
             &self.function_die,
             &VariableLocation::Unknown,
             memory,
-            StackFrameInfo {
-                registers: stackframe_registers,
-                frame_base: None,
-                canonical_frame_address: None,
-            },
+            frame_info,
         )? {
             ExpressionResult::Location(VariableLocation::Address(address)) => Ok(Some(address)),
             _ => Ok(None),

--- a/probe-rs/src/debug/function_die.rs
+++ b/probe-rs/src/debug/function_die.rs
@@ -1,4 +1,4 @@
-use crate::MemoryInterface;
+use crate::{debug::stack_frame::StackFrameInfo, MemoryInterface};
 
 use super::{
     debug_info, extract_file,
@@ -187,9 +187,11 @@ impl<'debugunit, 'abbrev, 'unit: 'debugunit, 'unit_info> FunctionDie<'abbrev, 'u
             &self.function_die,
             &VariableLocation::Unknown,
             memory,
-            stackframe_registers,
-            None,
-            None,
+            StackFrameInfo {
+                registers: stackframe_registers,
+                frame_base: None,
+                canonical_frame_address: None,
+            },
         )? {
             ExpressionResult::Location(VariableLocation::Address(address)) => Ok(Some(address)),
             _ => Ok(None),

--- a/probe-rs/src/debug/function_die.rs
+++ b/probe-rs/src/debug/function_die.rs
@@ -189,6 +189,7 @@ impl<'debugunit, 'abbrev, 'unit: 'debugunit, 'unit_info> FunctionDie<'abbrev, 'u
             memory,
             stackframe_registers,
             None,
+            None,
         )? {
             ExpressionResult::Location(VariableLocation::Address(address)) => Ok(Some(address)),
             _ => Ok(None),

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040__full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040__full_unwind.snap
@@ -764,6 +764,7 @@ expression: stack_frames
           type_name:
             Base: usize
           value: "6"
+  canonical_frame_address: 536883280
 - function_name: test_deep_stack
   source_location:
     line: 337
@@ -1518,6 +1519,7 @@ expression: stack_frames
           type_name:
             Base: usize
           value: "5"
+  canonical_frame_address: 536883408
 - function_name: test_deep_stack
   source_location:
     line: 337
@@ -2272,6 +2274,7 @@ expression: stack_frames
           type_name:
             Base: usize
           value: "4"
+  canonical_frame_address: 536883536
 - function_name: test_deep_stack
   source_location:
     line: 337
@@ -3026,6 +3029,7 @@ expression: stack_frames
           type_name:
             Base: usize
           value: "3"
+  canonical_frame_address: 536883664
 - function_name: test_deep_stack
   source_location:
     line: 337
@@ -3780,6 +3784,7 @@ expression: stack_frames
           type_name:
             Base: usize
           value: "2"
+  canonical_frame_address: 536883792
 - function_name: test_deep_stack
   source_location:
     line: 337
@@ -4534,6 +4539,7 @@ expression: stack_frames
           type_name:
             Base: usize
           value: "1"
+  canonical_frame_address: 536883920
 - function_name: setup_data_types
   source_location:
     line: 324
@@ -7828,6 +7834,7 @@ expression: stack_frames
                                       type_name:
                                         Base: usize
                                       value: "1"
+  canonical_frame_address: 536886976
 - function_name: __cortex_m_rt_main
   source_location:
     line: 37
@@ -8038,6 +8045,7 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: Unknown
+  canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main_trampoline
   source_location:
     line: 34
@@ -8248,6 +8256,7 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: Unknown
+  canonical_frame_address: 536887296
 - function_name: "<unknown function @ 0x100001e6>"
   source_location: ~
   registers:
@@ -8443,6 +8452,7 @@ expression: stack_frames
   is_inlined: false
   static_variables: ~
   local_variables: ~
+  canonical_frame_address: ~
 - function_name: "<unknown function @ 0x100001e6>"
   source_location: ~
   registers:
@@ -8573,8 +8583,7 @@ expression: stack_frames
         data_type:
           UnsignedInteger: 32
       dwarf_id: 13
-      value:
-        U32: 536887296
+      value: ~
     - core_register:
         id: 14
         roles:
@@ -8637,4 +8646,5 @@ expression: stack_frames
   is_inlined: false
   static_variables: ~
   local_variables: ~
+  canonical_frame_address: ~
 

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__full_unwind.snap
@@ -764,6 +764,7 @@ expression: stack_frames
           type_name:
             Base: usize
           value: "6"
+  canonical_frame_address: 536883528
 - function_name: test_deep_stack
   source_location:
     line: 337
@@ -1518,6 +1519,7 @@ expression: stack_frames
           type_name:
             Base: usize
           value: "5"
+  canonical_frame_address: 536883656
 - function_name: test_deep_stack
   source_location:
     line: 337
@@ -2272,6 +2274,7 @@ expression: stack_frames
           type_name:
             Base: usize
           value: "4"
+  canonical_frame_address: 536883784
 - function_name: test_deep_stack
   source_location:
     line: 337
@@ -3026,6 +3029,7 @@ expression: stack_frames
           type_name:
             Base: usize
           value: "3"
+  canonical_frame_address: 536883912
 - function_name: test_deep_stack
   source_location:
     line: 337
@@ -3780,6 +3784,7 @@ expression: stack_frames
           type_name:
             Base: usize
           value: "2"
+  canonical_frame_address: 536884040
 - function_name: test_deep_stack
   source_location:
     line: 337
@@ -4534,6 +4539,7 @@ expression: stack_frames
           type_name:
             Base: usize
           value: "1"
+  canonical_frame_address: 536884168
 - function_name: setup_data_types
   source_location:
     line: 324
@@ -7828,6 +7834,7 @@ expression: stack_frames
                                       type_name:
                                         Base: usize
                                       value: "1"
+  canonical_frame_address: 536887112
 - function_name: __cortex_m_rt_main
   source_location:
     line: 51
@@ -8055,6 +8062,7 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: Unknown
+  canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main_trampoline
   source_location:
     line: 48
@@ -8281,7 +8289,8 @@ expression: stack_frames
       name: LocalScopeRoot
       type_name: Unknown
       value: Unknown
-- function_name: "<unknown function @ 0x0000013c>"
+  canonical_frame_address: 536887296
+- function_name: "<unknown function @ 0x0000013c> : ERROR: UNWIND: Tried to unwind `RegisterRule` at CFA = None."
   source_location: ~
   registers:
     - core_register:
@@ -8544,4 +8553,5 @@ expression: stack_frames
             Named: key
           type_name: Unknown
           value: "< <value optimized away by compiler, out of scope, or dropped> >"
+  canonical_frame_address: ~
 

--- a/probe-rs/src/debug/stack_frame.rs
+++ b/probe-rs/src/debug/stack_frame.rs
@@ -5,6 +5,22 @@ use std;
 #[cfg(test)]
 pub use test::TestFormatter;
 
+/// Helper struct to pass around multiple pieces of `StackFrame` related information.
+#[derive(Clone, Copy)]
+pub struct StackFrameInfo<'a> {
+    /// The current register state represented in this stackframe.
+    pub registers: &'a registers::DebugRegisters,
+
+    /// The DWARF debug info defines a `DW_AT_frame_base` attribute which can be used to calculate the memory location of variables in a stack frame.
+    /// The rustc compiler, has a compile flag, `-C force-frame-pointers`, which when set to `on`, will usually result in this being a pointer to the register value of the platform frame pointer.
+    /// However, some isa's (e.g. RISC-V) uses a default of `-C force-frame-pointers off` and will then use the stack pointer as the frame base address.
+    /// We store the frame_base of the relevant non-inlined parent function, to ensure correct calculation of the [`Variable::memory_location`] values.
+    pub frame_base: Option<u64>,
+
+    /// The value of the stack pointer just before the CALL instruction in the parent function.
+    pub canonical_frame_address: Option<u64>,
+}
+
 /// A full stack frame with all its information contained.
 #[derive(PartialEq, Serialize)]
 pub struct StackFrame {

--- a/probe-rs/src/debug/stack_frame.rs
+++ b/probe-rs/src/debug/stack_frame.rs
@@ -32,6 +32,8 @@ pub struct StackFrame {
     /// - Complex variables and pointers will have additional children.
     ///   - This structure is recursive until a base type is encountered.
     pub local_variables: Option<VariableCache>,
+    /// The value of the stack pointer just before the CALL instruction in the parent function.
+    pub canonical_frame_address: Option<u64>,
 }
 
 impl std::fmt::Display for StackFrame {

--- a/probe-rs/src/debug/stack_frame.rs
+++ b/probe-rs/src/debug/stack_frame.rs
@@ -28,7 +28,7 @@ pub struct StackFrame {
     pub is_inlined: bool,
     /// A cache of 'static' scoped variables for this stackframe
     pub static_variables: Option<VariableCache>,
-    /// A cache of 'local' scoped variables for this stafckframe, with a `Variable` for each in-scope variable.
+    /// A cache of 'local' scoped variables for this stackframe, with a `Variable` for each in-scope variable.
     /// - Complex variables and pointers will have additional children.
     ///   - This structure is recursive until a base type is encountered.
     pub local_variables: Option<VariableCache>,

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -1462,8 +1462,8 @@ impl UnitInfo {
                             Ok(result) => Ok(result),
                             Err(DebugError::UnwindIncompleteResults { message }) => {
                                 tracing::warn!("UnwindIncompleteResults: {:?}", message);
-                                    Ok(ExpressionResult::Location(VariableLocation::Unavailable))
-                                }
+                                Ok(ExpressionResult::Location(VariableLocation::Unavailable))
+                            }
                             e => e
                         };
                     }
@@ -1524,8 +1524,8 @@ impl UnitInfo {
                                             Ok(result) => Ok(result),
                                             Err(DebugError::UnwindIncompleteResults { message }) => {
                                                 tracing::warn!("UnwindIncompleteResults: {:?}", message);
-                                                    Ok(ExpressionResult::Location(VariableLocation::Unavailable))
-                                                }
+                                                Ok(ExpressionResult::Location(VariableLocation::Unavailable))
+                                            }
                                             e => e
                                         };
                                     } else {

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -1458,15 +1458,13 @@ impl UnitInfo {
                 | gimli::DW_AT_frame_base
                 | gimli::DW_AT_data_member_location => match attr.value() {
                     gimli::AttributeValue::Exprloc(expression) => {
-                        return match self.evaluate_expression(memory , expression, stack_frame_registers, frame_base) {
+                        return match self.evaluate_expression(memory, expression, stack_frame_registers, frame_base) {
                             Ok(result) => Ok(result),
-                            Err(error) => {
-                                if matches!(error, DebugError::UnwindIncompleteResults { message: _ }) {
+                            Err(DebugError::UnwindIncompleteResults { message }) => {
+                                tracing::warn!("UnwindIncompleteResults: {:?}", message);
                                     Ok(ExpressionResult::Location(VariableLocation::Unavailable))
-                                } else {
-                                    Err(error)
                                 }
-                            },
+                            e => e
                         };
                     }
                     gimli::AttributeValue::Udata(offset_from_location) => match parent_location {
@@ -1524,13 +1522,11 @@ impl UnitInfo {
                                             frame_base,
                                         ) {
                                             Ok(result) => Ok(result),
-                                            Err(error) => {
-                                                if matches!(error, DebugError::UnwindIncompleteResults { message: _ }) {
+                                            Err(DebugError::UnwindIncompleteResults { message }) => {
+                                                tracing::warn!("UnwindIncompleteResults: {:?}", message);
                                                     Ok(ExpressionResult::Location(VariableLocation::Unavailable))
-                                                } else {
-                                                    Err(error)
                                                 }
-                                            },
+                                            e => e
                                         };
                                     } else {
                                         return Ok(ExpressionResult::Location(

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -451,6 +451,7 @@ impl VariableCache {
         frame_base: Option<u64>,
         max_recursion_depth: usize,
         current_recursion_depth: usize,
+        cfa: Option<u64>,
     ) {
         if current_recursion_depth >= max_recursion_depth {
             return;
@@ -465,6 +466,7 @@ impl VariableCache {
             return;
         }
         .clone();
+
         if debug_info
             .cache_deferred_variables(
                 self,
@@ -472,6 +474,7 @@ impl VariableCache {
                 &mut variable_to_recurse,
                 registers,
                 frame_base,
+                cfa,
             )
             .is_err()
         {
@@ -486,6 +489,7 @@ impl VariableCache {
                 frame_base,
                 max_recursion_depth,
                 current_recursion_depth + 1,
+                cfa,
             );
         }
     }


### PR DESCRIPTION
 - We need to set `frame_section.set_address_size` as gimli defaults to host (8) which is just incorrect
 - This PR propagates (some?) CFA information to the evaluation as required by my elf
 - This PR moves CFA calculation to before determining frame base. In my case, the reverse failed due to CFA being None.

With this, I now have a decent call stack, but variable values are still not filly implemented (enums!). Also, struct fields are always read with the same byte count as the struct itself, it looks like.