### PR TITLE
Improve printing big arrays & a collection of small assorted improvements

### DIFF
--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040__full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040__full_unwind.snap
@@ -214,7 +214,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tstack_depth: usize = 5, \n\tinternal_depth_measure: usize = 6}"
+      value: "<unknown> {\n\tstack_depth: usize = 5,\n\tinternal_depth_measure: usize = 6}"
       children:
         - name:
             Named: stack_depth
@@ -431,7 +431,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tstack_depth: usize = 4, \n\tinternal_depth_measure: usize = 5}"
+      value: "<unknown> {\n\tstack_depth: usize = 4,\n\tinternal_depth_measure: usize = 5}"
       children:
         - name:
             Named: stack_depth
@@ -648,7 +648,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tstack_depth: usize = 3, \n\tinternal_depth_measure: usize = 4}"
+      value: "<unknown> {\n\tstack_depth: usize = 3,\n\tinternal_depth_measure: usize = 4}"
       children:
         - name:
             Named: stack_depth
@@ -865,7 +865,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tstack_depth: usize = 2, \n\tinternal_depth_measure: usize = 3}"
+      value: "<unknown> {\n\tstack_depth: usize = 2,\n\tinternal_depth_measure: usize = 3}"
       children:
         - name:
             Named: stack_depth
@@ -1082,7 +1082,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tstack_depth: usize = 1, \n\tinternal_depth_measure: usize = 2}"
+      value: "<unknown> {\n\tstack_depth: usize = 1,\n\tinternal_depth_measure: usize = 2}"
       children:
         - name:
             Named: stack_depth
@@ -1299,7 +1299,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tstack_depth: usize = 0, \n\tinternal_depth_measure: usize = 1}"
+      value: "<unknown> {\n\tstack_depth: usize = 0,\n\tinternal_depth_measure: usize = 1}"
       children:
         - name:
             Named: stack_depth
@@ -1516,7 +1516,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23, \n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced, \n\tlocal_reference_to_global_static: &str = A 'global' static variable, \n\tlocal_reference_to_global_static_struct: &common_testing_code::ComplexEnum = &common_testing_code::ComplexEnum @ 0x20003CBC, \n\tghosted_variable: usize = 0, \n\tghosted_variable: &str = New value and type for a different name, \n\tint8_twenty_six: i8 = 26, \n\tint128: i128 = -196710231994021419720322, \n\tu_int128: u128 = 340282366920938266753142613410348491134, \n\tfloat64: f64 = 1.7608695652173911, \n\tfloat64_ptr: &f64 = &f64 @ 0x20003CD4, \n\temoji: char = 💩, \n\temoji_ptr: &char = &char @ 0x20003CD8, \n\ttrue_bool: bool = true, \n\tany_old_string_slice: &str = How long is a piece of String., \n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x20003CDC, \n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x20003450, \n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x2000348C, \n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x2000360C, \n\tthree: SimpleEnum = SimpleEnum::Two, \n\tsimple_enum_pointer: &common_testing_code::SimpleEnum = &common_testing_code::SimpleEnum @ 0x20003A90, \n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x20003A94, \n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003AB8, \n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003AE8, \n\tstruct_with_one_variant: Option<common_testing_code::Univariant> = Option<common_testing_code::Univariant> @ 0x20003B08, \n\tstuct_with_one_variant_pointer: &core::option::Option<common_testing_code::Univariant> = &core::option::Option<common_testing_code::Univariant> @ 0x20003CE4, \n\tlong_lived: ComplexStruct = ComplexStruct @ 0x20003B70, \n\tshort_lived: ComplexStruct = ComplexStruct @ 0x20003B80, \n\ta1: Struct<i32> = Struct<i32> @ 0x20003CE8, \n\ta2: i64 = 1, \n\ta3: i64 = 2, \n\ta4: i64 = 3, \n\ta5: (i32, i64) = (i32, i64) @ 0x20003D10, \n\ta6: Enum<i32> = Enum<i32> @ 0x20003BC0, \n\ta7: Enum<i32> = Enum<i32> @ 0x20003BE0, \n\t[i32; 10] = [\n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55\n\t], \n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x20003D24, \n\t[i8; 10] = [\n\t\t1, \n\t\t2, \n\t\t3, \n\t\t4, \n\t\t5, \n\t\t6, \n\t\t7, \n\t\t8, \n\t\t9, \n\t\t0\n\t], \n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x20003C38, \n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x20003C48, \n\trtt_channels: Channels = Channels @ 0x20003C4C}"
+      value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23,\n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced,\n\tlocal_reference_to_global_static: &str = A 'global' static variable,\n\tlocal_reference_to_global_static_struct: &common_testing_code::ComplexEnum = &common_testing_code::ComplexEnum @ 0x20003CBC,\n\tghosted_variable: usize = 0,\n\tghosted_variable: &str = New value and type for a different name,\n\tint8_twenty_six: i8 = 26,\n\tint128: i128 = -196710231994021419720322,\n\tu_int128: u128 = 340282366920938266753142613410348491134,\n\tfloat64: f64 = 1.7608695652173911,\n\tfloat64_ptr: &f64 = &f64 @ 0x20003CD4,\n\temoji: char = 💩,\n\temoji_ptr: &char = &char @ 0x20003CD8,\n\ttrue_bool: bool = true,\n\tany_old_string_slice: &str = How long is a piece of String.,\n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x20003CDC,\n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x20003450,\n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x2000348C,\n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x2000360C,\n\tthree: SimpleEnum = SimpleEnum::Two,\n\tsimple_enum_pointer: &common_testing_code::SimpleEnum = &common_testing_code::SimpleEnum @ 0x20003A90,\n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x20003A94,\n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003AB8,\n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003AE8,\n\tstruct_with_one_variant: Option<common_testing_code::Univariant> = Option<common_testing_code::Univariant> @ 0x20003B08,\n\tstuct_with_one_variant_pointer: &core::option::Option<common_testing_code::Univariant> = &core::option::Option<common_testing_code::Univariant> @ 0x20003CE4,\n\tlong_lived: ComplexStruct = ComplexStruct @ 0x20003B70,\n\tshort_lived: ComplexStruct = ComplexStruct @ 0x20003B80,\n\ta1: Struct<i32> = Struct<i32> @ 0x20003CE8,\n\ta2: i64 = 1,\n\ta3: i64 = 2,\n\ta4: i64 = 3,\n\ta5: (i32, i64) = (i32, i64) @ 0x20003D10,\n\ta6: Enum<i32> = Enum<i32> @ 0x20003BC0,\n\ta7: Enum<i32> = Enum<i32> @ 0x20003BE0,\n\t[i32; 10] = [\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55\n\t],\n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x20003D24,\n\t[i8; 10] = [\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4,\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t8,\n\t\t9,\n\t\t0\n\t],\n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x20003C38,\n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x20003C48,\n\trtt_channels: Channels = Channels @ 0x20003C4C}"
       children:
         - name:
             Named: int8_minus_twenty_three
@@ -1841,7 +1841,7 @@ expression: stack_frames
                           count: 3
                       count: 2
                   count: 4
-              value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0, \n\t\t\t1, \n\t\t\t2\n\t\t], \n\t\t[i32; 3] = [\n\t\t\t3, \n\t\t\t4, \n\t\t\t5\n\t\t]\n\t], \n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6, \n\t\t\t7, \n\t\t\t8\n\t\t], \n\t\t[i32; 3] = [\n\t\t\t9, \n\t\t\t10, \n\t\t\t11\n\t\t]\n\t], \n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12, \n\t\t\t13, \n\t\t\t14\n\t\t], \n\t\t[i32; 3] = [\n\t\t\t15, \n\t\t\t16, \n\t\t\t17\n\t\t]\n\t], \n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18, \n\t\t\t19, \n\t\t\t20\n\t\t], \n\t\t[i32; 3] = [\n\t\t\t21, \n\t\t\t22, \n\t\t\t23\n\t\t]\n\t]]"
+              value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0,\n\t\t\t1,\n\t\t\t2\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t3,\n\t\t\t4,\n\t\t\t5\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6,\n\t\t\t7,\n\t\t\t8\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t9,\n\t\t\t10,\n\t\t\t11\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12,\n\t\t\t13,\n\t\t\t14\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t15,\n\t\t\t16,\n\t\t\t17\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18,\n\t\t\t19,\n\t\t\t20\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t21,\n\t\t\t22,\n\t\t\t23\n\t\t]\n\t]]"
               children:
                 - name:
                     Named: __0
@@ -1853,7 +1853,7 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       count: 2
-                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0, \n\t\t1, \n\t\t2\n\t], \n\t[i32; 3] = [\n\t\t3, \n\t\t4, \n\t\t5\n\t]]"
+                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0,\n\t\t1,\n\t\t2\n\t],\n\t[i32; 3] = [\n\t\t3,\n\t\t4,\n\t\t5\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -1862,7 +1862,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t0, \n\t1, \n\t2]"
+                      value: "[i32; 3] = [\n\t0,\n\t1,\n\t2]"
                       children:
                         - name:
                             Named: __0
@@ -1886,7 +1886,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t3, \n\t4, \n\t5]"
+                      value: "[i32; 3] = [\n\t3,\n\t4,\n\t5]"
                       children:
                         - name:
                             Named: __0
@@ -1913,7 +1913,7 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       count: 2
-                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6, \n\t\t7, \n\t\t8\n\t], \n\t[i32; 3] = [\n\t\t9, \n\t\t10, \n\t\t11\n\t]]"
+                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6,\n\t\t7,\n\t\t8\n\t],\n\t[i32; 3] = [\n\t\t9,\n\t\t10,\n\t\t11\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -1922,7 +1922,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t6, \n\t7, \n\t8]"
+                      value: "[i32; 3] = [\n\t6,\n\t7,\n\t8]"
                       children:
                         - name:
                             Named: __0
@@ -1946,7 +1946,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t9, \n\t10, \n\t11]"
+                      value: "[i32; 3] = [\n\t9,\n\t10,\n\t11]"
                       children:
                         - name:
                             Named: __0
@@ -1973,7 +1973,7 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       count: 2
-                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12, \n\t\t13, \n\t\t14\n\t], \n\t[i32; 3] = [\n\t\t15, \n\t\t16, \n\t\t17\n\t]]"
+                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12,\n\t\t13,\n\t\t14\n\t],\n\t[i32; 3] = [\n\t\t15,\n\t\t16,\n\t\t17\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -1982,7 +1982,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t12, \n\t13, \n\t14]"
+                      value: "[i32; 3] = [\n\t12,\n\t13,\n\t14]"
                       children:
                         - name:
                             Named: __0
@@ -2006,7 +2006,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t15, \n\t16, \n\t17]"
+                      value: "[i32; 3] = [\n\t15,\n\t16,\n\t17]"
                       children:
                         - name:
                             Named: __0
@@ -2033,7 +2033,7 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       count: 2
-                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18, \n\t\t19, \n\t\t20\n\t], \n\t[i32; 3] = [\n\t\t21, \n\t\t22, \n\t\t23\n\t]]"
+                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18,\n\t\t19,\n\t\t20\n\t],\n\t[i32; 3] = [\n\t\t21,\n\t\t22,\n\t\t23\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2042,7 +2042,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t18, \n\t19, \n\t20]"
+                      value: "[i32; 3] = [\n\t18,\n\t19,\n\t20]"
                       children:
                         - name:
                             Named: __0
@@ -2066,7 +2066,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t21, \n\t22, \n\t23]"
+                      value: "[i32; 3] = [\n\t21,\n\t22,\n\t23]"
                       children:
                         - name:
                             Named: __0
@@ -2102,7 +2102,7 @@ expression: stack_frames
                           count: 3
                       count: 2
                   count: 6
-              value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple, \n\t\t\tBanana, \n\t\t\tCherry\n\t\t], \n\t\t[&str; 3] = [\n\t\t\tDog, \n\t\t\tElephant, \n\t\t\tFish\n\t\t]\n\t], \n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar, \n\t\t\tHorse, \n\t\t\tIce Cream\n\t\t], \n\t\t[&str; 3] = [\n\t\t\tJaguar, \n\t\t\tKangaroo, \n\t\t\tLion\n\t\t]\n\t], \n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon, \n\t\t\tNewton, \n\t\t\tOwl\n\t\t], \n\t\t[&str; 3] = [\n\t\t\tPencil, \n\t\t\tQueen, \n\t\t\tRainbow\n\t\t]\n\t], \n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun, \n\t\t\tTree, \n\t\t\tUmbrella\n\t\t], \n\t\t[&str; 3] = [\n\t\t\tViolin, \n\t\t\tWatch, \n\t\t\tXylophone\n\t\t]\n\t], \n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow, \n\t\t\tZebra, \n\t\t\tAlpha\n\t\t], \n\t\t[&str; 3] = [\n\t\t\tBravo, \n\t\t\tCharlie, \n\t\t\tDelta\n\t\t]\n\t], \n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho, \n\t\t\tFoxtrot, \n\t\t\tGolf\n\t\t], \n\t\t[&str; 3] = [\n\t\t\tHotel, \n\t\t\tIndia, \n\t\t\tJuliet\n\t\t]\n\t]]"
+              value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple,\n\t\t\tBanana,\n\t\t\tCherry\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tDog,\n\t\t\tElephant,\n\t\t\tFish\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar,\n\t\t\tHorse,\n\t\t\tIce Cream\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tJaguar,\n\t\t\tKangaroo,\n\t\t\tLion\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon,\n\t\t\tNewton,\n\t\t\tOwl\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tPencil,\n\t\t\tQueen,\n\t\t\tRainbow\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun,\n\t\t\tTree,\n\t\t\tUmbrella\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tViolin,\n\t\t\tWatch,\n\t\t\tXylophone\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow,\n\t\t\tZebra,\n\t\t\tAlpha\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tBravo,\n\t\t\tCharlie,\n\t\t\tDelta\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho,\n\t\t\tFoxtrot,\n\t\t\tGolf\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tHotel,\n\t\t\tIndia,\n\t\t\tJuliet\n\t\t]\n\t]]"
               children:
                 - name:
                     Named: __0
@@ -2114,7 +2114,7 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       count: 2
-                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple, \n\t\tBanana, \n\t\tCherry\n\t], \n\t[&str; 3] = [\n\t\tDog, \n\t\tElephant, \n\t\tFish\n\t]]"
+                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple,\n\t\tBanana,\n\t\tCherry\n\t],\n\t[&str; 3] = [\n\t\tDog,\n\t\tElephant,\n\t\tFish\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2123,7 +2123,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tApple, \n\tBanana, \n\tCherry]"
+                      value: "[&str; 3] = [\n\tApple,\n\tBanana,\n\tCherry]"
                       children:
                         - name:
                             Named: __0
@@ -2198,7 +2198,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tDog, \n\tElephant, \n\tFish]"
+                      value: "[&str; 3] = [\n\tDog,\n\tElephant,\n\tFish]"
                       children:
                         - name:
                             Named: __0
@@ -2276,7 +2276,7 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       count: 2
-                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar, \n\t\tHorse, \n\t\tIce Cream\n\t], \n\t[&str; 3] = [\n\t\tJaguar, \n\t\tKangaroo, \n\t\tLion\n\t]]"
+                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar,\n\t\tHorse,\n\t\tIce Cream\n\t],\n\t[&str; 3] = [\n\t\tJaguar,\n\t\tKangaroo,\n\t\tLion\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2285,7 +2285,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tGuitar, \n\tHorse, \n\tIce Cream]"
+                      value: "[&str; 3] = [\n\tGuitar,\n\tHorse,\n\tIce Cream]"
                       children:
                         - name:
                             Named: __0
