### PR TITLE
Expose all probe settings via environment variables

### DIFF
--- a/changelog/added-expose-all-probe-options-as-env.md
+++ b/changelog/added-expose-all-probe-options-as-env.md
@@ -1,0 +1,1 @@
+Expose all probe options as environment variables

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -132,31 +132,39 @@ pub struct ReadWriteOptions {
 pub struct ProbeOptions {
     #[arg(long, env = "PROBE_RS_CHIP")]
     pub chip: Option<String>,
-    #[arg(value_name = "chip description file path", long)]
+    #[arg(
+        value_name = "chip description file path",
+        long,
+        env = "PROBE_RS_CHIP_DESCRIPTION_PATH"
+    )]
     pub chip_description_path: Option<PathBuf>,
 
     /// Protocol used to connect to chip. Possible options: [swd, jtag]
-    #[arg(long, help_heading = "PROBE CONFIGURATION")]
+    #[arg(long, env = "PROBE_RS_PROTOCOL", help_heading = "PROBE CONFIGURATION")]
     pub protocol: Option<WireProtocol>,
 
     /// Use this flag to select a specific probe in the list.
     ///
     /// Use '--probe VID:PID' or '--probe VID:PID:Serial' if you have more than one
     /// probe with the same VID:PID.",
-    #[arg(long = "probe", help_heading = "PROBE CONFIGURATION")]
+    #[arg(
+        long = "probe",
+        env = "PROBE_RS_PROBE",
+        help_heading = "PROBE CONFIGURATION"
+    )]
     pub probe_selector: Option<DebugProbeSelector>,
     /// The protocol speed in kHz.
-    #[arg(long, help_heading = "PROBE CONFIGURATION")]
+    #[arg(long, env = "PROBE_RS_SPEED", help_heading = "PROBE CONFIGURATION")]
     pub speed: Option<u32>,
     /// Use this flag to assert the nreset & ntrst pins during attaching the probe to
     /// the chip.
-    #[arg(long)]
+    #[arg(long, env = "PROBE_RS_CONNECT_UNDER_RESET")]
     pub connect_under_reset: bool,
-    #[arg(long)]
+    #[arg(long, env = "PROBE_RS_DRY_RUN")]
     pub dry_run: bool,
     /// Use this flag to allow all memory, including security keys and 3rd party
     /// firmware, to be erased even when it has read-only protection.
-    #[arg(long)]
+    #[arg(long, env = "PROBE_RS_ALLOW_ERASE_ALL")]
     pub allow_erase_all: bool,
 }
 


### PR DESCRIPTION
This helps when running multi probe system and you need to point the same commands to a lot of different probes