### PR TITLE
debugger: Don't put existing value into error message

### DIFF
--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -763,7 +763,7 @@ impl UnitInfo {
                             // These will be processed elsewhere, or not at all, until we discover a use case that needs to be implemented.
                         }
                         unimplemented => {
-                            parent_variable.set_value(VariableValue::Error(format!("Unimplemented: Encountered unimplemented DwTag {:?} for Variable {:?}", unimplemented.static_string(), parent_variable)));
+                            parent_variable.set_value(VariableValue::Error(format!("Unimplemented: Encountered unimplemented DwTag {:?} for Variable {:?}", unimplemented.static_string(), parent_variable.name)));
                         }
                     }
                 }


### PR DESCRIPTION
When setting an error message, the previous error is append to the newly added error. This is problematic if the new error also contains the whole value, due to the debug print.