@@ -2360,7 +2360,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tJaguar, \n\tKangaroo, \n\tLion]"
+                      value: "[&str; 3] = [\n\tJaguar,\n\tKangaroo,\n\tLion]"
                       children:
                         - name:
                             Named: __0
@@ -2438,7 +2438,7 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       count: 2
-                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon, \n\t\tNewton, \n\t\tOwl\n\t], \n\t[&str; 3] = [\n\t\tPencil, \n\t\tQueen, \n\t\tRainbow\n\t]]"
+                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon,\n\t\tNewton,\n\t\tOwl\n\t],\n\t[&str; 3] = [\n\t\tPencil,\n\t\tQueen,\n\t\tRainbow\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2447,7 +2447,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tMoon, \n\tNewton, \n\tOwl]"
+                      value: "[&str; 3] = [\n\tMoon,\n\tNewton,\n\tOwl]"
                       children:
                         - name:
                             Named: __0
@@ -2522,7 +2522,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tPencil, \n\tQueen, \n\tRainbow]"
+                      value: "[&str; 3] = [\n\tPencil,\n\tQueen,\n\tRainbow]"
                       children:
                         - name:
                             Named: __0
@@ -2600,7 +2600,7 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       count: 2
-                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun, \n\t\tTree, \n\t\tUmbrella\n\t], \n\t[&str; 3] = [\n\t\tViolin, \n\t\tWatch, \n\t\tXylophone\n\t]]"
+                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun,\n\t\tTree,\n\t\tUmbrella\n\t],\n\t[&str; 3] = [\n\t\tViolin,\n\t\tWatch,\n\t\tXylophone\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2609,7 +2609,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tSun, \n\tTree, \n\tUmbrella]"
+                      value: "[&str; 3] = [\n\tSun,\n\tTree,\n\tUmbrella]"
                       children:
                         - name:
                             Named: __0
@@ -2684,7 +2684,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tViolin, \n\tWatch, \n\tXylophone]"
+                      value: "[&str; 3] = [\n\tViolin,\n\tWatch,\n\tXylophone]"
                       children:
                         - name:
                             Named: __0
@@ -2762,7 +2762,7 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       count: 2
-                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow, \n\t\tZebra, \n\t\tAlpha\n\t], \n\t[&str; 3] = [\n\t\tBravo, \n\t\tCharlie, \n\t\tDelta\n\t]]"
+                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow,\n\t\tZebra,\n\t\tAlpha\n\t],\n\t[&str; 3] = [\n\t\tBravo,\n\t\tCharlie,\n\t\tDelta\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2771,7 +2771,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tYellow, \n\tZebra, \n\tAlpha]"
+                      value: "[&str; 3] = [\n\tYellow,\n\tZebra,\n\tAlpha]"
                       children:
                         - name:
                             Named: __0
@@ -2846,7 +2846,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tBravo, \n\tCharlie, \n\tDelta]"
+                      value: "[&str; 3] = [\n\tBravo,\n\tCharlie,\n\tDelta]"
                       children:
                         - name:
                             Named: __0
@@ -2924,7 +2924,7 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       count: 2
-                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho, \n\t\tFoxtrot, \n\t\tGolf\n\t], \n\t[&str; 3] = [\n\t\tHotel, \n\t\tIndia, \n\t\tJuliet\n\t]]"
+                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho,\n\t\tFoxtrot,\n\t\tGolf\n\t],\n\t[&str; 3] = [\n\t\tHotel,\n\t\tIndia,\n\t\tJuliet\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2933,7 +2933,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tEcho, \n\tFoxtrot, \n\tGolf]"
+                      value: "[&str; 3] = [\n\tEcho,\n\tFoxtrot,\n\tGolf]"
                       children:
                         - name:
                             Named: __0
@@ -3008,7 +3008,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tHotel, \n\tIndia, \n\tJuliet]"
+                      value: "[&str; 3] = [\n\tHotel,\n\tIndia,\n\tJuliet]"
                       children:
                         - name:
                             Named: __0
@@ -3515,7 +3515,7 @@ expression: stack_frames
               item_type_name:
                 Base: i32
               count: 10
-          value: "[i32; 10] = [\n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55]"
+          value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
           children:
             - name:
                 Named: __0
@@ -3580,7 +3580,7 @@ expression: stack_frames
                   item_type_name:
                     Base: i32
                   count: 10
-              value: "[i32; 10] = [\n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55]"
+              value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
               children:
                 - name:
                     Named: __0
@@ -3639,7 +3639,7 @@ expression: stack_frames
               item_type_name:
                 Base: i8
               count: 10
-          value: "[i8; 10] = [\n\t1, \n\t2, \n\t3, \n\t4, \n\t5, \n\t6, \n\t7, \n\t8, \n\t9, \n\t0]"
+          value: "[i8; 10] = [\n\t1,\n\t2,\n\t3,\n\t4,\n\t5,\n\t6,\n\t7,\n\t8,\n\t9,\n\t0]"
           children:
             - name:
                 Named: __0
@@ -3709,13 +3709,13 @@ expression: stack_frames
                   item_type_name:
                     Base: MaybeUninit<i8>
                   count: 10
-              value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3C\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3D\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3E\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3F\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C40\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C41\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C42\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C43\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C44\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C45\n\t}]"
+              value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3C\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3D\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3E\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3F\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C40\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C41\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C42\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C43\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C44\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C45\n\t}]"
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3C}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3C}"
                   children:
                     - name:
                         Named: uninit
@@ -3737,7 +3737,7 @@ expression: stack_frames
                     Named: __1
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3D}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3D}"
                   children:
                     - name:
                         Named: uninit
@@ -3759,7 +3759,7 @@ expression: stack_frames
                     Named: __2
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3E}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3E}"
                   children:
                     - name:
                         Named: uninit
@@ -3781,7 +3781,7 @@ expression: stack_frames
                     Named: __3
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3F}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C3F}"
                   children:
                     - name:
                         Named: uninit
@@ -3803,7 +3803,7 @@ expression: stack_frames
                     Named: __4
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C40}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C40}"
                   children:
                     - name:
                         Named: uninit
@@ -3825,7 +3825,7 @@ expression: stack_frames
                     Named: __5
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C41}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C41}"
                   children:
                     - name:
                         Named: uninit
@@ -3847,7 +3847,7 @@ expression: stack_frames
                     Named: __6
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C42}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C42}"
                   children:
                     - name:
                         Named: uninit
@@ -3869,7 +3869,7 @@ expression: stack_frames
                     Named: __7
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C43}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C43}"
                   children:
                     - name:
                         Named: uninit
@@ -3891,7 +3891,7 @@ expression: stack_frames
                     Named: __8
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C44}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C44}"
                   children:
                     - name:
                         Named: uninit
@@ -3913,7 +3913,7 @@ expression: stack_frames
                     Named: __9
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C45}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003C45}"
                   children:
                     - name:
                         Named: uninit

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040__static_variables.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040__static_variables.snap
@@ -5,7 +5,7 @@ expression: static_variables
 Child Variables:
   name: StaticScopeRoot
   type_name: Unknown
-  value: "<unknown> {\n\t<&u32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<usb_device::endpoint::EndpointType as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<core::convert::Infallible as core::fmt::Debug>::{vtable}: <core::convert::Infallible as core::fmt::Debug>::{vtable_type} = <core::convert::Infallible as core::fmt::Debug>::{vtable_type} @ 0x1000BAC8, \n\t<&rp2040_hal::gpio::func::DynSioConfig as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<rp2040_hal::gpio::pin::DynBankId as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<rp2040_hal::uart::reader::ReadErrorType as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&&[u8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&rp2040_hal::rtc::datetime::Error as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<usb_device::UsbDirection as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<usb_device::control::RequestType as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<usb_device::control::Recipient as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&usb_device::control::Request as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<pio::JmpCondition as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<pio::WaitSource as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&bool as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<pio::InSource as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<pio::OutDestination as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<bool as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<pio::MovDestination as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<pio::MovOperation as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&pio::MovSource as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<pio::SetDestination as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<pio::InstructionOperands as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&core::option::Option<u8> as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&pio::LabelState as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&cortex_m::peripheral::scb::Exception as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&&mut [u8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&&[u8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&embedded_hal::can::id::StandardId as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&embedded_hal::can::id::ExtendedId as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<cortex_m_rt::{impl#1}::fmt::Hex as core::fmt::Debug>::{vtable}: <cortex_m_rt::{impl#1}::fmt::Hex as core::fmt::Debug>::{vtable_type} = <cortex_m_rt::{impl#1}::fmt::Hex as core::fmt::Debug>::{vtable_type} @ 0x1000BFE4, \n\t<i64 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<i32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&i16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<rtt_target::TerminalWriter as core::fmt::Write>::{vtable}: <rtt_target::TerminalWriter as core::fmt::Write>::{vtable_type} = <rtt_target::TerminalWriter as core::fmt::Write>::{vtable_type} @ 0x1000C7F0, \n\t<rtt_target::rtt::RttWriter as core::fmt::Write>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&core::marker::PhantomData<&()> as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >}"
+  value: "<unknown> {\n\t<&u32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<usb_device::endpoint::EndpointType as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<core::convert::Infallible as core::fmt::Debug>::{vtable}: <core::convert::Infallible as core::fmt::Debug>::{vtable_type} = <core::convert::Infallible as core::fmt::Debug>::{vtable_type} @ 0x1000BAC8,\n\t<&rp2040_hal::gpio::func::DynSioConfig as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<rp2040_hal::gpio::pin::DynBankId as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<rp2040_hal::uart::reader::ReadErrorType as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&&[u8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&rp2040_hal::rtc::datetime::Error as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<usb_device::UsbDirection as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<usb_device::control::RequestType as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<usb_device::control::Recipient as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&usb_device::control::Request as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<pio::JmpCondition as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<pio::WaitSource as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&bool as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<pio::InSource as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<pio::OutDestination as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<bool as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<pio::MovDestination as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<pio::MovOperation as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&pio::MovSource as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<pio::SetDestination as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<pio::InstructionOperands as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&core::option::Option<u8> as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&pio::LabelState as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&cortex_m::peripheral::scb::Exception as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&&mut [u8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&&[u8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&embedded_hal::can::id::StandardId as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&embedded_hal::can::id::ExtendedId as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<cortex_m_rt::{impl#1}::fmt::Hex as core::fmt::Debug>::{vtable}: <cortex_m_rt::{impl#1}::fmt::Hex as core::fmt::Debug>::{vtable_type} = <cortex_m_rt::{impl#1}::fmt::Hex as core::fmt::Debug>::{vtable_type} @ 0x1000BFE4,\n\t<i64 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<i32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&i16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<rtt_target::TerminalWriter as core::fmt::Write>::{vtable}: <rtt_target::TerminalWriter as core::fmt::Write>::{vtable_type} = <rtt_target::TerminalWriter as core::fmt::Write>::{vtable_type} @ 0x1000C7F0,\n\t<rtt_target::rtt::RttWriter as core::fmt::Write>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&core::marker::PhantomData<&()> as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >}"
   children:
     - name:
         Namespace: rp_pico
@@ -19,7 +19,7 @@ Child Variables:
               item_type_name:
                 Base: u8
               count: 256
-          value: "[u8; 256] = [\n\t< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000008 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000008 of size 0x4)) >, \n\t... and 246 more]"
+          value: "[u8; 256] = [\n\t< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >,\n\t< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >,\n\t< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >,\n\t< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >,\n\t< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >,\n\t< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >,\n\t< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >,\n\t< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >,\n\t< Probe(Other(The coredump does not include the memory for address 0x10000008 of size 0x4)) >,\n\t< Probe(Other(The coredump does not include the memory for address 0x10000008 of size 0x4)) >,\n\t... and 246 more]"
           children:
             - name:
                 Named: __0
@@ -1582,13 +1582,13 @@ Child Variables:
               item_type_name:
                 Base: Vector
               count: 32
-          value: "[Vector; 32] = [\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000140, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000140 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000144, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000144 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000148, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000148 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000014C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000014c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000150, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000150 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000154, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000154 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000158, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000158 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000015C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000015c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000160, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000160 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000164, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000164 of size 0x4)) >\n\t}, \n\t... and 22 more]"
+          value: "[Vector; 32] = [\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000140,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000140 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000144,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000144 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000148,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000148 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000014C,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000014c of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000150,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000150 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000154,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000154 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000158,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000158 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000015C,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000015c of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000160,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000160 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000164,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000164 of size 0x4)) >\n\t},\n\t... and 22 more]"
           children:
             - name:
                 Named: __0
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000140, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000140 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000140,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000140 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1609,7 +1609,7 @@ Child Variables:
                 Named: __1
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000144, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000144 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000144,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000144 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1630,7 +1630,7 @@ Child Variables:
                 Named: __2
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000148, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000148 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000148,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000148 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1651,7 +1651,7 @@ Child Variables:
                 Named: __3
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000014C, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000014c of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000014C,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000014c of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1672,7 +1672,7 @@ Child Variables:
                 Named: __4
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000150, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000150 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000150,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000150 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1693,7 +1693,7 @@ Child Variables:
                 Named: __5
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000154, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000154 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000154,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000154 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1714,7 +1714,7 @@ Child Variables:
                 Named: __6
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000158, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000158 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000158,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000158 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1735,7 +1735,7 @@ Child Variables:
                 Named: __7
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000015C, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000015c of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000015C,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000015c of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1756,7 +1756,7 @@ Child Variables:
                 Named: __8
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000160, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000160 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000160,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000160 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1777,7 +1777,7 @@ Child Variables:
                 Named: __9
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000164, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000164 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000164,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000164 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1798,7 +1798,7 @@ Child Variables:
                 Named: __10
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000168, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000168 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000168,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000168 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1819,7 +1819,7 @@ Child Variables:
                 Named: __11
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000016C, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000016c of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000016C,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000016c of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1840,7 +1840,7 @@ Child Variables:
                 Named: __12
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000170, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000170 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000170,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000170 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1861,7 +1861,7 @@ Child Variables:
                 Named: __13
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000174, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000174 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000174,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000174 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1882,7 +1882,7 @@ Child Variables:
                 Named: __14
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000178, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000178 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000178,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000178 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1903,7 +1903,7 @@ Child Variables:
                 Named: __15
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000017C, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000017c of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000017C,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000017c of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1924,7 +1924,7 @@ Child Variables:
                 Named: __16
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000180, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000180 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000180,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000180 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1945,7 +1945,7 @@ Child Variables:
                 Named: __17
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000184, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000184 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000184,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000184 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1966,7 +1966,7 @@ Child Variables:
                 Named: __18
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000188, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000188 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000188,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000188 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1987,7 +1987,7 @@ Child Variables:
                 Named: __19
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000018C, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000018c of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000018C,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000018c of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2008,7 +2008,7 @@ Child Variables:
                 Named: __20
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000190, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000190 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000190,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000190 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2029,7 +2029,7 @@ Child Variables:
                 Named: __21
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000194, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000194 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000194,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000194 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2050,7 +2050,7 @@ Child Variables:
                 Named: __22
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000198, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000198 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000198,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000198 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2071,7 +2071,7 @@ Child Variables:
                 Named: __23
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000019C, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000019c of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000019C,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000019c of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2092,7 +2092,7 @@ Child Variables:
                 Named: __24
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A0, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001a0 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A0,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001a0 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2113,7 +2113,7 @@ Child Variables:
                 Named: __25
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A4, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001a4 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A4,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001a4 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2134,7 +2134,7 @@ Child Variables:
                 Named: __26
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A8, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001a8 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A8,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001a8 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2155,7 +2155,7 @@ Child Variables:
                 Named: __27
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001AC, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001ac of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001AC,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001ac of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2176,7 +2176,7 @@ Child Variables:
                 Named: __28
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B0, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001b0 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B0,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001b0 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2197,7 +2197,7 @@ Child Variables:
                 Named: __29
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B4, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001b4 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B4,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001b4 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2218,7 +2218,7 @@ Child Variables:
                 Named: __30
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B8, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001b8 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B8,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001b8 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2239,7 +2239,7 @@ Child Variables:
                 Named: __31
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001BC, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001bc of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001BC,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001bc of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -2347,13 +2347,13 @@ Child Variables:
               item_type_name:
                 Base: Vector
               count: 14
