### PR TITLE
Add note about musl-based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ cargo install probe-rs --locked --features cli
 
 This will compile the tools and place them into the cargo `bin` directory. See the [Cargo book](https://doc.rust-lang.org/cargo/commands/cargo-install.html) for details.
 
+**Note**: If you are using a musl-based Linux system like Alpine Linux, you have to set the compiler to
+dynamically link, instead of the default static linking. This prevents a [subtle bug](https://github.com/probe-rs/probe-rs/issues/2148) in `libudev-sys`<=0.1.4 from being introduced in the resulting binaries.
+
+For musl-based systems (e.g. Alpine Linux):
+
+```sh
+RUSTFLAGS="-C target-feature=-crt-static" cargo install probe-rs --locked --features cli
+```
+
 
 ### cargo-flash
 
@@ -181,6 +190,9 @@ Building requires Rust and Cargo which can be installed [using rustup](https://r
 
 # Fedora
 > sudo dnf install -y libudev-devel
+
+# Alpine
+> doas apk install eudev-dev
 ```
 
 ### Adding Targets


### PR DESCRIPTION
On musl-based systems you cannot properly build the CLI tools without specifying the `RUSTFLAGS=-C target-feature=-crt-static` which makes rustc no longer attempt to compile things statically (which is the default on musl-based systems). This PR adds a note about it in the README.md as well as instruction(s) on how to install the needed dependency on Alpine Linux.

See [#2148](https://github.com/probe-rs/probe-rs/issues/2148) for some of the details.