### PR TITLE
Remove unnecessary Result return value

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1464,7 +1464,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         if let Some(variable_cache) = variable_cache {
             if let Some(parent_variable) = parent_variable.as_mut() {
                 if parent_variable.variable_node_type.is_deferred()
-                    && !variable_cache.has_children(parent_variable)?
+                    && !variable_cache.has_children(parent_variable)
                 {
                     if let Some(frame_info) = frame_info {
                         target_core.core_data.debug_info.cache_deferred_variables(
@@ -1480,7 +1480,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             }
 
             let dap_variables: Vec<Variable> = variable_cache
-                .get_children(variable_ref)?
+                .get_children(variable_ref)
                 .iter()
                 // Filter out requested children, then map them as DAP variables
                 .filter(|variable| match &arguments.filter {

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1481,7 +1481,6 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
 
             let dap_variables: Vec<Variable> = variable_cache
                 .get_children(variable_ref)
-                .iter()
                 // Filter out requested children, then map them as DAP variables
                 .filter(|variable| match &arguments.filter {
                     Some(filter) => match filter.as_str() {

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/repl_commands_helpers.rs
@@ -67,12 +67,8 @@ pub(crate) fn get_local_variable(
     let variable_list = if variable.name == VariableName::LocalScopeRoot {
         variable_cache
             .get_children(variable.variable_key())
-            .map_err(|_| {
-                DebuggerError::UserMessage(format!(
-                    "No local variables available for frame : {}",
-                    stack_frame.function_name
-                ))
-            })?
+            .cloned()
+            .collect()
     } else {
         vec![variable]
     };

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
@@ -345,7 +345,7 @@ pub(crate) fn halt_core(
 /// (`variable_reference`, `named_child_variables_cnt`, `indexed_child_variables_cnt`)
 pub(crate) fn get_variable_reference(
     parent_variable: &probe_rs::debug::Variable,
-    cache: &mut probe_rs::debug::VariableCache,
+    cache: &probe_rs::debug::VariableCache,
 ) -> (ObjectRef, i64, i64) {
     if !parent_variable.is_valid() {
         return (ObjectRef::Invalid, 0, 0);
@@ -353,15 +353,13 @@ pub(crate) fn get_variable_reference(
 
     let mut named_child_variables_cnt = 0;
     let mut indexed_child_variables_cnt = 0;
-    if let Ok(children) = cache.get_children(parent_variable.variable_key()) {
-        for child_variable in children {
-            if child_variable.is_indexed() {
-                indexed_child_variables_cnt += 1;
-            } else {
-                named_child_variables_cnt += 1;
-            }
+    for child_variable in cache.get_children(parent_variable.variable_key()) {
+        if child_variable.is_indexed() {
+            indexed_child_variables_cnt += 1;
+        } else {
+            named_child_variables_cnt += 1;
         }
-    };
+    }
 
     if named_child_variables_cnt > 0 || indexed_child_variables_cnt > 0 {
         (

--- a/probe-rs/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/debug.rs
@@ -745,7 +745,7 @@ impl DebugCli {
                         let mut locals = local_variable_cache.root_variable();
                         // By default, the first level children are always are lazy loaded, so we will force a load here.
                         if locals.variable_node_type.is_deferred()
-                            && !local_variable_cache.has_children(&locals)?
+                            && !local_variable_cache.has_children(&locals)
                         {
                             if let Err(error) = cli_data
                                 .debug_info
@@ -767,7 +767,7 @@ impl DebugCli {
                                 return Ok(CliState::Continue);
                             }
                         }
-                        let children = local_variable_cache.get_children(locals.variable_key())?;
+                        let children = local_variable_cache.get_children(locals.variable_key());
 
                         for child in children {
                             println!(

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -306,7 +306,7 @@ impl DebugInfo {
         }
 
         // Only attempt this part if we have not yet resolved the referenced children.
-        if cache.has_children(parent_variable)? {
+        if cache.has_children(parent_variable) {
             return Ok(());
         }
 

--- a/probe-rs/src/debug/language/value.rs
+++ b/probe-rs/src/debug/language/value.rs
@@ -115,9 +115,9 @@ impl Value for String {
         variable_cache: &VariableCache,
     ) -> Result<Self, DebugError> {
         let mut str_value: String = "".to_owned();
-        if let Ok(children) = variable_cache.get_children(variable.variable_key) {
-            if !children.is_empty() {
-                let mut string_length = match children.iter().find(|child_variable| {
+        let children = variable_cache.get_children(variable.variable_key);
+        if !children.is_empty() {
+            let mut string_length = match children.iter().find(|child_variable| {
                     matches!(child_variable.name, VariableName::Named(ref name) if name == "length")
                 }) {
                     Some(string_length) => {
@@ -130,52 +130,46 @@ impl Value for String {
                     }
                     None => 0_usize,
                 };
-                let string_location = match children.iter().find(|child_variable| {
+            let string_location = match children.iter().find(|child_variable| {
                     matches!(child_variable.name, VariableName::Named(ref name) if name == "data_ptr")
                 }) {
                     Some(location_value) => {
-                        if let Ok(child_variables) =
-                            variable_cache.get_children(location_value.variable_key)
-                        {
-                            if let Some(first_child) = child_variables.first() {
-                                first_child.memory_location.memory_address()?
-                            } else {
-                                0_u64
-                            }
+                        let child_variables = variable_cache.get_children(location_value.variable_key);
+                        if let Some(first_child) = child_variables.first() {
+                            first_child.memory_location.memory_address()?
                         } else {
                             0_u64
                         }
                     }
                     None => 0_u64,
                 };
-                if string_location == 0 {
-                    str_value = "Error: Failed to determine &str memory location".to_string();
-                } else {
-                    // Limit string length to work around buggy information, otherwise the debugger
-                    // can hang due to buggy debug information.
-                    //
-                    // TODO: If implemented, the variable should not be fetched automatically,
-                    // but only when requested by the user. This workaround can then be removed.
-                    if string_length > 200 {
-                        tracing::warn!(
-                            "Very long string ({} bytes), truncating to 200 bytes.",
-                            string_length
-                        );
-                        string_length = 200;
-                    }
-
-                    if string_length == 0 {
-                        // A string with length 0 doesn't need to be read from memory.
-                    } else {
-                        let mut buff = vec![0u8; string_length];
-                        memory.read(string_location, &mut buff)?;
-                        str_value = core::str::from_utf8(&buff)?.to_owned();
-                    }
-                }
+            if string_location == 0 {
+                str_value = "Error: Failed to determine &str memory location".to_string();
             } else {
-                str_value = "Error: Failed to evaluate &str value".to_string();
+                // Limit string length to work around buggy information, otherwise the debugger
+                // can hang due to buggy debug information.
+                //
+                // TODO: If implemented, the variable should not be fetched automatically,
+                // but only when requested by the user. This workaround can then be removed.
+                if string_length > 200 {
+                    tracing::warn!(
+                        "Very long string ({} bytes), truncating to 200 bytes.",
+                        string_length
+                    );
+                    string_length = 200;
+                }
+
+                if string_length == 0 {
+                    // A string with length 0 doesn't need to be read from memory.
+                } else {
+                    let mut buff = vec![0u8; string_length];
+                    memory.read(string_location, &mut buff)?;
+                    str_value = core::str::from_utf8(&buff)?.to_owned();
+                }
             }
-        };
+        } else {
+            str_value = "Error: Failed to evaluate &str value".to_string();
+        }
         Ok(str_value)
     }
 

--- a/probe-rs/src/debug/language/value.rs
+++ b/probe-rs/src/debug/language/value.rs
@@ -115,7 +115,7 @@ impl Value for String {
         variable_cache: &VariableCache,
     ) -> Result<Self, DebugError> {
         let mut str_value: String = "".to_owned();
-        let children = variable_cache.get_children(variable.variable_key);
+        let children: Vec<_> = variable_cache.get_children(variable.variable_key).collect();
         if !children.is_empty() {
             let mut string_length = match children.iter().find(|child_variable| {
                     matches!(child_variable.name, VariableName::Named(ref name) if name == "length")
@@ -130,12 +130,13 @@ impl Value for String {
                     }
                     None => 0_usize,
                 };
+
             let string_location = match children.iter().find(|child_variable| {
                     matches!(child_variable.name, VariableName::Named(ref name) if name == "data_ptr")
                 }) {
                     Some(location_value) => {
-                        let child_variables = variable_cache.get_children(location_value.variable_key);
-                        if let Some(first_child) = child_variables.first() {
+                        let mut child_variables = variable_cache.get_children(location_value.variable_key);
+                        if let Some(first_child) = child_variables.next() {
                             first_child.memory_location.memory_address()?
                         } else {
                             0_u64

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -556,7 +556,7 @@ impl UnitInfo {
                     )?;
 
                     // Do not keep empty namespaces around
-                    if !cache.has_children(&namespace_variable)? {
+                    if !cache.has_children(&namespace_variable) {
                         cache.remove_cache_entry(namespace_variable.variable_key)?;
                     }
                 }
@@ -645,7 +645,7 @@ impl UnitInfo {
                 // Variant is a child of a structure, and one of them should have a discriminant value to match the DW_TAG_variant_part
                 gimli::DW_TAG_variant => {
                     // We only need to do this if we have not already found our variant,
-                    if !cache.has_children(parent_variable)? {
+                    if !cache.has_children(parent_variable) {
                         let mut child_variable = cache.create_variable(
                             parent_variable.variable_key,
                             Some(child_node.entry().offset()),
@@ -1039,7 +1039,7 @@ impl UnitInfo {
                 // Recursively process a child types.
                 self.process_tree(debug_info, node, child_variable, memory, cache, frame_info)?;
                 if parent_variable.is_valid() && child_variable.is_valid() {
-                    let enumerator_values = cache.get_children(child_variable.variable_key)?;
+                    let enumerator_values = cache.get_children(child_variable.variable_key);
 
                     let value = if let VariableLocation::Address(address) =
                         child_variable.memory_location
@@ -1195,7 +1195,7 @@ impl UnitInfo {
                 // Recursively process a child types.
                 // TODO: The DWARF does not currently hold information that allows decoding of which UNION arm is instantiated, so we have to display all available.
                 self.process_tree(debug_info, node, child_variable, memory, cache, frame_info)?;
-                if child_variable.is_valid() && !cache.has_children(child_variable)? {
+                if child_variable.is_valid() && !cache.has_children(child_variable) {
                     // Empty structs don't have values.
                     child_variable.set_value(VariableValue::Valid(format!(
                         "{:?}",

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -546,7 +546,7 @@ impl Variable {
         } else {
             // Infer a human readable value using the available children of this variable.
             let mut compound_value = String::new();
-            let children = variable_cache.get_children(self.variable_key);
+            let children: Vec<_> = variable_cache.get_children(self.variable_key).collect();
 
             // Make sure we can safely unwrap() children.
             match &self.type_name {
@@ -576,7 +576,7 @@ impl Variable {
                         compound_value, line_feed, "", self.type_name,
                     );
                     let mut child_count: usize = 0;
-                    for child in children.iter() {
+                    for child in &children {
                         child_count += 1;
 
                         compound_value = format!(

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -430,34 +430,29 @@ impl Variable {
             String::new()
         } else {
             // We need to construct a 'human readable' value using `fmt::Display` to represent the values of complex types and pointers.
-            match variable_cache.has_children(self) {
-                Ok(true) => self.formatted_variable_value(variable_cache, 0_usize, false),
-                Ok(false) => {
-                    if self.type_name == VariableType::Unknown || !self.memory_location.valid() {
-                        if self.variable_node_type.is_deferred() {
-                            // When we will do a lazy-load of variable children, and they have not yet been requested by the user, just display the type_name as the value
-                            format!("{:?}", self.type_name.clone())
-                        } else {
-                            // This condition should only be true for intermediate nodes from DWARF. These should not show up in the final `VariableCache`
-                            // If a user sees this error, then there is a logic problem in the stack unwind
-                            "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location".to_string()
-                        }
-                    } else if matches!(self.type_name, VariableType::Struct(ref name) if name == "None")
-                    {
-                        "None".to_string()
-                    } else if matches!(self.type_name, VariableType::Array { count: 0, .. }) {
-                        self.formatted_variable_value(variable_cache, 0_usize, false)
+            if variable_cache.has_children(self) {
+                self.formatted_variable_value(variable_cache, 0_usize, false)
+            } else {
+                if self.type_name == VariableType::Unknown || !self.memory_location.valid() {
+                    if self.variable_node_type.is_deferred() {
+                        // When we will do a lazy-load of variable children, and they have not yet been requested by the user, just display the type_name as the value
+                        format!("{:?}", self.type_name.clone())
                     } else {
-                        format!(
-                            "Unimplemented: Evaluate type {:?} of ({:?} bytes) at location 0x{:08x?}",
-                            self.type_name, self.byte_size, self.memory_location
-                          )
+                        // This condition should only be true for intermediate nodes from DWARF. These should not show up in the final `VariableCache`
+                        // If a user sees this error, then there is a logic problem in the stack unwind
+                        "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location".to_string()
                     }
+                } else if matches!(self.type_name, VariableType::Struct(ref name) if name == "None")
+                {
+                    "None".to_string()
+                } else if matches!(self.type_name, VariableType::Array { count: 0, .. }) {
+                    self.formatted_variable_value(variable_cache, 0_usize, false)
+                } else {
+                    format!(
+                        "Unimplemented: Evaluate type {:?} of ({:?} bytes) at location 0x{:08x?}",
+                        self.type_name, self.byte_size, self.memory_location
+                    )
                 }
-                Err(error) => format!(
-                    "Failed to determine children for `Variable`: {}. {:?}",
-                    self.name, error
-                ),
             }
         }
     }
@@ -551,37 +546,132 @@ impl Variable {
         } else {
             // Infer a human readable value using the available children of this variable.
             let mut compound_value = String::new();
-            if let Ok(children) = variable_cache.get_children(self.variable_key) {
-                // Make sure we can safely unwrap() children.
-                match &self.type_name {
-                    VariableType::Pointer(_) => {
-                        // Pointers
+            let children = variable_cache.get_children(self.variable_key);
+
+            // Make sure we can safely unwrap() children.
+            match &self.type_name {
+                VariableType::Pointer(_) => {
+                    // Pointers
+                    compound_value = format!(
+                        "{}{}{:\t<indentation$}{}",
+                        compound_value,
+                        line_feed,
+                        "",
+                        if let Some(first_child) = children.first() {
+                            first_child.formatted_variable_value(
+                                variable_cache,
+                                indentation + 1,
+                                true,
+                            )
+                        } else {
+                            "Unable to resolve referenced variable value".to_string()
+                        }
+                    );
+                    compound_value
+                }
+                VariableType::Array { .. } => {
+                    // Arrays
+                    compound_value = format!(
+                        "{}{}{:\t<indentation$}: {} = [",
+                        compound_value, line_feed, "", self.type_name,
+                    );
+                    let mut child_count: usize = 0;
+                    for child in children.iter() {
+                        child_count += 1;
+
                         compound_value = format!(
-                            "{}{}{:\t<indentation$}{}",
+                            "{}{}{}",
                             compound_value,
-                            line_feed,
-                            "",
-                            if let Some(first_child) = children.first() {
-                                first_child.formatted_variable_value(
-                                    variable_cache,
-                                    indentation + 1,
-                                    true,
-                                )
+                            child.formatted_variable_value(variable_cache, indentation + 1, false),
+                            if child_count == children.len() {
+                                // Do not add a separator at the end of the list
+                                ""
                             } else {
-                                "Unable to resolve referenced variable value".to_string()
+                                ", "
                             }
                         );
-                        compound_value
                     }
-                    VariableType::Array { .. } => {
-                        // Arrays
+                    format!("{}{}{:\t<indentation$}]", compound_value, line_feed, "")
+                }
+                VariableType::Struct(name) if name == "Ok" || name == "Err" => {
+                    // Handle special structure types like the variant values of `Option<>` and `Result<>`
+                    compound_value = format!(
+                        "{}{:\t<indentation$}{}: {} = {}(",
+                        line_feed, "", self.name, self.type_name, compound_value
+                    );
+                    for child in children {
                         compound_value = format!(
-                            "{}{}{:\t<indentation$}: {} = [",
-                            compound_value, line_feed, "", self.type_name,
+                            "{}{}",
+                            compound_value,
+                            child.formatted_variable_value(variable_cache, indentation + 1, false)
                         );
+                    }
+                    format!("{}{}{:\t<indentation$})", compound_value, line_feed, "")
+                }
+                _ => {
+                    // Generic handling of other structured types.
+                    // The pre- and post- fix is determined by the type of children.
+                    // compound_value = format!("{} {}", compound_value, self.type_name);
+
+                    if children.is_empty() {
+                        // Struct with no children -> just print type name
+                        // This is for example the None value of an Option.
+
+                        format!("{}{:\t<indentation$}{}", line_feed, "", self.name)
+                    } else {
+                        let (mut pre_fix, mut post_fix): (Option<String>, Option<String>) =
+                            (None, None);
+
                         let mut child_count: usize = 0;
+
+                        let mut is_tuple = false;
+
                         for child in children.iter() {
                             child_count += 1;
+                            if pre_fix.is_none() && post_fix.is_none() {
+                                if let VariableName::Named(child_name) = &child.name {
+                                    if child_name.starts_with("__0") {
+                                        is_tuple = true;
+                                        // Treat this structure as a tuple
+                                        pre_fix = Some(format!(
+                                            "{}{:\t<indentation$}{}: {}({}) = {}(",
+                                            line_feed,
+                                            "",
+                                            self.name,
+                                            self.type_name,
+                                            child.type_name,
+                                            self.type_name,
+                                        ));
+                                        post_fix =
+                                            Some(format!("{}{:\t<indentation$})", line_feed, ""));
+                                    } else {
+                                        // Treat this structure as a `struct`
+
+                                        if show_name {
+                                            pre_fix = Some(format!(
+                                                "{}{:\t<indentation$}{}: {} = {} {{",
+                                                line_feed,
+                                                "",
+                                                self.name,
+                                                self.type_name,
+                                                self.type_name,
+                                            ));
+                                        } else {
+                                            pre_fix = Some(format!(
+                                                "{}{:\t<indentation$}{} {{",
+                                                line_feed, "", self.type_name,
+                                            ));
+                                        }
+                                        post_fix =
+                                            Some(format!("{}{:\t<indentation$}}}", line_feed, ""));
+                                    }
+                                };
+                                if let Some(pre_fix) = &pre_fix {
+                                    compound_value = format!("{compound_value}{pre_fix}");
+                                };
+                            }
+
+                            let print_name = !is_tuple;
 
                             compound_value = format!(
                                 "{}{}{}",
@@ -589,7 +679,7 @@ impl Variable {
                                 child.formatted_variable_value(
                                     variable_cache,
                                     indentation + 1,
-                                    false
+                                    print_name
                                 ),
                                 if child_count == children.len() {
                                     // Do not add a separator at the end of the list
@@ -599,122 +689,12 @@ impl Variable {
                                 }
                             );
                         }
-                        format!("{}{}{:\t<indentation$}]", compound_value, line_feed, "")
-                    }
-                    VariableType::Struct(name) if name == "Ok" || name == "Err" => {
-                        // Handle special structure types like the variant values of `Option<>` and `Result<>`
-                        compound_value = format!(
-                            "{}{:\t<indentation$}{}: {} = {}(",
-                            line_feed, "", self.name, self.type_name, compound_value
-                        );
-                        for child in children {
-                            compound_value = format!(
-                                "{}{}",
-                                compound_value,
-                                child.formatted_variable_value(
-                                    variable_cache,
-                                    indentation + 1,
-                                    false
-                                )
-                            );
-                        }
-                        format!("{}{}{:\t<indentation$})", compound_value, line_feed, "")
-                    }
-                    _ => {
-                        // Generic handling of other structured types.
-                        // The pre- and post- fix is determined by the type of children.
-                        // compound_value = format!("{} {}", compound_value, self.type_name);
-
-                        if children.is_empty() {
-                            // Struct with no children -> just print type name
-                            // This is for example the None value of an Option.
-
-                            format!("{}{:\t<indentation$}{}", line_feed, "", self.name)
-                        } else {
-                            let (mut pre_fix, mut post_fix): (Option<String>, Option<String>) =
-                                (None, None);
-
-                            let mut child_count: usize = 0;
-
-                            let mut is_tuple = false;
-
-                            for child in children.iter() {
-                                child_count += 1;
-                                if pre_fix.is_none() && post_fix.is_none() {
-                                    if let VariableName::Named(child_name) = &child.name {
-                                        if child_name.starts_with("__0") {
-                                            is_tuple = true;
-                                            // Treat this structure as a tuple
-                                            pre_fix = Some(format!(
-                                                "{}{:\t<indentation$}{}: {}({}) = {}(",
-                                                line_feed,
-                                                "",
-                                                self.name,
-                                                self.type_name,
-                                                child.type_name,
-                                                self.type_name,
-                                            ));
-                                            post_fix = Some(format!(
-                                                "{}{:\t<indentation$})",
-                                                line_feed, ""
-                                            ));
-                                        } else {
-                                            // Treat this structure as a `struct`
-
-                                            if show_name {
-                                                pre_fix = Some(format!(
-                                                    "{}{:\t<indentation$}{}: {} = {} {{",
-                                                    line_feed,
-                                                    "",
-                                                    self.name,
-                                                    self.type_name,
-                                                    self.type_name,
-                                                ));
-                                            } else {
-                                                pre_fix = Some(format!(
-                                                    "{}{:\t<indentation$}{} {{",
-                                                    line_feed, "", self.type_name,
-                                                ));
-                                            }
-                                            post_fix = Some(format!(
-                                                "{}{:\t<indentation$}}}",
-                                                line_feed, ""
-                                            ));
-                                        }
-                                    };
-                                    if let Some(pre_fix) = &pre_fix {
-                                        compound_value = format!("{compound_value}{pre_fix}");
-                                    };
-                                }
-
-                                let print_name = !is_tuple;
-
-                                compound_value = format!(
-                                    "{}{}{}",
-                                    compound_value,
-                                    child.formatted_variable_value(
-                                        variable_cache,
-                                        indentation + 1,
-                                        print_name
-                                    ),
-                                    if child_count == children.len() {
-                                        // Do not add a separator at the end of the list
-                                        ""
-                                    } else {
-                                        ", "
-                                    }
-                                );
-                            }
-                            if let Some(post_fix) = &post_fix {
-                                compound_value = format!("{compound_value}{post_fix}");
-                            };
-                            compound_value
-                        }
+                        if let Some(post_fix) = &post_fix {
+                            compound_value = format!("{compound_value}{post_fix}");
+                        };
+                        compound_value
                     }
                 }
-            } else {
-                // We don't have a value, and we can't generate one from children values, so use the type_name
-                format!("{:\t<indentation$}{}", "", self.type_name)
             }
         }
     }

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -432,27 +432,24 @@ impl Variable {
             // We need to construct a 'human readable' value using `fmt::Display` to represent the values of complex types and pointers.
             if variable_cache.has_children(self) {
                 self.formatted_variable_value(variable_cache, 0_usize, false)
-            } else {
-                if self.type_name == VariableType::Unknown || !self.memory_location.valid() {
-                    if self.variable_node_type.is_deferred() {
-                        // When we will do a lazy-load of variable children, and they have not yet been requested by the user, just display the type_name as the value
-                        format!("{:?}", self.type_name.clone())
-                    } else {
-                        // This condition should only be true for intermediate nodes from DWARF. These should not show up in the final `VariableCache`
-                        // If a user sees this error, then there is a logic problem in the stack unwind
-                        "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location".to_string()
-                    }
-                } else if matches!(self.type_name, VariableType::Struct(ref name) if name == "None")
-                {
-                    "None".to_string()
-                } else if matches!(self.type_name, VariableType::Array { count: 0, .. }) {
-                    self.formatted_variable_value(variable_cache, 0_usize, false)
+            } else if self.type_name == VariableType::Unknown || !self.memory_location.valid() {
+                if self.variable_node_type.is_deferred() {
+                    // When we will do a lazy-load of variable children, and they have not yet been requested by the user, just display the type_name as the value
+                    format!("{:?}", self.type_name.clone())
                 } else {
-                    format!(
-                        "Unimplemented: Evaluate type {:?} of ({:?} bytes) at location 0x{:08x?}",
-                        self.type_name, self.byte_size, self.memory_location
-                    )
+                    // This condition should only be true for intermediate nodes from DWARF. These should not show up in the final `VariableCache`
+                    // If a user sees this error, then there is a logic problem in the stack unwind
+                    "Error: This is a bug! Attempted to evaluate a Variable with no type or no memory location".to_string()
                 }
+            } else if matches!(self.type_name, VariableType::Struct(ref name) if name == "None") {
+                "None".to_string()
+            } else if matches!(self.type_name, VariableType::Array { count: 0, .. }) {
+                self.formatted_variable_value(variable_cache, 0_usize, false)
+            } else {
+                format!(
+                    "Unimplemented: Evaluate type {:?} of ({:?} bytes) at location 0x{:08x?}",
+                    self.type_name, self.byte_size, self.memory_location
+                )
             }
         }
     }


### PR DESCRIPTION
The `get_children` function always returned `Ok`, so there is no point in it returning a `Result`. It should also be a bit more efficient to just return an iterator, instead of creating a `Vec` with cloned variables.