### PR TITLE
Update cargo install command in the readme to use Cargo.lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See <https://github.com/cargo-bins/cargo-binstall> for more information.
 The tools can also be installed from source. After installing the necessary [prerequisites](#building), the latest released version can be installed using `cargo install`:
 
 ```bash
-cargo install probe-rs --features cli
+cargo install probe-rs --locked --features cli
 ```
 
 This will compile the tools and place them into the cargo `bin` directory. See the [Cargo book](https://doc.rust-lang.org/cargo/commands/cargo-install.html) for details.


### PR DESCRIPTION
somewhat counterintuitively, `cargo install` command by default doesn't respect the `Cargo.lock` file (see https://github.com/rust-lang/cargo/issues/7169 ), leading to situations when the command offered in the README may fail if one of the dependencies has an incompatible update and isn't pinned in the Cargo.toml

This just happened because defmt-decoder 0.3.10 made some changes to their unstable APIs which broke `cargo install probe-rs`, because defmt-decode requirement was `0.3` and Cargo.lock wasn't respected.