### PR TITLE
Split SVD variable cache into a separate struct

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1351,56 +1351,52 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
         let variable_ref: ObjectRef = arguments.variables_reference.into();
 
-        if let Some(core_peripherals) = &mut target_core.core_data.core_peripherals {
-            // First we check the SVD VariableCache, we do this first because it is the lowest computational overhead.
-            if let Some(search_variable) = core_peripherals
-                .svd_variable_cache
-                .get_variable_by_key(variable_ref)
-            {
-                let dap_variables: Vec<Variable> = core_peripherals
-                    .svd_variable_cache
-                    .get_children(search_variable.variable_key())?
-                    .iter_mut()
-                    // Convert the `probe_rs::debug::Variable` to `probe_rs_debugger::dap_types::Variable`
-                    .map(|variable| {
-                        let (variables_reference, named_child_variables_cnt) =
-                            get_svd_variable_reference(
-                                variable,
-                                &core_peripherals.svd_variable_cache,
-                            );
+        // First we check the SVD VariableCache, we do this first because it is the lowest computational overhead.
+        if let Some(svd_cache) = target_core
+            .core_data
+            .core_peripherals
+            .as_ref()
+            .map(|cp| &cp.svd_variable_cache)
+        {
+            let dap_variables: Vec<Variable> = svd_cache
+                .get_children(variable_ref)
+                .iter()
+                // Convert the `probe_rs::debug::Variable` to `probe_rs_debugger::dap_types::Variable`
+                .map(|variable| {
+                    let (variables_reference, named_child_variables_cnt) =
+                        get_svd_variable_reference(variable, &svd_cache);
 
-                        // We use fully qualified Peripheral.Register.Field form to ensure the `evaluate` request can find the right registers and fields by name.
-                        let name =
-                            if let Some(last_part) = variable.name.split_terminator('.').last() {
-                                last_part.to_string()
-                            } else {
-                                variable.name.to_string()
-                            };
+                    // We use fully qualified Peripheral.Register.Field form to ensure the `evaluate` request can find the right registers and fields by name.
+                    let name = if let Some(last_part) = variable.name().split_terminator('.').last()
+                    {
+                        last_part.to_string()
+                    } else {
+                        variable.name().to_string()
+                    };
 
-                        Variable {
-                            name,
-                            evaluate_name: Some(variable.name.to_string()),
-                            memory_reference: variable.memory_reference(),
-                            indexed_variables: None,
-                            named_variables: Some(named_child_variables_cnt),
-                            presentation_hint: None,
-                            type_: variable.type_name(),
-                            value: {
-                                // The SVD cache is not automatically refreshed on every stack trace, and we only need to refresh the field values.
-                                variable.get_value(&mut target_core.core)
-                            },
-                            variables_reference: variables_reference.into(),
-                        }
-                    })
-                    .collect();
+                    Variable {
+                        name,
+                        evaluate_name: Some(variable.name().to_string()),
+                        memory_reference: variable.memory_reference(),
+                        indexed_variables: None,
+                        named_variables: Some(named_child_variables_cnt),
+                        presentation_hint: None,
+                        type_: variable.type_name(),
+                        value: {
+                            // The SVD cache is not automatically refreshed on every stack trace, and we only need to refresh the field values.
+                            variable.get_value(&mut target_core.core)
+                        },
+                        variables_reference: variables_reference.into(),
+                    }
+                })
+                .collect();
 
-                return self.send_response(
-                    request,
-                    Ok(Some(VariablesResponseBody {
-                        variables: dap_variables,
-                    })),
-                );
-            }
+            return self.send_response(
+                request,
+                Ok(Some(VariablesResponseBody {
+                    variables: dap_variables,
+                })),
+            );
         }
 
         let mut parent_variable: Option<probe_rs::debug::Variable> = None;

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1364,7 +1364,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                 // Convert the `probe_rs::debug::Variable` to `probe_rs_debugger::dap_types::Variable`
                 .map(|variable| {
                     let (variables_reference, named_child_variables_cnt) =
-                        get_svd_variable_reference(variable, &svd_cache);
+                        get_svd_variable_reference(variable, svd_cache);
 
                     // We use fully qualified Peripheral.Register.Field form to ensure the `evaluate` request can find the right registers and fields by name.
                     let name = if let Some(last_part) = variable.name().split_terminator('.').last()

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
@@ -1,5 +1,6 @@
 use crate::cmd::dap_server::{
     debug_adapter::dap::dap_types::{DisassembledInstruction, Source},
+    peripherals::svd_cache::{SvdVariable, SvdVariableCache},
     server::{core_data::CoreHandle, session_data::BreakpointType},
     DebuggerError,
 };
@@ -374,6 +375,41 @@ pub(crate) fn get_variable_reference(
         // We have not yet cached the children for this reference.
         // Provide DAP Client with a reference so that it will explicitly ask for children when the user expands it.
         (parent_variable.variable_key(), 0, 0)
+    } else {
+        // Returning 0's allows VSCode DAP Client to behave correctly for frames that have no variables, and variables that have no children.
+        (ObjectRef::Invalid, 0, 0)
+    }
+}
+
+/// The DAP protocol uses three related values to determine how to invoke the `Variables` request.
+/// This function retrieves that information from the `DebugInfo::VariableCache` and returns it as
+/// (`variable_reference`, `named_child_variables_cnt`, `indexed_child_variables_cnt`)
+pub(crate) fn get_svd_variable_reference(
+    parent_variable: &SvdVariable,
+    cache: &mut SvdVariableCache,
+) -> (ObjectRef, i64, i64) {
+    if !parent_variable.is_valid() {
+        return (ObjectRef::Invalid, 0, 0);
+    }
+
+    let mut named_child_variables_cnt = 0;
+    let mut indexed_child_variables_cnt = 0;
+    if let Ok(children) = cache.get_children(parent_variable.variable_key()) {
+        for child_variable in children {
+            if child_variable.is_indexed() {
+                indexed_child_variables_cnt += 1;
+            } else {
+                named_child_variables_cnt += 1;
+            }
+        }
+    };
+
+    if named_child_variables_cnt > 0 || indexed_child_variables_cnt > 0 {
+        (
+            parent_variable.variable_key(),
+            named_child_variables_cnt,
+            indexed_child_variables_cnt,
+        )
     } else {
         // Returning 0's allows VSCode DAP Client to behave correctly for frames that have no variables, and variables that have no children.
         (ObjectRef::Invalid, 0, 0)

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
@@ -1,6 +1,6 @@
 use crate::cmd::dap_server::{
     debug_adapter::dap::dap_types::{DisassembledInstruction, Source},
-    peripherals::svd_cache::{SvdVariable, SvdVariableCache},
+    peripherals::svd_cache::{SvdVariableCache, Variable},
     server::{core_data::CoreHandle, session_data::BreakpointType},
     DebuggerError,
 };
@@ -385,13 +385,10 @@ pub(crate) fn get_variable_reference(
 /// This function retrieves that information from the `DebugInfo::VariableCache` and returns it as
 /// (`variable_reference`, `named_child_variables_cnt`, `indexed_child_variables_cnt`)
 pub(crate) fn get_svd_variable_reference(
-    parent_variable: &SvdVariable,
+    parent_variable: &Variable,
     cache: &SvdVariableCache,
 ) -> (ObjectRef, i64) {
-    let mut named_child_variables_cnt = 0;
-    if let Ok(children) = cache.get_children(parent_variable.variable_key()) {
-        named_child_variables_cnt = children.len();
-    };
+    let named_child_variables_cnt = cache.get_children(parent_variable.variable_key()).len();
 
     if named_child_variables_cnt > 0 {
         (

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
@@ -386,33 +386,21 @@ pub(crate) fn get_variable_reference(
 /// (`variable_reference`, `named_child_variables_cnt`, `indexed_child_variables_cnt`)
 pub(crate) fn get_svd_variable_reference(
     parent_variable: &SvdVariable,
-    cache: &mut SvdVariableCache,
-) -> (ObjectRef, i64, i64) {
-    if !parent_variable.is_valid() {
-        return (ObjectRef::Invalid, 0, 0);
-    }
-
+    cache: &SvdVariableCache,
+) -> (ObjectRef, i64) {
     let mut named_child_variables_cnt = 0;
-    let mut indexed_child_variables_cnt = 0;
     if let Ok(children) = cache.get_children(parent_variable.variable_key()) {
-        for child_variable in children {
-            if child_variable.is_indexed() {
-                indexed_child_variables_cnt += 1;
-            } else {
-                named_child_variables_cnt += 1;
-            }
-        }
+        named_child_variables_cnt = children.len();
     };
 
-    if named_child_variables_cnt > 0 || indexed_child_variables_cnt > 0 {
+    if named_child_variables_cnt > 0 {
         (
             parent_variable.variable_key(),
-            named_child_variables_cnt,
-            indexed_child_variables_cnt,
+            named_child_variables_cnt as i64,
         )
     } else {
         // Returning 0's allows VSCode DAP Client to behave correctly for frames that have no variables, and variables that have no children.
-        (ObjectRef::Invalid, 0, 0)
+        (ObjectRef::Invalid, 0)
     }
 }
 

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals.rs
@@ -1,3 +1,4 @@
+pub(crate) mod svd_cache;
 /// Notes about SVD:
 /// - Peripherals are 'grouped', but many only belong to a single group.
 /// - We only have to build the structure once down to 'fields' level.

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_cache.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_cache.rs
@@ -1,0 +1,617 @@
+use std::collections::BTreeMap;
+use std::ops::Range;
+
+use probe_rs::debug::{get_object_reference, DebugError, ObjectRef};
+use probe_rs::{Error, MemoryInterface};
+
+use anyhow::anyhow;
+use serde::Serialize;
+
+/// VariableCache stores available `Variable`s, and provides methods to create and navigate the parent-child relationships of the Variables.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SvdVariableCache {
+    root_variable_key: ObjectRef,
+
+    variable_hash_map: BTreeMap<ObjectRef, SvdVariable>,
+}
+
+impl SvdVariableCache {
+    fn new(mut variable: SvdVariable) -> Self {
+        let key = get_object_reference();
+
+        variable.variable_key = key;
+
+        SvdVariableCache {
+            root_variable_key: key,
+            variable_hash_map: BTreeMap::from([(key, variable)]),
+        }
+    }
+
+    /// Create a new cache for SVD variables
+    pub fn new_svd_cache() -> Self {
+        let mut device_root_variable = SvdVariable::new(
+            SvdVariableName::PeripheralScopeRoot,
+            SvdVariableType::Other("<Unknown>".to_string()),
+        );
+        device_root_variable.variable_node_type = SvdVariableNodeType::DoNotRecurse;
+
+        SvdVariableCache::new(device_root_variable)
+    }
+
+    pub fn has_children(&self, parent_variable: &SvdVariable) -> Result<bool, Error> {
+        self.get_children(parent_variable.variable_key)
+            .map(|children| !children.is_empty())
+    }
+
+    /// Retrieve `clone`d version of all the children of a `Variable`.
+    /// If `parent_key == None`, it will return all the top level variables (no parents) in this cache.
+    pub fn get_children(&self, parent_key: ObjectRef) -> Result<Vec<SvdVariable>, Error> {
+        let children: Vec<SvdVariable> = self
+            .variable_hash_map
+            .values()
+            .filter(|child_variable| child_variable.parent_key == parent_key)
+            .cloned()
+            .collect::<Vec<SvdVariable>>();
+
+        Ok(children)
+    }
+
+    /// Retrieve a clone of a specific `Variable`, using the `variable_key`.
+    pub fn get_variable_by_key(&self, variable_key: ObjectRef) -> Option<SvdVariable> {
+        self.variable_hash_map.get(&variable_key).cloned()
+    }
+
+    /// Get the root variable of the cache
+    pub fn root_variable(&self) -> SvdVariable {
+        self.variable_hash_map[&self.root_variable_key].clone()
+    }
+
+    /// Retrieve a clone of a specific `Variable`, using the `name`.
+    /// If there is more than one, it will be logged (tracing::warn!), and only the first will be returned.
+    /// It is possible for a hierarchy of variables in a cache to have duplicate names under different parents.
+    pub fn get_variable_by_name(&self, variable_name: &SvdVariableName) -> Option<SvdVariable> {
+        let child_variables = self
+            .variable_hash_map
+            .values()
+            .filter(|child_variable| child_variable.name.eq(variable_name))
+            .collect::<Vec<&SvdVariable>>();
+
+        match &child_variables[..] {
+            [] => None,
+            [variable] => Some((*variable).clone()),
+            [first, ..] => {
+                tracing::warn!(
+                    "Found {} variables with name={}. Please report this as a bug.",
+                    child_variables.len(),
+                    variable_name
+                );
+                Some((*first).clone())
+            }
+        }
+    }
+
+    /// Retrieve a clone of a specific `Variable`, using the `name` and `parent_key`.
+    /// If there is more than one, it will be logged (tracing::error!), and only the last will be returned.
+    pub fn get_variable_by_name_and_parent(
+        &self,
+        variable_name: &SvdVariableName,
+        parent_key: ObjectRef,
+    ) -> Option<SvdVariable> {
+        let child_variables = self
+            .variable_hash_map
+            .values()
+            .filter(|child_variable| {
+                &child_variable.name == variable_name && child_variable.parent_key == parent_key
+            })
+            .collect::<Vec<&SvdVariable>>();
+
+        match &child_variables[..] {
+            [] => None,
+            [variable] => Some((*variable).clone()),
+            [.., last] => {
+                tracing::error!("Found {} variables with parent_key={:?} and name={}. Please report this as a bug.", child_variables.len(), parent_key, variable_name);
+                Some((*last).clone())
+            }
+        }
+    }
+
+    pub fn add_variable(
+        &mut self,
+        parent_key: ObjectRef,
+        cache_variable: &mut SvdVariable,
+    ) -> Result<(), Error> {
+        // Validate that the parent_key exists ...
+        if self.variable_hash_map.contains_key(&parent_key) {
+            cache_variable.parent_key = parent_key;
+        } else {
+            return Err(anyhow!("SvdVariableCache: Attempted to add a new variable: {} with non existent `parent_key`: {:?}. Please report this as a bug", cache_variable.name, parent_key).into());
+        }
+
+        if cache_variable.variable_key != ObjectRef::Invalid {
+            return Err(anyhow!("SvdVariableCache: Attempted to add a new variable: {} with already set key: {:?}. Please report this as a bug", cache_variable.name, cache_variable.variable_key).into());
+        }
+
+        // The caller is telling us this is definitely a new `Variable`
+        cache_variable.variable_key = get_object_reference();
+
+        tracing::trace!(
+            "SvdVariableCache: Add Variable: key={:?}, parent={:?}, name={:?}",
+            cache_variable.variable_key,
+            cache_variable.parent_key,
+            &cache_variable.name
+        );
+
+        if let Some(old_variable) = self
+            .variable_hash_map
+            .insert(cache_variable.variable_key, cache_variable.clone())
+        {
+            return Err(anyhow!("Attempt to insert a new `SvdVariable`:{:?} with a duplicate cache key: {:?}. Please report this as a bug.", cache_variable.name, old_variable.variable_key).into());
+        }
+
+        Ok(())
+    }
+
+    pub fn update_variable(&mut self, cache_variable: &SvdVariable) -> Result<(), Error> {
+        if cache_variable.variable_key == ObjectRef::Invalid {
+            return Err(anyhow!("Attempt to update an existing `Variable`:{:?} with a non-existent cache key: {:?}. Please report this as a bug.", cache_variable.name, cache_variable.variable_key).into());
+        }
+
+        // Attempt to update an existing `Variable` in the cache
+        tracing::trace!(
+            "SvdVariableCache: Update SvdVariable, key={:?}, name={:?}",
+            cache_variable.variable_key,
+            &cache_variable.name
+        );
+
+        if let Some(prev_entry) = self.variable_hash_map.get_mut(&cache_variable.variable_key) {
+            if cache_variable != prev_entry {
+                tracing::trace!("Updated:  {:?}", cache_variable);
+                tracing::trace!("Previous: {:?}", prev_entry);
+                *prev_entry = cache_variable.clone();
+            }
+        } else {
+            return Err(anyhow!("Attempt to update an existing `Variable`:{:?} with a non-existent cache key: {:?}. Please report this as a bug.", cache_variable.name, cache_variable.variable_key).into());
+        }
+
+        Ok(())
+    }
+}
+
+/// The `Variable` struct is used in conjunction with `VariableCache` to cache data about variables.
+///
+/// Any modifications to the `Variable` value will be transient (lost when it goes out of scope),
+/// unless it is updated through one of the available methods on `VariableCache`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SvdVariable {
+    /// Every variable must have a unique key value assigned to it. The value will be zero until it is stored in VariableCache, at which time its value will be set to the same as the VariableCache::variable_cache_key
+    pub(super) variable_key: ObjectRef,
+    /// Every variable must have a unique parent assigned to it when stored in the VariableCache.
+    pub parent_key: ObjectRef,
+    /// The variable name refers to the name of any of the types of values described in the [VariableCache]
+    pub name: SvdVariableName,
+    /// Use `Variable::set_value()` and `Variable::get_value()` to correctly process this `value`
+    value: SvdVariableValue,
+
+    /// The name of the type of this variable.
+    pub type_name: SvdVariableType,
+    /// For 'lazy loading' of certain variable types we have to determine if the variable recursion should be deferred, and if so, how to resolve it when the request for further recursion happens.
+    /// See [VariableNodeType] for more information.
+    pub variable_node_type: SvdVariableNodeType,
+    /// The starting location/address in memory where this Variable's value is stored.
+    pub memory_location: SvdVariableLocation,
+    /// If this is a subrange (array, vector, etc.), we need to temporarily store the lower bound.
+    pub range_lower_bound: i64,
+    /// If this is a subrange (array, vector, etc.), we need to temporarily store the the upper bound of the range.
+    pub range_upper_bound: i64,
+}
+
+impl SvdVariable {
+    pub fn new(name: SvdVariableName, type_name: SvdVariableType) -> SvdVariable {
+        SvdVariable {
+            variable_key: ObjectRef::default(),
+            parent_key: ObjectRef::default(),
+            name,
+            value: SvdVariableValue::default(),
+            type_name,
+            variable_node_type: SvdVariableNodeType::default(),
+            memory_location: SvdVariableLocation::default(),
+            range_lower_bound: 0,
+            range_upper_bound: 0,
+        }
+    }
+
+    /// Get a unique key for this variable.
+    pub fn variable_key(&self) -> ObjectRef {
+        self.variable_key
+    }
+
+    /// Implementing get_value(), because Variable.value has to be private (a requirement of updating the value without overriding earlier values ... see set_value()).
+    pub fn get_value(&self, variable_cache: &SvdVariableCache) -> String {
+        // Allow for chained `if let` without complaining
+        if SvdVariableNodeType::SvdRegister == self.variable_node_type {
+            if let SvdVariableValue::Valid(register_value) = &self.value {
+                if let Ok(register_u32_value) = register_value.parse::<u32>() {
+                    format!(
+                        "{:032b} @ {:#010X}",
+                        register_u32_value,
+                        self.memory_location.memory_address().unwrap_or(u64::MAX) // We should never encounter a memory location that is invalid if we already used it to read the register value.
+                    )
+                } else {
+                    format!("Invalid register value {register_value}")
+                }
+            } else {
+                format!("{}", self.value)
+            }
+        } else if SvdVariableNodeType::SvdField == self.variable_node_type {
+            // In this special case, we extract just the bits we need from the stored value of the register.
+            if let SvdVariableValue::Valid(register_value) = &self.value {
+                if let Ok(register_u32_value) = register_value.parse::<u32>() {
+                    let mut bit_value: u32 = register_u32_value;
+                    bit_value <<= 32 - self.range_upper_bound;
+                    bit_value >>= 32 - (self.range_upper_bound - self.range_lower_bound);
+                    format!(
+                        "{:0width$b} @ {:#010X}:{}..{}",
+                        bit_value,
+                        self.memory_location.memory_address().unwrap_or(u64::MAX),
+                        self.range_lower_bound,
+                        self.range_upper_bound,
+                        width = self.subrange_bounds().count()
+                    )
+                } else {
+                    format!(
+                        "Invalid bit range {}..{} from value {}",
+                        self.range_lower_bound, self.range_upper_bound, register_value
+                    )
+                }
+            } else {
+                format!("{}", self.value)
+            }
+        } else if !self.value.is_empty() {
+            // The `value` for this `Variable` is non empty because ...
+            // - It is base data type for which a value was determined based on the core runtime, or ...
+            // - We encountered an error somewhere, so report it to the user
+            format!("{}", self.value)
+        } else {
+            // We need to construct a 'human readable' value using `fmt::Display` to represent the values of complex types and pointers.
+            match variable_cache.has_children(self) {
+                Ok(true) => self.formatted_variable_value(variable_cache, 0_usize, false),
+                Ok(false) => {
+                    if !self.memory_location.valid() {
+                        // This condition should only be true for intermediate nodes from DWARF. These should not show up in the final `VariableCache`
+                        // If a user sees this error, then there is a logic problem in the stack unwind
+                        "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location".to_string()
+                    } else {
+                        format!(
+                            "Unimplemented: Evaluate type {:?} at location 0x{:08x?}",
+                            self.type_name, self.memory_location
+                        )
+                    }
+                }
+                Err(error) => format!(
+                    "Failed to determine children for `Variable`:{}. {:?}",
+                    self.name, error
+                ),
+            }
+        }
+    }
+
+    pub fn extract_value(&mut self, memory: &mut dyn MemoryInterface) {
+        if let SvdVariableValue::Error(_) = self.value {
+            // Nothing more to do ...
+            return;
+        }
+
+        if self.variable_node_type == SvdVariableNodeType::SvdRegister
+            || self.variable_node_type == SvdVariableNodeType::SvdField
+        {
+            // Special handling for SVD registers.
+            // Because we cache the SVD structure once per sesion, we have to re-read the actual register values whenever queried.
+            match memory.read_word_32(self.memory_location.memory_address().unwrap_or(u64::MAX)) {
+                Ok(u32_value) => {
+                    self.value = SvdVariableValue::Valid(u32_value.to_le().to_string())
+                }
+                Err(error) => {
+                    self.value = SvdVariableValue::Error(format!(
+                        "Unable to read peripheral register value @ {:#010X} : {:?}",
+                        self.memory_location.memory_address().unwrap_or(u64::MAX),
+                        error
+                    ))
+                }
+            }
+            return;
+        }
+
+        todo!("Implement `Variable::extract_value` for SvdVariable");
+    }
+
+    pub(crate) fn subrange_bounds(&self) -> Range<i64> {
+        self.range_lower_bound..self.range_upper_bound
+    }
+
+    fn formatted_variable_value(
+        &self,
+        variable_cache: &SvdVariableCache,
+        indentation: usize,
+        show_name: bool,
+    ) -> String {
+        let line_feed = if indentation == 0 { "" } else { "\n" }.to_string();
+        // Allow for chained `if let` without complaining
+        #[allow(clippy::if_same_then_else)]
+        if !self.value.is_empty() {
+            if show_name {
+                // Use the supplied value or error message.
+                format!(
+                    "{}{:\t<indentation$}{}: {} = {}",
+                    line_feed, "", self.name, self.type_name, self.value
+                )
+            } else {
+                // Use the supplied value or error message.
+                format!("{}{:\t<indentation$}{}", line_feed, "", self.value)
+            }
+        } else {
+            // Infer a human readable value using the available children of this variable.
+            let mut compound_value = String::new();
+            if let Ok(children) = variable_cache.get_children(self.variable_key) {
+                // Generic handling of other structured types.
+                // The pre- and post- fix is determined by the type of children.
+                // compound_value = format!("{} {}", compound_value, self.type_name);
+
+                if children.is_empty() {
+                    // Struct with no children -> just print type name
+                    // This is for example the None value of an Option.
+
+                    format!("{}{:\t<indentation$}{}", line_feed, "", self.name)
+                } else {
+                    let (mut pre_fix, mut post_fix): (Option<String>, Option<String>) =
+                        (None, None);
+
+                    let mut child_count: usize = 0;
+
+                    let mut is_tuple = false;
+
+                    for child in children.iter() {
+                        child_count += 1;
+                        if pre_fix.is_none() && post_fix.is_none() {
+                            if let SvdVariableName::Named(child_name) = &child.name {
+                                if child_name.starts_with("__0") {
+                                    is_tuple = true;
+                                    // Treat this structure as a tuple
+                                    pre_fix = Some(format!(
+                                        "{}{:\t<indentation$}{}: {}({}) = {}(",
+                                        line_feed,
+                                        "",
+                                        self.name,
+                                        self.type_name,
+                                        child.type_name,
+                                        self.type_name,
+                                    ));
+                                    post_fix =
+                                        Some(format!("{}{:\t<indentation$})", line_feed, ""));
+                                } else {
+                                    // Treat this structure as a `struct`
+
+                                    if show_name {
+                                        pre_fix = Some(format!(
+                                            "{}{:\t<indentation$}{}: {} = {} {{",
+                                            line_feed,
+                                            "",
+                                            self.name,
+                                            self.type_name,
+                                            self.type_name,
+                                        ));
+                                    } else {
+                                        pre_fix = Some(format!(
+                                            "{}{:\t<indentation$}{} {{",
+                                            line_feed, "", self.type_name,
+                                        ));
+                                    }
+                                    post_fix =
+                                        Some(format!("{}{:\t<indentation$}}}", line_feed, ""));
+                                }
+                            };
+                            if let Some(pre_fix) = &pre_fix {
+                                compound_value = format!("{compound_value}{pre_fix}");
+                            };
+                        }
+
+                        let print_name = !is_tuple;
+
+                        compound_value = format!(
+                            "{}{}{}",
+                            compound_value,
+                            child.formatted_variable_value(
+                                variable_cache,
+                                indentation + 1,
+                                print_name
+                            ),
+                            if child_count == children.len() {
+                                // Do not add a separator at the end of the list
+                                ""
+                            } else {
+                                ", "
+                            }
+                        );
+                    }
+                    if let Some(post_fix) = &post_fix {
+                        compound_value = format!("{compound_value}{post_fix}");
+                    };
+                    compound_value
+                }
+            } else {
+                // We don't have a value, and we can't generate one from children values, so use the type_name
+                format!("{:\t<indentation$}{}", "", self.type_name)
+            }
+        }
+    }
+
+    /// `true` if the Variable has a valid value, or an empty value.
+    /// `false` if the Variable has a VariableValue::Error(_)value
+    pub fn is_valid(&self) -> bool {
+        self.value.is_valid()
+    }
+
+    /// The variable is considered to be an 'indexed' variable if the name starts with two underscores followed by a number. e.g. "__1".
+    /// TODO: Consider replacing this logic with `std::str::pattern::Pattern` when that API stabilizes
+    pub fn is_indexed(&self) -> bool {
+        match &self.name {
+            SvdVariableName::Named(name) => {
+                name.starts_with("__")
+                    && name
+                        .find(char::is_numeric)
+                        .map_or(false, |zero_based_position| zero_based_position == 2)
+            }
+            // Other kind of variables are never indexed
+            _ => false,
+        }
+    }
+
+    /// Implementing set_value(), because the library passes errors into the value of the variable.
+    /// This ensures debug front ends can see the errors, but doesn't fail because of a single variable not being able to decode correctly.
+    pub fn set_value(&mut self, new_value: SvdVariableValue) {
+        // Allow some block when logic requires it.
+        #[allow(clippy::if_same_then_else)]
+        if new_value.is_valid() {
+            // Simply overwrite existing value with a new valid one.
+            self.value = new_value;
+        } else if self.value.is_valid() {
+            // Overwrite a valid value with an error.
+            self.value = new_value;
+        } else {
+            // Concatenate the error messages ...
+            self.value = SvdVariableValue::Error(format!("{} : {}", self.value, new_value));
+        }
+        if !self.value.is_valid() {
+            // If the value is invalid, then make sure we don't propogate invalid memory location values.
+            self.memory_location = SvdVariableLocation::Unavailable;
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum SvdVariableNodeType {
+    DoNotRecurse,
+    SvdRegister,
+    SvdField,
+    SvdPeripheral,
+    #[default]
+    RecurseToBaseType,
+}
+
+/// The variants of VariableType allows us to streamline the conditional logic that requires specific handling depending on the nature of the variable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum SvdVariableType {
+    /// For infrequently used categories of variables that does not fall into any of the other `VariableType` variants.
+    Other(String),
+}
+
+impl std::fmt::Display for SvdVariableType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SvdVariableType::Other(other) => other.fmt(f),
+        }
+    }
+}
+
+/// Location of a variable
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum SvdVariableLocation {
+    /// Location of the variable is not known. This means that it has not been evaluated yet.
+    #[default]
+    Unknown,
+    /// The variable does not have a location currently, probably due to optimisations.
+    Unavailable,
+    /// The variable can be found in memory, at this address.
+    Address(u64),
+}
+
+impl SvdVariableLocation {
+    /// Return the memory address, if available. Otherwise an error is returned.
+    pub fn memory_address(&self) -> Result<u64, DebugError> {
+        match self {
+            SvdVariableLocation::Address(address) => Ok(*address),
+            other => Err(DebugError::UnwindIncompleteResults {
+                message: format!("Variable does not have a memory location: location={other:?}"),
+            }),
+        }
+    }
+
+    /// Check if the location is valid, ie. not an error, unsupported, or unavailable.
+    pub fn valid(&self) -> bool {
+        match self {
+            SvdVariableLocation::Address(_) | SvdVariableLocation::Unknown => true,
+            _other => false,
+        }
+    }
+}
+
+impl std::fmt::Display for SvdVariableLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SvdVariableLocation::Unknown => "<unknown value>".fmt(f),
+            SvdVariableLocation::Unavailable => "<value not available>".fmt(f),
+            SvdVariableLocation::Address(address) => write!(f, "{address:#010X}"),
+        }
+    }
+}
+
+/// The type of variable we have at hand.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
+pub enum SvdVariableName {
+    /// Top-level variable for CMSIS-SVD file Device peripherals/registers/fields.
+    PeripheralScopeRoot,
+    /// Variable with a specific name
+    Named(String),
+}
+
+impl std::fmt::Display for SvdVariableName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SvdVariableName::PeripheralScopeRoot => write!(f, "Peripheral Variable"),
+            SvdVariableName::Named(name) => name.fmt(f),
+        }
+    }
+}
+
+/// A [Variable] will have either a valid value, or some reason why a value could not be constructed.
+/// - If we encounter expected errors, they will be displayed to the user as defined below.
+/// - If we encounter unexpected errors, they will be treated as proper errors and will propagated to the calling process as an `Err()`
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub enum SvdVariableValue {
+    /// A valid value of this variable
+    Valid(String),
+    /// Notify the user that we encountered a problem correctly resolving the variable.
+    /// - The variable will be visible to the user, as will the other field of the variable.
+    /// - The contained warning message will be displayed to the user.
+    /// - The debugger will not attempt to resolve additional fields or children of this variable.
+    Error(String),
+    /// The value has not been set. This could be because ...
+    /// - It is too early in the process to have discovered its value, or ...
+    /// - The variable cannot have a stored value, e.g. a `struct`. In this case, please use `Variable::get_value` to infer a human readable value from the value of the struct's fields.
+    #[default]
+    Empty,
+}
+
+impl std::fmt::Display for SvdVariableValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SvdVariableValue::Valid(value) => value.fmt(f),
+            SvdVariableValue::Error(error) => write!(f, "< {error} >",),
+            SvdVariableValue::Empty => write!(
+                f,
+                "Value not set. Please use Variable::get_value() to infer a human readable variable value"
+            ),
+        }
+    }
+}
+
+impl SvdVariableValue {
+    /// Returns `true` if the variable resolver did not encounter an error, `false` otherwise.
+    pub fn is_valid(&self) -> bool {
+        !matches!(self, SvdVariableValue::Error(_))
+    }
+
+    /// Returns `true` if no value or error is present, `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        matches!(self, SvdVariableValue::Empty)
+    }
+}

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_cache.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_cache.rs
@@ -41,7 +41,7 @@ impl SvdVariableCache {
         Ok(children)
     }
 
