### PR TITLE
Unwind C enum variants, handle all C versions known by gimli, fix struct members

### DIFF
--- a/probe-rs/src/debug/language.rs
+++ b/probe-rs/src/debug/language.rs
@@ -1,7 +1,7 @@
 use gimli::DwLang;
 
 use crate::{
-    debug::{DebugError, Variable, VariableCache, VariableValue},
+    debug::{DebugError, Variable, VariableCache, VariableName, VariableType, VariableValue},
     MemoryInterface,
 };
 
@@ -41,6 +41,10 @@ pub trait ProgrammingLanguage {
                 variable.type_name
             ),
         })
+    }
+
+    fn format_enum_value(&self, type_name: &VariableType, value: &VariableName) -> VariableValue {
+        VariableValue::Valid(format!("{}::{}", type_name, value))
     }
 }
 

--- a/probe-rs/src/debug/language.rs
+++ b/probe-rs/src/debug/language.rs
@@ -5,14 +5,20 @@ use crate::{
     MemoryInterface,
 };
 
-/// C, C89, C99, C11
+/// C, C89, C99, C11, ...
 pub mod c;
 /// Rust
 pub mod rust;
 
 pub fn from_dwarf(dwarf_language: DwLang) -> Box<dyn ProgrammingLanguage> {
     match dwarf_language {
-        gimli::DW_LANG_C => Box::new(c::C),
+        // Handle all C-like languages the same now.
+        // We may have to split it later if this is not good enough.
+        gimli::DW_LANG_C
+        | gimli::DW_LANG_C89
+        | gimli::DW_LANG_C99
+        | gimli::DW_LANG_C11
+        | gimli::DW_LANG_C17 => Box::new(c::C),
         gimli::DW_LANG_Rust => Box::new(rust::Rust),
         _ => Box::new(UnknownLanguage),
     }

--- a/probe-rs/src/debug/language.rs
+++ b/probe-rs/src/debug/language.rs
@@ -52,6 +52,10 @@ pub trait ProgrammingLanguage {
     fn format_enum_value(&self, type_name: &VariableType, value: &VariableName) -> VariableValue {
         VariableValue::Valid(format!("{}::{}", type_name, value))
     }
+
+    fn process_tag_with_no_type(&self, tag: gimli::DwTag) -> VariableValue {
+        VariableValue::Error(format!("Error: Failed to decode {tag} type reference"))
+    }
 }
 
 #[derive(Clone)]

--- a/probe-rs/src/debug/language/c.rs
+++ b/probe-rs/src/debug/language/c.rs
@@ -64,6 +64,13 @@ impl ProgrammingLanguage for C {
     fn format_enum_value(&self, _type_name: &VariableType, value: &VariableName) -> VariableValue {
         VariableValue::Valid(value.to_string())
     }
+
+    fn process_tag_with_no_type(&self, tag: gimli::DwTag) -> VariableValue {
+        match tag {
+            gimli::DW_TAG_const_type => VariableValue::Valid("<void>".to_string()),
+            _ => VariableValue::Error(format!("Error: Failed to decode {tag} type reference")),
+        }
+    }
 }
 
 fn read_c_char(

--- a/probe-rs/src/debug/language/c.rs
+++ b/probe-rs/src/debug/language/c.rs
@@ -1,7 +1,7 @@
 use crate::{
     debug::{
         language::ProgrammingLanguage, DebugError, Variable, VariableCache, VariableLocation,
-        VariableType, VariableValue,
+        VariableName, VariableType, VariableValue,
     },
     MemoryInterface,
 };
@@ -59,6 +59,10 @@ impl ProgrammingLanguage for C {
             },
             _other => VariableValue::Empty,
         }
+    }
+
+    fn format_enum_value(&self, _type_name: &VariableType, value: &VariableName) -> VariableValue {
+        VariableValue::Valid(value.to_string())
     }
 }
 

--- a/probe-rs/src/debug/language/rust.rs
+++ b/probe-rs/src/debug/language/rust.rs
@@ -140,6 +140,10 @@ impl ProgrammingLanguage for Rust {
             }),
         }
     }
+
+    fn format_enum_value(&self, type_name: &VariableType, value: &VariableName) -> VariableValue {
+        VariableValue::Valid(format!("{}::{}", type_name, value))
+    }
 }
 
 /// Traits and Impl's to read from, and write to, memory value based on Variable::typ and Variable::location.

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -270,6 +270,10 @@ fn extract_byte_size(node_die: &DebuggingInformationEntry<GimliReader>) -> Optio
         Ok(optional_byte_size_attr) => match optional_byte_size_attr {
             Some(byte_size_attr) => match byte_size_attr.value() {
                 gimli::AttributeValue::Udata(byte_size) => Some(byte_size),
+                gimli::AttributeValue::Data1(byte_size) => Some(byte_size as u64),
+                gimli::AttributeValue::Data2(byte_size) => Some(byte_size as u64),
+                gimli::AttributeValue::Data4(byte_size) => Some(byte_size as u64),
+                gimli::AttributeValue::Data8(byte_size) => Some(byte_size as u64),
                 other => {
                     tracing::warn!("Unimplemented: DW_AT_byte_size value: {:?} ", other);
                     None

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -273,7 +273,7 @@ fn extract_byte_size(node_die: &DebuggingInformationEntry<GimliReader>) -> Optio
                 gimli::AttributeValue::Data1(byte_size) => Some(byte_size as u64),
                 gimli::AttributeValue::Data2(byte_size) => Some(byte_size as u64),
                 gimli::AttributeValue::Data4(byte_size) => Some(byte_size as u64),
-                gimli::AttributeValue::Data8(byte_size) => Some(byte_size as u64),
+                gimli::AttributeValue::Data8(byte_size) => Some(byte_size),
                 other => {
                     tracing::warn!("Unimplemented: DW_AT_byte_size value: {:?} ", other);
                     None

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -1252,9 +1252,9 @@ impl UnitInfo {
                     }
                 },
 
-                Ok(None) => child_variable.set_value(VariableValue::Error(format!(
-                    "Error: Failed to decode {other:?} type reference"
-                ))),
+                Ok(None) => child_variable.set_value(
+                    language::from_dwarf(self.get_language()).process_tag_with_no_type(other),
+                ),
 
                 Err(error) => child_variable.set_value(VariableValue::Error(format!(
                     "Error: Failed to decode {other:?} type reference: {error:?}"


### PR DESCRIPTION
Continuation of #2150

GCC seems to encode enum variants as `data1` (or wider), while LLVM used `udata` for Rust. In this PR I'm adding code to handle all the constant values (that I found). `dataN` can be any data format, but right now I've went with the path of least resistance and am handling them as unsigned integers.