### PR TITLE
Improve variable typing: follow typedefs, resolve pointer types better

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -493,7 +493,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                                 Some(variable.memory_location.to_string());
                             response_body.named_variables = Some(named_child_variables_cnt);
                             response_body.result = variable.get_value(variable_cache);
-                            response_body.type_ = Some(variable.type_name.to_string());
+                            response_body.type_ = Some(variable.type_name());
                             response_body.variables_reference = variables_reference.into();
                         } else {
                             // If we made it to here, no register or variable matched the expression.
@@ -1514,7 +1514,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
                         indexed_variables: Some(indexed_child_variables_cnt),
                         named_variables: Some(named_child_variables_cnt),
                         presentation_hint: None,
-                        type_: Some(variable.type_name.to_string()),
+                        type_: Some(variable.type_name()),
                         value: variable.get_value(variable_cache),
                         variables_reference: variables_reference.into(),
                     }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -90,13 +90,13 @@ pub(crate) fn get_local_variable(
                 variable.name,
                 variable.get_value(variable_cache)
             );
-            response_body.type_ = Some(variable.type_name.to_string());
+            response_body.type_ = Some(variable.type_name());
             response_body.variables_reference = variable.variable_key().into();
         } else {
             response_body.result.push_str(&format!(
                 "\n{} [{} @ {}]: {} ",
                 variable.name,
-                variable.type_name,
+                variable.type_name(),
                 variable.memory_location,
                 variable.get_value(variable_cache)
             ));

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_cache.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_cache.rs
@@ -190,7 +190,7 @@ impl Variable {
 
     /// Value of the variable, compatible with DAP
     ///
-    /// The value might be retrieved usng the `MemoryInterface` to read the value from the target.
+    /// The value might be retrieved using the `MemoryInterface` to read the value from the target.
     pub fn get_value(&self, memory: &mut dyn MemoryInterface) -> String {
         self.variable_kind.get_value(memory)
     }

--- a/probe-rs/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/debug.rs
@@ -773,7 +773,7 @@ impl DebugCli {
                             println!(
                                 "{}: {} = {}",
                                 child.name,
-                                child.type_name,
+                                child.type_name(),
                                 child.get_value(local_variable_cache)
                             );
                         }

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -347,7 +347,7 @@ impl DebugInfo {
                     frame_info,
                 )?;
 
-                if matches!(referenced_variable.type_name, VariableType::Base(ref name) if name == "()")
+                if matches!(referenced_variable.type_name.inner(), VariableType::Base(name) if name == "()")
                 {
                     // Only use this, if it is NOT a unit datatype.
                     cache.remove_cache_entry(referenced_variable.variable_key)?;

--- a/probe-rs/src/debug/language.rs
+++ b/probe-rs/src/debug/language.rs
@@ -1,7 +1,9 @@
 use gimli::DwLang;
 
 use crate::{
-    debug::{DebugError, Variable, VariableCache, VariableName, VariableType, VariableValue},
+    debug::{
+        DebugError, Modifier, Variable, VariableCache, VariableName, VariableType, VariableValue,
+    },
     MemoryInterface,
 };
 
@@ -43,16 +45,26 @@ pub trait ProgrammingLanguage {
         _new_value: &str,
     ) -> Result<(), DebugError>;
 
-    fn format_enum_value(&self, type_name: &VariableType, value: &VariableName) -> VariableValue {
-        VariableValue::Valid(format!("{}::{}", type_name, value))
-    }
+    fn format_enum_value(&self, type_name: &VariableType, value: &VariableName) -> VariableValue;
 
-    fn process_tag_with_no_type(&self, tag: gimli::DwTag) -> VariableValue {
+    fn format_array_type(&self, item_type: &str, length: usize) -> String;
+
+    fn format_pointer_type(&self, pointee: Option<&str>) -> String;
+
+    fn process_tag_with_no_type(&self, _variable: &Variable, tag: gimli::DwTag) -> VariableValue {
         VariableValue::Error(format!("Error: Failed to decode {tag} type reference"))
     }
 
     fn auto_resolve_children(&self, _name: &str) -> bool {
         false
+    }
+
+    fn modified_type_name(&self, modifier: &Modifier, name: &str) -> String {
+        match modifier {
+            Modifier::Const => format!("const {}", name),
+            Modifier::Volatile => format!("volatile {}", name),
+            Modifier::Typedef(ty) => ty.to_string(),
+        }
     }
 }
 
@@ -82,5 +94,17 @@ impl ProgrammingLanguage for UnknownLanguage {
             "Updating variables for language {} is not supported.",
             self.0
         )))
+    }
+
+    fn format_enum_value(&self, type_name: &VariableType, value: &VariableName) -> VariableValue {
+        VariableValue::Valid(format!("{}::{}", type_name.display_name(self), value))
+    }
+
+    fn format_array_type(&self, item_type: &str, length: usize) -> String {
+        format!("[{item_type}; {length}]")
+    }
+
+    fn format_pointer_type(&self, pointee: Option<&str>) -> String {
+        pointee.unwrap_or("<unknown pointer>").to_string()
     }
 }

--- a/probe-rs/src/debug/language.rs
+++ b/probe-rs/src/debug/language.rs
@@ -63,6 +63,8 @@ pub trait ProgrammingLanguage {
         match modifier {
             Modifier::Const => format!("const {}", name),
             Modifier::Volatile => format!("volatile {}", name),
+            Modifier::Restrict => format!("restrict {}", name),
+            Modifier::Atomic => format!("_Atomic {}", name),
             Modifier::Typedef(ty) => ty.to_string(),
         }
     }

--- a/probe-rs/src/debug/language/c.rs
+++ b/probe-rs/src/debug/language/c.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     MemoryInterface,
 };
+use std::fmt::{Display, Write};
 
 #[derive(Clone)]
 pub struct C;