-          value: "[Vector; 14] = [\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000108, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000108 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000010C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000010c of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000110, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000110 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000114, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000114 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000118, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000118 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000011C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000011c of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000120, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000120 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000124, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000124 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000128, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000128 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000012C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000012c of size 0x4)) >\n\t}, \n\t... and 4 more]"
+          value: "[Vector; 14] = [\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000108,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000108 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000010C,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000010c of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000110,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000110 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000114,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000114 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000118,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000118 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000011C,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000011c of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000120,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000120 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000124,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000124 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000128,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000128 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000012C,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000012c of size 0x4)) >\n\t},\n\t... and 4 more]"
           children:
             - name:
                 Named: __0
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000108, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000108 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000108,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000108 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2374,7 +2374,7 @@ Child Variables:
                 Named: __1
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000010C, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000010c of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000010C,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000010c of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2395,7 +2395,7 @@ Child Variables:
                 Named: __2
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000110, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000110 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000110,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000110 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2416,7 +2416,7 @@ Child Variables:
                 Named: __3
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000114, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000114 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000114,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000114 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2437,7 +2437,7 @@ Child Variables:
                 Named: __4
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000118, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000118 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000118,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000118 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2458,7 +2458,7 @@ Child Variables:
                 Named: __5
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000011C, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000011c of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000011C,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000011c of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2479,7 +2479,7 @@ Child Variables:
                 Named: __6
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000120, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000120 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000120,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000120 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2500,7 +2500,7 @@ Child Variables:
                 Named: __7
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000124, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000124 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000124,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000124 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2521,7 +2521,7 @@ Child Variables:
                 Named: __8
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000128, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000128 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000128,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000128 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2542,7 +2542,7 @@ Child Variables:
                 Named: __9
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000012C, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000012c of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000012C,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000012c of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2563,7 +2563,7 @@ Child Variables:
                 Named: __10
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000130, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000130 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000130,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000130 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2584,7 +2584,7 @@ Child Variables:
                 Named: __11
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000134, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000134 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000134,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000134 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2605,7 +2605,7 @@ Child Variables:
                 Named: __12
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000138, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000138 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000138,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000138 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2626,7 +2626,7 @@ Child Variables:
                 Named: __13
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000013C, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000013c of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000013C,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000013c of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -2835,7 +2835,7 @@ Child Variables:
                 Named: CONTROL_BLOCK
               type_name:
                 Base: "MaybeUninit<common_testing_code::setup_data_types::RttControlBlock>"
-              value: "MaybeUninit<common_testing_code::setup_data_types::RttControlBlock> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<common_testing_code::setup_data_types::RttControlBlock> = ManuallyDrop<common_testing_code::setup_data_types::RttControlBlock> @ 0x2000007C}"
+              value: "MaybeUninit<common_testing_code::setup_data_types::RttControlBlock> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<common_testing_code::setup_data_types::RttControlBlock> = ManuallyDrop<common_testing_code::setup_data_types::RttControlBlock> @ 0x2000007C}"
               children:
                 - name:
                     Named: uninit
@@ -2867,7 +2867,7 @@ Child Variables:
                                   item_type_name:
                                     Base: u8
                                   count: 16
-                              value: "[u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t... and 6 more]"
+                              value: "[u8; 16] = [\n\t83,\n\t69,\n\t71,\n\t71,\n\t69,\n\t82,\n\t32,\n\t82,\n\t84,\n\t84,\n\t... and 6 more]"
                               children:
                                 - name:
                                     Named: __0
@@ -2966,7 +2966,7 @@ Child Variables:
                               item_type_name:
                                 Struct: RttChannel
                               count: 2
-                          value: "[RttChannel; 2] = [\n\tRttChannel @ 0x20000094, \n\tRttChannel @ 0x200000AC]"
+                          value: "[RttChannel; 2] = [\n\tRttChannel @ 0x20000094,\n\tRttChannel @ 0x200000AC]"
                           children:
                             - name:
                                 Named: __0
@@ -3148,7 +3148,7 @@ Child Variables:
                 Named: _RTT_CHANNEL_BUFFER
               type_name:
                 Base: "MaybeUninit<[u8; 1024]>"
-              value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200000C4}"
+              value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200000C4}"
               children:
                 - name:
                     Named: uninit
@@ -3168,7 +3168,7 @@ Child Variables:
                           item_type_name:
                             Base: u8
                           count: 1024
-                      value: "[u8; 1024] = [\n\t70, \n\t111, \n\t114, \n\t99, \n\t105, \n\t110, \n\t103, \n\t32, \n\t117, \n\t115, \n\t... and 1014 more]"
+                      value: "[u8; 1024] = [\n\t70,\n\t111,\n\t114,\n\t99,\n\t105,\n\t110,\n\t103,\n\t32,\n\t117,\n\t115,\n\t... and 1014 more]"
                       children:
                         - name:
                             Named: __0
@@ -3427,7 +3427,7 @@ Child Variables:
                 Named: _RTT_CHANNEL_BUFFER
               type_name:
                 Base: "MaybeUninit<[u8; 1024]>"
-              value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200004C4}"
+              value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200004C4}"
               children:
                 - name:
                     Named: uninit
@@ -3447,7 +3447,7 @@ Child Variables:
                           item_type_name:
                             Base: u8
                           count: 1024
-                      value: "[u8; 1024] = [\n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t... and 1014 more]"
+                      value: "[u8; 1024] = [\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t... and 1014 more]"
                       children:
                         - name:
                             Named: __0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040__static_variables.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__RP2040__static_variables.snap
@@ -19,7 +19,261 @@ Child Variables:
               item_type_name:
                 Base: u8
               count: 256
-          value: Data types with more than 50 members are excluded from this output. This variable has 256 child members.
+          value: "[u8; 256] = [\n\t< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000008 of size 0x4)) >, \n\t< Probe(Other(The coredump does not include the memory for address 0x10000008 of size 0x4)) >, \n\t... and 246 more]"
+          children:
+            - name:
+                Named: __0
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >"
+            - name:
+                Named: __1
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >"
+            - name:
+                Named: __2
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >"
+            - name:
+                Named: __3
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000000 of size 0x4)) >"
+            - name:
+                Named: __4
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >"
+            - name:
+                Named: __5
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >"
+            - name:
+                Named: __6
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >"
+            - name:
+                Named: __7
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000004 of size 0x4)) >"
+            - name:
+                Named: __8
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000008 of size 0x4)) >"
+            - name:
+                Named: __9
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000008 of size 0x4)) >"
+            - name:
+                Named: __10
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000008 of size 0x4)) >"
+            - name:
+                Named: __11
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000008 of size 0x4)) >"
+            - name:
+                Named: __12
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x1000000c of size 0x4)) >"
+            - name:
+                Named: __13
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x1000000c of size 0x4)) >"
+            - name:
+                Named: __14
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x1000000c of size 0x4)) >"
+            - name:
+                Named: __15
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x1000000c of size 0x4)) >"
+            - name:
+                Named: __16
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000010 of size 0x4)) >"
+            - name:
+                Named: __17
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000010 of size 0x4)) >"
+            - name:
+                Named: __18
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000010 of size 0x4)) >"
+            - name:
+                Named: __19
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000010 of size 0x4)) >"
+            - name:
+                Named: __20
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000014 of size 0x4)) >"
+            - name:
+                Named: __21
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000014 of size 0x4)) >"
+            - name:
+                Named: __22
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000014 of size 0x4)) >"
+            - name:
+                Named: __23
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000014 of size 0x4)) >"
+            - name:
+                Named: __24
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000018 of size 0x4)) >"
+            - name:
+                Named: __25
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000018 of size 0x4)) >"
+            - name:
+                Named: __26
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000018 of size 0x4)) >"
+            - name:
+                Named: __27
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000018 of size 0x4)) >"
+            - name:
+                Named: __28
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x1000001c of size 0x4)) >"
+            - name:
+                Named: __29
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x1000001c of size 0x4)) >"
+            - name:
+                Named: __30
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x1000001c of size 0x4)) >"
+            - name:
+                Named: __31
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x1000001c of size 0x4)) >"
+            - name:
+                Named: __32
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000020 of size 0x4)) >"
+            - name:
+                Named: __33
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000020 of size 0x4)) >"
+            - name:
+                Named: __34
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000020 of size 0x4)) >"
+            - name:
+                Named: __35
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000020 of size 0x4)) >"
+            - name:
+                Named: __36
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000024 of size 0x4)) >"
+            - name:
+                Named: __37
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000024 of size 0x4)) >"
+            - name:
+                Named: __38
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000024 of size 0x4)) >"
+            - name:
+                Named: __39
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000024 of size 0x4)) >"
+            - name:
+                Named: __40
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000028 of size 0x4)) >"
+            - name:
+                Named: __41
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000028 of size 0x4)) >"
+            - name:
+                Named: __42
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000028 of size 0x4)) >"
+            - name:
+                Named: __43
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000028 of size 0x4)) >"
+            - name:
+                Named: __44
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x1000002c of size 0x4)) >"
+            - name:
+                Named: __45
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x1000002c of size 0x4)) >"
+            - name:
+                Named: __46
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x1000002c of size 0x4)) >"
+            - name:
+                Named: __47
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x1000002c of size 0x4)) >"
+            - name:
+                Named: __48
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000030 of size 0x4)) >"
+            - name:
+                Named: __49
+              type_name:
+                Base: u8
+              value: "< Probe(Other(The coredump does not include the memory for address 0x10000030 of size 0x4)) >"
+            - name: Artifical
+              type_name: Unknown
+              value: "... and 206 more"
     - name:
         Namespace: rp2040_hal
       type_name: Namespace
@@ -1328,7 +1582,7 @@ Child Variables:
               item_type_name:
                 Base: Vector
               count: 32
-          value: "[Vector; 32] = [\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000140, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000140 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000144, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000144 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000148, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000148 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000014C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000014c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000150, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000150 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000154, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000154 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000158, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000158 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000015C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000015c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000160, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000160 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000164, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000164 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000168, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000168 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000016C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000016c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000170, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000170 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000174, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000174 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000178, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000178 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000017C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000017c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000180, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000180 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000184, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000184 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000188, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000188 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000018C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000018c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000190, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000190 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000194, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000194 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000198, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000198 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000019C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000019c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A0, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001a0 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A4, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001a4 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001A8, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001a8 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001AC, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001ac of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B0, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001b0 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B4, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001b4 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001B8, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001b8 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x100001BC, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x100001bc of size 0x4)) >\n\t}]"
+          value: "[Vector; 32] = [\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000140, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000140 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000144, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000144 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000148, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000148 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000014C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000014c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000150, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000150 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000154, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000154 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000158, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000158 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000015C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x1000015c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000160, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000160 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000164, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x10000164 of size 0x4)) >\n\t}, \n\t... and 22 more]"
           children:
             - name:
                 Named: __0
@@ -2093,7 +2347,7 @@ Child Variables:
               item_type_name:
                 Base: Vector
               count: 14
-          value: "[Vector; 14] = [\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000108, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000108 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000010C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000010c of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000110, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000110 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000114, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000114 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000118, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000118 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000011C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000011c of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000120, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000120 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000124, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000124 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000128, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000128 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000012C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000012c of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000130, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000130 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000134, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000134 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000138, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000138 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000013C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000013c of size 0x4)) >\n\t}]"
+          value: "[Vector; 14] = [\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000108, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000108 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000010C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000010c of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000110, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000110 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000114, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000114 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000118, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000118 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000011C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000011c of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000120, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000120 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000124, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000124 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x10000128, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10000128 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x1000012C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1000012c of size 0x4)) >\n\t}, \n\t... and 4 more]"
           children:
             - name:
                 Named: __0
@@ -2613,7 +2867,7 @@ Child Variables:
                                   item_type_name:
                                     Base: u8
                                   count: 16
-                              value: "[u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
+                              value: "[u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t... and 6 more]"
                               children:
                                 - name:
                                     Named: __0
@@ -2914,7 +3168,261 @@ Child Variables:
                           item_type_name:
                             Base: u8
                           count: 1024
-                      value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
+                      value: "[u8; 1024] = [\n\t70, \n\t111, \n\t114, \n\t99, \n\t105, \n\t110, \n\t103, \n\t32, \n\t117, \n\t115, \n\t... and 1014 more]"
+                      children:
+                        - name:
+                            Named: __0
+                          type_name:
+                            Base: u8
+                          value: "70"
+                        - name:
+                            Named: __1
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __2
+                          type_name:
+                            Base: u8
+                          value: "114"
+                        - name:
+                            Named: __3
+                          type_name:
+                            Base: u8
+                          value: "99"
+                        - name:
+                            Named: __4
+                          type_name:
+                            Base: u8
+                          value: "105"
+                        - name:
+                            Named: __5
+                          type_name:
+                            Base: u8
+                          value: "110"
+                        - name:
+                            Named: __6
+                          type_name:
+                            Base: u8
+                          value: "103"
+                        - name:
+                            Named: __7
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __8
+                          type_name:
+                            Base: u8
+                          value: "117"
+                        - name:
+                            Named: __9
+                          type_name:
+                            Base: u8
+                          value: "115"
+                        - name:
+                            Named: __10
+                          type_name:
+                            Base: u8
+                          value: "101"
+                        - name:
+                            Named: __11
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __12
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __13
+                          type_name:
+                            Base: u8
+                          value: "102"
+                        - name:
+                            Named: __14
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __15
+                          type_name:
+                            Base: u8
+                          value: "58"
+                        - name:
+                            Named: __16
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __17
+                          type_name:
+                            Base: u8
+                          value: "84"
+                        - name:
+                            Named: __18
+                          type_name:
+                            Base: u8
+                          value: "119"
+                        - name:
+                            Named: __19
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __20
+                          type_name:
+                            Base: u8
+                          value: "10"
+                        - name:
+                            Named: __21
+                          type_name:
+                            Base: u8
+                          value: "70"
+                        - name:
+                            Named: __22
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __23
+                          type_name:
+                            Base: u8
+                          value: "114"
+                        - name:
+                            Named: __24
+                          type_name:
+                            Base: u8
+                          value: "99"
+                        - name:
+                            Named: __25
+                          type_name:
+                            Base: u8
+                          value: "105"
+                        - name:
+                            Named: __26
+                          type_name:
+                            Base: u8
+                          value: "110"
+                        - name:
+                            Named: __27
+                          type_name:
+                            Base: u8
+                          value: "103"
+                        - name:
+                            Named: __28
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __29
+                          type_name:
+                            Base: u8
+                          value: "117"
+                        - name:
+                            Named: __30
+                          type_name:
+                            Base: u8
+                          value: "115"
+                        - name:
+                            Named: __31
+                          type_name:
+                            Base: u8
+                          value: "101"
+                        - name:
+                            Named: __32
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __33
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __34
+                          type_name:
+                            Base: u8
+                          value: "102"
+                        - name:
+                            Named: __35
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __36
+                          type_name:
+                            Base: u8
+                          value: "58"
+                        - name:
+                            Named: __37
+                          type_name:
+                            Base: u8
+                          value: "65"
+                        - name:
+                            Named: __38
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __39
+                          type_name:
+                            Base: u8
+                          value: "39"
+                        - name:
+                            Named: __40
+                          type_name:
+                            Base: u8
+                          value: "108"
+                        - name:
+                            Named: __41
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __42
+                          type_name:
+                            Base: u8
+                          value: "99"
+                        - name:
+                            Named: __43
+                          type_name:
+                            Base: u8
+                          value: "97"
+                        - name:
+                            Named: __44
+                          type_name:
+                            Base: u8
+                          value: "108"
+                        - name:
+                            Named: __45
+                          type_name:
+                            Base: u8
+                          value: "39"
+                        - name:
+                            Named: __46
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __47
+                          type_name:
+                            Base: u8
+                          value: "116"
+                        - name:
+                            Named: __48
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __49
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name: Artifical
+                          type_name: Unknown
+                          value: "... and 974 more"
             - name:
                 Named: _RTT_CHANNEL_BUFFER
               type_name:
@@ -2939,7 +3447,261 @@ Child Variables:
                           item_type_name:
                             Base: u8
                           count: 1024
-                      value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
+                      value: "[u8; 1024] = [\n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t... and 1014 more]"
+                      children:
+                        - name:
+                            Named: __0
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __1
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __2
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __3
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __4
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __5
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __6
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __7
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __8
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __9
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __10
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __11
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __12
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __13
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __14
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __15
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __16
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __17
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __18
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __19
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __20
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __21
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __22
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __23
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __24
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __25
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __26
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __27
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __28
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __29
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __30
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __31
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __32
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __33
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __34
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __35
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __36
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __37
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __38
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __39
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __40
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __41
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __42
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __43
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __44
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __45
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __46
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __47
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __48
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __49
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name: Artifical
+                          type_name: Unknown
+                          value: "... and 974 more"
     - name:
         Named: "<i64 as core::fmt::Debug>::{vtable}"
       type_name: Unknown

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a__full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a__full_unwind.snap
@@ -214,7 +214,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tconst_void_pointer: void* = void* @ 0x20000008, \n\tconst_void_const_pointer: const void* = void* @ 0x00001710}"
+      value: "<unknown> {\n\tconst_void_pointer: void* = void* @ 0x20000008,\n\tconst_void_const_pointer: const void* = void* @ 0x00001710}"
       children:
         - name:
             Named: const_void_pointer
@@ -443,7 +443,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tvoid_pointer: void* = void* @ 2000000C, \n\tvoid_const_pointer: const void* = void* @ 1714}"
+      value: "<unknown> {\n\tvoid_pointer: void* = void* @ 2000000C,\n\tvoid_const_pointer: const void* = void* @ 1714}"
       children:
         - name:
             Named: void_pointer
@@ -882,7 +882,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tpSrc: uint32_t* = uint32_t* @ 0x20001024, \n\tpDest: uint32_t* = uint32_t* @ 0x20001020}"
+      value: "<unknown> {\n\tpSrc: uint32_t* = uint32_t* @ 0x20001024,\n\tpDest: uint32_t* = uint32_t* @ 0x20001020}"
       children:
         - name:
             Named: pSrc

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a__static_variables.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a__static_variables.snap
@@ -5,7 +5,7 @@ expression: static_variables
 Child Variables:
   name: StaticScopeRoot
   type_name: Unknown
-  value: "<unknown> {\n\texception_table: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t_aTerminalId: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, <unknown>, \n\tchar[1024] = [\n\t\tH, \n\t\te, \n\t\tl, \n\t\tl, \n\t\to, \n\t\t , \n\t\tH, \n\t\te, \n\t\tl, \n\t\tl, \n\t\to, \n\t\t,, \n\t\t , \n\t\tW, \n\t\to, \n\t\tr, \n\t\tl, \n\t\td, \n\t\t!, \n\t\t\r, \n\t\t\n, \n\t\tv, \n\t\to, \n\t\ti, \n\t\td, \n\t\t*, \n\t\t , \n\t\t5, \n\t\t3, \n\t\t6, \n\t\t8, \n\t\t7, \n\t\t0, \n\t\t9, \n\t\t1, \n\t\t2, \n\t\t\r, \n\t\t\n, \n\t\tv, \n\t\to, \n\t\ti, \n\t\td, \n\t\t*, \n\t\t , \n\t\tc, \n\t\to, \n\t\tn, \n\t\ts, \n\t\tt, \n\t\t , \n\t\t5, \n\t\t3, \n\t\t6, \n\t\t8, \n\t\t7, \n\t\t0, \n\t\t9, \n\t\t1, \n\t\t2, \n\t\t\r, \n\t\t\n, \n\t\tc, \n\t\to, \n\t\tn, \n\t\ts, \n\t\tt, \n\t\t , \n\t\tv, \n\t\to, \n\t\ti, \n\t\td, \n\t\t*, \n\t\t , \n\t\t5, \n\t\t3, \n\t\t6, \n\t\t8, \n\t\t7, \n\t\t0, \n\t\t9, \n\t\t1, \n\t\t2, \n\t\t\r, \n\t\t\n, \n\t\tc, \n\t\to, \n\t\tn, \n\t\ts, \n\t\tt, \n\t\t , \n\t\tv, \n\t\to, \n\t\ti, \n\t\td, \n\t\t*, \n\t\t , \n\t\tc, \n\t\to, \n\t\tn, \n\t\ts, \n\t\tt, \n\t\t , \n\t\t5, \n\t\t3, \n\t\t6, \n\t\t8, \n\t\t7, \n\t\t0, \n\t\t9, \n\t\t1, \n\t\t2, \n\t\t\r, \n\t\t\n, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000\n\t], \n\tchar[16] = [\n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000\n\t], \n\t_ActiveTerminal: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\tfoo: Foo_t = Foo_t @ 0x20000000, \n\tconst Foo_t[2] = [\n\t\tFoo_t @ 0x0000165C, \n\t\tFoo_t @ 0x00001664\n\t]}"
+  value: "<unknown> {\n\texception_table: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t_aTerminalId: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, <unknown>, \n\tchar[1024] = [\n\t\tH, \n\t\te, \n\t\tl, \n\t\tl, \n\t\to, \n\t\t , \n\t\tH, \n\t\te, \n\t\tl, \n\t\tl, \n\n\t\t... and 1014 more\n\t], \n\tchar[16] = [\n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\n\t\t... and 6 more\n\t], \n\t_ActiveTerminal: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\tfoo: Foo_t = Foo_t @ 0x20000000, \n\tconst Foo_t[2] = [\n\t\tFoo_t @ 0x0000165C, \n\t\tFoo_t @ 0x00001664\n\t]}"
   children:
     - name:
         Named: exception_table
@@ -25,7 +25,261 @@ Child Variables:
           item_type_name:
             Base: char
           count: 1024
-      value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
+      value: "char[1024] = [\n\tH, \n\te, \n\tl, \n\tl, \n\to, \n\t , \n\tH, \n\te, \n\tl, \n\tl, \n\t... and 1014 more]"
+      children:
+        - name:
+            Named: __0
+          type_name:
+            Base: char
+          value: H
+        - name:
+            Named: __1
+          type_name:
+            Base: char
+          value: e
+        - name:
+            Named: __2
+          type_name:
+            Base: char
+          value: l
+        - name:
+            Named: __3
+          type_name:
+            Base: char
+          value: l
+        - name:
+            Named: __4
+          type_name:
+            Base: char
+          value: o
+        - name:
+            Named: __5
+          type_name:
+            Base: char
+          value: " "
+        - name:
+            Named: __6
+          type_name:
+            Base: char
+          value: H
+        - name:
+            Named: __7
+          type_name:
+            Base: char
+          value: e
+        - name:
+            Named: __8
+          type_name:
+            Base: char
+          value: l
+        - name:
+            Named: __9
+          type_name:
+            Base: char
+          value: l
+        - name:
+            Named: __10
+          type_name:
+            Base: char
+          value: o
+        - name:
+            Named: __11
+          type_name:
+            Base: char
+          value: ","
+        - name:
+            Named: __12
+          type_name:
+            Base: char
+          value: " "
+        - name:
+            Named: __13
+          type_name:
+            Base: char
+          value: W
+        - name:
+            Named: __14
+          type_name:
+            Base: char
+          value: o
+        - name:
+            Named: __15
+          type_name:
+            Base: char
+          value: r
+        - name:
+            Named: __16
+          type_name:
+            Base: char
+          value: l
+        - name:
+            Named: __17
+          type_name:
+            Base: char
+          value: d
+        - name:
+            Named: __18
+          type_name:
+            Base: char
+          value: "!"
+        - name:
+            Named: __19
+          type_name:
+            Base: char
+          value: "\r"
+        - name:
+            Named: __20
+          type_name:
+            Base: char
+          value: "\n"
+        - name:
+            Named: __21
+          type_name:
+            Base: char
+          value: v
+        - name:
+            Named: __22
+          type_name:
+            Base: char
+          value: o
+        - name:
+            Named: __23
+          type_name:
+            Base: char
+          value: i
+        - name:
+            Named: __24
+          type_name:
+            Base: char
+          value: d
+        - name:
+            Named: __25
+          type_name:
+            Base: char
+          value: "*"
+        - name:
+            Named: __26
+          type_name:
+            Base: char
+          value: " "
+        - name:
+            Named: __27
+          type_name:
+            Base: char
+          value: "5"
+        - name:
+            Named: __28
+          type_name:
+            Base: char
+          value: "3"
+        - name:
+            Named: __29
+          type_name:
+            Base: char
+          value: "6"
+        - name:
+            Named: __30
+          type_name:
+            Base: char
+          value: "8"
+        - name:
+            Named: __31
+          type_name:
+            Base: char
+          value: "7"
+        - name:
+            Named: __32
+          type_name:
+            Base: char
+          value: "0"
+        - name:
+            Named: __33
+          type_name:
+            Base: char
+          value: "9"
+        - name:
+            Named: __34
+          type_name:
+            Base: char
+          value: "1"
+        - name:
+            Named: __35
+          type_name:
+            Base: char
+          value: "2"
+        - name:
+            Named: __36
+          type_name:
+            Base: char
+          value: "\r"
+        - name:
+            Named: __37
+          type_name:
+            Base: char
+          value: "\n"
+        - name:
+            Named: __38
+          type_name:
+            Base: char
+          value: v
+        - name:
+            Named: __39
+          type_name:
+            Base: char
+          value: o
+        - name:
+            Named: __40
+          type_name:
+            Base: char
+          value: i
+        - name:
+            Named: __41
+          type_name:
+            Base: char
+          value: d
+        - name:
+            Named: __42
+          type_name:
+            Base: char
+          value: "*"
+        - name:
+            Named: __43
+          type_name:
+            Base: char
+          value: " "
+        - name:
+            Named: __44
+          type_name:
+            Base: char
+          value: c
+        - name:
+            Named: __45
+          type_name:
+            Base: char
+          value: o
+        - name:
+            Named: __46
+          type_name:
+            Base: char
+          value: n
+        - name:
+            Named: __47
+          type_name:
+            Base: char
+          value: s
+        - name:
+            Named: __48
+          type_name:
+            Base: char
+          value: t
+        - name:
+            Named: __49
+          type_name:
+            Base: char
+          value: " "
+        - name: Artifical
+          type_name: Unknown
+          value: "... and 974 more"
     - name:
         Named: _acDownBuffer
       type_name:
@@ -33,7 +287,7 @@ Child Variables:
           item_type_name:
             Base: char
           count: 16
-      value: "char[16] = [\n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000]"
+      value: "char[16] = [\n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t... and 6 more]"
       children:
         - name:
             Named: __0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a__static_variables.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__atsamd51p19a__static_variables.snap
@@ -5,7 +5,7 @@ expression: static_variables
 Child Variables:
   name: StaticScopeRoot
   type_name: Unknown
-  value: "<unknown> {\n\texception_table: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t_aTerminalId: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, <unknown>, \n\tchar[1024] = [\n\t\tH, \n\t\te, \n\t\tl, \n\t\tl, \n\t\to, \n\t\t , \n\t\tH, \n\t\te, \n\t\tl, \n\t\tl, \n\n\t\t... and 1014 more\n\t], \n\tchar[16] = [\n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\t\t\u0000, \n\n\t\t... and 6 more\n\t], \n\t_ActiveTerminal: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\tfoo: Foo_t = Foo_t @ 0x20000000, \n\tconst Foo_t[2] = [\n\t\tFoo_t @ 0x0000165C, \n\t\tFoo_t @ 0x00001664\n\t]}"
+  value: "<unknown> {\n\texception_table: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t_aTerminalId: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,<unknown>,\n\tchar[1024] = [\n\t\tH,\n\t\te,\n\t\tl,\n\t\tl,\n\t\to,\n\t\t ,\n\t\tH,\n\t\te,\n\t\tl,\n\t\tl,\n\n\t\t... and 1014 more\n\t],\n\tchar[16] = [\n\t\t\u0000,\n\t\t\u0000,\n\t\t\u0000,\n\t\t\u0000,\n\t\t\u0000,\n\t\t\u0000,\n\t\t\u0000,\n\t\t\u0000,\n\t\t\u0000,\n\t\t\u0000,\n\n\t\t... and 6 more\n\t],\n\t_ActiveTerminal: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\tfoo: Foo_t = Foo_t @ 0x20000000,\n\tconst Foo_t[2] = [\n\t\tFoo_t @ 0x0000165C,\n\t\tFoo_t @ 0x00001664\n\t]}"
   children:
     - name:
         Named: exception_table
@@ -25,7 +25,7 @@ Child Variables:
           item_type_name:
             Base: char
           count: 1024
-      value: "char[1024] = [\n\tH, \n\te, \n\tl, \n\tl, \n\to, \n\t , \n\tH, \n\te, \n\tl, \n\tl, \n\t... and 1014 more]"
+      value: "char[1024] = [\n\tH,\n\te,\n\tl,\n\tl,\n\to,\n\t ,\n\tH,\n\te,\n\tl,\n\tl,\n\t... and 1014 more]"
       children:
         - name:
             Named: __0
@@ -287,7 +287,7 @@ Child Variables:
           item_type_name:
             Base: char
           count: 16
-      value: "char[16] = [\n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t\u0000, \n\t... and 6 more]"
+      value: "char[16] = [\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t\u0000,\n\t... and 6 more]"
       children:
         - name:
             Named: __0
@@ -384,7 +384,7 @@ Child Variables:
         - name: Unknown
           type_name:
             Base: "<unnamed union>"
-          value: "<unnamed union> {\n\t<unknown>: <unnamed struct> = <unnamed struct> @ 0x20000000, \n\tx: uint32_t = 1200000}"
+          value: "<unnamed union> {\n\t<unknown>: <unnamed struct> = <unnamed struct> @ 0x20000000,\n\tx: uint32_t = 1200000}"
           children:
             - name: Unknown
               type_name:
@@ -513,7 +513,7 @@ Child Variables:
                       - Typedef: Foo_t
                       - Struct: "<unnamed struct>"
               count: 2
-      value: "const Foo_t[2] = [\n\tFoo_t @ 0x0000165C, \n\tFoo_t @ 0x00001664]"
+      value: "const Foo_t[2] = [\n\tFoo_t @ 0x0000165C,\n\tFoo_t @ 0x00001664]"
       children:
         - name:
             Named: __0
@@ -528,7 +528,7 @@ Child Variables:
             - name: Unknown
               type_name:
                 Base: "<unnamed union>"
-              value: "<unnamed union> {\n\t<unknown>: <unnamed struct> = <unnamed struct> @ 0x0000165C, \n\tx: uint32_t = 0}"
+              value: "<unnamed union> {\n\t<unknown>: <unnamed struct> = <unnamed struct> @ 0x0000165C,\n\tx: uint32_t = 0}"
               children:
                 - name: Unknown
                   type_name:
@@ -657,7 +657,7 @@ Child Variables:
             - name: Unknown
               type_name:
                 Base: "<unnamed union>"
-              value: "<unnamed union> {\n\t<unknown>: <unnamed struct> = <unnamed struct> @ 0x00001664, \n\tx: uint32_t = 0}"
+              value: "<unnamed union> {\n\t<unknown>: <unnamed struct> = <unnamed struct> @ 0x00001664,\n\tx: uint32_t = 0}"
               children:
                 - name: Unknown
                   type_name:

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__full_unwind.snap
@@ -214,7 +214,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tstack_depth: usize = 5, \n\tinternal_depth_measure: usize = 6}"
+      value: "<unknown> {\n\tstack_depth: usize = 5,\n\tinternal_depth_measure: usize = 6}"
       children:
         - name:
             Named: stack_depth
@@ -431,7 +431,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tstack_depth: usize = 4, \n\tinternal_depth_measure: usize = 5}"
+      value: "<unknown> {\n\tstack_depth: usize = 4,\n\tinternal_depth_measure: usize = 5}"
       children:
         - name:
             Named: stack_depth
@@ -648,7 +648,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tstack_depth: usize = 3, \n\tinternal_depth_measure: usize = 4}"
+      value: "<unknown> {\n\tstack_depth: usize = 3,\n\tinternal_depth_measure: usize = 4}"
       children:
         - name:
             Named: stack_depth
@@ -865,7 +865,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tstack_depth: usize = 2, \n\tinternal_depth_measure: usize = 3}"
+      value: "<unknown> {\n\tstack_depth: usize = 2,\n\tinternal_depth_measure: usize = 3}"
       children:
         - name:
             Named: stack_depth
@@ -1082,7 +1082,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tstack_depth: usize = 1, \n\tinternal_depth_measure: usize = 2}"
+      value: "<unknown> {\n\tstack_depth: usize = 1,\n\tinternal_depth_measure: usize = 2}"
       children:
         - name:
             Named: stack_depth
@@ -1299,7 +1299,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tstack_depth: usize = 0, \n\tinternal_depth_measure: usize = 1}"
+      value: "<unknown> {\n\tstack_depth: usize = 0,\n\tinternal_depth_measure: usize = 1}"
       children:
         - name:
             Named: stack_depth
@@ -1516,7 +1516,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23, \n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced, \n\tlocal_reference_to_global_static: &str = A 'global' static variable, \n\tlocal_reference_to_global_static_struct: &common_testing_code::ComplexEnum = &common_testing_code::ComplexEnum @ 0x20003D3C, \n\tghosted_variable: usize = 0, \n\tghosted_variable: &str = New value and type for a different name, \n\tint8_twenty_six: i8 = 26, \n\tint128: i128 = -196710231994021419720322, \n\tu_int128: u128 = 340282366920938266753142613410348491134, \n\tfloat64: f64 = 1.7608695652173911, \n\tfloat64_ptr: &f64 = &f64 @ 0x20003D54, \n\temoji: char = 💩, \n\temoji_ptr: &char = &char @ 0x20003D58, \n\ttrue_bool: bool = true, \n\tany_old_string_slice: &str = How long is a piece of String., \n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x20003D5C, \n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x200034D0, \n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x2000350C, \n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x2000368C, \n\tthree: SimpleEnum = SimpleEnum::Two, \n\tsimple_enum_pointer: &common_testing_code::SimpleEnum = &common_testing_code::SimpleEnum @ 0x20003B10, \n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x20003B14, \n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003B38, \n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003B68, \n\tstruct_with_one_variant: Option<common_testing_code::Univariant> = Option<common_testing_code::Univariant> @ 0x20003B88, \n\tstuct_with_one_variant_pointer: &core::option::Option<common_testing_code::Univariant> = &core::option::Option<common_testing_code::Univariant> @ 0x20003D64, \n\tlong_lived: ComplexStruct = ComplexStruct @ 0x20003BF0, \n\tshort_lived: ComplexStruct = ComplexStruct @ 0x20003C00, \n\ta1: Struct<i32> = Struct<i32> @ 0x20003D68, \n\ta2: i64 = 1, \n\ta3: i64 = 2, \n\ta4: i64 = 3, \n\ta5: (i32, i64) = (i32, i64) @ 0x20003D90, \n\ta6: Enum<i32> = Enum<i32> @ 0x20003C40, \n\ta7: Enum<i32> = Enum<i32> @ 0x20003C60, \n\t[i32; 10] = [\n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55, \n\t\t55\n\t], \n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x20003DA0, \n\t[i8; 10] = [\n\t\t1, \n\t\t2, \n\t\t3, \n\t\t4, \n\t\t5, \n\t\t6, \n\t\t7, \n\t\t8, \n\t\t9, \n\t\t0\n\t], \n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x20003CB8, \n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x20003CCB, \n\trtt_channels: Channels = Channels @ 0x20003CCC}"
+      value: "<unknown> {\n\tint8_minus_twenty_three: i8 = -23,\n\tlocal_reference_to_global_const: &str = This global `const` value will only show up in the debugger in the variables where it is referenced,\n\tlocal_reference_to_global_static: &str = A 'global' static variable,\n\tlocal_reference_to_global_static_struct: &common_testing_code::ComplexEnum = &common_testing_code::ComplexEnum @ 0x20003D3C,\n\tghosted_variable: usize = 0,\n\tghosted_variable: &str = New value and type for a different name,\n\tint8_twenty_six: i8 = 26,\n\tint128: i128 = -196710231994021419720322,\n\tu_int128: u128 = 340282366920938266753142613410348491134,\n\tfloat64: f64 = 1.7608695652173911,\n\tfloat64_ptr: &f64 = &f64 @ 0x20003D54,\n\temoji: char = 💩,\n\temoji_ptr: &char = &char @ 0x20003D58,\n\ttrue_bool: bool = true,\n\tany_old_string_slice: &str = How long is a piece of String.,\n\tfunction_result: Result<(), &str> = Result<(), &str> @ 0x20003D5C,\n\tglobal_types: (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) = (bool, isize, char, i8, i16, i32, i64, usize, u8, u16, u32, u64, f32, f64) @ 0x200034D0,\n\tthree_d_usize_array: Matrix<i32, 2, 3, 4> = Matrix<i32, 2, 3, 4> @ 0x2000350C,\n\tthree_d_string_array: Matrix<&str, 2, 3, 6> = Matrix<&str, 2, 3, 6> @ 0x2000368C,\n\tthree: SimpleEnum = SimpleEnum::Two,\n\tsimple_enum_pointer: &common_testing_code::SimpleEnum = &common_testing_code::SimpleEnum @ 0x20003B10,\n\tthree_level_recursive_struct: RecursiveStruct = RecursiveStruct @ 0x20003B14,\n\tfirst_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003B38,\n\tsecond_case_of_struct_variants: ComplexEnum = ComplexEnum @ 0x20003B68,\n\tstruct_with_one_variant: Option<common_testing_code::Univariant> = Option<common_testing_code::Univariant> @ 0x20003B88,\n\tstuct_with_one_variant_pointer: &core::option::Option<common_testing_code::Univariant> = &core::option::Option<common_testing_code::Univariant> @ 0x20003D64,\n\tlong_lived: ComplexStruct = ComplexStruct @ 0x20003BF0,\n\tshort_lived: ComplexStruct = ComplexStruct @ 0x20003C00,\n\ta1: Struct<i32> = Struct<i32> @ 0x20003D68,\n\ta2: i64 = 1,\n\ta3: i64 = 2,\n\ta4: i64 = 3,\n\ta5: (i32, i64) = (i32, i64) @ 0x20003D90,\n\ta6: Enum<i32> = Enum<i32> @ 0x20003C40,\n\ta7: Enum<i32> = Enum<i32> @ 0x20003C60,\n\t[i32; 10] = [\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55,\n\t\t55\n\t],\n\tmy_array_ptr: &[i32; 10] = &[i32; 10] @ 0x20003DA0,\n\t[i8; 10] = [\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4,\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t8,\n\t\t9,\n\t\t0\n\t],\n\theapless_vec: Vec<i8, 10> = Vec<i8, 10> @ 0x20003CB8,\n\tloop_counter: Wrapping<u8> = Wrapping<u8> @ 0x20003CCB,\n\trtt_channels: Channels = Channels @ 0x20003CCC}"
       children:
         - name:
             Named: int8_minus_twenty_three
@@ -1841,7 +1841,7 @@ expression: stack_frames
                           count: 3
                       count: 2
                   count: 4
-              value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0, \n\t\t\t1, \n\t\t\t2\n\t\t], \n\t\t[i32; 3] = [\n\t\t\t3, \n\t\t\t4, \n\t\t\t5\n\t\t]\n\t], \n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6, \n\t\t\t7, \n\t\t\t8\n\t\t], \n\t\t[i32; 3] = [\n\t\t\t9, \n\t\t\t10, \n\t\t\t11\n\t\t]\n\t], \n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12, \n\t\t\t13, \n\t\t\t14\n\t\t], \n\t\t[i32; 3] = [\n\t\t\t15, \n\t\t\t16, \n\t\t\t17\n\t\t]\n\t], \n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18, \n\t\t\t19, \n\t\t\t20\n\t\t], \n\t\t[i32; 3] = [\n\t\t\t21, \n\t\t\t22, \n\t\t\t23\n\t\t]\n\t]]"
+              value: "[[[i32; 3]; 2]; 4] = [\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t0,\n\t\t\t1,\n\t\t\t2\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t3,\n\t\t\t4,\n\t\t\t5\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t6,\n\t\t\t7,\n\t\t\t8\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t9,\n\t\t\t10,\n\t\t\t11\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t12,\n\t\t\t13,\n\t\t\t14\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t15,\n\t\t\t16,\n\t\t\t17\n\t\t]\n\t],\n\t[[i32; 3]; 2] = [\n\t\t[i32; 3] = [\n\t\t\t18,\n\t\t\t19,\n\t\t\t20\n\t\t],\n\t\t[i32; 3] = [\n\t\t\t21,\n\t\t\t22,\n\t\t\t23\n\t\t]\n\t]]"
               children:
                 - name:
                     Named: __0
@@ -1853,7 +1853,7 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       count: 2
-                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0, \n\t\t1, \n\t\t2\n\t], \n\t[i32; 3] = [\n\t\t3, \n\t\t4, \n\t\t5\n\t]]"
+                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t0,\n\t\t1,\n\t\t2\n\t],\n\t[i32; 3] = [\n\t\t3,\n\t\t4,\n\t\t5\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -1862,7 +1862,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t0, \n\t1, \n\t2]"
+                      value: "[i32; 3] = [\n\t0,\n\t1,\n\t2]"
                       children:
                         - name:
                             Named: __0
@@ -1886,7 +1886,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t3, \n\t4, \n\t5]"
+                      value: "[i32; 3] = [\n\t3,\n\t4,\n\t5]"
                       children:
                         - name:
                             Named: __0
@@ -1913,7 +1913,7 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       count: 2
-                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6, \n\t\t7, \n\t\t8\n\t], \n\t[i32; 3] = [\n\t\t9, \n\t\t10, \n\t\t11\n\t]]"
+                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t6,\n\t\t7,\n\t\t8\n\t],\n\t[i32; 3] = [\n\t\t9,\n\t\t10,\n\t\t11\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -1922,7 +1922,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t6, \n\t7, \n\t8]"
+                      value: "[i32; 3] = [\n\t6,\n\t7,\n\t8]"
                       children:
                         - name:
                             Named: __0
@@ -1946,7 +1946,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t9, \n\t10, \n\t11]"
+                      value: "[i32; 3] = [\n\t9,\n\t10,\n\t11]"
                       children:
                         - name:
                             Named: __0
@@ -1973,7 +1973,7 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       count: 2
-                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12, \n\t\t13, \n\t\t14\n\t], \n\t[i32; 3] = [\n\t\t15, \n\t\t16, \n\t\t17\n\t]]"
+                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t12,\n\t\t13,\n\t\t14\n\t],\n\t[i32; 3] = [\n\t\t15,\n\t\t16,\n\t\t17\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -1982,7 +1982,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t12, \n\t13, \n\t14]"
+                      value: "[i32; 3] = [\n\t12,\n\t13,\n\t14]"
                       children:
                         - name:
                             Named: __0
@@ -2006,7 +2006,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t15, \n\t16, \n\t17]"
+                      value: "[i32; 3] = [\n\t15,\n\t16,\n\t17]"
                       children:
                         - name:
                             Named: __0
@@ -2033,7 +2033,7 @@ expression: stack_frames
                             Base: i32
                           count: 3
                       count: 2
-                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18, \n\t\t19, \n\t\t20\n\t], \n\t[i32; 3] = [\n\t\t21, \n\t\t22, \n\t\t23\n\t]]"
+                  value: "[[i32; 3]; 2] = [\n\t[i32; 3] = [\n\t\t18,\n\t\t19,\n\t\t20\n\t],\n\t[i32; 3] = [\n\t\t21,\n\t\t22,\n\t\t23\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2042,7 +2042,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t18, \n\t19, \n\t20]"
+                      value: "[i32; 3] = [\n\t18,\n\t19,\n\t20]"
                       children:
                         - name:
                             Named: __0
@@ -2066,7 +2066,7 @@ expression: stack_frames
                           item_type_name:
                             Base: i32
                           count: 3
-                      value: "[i32; 3] = [\n\t21, \n\t22, \n\t23]"
+                      value: "[i32; 3] = [\n\t21,\n\t22,\n\t23]"
                       children:
                         - name:
                             Named: __0
@@ -2102,7 +2102,7 @@ expression: stack_frames
                           count: 3
                       count: 2
                   count: 6
-              value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple, \n\t\t\tBanana, \n\t\t\tCherry\n\t\t], \n\t\t[&str; 3] = [\n\t\t\tDog, \n\t\t\tElephant, \n\t\t\tFish\n\t\t]\n\t], \n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar, \n\t\t\tHorse, \n\t\t\tIce Cream\n\t\t], \n\t\t[&str; 3] = [\n\t\t\tJaguar, \n\t\t\tKangaroo, \n\t\t\tLion\n\t\t]\n\t], \n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon, \n\t\t\tNewton, \n\t\t\tOwl\n\t\t], \n\t\t[&str; 3] = [\n\t\t\tPencil, \n\t\t\tQueen, \n\t\t\tRainbow\n\t\t]\n\t], \n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun, \n\t\t\tTree, \n\t\t\tUmbrella\n\t\t], \n\t\t[&str; 3] = [\n\t\t\tViolin, \n\t\t\tWatch, \n\t\t\tXylophone\n\t\t]\n\t], \n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow, \n\t\t\tZebra, \n\t\t\tAlpha\n\t\t], \n\t\t[&str; 3] = [\n\t\t\tBravo, \n\t\t\tCharlie, \n\t\t\tDelta\n\t\t]\n\t], \n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho, \n\t\t\tFoxtrot, \n\t\t\tGolf\n\t\t], \n\t\t[&str; 3] = [\n\t\t\tHotel, \n\t\t\tIndia, \n\t\t\tJuliet\n\t\t]\n\t]]"
+              value: "[[[&str; 3]; 2]; 6] = [\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tApple,\n\t\t\tBanana,\n\t\t\tCherry\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tDog,\n\t\t\tElephant,\n\t\t\tFish\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tGuitar,\n\t\t\tHorse,\n\t\t\tIce Cream\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tJaguar,\n\t\t\tKangaroo,\n\t\t\tLion\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tMoon,\n\t\t\tNewton,\n\t\t\tOwl\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tPencil,\n\t\t\tQueen,\n\t\t\tRainbow\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tSun,\n\t\t\tTree,\n\t\t\tUmbrella\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tViolin,\n\t\t\tWatch,\n\t\t\tXylophone\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tYellow,\n\t\t\tZebra,\n\t\t\tAlpha\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tBravo,\n\t\t\tCharlie,\n\t\t\tDelta\n\t\t]\n\t],\n\t[[&str; 3]; 2] = [\n\t\t[&str; 3] = [\n\t\t\tEcho,\n\t\t\tFoxtrot,\n\t\t\tGolf\n\t\t],\n\t\t[&str; 3] = [\n\t\t\tHotel,\n\t\t\tIndia,\n\t\t\tJuliet\n\t\t]\n\t]]"
               children:
                 - name:
                     Named: __0
