### PR TITLE
AArch64: Fix FPCR other name

### DIFF
--- a/probe-rs/src/gdb_server/target/desc/data.rs
+++ b/probe-rs/src/gdb_server/target/desc/data.rs
@@ -269,7 +269,7 @@ fn build_aarch64_registers(desc: &mut TargetDescription, regs: &CoreRegisters) {
     // AArch64 always has FP support
     desc.add_gdb_feature("org.gnu.gdb.aarch64.fpu");
     desc.add_registers(regs.fpu_registers().unwrap());
-    desc.add_register(regs.other_by_name("FPCR").unwrap());
+    desc.add_register(regs.other_by_name("Floating Point Control").unwrap());
     desc.add_register(regs.fpsr().unwrap());
 
     // GDB expects PSTATE to be called CPSR, even though that's the old v7 name


### PR DESCRIPTION
Fix panics caused by the wrong other_name when connecting AArch64 devices.

I tested with a Raspberry Pi 5.