### PR TITLE
Remove unused code

### DIFF
--- a/probe-rs/src/probe/common.rs
+++ b/probe-rs/src/probe/common.rs
@@ -426,16 +426,8 @@ pub(crate) trait RawJtagIo {
     /// in batches for performance reasons.
     fn shift_bit(&mut self, tms: bool, tdi: bool, capture: bool) -> Result<(), DebugProbeError>;
 
-    /// Ensures internal buffers are flushed.
-    fn flush(&mut self) -> Result<(), DebugProbeError>;
-
     /// Returns the bits captured from TDO and clears the capture buffer.
     fn read_captured_bits(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError>;
-
-    /// Set the IR register length
-    fn set_ir_len(&mut self, len: usize) {
-        self.state_mut().chain_params.irlen = len;
-    }
 
     /// Resets the JTAG state machine by shifting out a number of high TMS bits.
     fn reset_jtag_state_machine(&mut self) -> Result<(), DebugProbeError> {

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -79,10 +79,6 @@ impl RawJtagIo for EspUsbJtag {
     fn state(&self) -> &JtagDriverState {
         &self.jtag_state
     }
-
-    fn flush(&mut self) -> Result<(), DebugProbeError> {
-        self.protocol.flush()
-    }
 }
 
 impl DebugProbe for EspUsbJtag {

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -498,10 +498,6 @@ impl RawJtagIo for FtdiProbe {
     fn state(&self) -> &JtagDriverState {
         &self.jtag_state
     }
-
-    fn flush(&mut self) -> Result<(), DebugProbeError> {
-        self.adapter.flush()
-    }
 }
 
 /// Known properties associated to particular FTDI chip types.

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -1125,11 +1125,6 @@ impl RawJtagIo for JLink {
         self.shift_jtag_bit(tms, tdi, capture)
     }
 
-    fn flush(&mut self) -> Result<(), DebugProbeError> {
-        self.flush_jtag()?;
-        Ok(())
-    }
-
     fn read_captured_bits(&mut self) -> Result<BitVec<u8, Lsb0>, DebugProbeError> {
         self.read_captured_bits()
     }


### PR DESCRIPTION
Some newer nightly started complaining and these are really unused. I'm surprised about `flush` but I guess we're always reading back something currently.