@@ -21,12 +22,12 @@ impl ProgrammingLanguage for C {
         memory: &mut dyn MemoryInterface,
         variable_cache: &VariableCache,
     ) -> VariableValue {
-        match &variable.type_name {
+        match variable.type_name.inner() {
             VariableType::Base(_) if variable.memory_location == VariableLocation::Unknown => {
                 VariableValue::Empty
             }
 
-            VariableType::Base(type_name) => match type_name.as_str() {
+            VariableType::Base(name) => match name.as_str() {
                 "_Bool" => UnsignedInt::get_value(variable, memory, variable_cache).into(),
                 "char" => CChar::get_value(variable, memory, variable_cache).into(),
 
@@ -59,7 +60,7 @@ impl ProgrammingLanguage for C {
         memory: &mut dyn MemoryInterface,
         new_value: &str,
     ) -> Result<(), DebugError> {
-        match &variable.type_name {
+        match variable.type_name.inner() {
             VariableType::Base(name) => match name.as_str() {
                 "_Bool" => UnsignedInt::update_value(variable, memory, new_value),
                 "char" => CChar::update_value(variable, memory, new_value),
@@ -82,13 +83,30 @@ impl ProgrammingLanguage for C {
         }
     }
 
+    fn format_array_type(&self, item_type: &str, length: usize) -> String {
+        format!("{item_type}[{length}]")
+    }
+
     fn format_enum_value(&self, _type_name: &VariableType, value: &VariableName) -> VariableValue {
         VariableValue::Valid(value.to_string())
     }
 
-    fn process_tag_with_no_type(&self, tag: gimli::DwTag) -> VariableValue {
+    fn format_pointer_type(&self, pointee: Option<&str>) -> String {
+        format!("{}*", pointee.unwrap_or("void"))
+    }
+
+    fn process_tag_with_no_type(&self, variable: &Variable, tag: gimli::DwTag) -> VariableValue {
         match tag {
-            gimli::DW_TAG_const_type => VariableValue::Valid("<void>".to_string()),
+            gimli::DW_TAG_const_type => VariableValue::Valid("const void".to_string()),
+            gimli::DW_TAG_pointer_type => {
+                let name = if let VariableLocation::Address(addr) = variable.memory_location {
+                    format!("void* @ {addr:X}")
+                } else {
+                    "void*".to_string()
+                };
+
+                VariableValue::Valid(name)
+            }
             _ => VariableValue::Error(format!("Error: Failed to decode {tag} type reference")),
         }
     }
@@ -96,13 +114,13 @@ impl ProgrammingLanguage for C {
 
 struct CChar(u8);
 
-impl ToString for CChar {
-    fn to_string(&self) -> String {
+impl Display for CChar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let c = self.0;
         if c.is_ascii() {
-            (c as char).to_string()
+            f.write_char(c as char)
         } else {
-            format!("\\x{:02x}", c)
+            f.write_fmt(format_args!("\\x{:02x}", c))
         }
     }
 }
@@ -156,9 +174,9 @@ impl Value for CChar {
 
 struct UnsignedInt(u128);
 
-impl ToString for UnsignedInt {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl Display for UnsignedInt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{}", self.0))
     }
 }
 
@@ -198,9 +216,9 @@ impl Value for UnsignedInt {
 
 struct SignedInt(i128);
 
-impl ToString for SignedInt {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl Display for SignedInt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{}", self.0))
     }
 }
 

--- a/probe-rs/src/debug/language/rust.rs
+++ b/probe-rs/src/debug/language/rust.rs
@@ -20,7 +20,7 @@ impl ProgrammingLanguage for Rust {
         memory: &mut dyn MemoryInterface,
         variable_cache: &VariableCache,
     ) -> VariableValue {
-        match &variable.type_name {
+        match variable.type_name.inner() {
             VariableType::Base(_) if variable.memory_location == VariableLocation::Unknown => {
                 VariableValue::Empty
             }
@@ -70,7 +70,7 @@ impl ProgrammingLanguage for Rust {
         memory: &mut dyn MemoryInterface,
         new_value: &str,
     ) -> Result<(), DebugError> {
-        match &variable.type_name {
+        match variable.type_name.inner() {
             VariableType::Base(name) => match name.as_str() {
                 "bool" => bool::update_value(variable, memory, new_value),
                 "char" => char::update_value(variable, memory, new_value),
@@ -101,7 +101,22 @@ impl ProgrammingLanguage for Rust {
     }
 
     fn format_enum_value(&self, type_name: &VariableType, value: &VariableName) -> VariableValue {
-        VariableValue::Valid(format!("{}::{}", type_name, value))
+        VariableValue::Valid(format!("{}::{}", type_name.display_name(self), value))
+    }
+
+    fn format_array_type(&self, item_type: &str, length: usize) -> String {
+        format!("[{item_type}; {length}]")
+    }
+
+    fn format_pointer_type(&self, pointee: Option<&str>) -> String {
+        let ptr_type = pointee.unwrap_or("<unknown pointer>");
+
+        if ptr_type.starts_with(['*', '&']) {
+            ptr_type.to_string()
+        } else {
+            // FIXME: we should track where the type name came from - the pointer node, or the pointee.
+            format!("*raw {}", ptr_type)
+        }
     }
 
     fn auto_resolve_children(&self, name: &str) -> bool {

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040__full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040__full_unwind.snap
@@ -300,8 +300,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -365,8 +365,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -411,7 +411,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -509,7 +510,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000094, \n\tRttChannel @ 0x200000AC]"
                               children:
@@ -685,7 +687,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -709,7 +712,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -733,7 +737,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -1055,8 +1060,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -1120,8 +1125,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -1166,7 +1171,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -1264,7 +1270,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000094, \n\tRttChannel @ 0x200000AC]"
                               children:
@@ -1440,7 +1447,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -1464,7 +1472,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -1488,7 +1497,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -1810,8 +1820,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -1875,8 +1885,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -1921,7 +1931,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -2019,7 +2030,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000094, \n\tRttChannel @ 0x200000AC]"
                               children:
@@ -2195,7 +2207,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -2219,7 +2232,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -2243,7 +2257,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -2565,8 +2580,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -2630,8 +2645,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -2676,7 +2691,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -2774,7 +2790,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000094, \n\tRttChannel @ 0x200000AC]"
                               children:
@@ -2950,7 +2967,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -2974,7 +2992,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -2998,7 +3017,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -3320,8 +3340,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -3385,8 +3405,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -3431,7 +3451,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -3529,7 +3550,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000094, \n\tRttChannel @ 0x200000AC]"
                               children:
@@ -3705,7 +3727,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -3729,7 +3752,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -3753,7 +3777,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -4075,8 +4100,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -4140,8 +4165,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -4186,7 +4211,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -4284,7 +4310,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000094, \n\tRttChannel @ 0x200000AC]"
                               children:
@@ -4460,7 +4487,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -4484,7 +4512,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -4508,7 +4537,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -4830,8 +4860,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -4895,8 +4925,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -4941,7 +4971,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -5039,7 +5070,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000094, \n\tRttChannel @ 0x200000AC]"
                               children:
@@ -5215,7 +5247,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -5239,7 +5272,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -5263,7 +5297,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -5298,8 +5333,8 @@ expression: stack_frames
             - name:
                 Named: data_ptr
               type_name:
-                Pointer: ~
-              value: "<referenced type> @ 0x20003400"
+                Pointer: u8
+              value: "*raw u8 @ 0x20003400"
               children:
                 - name:
                     Named: "*data_ptr"
@@ -5320,8 +5355,8 @@ expression: stack_frames
             - name:
                 Named: data_ptr
               type_name:
-                Pointer: ~
-              value: "<referenced type> @ 0x20003CB4"
+                Pointer: u8
+              value: "*raw u8 @ 0x20003CB4"
               children:
                 - name:
                     Named: "*data_ptr"
@@ -5391,8 +5426,8 @@ expression: stack_frames
             - name:
                 Named: data_ptr
               type_name:
-                Pointer: ~
-              value: "<referenced type> @ 0x2000340C"
+                Pointer: u8
+              value: "*raw u8 @ 0x2000340C"
               children:
                 - name:
                     Named: "*data_ptr"
@@ -5465,8 +5500,8 @@ expression: stack_frames
             - name:
                 Named: data_ptr
               type_name:
-                Pointer: ~
-              value: "<referenced type> @ 0x20003430"
+                Pointer: u8
+              value: "*raw u8 @ 0x20003430"
               children:
                 - name:
                     Named: "*data_ptr"
@@ -5499,8 +5534,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20003CDC"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20003CDC"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -5598,7 +5633,14 @@ expression: stack_frames
                 Named: raw
               type_name:
                 Array:
-                  item_type_name: "[[i32; 3]; 2]"
+                  item_type_name:
+                    Array:
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Base: i32
+                          count: 3
+                      count: 2
                   count: 4
               value: ": [[[i32; 3]; 2]; 4] = [\n\t: [[i32; 3]; 2] = [\n\t\t: [i32; 3] = [\n\t\t\t0, \n\t\t\t1, \n\t\t\t2\n\t\t], \n\t\t: [i32; 3] = [\n\t\t\t3, \n\t\t\t4, \n\t\t\t5\n\t\t]\n\t], \n\t: [[i32; 3]; 2] = [\n\t\t: [i32; 3] = [\n\t\t\t6, \n\t\t\t7, \n\t\t\t8\n\t\t], \n\t\t: [i32; 3] = [\n\t\t\t9, \n\t\t\t10, \n\t\t\t11\n\t\t]\n\t], \n\t: [[i32; 3]; 2] = [\n\t\t: [i32; 3] = [\n\t\t\t12, \n\t\t\t13, \n\t\t\t14\n\t\t], \n\t\t: [i32; 3] = [\n\t\t\t15, \n\t\t\t16, \n\t\t\t17\n\t\t]\n\t], \n\t: [[i32; 3]; 2] = [\n\t\t: [i32; 3] = [\n\t\t\t18, \n\t\t\t19, \n\t\t\t20\n\t\t], \n\t\t: [i32; 3] = [\n\t\t\t21, \n\t\t\t22, \n\t\t\t23\n\t\t]\n\t]]"
               children:
@@ -5606,7 +5648,11 @@ expression: stack_frames
                     Named: __0
                   type_name:
                     Array:
-                      item_type_name: "[i32; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Base: i32
+                          count: 3
                       count: 2
                   value: ": [[i32; 3]; 2] = [\n\t: [i32; 3] = [\n\t\t0, \n\t\t1, \n\t\t2\n\t], \n\t: [i32; 3] = [\n\t\t3, \n\t\t4, \n\t\t5\n\t]]"
                   children:
@@ -5614,7 +5660,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t0, \n\t1, \n\t2]"
                       children:
@@ -5637,7 +5684,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t3, \n\t4, \n\t5]"
                       children:
@@ -5660,7 +5708,11 @@ expression: stack_frames
                     Named: __1
                   type_name:
                     Array:
-                      item_type_name: "[i32; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Base: i32
+                          count: 3
                       count: 2
                   value: ": [[i32; 3]; 2] = [\n\t: [i32; 3] = [\n\t\t6, \n\t\t7, \n\t\t8\n\t], \n\t: [i32; 3] = [\n\t\t9, \n\t\t10, \n\t\t11\n\t]]"
                   children:
@@ -5668,7 +5720,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t6, \n\t7, \n\t8]"
                       children:
@@ -5691,7 +5744,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t9, \n\t10, \n\t11]"
                       children:
@@ -5714,7 +5768,11 @@ expression: stack_frames
                     Named: __2
                   type_name:
                     Array:
-                      item_type_name: "[i32; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Base: i32
+                          count: 3
                       count: 2
                   value: ": [[i32; 3]; 2] = [\n\t: [i32; 3] = [\n\t\t12, \n\t\t13, \n\t\t14\n\t], \n\t: [i32; 3] = [\n\t\t15, \n\t\t16, \n\t\t17\n\t]]"
                   children:
@@ -5722,7 +5780,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t12, \n\t13, \n\t14]"
                       children:
@@ -5745,7 +5804,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t15, \n\t16, \n\t17]"
                       children:
@@ -5768,7 +5828,11 @@ expression: stack_frames
                     Named: __3
                   type_name:
                     Array:
-                      item_type_name: "[i32; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Base: i32
+                          count: 3
                       count: 2
                   value: ": [[i32; 3]; 2] = [\n\t: [i32; 3] = [\n\t\t18, \n\t\t19, \n\t\t20\n\t], \n\t: [i32; 3] = [\n\t\t21, \n\t\t22, \n\t\t23\n\t]]"
                   children:
@@ -5776,7 +5840,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t18, \n\t19, \n\t20]"
                       children:
@@ -5799,7 +5864,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t21, \n\t22, \n\t23]"
                       children:
@@ -5828,7 +5894,14 @@ expression: stack_frames
                 Named: raw
               type_name:
                 Array:
-                  item_type_name: "[[&str; 3]; 2]"
+                  item_type_name:
+                    Array:
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
+                      count: 2
                   count: 6
               value: ": [[[&str; 3]; 2]; 6] = [\n\t: [[&str; 3]; 2] = [\n\t\t: [&str; 3] = [\n\t\t\tApple, \n\t\t\tBanana, \n\t\t\tCherry\n\t\t], \n\t\t: [&str; 3] = [\n\t\t\tDog, \n\t\t\tElephant, \n\t\t\tFish\n\t\t]\n\t], \n\t: [[&str; 3]; 2] = [\n\t\t: [&str; 3] = [\n\t\t\tGuitar, \n\t\t\tHorse, \n\t\t\tIce Cream\n\t\t], \n\t\t: [&str; 3] = [\n\t\t\tJaguar, \n\t\t\tKangaroo, \n\t\t\tLion\n\t\t]\n\t], \n\t: [[&str; 3]; 2] = [\n\t\t: [&str; 3] = [\n\t\t\tMoon, \n\t\t\tNewton, \n\t\t\tOwl\n\t\t], \n\t\t: [&str; 3] = [\n\t\t\tPencil, \n\t\t\tQueen, \n\t\t\tRainbow\n\t\t]\n\t], \n\t: [[&str; 3]; 2] = [\n\t\t: [&str; 3] = [\n\t\t\tSun, \n\t\t\tTree, \n\t\t\tUmbrella\n\t\t], \n\t\t: [&str; 3] = [\n\t\t\tViolin, \n\t\t\tWatch, \n\t\t\tXylophone\n\t\t]\n\t], \n\t: [[&str; 3]; 2] = [\n\t\t: [&str; 3] = [\n\t\t\tYellow, \n\t\t\tZebra, \n\t\t\tAlpha\n\t\t], \n\t\t: [&str; 3] = [\n\t\t\tBravo, \n\t\t\tCharlie, \n\t\t\tDelta\n\t\t]\n\t], \n\t: [[&str; 3]; 2] = [\n\t\t: [&str; 3] = [\n\t\t\tEcho, \n\t\t\tFoxtrot, \n\t\t\tGolf\n\t\t], \n\t\t: [&str; 3] = [\n\t\t\tHotel, \n\t\t\tIndia, \n\t\t\tJuliet\n\t\t]\n\t]]"
               children:
@@ -5836,7 +5909,11 @@ expression: stack_frames
                     Named: __0
                   type_name:
                     Array:
-                      item_type_name: "[&str; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
                       count: 2
                   value: ": [[&str; 3]; 2] = [\n\t: [&str; 3] = [\n\t\tApple, \n\t\tBanana, \n\t\tCherry\n\t], \n\t: [&str; 3] = [\n\t\tDog, \n\t\tElephant, \n\t\tFish\n\t]]"
                   children:
@@ -5844,7 +5921,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tApple, \n\tBanana, \n\tCherry]"
                       children:
@@ -5857,8 +5935,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000360C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000360C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -5879,8 +5957,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003614"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003614"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -5901,8 +5979,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000361C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000361C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -5918,7 +5996,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tDog, \n\tElephant, \n\tFish]"
                       children:
@@ -5931,8 +6010,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003624"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003624"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -5953,8 +6032,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000362C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000362C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -5975,8 +6054,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003634"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003634"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -5992,7 +6071,11 @@ expression: stack_frames
                     Named: __1
                   type_name:
                     Array:
-                      item_type_name: "[&str; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
                       count: 2
                   value: ": [[&str; 3]; 2] = [\n\t: [&str; 3] = [\n\t\tGuitar, \n\t\tHorse, \n\t\tIce Cream\n\t], \n\t: [&str; 3] = [\n\t\tJaguar, \n\t\tKangaroo, \n\t\tLion\n\t]]"
                   children:
@@ -6000,7 +6083,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tGuitar, \n\tHorse, \n\tIce Cream]"
                       children:
@@ -6013,8 +6097,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000363C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000363C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6035,8 +6119,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003644"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003644"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6057,8 +6141,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000364C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000364C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6074,7 +6158,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tJaguar, \n\tKangaroo, \n\tLion]"
                       children:
@@ -6087,8 +6172,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003654"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003654"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6109,8 +6194,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000365C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000365C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6131,8 +6216,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003664"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003664"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6148,7 +6233,11 @@ expression: stack_frames
                     Named: __2
                   type_name:
                     Array:
-                      item_type_name: "[&str; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
                       count: 2
                   value: ": [[&str; 3]; 2] = [\n\t: [&str; 3] = [\n\t\tMoon, \n\t\tNewton, \n\t\tOwl\n\t], \n\t: [&str; 3] = [\n\t\tPencil, \n\t\tQueen, \n\t\tRainbow\n\t]]"
                   children:
@@ -6156,7 +6245,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tMoon, \n\tNewton, \n\tOwl]"
                       children:
@@ -6169,8 +6259,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000366C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000366C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6191,8 +6281,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003674"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003674"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6213,8 +6303,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000367C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000367C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6230,7 +6320,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tPencil, \n\tQueen, \n\tRainbow]"
                       children:
@@ -6243,8 +6334,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003684"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003684"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6265,8 +6356,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000368C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000368C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6287,8 +6378,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003694"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003694"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6304,7 +6395,11 @@ expression: stack_frames
                     Named: __3
                   type_name:
                     Array:
-                      item_type_name: "[&str; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
                       count: 2
                   value: ": [[&str; 3]; 2] = [\n\t: [&str; 3] = [\n\t\tSun, \n\t\tTree, \n\t\tUmbrella\n\t], \n\t: [&str; 3] = [\n\t\tViolin, \n\t\tWatch, \n\t\tXylophone\n\t]]"
                   children:
@@ -6312,7 +6407,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tSun, \n\tTree, \n\tUmbrella]"
                       children:
@@ -6325,8 +6421,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000369C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000369C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6347,8 +6443,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036A4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036A4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6369,8 +6465,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036AC"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036AC"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6386,7 +6482,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tViolin, \n\tWatch, \n\tXylophone]"
                       children:
@@ -6399,8 +6496,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036B4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036B4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6421,8 +6518,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036BC"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036BC"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6443,8 +6540,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036C4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036C4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6460,7 +6557,11 @@ expression: stack_frames
                     Named: __4
                   type_name:
                     Array:
-                      item_type_name: "[&str; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
                       count: 2
                   value: ": [[&str; 3]; 2] = [\n\t: [&str; 3] = [\n\t\tYellow, \n\t\tZebra, \n\t\tAlpha\n\t], \n\t: [&str; 3] = [\n\t\tBravo, \n\t\tCharlie, \n\t\tDelta\n\t]]"
                   children:
@@ -6468,7 +6569,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tYellow, \n\tZebra, \n\tAlpha]"
                       children:
@@ -6481,8 +6583,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036CC"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036CC"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6503,8 +6605,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036D4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036D4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6525,8 +6627,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036DC"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036DC"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6542,7 +6644,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tBravo, \n\tCharlie, \n\tDelta]"
                       children:
@@ -6555,8 +6658,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036E4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036E4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6577,8 +6680,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036EC"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036EC"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6599,8 +6702,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036F4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036F4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6616,7 +6719,11 @@ expression: stack_frames
                     Named: __5
                   type_name:
                     Array:
-                      item_type_name: "[&str; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
                       count: 2
                   value: ": [[&str; 3]; 2] = [\n\t: [&str; 3] = [\n\t\tEcho, \n\t\tFoxtrot, \n\t\tGolf\n\t], \n\t: [&str; 3] = [\n\t\tHotel, \n\t\tIndia, \n\t\tJuliet\n\t]]"
                   children:
@@ -6624,7 +6731,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tEcho, \n\tFoxtrot, \n\tGolf]"
                       children:
@@ -6637,8 +6745,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036FC"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036FC"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6659,8 +6767,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003704"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003704"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6681,8 +6789,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000370C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000370C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6698,7 +6806,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tHotel, \n\tIndia, \n\tJuliet]"
                       children:
@@ -6711,8 +6820,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003714"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003714"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6733,8 +6842,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000371C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000371C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6755,8 +6864,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003724"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003724"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -7204,7 +7313,8 @@ expression: stack_frames
             Named: my_array
           type_name:
             Array:
-              item_type_name: i32
+              item_type_name:
+                Base: i32
               count: 10
           value: ": [i32; 10] = [\n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55]"
           children:
@@ -7268,7 +7378,8 @@ expression: stack_frames
                 Named: "*my_array_ptr"
               type_name:
                 Array:
-                  item_type_name: i32
+                  item_type_name:
+                    Base: i32
                   count: 10
               value: ": [i32; 10] = [\n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55]"
               children:
@@ -7326,7 +7437,8 @@ expression: stack_frames
             Named: my_array_of_i8
           type_name:
             Array:
-              item_type_name: i8
+              item_type_name:
+                Base: i8
               count: 10
           value: ": [i8; 10] = [\n\t1, \n\t2, \n\t3, \n\t4, \n\t5, \n\t6, \n\t7, \n\t8, \n\t9, \n\t0]"
           children:
@@ -7395,7 +7507,8 @@ expression: stack_frames
                 Named: buffer
               type_name:
                 Array:
-                  item_type_name: MaybeUninit<i8>
+                  item_type_name:
+                    Base: MaybeUninit<i8>
                   count: 10
               value: ": [MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3C\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3D\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3E\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3F\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C40\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C41\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C42\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C43\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C44\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C45\n\t}]"
               children:
@@ -8039,12 +8152,12 @@ expression: stack_frames
     Child Variables:
       name: StaticScopeRoot
       type_name: Unknown
-      value: Unknown
+      value: "<unknown>"
   local_variables:
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: Unknown
+      value: "<unknown>"
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main_trampoline
   source_location:
@@ -8250,12 +8363,12 @@ expression: stack_frames
     Child Variables:
       name: StaticScopeRoot
       type_name: Unknown
-      value: Unknown
+      value: "<unknown>"
   local_variables:
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: Unknown
+      value: "<unknown>"
   canonical_frame_address: 536887296
 - function_name: "<unknown function @ 0x100001e6>"
   source_location: ~

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__full_unwind.snap
@@ -300,8 +300,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -365,8 +365,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -411,7 +411,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -509,7 +510,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000090, \n\tRttChannel @ 0x200000A8]"
                               children:
@@ -685,7 +687,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -709,7 +712,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -733,7 +737,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -1055,8 +1060,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -1120,8 +1125,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -1166,7 +1171,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -1264,7 +1270,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000090, \n\tRttChannel @ 0x200000A8]"
                               children:
@@ -1440,7 +1447,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -1464,7 +1472,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -1488,7 +1497,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -1810,8 +1820,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -1875,8 +1885,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -1921,7 +1931,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -2019,7 +2030,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000090, \n\tRttChannel @ 0x200000A8]"
                               children:
@@ -2195,7 +2207,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -2219,7 +2232,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -2243,7 +2257,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -2565,8 +2580,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -2630,8 +2645,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -2676,7 +2691,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -2774,7 +2790,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000090, \n\tRttChannel @ 0x200000A8]"
                               children:
@@ -2950,7 +2967,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -2974,7 +2992,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -2998,7 +3017,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -3320,8 +3340,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -3385,8 +3405,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -3431,7 +3451,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -3529,7 +3550,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000090, \n\tRttChannel @ 0x200000A8]"
                               children:
@@ -3705,7 +3727,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -3729,7 +3752,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -3753,7 +3777,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -4075,8 +4100,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -4140,8 +4165,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -4186,7 +4211,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -4284,7 +4310,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000090, \n\tRttChannel @ 0x200000A8]"
                               children:
@@ -4460,7 +4487,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -4484,7 +4512,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -4508,7 +4537,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -4830,8 +4860,8 @@ expression: stack_frames
                 - name:
                     Named: data_ptr
                   type_name:
-                    Pointer: ~
-                  value: "<referenced type> @ 0x20000040"
+                    Pointer: u8
+                  value: "*raw u8 @ 0x20000040"
                   children:
                     - name:
                         Named: "*data_ptr"
@@ -4895,8 +4925,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20000068"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20000068"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -4941,7 +4971,8 @@ expression: stack_frames
                                     Named: id
                                   type_name:
                                     Array:
-                                      item_type_name: u8
+                                      item_type_name:
+                                        Base: u8
                                       count: 16
                                   value: ": [u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
                                   children:
@@ -5039,7 +5070,8 @@ expression: stack_frames
                                 Named: up_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 2
                               value: ": [RttChannel; 2] = [\n\tRttChannel @ 0x20000090, \n\tRttChannel @ 0x200000A8]"
                               children:
@@ -5215,7 +5247,8 @@ expression: stack_frames
                                 Named: down_channels
                               type_name:
                                 Array:
-                                  item_type_name: RttChannel
+                                  item_type_name:
+                                    Struct: RttChannel
                                   count: 0
                               value: ": [RttChannel; 0] = []"
                 - name:
@@ -5239,7 +5272,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
                 - name:
@@ -5263,7 +5297,8 @@ expression: stack_frames
                             Named: value
                           type_name:
                             Array:
-                              item_type_name: u8
+                              item_type_name:
+                                Base: u8
                               count: 1024
                           value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
         - name:
@@ -5298,8 +5333,8 @@ expression: stack_frames
             - name:
                 Named: data_ptr
               type_name:
-                Pointer: ~
-              value: "<referenced type> @ 0x20003480"
+                Pointer: u8
+              value: "*raw u8 @ 0x20003480"
               children:
                 - name:
                     Named: "*data_ptr"
@@ -5320,8 +5355,8 @@ expression: stack_frames
             - name:
                 Named: data_ptr
               type_name:
-                Pointer: ~
-              value: "<referenced type> @ 0x20003D34"
+                Pointer: u8
+              value: "*raw u8 @ 0x20003D34"
               children:
                 - name:
                     Named: "*data_ptr"
@@ -5391,8 +5426,8 @@ expression: stack_frames
             - name:
                 Named: data_ptr
               type_name:
-                Pointer: ~
-              value: "<referenced type> @ 0x2000348C"
+                Pointer: u8
+              value: "*raw u8 @ 0x2000348C"
               children:
                 - name:
                     Named: "*data_ptr"
@@ -5465,8 +5500,8 @@ expression: stack_frames
             - name:
                 Named: data_ptr
               type_name:
-                Pointer: ~
-              value: "<referenced type> @ 0x200034B0"
+                Pointer: u8
+              value: "*raw u8 @ 0x200034B0"
               children:
                 - name:
                     Named: "*data_ptr"
@@ -5499,8 +5534,8 @@ expression: stack_frames
                     - name:
                         Named: data_ptr
                       type_name:
-                        Pointer: ~
-                      value: "<referenced type> @ 0x20003D5C"
+                        Pointer: u8
+                      value: "*raw u8 @ 0x20003D5C"
                       children:
                         - name:
                             Named: "*data_ptr"
@@ -5598,7 +5633,14 @@ expression: stack_frames
                 Named: raw
               type_name:
                 Array:
-                  item_type_name: "[[i32; 3]; 2]"
+                  item_type_name:
+                    Array:
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Base: i32
+                          count: 3
+                      count: 2
                   count: 4
               value: ": [[[i32; 3]; 2]; 4] = [\n\t: [[i32; 3]; 2] = [\n\t\t: [i32; 3] = [\n\t\t\t0, \n\t\t\t1, \n\t\t\t2\n\t\t], \n\t\t: [i32; 3] = [\n\t\t\t3, \n\t\t\t4, \n\t\t\t5\n\t\t]\n\t], \n\t: [[i32; 3]; 2] = [\n\t\t: [i32; 3] = [\n\t\t\t6, \n\t\t\t7, \n\t\t\t8\n\t\t], \n\t\t: [i32; 3] = [\n\t\t\t9, \n\t\t\t10, \n\t\t\t11\n\t\t]\n\t], \n\t: [[i32; 3]; 2] = [\n\t\t: [i32; 3] = [\n\t\t\t12, \n\t\t\t13, \n\t\t\t14\n\t\t], \n\t\t: [i32; 3] = [\n\t\t\t15, \n\t\t\t16, \n\t\t\t17\n\t\t]\n\t], \n\t: [[i32; 3]; 2] = [\n\t\t: [i32; 3] = [\n\t\t\t18, \n\t\t\t19, \n\t\t\t20\n\t\t], \n\t\t: [i32; 3] = [\n\t\t\t21, \n\t\t\t22, \n\t\t\t23\n\t\t]\n\t]]"
               children:
@@ -5606,7 +5648,11 @@ expression: stack_frames
                     Named: __0
                   type_name:
                     Array:
-                      item_type_name: "[i32; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Base: i32
+                          count: 3
                       count: 2
                   value: ": [[i32; 3]; 2] = [\n\t: [i32; 3] = [\n\t\t0, \n\t\t1, \n\t\t2\n\t], \n\t: [i32; 3] = [\n\t\t3, \n\t\t4, \n\t\t5\n\t]]"
                   children:
@@ -5614,7 +5660,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t0, \n\t1, \n\t2]"
                       children:
@@ -5637,7 +5684,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t3, \n\t4, \n\t5]"
                       children:
@@ -5660,7 +5708,11 @@ expression: stack_frames
                     Named: __1
                   type_name:
                     Array:
-                      item_type_name: "[i32; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Base: i32
+                          count: 3
                       count: 2
                   value: ": [[i32; 3]; 2] = [\n\t: [i32; 3] = [\n\t\t6, \n\t\t7, \n\t\t8\n\t], \n\t: [i32; 3] = [\n\t\t9, \n\t\t10, \n\t\t11\n\t]]"
                   children:
@@ -5668,7 +5720,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t6, \n\t7, \n\t8]"
                       children:
@@ -5691,7 +5744,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t9, \n\t10, \n\t11]"
                       children:
@@ -5714,7 +5768,11 @@ expression: stack_frames
                     Named: __2
                   type_name:
                     Array:
