### PR TITLE
fix nusb dep version.

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -99,7 +99,7 @@ object = { version = "0.32", default-features = false, features = [
     "std",
 ] }
 paste = "1"
-nusb = { version = "0.1" }
+nusb = { version = "0.1.6" }
 futures-lite = "2"
 async-io = "2"
 scroll = "0.12"


### PR DESCRIPTION
we use `detach_and_claim_interface` which is only present in 0.1.6+.