@@ -2114,7 +2114,7 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       count: 2
-                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple, \n\t\tBanana, \n\t\tCherry\n\t], \n\t[&str; 3] = [\n\t\tDog, \n\t\tElephant, \n\t\tFish\n\t]]"
+                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tApple,\n\t\tBanana,\n\t\tCherry\n\t],\n\t[&str; 3] = [\n\t\tDog,\n\t\tElephant,\n\t\tFish\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2123,7 +2123,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tApple, \n\tBanana, \n\tCherry]"
+                      value: "[&str; 3] = [\n\tApple,\n\tBanana,\n\tCherry]"
                       children:
                         - name:
                             Named: __0
@@ -2198,7 +2198,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tDog, \n\tElephant, \n\tFish]"
+                      value: "[&str; 3] = [\n\tDog,\n\tElephant,\n\tFish]"
                       children:
                         - name:
                             Named: __0
@@ -2276,7 +2276,7 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       count: 2
-                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar, \n\t\tHorse, \n\t\tIce Cream\n\t], \n\t[&str; 3] = [\n\t\tJaguar, \n\t\tKangaroo, \n\t\tLion\n\t]]"
+                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tGuitar,\n\t\tHorse,\n\t\tIce Cream\n\t],\n\t[&str; 3] = [\n\t\tJaguar,\n\t\tKangaroo,\n\t\tLion\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2285,7 +2285,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tGuitar, \n\tHorse, \n\tIce Cream]"
+                      value: "[&str; 3] = [\n\tGuitar,\n\tHorse,\n\tIce Cream]"
                       children:
                         - name:
                             Named: __0
@@ -2360,7 +2360,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tJaguar, \n\tKangaroo, \n\tLion]"
+                      value: "[&str; 3] = [\n\tJaguar,\n\tKangaroo,\n\tLion]"
                       children:
                         - name:
                             Named: __0
@@ -2438,7 +2438,7 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       count: 2
-                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon, \n\t\tNewton, \n\t\tOwl\n\t], \n\t[&str; 3] = [\n\t\tPencil, \n\t\tQueen, \n\t\tRainbow\n\t]]"
+                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tMoon,\n\t\tNewton,\n\t\tOwl\n\t],\n\t[&str; 3] = [\n\t\tPencil,\n\t\tQueen,\n\t\tRainbow\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2447,7 +2447,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tMoon, \n\tNewton, \n\tOwl]"
+                      value: "[&str; 3] = [\n\tMoon,\n\tNewton,\n\tOwl]"
                       children:
                         - name:
                             Named: __0
@@ -2522,7 +2522,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tPencil, \n\tQueen, \n\tRainbow]"
+                      value: "[&str; 3] = [\n\tPencil,\n\tQueen,\n\tRainbow]"
                       children:
                         - name:
                             Named: __0
@@ -2600,7 +2600,7 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       count: 2
-                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun, \n\t\tTree, \n\t\tUmbrella\n\t], \n\t[&str; 3] = [\n\t\tViolin, \n\t\tWatch, \n\t\tXylophone\n\t]]"
+                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tSun,\n\t\tTree,\n\t\tUmbrella\n\t],\n\t[&str; 3] = [\n\t\tViolin,\n\t\tWatch,\n\t\tXylophone\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2609,7 +2609,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tSun, \n\tTree, \n\tUmbrella]"
+                      value: "[&str; 3] = [\n\tSun,\n\tTree,\n\tUmbrella]"
                       children:
                         - name:
                             Named: __0
@@ -2684,7 +2684,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tViolin, \n\tWatch, \n\tXylophone]"
+                      value: "[&str; 3] = [\n\tViolin,\n\tWatch,\n\tXylophone]"
                       children:
                         - name:
                             Named: __0
@@ -2762,7 +2762,7 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       count: 2
-                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow, \n\t\tZebra, \n\t\tAlpha\n\t], \n\t[&str; 3] = [\n\t\tBravo, \n\t\tCharlie, \n\t\tDelta\n\t]]"
+                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tYellow,\n\t\tZebra,\n\t\tAlpha\n\t],\n\t[&str; 3] = [\n\t\tBravo,\n\t\tCharlie,\n\t\tDelta\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2771,7 +2771,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tYellow, \n\tZebra, \n\tAlpha]"
+                      value: "[&str; 3] = [\n\tYellow,\n\tZebra,\n\tAlpha]"
                       children:
                         - name:
                             Named: __0
@@ -2846,7 +2846,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tBravo, \n\tCharlie, \n\tDelta]"
+                      value: "[&str; 3] = [\n\tBravo,\n\tCharlie,\n\tDelta]"
                       children:
                         - name:
                             Named: __0
@@ -2924,7 +2924,7 @@ expression: stack_frames
                             Struct: "&str"
                           count: 3
                       count: 2
-                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho, \n\t\tFoxtrot, \n\t\tGolf\n\t], \n\t[&str; 3] = [\n\t\tHotel, \n\t\tIndia, \n\t\tJuliet\n\t]]"
+                  value: "[[&str; 3]; 2] = [\n\t[&str; 3] = [\n\t\tEcho,\n\t\tFoxtrot,\n\t\tGolf\n\t],\n\t[&str; 3] = [\n\t\tHotel,\n\t\tIndia,\n\t\tJuliet\n\t]]"
                   children:
                     - name:
                         Named: __0
@@ -2933,7 +2933,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tEcho, \n\tFoxtrot, \n\tGolf]"
+                      value: "[&str; 3] = [\n\tEcho,\n\tFoxtrot,\n\tGolf]"
                       children:
                         - name:
                             Named: __0
@@ -3008,7 +3008,7 @@ expression: stack_frames
                           item_type_name:
                             Struct: "&str"
                           count: 3
-                      value: "[&str; 3] = [\n\tHotel, \n\tIndia, \n\tJuliet]"
+                      value: "[&str; 3] = [\n\tHotel,\n\tIndia,\n\tJuliet]"
                       children:
                         - name:
                             Named: __0
@@ -3515,7 +3515,7 @@ expression: stack_frames
               item_type_name:
                 Base: i32
               count: 10
-          value: "[i32; 10] = [\n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55]"
+          value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
           children:
             - name:
                 Named: __0
@@ -3580,7 +3580,7 @@ expression: stack_frames
                   item_type_name:
                     Base: i32
                   count: 10
-              value: "[i32; 10] = [\n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55, \n\t55]"
+              value: "[i32; 10] = [\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55,\n\t55]"
               children:
                 - name:
                     Named: __0
@@ -3639,7 +3639,7 @@ expression: stack_frames
               item_type_name:
                 Base: i8
               count: 10
-          value: "[i8; 10] = [\n\t1, \n\t2, \n\t3, \n\t4, \n\t5, \n\t6, \n\t7, \n\t8, \n\t9, \n\t0]"
+          value: "[i8; 10] = [\n\t1,\n\t2,\n\t3,\n\t4,\n\t5,\n\t6,\n\t7,\n\t8,\n\t9,\n\t0]"
           children:
             - name:
                 Named: __0
@@ -3709,13 +3709,13 @@ expression: stack_frames
                   item_type_name:
                     Base: MaybeUninit<i8>
                   count: 10
-              value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBC\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBD\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBE\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBF\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC0\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC1\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC2\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC3\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC4\n\t}, \n\tMaybeUninit<i8> {\n\t\tuninit: () = (), \n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC5\n\t}]"
+              value: "[MaybeUninit<i8>; 10] = [\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBC\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBD\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBE\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBF\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC0\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC1\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC2\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC3\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC4\n\t},\n\tMaybeUninit<i8> {\n\t\tuninit: () = (),\n\t\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC5\n\t}]"
               children:
                 - name:
                     Named: __0
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBC}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBC}"
                   children:
                     - name:
                         Named: uninit
@@ -3737,7 +3737,7 @@ expression: stack_frames
                     Named: __1
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBD}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBD}"
                   children:
                     - name:
                         Named: uninit
@@ -3759,7 +3759,7 @@ expression: stack_frames
                     Named: __2
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBE}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBE}"
                   children:
                     - name:
                         Named: uninit
@@ -3781,7 +3781,7 @@ expression: stack_frames
                     Named: __3
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBF}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CBF}"
                   children:
                     - name:
                         Named: uninit
@@ -3803,7 +3803,7 @@ expression: stack_frames
                     Named: __4
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC0}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC0}"
                   children:
                     - name:
                         Named: uninit
@@ -3825,7 +3825,7 @@ expression: stack_frames
                     Named: __5
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC1}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC1}"
                   children:
                     - name:
                         Named: uninit
@@ -3847,7 +3847,7 @@ expression: stack_frames
                     Named: __6
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC2}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC2}"
                   children:
                     - name:
                         Named: uninit
@@ -3869,7 +3869,7 @@ expression: stack_frames
                     Named: __7
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC3}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC3}"
                   children:
                     - name:
                         Named: uninit
@@ -3891,7 +3891,7 @@ expression: stack_frames
                     Named: __8
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC4}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC4}"
                   children:
                     - name:
                         Named: uninit
@@ -3913,7 +3913,7 @@ expression: stack_frames
                     Named: __9
                   type_name:
                     Base: MaybeUninit<i8>
-                  value: "MaybeUninit<i8> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC5}"
+                  value: "MaybeUninit<i8> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<i8> = ManuallyDrop<i8> @ 0x20003CC5}"
                   children:
                     - name:
                         Named: uninit
@@ -4757,7 +4757,7 @@ expression: stack_frames
     Child Variables:
       name: LocalScopeRoot
       type_name: Unknown
-      value: "<unknown> {\n\tself: &mut nrf_hal_common::ecb::Ecb = &mut nrf_hal_common::ecb::Ecb @ 0x200040C8, \n\tblock: <unknown> = < <value optimized away by compiler, out of scope, or dropped> >, \n\tkey: <unknown> = < <value optimized away by compiler, out of scope, or dropped> >}"
+      value: "<unknown> {\n\tself: &mut nrf_hal_common::ecb::Ecb = &mut nrf_hal_common::ecb::Ecb @ 0x200040C8,\n\tblock: <unknown> = < <value optimized away by compiler, out of scope, or dropped> >,\n\tkey: <unknown> = < <value optimized away by compiler, out of scope, or dropped> >}"
       children:
         - name:
             Named: self

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__static_variables.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__static_variables.snap
@@ -5,7 +5,7 @@ expression: static_variables
 Child Variables:
   name: StaticScopeRoot
   type_name: Unknown
-  value: "<unknown> {\n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&nrf_hal_common::pwm::Seq as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<void::Void as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&usize as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<[u8; 16] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<[u8; 8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&[u8; 8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&nrf52833_pac::comp::extrefsel::EXTREFSEL_A as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<usb_device::UsbDirection as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<usb_device::control::RequestType as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<usb_device::control::Recipient as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&usb_device::control::Request as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<u128 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u128 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&i128 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&fixed::from_str::BitExp as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&usize as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<fixed::debug_hex::Discard as core::fmt::Write>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<usize as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<bool as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&core::option::Option<usize> as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<core::str::error::Utf8Error as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<*const u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<usize as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&core::marker::PhantomData<&[u8]> as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<fixed::bytes::Bytes as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&usize as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<fixed::bytes::DigitsUnds as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u128 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<core::num::nonzero::NonZeroU32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<bool as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<fixed::bytes::DigitsExp as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&core::option::Option<fixed::from_str::BitExp> as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&fixed::from_str::ParseErrorKind as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<cortex_m_rt::{impl#1}::fmt::Hex as core::fmt::Debug>::{vtable}: <cortex_m_rt::{impl#1}::fmt::Hex as core::fmt::Debug>::{vtable_type} = <cortex_m_rt::{impl#1}::fmt::Hex as core::fmt::Debug>::{vtable_type} @ 0x00005048, \n\t<&cortex_m::peripheral::scb::Exception as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&&mut [u8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&&[u8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&u32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&embedded_hal::can::id::StandardId as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&embedded_hal::can::id::ExtendedId as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<i64 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<i32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&i16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<rtt_target::TerminalWriter as core::fmt::Write>::{vtable}: <rtt_target::TerminalWriter as core::fmt::Write>::{vtable_type} = <rtt_target::TerminalWriter as core::fmt::Write>::{vtable_type} @ 0x00005914, \n\t<rtt_target::rtt::RttWriter as core::fmt::Write>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&core::marker::PhantomData<&()> as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >, \n\t<&bool as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >}"
+  value: "<unknown> {\n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&nrf_hal_common::pwm::Seq as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<void::Void as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&usize as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<[u8; 16] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<[u8; 8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&[u8; 8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&nrf52833_pac::comp::extrefsel::EXTREFSEL_A as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<usb_device::UsbDirection as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<usb_device::control::RequestType as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<usb_device::control::Recipient as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&usb_device::control::Request as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<u128 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u128 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&i128 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&fixed::from_str::BitExp as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&usize as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<fixed::debug_hex::Discard as core::fmt::Write>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<usize as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<bool as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&core::option::Option<usize> as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<core::str::error::Utf8Error as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<*const u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<usize as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&core::marker::PhantomData<&[u8]> as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<fixed::bytes::Bytes as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&usize as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<fixed::bytes::DigitsUnds as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u128 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<core::num::nonzero::NonZeroU32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<bool as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<fixed::bytes::DigitsExp as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&core::option::Option<fixed::from_str::BitExp> as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&fixed::from_str::ParseErrorKind as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<cortex_m_rt::{impl#1}::fmt::Hex as core::fmt::Debug>::{vtable}: <cortex_m_rt::{impl#1}::fmt::Hex as core::fmt::Debug>::{vtable_type} = <cortex_m_rt::{impl#1}::fmt::Hex as core::fmt::Debug>::{vtable_type} @ 0x00005048,\n\t<&cortex_m::peripheral::scb::Exception as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u8 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&&mut [u8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&&[u8] as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&u32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&embedded_hal::can::id::StandardId as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&embedded_hal::can::id::ExtendedId as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<i64 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<i32 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&i16 as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<rtt_target::TerminalWriter as core::fmt::Write>::{vtable}: <rtt_target::TerminalWriter as core::fmt::Write>::{vtable_type} = <rtt_target::TerminalWriter as core::fmt::Write>::{vtable_type} @ 0x00005914,\n\t<rtt_target::rtt::RttWriter as core::fmt::Write>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&core::marker::PhantomData<&()> as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >,\n\t<&bool as core::fmt::Debug>::{vtable}: <unknown> = < The value of this variable may have been optimized out of the debug info, by the compiler. >}"
   children:
     - name:
         Namespace: nRF52833_xxAA
@@ -238,13 +238,13 @@ Child Variables:
               item_type_name:
                 Base: Vector
               count: 48