-                      item_type_name: "[i32; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Base: i32
+                          count: 3
                       count: 2
                   value: ": [[i32; 3]; 2] = [\n\t: [i32; 3] = [\n\t\t12, \n\t\t13, \n\t\t14\n\t], \n\t: [i32; 3] = [\n\t\t15, \n\t\t16, \n\t\t17\n\t]]"
                   children:
@@ -5722,7 +5780,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t12, \n\t13, \n\t14]"
                       children:
@@ -5745,7 +5804,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t15, \n\t16, \n\t17]"
                       children:
@@ -5768,7 +5828,11 @@ expression: stack_frames
                     Named: __3
                   type_name:
                     Array:
-                      item_type_name: "[i32; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Base: i32
+                          count: 3
                       count: 2
                   value: ": [[i32; 3]; 2] = [\n\t: [i32; 3] = [\n\t\t18, \n\t\t19, \n\t\t20\n\t], \n\t: [i32; 3] = [\n\t\t21, \n\t\t22, \n\t\t23\n\t]]"
                   children:
@@ -5776,7 +5840,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t18, \n\t19, \n\t20]"
                       children:
@@ -5799,7 +5864,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: i32
+                          item_type_name:
+                            Base: i32
                           count: 3
                       value: ": [i32; 3] = [\n\t21, \n\t22, \n\t23]"
                       children:
@@ -5828,7 +5894,14 @@ expression: stack_frames
                 Named: raw
               type_name:
                 Array:
-                  item_type_name: "[[&str; 3]; 2]"
+                  item_type_name:
+                    Array:
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
+                      count: 2
                   count: 6
               value: ": [[[&str; 3]; 2]; 6] = [\n\t: [[&str; 3]; 2] = [\n\t\t: [&str; 3] = [\n\t\t\tApple, \n\t\t\tBanana, \n\t\t\tCherry\n\t\t], \n\t\t: [&str; 3] = [\n\t\t\tDog, \n\t\t\tElephant, \n\t\t\tFish\n\t\t]\n\t], \n\t: [[&str; 3]; 2] = [\n\t\t: [&str; 3] = [\n\t\t\tGuitar, \n\t\t\tHorse, \n\t\t\tIce Cream\n\t\t], \n\t\t: [&str; 3] = [\n\t\t\tJaguar, \n\t\t\tKangaroo, \n\t\t\tLion\n\t\t]\n\t], \n\t: [[&str; 3]; 2] = [\n\t\t: [&str; 3] = [\n\t\t\tMoon, \n\t\t\tNewton, \n\t\t\tOwl\n\t\t], \n\t\t: [&str; 3] = [\n\t\t\tPencil, \n\t\t\tQueen, \n\t\t\tRainbow\n\t\t]\n\t], \n\t: [[&str; 3]; 2] = [\n\t\t: [&str; 3] = [\n\t\t\tSun, \n\t\t\tTree, \n\t\t\tUmbrella\n\t\t], \n\t\t: [&str; 3] = [\n\t\t\tViolin, \n\t\t\tWatch, \n\t\t\tXylophone\n\t\t]\n\t], \n\t: [[&str; 3]; 2] = [\n\t\t: [&str; 3] = [\n\t\t\tYellow, \n\t\t\tZebra, \n\t\t\tAlpha\n\t\t], \n\t\t: [&str; 3] = [\n\t\t\tBravo, \n\t\t\tCharlie, \n\t\t\tDelta\n\t\t]\n\t], \n\t: [[&str; 3]; 2] = [\n\t\t: [&str; 3] = [\n\t\t\tEcho, \n\t\t\tFoxtrot, \n\t\t\tGolf\n\t\t], \n\t\t: [&str; 3] = [\n\t\t\tHotel, \n\t\t\tIndia, \n\t\t\tJuliet\n\t\t]\n\t]]"
               children:
@@ -5836,7 +5909,11 @@ expression: stack_frames
                     Named: __0
                   type_name:
                     Array:
-                      item_type_name: "[&str; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
                       count: 2
                   value: ": [[&str; 3]; 2] = [\n\t: [&str; 3] = [\n\t\tApple, \n\t\tBanana, \n\t\tCherry\n\t], \n\t: [&str; 3] = [\n\t\tDog, \n\t\tElephant, \n\t\tFish\n\t]]"
                   children:
@@ -5844,7 +5921,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tApple, \n\tBanana, \n\tCherry]"
                       children:
@@ -5857,8 +5935,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000368C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000368C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -5879,8 +5957,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003694"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003694"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -5901,8 +5979,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000369C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000369C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -5918,7 +5996,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tDog, \n\tElephant, \n\tFish]"
                       children:
@@ -5931,8 +6010,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036A4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036A4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -5953,8 +6032,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036AC"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036AC"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -5975,8 +6054,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036B4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036B4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -5992,7 +6071,11 @@ expression: stack_frames
                     Named: __1
                   type_name:
                     Array:
-                      item_type_name: "[&str; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
                       count: 2
                   value: ": [[&str; 3]; 2] = [\n\t: [&str; 3] = [\n\t\tGuitar, \n\t\tHorse, \n\t\tIce Cream\n\t], \n\t: [&str; 3] = [\n\t\tJaguar, \n\t\tKangaroo, \n\t\tLion\n\t]]"
                   children:
@@ -6000,7 +6083,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tGuitar, \n\tHorse, \n\tIce Cream]"
                       children:
@@ -6013,8 +6097,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036BC"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036BC"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6035,8 +6119,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036C4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036C4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6057,8 +6141,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036CC"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036CC"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6074,7 +6158,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tJaguar, \n\tKangaroo, \n\tLion]"
                       children:
@@ -6087,8 +6172,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036D4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036D4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6109,8 +6194,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036DC"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036DC"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6131,8 +6216,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036E4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036E4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6148,7 +6233,11 @@ expression: stack_frames
                     Named: __2
                   type_name:
                     Array:
-                      item_type_name: "[&str; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
                       count: 2
                   value: ": [[&str; 3]; 2] = [\n\t: [&str; 3] = [\n\t\tMoon, \n\t\tNewton, \n\t\tOwl\n\t], \n\t: [&str; 3] = [\n\t\tPencil, \n\t\tQueen, \n\t\tRainbow\n\t]]"
                   children:
@@ -6156,7 +6245,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tMoon, \n\tNewton, \n\tOwl]"
                       children:
@@ -6169,8 +6259,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036EC"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036EC"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6191,8 +6281,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036F4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036F4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6213,8 +6303,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200036FC"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200036FC"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6230,7 +6320,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tPencil, \n\tQueen, \n\tRainbow]"
                       children:
@@ -6243,8 +6334,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003704"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003704"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6265,8 +6356,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000370C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000370C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6287,8 +6378,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003714"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003714"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6304,7 +6395,11 @@ expression: stack_frames
                     Named: __3
                   type_name:
                     Array:
-                      item_type_name: "[&str; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
                       count: 2
                   value: ": [[&str; 3]; 2] = [\n\t: [&str; 3] = [\n\t\tSun, \n\t\tTree, \n\t\tUmbrella\n\t], \n\t: [&str; 3] = [\n\t\tViolin, \n\t\tWatch, \n\t\tXylophone\n\t]]"
                   children:
@@ -6312,7 +6407,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tSun, \n\tTree, \n\tUmbrella]"
                       children:
@@ -6325,8 +6421,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000371C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000371C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6347,8 +6443,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003724"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003724"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6369,8 +6465,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000372C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000372C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6386,7 +6482,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tViolin, \n\tWatch, \n\tXylophone]"
                       children:
@@ -6399,8 +6496,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003734"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003734"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6421,8 +6518,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000373C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000373C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6443,8 +6540,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003744"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003744"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6460,7 +6557,11 @@ expression: stack_frames
                     Named: __4
                   type_name:
                     Array:
-                      item_type_name: "[&str; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
                       count: 2
                   value: ": [[&str; 3]; 2] = [\n\t: [&str; 3] = [\n\t\tYellow, \n\t\tZebra, \n\t\tAlpha\n\t], \n\t: [&str; 3] = [\n\t\tBravo, \n\t\tCharlie, \n\t\tDelta\n\t]]"
                   children:
@@ -6468,7 +6569,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tYellow, \n\tZebra, \n\tAlpha]"
                       children:
@@ -6481,8 +6583,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000374C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000374C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6503,8 +6605,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003754"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003754"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6525,8 +6627,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000375C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000375C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6542,7 +6644,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tBravo, \n\tCharlie, \n\tDelta]"
                       children:
@@ -6555,8 +6658,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003764"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003764"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6577,8 +6680,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000376C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000376C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6599,8 +6702,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003774"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003774"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6616,7 +6719,11 @@ expression: stack_frames
                     Named: __5
                   type_name:
                     Array:
-                      item_type_name: "[&str; 3]"
+                      item_type_name:
+                        Array:
+                          item_type_name:
+                            Struct: "&str"
+                          count: 3
                       count: 2
                   value: ": [[&str; 3]; 2] = [\n\t: [&str; 3] = [\n\t\tEcho, \n\t\tFoxtrot, \n\t\tGolf\n\t], \n\t: [&str; 3] = [\n\t\tHotel, \n\t\tIndia, \n\t\tJuliet\n\t]]"
                   children:
@@ -6624,7 +6731,8 @@ expression: stack_frames
                         Named: __0
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tEcho, \n\tFoxtrot, \n\tGolf]"
                       children:
@@ -6637,8 +6745,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000377C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000377C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6659,8 +6767,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003784"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003784"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6681,8 +6789,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000378C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000378C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6698,7 +6806,8 @@ expression: stack_frames
                         Named: __1
                       type_name:
                         Array:
-                          item_type_name: "&str"
+                          item_type_name:
+                            Struct: "&str"
                           count: 3
                       value: ": [&str; 3] = [\n\tHotel, \n\tIndia, \n\tJuliet]"
                       children:
@@ -6711,8 +6820,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x20003794"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x20003794"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6733,8 +6842,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x2000379C"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x2000379C"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -6755,8 +6864,8 @@ expression: stack_frames
                             - name:
                                 Named: data_ptr
                               type_name:
-                                Pointer: ~
-                              value: "<referenced type> @ 0x200037A4"
+                                Pointer: u8
+                              value: "*raw u8 @ 0x200037A4"
                               children:
                                 - name:
                                     Named: "*data_ptr"
@@ -7204,7 +7313,8 @@ expression: stack_frames
             Named: my_array
           type_name:
             Array:
-              item_type_name: i32
+              item_type_name:
+                Base: i32
               count: 10
           value: ": [i32; 10] = [\n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55]"
           children:
@@ -7268,7 +7378,8 @@ expression: stack_frames
                 Named: "*my_array_ptr"
               type_name:
                 Array:
-                  item_type_name: i32
+                  item_type_name:
+                    Base: i32
                   count: 10
               value: ": [i32; 10] = [\n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55]"
               children:
@@ -7326,7 +7437,8 @@ expression: stack_frames
             Named: my_array_of_i8
           type_name:
             Array:
-              item_type_name: i8
+              item_type_name:
+                Base: i8
               count: 10
           value: ": [i8; 10] = [\n\t1, \n\t2, \n\t3, \n\t4, \n\t5, \n\t6, \n\t7, \n\t8, \n\t9, \n\t0]"
           children:
@@ -7395,7 +7507,8 @@ expression: stack_frames
                 Named: buffer
               type_name:
                 Array:
-                  item_type_name: MaybeUninit<i8>
+                  item_type_name:
+                    Base: MaybeUninit<i8>
                   count: 10
               value: ": [MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBC\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBD\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBE\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBF\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC0\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC1\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC2\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC3\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC4\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC5\n\t}]"
               children:
@@ -8061,7 +8174,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: Unknown
+      value: "<unknown>"
   canonical_frame_address: 536887288
 - function_name: __cortex_m_rt_main_trampoline
   source_location:
