### PR TITLE
Debug: Improve breakpoints and debug stepping behavior

### DIFF
--- a/changelog/fixed-debug-breakpoint-step.md
+++ b/changelog/fixed-debug-breakpoint-step.md
@@ -1,0 +1,1 @@
+Fixed #2180, and improve breakpoint handling and debug stepping.

--- a/changelog/fixed-debug-breakpoint-step.md
+++ b/changelog/fixed-debug-breakpoint-step.md
@@ -1,1 +1,0 @@
-Fixed #2180, and improve breakpoint handling and debug stepping.

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1655,15 +1655,15 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         {
             Ok((new_status, program_counter)) => (new_status, program_counter),
             Err(error) => match &error {
-                probe_rs::debug::DebugError::IncompleteDebugInfo {
-                    message,
-                    pc_at_error,
-                } => {
+                probe_rs::debug::DebugError::WarnAndContinue { message } => {
+                    let pc_at_error = target_core
+                        .core
+                        .read_core_reg(target_core.core.program_counter())?;
                     self.show_message(
                         MessageSeverity::Information,
                         format!("Step error @{pc_at_error:#010X}: {message}"),
                     );
-                    (target_core.core.status()?, *pc_at_error)
+                    (target_core.core.status()?, pc_at_error)
                 }
                 other_error => {
                     target_core.core.halt(Duration::from_millis(100)).ok();

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -1085,9 +1085,8 @@ impl DebugInfo {
                 Err(_) => continue,
             };
         }
-        Err(DebugError::IncompleteDebugInfo{
-            message: "No debug information available for the specified instruction address. Please consider using instruction level stepping.".to_string(),
-            pc_at_error: address,
+        Err(DebugError::WarnAndContinue {
+            message: format!("No debug information available for the instruction at {address:#010x}. Please consider using instruction level stepping.")
         })
     }
 }

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -14,8 +14,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use gimli::{
-    BaseAddresses, DebugFrame, FileEntry, LineProgramHeader, UnwindContext, UnwindSection,
-    UnwindTableRow,
+    BaseAddresses, DebugFrame, LineProgramHeader, UnwindContext, UnwindSection, UnwindTableRow,
 };
 use object::read::{Object, ObjectSection};
 use probe_rs_target::InstructionSet;
@@ -193,7 +192,7 @@ impl DebugInfo {
 
                 let mut rows = program.resume_from(target_seq);
 
-                while let Ok(Some((header, row))) = rows.next_row() {
+                while let Ok(Some((_, row))) = rows.next_row() {
                     match row.address().cmp(&address) {
                         Ordering::Greater => {
                             // The address is after the current row, so we use the previous row data.
@@ -201,36 +200,32 @@ impl DebugInfo {
                             // (If we don't do this, you get the artificial effect where the debugger
                             // steps to the top of the file when it is steppping out of a function.)
                             if let Some(previous_row) = previous_row {
-                                if let Some(file_entry) = previous_row.file(header) {
-                                    if let Some((file, directory)) =
-                                        self.find_file_and_directory(unit, header, file_entry)
-                                    {
-                                        tracing::debug!("{} - {:?}", address, previous_row.isa());
-                                        return Some(SourceLocation {
-                                            line: previous_row.line().map(NonZeroU64::get),
-                                            column: Some(previous_row.column().into()),
-                                            file,
-                                            directory,
-                                        });
-                                    }
+                                if let Some((file, directory)) =
+                                    self.find_file_and_directory(unit, previous_row.file_index())
+                                {
+                                    tracing::debug!("{} - {:?}", address, previous_row.isa());
+                                    return Some(SourceLocation {
+                                        line: previous_row.line().map(NonZeroU64::get),
+                                        column: Some(previous_row.column().into()),
+                                        file,
+                                        directory,
+                                    });
                                 }
                             }
                         }
                         Ordering::Less => {}
                         Ordering::Equal => {
-                            if let Some(file_entry) = row.file(header) {
-                                if let Some((file, directory)) =
-                                    self.find_file_and_directory(unit, header, file_entry)
-                                {
-                                    tracing::debug!("{} - {:?}", address, row.isa());
+                            if let Some((file, directory)) =
+                                self.find_file_and_directory(unit, row.file_index())
+                            {
+                                tracing::debug!("{} - {:?}", address, row.isa());
 
-                                    return Some(SourceLocation {
-                                        line: row.line().map(NonZeroU64::get),
-                                        column: Some(row.column().into()),
-                                        file,
-                                        directory,
-                                    });
-                                }
+                                return Some(SourceLocation {
+                                    line: row.line().map(NonZeroU64::get),
+                                    column: Some(row.column().into()),
+                                    file,
+                                    directory,
+                                });
                             }
                         }
                     }
@@ -880,28 +875,31 @@ impl DebugInfo {
                 .unwrap_or_else(|| "-".to_owned())
         );
 
+        VerifiedBreakpoint::for_source_location(self, path, line, column)
         // We need to look through all the compilation units, and inspect their line programs,
         // to determine the correct address for the breakpoint.
-        for progam_unit in &self.unit_infos {
-            // TODO: We do NOT need to look up the line program here.
-            let Some(ref line_program) = &progam_unit.unit.line_program else {
-                continue;
-            };
+        /*
+                for progam_unit in &self.unit_infos {
+                    // TODO: We do NOT need to look up the line program here.
+                    let Some(ref line_program) = &progam_unit.unit.line_program else {
+                        continue;
+                    };
 
-            if let Some(location) =
-                self.get_breakpoint_location_in_unit(progam_unit, line_program, path, line, column)?
-            {
-                return Ok(location);
-            };
-        }
-
-        // If we get here, it means we didn't find any valid breakpoint locations.
-        Err(DebugError::Other(anyhow::anyhow!(
-            "No valid breakpoint information found for file: {}, line: {line:?}, column: {column:?}",
-            path.to_path().display()
-        )))
+                    if let Some(location) =
+                        self.get_breakpoint_location_in_unit(progam_unit, line_program, path, line, column)?
+                    {
+                        return Ok(location);
+                    };
+                }
+                // If we get here, it means we didn't find any valid breakpoint locations.
+                Err(DebugError::Other(anyhow::anyhow!(
+                    "No valid breakpoint information found for file: {}, line: {line:?}, column: {column:?}",
+                    path.to_path().display()
+                )))
+        */
     }
 
+    #[allow(dead_code)] // temp until this fn can be deleted.
     fn get_breakpoint_location_in_unit(
         &self,
         unit_header: &UnitInfo,
@@ -914,23 +912,26 @@ impl DebugInfo {
         let header: &LineProgramHeader<GimliReader, usize> = line_program.header();
 
         // Early return, if none of the file names in the header match the path we are looking for.
-        if !header.file_names().iter().any(|file_name| {
-            let combined_path = self.get_path(unit, header, file_name);
+        if !header
+            .file_names()
+            .iter()
+            .enumerate()
+            .any(|(file_index, _)| {
+                let combined_path = self.get_path(unit, file_index as u64);
 
-            combined_path
-                .map(|p| canonical_path_eq(path, &p))
-                .unwrap_or(false)
-        }) {
+                combined_path
+                    .map(|p| canonical_path_eq(path, &p))
+                    .unwrap_or(false)
+            })
+        {
             return Ok(None);
         }
 
         let mut rows = line_program.clone().rows();
 
-        while let Some((header, row)) = rows.next_row()? {
+        while let Some((_, row)) = rows.next_row()? {
             // If the row is not in the same file, we can skip it.
-            let row_path = row
-                .file(header)
-                .and_then(|file_entry| self.get_path(unit, header, file_entry));
+            let row_path = self.get_path(unit, row.file_index());
             if row_path
                 .as_ref()
                 .map(|p| !canonical_path_eq(path, p))
@@ -955,22 +956,16 @@ impl DebugInfo {
             let halt_address_and_location = |instruction_location: &InstructionLocation| {
                 (
                     instruction_location.address,
-                    line_program
-                        .header()
-                        .file(instruction_location.file_index)
-                        .and_then(|file_entry| {
-                            self.find_file_and_directory(
-                                &unit_header.unit,
-                                line_program.header(),
-                                file_entry,
-                            )
-                            .map(|(file, directory)| SourceLocation {
-                                line: instruction_location.line.map(std::num::NonZeroU64::get),
-                                column: Some(instruction_location.column),
-                                file,
-                                directory,
-                            })
-                        }),
+                    self.find_file_and_directory(
+                        &unit_header.unit,
+                        instruction_location.file_index,
+                    )
+                    .map(|(file, directory)| SourceLocation {
+                        line: instruction_location.line.map(std::num::NonZeroU64::get),
+                        column: Some(instruction_location.column),
+                        file,
+                        directory,
+                    }),
                 )
             };
 
@@ -1014,9 +1009,17 @@ impl DebugInfo {
     pub(crate) fn get_path(
         &self,
         unit: &gimli::read::Unit<DwarfReader>,
-        header: &LineProgramHeader<DwarfReader>,
-        file_entry: &FileEntry<DwarfReader>,
+        file_index: u64,
     ) -> Option<TypedPathBuf> {
+        let line_program = unit.line_program.as_ref()?;
+        let header = line_program.header();
+        let Some(file_entry) = header.file(file_index) else {
+            tracing::warn!(
+                "Unable to extract file entry for file_index {:?}.",
+                file_index
+            );
+            return None;
+        };
         let file_name_attr_string = self.dwarf.attr_string(unit, file_entry.path_name()).ok()?;
         let name_path = from_utf8(&file_name_attr_string).ok()?;
 
@@ -1054,10 +1057,9 @@ impl DebugInfo {
     pub(crate) fn find_file_and_directory(
         &self,
         unit: &gimli::read::Unit<DwarfReader>,
-        header: &LineProgramHeader<DwarfReader>,
-        file_entry: &FileEntry<DwarfReader>,
+        file_index: u64,
     ) -> Option<(Option<String>, Option<TypedPathBuf>)> {
-        let combined_path = self.get_path(unit, header, file_entry)?;
+        let combined_path = self.get_path(unit, file_index)?;
 
         let file_name = combined_path
             .file_name()

--- a/probe-rs/src/debug/debug_step.rs
+++ b/probe-rs/src/debug/debug_step.rs
@@ -262,7 +262,7 @@ impl SteppingMode {
                         if function.attribute(gimli::DW_AT_noreturn).is_some() {
                             return Err(DebugError::Other(anyhow::anyhow!(
                                 "Function {:?} is marked as `noreturn`. Cannot step out of this function.",
-                                function.function_name(debug_info)
+                                function.function_name(debug_info).unwrap_or("<unknown>".to_string())
                             )));
                         } else if function.low_pc <= program_counter
                             && function.high_pc > program_counter
@@ -316,12 +316,7 @@ fn run_to_address(
     target_address: u64,
     core: &mut impl CoreInterface,
 ) -> Result<(CoreStatus, u64), DebugError> {
-    Ok(if target_address < program_counter {
-        // We are not able to calculate a step_out_address. Notify the user to try something else.
-        return Err(DebugError::WarnAndContinue  {
-            message: "Unable to determine target address for this step request. Please try a different form of stepping.".to_string(),
-        });
-    } else if target_address == program_counter {
+    Ok(if target_address == program_counter {
         // No need to step further. e.g. For inline functions we have already stepped to the best available target address..
         (
             core.status()?,

--- a/probe-rs/src/debug/language/c.rs
+++ b/probe-rs/src/debug/language/c.rs
@@ -85,7 +85,7 @@ impl ProgrammingLanguage for C {
                 }
                 "float" => f32::update_value(variable, memory, new_value),
                 // TODO: doubles
-                other => Err(DebugError::UnwindIncompleteResults {
+                other => Err(DebugError::WarnAndContinue {
                     message: format!("Updating {other} variables is not yet supported."),
                 }),
             },
@@ -99,7 +99,7 @@ impl ProgrammingLanguage for C {
                     }
                 }
 
-                other => Err(DebugError::UnwindIncompleteResults {
+                other => Err(DebugError::WarnAndContinue {
                     message: format!(
                         "Updating {} bitfield variables is not yet supported.",
                         other.kind()
@@ -107,7 +107,7 @@ impl ProgrammingLanguage for C {
                 }),
             },
 
-            other => Err(DebugError::UnwindIncompleteResults {
+            other => Err(DebugError::WarnAndContinue {
                 message: format!("Updating {} variables is not yet supported.", other.kind()),
             }),
         }
@@ -179,7 +179,7 @@ impl Value for CChar {
         new_value: &str,
     ) -> Result<(), DebugError> {
         fn input_error(value: &str) -> DebugError {
-            DebugError::UnwindIncompleteResults {
+            DebugError::WarnAndContinue {
                 message: format!(
                     "Invalid value for char: {value}. Please provide a single character."
                 ),
@@ -246,7 +246,7 @@ impl UnsignedInt {
     ) -> Result<(), DebugError> {
         match parse_int::parse::<u128>(new_value) {
             Ok(value) => write_unsigned_bytes(variable, bitfield, memory, value),
-            Err(e) => Err(DebugError::UnwindIncompleteResults {
+            Err(e) => Err(DebugError::WarnAndContinue {
                 message: format!("Invalid data conversion from value: {new_value:?}. {e:?}"),
             }),
         }
@@ -334,7 +334,7 @@ impl SignedInt {
     ) -> Result<(), DebugError> {
         match parse_int::parse::<i128>(new_value) {
             Ok(value) => write_unsigned_bytes(variable, bitfield, memory, value as u128),
-            Err(e) => Err(DebugError::UnwindIncompleteResults {
+            Err(e) => Err(DebugError::WarnAndContinue {
                 message: format!("Invalid data conversion from value: {new_value:?}. {e:?}"),
             }),
         }

--- a/probe-rs/src/debug/language/parsing.rs
+++ b/probe-rs/src/debug/language/parsing.rs
@@ -20,7 +20,7 @@ macro_rules! impl_parse {
             fn parse_to_bytes(s: &str) -> Result<Self::Out, DebugError> {
                 match ::parse_int::parse::<$t>(s) {
                     Ok(value) => Ok(<$t>::to_le_bytes(value)),
-                    Err(e) => Err(DebugError::UnwindIncompleteResults {
+                    Err(e) => Err(DebugError::WarnAndContinue {
                         message: format!("Invalid data conversion from value: {s:?}. {e:?}"),
                     }),
                 }

--- a/probe-rs/src/debug/language/rust.rs
+++ b/probe-rs/src/debug/language/rust.rs
@@ -90,11 +90,11 @@ impl ProgrammingLanguage for Rust {
                 "usize" => u32::update_value(variable, memory, new_value),
                 "f32" => f32::update_value(variable, memory, new_value),
                 "f64" => f64::update_value(variable, memory, new_value),
-                other => Err(DebugError::UnwindIncompleteResults {
+                other => Err(DebugError::WarnAndContinue {
                     message: format!("Updating {other} variables is not yet supported."),
                 }),
             },
-            other => Err(DebugError::UnwindIncompleteResults {
+            other => Err(DebugError::WarnAndContinue {
                 message: format!("Updating {} variables is not yet supported.", other.kind()),
             }),
         }

--- a/probe-rs/src/debug/language/value.rs
+++ b/probe-rs/src/debug/language/value.rs
@@ -61,14 +61,14 @@ impl Value for bool {
             .write_word_8(
                 variable.memory_location.memory_address()?,
                 <bool as FromStr>::from_str(new_value).map_err(|error| {
-                    DebugError::UnwindIncompleteResults {
+                    DebugError::WarnAndContinue {
                         message: format!(
                             "Invalid data conversion from value: {new_value:?}. {error:?}"
                         ),
                     }
                 })? as u8,
             )
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -96,14 +96,14 @@ impl Value for char {
             .write_word_32(
                 variable.memory_location.memory_address()?,
                 <char as FromStr>::from_str(new_value).map_err(|error| {
-                    DebugError::UnwindIncompleteResults {
+                    DebugError::WarnAndContinue {
                         message: format!(
                             "Invalid data conversion from value: {new_value:?}. {error:?}"
                         ),
                     }
                 })? as u32,
             )
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -179,7 +179,7 @@ impl Value for String {
         _memory: &mut dyn MemoryInterface,
         _new_value: &str,
     ) -> Result<(), DebugError> {
-        Err(DebugError::UnwindIncompleteResults { message:"Unsupported datatype: \"String\". Please only update variables with a base data type.".to_string()})
+        Err(DebugError::WarnAndContinue { message:"Unsupported datatype: \"String\". Please only update variables with a base data type.".to_string()})
     }
 }
 impl Value for i8 {
@@ -202,7 +202,7 @@ impl Value for i8 {
         let buff = i8::parse_to_bytes(new_value)?;
         memory
             .write_word_8(variable.memory_location.memory_address()?, buff[0])
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -227,7 +227,7 @@ impl Value for i16 {
         let buff = i16::parse_to_bytes(new_value)?;
         memory
             .write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -252,7 +252,7 @@ impl Value for i32 {
         let buff = i32::parse_to_bytes(new_value)?;
         memory
             .write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -277,7 +277,7 @@ impl Value for i64 {
         let buff = i64::parse_to_bytes(new_value)?;
         memory
             .write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -302,7 +302,7 @@ impl Value for i128 {
         let buff = i128::parse_to_bytes(new_value)?;
         memory
             .write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -327,7 +327,7 @@ impl Value for u8 {
         let buff = u8::parse_to_bytes(new_value)?;
         memory
             .write_word_8(variable.memory_location.memory_address()?, buff[0])
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -352,7 +352,7 @@ impl Value for u16 {
         let buff = u16::parse_to_bytes(new_value)?;
         memory
             .write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -377,7 +377,7 @@ impl Value for u32 {
         let buff = u32::parse_to_bytes(new_value)?;
         memory
             .write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -402,7 +402,7 @@ impl Value for u64 {
         let buff = u64::parse_to_bytes(new_value)?;
         memory
             .write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -427,7 +427,7 @@ impl Value for u128 {
         let buff = u128::parse_to_bytes(new_value)?;
         memory
             .write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -452,7 +452,7 @@ impl Value for f32 {
         let buff = f32::parse_to_bytes(new_value)?;
         memory
             .write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }
@@ -477,7 +477,7 @@ impl Value for f64 {
         let buff = f64::parse_to_bytes(new_value)?;
         memory
             .write_8(variable.memory_location.memory_address()?, &buff)
-            .map_err(|error| DebugError::UnwindIncompleteResults {
+            .map_err(|error| DebugError::WarnAndContinue {
                 message: format!("{error:?}"),
             })
     }

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -71,22 +71,11 @@ pub enum DebugError {
     /// An int could not be created from the given string.
     #[error(transparent)]
     IntConversion(#[from] std::num::TryFromIntError),
-    /// Errors encountered while determining valid locations for memory addresses involved in actions like
-    /// setting breakpoints and/or stepping through source code.
-    /// These are distinct from other errors because they gracefully terminate the current action,
-    /// and result in a user message, but they do not interrupt the rest of the debug session.
-    #[error("{message}  @program_counter={:#010X}.", pc_at_error)]
-    IncompleteDebugInfo {
-        /// A message that can be displayed to the user to help them make an informed recovery choice.
-        message: String,
-        /// The value of the program counter for which a halt was requested.
-        pc_at_error: u64,
-    },
     /// Non-terminal Errors encountered while unwinding the stack, e.g. Could not resolve the value of a variable in the stack.
     /// These are distinct from other errors because they do not interrupt processing.
     /// Instead, the cause of incomplete results are reported back/explained to the user, and the stack continues to unwind.
     #[error("{message}")]
-    UnwindIncompleteResults {
+    WarnAndContinue {
         /// A message that can be displayed to the user to help them understand the reason for the incomplete results.
         message: String,
     },

--- a/probe-rs/src/debug/mod.rs
+++ b/probe-rs/src/debug/mod.rs
@@ -178,24 +178,17 @@ fn extract_file(
     attribute_value: gimli::AttributeValue<GimliReader>,
 ) -> Option<(TypedPathBuf, String)> {
     match attribute_value {
-        gimli::AttributeValue::FileIndex(index) => unit.line_program.as_ref().and_then(|ilnp| {
-            let header = ilnp.header();
-
-            if let Some(file_entry) = header.file(index) {
-                if let Some((Some(path), Some(file))) = debug_info
-                    .find_file_and_directory(unit, header, file_entry)
-                    .map(|(file, path)| (path, file))
-                {
-                    Some((path, file))
-                } else {
-                    tracing::warn!("Unable to extract file or path from {:?}.", attribute_value);
-                    None
-                }
+        gimli::AttributeValue::FileIndex(index) => {
+            if let Some((Some(path), Some(file))) = debug_info
+                .find_file_and_directory(unit, index)
+                .map(|(file, path)| (path, file))
+            {
+                Some((path, file))
             } else {
-                tracing::warn!("Unable to extract file entry for {:?}.", attribute_value);
+                tracing::warn!("Unable to extract file or path from {:?}.", attribute_value);
                 None
             }
-        }),
+        }
         other => {
             tracing::warn!(
                 "Unable to extract file information from attribute value {:?}: Not implemented.",

--- a/probe-rs/src/debug/source_instructions.rs
+++ b/probe-rs/src/debug/source_instructions.rs
@@ -44,9 +44,8 @@ impl VerifiedBreakpoint {
             return verified_breakpoint;
         }
         // If we get here, we have not found a valid breakpoint location.
-        Err(DebugError::WarnAndContinue{
-            message: format!("Could not identify a valid breakpoint for address: {address:#010x}. Please consider using instruction level stepping."),
-        })
+        let message = format!("Could not identify a valid breakpoint for address: {address:#010x}. Please consider using instruction level stepping.");
+        Err(DebugError::WarnAndContinue { message })
     }
 
     /// Identifying the breakpoint location for a specific location (path, line, colunmn) is a bit more complex,
@@ -350,9 +349,8 @@ impl<'debug_info> InstructionSequence<'debug_info> {
                 line_program.header().address_size(),
             )
         } else {
-            return Err(DebugError::WarnAndContinue{
-                        message: "The specified source location does not have any line_program information available. Please consider using instruction level stepping.".to_string()
-                    });
+            let message = "The specified source location does not have any line_program information available. Please consider using instruction level stepping.".to_string();
+            return Err(DebugError::WarnAndContinue { message });
         };
 
         // Get the sequences of rows from the CompleteLineProgram at the given program_counter.
@@ -366,9 +364,8 @@ impl<'debug_info> InstructionSequence<'debug_info> {
         let Some(line_sequence) = line_sequences.iter().find(|line_sequence| {
             line_sequence.start <= program_counter && program_counter < line_sequence.end
         }) else {
-            return Err(DebugError::WarnAndContinue{
-                        message: "The specified source location does not have any line information available. Please consider using instruction level stepping.".to_string(),
-                    });
+            let message = "The specified source location does not have any line information available. Please consider using instruction level stepping.".to_string();
+            return Err(DebugError::WarnAndContinue { message });
         };
         let instruction_sequence = Self::from_line_sequence(
             debug_info,
@@ -378,8 +375,8 @@ impl<'debug_info> InstructionSequence<'debug_info> {
         );
 
         if instruction_sequence.len() == 0 {
-            Err(DebugError::WarnAndContinue{
-                message: "Could not find valid instruction locations for this address. Consider using instruction level stepping.".to_string(),            })
+            let message = "Could not find valid instruction locations for this address. Consider using instruction level stepping.".to_string();
+            Err(DebugError::WarnAndContinue { message })
         } else {
             tracing::trace!(
                 "Instruction location for pc={:#010x}\n{:?}",

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -394,7 +394,7 @@ impl VariableLocation {
     pub fn memory_address(&self) -> Result<u64, DebugError> {
         match self {
             VariableLocation::Address(address) => Ok(*address),
-            other => Err(DebugError::UnwindIncompleteResults {
+            other => Err(DebugError::WarnAndContinue {
                 message: format!("Variable does not have a memory location: location={other:?}"),
             }),
         }
@@ -535,7 +535,7 @@ impl Variable {
             // We have everything we need to update the variable value.
             language::from_dwarf(self.language)
                 .update_variable(self, memory, &new_value)
-                .map_err(|error| DebugError::UnwindIncompleteResults {
+                .map_err(|error| DebugError::WarnAndContinue {
                     message: format!("Invalid data value={new_value:?}: {error}"),
                 })?;
 


### PR DESCRIPTION
This is a continuation of #2181 , to fix known issues and add new tests.

### Statement of work
- [x] Centralize handling of source-to-address in `debug::source_instructions` module, and ensure existing tests pass.

### Related/Outstanding for future PR
- [ ] Add new tests to reproduce the issue reported in #2180.
- [ ] Add new tests for components of code used during stepping. We can't CI test stepping, because it requires a live target, but we can ensure that the code used will return the results we need to ensure successful stepping on a target.
- [ ] Fix stepping. It has always been a bit 'wonky', and refactoring in #2180 should give us the framework for improvements.