### PR TITLE
Fix cargo subcommand build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ For example, `added-ultra-fast-flashing.md` would lead to an entry in the `## Ad
 
 ## How to build cargo-embed/ cargo-flash from source
 
-cargo-embed is a so called [cargo subcommand](https://doc.rust-lang.org/book/ch14-05-extending-cargo.html). It is a programm named cargo-embed which is installed in the users path. Thus when applying some small fixes cargo-embed you can run `cargo build` and then use the executable in the target folder named cargo-embed directly. You can also use [cargo install --path .](https://doc.rust-lang.org/cargo/commands/cargo-install.html) to install your current checkout locally overriding what you previously had installed using `cargo install cargo-embed`.
+`cargo-embed` is a so called [cargo subcommand](https://doc.rust-lang.org/book/ch14-05-extending-cargo.html). It is a programm named `cargo-embed` which is installed in the users path. Thus when applying some small fixes to `cargo-embed` you can run `cargo build --features cli` and then use the executable in the target folder named cargo-embed directly. You can also use [cargo install --path probe-rs --features cli](https://doc.rust-lang.org/cargo/commands/cargo-install.html) to install your current checkout locally overriding what you previously had installed using `cargo install cargo-embed`.
 
 The steps are the same for cargo-embed or cargo-flash. Both use probe-rs inside and wrap it with a user friendly command line interface.
 


### PR DESCRIPTION
Currently the `probe-rs` binary needs `cli` which is not a default feature.