@@ -8288,7 +8401,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: Unknown
+      value: "<unknown>"
   canonical_frame_address: 536887296
 - function_name: "<unknown function @ 0x0000013c> : ERROR: UNWIND: Tried to unwind `RegisterRule` at CFA = None."
   source_location: ~

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -294,10 +294,8 @@ impl UnitInfo {
                     }
                     gimli::DW_AT_enum_class => match attr.value() {
                         gimli::AttributeValue::Flag(true) => {
-                            child_variable.set_value(VariableValue::Valid(format!(
-                                "{:?}",
-                                child_variable.type_name
-                            )));
+                            child_variable
+                                .set_value(VariableValue::Valid(child_variable.type_name()));
                         }
                         gimli::AttributeValue::Flag(false) => {
                             child_variable.set_value(VariableValue::Error(
@@ -935,7 +933,7 @@ impl UnitInfo {
         cache: &mut VariableCache,
         frame_info: StackFrameInfo<'_>,
     ) -> Result<(), DebugError> {
-        let type_name = match extract_name(debug_info, node.entry()) {
+        let type_name = match self.extract_type_name(debug_info, node.entry()) {
             Ok(name) => name,
             Err(error) => {
                 let message = format!("Error: evaluating type name: {error:?}");
@@ -953,8 +951,9 @@ impl UnitInfo {
 
         match node.entry().tag() {
             gimli::DW_TAG_base_type => {
-                child_variable.type_name =
-                    VariableType::Base(type_name.unwrap_or_else(|| "<unnamed>".to_string()));
+                child_variable.type_name = VariableType::Base(
+                    type_name.unwrap_or_else(|| "<unnamed base type>".to_string()),
+                );
                 self.process_memory_location(
                     debug_info,
                     node.entry(),
@@ -977,54 +976,37 @@ impl UnitInfo {
 
                 // This needs to resolve the pointer before the regular recursion can continue.
                 match node.entry().attr(gimli::DW_AT_type) {
-                    Ok(Some(data_type_attribute)) => {
-                        match data_type_attribute.value() {
-                            gimli::AttributeValue::UnitRef(unit_ref) => {
-                                // The default behaviour is to defer the processing of child types.
-                                child_variable.variable_node_type =
-                                    VariableNodeType::ReferenceOffset(unit_ref);
+                    Ok(Some(data_type_attribute)) => match data_type_attribute.value() {
+                        // NOTE: surprisingly, as opposed to `void*`, this can be a `const void*`.
+                        gimli::AttributeValue::UnitRef(unit_ref) => {
+                            child_variable.variable_node_type =
+                                VariableNodeType::ReferenceOffset(unit_ref);
 
-                                if let VariableType::Pointer(optional_name) =
-                                    &child_variable.type_name
-                                {
-                                    #[allow(clippy::unwrap_used)]
-                                    // Use of `unwrap` below is safe because we first check for `is_none()`.
-                                    if optional_name.is_none()
-                                        || optional_name.as_ref().unwrap().starts_with("*const")
-                                        || optional_name.as_ref().unwrap().starts_with("*mut")
-                                    {
-                                        // Resolve the children of this variable, because they contain essential information required to resolve the value
-                                        debug_info.cache_deferred_variables(
-                                            cache,
-                                            memory,
-                                            child_variable,
-                                            frame_info,
-                                        )?;
-                                    } else {
-                                        // This is the case where we defer the processing of child types.
-                                    }
-                                } else {
-                                    debug_info.cache_deferred_variables(
-                                        cache,
-                                        memory,
-                                        child_variable,
-                                        frame_info,
-                                    )?;
-                                }
-                            }
-                            other_attribute_value => {
-                                child_variable.set_value(VariableValue::Error(format!(
-                                    "Unimplemented: Attribute Value for DW_AT_type {:.100}",
-                                    format!("{other_attribute_value:?}")
-                                )));
-                            }
+                            debug_info.cache_deferred_variables(
+                                cache,
+                                memory,
+                                child_variable,
+                                frame_info,
+                            )?;
                         }
-                    }
+                        other_attribute_value => {
+                            child_variable.set_value(VariableValue::Error(format!(
+                                "Unimplemented: Attribute Value for DW_AT_type {:.100}",
+                                format!("{other_attribute_value:?}")
+                            )));
+                        }
+                    },
                     Ok(None) => {
-                        child_variable.set_value(VariableValue::Error(format!(
-                            "Error: No Attribute Value for DW_AT_type for variable {:?}",
-                            child_variable.name
-                        )));
+                        // NOTE: this can be a `void*` pointer. Some C compilers model `void` as
+                        // a type without `DW_AT_type`.
+                        // FIXME: this differs from `const void*` which may be surprising. Should we
+                        // add a dummy child variable?
+                        child_variable.set_value(
+                            self.language.process_tag_with_no_type(
+                                child_variable,
+                                gimli::DW_TAG_pointer_type,
+                            ),
+                        );
                     }
                     Err(error) => {
                         child_variable.set_value(VariableValue::Error(format!(
@@ -1034,8 +1016,9 @@ impl UnitInfo {
                 }
             }
             gimli::DW_TAG_structure_type => {
-                child_variable.type_name =
-                    VariableType::Struct(type_name.unwrap_or_else(|| "<unnamed>".to_string()));
+                child_variable.type_name = VariableType::Struct(
+                    type_name.unwrap_or_else(|| "<unnamed struct>".to_string()),
+                );
                 self.process_memory_location(
                     debug_info,
                     node.entry(),
@@ -1074,7 +1057,7 @@ impl UnitInfo {
             }
             gimli::DW_TAG_enumeration_type => {
                 child_variable.type_name =
-                    VariableType::Enum(type_name.unwrap_or_else(|| "<unnamed>".to_string()));
+                    VariableType::Enum(type_name.unwrap_or_else(|| "<unnamed enum>".to_string()));
                 self.process_memory_location(
                     debug_info,
                     node.entry(),
@@ -1190,10 +1173,10 @@ impl UnitInfo {
                                         ));
                             }
                             Ok(None) => {
-                                child_variable.set_value(VariableValue::Error(format!(
-                                    "Error: No Attribute Value for DW_AT_type for variable {:?}",
-                                    child_variable.name
-                                )));
+                                child_variable.set_value(self.language.process_tag_with_no_type(
+                                    child_variable,
+                                    gimli::DW_TAG_array_type,
+                                ));
                             }
                             Err(error) => {
                                 child_variable.set_value(VariableValue::Error(format!(
@@ -1214,7 +1197,7 @@ impl UnitInfo {
             }
             gimli::DW_TAG_union_type => {
                 child_variable.type_name =
-                    VariableType::Base(type_name.unwrap_or_else(|| "<unnamed>".to_string()));
+                    VariableType::Base(type_name.unwrap_or_else(|| "<unnamed union>".to_string()));
                 self.process_memory_location(
                     debug_info,
                     node.entry(),
@@ -1228,10 +1211,7 @@ impl UnitInfo {
                 self.process_tree(debug_info, node, child_variable, memory, cache, frame_info)?;
                 if child_variable.is_valid() && !cache.has_children(child_variable) {
                     // Empty structs don't have values.
-                    child_variable.set_value(VariableValue::Valid(format!(
-                        "{:?}",
-                        child_variable.type_name
-                    )));
+                    child_variable.set_value(VariableValue::Valid(child_variable.type_name()));
                 }
             }
             gimli::DW_TAG_subroutine_type => {
@@ -1242,6 +1222,7 @@ impl UnitInfo {
                         gimli::AttributeValue::UnitRef(unit_ref) => {
                             let subroutine_type_node =
                                 self.unit.header.entry(&self.unit.abbreviations, unit_ref)?;
+
                             child_variable.type_name =
                                 match extract_name(debug_info, &subroutine_type_node) {
                                     Ok(Some(name_attr)) => VariableType::Other(name_attr),
@@ -1281,18 +1262,47 @@ impl UnitInfo {
             other @ (gimli::DW_TAG_typedef
             | gimli::DW_TAG_const_type
             | gimli::DW_TAG_volatile_type) => match node.entry().attr(gimli::DW_AT_type) {
-                Ok(Some(attr)) => self.process_type_attribute(
-                    &attr,
-                    debug_info,
-                    node.entry(),
-                    parent_variable,
-                    child_variable,
-                    memory,
-                    frame_info,
-                    cache,
-                )?,
+                Ok(Some(attr)) => {
+                    self.process_type_attribute(
+                        &attr,
+                        debug_info,
+                        node.entry(),
+                        parent_variable,
+                        child_variable,
+                        memory,
+                        frame_info,
+                        cache,
+                    )?;
 
-                Ok(None) => child_variable.set_value(self.language.process_tag_with_no_type(other)),
+                    let modifier = match other {
+                        gimli::DW_TAG_typedef => {
+                            if child_variable.variable_node_type.is_deferred() {
+                                // Invalidate the value so we can read it again using the resolved
+                                // type information.
+                                child_variable.value = VariableValue::Empty;
+                            }
+                            Modifier::Typedef(
+                                type_name.unwrap_or_else(|| "<unnamed typedef>".to_string()),
+                            )
+                        }
+                        gimli::DW_TAG_const_type => Modifier::Const,
+                        gimli::DW_TAG_volatile_type => Modifier::Volatile,
+                        _ => unreachable!(),
+                    };
+
+                    child_variable.type_name = VariableType::Modified(
+                        modifier,
+                        Box::new(std::mem::replace(
+                            &mut child_variable.type_name,
+                            VariableType::Unknown,
+                        )),
+                    );
+                }
+
+                Ok(None) => child_variable.set_value(
+                    self.language
+                        .process_tag_with_no_type(child_variable, other),
+                ),
 
                 Err(error) => child_variable.set_value(VariableValue::Error(format!(
                     "Error: Failed to decode {other:?} type reference: {error:?}"
@@ -1364,7 +1374,7 @@ impl UnitInfo {
             // Once we know the type of the first member, we can set the array type.
             child_variable.type_name = VariableType::Array {
                 count: subrange_bounds.end as usize,
-                item_type_name: array_member_variable.type_name.to_string(),
+                item_type_name: Box::new(array_member_variable.type_name.clone()),
             };
             // Once we know the byte_size of the first member, we can set the array byte_size.
             if let Some(array_member_byte_size) = array_member_variable.byte_size {
@@ -1882,6 +1892,49 @@ impl UnitInfo {
             }
         }
         Ok(false)
+    }
+
+    /// Returns the `DW_AT_name` attribute in the subtree of a given node or recurses into the node referenced by the `DW_AT_type` attribute.
+    fn extract_type_name(
+        &self,
+        debug_info: &DebugInfo,
+        entry: &gimli::DebuggingInformationEntry<GimliReader>,
+    ) -> Result<Option<String>, gimli::Error> {
+        match entry.attr(gimli::DW_AT_name) {
+            Ok(Some(attr)) => {
+                let name = match attr.value() {
+                    gimli::AttributeValue::DebugStrRef(name_ref) => {
+                        if let Ok(name_raw) = debug_info.dwarf.string(name_ref) {
+                            String::from_utf8_lossy(&name_raw).to_string()
+                        } else {
+                            "Invalid DW_AT_name value".to_string()
+                        }
+                    }
+                    gimli::AttributeValue::String(name) => {
+                        String::from_utf8_lossy(&name).to_string()
+                    }
+                    other => format!("Unimplemented: Evaluate name from {other:?}"),
+                };
+
+                Ok(Some(name))
+            }
+            Ok(None) => {
+                let Ok(Some(attr)) = entry.attr(gimli::DW_AT_type) else {
+                    // No type attribute.
+                    return Ok(None);
+                };
+
+                let gimli::AttributeValue::UnitRef(unit_ref) = attr.value() else {
+                    // TODO: should we handle other types of references?
+                    return Ok(None);
+                };
+
+                // Try to read the name of the referenced type node.
+                let node = self.unit.header.entry(&self.unit.abbreviations, unit_ref)?;
+                self.extract_type_name(debug_info, &node)
+            }
+            Err(error) => Err(error),
+        }
     }
 }
 

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -1261,7 +1261,9 @@ impl UnitInfo {
 
             other @ (gimli::DW_TAG_typedef
             | gimli::DW_TAG_const_type
-            | gimli::DW_TAG_volatile_type) => match node.entry().attr(gimli::DW_AT_type) {
+            | gimli::DW_TAG_volatile_type
+            | gimli::DW_TAG_restrict_type
+            | gimli::DW_TAG_atomic_type) => match node.entry().attr(gimli::DW_AT_type) {
                 Ok(Some(attr)) => {
                     self.process_type_attribute(
                         &attr,
@@ -1287,6 +1289,8 @@ impl UnitInfo {
                         }
                         gimli::DW_TAG_const_type => Modifier::Const,
                         gimli::DW_TAG_volatile_type => Modifier::Volatile,
+                        gimli::DW_TAG_restrict_type => Modifier::Restrict,
+                        gimli::DW_TAG_atomic_type => Modifier::Atomic,
                         _ => unreachable!(),
                     };
 

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -1,4 +1,4 @@
-use crate::debug::unit_info::UnitInfo;
+use crate::debug::{language::ProgrammingLanguage, unit_info::UnitInfo};
 
 use super::*;
 use anyhow::anyhow;
@@ -41,7 +41,7 @@ impl std::fmt::Display for VariableValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             VariableValue::Valid(value) => value.fmt(f),
-            VariableValue::Error(error) => write!(f, "< {error} >",),
+            VariableValue::Error(error) => write!(f, "< {error} >"),
             VariableValue::Empty => write!(
                 f,
                 "Value not set. Please use Variable::get_value() to infer a human readable variable value"
@@ -143,6 +143,19 @@ impl VariableNodeType {
     }
 }
 
+/// A modifier to a variable type.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub enum Modifier {
+    /// The type is declared as `volatile`.
+    Volatile,
+
+    /// The type is declared as `const`.
+    Const,
+
+    /// The type is an alias with the given name.
+    Typedef(String),
+}
+
 /// The variants of VariableType allows us to streamline the conditional logic that requires specific handling depending on the nature of the variable.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 pub enum VariableType {
@@ -159,10 +172,12 @@ pub enum VariableType {
     /// A Rust array.
     Array {
         /// The type name of the variable.
-        item_type_name: String,
+        item_type_name: Box<VariableType>,
         /// The number of entries in the array.
         count: usize,
     },
+    /// A type alias.
+    Modified(Modifier, Box<VariableType>),
     /// When we are unable to determine the name of a variable.
     #[default]
     Unknown,
@@ -171,18 +186,19 @@ pub enum VariableType {
 }
 
 impl VariableType {
+    /// Get the inner type of a modified type.
+    pub fn inner(&self) -> &Self {
+        if let Self::Modified(_, ty) = self {
+            ty.inner()
+        } else {
+            self
+        }
+    }
+
     /// Is this variable of a Rust PhantomData marker type?
     pub fn is_phantom_data(&self) -> bool {
         match self {
             VariableType::Struct(name) => name.starts_with("PhantomData"),
-            _ => false,
-        }
-    }
-
-    /// Is this variable is a reference to another variable?
-    pub fn is_reference(&self) -> bool {
-        match self {
-            VariableType::Pointer(Some(name)) => name.starts_with('&'),
             _ => false,
         }
     }
@@ -203,28 +219,50 @@ impl VariableType {
             VariableType::Array { .. } => "array",
             VariableType::Unknown => "unknown",
             VariableType::Other(_) => "other",
+            VariableType::Modified(_, inner) => inner.kind(),
         }
     }
-}
 
-impl std::fmt::Display for VariableType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    pub(crate) fn display_name(&self, language: &dyn ProgrammingLanguage) -> String {
         match self {
-            VariableType::Base(base) => base.fmt(f),
-            VariableType::Struct(struct_name) => struct_name.fmt(f),
-            VariableType::Enum(enum_name) => enum_name.fmt(f),
-            VariableType::Namespace => "<namespace>".fmt(f),
-            VariableType::Pointer(pointer_name) => pointer_name
-                .clone()
-                .unwrap_or_else(|| "<referenced type>".to_string())
-                .fmt(f),
+            VariableType::Modified(Modifier::Typedef(name), _) => name.clone(),
+            VariableType::Modified(modifier, ty) => {
+                language.modified_type_name(modifier, &ty.display_name(language))
+            }
+
             VariableType::Array {
-                item_type_name: entry_type,
+                item_type_name,
                 count,
-            } => write!(f, "[{entry_type}; {count}]"),
-            VariableType::Unknown => "<unknown>".fmt(f),
-            VariableType::Other(other) => other.fmt(f),
+            } => language.format_array_type(&item_type_name.display_name(language), *count),
+
+            _ => self.type_name(language),
         }
+    }
+
+    /// Returns the type name after resolving aliases.
+    pub(crate) fn type_name(&self, language: &dyn ProgrammingLanguage) -> String {
+        let type_name = match self {
+            VariableType::Base(name)
+            | VariableType::Struct(name)
+            | VariableType::Enum(name)
+            | VariableType::Other(name) => Some(name.as_str()),
+            VariableType::Namespace => Some("namespace"),
+            VariableType::Unknown => None,
+
+            VariableType::Pointer(pointee) => {
+                // TODO: we should also carry the constness
+                return language.format_pointer_type(pointee.as_deref());
+            }
+
+            VariableType::Array {
+                item_type_name,
+                count,
+            } => return language.format_array_type(&item_type_name.type_name(language), *count),
+
+            VariableType::Modified(_, ty) => return ty.type_name(language),
+        };
+
+        type_name.unwrap_or("<unknown>").to_string()
     }
 }
 
@@ -346,6 +384,12 @@ impl Variable {
         }
     }
 
+    /// Returns the readable name of the variable type.
+    pub fn type_name(&self) -> String {
+        self.type_name
+            .display_name(language::from_dwarf(self.language).as_ref())
+    }
+
     /// Get a unique key for this variable.
     pub fn variable_key(&self) -> ObjectRef {
         self.variable_key
@@ -429,7 +473,8 @@ impl Variable {
             } else if self.type_name == VariableType::Unknown || !self.memory_location.valid() {
                 if self.variable_node_type.is_deferred() {
                     // When we will do a lazy-load of variable children, and they have not yet been requested by the user, just display the type_name as the value
-                    format!("{:?}", self.type_name.clone())
+                    self.type_name
+                        .display_name(language::from_dwarf(self.language).as_ref())
                 } else {
                     // This condition should only be true for intermediate nodes from DWARF. These should not show up in the final `VariableCache`
                     // If a user sees this error, then there is a logic problem in the stack unwind
@@ -463,7 +508,7 @@ impl Variable {
         // The value was set explicitly, so just leave it as is, or it was an error, so don't attempt anything else
         || !self.memory_location.valid()
         // This may just be that we are early on in the process of `Variable` evaluation
-        || self.type_name == VariableType::Unknown
+        || matches!(self.type_name.inner(), VariableType::Unknown)
         // This may just be that we are early on in the process of `Variable` evaluation
         {
             // Quick exit if we don't really need to do much more.
@@ -472,8 +517,12 @@ impl Variable {
 
         if self.variable_node_type.is_deferred() {
             // And we have not previously assigned the value, then assign the type and address as the value
-            self.value =
-                VariableValue::Valid(format!("{} @ {}", self.type_name, self.memory_location));
+            self.value = VariableValue::Valid(format!(
+                "{} @ {}",
+                self.type_name
+                    .display_name(language::from_dwarf(self.language).as_ref()),
+                self.memory_location
+            ));
             return;
         }
 
@@ -503,7 +552,7 @@ impl Variable {
     }
 
     /// `true` if the Variable has a valid value, or an empty value.
-    /// `false` if the Variable has a VariableValue::Error(_)value
+    /// `false` if the Variable has a VariableValue::Error(_) value
     pub fn is_valid(&self) -> bool {
         self.value.is_valid()
     }
@@ -515,6 +564,8 @@ impl Variable {
         show_name: bool,
     ) -> String {
         let line_feed = if indentation == 0 { "" } else { "\n" };
+        let type_name = self.type_name();
+
         // Allow for chained `if let` without complaining
         #[allow(clippy::if_same_then_else)]
         if !self.value.is_empty() {
@@ -522,7 +573,7 @@ impl Variable {
                 // Use the supplied value or error message.
                 format!(
                     "{}{:\t<indentation$}{}: {} = {}",
-                    line_feed, "", self.name, self.type_name, self.value
+                    line_feed, "", self.name, type_name, self.value
                 )
             } else {
                 // Use the supplied value or error message.
@@ -564,7 +615,7 @@ impl Variable {
                     // Arrays
                     compound_value = format!(
                         "{}{}{:\t<indentation$}: {} = [",
-                        compound_value, line_feed, "", self.type_name,
+                        compound_value, line_feed, "", type_name,
                     );
                     let mut child_count: usize = 0;
                     for child in &children {
@@ -588,7 +639,7 @@ impl Variable {
                     // Handle special structure types like the variant values of `Option<>` and `Result<>`
                     compound_value = format!(
                         "{}{:\t<indentation$}{}: {} = {}(",
-                        line_feed, "", self.name, self.type_name, compound_value
+                        line_feed, "", self.name, type_name, compound_value
                     );
                     for child in children {
                         compound_value = format!(
@@ -629,9 +680,9 @@ impl Variable {
                                             line_feed,
                                             "",
                                             self.name,
-                                            self.type_name,
-                                            child.type_name,
-                                            self.type_name,
+                                            type_name,
+                                            child.type_name(),
+                                            type_name,
                                         ));
                                         post_fix =
                                             Some(format!("{}{:\t<indentation$})", line_feed, ""));
@@ -641,16 +692,12 @@ impl Variable {
                                         if show_name {
                                             pre_fix = Some(format!(
                                                 "{}{:\t<indentation$}{}: {} = {} {{",
-                                                line_feed,
-                                                "",
-                                                self.name,
-                                                self.type_name,
-                                                self.type_name,
+                                                line_feed, "", self.name, type_name, type_name,
                                             ));
                                         } else {
                                             pre_fix = Some(format!(
                                                 "{}{:\t<indentation$}{} {{",
-                                                line_feed, "", self.type_name,
+                                                line_feed, "", type_name,
                                             ));
                                         }
                                         post_fix =

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -143,7 +143,7 @@ impl VariableNodeType {
     }
 }
 
-/// A modifier to a variable type.
+/// A modifier to a variable type. Currently only used to format the type name.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub enum Modifier {
     /// The type is declared as `volatile`.
@@ -151,6 +151,12 @@ pub enum Modifier {
 
     /// The type is declared as `const`.
     Const,
+
+    /// The type is declared as `restrict`.
+    Restrict,
+
+    /// The type is declared as `atomic`.
+    Atomic,
 
     /// The type is an alias with the given name.
     Typedef(String),

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -444,13 +444,14 @@ impl VariableCache {
                     memory_ranges.push(memory_range);
                 }
             }
+
             // The datatype &str is a special case, because it is stores a pointer to the string data,
             // and the length of the string.
-            if variable.type_name == VariableType::Struct("&str".to_string()) {
+            if matches!(variable.type_name, VariableType::Struct(ref name) if name == "&str") {
                 let children: Vec<_> = self.get_children(variable.variable_key).collect();
                 if !children.is_empty() {
                     let string_length = match children.iter().find(|child_variable| {
-                        child_variable.name == VariableName::Named("length".to_string())
+                        matches!(child_variable.name, VariableName::Named(ref name) if name == "length")
                     }) {
                         Some(string_length) => {
                             if string_length.is_valid() {
@@ -462,7 +463,7 @@ impl VariableCache {
                         None => 0_usize,
                     };
                     let string_location = match children.iter().find(|child_variable| {
-                        child_variable.name == VariableName::Named("data_ptr".to_string())
+                        matches!(child_variable.name, VariableName::Named(ref name ) if name == "data_ptr")
                     }) {
                         Some(location_value) => {
                             let mut child_variables =
@@ -552,7 +553,7 @@ mod test {
             VariableNodeType::DirectLookup
         );
 
-        assert_eq!(cache_variable.get_value(&c), "Unknown");
+        assert_eq!(cache_variable.get_value(&c), "<unknown>");
 
         assert_eq!(cache_variable.source_location, Default::default());
         assert_eq!(cache_variable.memory_location, VariableLocation::Unknown);


### PR DESCRIPTION
Continuation of #2171

This PR aims at reducing the number of `<unnamed>` variables while debugging C code. We're doing this by passing the type name from upper tree nodes if they are `typedef`, (or `const` or `volatile`, so this is possibly not only hacky, but wrong). While not perfect (we still ignore modifiers, pointer constness, etc) this now allows showing more type names to the user.