### PR TITLE
Halt the core after attaching so sequences can run freely

### DIFF
--- a/changelog/changed-ensure-core-halted-during-setup.md
+++ b/changelog/changed-ensure-core-halted-during-setup.md
@@ -1,0 +1,1 @@
+Ensure then when executing setup commands and sequences that the core is halted.

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -239,7 +239,7 @@ impl LoadedProbeOptions {
     /// Attaches to specified probe and configures it.
     pub fn attach_probe(&self, lister: &Lister) -> Result<Probe, OperationError> {
         let mut probe = if self.0.dry_run {
-            Probe::from_specific_probe(Box::new(FakeProbe::new()))
+            Probe::from_specific_probe(Box::new(FakeProbe::with_mocked_core()))
         } else {
             // If we got a probe selector as an argument, open the probe
             // matching the selector if possible.

--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -614,7 +614,7 @@ mod test {
 
     #[test]
     fn create_session_with_fake_probe() {
-        let fake_probe = FakeProbe::new();
+        let fake_probe = FakeProbe::with_mocked_core();
 
         let probe = fake_probe.into_probe();
 

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -336,14 +336,9 @@ impl Session {
             configured_trace_sink: None,
         };
 
-        {
-            // Todo: Add multicore support. How to deal with any cores that are not active and won't respond?
-            let mut core = session.core(0)?;
-
-            core.halt(Duration::from_millis(100))?;
-        }
-
-        sequence_handle.on_connect(session.get_xtensa_interface()?)?;
+        session.halted_access(|sess| {
+            sequence_handle.on_connect(sess.get_xtensa_interface()?)
+        })?;
 
         Ok(session)
     }

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -688,10 +688,7 @@ static_assertions::assert_impl_all!(Session: Send);
 impl Drop for Session {
     #[tracing::instrument(name = "session_drop", skip(self))]
     fn drop(&mut self) {
-        if let Err(err) = { 0..self.cores.len() }.try_for_each(|i| {
-            self.core(i)
-                .and_then(|mut core| core.clear_all_hw_breakpoints())
-        }) {
+        if let Err(err) = self.clear_all_hw_breakpoints() {
             tracing::warn!(
                 "Could not clear all hardware breakpoints: {:?}",
                 anyhow!(err)

--- a/probe-rs/tests/flash_dry_run.rs
+++ b/probe-rs/tests/flash_dry_run.rs
@@ -3,7 +3,7 @@ use probe_rs::{flashing::DownloadOptions, integration::FakeProbe, probe::Probe, 
 /// A chip where the flash algorithm's range is greater than the NVM range.
 #[test]
 fn flash_dry_run_stm32wb55ccux() {
-    let probe = Probe::from_specific_probe(Box::new(FakeProbe::new()));
+    let probe = Probe::from_specific_probe(Box::new(FakeProbe::with_mocked_core()));
 
     let mut session = probe
         .attach("stm32wb55ccux", Permissions::default())
@@ -27,7 +27,7 @@ fn flash_dry_run_stm32wb55ccux() {
 /// A chip where the flash algorithm's range could be less than the NVM range.
 #[test]
 fn flash_dry_run_mimxrt1010() {
-    let probe = Probe::from_specific_probe(Box::new(FakeProbe::new()));
+    let probe = Probe::from_specific_probe(Box::new(FakeProbe::with_mocked_core()));
 
     let mut session = probe
         .attach("mimxrt1010", Permissions::default())


### PR DESCRIPTION
This PR adds a new method on Session, which currently isn't public which allows blocks of code to be run when all cores are halted. This is useful for running sequences, especially in the case of the esps, as some sequences poke flash. Doing so during operation of the chip can cause all manner of issues, related to cache pulls.

Closes #2023