### PR TITLE
Print at least one fractional digit for floats

### DIFF
--- a/probe-rs/src/debug/language/c.rs
+++ b/probe-rs/src/debug/language/c.rs
@@ -1,6 +1,10 @@
 use crate::{
     debug::{
-        language::{parsing::ParseToBytes, value::Value, ProgrammingLanguage},
+        language::{
+            parsing::ParseToBytes,
+            value::{format_float, Value},
+            ProgrammingLanguage,
+        },
         DebugError, Variable, VariableCache, VariableLocation, VariableName, VariableType,
         VariableValue,
     },
@@ -35,7 +39,9 @@ impl ProgrammingLanguage for C {
                 }
 
                 "float" => match variable.byte_size {
-                    Some(4) | None => f32::get_value(variable, memory, variable_cache).into(),
+                    Some(4) | None => f32::get_value(variable, memory, variable_cache)
+                        .map(|f| format_float(f as f64))
+                        .into(),
                     Some(size) => {
                         VariableValue::Error(format!("Invalid byte size for float: {size}"))
                     }

--- a/probe-rs/src/debug/language/rust.rs
+++ b/probe-rs/src/debug/language/rust.rs
@@ -1,6 +1,9 @@
 use crate::{
     debug::{
-        language::{value::Value, ProgrammingLanguage},
+        language::{
+            value::{format_float, Value},
+            ProgrammingLanguage,
+        },
         DebugError, Variable, VariableCache, VariableLocation, VariableName, VariableType,
         VariableValue,
     },
@@ -44,8 +47,12 @@ impl ProgrammingLanguage for Rust {
                 "u128" => u128::get_value(variable, memory, variable_cache).into(),
                 // TODO: We can get the actual WORD length from DWARF instead of assuming `u32`
                 "usize" => u32::get_value(variable, memory, variable_cache).into(),
-                "f32" => f32::get_value(variable, memory, variable_cache).into(),
-                "f64" => f64::get_value(variable, memory, variable_cache).into(),
+                "f32" => f32::get_value(variable, memory, variable_cache)
+                    .map(|f| format_float(f as f64))
+                    .into(),
+                "f64" => f64::get_value(variable, memory, variable_cache)
+                    .map(format_float)
+                    .into(),
                 "None" => VariableValue::Valid("None".to_string()),
 
                 _undetermined_value => VariableValue::Empty,

--- a/probe-rs/src/debug/language/value.rs
+++ b/probe-rs/src/debug/language/value.rs
@@ -487,3 +487,19 @@ impl Value for f64 {
             })
     }
 }
+
+/// Format a float value to a string, preserving at least one fractional digit.
+pub fn format_float(value: f64) -> String {
+    let mut s = format!("{}", value);
+    if !s.contains('.') {
+        s.push('.');
+    }
+    while s.ends_with('0') {
+        s.pop();
+    }
+    if s.ends_with('.') {
+        s.push('0');
+    }
+
+    s
+}


### PR DESCRIPTION
A bit subjective, but this PR will print "1.0" for float values instead of "1", which is much less surprising to me.