### PR TITLE
Ensure we have valid descriptor data when initially accessing espusbjtag

### DIFF
--- a/changelog/fixed-espusbjtag-cold-start.md
+++ b/changelog/fixed-espusbjtag-cold-start.md
@@ -1,0 +1,1 @@
+Fix reading back an empty buffer from the espusbjtag probe on a cold boot.


### PR DESCRIPTION
This solves the

```rust
thread 'main' panicked at probe-rs/src/probe/espusbjtag/protocol.rs:152:38:
index out of bounds: the len is 0 but the index is 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
errors.

It's likely a regression by switching to nusb, but simple enough to work around.