### PR TITLE
Do not debug-print VariableType variant when hovering over a variable

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -487,10 +487,10 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                             ) = get_variable_reference(&variable, variable_cache);
                             response_body.indexed_variables = Some(indexed_child_variables_cnt);
                             response_body.memory_reference =
-                                Some(format!("{}", variable.memory_location));
+                                Some(variable.memory_location.to_string());
                             response_body.named_variables = Some(named_child_variables_cnt);
                             response_body.result = variable.get_value(variable_cache);
-                            response_body.type_ = Some(format!("{:?}", variable.type_name));
+                            response_body.type_ = Some(variable.type_name.to_string());
                             response_body.variables_reference = variables_reference.into();
                         } else {
                             // If we made it to here, no register or variable matched the expression.
@@ -1510,7 +1510,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                         indexed_variables: Some(indexed_child_variables_cnt),
                         named_variables: Some(named_child_variables_cnt),
                         presentation_hint: None,
-                        type_: Some(format!("{:?}", variable.type_name)),
+                        type_: Some(variable.type_name.to_string()),
                         value: variable.get_value(variable_cache),
                         variables_reference: variables_reference.into(),
                     }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -94,7 +94,7 @@ pub(crate) fn get_local_variable(
                 variable.name,
                 variable.get_value(variable_cache)
             );
-            response_body.type_ = Some(format!("{:?}", variable.type_name));
+            response_body.type_ = Some(variable.type_name.to_string());
             response_body.variables_reference = variable.variable_key().into();
         } else {
             response_body.result.push_str(&format!(


### PR DESCRIPTION
I find `"Base(unsigned int)"` a very unfriendly type if I hover over a variable. This PR tries to avoid debug-printing the type name. I'm not sure I found all of them :)