### PR TITLE
Do not error if we encounter unknown attributes

### DIFF
--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -425,13 +425,12 @@ impl UnitInfo {
                         // Processed by `extract_type()`
                     }
                     other_attribute => {
-                        // This follows the examples of the "format!" documenation as the way to limit string length of a {:?} parameter.
-                        child_variable.set_value(VariableValue::Error(format!(
+                        tracing::info!(
                             "Unimplemented: Variable Attribute {:.100} : {:.100}, with children = {}",
                             format!("{:?}", other_attribute.static_string()),
                             format!("{:?}", attributes_entry.attr_value(other_attribute)),
                             attributes_entry.has_children()
-                        )));
+                        );
                     }
                 }
             }


### PR DESCRIPTION
@noppej do you have a better idea maybe? I think failing if we encounter something we haven't seen before is a bit harsh as strategies go, especially considering that DWARF allows vendor-specific extensions.

Should fix #2188 (or at least fail less loudly)