### PR TITLE
Group arguments into a context type

### DIFF
--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -292,13 +292,6 @@ fn extract_byte_size(node_die: &DebuggingInformationEntry<GimliReader>) -> Optio
     }
 }
 
-fn extract_line(attribute_value: gimli::AttributeValue<GimliReader>) -> Option<u64> {
-    match attribute_value {
-        gimli::AttributeValue::Udata(line) => Some(line),
-        _ => None,
-    }
-}
-
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 pub(crate) fn _print_all_attributes(
     core: &mut Core<'_>,

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -1,6 +1,6 @@
 use super::{
-    debug_info::*, extract_byte_size, extract_file, extract_line, function_die::FunctionDie,
-    variable::*, DebugError, DebugRegisters, EndianReader, VariableCache,
+    debug_info::*, extract_byte_size, extract_file, function_die::FunctionDie, variable::*,
+    DebugError, DebugRegisters, EndianReader, VariableCache,
 };
 use crate::{
     debug::{language, stack_frame::StackFrameInfo},
@@ -264,7 +264,7 @@ impl UnitInfo {
                         }
                     }
                     gimli::DW_AT_decl_line => {
-                        if let Some(line_number) = extract_line(attr.value()) {
+                        if let Some(line_number) = attr.value().udata_value() {
                             child_variable.source_location.line = Some(line_number);
                         }
                     }

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -120,7 +120,7 @@ impl UnitInfo {
 
     /// Check if the function located at the given offset contains inlined functions at the
     /// given address.
-    pub(crate) fn find_inlined_functions(
+    fn find_inlined_functions(
         &self,
         debug_info: &DebugInfo,
         address: u64,


### PR DESCRIPTION
@Tiwalun I wanted to run this idea by you. I know I'm basically just causing conflicts here, but this change would also make it easier to pass the type cache around - and more if we keep expanding the parameter lists of these functions. What do you think?

One hurdle that came up is that not everything needs the variable cache and in these cases creating an empty cache is a bit of a chore.