-          value: "[Vector; 48] = [\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000040, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x40 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000044, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x44 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000048, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x48 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000004C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x4c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000050, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x50 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000054, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x54 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000058, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x58 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000005C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x5c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000060, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x60 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000064, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x64 of size 0x4)) >\n\t}, \n\t... and 38 more]"
+          value: "[Vector; 48] = [\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000040,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x40 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000044,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x44 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000048,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x48 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000004C,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x4c of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000050,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x50 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000054,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x54 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000058,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x58 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000005C,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x5c of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000060,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x60 of size 0x4)) >\n\t},\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000064,\n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x64 of size 0x4)) >\n\t},\n\t... and 38 more]"
           children:
             - name:
                 Named: __0
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000040, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x40 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000040,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x40 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -265,7 +265,7 @@ Child Variables:
                 Named: __1
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000044, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x44 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000044,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x44 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -286,7 +286,7 @@ Child Variables:
                 Named: __2
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000048, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x48 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000048,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x48 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -307,7 +307,7 @@ Child Variables:
                 Named: __3
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000004C, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x4c of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000004C,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x4c of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -328,7 +328,7 @@ Child Variables:
                 Named: __4
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000050, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x50 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000050,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x50 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -349,7 +349,7 @@ Child Variables:
                 Named: __5
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000054, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x54 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000054,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x54 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -370,7 +370,7 @@ Child Variables:
                 Named: __6
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000058, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x58 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000058,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x58 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -391,7 +391,7 @@ Child Variables:
                 Named: __7
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000005C, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x5c of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000005C,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x5c of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -412,7 +412,7 @@ Child Variables:
                 Named: __8
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000060, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x60 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000060,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x60 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -433,7 +433,7 @@ Child Variables:
                 Named: __9
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000064, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x64 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000064,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x64 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -454,7 +454,7 @@ Child Variables:
                 Named: __10
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000068, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x68 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000068,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x68 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -475,7 +475,7 @@ Child Variables:
                 Named: __11
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000006C, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x6c of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000006C,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x6c of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -496,7 +496,7 @@ Child Variables:
                 Named: __12
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000070, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x70 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000070,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x70 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -517,7 +517,7 @@ Child Variables:
                 Named: __13
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000074, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x74 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000074,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x74 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -538,7 +538,7 @@ Child Variables:
                 Named: __14
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000078, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x78 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000078,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x78 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -559,7 +559,7 @@ Child Variables:
                 Named: __15
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000007C, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x7c of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000007C,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x7c of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -580,7 +580,7 @@ Child Variables:
                 Named: __16
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000080, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x80 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000080,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x80 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -601,7 +601,7 @@ Child Variables:
                 Named: __17
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000084, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x84 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000084,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x84 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -622,7 +622,7 @@ Child Variables:
                 Named: __18
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000088, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x88 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000088,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x88 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -643,7 +643,7 @@ Child Variables:
                 Named: __19
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000008C, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x8c of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000008C,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x8c of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -664,7 +664,7 @@ Child Variables:
                 Named: __20
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000090, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x90 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000090,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x90 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -685,7 +685,7 @@ Child Variables:
                 Named: __21
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000094, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x94 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000094,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x94 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -706,7 +706,7 @@ Child Variables:
                 Named: __22
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000098, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x98 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000098,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x98 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -727,7 +727,7 @@ Child Variables:
                 Named: __23
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000009C, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x9c of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000009C,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x9c of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -748,7 +748,7 @@ Child Variables:
                 Named: __24
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000A0, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xa0 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000A0,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xa0 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -769,7 +769,7 @@ Child Variables:
                 Named: __25
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000A4, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xa4 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000A4,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xa4 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -790,7 +790,7 @@ Child Variables:
                 Named: __26
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000A8, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xa8 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000A8,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xa8 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -811,7 +811,7 @@ Child Variables:
                 Named: __27
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000AC, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xac of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000AC,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xac of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -832,7 +832,7 @@ Child Variables:
                 Named: __28
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000B0, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xb0 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000B0,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xb0 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -853,7 +853,7 @@ Child Variables:
                 Named: __29
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000B4, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xb4 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000B4,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xb4 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -874,7 +874,7 @@ Child Variables:
                 Named: __30
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000B8, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xb8 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000B8,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xb8 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -895,7 +895,7 @@ Child Variables:
                 Named: __31
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000BC, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xbc of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000BC,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xbc of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -916,7 +916,7 @@ Child Variables:
                 Named: __32
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000C0, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xc0 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000C0,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xc0 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -937,7 +937,7 @@ Child Variables:
                 Named: __33
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000C4, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xc4 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000C4,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xc4 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -958,7 +958,7 @@ Child Variables:
                 Named: __34
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000C8, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xc8 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000C8,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xc8 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -979,7 +979,7 @@ Child Variables:
                 Named: __35
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000CC, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xcc of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000CC,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xcc of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1000,7 +1000,7 @@ Child Variables:
                 Named: __36
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000D0, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xd0 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000D0,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xd0 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1021,7 +1021,7 @@ Child Variables:
                 Named: __37
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000D4, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xd4 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000D4,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xd4 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1042,7 +1042,7 @@ Child Variables:
                 Named: __38
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000D8, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xd8 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000D8,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xd8 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1063,7 +1063,7 @@ Child Variables:
                 Named: __39
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000DC, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xdc of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000DC,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xdc of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1084,7 +1084,7 @@ Child Variables:
                 Named: __40
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000E0, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xe0 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000E0,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xe0 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1105,7 +1105,7 @@ Child Variables:
                 Named: __41
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000E4, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xe4 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000E4,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xe4 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1126,7 +1126,7 @@ Child Variables:
                 Named: __42
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000E8, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xe8 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000E8,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xe8 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1147,7 +1147,7 @@ Child Variables:
                 Named: __43
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000EC, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xec of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000EC,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xec of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1168,7 +1168,7 @@ Child Variables:
                 Named: __44
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000F0, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xf0 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000F0,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xf0 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1189,7 +1189,7 @@ Child Variables:
                 Named: __45
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000F4, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xf4 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000F4,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xf4 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1210,7 +1210,7 @@ Child Variables:
                 Named: __46
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000F8, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xf8 of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000F8,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xf8 of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1231,7 +1231,7 @@ Child Variables:
                 Named: __47
               type_name:
                 Base: Vector
-              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000FC, \n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xfc of size 0x4)) >}"
+              value: "Vector {\n\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000FC,\n\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xfc of size 0x4)) >}"
               children:
                 - name:
                     Named: _handler
@@ -1280,13 +1280,13 @@ Child Variables:
               item_type_name:
                 Base: Vector
               count: 14
-          value: "[Vector; 14] = [\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000008, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x8 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000000C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0xc of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000010, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000014, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x14 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000018, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x18 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000001C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1c of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000020, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x20 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000024, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x24 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000028, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x28 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000002C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x2c of size 0x4)) >\n\t}, \n\t... and 4 more]"
+          value: "[Vector; 14] = [\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000008,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x8 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000000C,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0xc of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000010,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000014,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x14 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000018,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x18 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000001C,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1c of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000020,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x20 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000024,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x24 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000028,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x28 of size 0x4)) >\n\t},\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000002C,\n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x2c of size 0x4)) >\n\t},\n\t... and 4 more]"
           children:
             - name:
                 Named: __0
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000008, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x8 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000008,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x8 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1307,7 +1307,7 @@ Child Variables:
                 Named: __1
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000000C, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0xc of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000000C,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0xc of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1328,7 +1328,7 @@ Child Variables:
                 Named: __2
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000010, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000010,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1349,7 +1349,7 @@ Child Variables:
                 Named: __3
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000014, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x14 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000014,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x14 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1370,7 +1370,7 @@ Child Variables:
                 Named: __4
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000018, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x18 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000018,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x18 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1391,7 +1391,7 @@ Child Variables:
                 Named: __5
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000001C, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1c of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000001C,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1c of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1412,7 +1412,7 @@ Child Variables:
                 Named: __6
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000020, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x20 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000020,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x20 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1433,7 +1433,7 @@ Child Variables:
                 Named: __7
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000024, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x24 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000024,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x24 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1454,7 +1454,7 @@ Child Variables:
                 Named: __8
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000028, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x28 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000028,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x28 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1475,7 +1475,7 @@ Child Variables:
                 Named: __9
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000002C, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x2c of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000002C,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x2c of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1496,7 +1496,7 @@ Child Variables:
                 Named: __10
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000030, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x30 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000030,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x30 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1517,7 +1517,7 @@ Child Variables:
                 Named: __11
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000034, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x34 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000034,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x34 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1538,7 +1538,7 @@ Child Variables:
                 Named: __12
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000038, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x38 of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000038,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x38 of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1559,7 +1559,7 @@ Child Variables:
                 Named: __13
               type_name:
                 Base: Vector
-              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000003C, \n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x3c of size 0x4)) >}"
+              value: "Vector {\n\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000003C,\n\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x3c of size 0x4)) >}"
               children:
                 - name:
                     Named: handler
@@ -1827,7 +1827,7 @@ Child Variables:
                 Named: CONTROL_BLOCK
               type_name:
                 Base: "MaybeUninit<common_testing_code::setup_data_types::RttControlBlock>"
-              value: "MaybeUninit<common_testing_code::setup_data_types::RttControlBlock> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<common_testing_code::setup_data_types::RttControlBlock> = ManuallyDrop<common_testing_code::setup_data_types::RttControlBlock> @ 0x20000078}"
+              value: "MaybeUninit<common_testing_code::setup_data_types::RttControlBlock> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<common_testing_code::setup_data_types::RttControlBlock> = ManuallyDrop<common_testing_code::setup_data_types::RttControlBlock> @ 0x20000078}"
               children:
                 - name:
                     Named: uninit
@@ -1859,7 +1859,7 @@ Child Variables:
                                   item_type_name:
                                     Base: u8
                                   count: 16
-                              value: "[u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t... and 6 more]"
+                              value: "[u8; 16] = [\n\t83,\n\t69,\n\t71,\n\t71,\n\t69,\n\t82,\n\t32,\n\t82,\n\t84,\n\t84,\n\t... and 6 more]"
                               children:
                                 - name:
                                     Named: __0
@@ -1958,7 +1958,7 @@ Child Variables:
                               item_type_name:
                                 Struct: RttChannel
                               count: 2
-                          value: "[RttChannel; 2] = [\n\tRttChannel @ 0x20000090, \n\tRttChannel @ 0x200000A8]"
+                          value: "[RttChannel; 2] = [\n\tRttChannel @ 0x20000090,\n\tRttChannel @ 0x200000A8]"
                           children:
                             - name:
                                 Named: __0
@@ -2140,7 +2140,7 @@ Child Variables:
                 Named: _RTT_CHANNEL_BUFFER
               type_name:
                 Base: "MaybeUninit<[u8; 1024]>"
-              value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200000C0}"
+              value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200000C0}"
               children:
                 - name:
                     Named: uninit
@@ -2160,7 +2160,7 @@ Child Variables:
                           item_type_name:
                             Base: u8
                           count: 1024
-                      value: "[u8; 1024] = [\n\t70, \n\t111, \n\t114, \n\t99, \n\t105, \n\t110, \n\t103, \n\t32, \n\t117, \n\t115, \n\t... and 1014 more]"
+                      value: "[u8; 1024] = [\n\t70,\n\t111,\n\t114,\n\t99,\n\t105,\n\t110,\n\t103,\n\t32,\n\t117,\n\t115,\n\t... and 1014 more]"
                       children:
                         - name:
                             Named: __0
@@ -2419,7 +2419,7 @@ Child Variables:
                 Named: _RTT_CHANNEL_BUFFER
               type_name:
                 Base: "MaybeUninit<[u8; 1024]>"
-              value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (), \n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200004C0}"
+              value: "MaybeUninit<[u8; 1024]> {\n\tuninit: () = (),\n\tvalue: ManuallyDrop<[u8; 1024]> = ManuallyDrop<[u8; 1024]> @ 0x200004C0}"
               children:
                 - name:
                     Named: uninit
@@ -2439,7 +2439,7 @@ Child Variables:
                           item_type_name:
                             Base: u8
                           count: 1024
-                      value: "[u8; 1024] = [\n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t... and 1014 more]"
+                      value: "[u8; 1024] = [\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t... and 1014 more]"
                       children:
                         - name:
                             Named: __0

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__static_variables.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__static_variables.snap
@@ -238,7 +238,7 @@ Child Variables:
               item_type_name:
                 Base: Vector
               count: 48
-          value: "[Vector; 48] = [\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000040, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x40 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000044, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x44 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000048, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x48 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000004C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x4c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000050, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x50 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000054, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x54 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000058, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x58 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000005C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x5c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000060, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x60 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000064, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x64 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000068, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x68 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000006C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x6c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000070, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x70 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000074, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x74 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000078, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x78 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000007C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x7c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000080, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x80 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000084, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x84 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000088, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x88 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000008C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x8c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000090, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x90 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000094, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x94 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000098, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x98 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000009C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x9c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000A0, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xa0 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000A4, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xa4 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000A8, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xa8 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000AC, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xac of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000B0, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xb0 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000B4, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xb4 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000B8, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xb8 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000BC, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xbc of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000C0, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xc0 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000C4, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xc4 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000C8, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xc8 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000CC, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xcc of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000D0, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xd0 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000D4, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xd4 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000D8, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xd8 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000DC, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xdc of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000E0, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xe0 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000E4, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xe4 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000E8, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xe8 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000EC, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xec of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000F0, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xf0 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000F4, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xf4 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000F8, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xf8 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x000000FC, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0xfc of size 0x4)) >\n\t}]"
+          value: "[Vector; 48] = [\n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000040, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x40 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000044, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x44 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000048, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x48 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000004C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x4c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000050, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x50 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000054, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x54 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000058, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x58 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000005C, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x5c of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000060, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x60 of size 0x4)) >\n\t}, \n\tVector {\n\t\t_handler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000064, \n\t\t_reserved: u32 = < Probe(Other(The coredump does not include the memory for address 0x64 of size 0x4)) >\n\t}, \n\t... and 38 more]"
           children:
             - name:
                 Named: __0
@@ -1280,7 +1280,7 @@ Child Variables:
               item_type_name:
                 Base: Vector
               count: 14
-          value: "[Vector; 14] = [\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000008, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x8 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000000C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0xc of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000010, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000014, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x14 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000018, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x18 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000001C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1c of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000020, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x20 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000024, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x24 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000028, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x28 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000002C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x2c of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000030, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x30 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000034, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x34 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000038, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x38 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000003C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x3c of size 0x4)) >\n\t}]"
+          value: "[Vector; 14] = [\n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000008, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x8 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000000C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0xc of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000010, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x10 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000014, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x14 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000018, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x18 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000001C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x1c of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000020, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x20 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000024, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x24 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x00000028, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x28 of size 0x4)) >\n\t}, \n\tVector {\n\t\thandler: *raw unsafe extern \"C\" fn() = *raw unsafe extern \"C\" fn() @ 0x0000002C, \n\t\treserved: usize = < Probe(Other(The coredump does not include the memory for address 0x2c of size 0x4)) >\n\t}, \n\t... and 4 more]"
           children:
             - name:
                 Named: __0
@@ -1859,7 +1859,7 @@ Child Variables:
                                   item_type_name:
                                     Base: u8
                                   count: 16
-                              value: "[u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0]"
+                              value: "[u8; 16] = [\n\t83, \n\t69, \n\t71, \n\t71, \n\t69, \n\t82, \n\t32, \n\t82, \n\t84, \n\t84, \n\t... and 6 more]"
                               children:
                                 - name:
                                     Named: __0
@@ -2160,7 +2160,261 @@ Child Variables:
                           item_type_name:
                             Base: u8
                           count: 1024
