### PR TITLE
Don't use debug for end user output of probe types

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -207,7 +207,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
                     You can also set the [default.probe] config attribute \
                     (in your Embed.toml) to select which probe to use. \
                     For usage examples see https://github.com/probe-rs/cargo-embed/blob/master/src/config/default.toml .",
-                    list.iter().enumerate().fold(String::new(), |mut s, (num, link)| { let _ = writeln!(s, "[{num}]: {link:?}"); s })));
+                    list.iter().enumerate().fold(String::new(), |mut s, (num, link)| { let _ = writeln!(s, "[{num}]: {link}"); s })));
         }
         Err(OperationError::AttachingFailed {
             source,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -914,6 +914,7 @@ mod test {
 
     use core::panic;
     use std::collections::{BTreeMap, HashMap, VecDeque};
+    use std::fmt::Display;
     use std::path::PathBuf;
 
     use probe_rs::architecture::arm::ApAddress;
@@ -948,6 +949,12 @@ mod test {
 
     #[derive(Debug)]
     struct MockProbeFactory;
+
+    impl Display for MockProbeFactory {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("Mocked Probe")
+        }
+    }
 
     impl ProbeFactory for MockProbeFactory {
         fn open(

--- a/probe-rs/src/bin/probe-rs/cmd/list.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/list.rs
@@ -10,7 +10,7 @@ impl Cmd {
         if !probes.is_empty() {
             println!("The following debug probes were found:");
             for (num, link) in probes.iter().enumerate() {
-                println!("[{num}]: {link:?}");
+                println!("[{num}]: {link}");
             }
         } else {
             println!("No debug probes were found.");

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -556,11 +556,11 @@ pub enum OperationError {
 }
 
 /// Used in errors it can print a list of items.
-fn print_list(list: &[impl std::fmt::Debug]) -> String {
+fn print_list(list: &[impl std::fmt::Display]) -> String {
     let mut output = String::new();
 
     for (i, entry) in list.iter().enumerate() {
-        output.push_str(&format!("\n    {}. {:?}", i + 1, entry));
+        output.push_str(&format!("\n    {}. {}", i + 1, entry));
     }
 
     output

--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -487,7 +487,10 @@ impl Probe {
 /// An abstraction over a probe driver type.
 ///
 /// This trait has to be implemented by ever debug probe driver.
-pub trait ProbeFactory: std::any::Any + std::fmt::Debug + Sync {
+///
+/// The `std::fmt::Display` implementation will be used to display the probe in the list of available probes,
+/// and should return a human-readable name for the probe type.
+pub trait ProbeFactory: std::any::Any + std::fmt::Display + std::fmt::Debug + Sync {
     /// Creates a new boxed [`DebugProbe`] from a given [`DebugProbeSelector`].
     /// This will be called for all available debug drivers when discovering probes.
     /// When opening, it will open the first probe which succeeds during this call.
@@ -664,7 +667,7 @@ impl PartialEq for dyn ProbeFactory {
 }
 
 /// Gathers some information about a debug probe which was found during a scan.
-#[derive(Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DebugProbeInfo {
     /// The name of the debug probe.
     pub identifier: String,
@@ -682,11 +685,11 @@ pub struct DebugProbeInfo {
     pub hid_interface: Option<u8>,
 }
 
-impl std::fmt::Debug for DebugProbeInfo {
+impl std::fmt::Display for DebugProbeInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "{} (VID: {:04x}, PID: {:04x}, {}{:?})",
+            "{} (VID: {:04x}, PID: {:04x}, {}{})",
             self.identifier,
             self.vendor_id,
             self.product_id,

--- a/probe-rs/src/probe/cmsisdap/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/mod.rs
@@ -62,11 +62,12 @@ use bitvec::prelude::*;
 use super::common::{extract_idcodes, extract_ir_lengths, ScanChainError};
 
 /// A factory for creating [`CmsisDap`] probes.
+#[derive(Debug)]
 pub struct CmsisDapFactory;
 
-impl std::fmt::Debug for CmsisDapFactory {
+impl std::fmt::Display for CmsisDapFactory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CmsisDap").finish()
+        f.write_str("CMSIS-DAP")
     }
 }
 

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -42,10 +42,10 @@ pub fn list_cmsisdap_devices() -> Vec<DebugProbeInfo> {
                         && p.product_id == info.product_id
                         && p.serial_number == info.serial_number
                 }) {
-                    tracing::trace!("Adding new HID-only probe {:?}", info);
+                    tracing::trace!("Adding new HID-only probe {}", info);
                     probes.push(info)
                 } else {
-                    tracing::trace!("Ignoring duplicate {:?}", info);
+                    tracing::trace!("Ignoring duplicate {}", info);
                 }
             }
         }

--- a/probe-rs/src/probe/cmsisdap/tools.rs
+++ b/probe-rs/src/probe/cmsisdap/tools.rs
@@ -42,10 +42,10 @@ pub fn list_cmsisdap_devices() -> Vec<DebugProbeInfo> {
                         && p.product_id == info.product_id
                         && p.serial_number == info.serial_number
                 }) {
-                    tracing::trace!("Adding new HID-only probe {}", info);
+                    tracing::trace!("Adding new HID-only probe {:?}", info);
                     probes.push(info)
                 } else {
-                    tracing::trace!("Ignoring duplicate {}", info);
+                    tracing::trace!("Ignoring duplicate {:?}", info);
                 }
             }
         }

--- a/probe-rs/src/probe/espusbjtag/mod.rs
+++ b/probe-rs/src/probe/espusbjtag/mod.rs
@@ -25,11 +25,12 @@ use crate::architecture::riscv::dtm::jtag_dtm::JtagDtm;
 use probe_rs_target::ScanChainElement;
 
 /// Probe factory for USB JTAG interfaces built into certain ESP32 chips.
+#[derive(Debug)]
 pub struct EspUsbJtagFactory;
 
-impl std::fmt::Debug for EspUsbJtagFactory {
+impl std::fmt::Display for EspUsbJtagFactory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EspJtag").finish()
+        f.write_str("EspJtag")
     }
 }
 

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -243,11 +243,12 @@ impl JtagAdapter {
 }
 
 /// A factory for creating [`FtdiProbe`] instances.
+#[derive(Debug)]
 pub struct FtdiProbeFactory;
 
-impl std::fmt::Debug for FtdiProbeFactory {
+impl std::fmt::Display for FtdiProbeFactory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FTDI").finish()
+        f.write_str("FTDI")
     }
 }
 

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -57,11 +57,12 @@ const SWO_BUFFER_SIZE: u16 = 128;
 const TIMEOUT_DEFAULT: Duration = Duration::from_millis(500);
 
 /// Factory to create [`JLink`] probes.
+#[derive(Debug)]
 pub struct JLinkFactory;
 
-impl std::fmt::Debug for JLinkFactory {
+impl std::fmt::Display for JLinkFactory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("JLink").finish()
+        f.write_str("J-Link")
     }
 }
 

--- a/probe-rs/src/probe/stlink/mod.rs
+++ b/probe-rs/src/probe/stlink/mod.rs
@@ -42,11 +42,12 @@ const STLINK_MAX_WRITE_LEN: usize = 0xFFFC;
 const DP_PORT: u16 = 0xFFFF;
 
 /// A factory for creating [`StLink`] probes.
+#[derive(Debug)]
 pub struct StLinkFactory;
 
-impl std::fmt::Debug for StLinkFactory {
+impl std::fmt::Display for StLinkFactory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("StLink").finish()
+        f.write_str("ST-LINK")
     }
 }
 

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -149,11 +149,12 @@ impl RiscvChip {
 }
 
 /// Factory for creating [`WchLink`] probes.
+#[derive(Debug)]
 pub struct WchLinkFactory;
 
-impl std::fmt::Debug for WchLinkFactory {
+impl std::fmt::Display for WchLinkFactory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("WchLink").finish()
+        f.write_str("WchLink")
     }
 }
 


### PR DESCRIPTION
Somewhat opinionated, but `Debug` should be for debugging output, and `Display` should be used for user-facing output.  