-    /// Retrieve a clone of a specific `Variable`, using the `variable_key`.
+    /// Retrieve a specific `Variable`, using the `variable_key`.
     pub fn get_variable_by_key(&self, variable_key: ObjectRef) -> Option<&SvdVariable> {
         self.variable_hash_map.get(&variable_key)
     }
@@ -103,8 +103,8 @@ impl SvdVariableCache {
     pub fn add_variable(
         &mut self,
         parent_key: ObjectRef,
-        cache_variable: &mut SvdVariable,
-    ) -> Result<(), Error> {
+        mut cache_variable: SvdVariable,
+    ) -> Result<ObjectRef, Error> {
         // Validate that the parent_key exists ...
         if self.variable_hash_map.contains_key(&parent_key) || parent_key == self.root_variable_key
         {
@@ -134,32 +134,7 @@ impl SvdVariableCache {
             return Err(anyhow!("Attempt to insert a new `SvdVariable`:{:?} with a duplicate cache key: {:?}. Please report this as a bug.", cache_variable.name, old_variable.variable_key).into());
         }
 
-        Ok(())
-    }
-
-    pub fn update_variable(&mut self, cache_variable: &SvdVariable) -> Result<(), Error> {
-        if cache_variable.variable_key == ObjectRef::Invalid {
-            return Err(anyhow!("Attempt to update an existing `Variable`:{:?} with a non-existent cache key: {:?}. Please report this as a bug.", cache_variable.name, cache_variable.variable_key).into());
-        }
-
-        // Attempt to update an existing `Variable` in the cache
-        tracing::trace!(
-            "SvdVariableCache: Update SvdVariable, key={:?}, name={:?}",
-            cache_variable.variable_key,
-            &cache_variable.name
-        );
-
-        if let Some(prev_entry) = self.variable_hash_map.get_mut(&cache_variable.variable_key) {
-            if cache_variable != prev_entry {
-                tracing::trace!("Updated:  {:?}", cache_variable);
-                tracing::trace!("Previous: {:?}", prev_entry);
-                *prev_entry = cache_variable.clone();
-            }
-        } else {
-            return Err(anyhow!("Attempt to update an existing `Variable`:{:?} with a non-existent cache key: {:?}. Please report this as a bug.", cache_variable.name, cache_variable.variable_key).into());
-        }
-
-        Ok(())
+        Ok(cache_variable.variable_key)
     }
 }
 

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_cache.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_cache.rs
@@ -111,8 +111,8 @@ impl SvdVariableCache {
             let variable_key = get_object_reference();
             Variable {
                 variable_key,
-                parent_key: parent_key,
-                name: name,
+                parent_key,
+                name,
                 variable_kind: variable,
             }
         };

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_cache.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_cache.rs
@@ -4,7 +4,6 @@ use probe_rs::debug::{get_object_reference, ObjectRef};
 use probe_rs::{Error, MemoryInterface};
 
 use anyhow::anyhow;
-use serde::Serialize;
 
 /// VariableCache stores available `Variable`s, and provides methods to create and navigate the parent-child relationships of the Variables.
 #[derive(Debug, Clone, PartialEq)]
@@ -15,26 +14,18 @@ pub struct SvdVariableCache {
 }
 
 impl SvdVariableCache {
-    fn new(mut variable: SvdVariable) -> Self {
+    /// Create a new cache for SVD variables
+    pub fn new_svd_cache() -> Self {
         let key = get_object_reference();
 
+        let mut variable =
+            SvdVariable::new("Peripheral variable".to_string(), SvdVariableNodeType::Root);
         variable.variable_key = key;
 
         SvdVariableCache {
             root_variable_key: key,
             variable_hash_map: BTreeMap::from([(key, variable)]),
         }
-    }
-
-    /// Create a new cache for SVD variables
-    pub fn new_svd_cache() -> Self {
-        let mut device_root_variable = SvdVariable::new(
-            SvdVariableName::PeripheralScopeRoot,
-            SvdVariableType::Other("<Unknown>".to_string()),
-        );
-        device_root_variable.variable_node_type = SvdVariableNodeType::DoNotRecurse;
-
-        SvdVariableCache::new(device_root_variable)
     }
 
     /// Retrieve `clone`d version of all the children of a `Variable`.
@@ -51,19 +42,19 @@ impl SvdVariableCache {
     }
 
     /// Retrieve a clone of a specific `Variable`, using the `variable_key`.
-    pub fn get_variable_by_key(&self, variable_key: ObjectRef) -> Option<SvdVariable> {
-        self.variable_hash_map.get(&variable_key).cloned()
+    pub fn get_variable_by_key(&self, variable_key: ObjectRef) -> Option<&SvdVariable> {
+        self.variable_hash_map.get(&variable_key)
     }
 
     /// Get the root variable of the cache
-    pub fn root_variable(&self) -> SvdVariable {
-        self.variable_hash_map[&self.root_variable_key].clone()
+    pub fn root_variable_key(&self) -> ObjectRef {
+        self.root_variable_key
     }
 
     /// Retrieve a clone of a specific `Variable`, using the `name`.
     /// If there is more than one, it will be logged (tracing::warn!), and only the first will be returned.
     /// It is possible for a hierarchy of variables in a cache to have duplicate names under different parents.
-    pub fn get_variable_by_name(&self, variable_name: &SvdVariableName) -> Option<SvdVariable> {
+    pub fn get_variable_by_name(&self, variable_name: &str) -> Option<&SvdVariable> {
         let child_variables = self
             .variable_hash_map
             .values()
@@ -72,14 +63,14 @@ impl SvdVariableCache {
 
         match &child_variables[..] {
             [] => None,
-            [variable] => Some((*variable).clone()),
+            [variable] => Some(*variable),
             [first, ..] => {
                 tracing::warn!(
                     "Found {} variables with name={}. Please report this as a bug.",
                     child_variables.len(),
                     variable_name
                 );
-                Some((*first).clone())
+                Some(*first)
             }
         }
     }
@@ -88,14 +79,14 @@ impl SvdVariableCache {
     /// If there is more than one, it will be logged (tracing::error!), and only the last will be returned.
     pub fn get_variable_by_name_and_parent(
         &self,
-        variable_name: &SvdVariableName,
+        variable_name: &str,
         parent_key: ObjectRef,
     ) -> Option<SvdVariable> {
         let child_variables = self
             .variable_hash_map
             .values()
             .filter(|child_variable| {
-                &child_variable.name == variable_name && child_variable.parent_key == parent_key
+                child_variable.name == variable_name && child_variable.parent_key == parent_key
             })
             .collect::<Vec<&SvdVariable>>();
 
@@ -115,7 +106,8 @@ impl SvdVariableCache {
         cache_variable: &mut SvdVariable,
     ) -> Result<(), Error> {
         // Validate that the parent_key exists ...
-        if self.variable_hash_map.contains_key(&parent_key) {
+        if self.variable_hash_map.contains_key(&parent_key) || parent_key == self.root_variable_key
+        {
             cache_variable.parent_key = parent_key;
         } else {
             return Err(anyhow!("SvdVariableCache: Attempted to add a new variable: {} with non existent `parent_key`: {:?}. Please report this as a bug", cache_variable.name, parent_key).into());
@@ -182,26 +174,20 @@ pub struct SvdVariable {
     /// Every variable must have a unique parent assigned to it when stored in the VariableCache.
     pub parent_key: ObjectRef,
     /// The variable name refers to the name of any of the types of values described in the [VariableCache]
-    pub name: SvdVariableName,
-    /// Use `Variable::set_value()` and `Variable::get_value()` to correctly process this `value`
-    value: SvdVariableValue,
+    pub name: String,
 
-    /// The name of the type of this variable.
-    pub type_name: SvdVariableType,
     /// For 'lazy loading' of certain variable types we have to determine if the variable recursion should be deferred, and if so, how to resolve it when the request for further recursion happens.
     /// See [VariableNodeType] for more information.
     pub variable_node_type: SvdVariableNodeType,
 }
 
 impl SvdVariable {
-    pub fn new(name: SvdVariableName, type_name: SvdVariableType) -> SvdVariable {
+    pub fn new(name: String, variable_node_type: SvdVariableNodeType) -> SvdVariable {
         SvdVariable {
             variable_key: ObjectRef::default(),
             parent_key: ObjectRef::default(),
             name,
-            value: SvdVariableValue::default(),
-            type_name,
-            variable_node_type: SvdVariableNodeType::default(),
+            variable_node_type,
         }
     }
 
@@ -213,22 +199,53 @@ impl SvdVariable {
     /// Memory reference, compatible with DAP
     pub fn memory_reference(&self) -> Option<String> {
         match self.variable_node_type {
-            SvdVariableNodeType::SvdRegister(address) => Some(format!("{:#010X}", address)),
-            SvdVariableNodeType::SvdField { address, .. } => Some(format!("{:#010X}", address)),
+            SvdVariableNodeType::SvdRegister {
+                address,
+                restricted_read: false,
+                ..
+            } => Some(format!("{:#010X}", address)),
+
+            SvdVariableNodeType::SvdField {
+                address,
+                restricted_read: false,
+                ..
+            } => Some(format!("{:#010X}", address)),
             _ => None,
+        }
+    }
+
+    pub fn type_name(&self) -> Option<String> {
+        match &self.variable_node_type {
+            SvdVariableNodeType::SvdRegister { description, .. }
+            | SvdVariableNodeType::SvdField { description, .. } => description.clone(),
+            SvdVariableNodeType::SvdPeripheral { .. } => Some("Peripheral".to_string()),
+            SvdVariableNodeType::SvdPeripheralGroup { .. } => Some("Peripheral Group".to_string()),
+            SvdVariableNodeType::Root => None,
         }
     }
 
     /// Implementing get_value(), because Variable.value has to be private (a requirement of updating the value without overriding earlier values ... see set_value()).
     pub fn get_value(&self, memory: &mut dyn MemoryInterface) -> String {
-        match &self.value {
-            SvdVariableValue::Fixed(s) => s.clone(),
-            SvdVariableValue::Error(s) => s.clone(),
-            SvdVariableValue::Empty => "<empty>".to_string(),
-            SvdVariableValue::Lookup => {
-                // Allow for chained `if let` without complaining
-                if let SvdVariableNodeType::SvdRegister(address) = self.variable_node_type {
-                    let value = match memory.read_word_32(address) {
+        match &self.variable_node_type {
+            SvdVariableNodeType::Root => "".to_string(),
+            SvdVariableNodeType::SvdPeripheral { description, .. }
+            | SvdVariableNodeType::SvdPeripheralGroup { description } => description
+                .as_ref()
+                .cloned()
+                .unwrap_or_else(|| self.name.to_string()),
+
+            SvdVariableNodeType::SvdRegister {
+                address,
+                restricted_read,
+                ..
+            } => {
+                if *restricted_read {
+                    format!(
+                        "Register cannot be read without side effects @ {:#010X}",
+                        address
+                    )
+                } else {
+                    let value = match memory.read_word_32(*address) {
                         Ok(u32_value) => Ok(u32_value),
                         Err(error) => Err(format!(
                             "Unable to read peripheral register value @ {:#010X} : {:?}",
@@ -242,16 +259,25 @@ impl SvdVariable {
                         }
                         Err(error) => error,
                     }
-                } else if let SvdVariableNodeType::SvdField {
-                    address,
-                    bit_range_lower_bound,
-                    bit_range_upper_bound,
-                } = self.variable_node_type
-                {
-                    let value = match memory.read_word_32(address) {
+                }
+            }
+            SvdVariableNodeType::SvdField {
+                address,
+                restricted_read,
+                bit_range_lower_bound,
+                bit_range_upper_bound,
+                ..
+            } => {
+                if *restricted_read {
+                    format!(
+                        "Field cannot be read without side effects @ {:#010X}",
+                        address
+                    )
+                } else {
+                    let value = match memory.read_word_32(*address) {
                         Ok(u32_value) => Ok(u32_value),
                         Err(error) => Err(format!(
-                            "Unable to read peripheral register value @ {:#010X} : {:?}",
+                            "Unable to read peripheral register field value @ {:#010X} : {:?}",
                             address, error
                         )),
                     };
@@ -268,172 +294,45 @@ impl SvdVariable {
                                 address,
                                 bit_range_lower_bound,
                                 bit_range_upper_bound,
-                                width = (bit_range_lower_bound..bit_range_upper_bound).count()
+                                width = (*bit_range_lower_bound..*bit_range_upper_bound).count()
                             )
                         }
                         Err(e) => e,
                     }
-                } else {
-                    unreachable!("Should never get here")
                 }
             }
         }
     }
-
-    /// `true` if the Variable has a valid value, or an empty value.
-    /// `false` if the Variable has a VariableValue::Error(_)value
-    pub fn is_valid(&self) -> bool {
-        self.value.is_valid()
-    }
-
-    /// The variable is considered to be an 'indexed' variable if the name starts with two underscores followed by a number. e.g. "__1".
-    /// TODO: Consider replacing this logic with `std::str::pattern::Pattern` when that API stabilizes
-    pub fn is_indexed(&self) -> bool {
-        match &self.name {
-            SvdVariableName::Named(name) => {
-                name.starts_with("__")
-                    && name
-                        .find(char::is_numeric)
-                        .map_or(false, |zero_based_position| zero_based_position == 2)
-            }
-            // Other kind of variables are never indexed
-            _ => false,
-        }
-    }
-
-    /// Implementing set_value(), because the library passes errors into the value of the variable.
-    /// This ensures debug front ends can see the errors, but doesn't fail because of a single variable not being able to decode correctly.
-    pub fn set_value(&mut self, new_value: SvdVariableValue) {
-        // Allow some block when logic requires it.
-        #[allow(clippy::if_same_then_else)]
-        if new_value.is_valid() {
-            // Simply overwrite existing value with a new valid one.
-            self.value = new_value;
-        } else if self.value.is_valid() {
-            // Overwrite a valid value with an error.
-            self.value = new_value;
-        } else {
-            // Concatenate the error messages ...
-            self.value = SvdVariableValue::Error(format!("{} : {}", self.value, new_value));
-        }
-    }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SvdVariableNodeType {
-    DoNotRecurse,
+    Root,
     /// Register with address
-    SvdRegister(u64),
-    /// Field with address (of what exactly?)
+    SvdRegister {
+        address: u64,
+        /// true if the register is write-only or  if a ride has side effects
+        restricted_read: bool,
+
+        /// Description of the register, used as type in DAP
+        description: Option<String>,
+    },
+    /// Field with address
     SvdField {
         address: u64,
-        bit_range_lower_bound: i64,
-        bit_range_upper_bound: i64,
+        /// true if the register is write-only or  if a ride has side effects
+        restricted_read: bool,
+        bit_range_lower_bound: u32,
+        bit_range_upper_bound: u32,
+
+        description: Option<String>,
     },
-    /// Peripherl with peripheral base address
+    /// Peripheral with peripheral base address
     SvdPeripheral {
         base_address: u64,
+        description: Option<String>,
     },
-    SvdPeripheralGroup,
-    #[default]
-    RecurseToBaseType,
-}
-
-/// The variants of VariableType allows us to streamline the conditional logic that requires specific handling depending on the nature of the variable.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub enum SvdVariableType {
-    PeripheralGroup,
-    Peripheral,
-    /// For infrequently used categories of variables that does not fall into any of the other `VariableType` variants.
-    Other(String),
-}
-
-impl std::fmt::Display for SvdVariableType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SvdVariableType::PeripheralGroup => write!(f, "Peripheral Group"),
-            SvdVariableType::Peripheral => write!(f, "Peripheral"),
-            SvdVariableType::Other(other) => other.fmt(f),
-        }
-    }
-}
-
-/// Location of a variable
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub enum SvdVariableLocation {
-    /// Location of the variable is not known. This means that it has not been evaluated yet.
-    #[default]
-    Unknown,
-}
-
-impl std::fmt::Display for SvdVariableLocation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SvdVariableLocation::Unknown => "<unknown value>".fmt(f),
-        }
-    }
-}
-
-/// The type of variable we have at hand.
-#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
-pub enum SvdVariableName {
-    /// Top-level variable for CMSIS-SVD file Device peripherals/registers/fields.
-    PeripheralScopeRoot,
-    /// Variable with a specific name
-    Named(String),
-}
-
-impl std::fmt::Display for SvdVariableName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SvdVariableName::PeripheralScopeRoot => write!(f, "Peripheral Variable"),
-            SvdVariableName::Named(name) => name.fmt(f),
-        }
-    }
-}
-
-/// A [Variable] will have either a valid value, or some reason why a value could not be constructed.
-/// - If we encounter expected errors, they will be displayed to the user as defined below.
-/// - If we encounter unexpected errors, they will be treated as proper errors and will propagated to the calling process as an `Err()`
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
-pub enum SvdVariableValue {
-    /// Fixed value, e.g. description
-    Fixed(String),
-    Lookup,
-    /// Notify the user that we encountered a problem correctly resolving the variable.
-    /// - The variable will be visible to the user, as will the other field of the variable.
-    /// - The contained warning message will be displayed to the user.
-    /// - The debugger will not attempt to resolve additional fields or children of this variable.
-    Error(String),
-    /// The value has not been set. This could be because ...
-    /// - It is too early in the process to have discovered its value, or ...
-    /// - The variable cannot have a stored value, e.g. a `struct`. In this case, please use `Variable::get_value` to infer a human readable value from the value of the struct's fields.
-    #[default]
-    Empty,
-}
-
-impl std::fmt::Display for SvdVariableValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SvdVariableValue::Fixed(value) => value.fmt(f),
-            SvdVariableValue::Lookup => write!(f, "<Lookup>"),
-            SvdVariableValue::Error(error) => write!(f, "< {error} >",),
-            SvdVariableValue::Empty => write!(
-                f,
-                "Value not set. Please use Variable::get_value() to infer a human readable variable value"
-            ),
-        }
-    }
-}
-
-impl SvdVariableValue {
-    /// Returns `true` if the variable resolver did not encounter an error, `false` otherwise.
-    pub fn is_valid(&self) -> bool {
-        !matches!(self, SvdVariableValue::Error(_))
-    }
-
-    /// Returns `true` if no value or error is present, `false` otherwise.
-    pub fn is_empty(&self) -> bool {
-        matches!(self, SvdVariableValue::Empty)
-    }
+    SvdPeripheralGroup {
+        description: Option<String>,
+    },
 }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_variables.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_variables.rs
@@ -3,16 +3,9 @@ use crate::cmd::dap_server::{
     DebuggerError,
 };
 use std::{fmt::Debug, fs::File, io::Read, path::Path};
-use svd_parser::{
-    self as svd,
-    svd::{Access, Device},
-    Config,
-};
+use svd_parser::{self as svd, svd::Device, Config};
 
-use super::svd_cache::{
-    SvdVariable, SvdVariableCache, SvdVariableName, SvdVariableNodeType, SvdVariableType,
-    SvdVariableValue,
-};
+use super::svd_cache::{SvdVariable, SvdVariableCache, SvdVariableNodeType};
 
 /// The SVD file contents and related data
 #[derive(Debug)]
@@ -82,45 +75,40 @@ pub(crate) fn variable_cache_from_svd<P: ProtocolAdapter>(
     progress_id: i64,
 ) -> Result<SvdVariableCache, DebuggerError> {
     let mut svd_cache = SvdVariableCache::new_svd_cache();
-    let device_root_variable = svd_cache.root_variable();
+    let device_root_variable_key = svd_cache.root_variable_key();
 
     // Adding the Peripheral Group Name as an additional level in the structure helps to keep the 'variable tree' more compact,
     // but more importantly, it helps to avoid having duplicate variable names that conflict with hal crates.
     let mut peripheral_group_variable = SvdVariable::new(
-        SvdVariableName::Named(peripheral_device.name.clone()),
-        SvdVariableType::PeripheralGroup,
+        peripheral_device.name.clone(),
+        SvdVariableNodeType::SvdPeripheralGroup {
+            description: Some(peripheral_device.description.clone()),
+        },
     );
-    let mut peripheral_parent_key = device_root_variable.variable_key();
+    let mut peripheral_parent_key = device_root_variable_key;
 
     for peripheral in &peripheral_device.peripherals {
-        if let (Some(peripheral_group_name), SvdVariableName::Named(variable_group_name)) =
+        if let (Some(peripheral_group_name), variable_group_name) =
             (&peripheral.group_name, &peripheral_group_variable.name)
         {
             if variable_group_name != peripheral_group_name {
                 // Before we create a new group variable, check if we have one by that name already.
                 match svd_cache.get_variable_by_name_and_parent(
-                    &SvdVariableName::Named(peripheral_group_name.clone()),
-                    device_root_variable.variable_key(),
+                    peripheral_group_name,
+                    device_root_variable_key,
                 ) {
                     Some(existing_peripharal_group_variable) => {
                         peripheral_group_variable = existing_peripharal_group_variable
                     }
                     None => {
                         peripheral_group_variable = SvdVariable::new(
-                            SvdVariableName::Named(peripheral_group_name.clone()),
-                            SvdVariableType::PeripheralGroup,
+                            peripheral_group_name.clone(),
+                            SvdVariableNodeType::SvdPeripheralGroup {
+                                description: peripheral.description.clone(),
+                            },
                         );
-
-                        peripheral_group_variable.variable_node_type =
-                            SvdVariableNodeType::SvdPeripheralGroup;
-                        peripheral_group_variable.set_value(SvdVariableValue::Fixed(
-                            peripheral
-                                .description
-                                .clone()
-                                .unwrap_or_else(|| peripheral.name.clone()),
-                        ));
                         svd_cache.add_variable(
-                            device_root_variable.variable_key(),
+                            device_root_variable_key,
                             &mut peripheral_group_variable,
                         )?;
                     }
@@ -141,101 +129,59 @@ pub(crate) fn variable_cache_from_svd<P: ProtocolAdapter>(
         }
 
         let mut peripheral_variable = SvdVariable::new(
-            SvdVariableName::Named(format!(
-                "{}.{}",
-                peripheral_group_variable.name, peripheral.name
-            )),
-            SvdVariableType::Peripheral,
+            format!("{}.{}", peripheral_group_variable.name, peripheral.name),
+            SvdVariableNodeType::SvdPeripheral {
+                base_address: peripheral.base_address,
+                description: peripheral.description.clone(),
+            },
         );
-        peripheral_variable.variable_node_type = SvdVariableNodeType::SvdPeripheral {
-            base_address: peripheral.base_address,
-        };
-        peripheral_variable.set_value(SvdVariableValue::Fixed(
-            peripheral
-                .description
-                .clone()
-                .unwrap_or_else(|| format!("{}", peripheral_variable.name)),
-        ));
         svd_cache.add_variable(peripheral_parent_key, &mut peripheral_variable)?;
 
         for register in peripheral.all_registers() {
-            let mut register_variable = SvdVariable::new(
-                SvdVariableName::Named(format!(
-                    "{}.{}",
-                    &peripheral_variable.name,
-                    register.name.clone()
-                )),
-                SvdVariableType::Other(
-                    register
-                        .description
-                        .clone()
-                        .unwrap_or_else(|| "Peripheral Register".to_string()),
-                ),
-            );
-
             let register_address = peripheral.base_address + register.address_offset as u64;
 
-            register_variable.variable_node_type =
-                SvdVariableNodeType::SvdRegister(register_address);
+            let mut register_has_restricted_read = register.read_action.is_some()
+                || register
+                    .properties
+                    .access
+                    .map(|a| !a.can_read())
+                    .unwrap_or(true);
 
-            let mut register_has_restricted_read = false;
-            if register.read_action.is_some()
-                || (if let Some(register_access) = register.properties.access {
-                    register_access == Access::ReadWriteOnce || register_access == Access::WriteOnly
-                } else {
-                    false
-                })
-            {
-                register_variable.set_value(SvdVariableValue::Error(
-                    "Register access doesn't allow reading, or will have side effects.".to_string(),
-                ));
-                register_has_restricted_read = true;
-            }
+            let mut register_variable = SvdVariable::new(
+                format!("{}.{}", &peripheral_variable.name, register.name.clone()),
+                SvdVariableNodeType::SvdRegister {
+                    address: register_address,
+                    restricted_read: register_has_restricted_read,
+                    description: register.description.clone(),
+                },
+            );
+
             svd_cache.add_variable(peripheral_variable.variable_key(), &mut register_variable)?;
 
             for field in register.fields() {
+                let field_has_restricted_read = register_has_restricted_read
+                    || field.read_action.is_some()
+                    || field
+                        .access
+                        .map(|a| !a.can_read())
+                        .unwrap_or(register_has_restricted_read);
+
                 let mut field_variable = SvdVariable::new(
-                    SvdVariableName::Named(format!(
-                        "{}.{}",
-                        &register_variable.name,
-                        field.name.clone()
-                    )),
-                    SvdVariableType::Other(
-                        field
-                            .description
-                            .clone()
-                            .unwrap_or_else(|| "Register Field".to_string()),
-                    ),
+                    format!("{}.{}", &register_variable.name, field.name.clone()),
+                    SvdVariableNodeType::SvdField {
+                        address: register_address,
+                        restricted_read: field_has_restricted_read,
+                        bit_range_lower_bound: field.bit_offset(),
+                        bit_range_upper_bound: (field.bit_offset() + field.bit_width()),
+                        description: field.description.clone(),
+                    },
                 );
-                field_variable.variable_node_type = SvdVariableNodeType::SvdField {
-                    address: register_address,
-                    bit_range_lower_bound: field.bit_offset() as i64,
-                    bit_range_upper_bound: (field.bit_offset() + field.bit_width()) as i64,
-                };
-                if register_has_restricted_read {
-                    register_variable.set_value(SvdVariableValue::Error(
-                        "Register access doesn't allow reading, or will have side effects."
-                            .to_string(),
-                    ));
-                } else if field.read_action.is_some()
-                    || (if let Some(field_access) = field.access {
-                        field_access == Access::ReadWriteOnce || field_access == Access::WriteOnly
-                    } else {
-                        false
-                    })
-                {
-                    field_variable.set_value(SvdVariableValue::Error(
-                        "Field access doesn't allow reading, or will have side effects."
-                            .to_string(),
-                    ));
-                    // If we can't read any of the bits, then don't read the register either.
-                    register_variable.set_value(SvdVariableValue::Error(
-                        "Some fields' access doesn't allow reading, or will have side effects."
-                            .to_string(),
-                    ));
+
+                if field_has_restricted_read && !register_has_restricted_read {
                     register_has_restricted_read = true;
                     svd_cache.update_variable(&register_variable)?;
                 }
+
                 // TODO: Extend the Variable definition, so that we can resolve the EnumeratedValues for fields.
                 svd_cache.add_variable(register_variable.variable_key(), &mut field_variable)?;
             }

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -73,8 +73,6 @@ pub enum VariableName {
     RegistersRoot,
     /// Top-level variable for local scoped variables, child of a stack frame variable.
     LocalScopeRoot,
-    /// Top-level variable for CMSIS-SVD file Device peripherals/registers/fields.
-    PeripheralScopeRoot,
     /// Artificial variable, without a name (e.g. enum discriminant)
     Artifical,
     /// Anonymous namespace
@@ -94,7 +92,6 @@ impl std::fmt::Display for VariableName {
             VariableName::StaticScopeRoot => write!(f, "Static Variable"),
             VariableName::RegistersRoot => write!(f, "Platform Register"),
             VariableName::LocalScopeRoot => write!(f, "Function Variable"),
-            VariableName::PeripheralScopeRoot => write!(f, "Peripheral Variable"),
             VariableName::Artifical => write!(f, "<artifical>"),
             VariableName::AnonymousNamespace => write!(f, "<anonymous_namespace>"),
             VariableName::Namespace(name) => name.fmt(f),

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -130,12 +130,6 @@ pub enum VariableNodeType {
     /// - Rule: For now, Union types WILL ALWAYS BE recursed. TODO: Evaluate if it is beneficial to defer these.
     #[default]
     RecurseToBaseType,
-    /// SVD Device Peripherals
-    SvdPeripheral,
-    /// SVD Peripheral Registers
-    SvdRegister,
-    /// SVD Register Fields
-    SvdField,
 }
 
 impl VariableNodeType {
@@ -430,45 +424,7 @@ impl Variable {
     /// Implementing get_value(), because Variable.value has to be private (a requirement of updating the value without overriding earlier values ... see set_value()).
     pub fn get_value(&self, variable_cache: &variable_cache::VariableCache) -> String {
         // Allow for chained `if let` without complaining
-        if VariableNodeType::SvdRegister == self.variable_node_type {
-            if let VariableValue::Valid(register_value) = &self.value {
-                if let Ok(register_u32_value) = register_value.parse::<u32>() {
-                    format!(
-                        "{:032b} @ {:#010X}",
-                        register_u32_value,
-                        self.memory_location.memory_address().unwrap_or(u64::MAX) // We should never encounter a memory location that is invalid if we already used it to read the register value.
-                    )
-                } else {
-                    format!("Invalid register value {register_value}")
-                }
-            } else {
-                format!("{}", self.value)
-            }
-        } else if VariableNodeType::SvdField == self.variable_node_type {
-            // In this special case, we extract just the bits we need from the stored value of the register.
-            if let VariableValue::Valid(register_value) = &self.value {
-                if let Ok(register_u32_value) = register_value.parse::<u32>() {
-                    let mut bit_value: u32 = register_u32_value;
-                    bit_value <<= 32 - self.range_upper_bound;
-                    bit_value >>= 32 - (self.range_upper_bound - self.range_lower_bound);
-                    format!(
-                        "{:0width$b} @ {:#010X}:{}..{}",
-                        bit_value,
-                        self.memory_location.memory_address().unwrap_or(u64::MAX),
-                        self.range_lower_bound,
-                        self.range_upper_bound,
-                        width = self.subrange_bounds().count()
-                    )
-                } else {
-                    format!(
-                        "Invalid bit range {}..{} from value {}",
-                        self.range_lower_bound, self.range_upper_bound, register_value
-                    )
-                }
-            } else {
-                format!("{}", self.value)
-            }
-        } else if !self.value.is_empty() {
+        if !self.value.is_empty() {
             // The `value` for this `Variable` is non empty because ...
             // - It is base data type for which a value was determined based on the core runtime, or ...
             // - We encountered an error somewhere, so report it to the user
@@ -521,24 +477,6 @@ impl Variable {
     ) {
         if let VariableValue::Error(_) = self.value {
             // Nothing more to do ...
-            return;
-        }
-
-        if self.variable_node_type == VariableNodeType::SvdRegister
-            || self.variable_node_type == VariableNodeType::SvdField
-        {
-            // Special handling for SVD registers.
-            // Because we cache the SVD structure once per sesion, we have to re-read the actual register values whenever queried.
-            match memory.read_word_32(self.memory_location.memory_address().unwrap_or(u64::MAX)) {
-                Ok(u32_value) => self.value = VariableValue::Valid(u32_value.to_le().to_string()),
-                Err(error) => {
-                    self.value = VariableValue::Error(format!(
-                        "Unable to read peripheral register value @ {:#010X} : {:?}",
-                        self.memory_location.memory_address().unwrap_or(u64::MAX),
-                        error
-                    ))
-                }
-            }
             return;
         }
 

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -121,15 +121,6 @@ impl VariableCache {
         VariableCache::new(static_root_variable)
     }
 
-    /// Create a new cache for SVD variables
-    pub fn new_svd_cache() -> Self {
-        let mut device_root_variable = Variable::new(None, None);
-        device_root_variable.variable_node_type = VariableNodeType::DoNotRecurse;
-        device_root_variable.name = VariableName::PeripheralScopeRoot;
-
-        VariableCache::new(device_root_variable)
-    }
-
     /// Get the root variable of the cache
     pub fn root_variable(&self) -> Variable {
         self.variable_hash_map[&self.root_variable_key].clone()
@@ -561,7 +552,7 @@ impl VariableCache {
 
 #[cfg(test)]
 mod test {
-    use gimli::{DebugInfoOffset, UnitOffset};
+    use gimli::{DebugInfoOffset, UnitOffset, UnitSectionOffset};
     use termtree::Tree;
 
     use crate::debug::{
@@ -626,7 +617,11 @@ mod test {
 
     #[test]
     fn find_children() {
-        let mut cache = VariableCache::new_svd_cache();
+        let mut cache = VariableCache::new_dwarf_cache(
+            UnitSectionOffset::DebugInfoOffset(DebugInfoOffset(0)),
+            UnitOffset(0),
+            VariableName::Named("root".to_string()),
+        );
         let root_key = cache.root_variable().variable_key;
 
         let var_1 = cache.create_variable(root_key, None, None).unwrap();
@@ -642,7 +637,11 @@ mod test {
 
     #[test]
     fn find_entry() {
-        let mut cache = VariableCache::new_svd_cache();
+        let mut cache = VariableCache::new_dwarf_cache(
+            UnitSectionOffset::DebugInfoOffset(DebugInfoOffset(0)),
+            UnitOffset(0),
+            VariableName::Named("root".to_string()),
+        );
         let root_key = cache.root_variable().variable_key;
 
         let var_1 = cache.create_variable(root_key, None, None).unwrap();
@@ -669,7 +668,11 @@ mod test {
     ///     |
     ///     +-- [var_7]
     fn build_test_tree() -> (VariableCache, Vec<Variable>) {
-        let mut cache = VariableCache::new_svd_cache();
+        let mut cache = VariableCache::new_dwarf_cache(
+            UnitSectionOffset::DebugInfoOffset(DebugInfoOffset(0)),
+            UnitOffset(0),
+            VariableName::Named("root".to_string()),
+        );
         let root_key = cache.root_variable().variable_key;
 
         let var_1 = cache.create_variable(root_key, None, None).unwrap();


### PR DESCRIPTION
The SVD handling is not related to debug information at all, so I think it's cleaner to have it separate. It introduces some small duplication in the cache handling.