-                      value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
+                      value: "[u8; 1024] = [\n\t70, \n\t111, \n\t114, \n\t99, \n\t105, \n\t110, \n\t103, \n\t32, \n\t117, \n\t115, \n\t... and 1014 more]"
+                      children:
+                        - name:
+                            Named: __0
+                          type_name:
+                            Base: u8
+                          value: "70"
+                        - name:
+                            Named: __1
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __2
+                          type_name:
+                            Base: u8
+                          value: "114"
+                        - name:
+                            Named: __3
+                          type_name:
+                            Base: u8
+                          value: "99"
+                        - name:
+                            Named: __4
+                          type_name:
+                            Base: u8
+                          value: "105"
+                        - name:
+                            Named: __5
+                          type_name:
+                            Base: u8
+                          value: "110"
+                        - name:
+                            Named: __6
+                          type_name:
+                            Base: u8
+                          value: "103"
+                        - name:
+                            Named: __7
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __8
+                          type_name:
+                            Base: u8
+                          value: "117"
+                        - name:
+                            Named: __9
+                          type_name:
+                            Base: u8
+                          value: "115"
+                        - name:
+                            Named: __10
+                          type_name:
+                            Base: u8
+                          value: "101"
+                        - name:
+                            Named: __11
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __12
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __13
+                          type_name:
+                            Base: u8
+                          value: "102"
+                        - name:
+                            Named: __14
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __15
+                          type_name:
+                            Base: u8
+                          value: "58"
+                        - name:
+                            Named: __16
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __17
+                          type_name:
+                            Base: u8
+                          value: "84"
+                        - name:
+                            Named: __18
+                          type_name:
+                            Base: u8
+                          value: "119"
+                        - name:
+                            Named: __19
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __20
+                          type_name:
+                            Base: u8
+                          value: "10"
+                        - name:
+                            Named: __21
+                          type_name:
+                            Base: u8
+                          value: "70"
+                        - name:
+                            Named: __22
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __23
+                          type_name:
+                            Base: u8
+                          value: "114"
+                        - name:
+                            Named: __24
+                          type_name:
+                            Base: u8
+                          value: "99"
+                        - name:
+                            Named: __25
+                          type_name:
+                            Base: u8
+                          value: "105"
+                        - name:
+                            Named: __26
+                          type_name:
+                            Base: u8
+                          value: "110"
+                        - name:
+                            Named: __27
+                          type_name:
+                            Base: u8
+                          value: "103"
+                        - name:
+                            Named: __28
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __29
+                          type_name:
+                            Base: u8
+                          value: "117"
+                        - name:
+                            Named: __30
+                          type_name:
+                            Base: u8
+                          value: "115"
+                        - name:
+                            Named: __31
+                          type_name:
+                            Base: u8
+                          value: "101"
+                        - name:
+                            Named: __32
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __33
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __34
+                          type_name:
+                            Base: u8
+                          value: "102"
+                        - name:
+                            Named: __35
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __36
+                          type_name:
+                            Base: u8
+                          value: "58"
+                        - name:
+                            Named: __37
+                          type_name:
+                            Base: u8
+                          value: "65"
+                        - name:
+                            Named: __38
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __39
+                          type_name:
+                            Base: u8
+                          value: "39"
+                        - name:
+                            Named: __40
+                          type_name:
+                            Base: u8
+                          value: "108"
+                        - name:
+                            Named: __41
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __42
+                          type_name:
+                            Base: u8
+                          value: "99"
+                        - name:
+                            Named: __43
+                          type_name:
+                            Base: u8
+                          value: "97"
+                        - name:
+                            Named: __44
+                          type_name:
+                            Base: u8
+                          value: "108"
+                        - name:
+                            Named: __45
+                          type_name:
+                            Base: u8
+                          value: "39"
+                        - name:
+                            Named: __46
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name:
+                            Named: __47
+                          type_name:
+                            Base: u8
+                          value: "116"
+                        - name:
+                            Named: __48
+                          type_name:
+                            Base: u8
+                          value: "111"
+                        - name:
+                            Named: __49
+                          type_name:
+                            Base: u8
+                          value: "32"
+                        - name: Artifical
+                          type_name: Unknown
+                          value: "... and 974 more"
             - name:
                 Named: _RTT_CHANNEL_BUFFER
               type_name:
@@ -2185,7 +2439,261 @@ Child Variables:
                           item_type_name:
                             Base: u8
                           count: 1024
-                      value: Data types with more than 50 members are excluded from this output. This variable has 1024 child members.
+                      value: "[u8; 1024] = [\n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t0, \n\t... and 1014 more]"
+                      children:
+                        - name:
+                            Named: __0
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __1
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __2
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __3
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __4
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __5
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __6
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __7
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __8
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __9
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __10
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __11
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __12
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __13
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __14
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __15
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __16
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __17
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __18
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __19
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __20
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __21
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __22
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __23
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __24
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __25
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __26
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __27
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __28
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __29
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __30
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __31
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __32
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __33
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __34
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __35
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __36
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __37
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __38
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __39
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __40
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __41
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __42
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __43
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __44
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __45
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __46
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __47
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __48
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name:
+                            Named: __49
+                          type_name:
+                            Base: u8
+                          value: "0"
+                        - name: Artifical
+                          type_name: Unknown
+                          value: "... and 974 more"
     - name:
         Named: "<i64 as core::fmt::Debug>::{vtable}"
       type_name: Unknown

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -704,10 +704,16 @@ impl Variable {
                     )
                 }
                 VariableType::Array { .. } => {
-                    // Limit arrays to 10 elements
+                    // Limit arrays to 10(+1) elements
                     const ARRAY_MAX_LENGTH: usize = 10;
                     compound_value = format!("{line_start}{type_name} = [");
-                    for (idx, child) in children.iter().take(ARRAY_MAX_LENGTH).enumerate() {
+                    // Be lenient, allow for 1 more than the max length
+                    let display_count = if children.len() > ARRAY_MAX_LENGTH + 1 {
+                        ARRAY_MAX_LENGTH
+                    } else {
+                        children.len()
+                    };
+                    for (idx, child) in children.iter().take(display_count).enumerate() {
                         compound_value = format!(
                             "{compound_value}{}{}",
                             child.formatted_variable_value(variable_cache, indentation + 1, false),
@@ -720,10 +726,10 @@ impl Variable {
                         );
                     }
 
-                    if children.len() > ARRAY_MAX_LENGTH {
+                    if children.len() > display_count {
                         compound_value = format!(
                             "{compound_value}\n{line_start}\t... and {} more",
-                            children.len() - ARRAY_MAX_LENGTH
+                            children.len() - display_count
                         );
                     }
 

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -708,28 +708,25 @@ impl Variable {
                     const ARRAY_MAX_LENGTH: usize = 10;
                     compound_value = format!("{line_start}{type_name} = [");
                     // Be lenient, allow for 1 more than the max length
-                    let display_count = if children.len() > ARRAY_MAX_LENGTH + 1 {
+                    let child_count = children.len();
+                    let display_count = if child_count > ARRAY_MAX_LENGTH + 1 {
                         ARRAY_MAX_LENGTH
                     } else {
-                        children.len()
+                        child_count
                     };
-                    for (idx, child) in children.iter().take(display_count).enumerate() {
+                    let mut comma = "";
+                    for child in children.iter().take(display_count) {
                         compound_value = format!(
-                            "{compound_value}{}{}",
+                            "{compound_value}{comma}{}",
                             child.formatted_variable_value(variable_cache, indentation + 1, false),
-                            if idx == children.len() - 1 {
-                                // Do not add a separator at the end of the list
-                                ""
-                            } else {
-                                ", "
-                            }
                         );
+                        comma = ", ";
                     }
 
-                    if children.len() > display_count {
+                    if child_count > display_count {
                         compound_value = format!(
-                            "{compound_value}\n{line_start}\t... and {} more",
-                            children.len() - display_count
+                            "{compound_value}, \n{line_start}\t... and {} more",
+                            child_count - display_count
                         );
                     }
 
@@ -765,23 +762,16 @@ impl Variable {
                 {
                     compound_value = format!("{compound_value}{line_start}{type_name} {{");
 
-                    for (idx, child) in children.iter().enumerate() {
+                    let mut comma = "";
+                    for child in children.iter() {
                         let formatted =
                             child.formatted_variable_value(variable_cache, indentation + 1, true);
                         if formatted.is_empty() {
                             // Avoid printing empty commas
                             continue;
                         }
-                        compound_value = format!(
-                            "{compound_value}{}{}",
-                            formatted,
-                            if idx == children.len() - 1 {
-                                // Do not add a separator at the end of the list
-                                ""
-                            } else {
-                                ", "
-                            }
-                        );
+                        compound_value = format!("{compound_value}{comma}{formatted}");
+                        comma = ", ";
                     }
                     format!("{compound_value}{line_start}}}")
                 }
@@ -828,21 +818,17 @@ impl Variable {
 
                     let print_name = !is_tuple;
 
-                    for (idx, child) in children.iter().enumerate() {
+                    let mut comma = "";
+                    for child in children.iter() {
                         compound_value = format!(
-                            "{compound_value}{}{}",
+                            "{compound_value}{comma}{}",
                             child.formatted_variable_value(
                                 variable_cache,
                                 indentation + 1,
                                 print_name
                             ),
-                            if idx == children.len() - 1 {
-                                // Do not add a separator at the end of the list
-                                ""
-                            } else {
-                                ", "
-                            }
                         );
+                        comma = ", ";
                     }
                     if let Some(post_fix) = &post_fix {
                         compound_value = format!("{compound_value}{line_start}{post_fix}");

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -720,12 +720,12 @@ impl Variable {
                             "{compound_value}{comma}{}",
                             child.formatted_variable_value(variable_cache, indentation + 1, false),
                         );
-                        comma = ", ";
+                        comma = ",";
                     }
 
                     if child_count > display_count {
                         compound_value = format!(
-                            "{compound_value}, \n{line_start}\t... and {} more",
+                            "{compound_value},\n{line_start}\t... and {} more",
                             child_count - display_count
                         );
                     }
@@ -771,7 +771,7 @@ impl Variable {
                             continue;
                         }
                         compound_value = format!("{compound_value}{comma}{formatted}");
-                        comma = ", ";
+                        comma = ",";
                     }
                     format!("{compound_value}{line_start}}}")
                 }
@@ -828,7 +828,7 @@ impl Variable {
                                 print_name
                             ),
                         );
-                        comma = ", ";
+                        comma = ",";
                     }
                     if let Some(post_fix) = &post_fix {
                         compound_value = format!("{compound_value}{line_start}{post_fix}");

--- a/probe-rs/src/debug/variable_cache.rs
+++ b/probe-rs/src/debug/variable_cache.rs
@@ -194,11 +194,11 @@ impl VariableCache {
         cache_variable: &mut Variable,
     ) -> Result<(), Error> {
         // Validate that the parent_key exists ...
-        if self.variable_hash_map.contains_key(&parent_key) {
-            cache_variable.parent_key = parent_key;
-        } else {
+        if !self.variable_hash_map.contains_key(&parent_key) {
             return Err(anyhow!("VariableCache: Attempted to add a new variable: {} with non existent `parent_key`: {:?}. Please report this as a bug", cache_variable.name, parent_key).into());
         }
+
+        cache_variable.parent_key = parent_key;
 
         if cache_variable.variable_key != ObjectRef::Invalid {
             return Err(anyhow!("VariableCache: Attempted to add a new variable: {} with already set key: {:?}. Please report this as a bug", cache_variable.name, cache_variable.variable_key).into());
@@ -239,14 +239,14 @@ impl VariableCache {
             &cache_variable.name
         );
 
-        if let Some(prev_entry) = self.variable_hash_map.get_mut(&cache_variable.variable_key) {
-            if cache_variable != prev_entry {
-                tracing::trace!("Updated:  {:?}", cache_variable);
-                tracing::trace!("Previous: {:?}", prev_entry);
-                *prev_entry = cache_variable.clone();
-            }
-        } else {
+        let Some(prev_entry) = self.variable_hash_map.get_mut(&cache_variable.variable_key) else {
             return Err(anyhow!("Attempt to update an existing `Variable`:{:?} with a non-existent cache key: {:?}. Please report this as a bug.", cache_variable.name, cache_variable.variable_key).into());
+        };
+
+        if cache_variable != prev_entry {
+            tracing::trace!("Updated:  {:?}", cache_variable);
+            tracing::trace!("Previous: {:?}", prev_entry);
+            *prev_entry = cache_variable.clone();
         }
 
         Ok(())
@@ -264,21 +264,26 @@ impl VariableCache {
         variable_name: &VariableName,
         parent_key: ObjectRef,
     ) -> Option<Variable> {
-        let child_variables = self
-            .variable_hash_map
-            .values()
-            .filter(|child_variable| {
-                &child_variable.name == variable_name && child_variable.parent_key == parent_key
-            })
-            .collect::<Vec<&Variable>>();
+        let child_variables = self.variable_hash_map.values().filter(|child_variable| {
+            &child_variable.name == variable_name && child_variable.parent_key == parent_key
+        });
 
-        match &child_variables[..] {
-            [] => None,
-            [variable] => Some((*variable).clone()),
-            [.., last] => {
-                tracing::error!("Found {} variables with parent_key={:?} and name={}. Please report this as a bug.", child_variables.len(), parent_key, variable_name);
-                Some((*last).clone())
-            }
+        // Clone the iterator. This is cheap and makes rewinding easier.
+        let mut first_iter = child_variables.clone();
+        let first = first_iter.next();
+        let more = first_iter.next().is_some();
+
+        if more {
+            let (last_index, last) = child_variables.enumerate().last().unwrap();
+            tracing::error!(
+                "Found {} variables with parent_key={:?} and name={}. Please report this as a bug.",
+                last_index + 1,
+                parent_key,
+                variable_name
+            );
+            Some(last.clone())
+        } else {
+            first.cloned()
         }
     }
 
@@ -286,24 +291,23 @@ impl VariableCache {
     /// If there is more than one, it will be logged (tracing::warn!), and only the first will be returned.
     /// It is possible for a hierarchy of variables in a cache to have duplicate names under different parents.
     pub fn get_variable_by_name(&self, variable_name: &VariableName) -> Option<Variable> {
-        let child_variables = self
+        let mut child_variables = self
             .variable_hash_map
             .values()
-            .filter(|child_variable| child_variable.name.eq(variable_name))
-            .collect::<Vec<&Variable>>();
+            .filter(|child_variable| child_variable.name.eq(variable_name));
 
-        match &child_variables[..] {
-            [] => None,
-            [variable] => Some((*variable).clone()),
-            [first, ..] => {
-                tracing::warn!(
-                    "Found {} variables with name={}. Please report this as a bug.",
-                    child_variables.len(),
-                    variable_name
-                );
-                Some((*first).clone())
-            }
+        let first = child_variables.next();
+        let more = child_variables.next().is_some();
+
+        if more {
+            tracing::warn!(
+                "Found {} variables with name={}. Please report this as a bug.",
+                self.variable_hash_map.len(),
+                variable_name
+            );
         }
+
+        first.cloned()
     }
 
     /// Retrieve `clone`d version of all the children of a `Variable`.
@@ -316,7 +320,9 @@ impl VariableCache {
 
     /// Check if variable has children. If the variable doesn't exist, it will return false.
     pub fn has_children(&self, parent_variable: &Variable) -> bool {
-        self.get_children(parent_variable.variable_key).count() > 0
+        self.get_children(parent_variable.variable_key)
+            .next()
+            .is_some()
     }
 
     /// Sometimes DWARF uses intermediate nodes that are not part of the coded variable structure.


### PR DESCRIPTION
 - Display a few children for big arrays, too
 - Do not include invisible spaces
 - Reduce the number of allocations around variable printing and cache