### PR TITLE
Fix: Debug cannot resolve variables with DW_AT_accessibility attribute

### DIFF
--- a/changelog/fixed-debug-dw-at-accessibility.md
+++ b/changelog/fixed-debug-dw-at-accessibility.md
@@ -1,0 +1,1 @@
+Debug: Do not fail when encountering new `DW_AT_accessibility` attribute in debug info.

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/protocol.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/protocol.rs
@@ -55,8 +55,7 @@ where
     fn show_message(&mut self, severity: MessageSeverity, message: impl Into<String>) -> bool {
         let msg = message.into();
 
-        tracing::debug!("show_message");
-        println!("Do log message: {msg}");
+        tracing::debug!("show_message: {msg}");
 
         let event_body = match serde_json::to_value(ShowMessageEventBody {
             severity,

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -451,6 +451,10 @@ impl UnitInfo {
                             }
                         }
                     }
+                    gimli::DW_AT_accessibility => {
+                        // Silently ignore these for now.
+                        // TODO: Add flag for public/private/protected for `Variable`, once we have a use case.
+                    }
                     gimli::DW_AT_external => {
                         // TODO: Implement globally visible variables.
                     }


### PR DESCRIPTION
Fixes probe-rs/probe-rs#2140

It turns out that silently ignoring this attribute (for now) fixes the unwind of variables that failed when Rust codegen for LLVM introduced the use of the `DW_AT_accessibility` attribute.

Our current debug capabilities has no use case for using the 'public/private/protected' variants of this attribute.

The DAP Specification allows these as [presentation hints](https://microsoft.github.io/debug-adapter-protocol/specification#Types_VariablePresentationHint), so that is one possible use case for future consideration.

