### PR TITLE
Don't accidentally disable the Risc-V debug module

### DIFF
--- a/changelog/fixed-riscv-dm-disabled.md
+++ b/changelog/fixed-riscv-dm-disabled.md
@@ -1,0 +1,1 @@
+RISC-V: fixed an issue that accidentally disabled the debug module during certain operations

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -426,8 +426,6 @@ impl RiscvCommunicationInterface {
     }
 
     fn enter_debug_mode(&mut self) -> Result<(), RiscvError> {
-        // We need a jtag interface
-
         tracing::debug!("Building RISC-V interface");
 
         // Reset error bits from previous connections

--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -351,6 +351,7 @@ impl RiscvCommunicationInterface {
         }
 
         let mut control: Dmcontrol = self.read_dm_register()?;
+        control.set_dmactive(true);
         control.set_hartsel(hart);
         self.write_dm_register(control)?;
         self.last_selected_hart = hart;
@@ -530,8 +531,8 @@ impl RiscvCommunicationInterface {
 
         // Select hart 0 again - assuming all harts are same in regards of discovered features
         let mut control = Dmcontrol(0);
-        control.set_hartsel(0);
         control.set_dmactive(true);
+        control.set_hartsel(0);
 
         self.write_dm_register(control)?;
 
@@ -628,6 +629,7 @@ impl RiscvCommunicationInterface {
             dmcontrol
         );
 
+        dmcontrol.set_dmactive(true);
         dmcontrol.set_haltreq(true);
 
         self.write_dm_register(dmcontrol)?;
@@ -1168,10 +1170,10 @@ impl RiscvCommunicationInterface {
         // ackhavereset = 0
 
         let mut dmcontrol: Dmcontrol = self.read_dm_register()?;
+        dmcontrol.set_dmactive(true);
         dmcontrol.set_haltreq(false);
         dmcontrol.set_resumereq(false);
         dmcontrol.set_ackhavereset(false);
-        dmcontrol.set_dmactive(true);
         self.schedule_write_dm_register(dmcontrol)?;
 
         // Clear any previous command errors.

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -77,6 +77,7 @@ impl<'probe> Riscv32<'probe> {
 
         // set resume request.
         let mut dmcontrol: Dmcontrol = self.interface.read_dm_register()?;
+        dmcontrol.set_dmactive(true);
         dmcontrol.set_resumereq(true);
         self.interface.write_dm_register(dmcontrol)?;
 
@@ -262,6 +263,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         tracing::debug!("Resetting core, setting hartreset bit");
 
         let mut dmcontrol: Dmcontrol = self.interface.read_dm_register()?;
+        dmcontrol.set_dmactive(true);
         dmcontrol.set_hartreset(true);
         dmcontrol.set_haltreq(true);
 
@@ -274,6 +276,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
             tracing::debug!("Clearing hartreset bit");
             // Reset is performed by setting the bit high, and then low again
             let mut dmcontrol = readback;
+            dmcontrol.set_dmactive(true);
             dmcontrol.set_hartreset(false);
 
             self.interface.write_dm_register(dmcontrol)?;
@@ -738,6 +741,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
 
         let mut dmcontrol: Dmcontrol = self.interface.read_dm_register()?;
 
+        dmcontrol.set_dmactive(true);
         dmcontrol.set_resethaltreq(true);
 
         self.interface.write_dm_register(dmcontrol)?;
@@ -754,6 +758,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
 
         let mut dmcontrol: Dmcontrol = self.interface.read_dm_register()?;
 
+        dmcontrol.set_dmactive(true);
         dmcontrol.set_clrresethaltreq(true);
 
         self.interface.write_dm_register(dmcontrol)?;

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -311,7 +311,6 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         }
 
         // acknowledge the reset, clear the halt request
-        let mut dmcontrol = Dmcontrol(0);
         dmcontrol.set_hartreset(false);
         dmcontrol.set_ndmreset(false);
         dmcontrol.set_ackhavereset(true);


### PR DESCRIPTION
Introduced in #2080

cc @bjoernQ can you tell me please if this (not using the already read `dmcontrol`, instead writing a new one with `dmactive=0`) is indeed a mistake or just an oversight?