### PR TITLE
Rtt refactor vol 2

### DIFF
--- a/changelog/changed-embed-toml.md
+++ b/changelog/changed-embed-toml.md
@@ -1,0 +1,1 @@
+Reworked the `rtt` section in `Embed.toml`.

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -45,28 +45,40 @@ connect_under_reset = false
 [default.rtt]
 # Whether or not an RTTUI should be opened after flashing.
 enabled = false
-# How the target handles RTT outputs that won't fit in the buffer.  This can be
-# overridden per-channel. If left unset, the firmware will determine the default
-# for each RTT up channel.
-#   NoBlockSkip - Skip writing the data completely if it doesn't fit in its
-#                 entirety.
-#   NoBlockTrim - Write as much as possible of the data and ignore the rest.
-#   BlockIfFull - Spin until the host reads data.  Can result in app freezing.
-#
-# up_mode = "BlockIfFull"
-
-# A list of channel associations to be displayed. If left empty, all channels are displayed.
-# up, down (Optional) - RTT channel numbers
-# name     (Optional) - String to be displayed in the RTTUI tab
-# up_mode  (Optional) - RTT channel specific as described above
-# format   (Required) - How to interpret data from target firmware.  One of:
-#              String - Directly show output from the target
-#              Defmt  - Format output on the host, see https://defmt.ferrous-systems.com/
-#              BinaryLE - Display as raw hex
-# socket   (Optional, up channel only) - Server socket address (for optional external frontend or endpoint).
-channels = [
-    # { up = 0, down = 0, name = "name", up_mode = "BlockIfFull", format = "Defmt" },
-    # { up = 1, down = 0, name = "name", up_mode = "BlockIfFull", format = "String", socket = "127.0.0.1:12345" },
+# A list of up (target -> host) channel settings associations to be displayed. If left empty, all channels are displayed.
+# channel_number      - RTT channel identifier number
+# mode     (Optional) - RTT operation mode. Describes how the target handles RTT outputs that won't
+#                       fit in the buffer. If left unset, the firmware will determine the default
+#                       for each RTT up channel.
+#              * NoBlockSkip - Skip writing the data completely if it doesn't fit in its
+#                            entirety.
+#              * NoBlockTrim - Write as much as possible of the data and ignore the rest.
+#              * BlockIfFull - Spin until the host reads data.  Can result in app freezing.
+# format   (Optional) - How to interpret data from target firmware.  One of:
+#              * String - Directly show output from the target (default)
+#              * Defmt  - Format output on the host, see https://defmt.ferrous-systems.com/
+#              * BinaryLE - Display as raw hex
+# socket   (Optional) - Server socket address (for optional external frontend or endpoint).
+# TODO: change format into objects, add per-format settings (e.g. defmt format string)
+# TODO: per-channel log settings
+up_channels = [
+    # { channel_number = 0, mode = "BlockIfFull", format = "Defmt" },
+    # { channel_number = 1, mode = "BlockIfFull", format = "String", socket = "127.0.0.1:12345" },
+]
+# A list of down (host -> target) channel settings. You can select a down channel for each UI tab,
+# which will be used to send data to the target.
+down_channels = [
+    # { channel_number: 0, mode = "BlockIfFull" }
+]
+# UI tab settings. All up channels are displayed, except when hidden here. You can specify how each
+# tab is displayed and whether they allow sending data to the target.
+# up_channel              - The channel_number of the RTT up channel to display
+# hide         (Optional) - Whether to hide the tab. Defaults to false.
+# down_channel (Optional) - The channel_number of the RTT down channel to use for this tab.
+# name         (Optional) - String to be displayed in the RTTUI tab. Defaults to the channel name.
+tabs = [
+    { up_channel = 0, down_channel = 0, name = "name" },
+    { up_channel = 1, hide = true },
 ]
 # The duration in ms for which the logger should retry to attach to RTT.
 timeout = 3000

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -69,10 +69,11 @@ log_path = "./logs"
 #              * Defmt  - Format output on the host, see https://defmt.ferrous-systems.com/
 #              * BinaryLE - Display as raw hex
 # show_location (Optional) - Whether to show the location of defmt messages in the UI.
+# show_timestamps (Optional) - Whether to show the timestamps of String messages in the UI.
 # socket   (Optional) - Server socket address (for optional external frontend or endpoint).
 up_channels = [
     # { channel = 0, mode = "BlockIfFull", format = "Defmt", show_location = true },
-    # { channel = 1, mode = "BlockIfFull", format = "String", socket = "127.0.0.1:12345" },
+    # { channel = 1, mode = "BlockIfFull", format = "String", show_timestamps = false, socket = "127.0.0.1:12345" },
 ]
 
 # A list of down (host -> target) channel settings. You can select a down channel for each UI tab,

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -45,8 +45,16 @@ connect_under_reset = false
 [default.rtt]
 # Whether or not an RTTUI should be opened after flashing.
 enabled = false
+# The duration in ms for which the logger should retry to attach to RTT.
+timeout = 3000
+# Whether timestamps in the RTTUI are enabled
+show_timestamps = true
+# Whether to save rtt history buffer on exit.
+log_enabled = false
+# Where to save rtt history buffer relative to manifest path.
+log_path = "./logs"
 # A list of up (target -> host) channel settings associations to be displayed. If left empty, all channels are displayed.
-# channel_number      - RTT channel identifier number
+# object key  - RTT channel identifier number
 # mode     (Optional) - RTT operation mode. Describes how the target handles RTT outputs that won't
 #                       fit in the buffer. If left unset, the firmware will determine the default
 #                       for each RTT up channel.
@@ -62,14 +70,20 @@ enabled = false
 # TODO: change format into objects, add per-format settings (e.g. defmt format string)
 # TODO: per-channel log settings
 up_channels = [
-    # { channel_number = 0, mode = "BlockIfFull", format = "Defmt" },
-    # { channel_number = 1, mode = "BlockIfFull", format = "String", socket = "127.0.0.1:12345" },
+    # { channel = 0, mode = "BlockIfFull", format = "Defmt" },
+    # { channel = 1, mode = "BlockIfFull", format = "String", socket = "127.0.0.1:12345" },
 ]
+
 # A list of down (host -> target) channel settings. You can select a down channel for each UI tab,
 # which will be used to send data to the target.
+# object key  - RTT channel identifier number
+# mode     (Optional) - RTT operation mode. Describes how the target handles RTT outputs that won't
+#                       fit in the buffer. If left unset, the firmware will determine the default
+#                       for each RTT down channel.
 down_channels = [
-    # { channel_number: 0, mode = "BlockIfFull" }
+    # { channel = 0, mode = "BlockIfFull" }
 ]
+
 # UI tab settings. All up channels are displayed, except when hidden here. You can specify how each
 # tab is displayed and whether they allow sending data to the target.
 # up_channel              - The channel_number of the RTT up channel to display
@@ -77,17 +91,9 @@ down_channels = [
 # down_channel (Optional) - The channel_number of the RTT down channel to use for this tab.
 # name         (Optional) - String to be displayed in the RTTUI tab. Defaults to the channel name.
 tabs = [
-    { up_channel = 0, down_channel = 0, name = "name" },
-    { up_channel = 1, hide = true },
+    # { up_channel = 0, down_channel = 0, name = "My channel" },
+    # { up_channel = 1, hide = true },
 ]
-# The duration in ms for which the logger should retry to attach to RTT.
-timeout = 3000
-# Whether timestamps in the RTTUI are enabled
-show_timestamps = true
-# Whether to save rtt history buffer on exit.
-log_enabled = false
-# Where to save rtt history buffer relative to manifest path.
-log_path = "./logs"
 
 [default.gdb]
 # Whether or not a GDB server should be opened after flashing.

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -49,6 +49,8 @@ enabled = false
 timeout = 3000
 # Whether timestamps in the RTTUI are enabled
 show_timestamps = true
+# Whether locations for defmt messages are enabled in the RTTUI
+show_location = false
 # Whether to save rtt history buffer on exit.
 log_enabled = false
 # Where to save rtt history buffer relative to manifest path.
@@ -66,11 +68,10 @@ log_path = "./logs"
 #              * String - Directly show output from the target (default)
 #              * Defmt  - Format output on the host, see https://defmt.ferrous-systems.com/
 #              * BinaryLE - Display as raw hex
+# show_location (Optional) - Whether to show the location of defmt messages in the UI.
 # socket   (Optional) - Server socket address (for optional external frontend or endpoint).
-# TODO: change format into objects, add per-format settings (e.g. defmt format string)
-# TODO: per-channel log settings
 up_channels = [
-    # { channel = 0, mode = "BlockIfFull", format = "Defmt" },
+    # { channel = 0, mode = "BlockIfFull", format = "Defmt", show_location = true },
     # { channel = 1, mode = "BlockIfFull", format = "String", socket = "127.0.0.1:12345" },
 ]
 

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -10,7 +10,7 @@ use std::{path::PathBuf, time::Duration};
 
 use crate::util::logging::LevelFilter;
 
-use super::rttui::channel::ChannelConfig;
+use super::rttui::tab::TabConfig;
 
 /// A struct which holds all configs.
 #[derive(Debug, Clone)]
@@ -84,7 +84,7 @@ pub struct Rtt {
     /// Up mode, when not specified per-channel.  Target picks if neither is set
     pub up_mode: Option<ChannelMode>,
     /// Channels to be displayed, and options for them
-    pub channels: Vec<ChannelConfig>,
+    pub channels: Vec<TabConfig>,
     /// Connection timeout in ms.
     #[serde(with = "duration_ms")]
     pub timeout: Duration,

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -87,6 +87,13 @@ pub struct UpChannelConfig {
     pub show_location: Option<bool>,
     #[serde(default)]
     pub socket: Option<SocketAddr>,
+    // TODO: it should be possible to move these into DataFormat
+    #[serde(default)]
+    /// Control the inclusion of timestamps for DataFormat::String.
+    pub show_timestamps: Option<bool>,
+    #[serde(default)]
+    /// Control the output format for DataFormat::Defmt.
+    pub defmt_log_format: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -6,9 +6,9 @@ use figment::{
 use probe_rs::probe::WireProtocol;
 use probe_rs::rtt::ChannelMode;
 use serde::{Deserialize, Serialize};
-use std::{path::PathBuf, time::Duration};
+use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
-use crate::util::logging::LevelFilter;
+use crate::util::{logging::LevelFilter, rtt::DataFormat};
 
 use super::rttui::tab::TabConfig;
 
@@ -76,6 +76,24 @@ pub struct General {
     pub connect_under_reset: bool,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct UpChannelConfig {
+    pub channel: usize,
+    #[serde(default)]
+    pub mode: Option<ChannelMode>,
+    #[serde(default)]
+    pub format: DataFormat,
+    #[serde(default)]
+    pub socket: Option<SocketAddr>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DownChannelConfig {
+    pub channel: usize,
+    #[serde(default)]
+    pub mode: Option<ChannelMode>,
+}
+
 /// The rtt config struct holding all the possible rtt options.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -84,7 +102,11 @@ pub struct Rtt {
     /// Up mode, when not specified per-channel.  Target picks if neither is set
     pub up_mode: Option<ChannelMode>,
     /// Channels to be displayed, and options for them
-    pub channels: Vec<TabConfig>,
+    pub up_channels: Vec<UpChannelConfig>,
+    /// Channels to be displayed, and options for them
+    pub down_channels: Vec<DownChannelConfig>,
+    ///
+    pub tabs: Vec<TabConfig>,
     /// Connection timeout in ms.
     #[serde(with = "duration_ms")]
     pub timeout: Duration,

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -84,6 +84,8 @@ pub struct UpChannelConfig {
     #[serde(default)]
     pub format: DataFormat,
     #[serde(default)]
+    pub show_location: Option<bool>,
+    #[serde(default)]
     pub socket: Option<SocketAddr>,
 }
 
@@ -105,13 +107,15 @@ pub struct Rtt {
     pub up_channels: Vec<UpChannelConfig>,
     /// Channels to be displayed, and options for them
     pub down_channels: Vec<DownChannelConfig>,
-    ///
+    /// UI tab configuration
     pub tabs: Vec<TabConfig>,
     /// Connection timeout in ms.
     #[serde(with = "duration_ms")]
     pub timeout: Duration,
     /// Whether to show timestamps in RTTUI
     pub show_timestamps: bool,
+    /// Whether to show location info in RTTUI for defmt channels.
+    pub show_location: bool,
     /// Whether to save rtt history buffer on exit to file named history.txt
     pub log_enabled: bool,
     /// Where to save rtt history buffer relative to manifest path.

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -122,6 +122,15 @@ pub struct Rtt {
     pub log_path: PathBuf,
 }
 
+impl Rtt {
+    /// Returns the configuration for the specified up channel number, if it exists.
+    pub fn up_channel_config(&self, channel_number: usize) -> Option<&UpChannelConfig> {
+        self.up_channels
+            .iter()
+            .find(|ch| ch.channel == channel_number)
+    }
+}
+
 mod duration_ms {
     use std::time::Duration;
 

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -333,7 +333,7 @@ fn run_rttui_app(
     };
 
     // Configure rtt channels according to configuration
-    rtt_config(session, &config, &mut rtt)?;
+    configure_rtt_modes(session, &config, &mut rtt)?;
 
     tracing::info!("RTT initialized.");
 
@@ -383,7 +383,7 @@ fn run_rttui_app(
     }
 }
 
-fn rtt_config(
+fn configure_rtt_modes(
     session: &Mutex<Session>,
     config: &config::Config,
     rtt: &mut Rtt,

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -429,7 +429,7 @@ fn run_rttui_app(
         / 1_000_000;
 
     let logname = format!("{name}_{chip_name}_{timestamp_millis}");
-    let mut app = rttui::app::App::new(rtt, &config, logname, defmt_state.as_ref())?;
+    let mut app = rttui::app::App::new(rtt, config, logname, defmt_state.as_ref())?;
     loop {
         app.render();
 

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -320,7 +320,9 @@ fn run_rttui_app(
             channel_name: None,
             data_format: channel_config.format,
             show_timestamps: config.rtt.show_timestamps,
-            show_location: true,
+            show_location: channel_config
+                .show_location
+                .unwrap_or(config.rtt.show_location),
             defmt_log_format: None,
         });
     }

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -334,11 +334,10 @@ fn run_rttui_app(
     }
     // In case we have down channels without up channels, add them separately.
     for channel_config in config.rtt.down_channels.iter() {
-        if !config
+        if config
             .rtt
-            .up_channels
-            .iter()
-            .any(|ch| ch.channel == channel_config.channel)
+            .up_channel_config(channel_config.channel)
+            .is_none()
         {
             // Set up channel defaults, we don't read from it anyway.
             rtt_config.channels.push(RttChannelConfig {

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -306,7 +306,7 @@ fn run_rttui_app(
     config: config::Config,
     elf_path: &Path,
     timezone_offset: UtcOffset,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     // Transform channel configurations
     let mut rtt_config = RttConfig {
         enabled: true,
@@ -314,7 +314,6 @@ fn run_rttui_app(
         channels: vec![],
     };
 
-    // Now we know that we only encounter unique channel numbers.
     for channel_config in config.rtt.up_channels.iter() {
         rtt_config.channels.push(RttChannelConfig {
             channel_number: Some(channel_config.channel),

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -523,7 +523,7 @@ fn rtt_attach(
 
             match crate::util::rtt::attach_to_rtt(&mut core, &memory_map, rtt_region, elf_file) {
                 Ok(Some(rtt)) => {
-                    let app = RttActiveTarget::new(rtt, elf_file, &rtt_config, timestamp_offset);
+                    let app = RttActiveTarget::new(rtt, elf_file, rtt_config, timestamp_offset);
 
                     match app {
                         Ok(app) => return Ok(Some(app)),

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -439,19 +439,12 @@ fn configure_rtt_modes(
     let default_up_mode = config.rtt.up_mode;
 
     // TODO: also configure down channels
-    for channel in rtt.active_channels.iter() {
-        let Some(up_channel) = &channel.up_channel else {
-            continue;
-        };
-        let Some(channel_config) = config
+    for up_channel in rtt.active_up_channels.values() {
+        if let Some(mode) = config
             .rtt
-            .up_channels
-            .iter()
-            .find(|ch| ch.channel == up_channel.number())
-        else {
-            continue;
-        };
-        if let Some(mode) = channel_config.mode.or(default_up_mode) {
+            .up_channel_config(up_channel.number())
+            .and_then(|ch| ch.mode.or(default_up_mode))
+        {
             // Only set the mode when the config file says to,
             // when not set explicitly, the firmware picks.
             tracing::debug!("Setting RTT channel {} to {:?}", up_channel.number(), &mode);

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -416,12 +416,12 @@ fn run_rttui_app(
             let mut session_handle = session.lock().unwrap();
             let mut core = session_handle.core(0)?;
 
-            app.poll_rtt(&mut core)?;
-
             if app.handle_event(&mut core) {
                 logging::println("Shutting down.");
                 return Ok(());
             }
+
+            app.poll_rtt(&mut core)?;
         }
 
         std::thread::sleep(Duration::from_millis(10));

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -329,7 +329,7 @@ impl<'defmt> App<'defmt> {
             }
             KeyCode::Enter => self.push_rtt(core),
             KeyCode::Char(c) => self.current_tab_mut().append_char(c),
-            KeyCode::Backspace => _ = self.current_tab_mut().pop_char(),
+            KeyCode::Backspace => self.current_tab_mut().pop_char(),
             KeyCode::PageUp => self.current_tab_mut().scroll_up(),
             KeyCode::PageDown => self.current_tab_mut().scroll_down(),
             _ => {}

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -177,6 +177,7 @@ impl<'defmt> App<'defmt> {
                 let scroll_offset = tab.scroll_offset();
 
                 let height = chunks[1].height as usize;
+                let width = chunks[1].width as usize;
 
                 let up_channel = self
                     .up_channels
@@ -191,7 +192,7 @@ impl<'defmt> App<'defmt> {
                         // We need to collect to generate message_num :(
                         messages
                             .iter()
-                            .flat_map(|m| textwrap::wrap(m, chunks[1].width as usize))
+                            .flat_map(|m| textwrap::wrap(m, width))
                             .collect()
                     }
                     ChannelData::Binary { data } => {
@@ -205,7 +206,7 @@ impl<'defmt> App<'defmt> {
                                 output
                             },
                         );
-                        textwrap::wrap(&binary_message, chunks[1].width as usize)
+                        textwrap::wrap(&binary_message, width)
                     }
                 };
 

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -150,6 +150,7 @@ impl<'defmt> App<'defmt> {
 
                 let height = chunks[1].height as usize;
 
+                // FIXME: Collecting messages over and over again isn't the most efficient thing
                 let binary_message;
                 let messages_wrapped = match tab.data() {
                     TabData::Strings { messages, .. } => {
@@ -160,11 +161,13 @@ impl<'defmt> App<'defmt> {
                             .collect()
                     }
                     TabData::Binary { data } => {
-                        // probably pretty bad
                         binary_message = data.iter().fold(
-                            String::with_capacity(data.len() * 6),
+                            String::with_capacity(data.len() * 5 - 1),
                             |mut output, byte| {
-                                let _ = write(&mut output, format_args!("{byte:#04x}, "));
+                                if !output.is_empty() {
+                                    output.push(' ');
+                                }
+                                let _ = write(&mut output, format_args!("{byte:#04x}"));
                                 output
                             },
                         );

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -9,8 +9,7 @@ use ratatui::{
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, Paragraph, Tabs},
+    widgets::{Block, Borders, List, Paragraph, Tabs},
     Terminal,
 };
 use std::{collections::BTreeMap, io::Write};
@@ -175,18 +174,16 @@ impl<'defmt> App<'defmt> {
 
                 let message_num = messages_wrapped.len();
 
-                let messages: Vec<ListItem> = messages_wrapped
-                    .iter()
+                let messages = messages_wrapped
+                    .into_iter()
                     .skip(message_num - (height + scroll_offset).min(message_num))
-                    .take(height)
-                    .map(|s| ListItem::new(Line::raw::<&str>(s.as_ref())))
-                    .collect();
+                    .take(height);
 
                 let messages = List::new(messages).block(Block::default().borders(Borders::NONE));
                 f.render_widget(messages, chunks[1]);
 
                 if has_down_channel {
-                    let input = Paragraph::new(Line::raw(&input))
+                    let input = Paragraph::new(input.as_str())
                         .style(Style::default().fg(Color::Yellow).bg(Color::Blue));
                     f.render_widget(input, chunks[2]);
                 }
@@ -343,10 +340,7 @@ fn render_tabs(
     tabs: &[Tab<'_>],
     current_tab: usize,
 ) {
-    let tab_names = tabs
-        .iter()
-        .map(|t| Line::from(t.name()))
-        .collect::<Vec<_>>();
+    let tab_names = tabs.iter().map(|t| t.name());
     let tabs = Tabs::new(tab_names)
         .select(current_tab)
         .style(Style::default().fg(Color::Black).bg(Color::Yellow))

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -58,41 +58,39 @@ impl<'defmt> App<'defmt> {
             }
         }
 
-        if !config.rtt.channels.is_empty() {
-            for channel in config.rtt.channels {
-                tabs.push(ChannelState::new(
-                    channel.up.and_then(|up| up_channels.remove(&up)),
-                    channel.down.and_then(|down| down_channels.remove(&down)),
-                    channel.name,
-                    channel.format,
-                    channel.socket,
-                    defmt_state,
-                ));
-            }
-        } else {
-            // Display all detected channels as String channels
-            for channel in up_channels.into_values() {
-                let number = channel.number();
-                tabs.push(ChannelState::new(
-                    Some(channel),
-                    down_channels.remove(&number),
-                    None,
-                    DataFormat::String,
-                    None,
-                    defmt_state,
-                ));
-            }
+        for channel in config.rtt.channels {
+            tabs.push(ChannelState::new(
+                channel.up.and_then(|up| up_channels.remove(&up)),
+                channel.down.and_then(|down| down_channels.remove(&down)),
+                channel.name,
+                channel.format,
+                channel.socket,
+                defmt_state,
+            ));
+        }
 
-            for channel in down_channels.into_values() {
-                tabs.push(ChannelState::new(
-                    None,
-                    Some(channel),
-                    None,
-                    DataFormat::String,
-                    None,
-                    defmt_state,
-                ));
-            }
+        // Display all detected channels as String channels
+        for channel in up_channels.into_values() {
+            let number = channel.number();
+            tabs.push(ChannelState::new(
+                Some(channel),
+                down_channels.remove(&number),
+                None,
+                DataFormat::String,
+                None,
+                defmt_state,
+            ));
+        }
+
+        for channel in down_channels.into_values() {
+            tabs.push(ChannelState::new(
+                None,
+                Some(channel),
+                None,
+                DataFormat::String,
+                None,
+                defmt_state,
+            ));
         }
 
         // Code farther down relies on tabs being configured and might panic

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -40,7 +40,7 @@ pub struct App<'defmt> {
 impl<'defmt> App<'defmt> {
     pub fn new(
         rtt: RttActiveTarget,
-        config: &config::Config,
+        config: config::Config,
         logname: String,
         defmt_state: Option<&'defmt DefmtState>,
     ) -> Result<Self> {
@@ -59,15 +59,15 @@ impl<'defmt> App<'defmt> {
         }
 
         if !config.rtt.channels.is_empty() {
-            for channel in &config.rtt.channels {
+            for channel in config.rtt.channels {
                 tabs.push(ChannelState::new(
                     channel.up.and_then(|up| up_channels.remove(&up)),
                     channel.down.and_then(|down| down_channels.remove(&down)),
-                    channel.name.clone(),
+                    channel.name,
                     channel.format,
                     channel.socket,
                     defmt_state,
-                ))
+                ));
             }
         } else {
             // Display all detected channels as String channels

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -54,43 +54,41 @@ impl<'defmt> App<'defmt> {
         let mut down_channels = BTreeMap::new();
 
         // Create tab config based on detected channels
-        for channel in rtt.active_channels {
-            if let Some(up) = channel.up_channel {
-                let number = up.number();
-                if !tab_config.iter().any(|tab| tab.up_channel == number) {
-                    tab_config.push(TabConfig {
-                        up_channel: number,
-                        down_channel: None,
-                        name: Some(up.channel_name.clone()),
-                        hide: false,
-                    });
-                }
-
-                if up_channels.insert(number, (up, None)).is_some() {
-                    return Err(anyhow!("Duplicate up channel configuration: {number}"));
-                }
+        for up in rtt.active_up_channels.into_values() {
+            let number = up.number();
+            if !tab_config.iter().any(|tab| tab.up_channel == number) {
+                tab_config.push(TabConfig {
+                    up_channel: number,
+                    down_channel: None,
+                    name: Some(up.channel_name.clone()),
+                    hide: false,
+                });
             }
-            if let Some(down) = channel.down_channel {
-                let number = down.number();
-                if !tab_config
-                    .iter()
-                    .any(|tab| tab.down_channel == Some(number))
-                {
-                    tab_config.push(TabConfig {
-                        up_channel: if up_channels.contains_key(&number) {
-                            number
-                        } else {
-                            0
-                        },
-                        down_channel: Some(number),
-                        name: Some(down.channel_name.clone()),
-                        hide: false,
-                    });
-                }
 
-                if down_channels.insert(number, down).is_some() {
-                    return Err(anyhow!("Duplicate down channel configuration: {number}"));
-                }
+            if up_channels.insert(number, (up, None)).is_some() {
+                return Err(anyhow!("Duplicate up channel configuration: {number}"));
+            }
+        }
+        for down in rtt.active_down_channels.into_values() {
+            let number = down.number();
+            if !tab_config
+                .iter()
+                .any(|tab| tab.down_channel == Some(number))
+            {
+                tab_config.push(TabConfig {
+                    up_channel: if up_channels.contains_key(&number) {
+                        number
+                    } else {
+                        0
+                    },
+                    down_channel: Some(number),
+                    name: Some(down.channel_name.clone()),
+                    hide: false,
+                });
+            }
+
+            if down_channels.insert(number, down).is_some() {
+                return Err(anyhow!("Duplicate down channel configuration: {number}"));
             }
         }
 

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -254,7 +254,7 @@ impl<'defmt> App<'defmt> {
                             for line in data {
                                 if let Err(e) = writeln!(file, "{line}") {
                                     eprintln!("\nError writing log channel {i}: {e}");
-                                    continue;
+                                    break;
                                 }
                             }
                             // Flush file

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
@@ -36,16 +36,6 @@ impl std::fmt::Debug for ChannelData {
 }
 
 impl ChannelData {
-    fn new_strings() -> Self {
-        Self::Strings {
-            messages: Vec::new(),
-        }
-    }
-
-    fn new_binary() -> Self {
-        Self::Binary { data: Vec::new() }
-    }
-
     fn clear(&mut self) {
         match self {
             Self::Strings { messages } => messages.clear(),
@@ -87,8 +77,10 @@ impl<'defmt> ChannelState<'defmt> {
             name,
             scroll_offset: 0,
             data: match data {
-                DataFormat::String | DataFormat::Defmt => ChannelData::new_strings(),
-                DataFormat::BinaryLE => ChannelData::new_binary(),
+                DataFormat::String | DataFormat::Defmt => ChannelData::Strings {
+                    messages: Vec::new(),
+                },
+                DataFormat::BinaryLE => ChannelData::Binary { data: Vec::new() },
             },
             tcp_socket,
             defmt_info,

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
@@ -1,0 +1,78 @@
+use std::net::SocketAddr;
+
+use crate::{
+    cmd::cargo_embed::rttui::tcp::TcpPublisher,
+    util::rtt::{ChannelDataCallbacks, ChannelDataConfig, DefmtState, RttActiveUpChannel},
+};
+
+pub enum ChannelData {
+    Strings { messages: Vec<String> },
+    Binary { data: Vec<u8> },
+}
+
+impl ChannelDataCallbacks for (&mut Option<TcpPublisher>, &mut ChannelData) {
+    fn on_string_data(&mut self, _channel: usize, data: String) -> anyhow::Result<()> {
+        if let Some(ref mut stream) = self.0 {
+            stream.send(data.as_bytes());
+        }
+
+        let ChannelData::Strings { messages } = &mut self.1 else {
+            unreachable!()
+        };
+        for line in data.split_terminator('\n') {
+            messages.push(line.to_string());
+        }
+
+        Ok(())
+    }
+
+    fn on_binary_data(&mut self, _channel: usize, incoming: &[u8]) -> anyhow::Result<()> {
+        if let Some(ref mut stream) = self.0 {
+            stream.send(incoming);
+        }
+
+        let ChannelData::Binary { data } = &mut self.1 else {
+            unreachable!()
+        };
+        data.extend_from_slice(incoming);
+
+        Ok(())
+    }
+}
+
+pub struct UpChannel<'defmt> {
+    rtt_channel: RttActiveUpChannel,
+    defmt_state: Option<&'defmt DefmtState>,
+    tcp_stream: Option<TcpPublisher>,
+    pub data: ChannelData,
+}
+
+impl<'defmt> UpChannel<'defmt> {
+    pub fn new(
+        rtt_channel: RttActiveUpChannel,
+        defmt_state: Option<&'defmt DefmtState>,
+        tcp_stream: Option<SocketAddr>,
+    ) -> Self {
+        Self {
+            data: match rtt_channel.data_format {
+                ChannelDataConfig::String { .. } | ChannelDataConfig::Defmt { .. } => {
+                    ChannelData::Strings {
+                        messages: Vec::new(),
+                    }
+                }
+                ChannelDataConfig::BinaryLE => ChannelData::Binary { data: Vec::new() },
+            },
+            defmt_state,
+            tcp_stream: tcp_stream.map(TcpPublisher::new),
+            rtt_channel,
+        }
+    }
+
+    pub fn poll_rtt(&mut self, core: &mut probe_rs::Core<'_>) -> anyhow::Result<()> {
+        self.rtt_channel.poll_process_rtt_data(
+            core,
+            self.defmt_state,
+            &mut (&mut self.tcp_stream, &mut self.data),
+        )
+    }
+}

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/mod.rs
@@ -1,4 +1,4 @@
 pub mod app;
-pub mod channel;
 pub mod event;
+pub mod tab;
 pub mod tcp;

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/mod.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod channel;
 pub mod event;
 pub mod tab;
 pub mod tcp;

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use probe_rs::Core;
 
-use crate::util::rtt::RttActiveDownChannel;
+use crate::util::rtt::{RttActiveDownChannel, RttActiveUpChannel};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TabConfig {
@@ -24,13 +24,15 @@ pub struct Tab {
 }
 
 impl Tab {
-    pub fn new(up_channel: usize, down_channel: Option<usize>, name: Option<String>) -> Self {
-        let name = name.unwrap_or_else(|| "Unnamed channel".to_owned());
-
+    pub fn new(
+        up_channel: &RttActiveUpChannel,
+        down_channel: Option<&RttActiveDownChannel>,
+        name: Option<String>,
+    ) -> Self {
         Self {
-            up_channel,
-            down_channel: down_channel.map(|id| (id, String::new())),
-            name,
+            up_channel: up_channel.number(),
+            down_channel: down_channel.map(|down| (down.number(), String::new())),
+            name: name.unwrap_or_else(|| up_channel.channel_name.clone()),
             scroll_offset: 0,
         }
     }

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
@@ -1,114 +1,38 @@
-use std::fmt;
-use std::net::SocketAddr;
+use std::collections::BTreeMap;
 
-use probe_rs::rtt::ChannelMode;
 use probe_rs::Core;
 
-use crate::cmd::cargo_embed::rttui::tcp::TcpPublisher;
-use crate::util::rtt::{
-    ChannelDataCallbacks, DataFormat, DefmtState, RttActiveDownChannel, RttActiveUpChannel,
-};
+use crate::util::rtt::RttActiveDownChannel;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-// TODO: separate this (UI config) from channel config
 pub struct TabConfig {
-    pub up: Option<usize>,
-    pub down: Option<usize>,
+    pub up_channel: usize,
+    #[serde(default)]
+    pub down_channel: Option<usize>,
+    #[serde(default)]
     pub name: Option<String>,
-    pub up_mode: Option<ChannelMode>,
-    pub format: DataFormat,
-    pub socket: Option<SocketAddr>,
-}
-
-pub enum TabData {
-    Strings { messages: Vec<String> },
-    Binary { data: Vec<u8> },
-}
-
-impl std::fmt::Debug for TabData {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Strings { messages: data } => {
-                f.debug_struct("Strings").field("data", data).finish()
-            }
-            Self::Binary { data } => f.debug_struct("Binary").field("data", data).finish(),
-        }
-    }
-}
-
-impl TabData {
-    fn clear(&mut self) {
-        match self {
-            Self::Strings { messages } => messages.clear(),
-            Self::Binary { data, .. } => data.clear(),
-        }
-    }
+    #[serde(default)]
+    pub hide: bool,
 }
 
 #[derive(Debug)]
-pub struct Tab<'defmt> {
-    up_channel: Option<RttActiveUpChannel>,
-    down_channel: Option<RttActiveDownChannel>,
+pub struct Tab {
+    up_channel: usize,
+    down_channel: Option<(usize, String)>,
     name: String,
-    data: TabData,
-    defmt_info: Option<&'defmt DefmtState>,
     scroll_offset: usize,
-    tcp_socket: Option<TcpPublisher>,
 }
 
-impl<'defmt> Tab<'defmt> {
-    pub fn new(
-        up_channel: Option<RttActiveUpChannel>,
-        down_channel: Option<RttActiveDownChannel>,
-        name: Option<String>,
-        data: DataFormat,
-        tcp_socket: Option<SocketAddr>,
-        defmt_info: Option<&'defmt DefmtState>,
-    ) -> Self {
-        let name = name
-            .or_else(|| up_channel.as_ref().map(|up| up.channel_name.clone()))
-            .or_else(|| down_channel.as_ref().map(|down| down.channel_name.clone()))
-            .unwrap_or_else(|| "Unnamed channel".to_owned());
-
-        let tcp_socket = tcp_socket.map(TcpPublisher::new);
+impl Tab {
+    pub fn new(up_channel: usize, down_channel: Option<usize>, name: Option<String>) -> Self {
+        let name = name.unwrap_or_else(|| "Unnamed channel".to_owned());
 
         Self {
             up_channel,
-            down_channel,
+            down_channel: down_channel.map(|id| (id, String::new())),
             name,
             scroll_offset: 0,
-            data: match data {
-                DataFormat::String | DataFormat::Defmt => TabData::Strings {
-                    messages: Vec::new(),
-                },
-                DataFormat::BinaryLE => TabData::Binary { data: Vec::new() },
-            },
-            tcp_socket,
-            defmt_info,
         }
-    }
-
-    pub fn has_down_channel(&self) -> bool {
-        self.down_channel.is_some()
-    }
-
-    pub fn append_char(&mut self, c: char) {
-        if let Some(down) = self.down_channel.as_mut() {
-            down.input_mut().push(c);
-        }
-    }
-
-    pub fn pop_char(&mut self) {
-        if let Some(down) = self.down_channel.as_mut() {
-            down.input_mut().pop();
-        }
-    }
-
-    pub fn input(&self) -> &str {
-        self.down_channel
-            .as_ref()
-            .map(|down| down.input())
-            .unwrap_or_default()
     }
 
     pub fn name(&self) -> &str {
@@ -123,6 +47,10 @@ impl<'defmt> Tab<'defmt> {
         self.scroll_offset = value;
     }
 
+    pub fn up_channel(&self) -> usize {
+        self.up_channel
+    }
+
     pub fn scroll_up(&mut self) {
         self.set_scroll_offset(self.scroll_offset().saturating_add(1));
     }
@@ -133,89 +61,36 @@ impl<'defmt> Tab<'defmt> {
 
     pub fn clear(&mut self) {
         self.set_scroll_offset(0);
-        self.data.clear();
-        if let Some(up) = self.up_channel.as_mut() {
-            up.data_format.clear();
+    }
+
+    pub fn push_input(&mut self, c: char) {
+        if let Some((_, input)) = self.down_channel.as_mut() {
+            input.push(c);
         }
     }
 
-    /// Polls the RTT target for new data on the specified channel.
-    ///
-    /// Processes all the new data and adds it to the linebuffer of the respective channel.
-    ///
-    /// # Errors
-    /// This function can return a [`time::Error`] if getting the local time or formatting a timestamp fails.
-    pub fn poll_rtt(&mut self, core: &mut Core) -> Result<(), time::Error> {
-        struct DataCollector<'a> {
-            data: &'a mut TabData,
-            scroll_offset: &'a mut usize,
-            tcp_stream: Option<&'a mut TcpPublisher>,
+    pub fn pop_input(&mut self) {
+        if let Some((_, input)) = self.down_channel.as_mut() {
+            input.pop();
         }
-        impl ChannelDataCallbacks for DataCollector<'_> {
-            fn on_string_data(&mut self, _channel: usize, data: String) -> anyhow::Result<()> {
-                if let Some(ref mut stream) = self.tcp_stream {
-                    stream.send(data.as_bytes());
-                }
+    }
 
-                let messages = match &mut self.data {
-                    TabData::Strings { messages, .. } => messages,
-                    TabData::Binary { .. } => {
-                        unreachable!()
-                    }
-                };
+    pub fn input(&self) -> Option<&str> {
+        self.down_channel.as_ref().map(|(_, input)| input.as_str())
+    }
 
-                for line in data.split_terminator('\n') {
-                    messages.push(line.to_string());
-
-                    if *self.scroll_offset != 0 {
-                        // We're not on the bottom of the list, make sure we don't
-                        // move the rendered messages.
-                        *self.scroll_offset = self.scroll_offset.saturating_add(1);
-                    }
-                }
-
-                Ok(())
-            }
-
-            fn on_binary_data(&mut self, _channel: usize, incoming: &[u8]) -> anyhow::Result<()> {
-                if let Some(ref mut stream) = self.tcp_stream {
-                    stream.send(incoming);
-                }
-
-                match &mut self.data {
-                    TabData::Binary { data } => data.extend_from_slice(incoming),
-                    TabData::Strings { .. } => {
-                        unreachable!()
-                    }
-                }
-
-                Ok(())
-            }
-        }
-
-        let mut collector = DataCollector {
-            data: &mut self.data,
-            scroll_offset: &mut self.scroll_offset,
-            tcp_stream: self.tcp_socket.as_mut(),
-        };
-
-        // TODO: Proper error handling.
-        if let Some(channel) = self.up_channel.as_mut() {
-            if let Err(err) = channel.poll_process_rtt_data(core, self.defmt_info, &mut collector) {
-                tracing::error!("\nError reading from RTT: {}", err);
-            }
+    pub fn send_input(
+        &mut self,
+        core: &mut Core,
+        channels: &mut BTreeMap<usize, RttActiveDownChannel>,
+    ) -> anyhow::Result<()> {
+        if let Some((channel, input)) = self.down_channel.as_mut() {
+            let channel = channels.get_mut(channel).expect("down channel disappeared");
+            input.push('\n');
+            channel.push_rtt(core, input.as_str())?;
+            input.clear();
         }
 
         Ok(())
-    }
-
-    pub fn push_rtt(&mut self, core: &mut Core) {
-        if let Some(down_channel) = self.down_channel.as_mut() {
-            down_channel.push_rtt(core).unwrap();
-        }
-    }
-
-    pub(crate) fn data(&self) -> &TabData {
-        &self.data
     }
 }

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
@@ -6,11 +6,18 @@ use crate::util::rtt::{RttActiveDownChannel, RttActiveUpChannel};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TabConfig {
+    /// Which up channel to use.
     pub up_channel: usize,
+
+    /// Which down channel to use, if any.
     #[serde(default)]
     pub down_channel: Option<usize>,
+
+    /// The name of the tab. If not set, the name of the up channel is used.
     #[serde(default)]
     pub name: Option<String>,
+
+    /// Whether to hide the tab. By default, all up channels are shown in separate tabs.
     #[serde(default)]
     pub hide: bool,
 }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1773,7 +1773,7 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         &mut self,
         channel_number: usize,
         channel_name: String,
-        data_format: rtt::ChannelDataFormat,
+        data_format: &rtt::ChannelDataConfig,
     ) -> bool {
         let Ok(event_body) = serde_json::to_value(RttChannelEventBody {
             channel_number,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1773,12 +1773,12 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         &mut self,
         channel_number: usize,
         channel_name: String,
-        data_format: &rtt::ChannelDataConfig,
+        data_format: rtt::DataFormat,
     ) -> bool {
         let Ok(event_body) = serde_json::to_value(RttChannelEventBody {
             channel_number,
             channel_name,
-            data_format: data_format.kind(),
+            data_format,
         }) else {
             return false;
         };

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1773,33 +1773,29 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         &mut self,
         channel_number: usize,
         channel_name: String,
-        data_format: rtt::DataFormat,
+        data_format: rtt::ChannelDataFormat,
     ) -> bool {
-        let event_body = match serde_json::to_value(RttChannelEventBody {
+        let Ok(event_body) = serde_json::to_value(RttChannelEventBody {
             channel_number,
             channel_name,
-            data_format,
-        }) {
-            Ok(event_body) => event_body,
-            Err(_) => {
-                return false;
-            }
+            data_format: data_format.kind(),
+        }) else {
+            return false;
         };
+
         self.send_event("probe-rs-rtt-channel-config", Some(event_body))
             .is_ok()
     }
 
     /// Send a custom `probe-rs-rtt-data` event to the MS DAP Client, to
     pub fn rtt_output(&mut self, channel_number: usize, rtt_data: String) -> bool {
-        let event_body = match serde_json::to_value(RttDataEventBody {
+        let Ok(event_body) = serde_json::to_value(RttDataEventBody {
             channel_number,
             data: rtt_data,
-        }) {
-            Ok(event_body) => event_body,
-            Err(_) => {
-                return false;
-            }
+        }) else {
+            return false;
         };
+
         self.send_event("probe-rs-rtt-data", Some(event_body))
             .is_ok()
     }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, ops::Range, path::Path};
 
 use super::session_data::{self, ActiveBreakpoint, BreakpointType, SourceLocationScope};
-use crate::util::rtt::{self, ChannelDataConfig, ChannelMode, RttActiveTarget};
+use crate::util::rtt::{self, ChannelMode, DataFormat, RttActiveTarget};
 use crate::{
     cmd::dap_server::{
         debug_adapter::{
@@ -195,7 +195,7 @@ impl<'p> CoreHandle<'p> {
 
         for any_channel in target_rtt.active_channels.iter() {
             if let Some(up_channel) = &any_channel.up_channel {
-                if matches!(any_channel.data_format, ChannelDataConfig::Defmt { .. }) {
+                if any_channel.data_format == DataFormat::Defmt {
                     // For defmt, we set the channel to be blocking when full.
                     up_channel.set_mode(&mut self.core, ChannelMode::BlockIfFull)?;
                 }
@@ -206,8 +206,8 @@ impl<'p> CoreHandle<'p> {
                 });
                 debug_adapter.rtt_window(
                     up_channel.number(),
-                    any_channel.channel_name.clone(),
-                    &any_channel.data_format,
+                    up_channel.channel_name.clone(),
+                    any_channel.data_format,
                 );
             }
         }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -452,13 +452,13 @@ fn try_attach_rtt(
         .map_err(|error| anyhow!("Error attempting to attach to RTT: {}", error))?;
 
     tracing::info!("RTT initialized.");
-    let target = RttActiveTarget::new(rtt, elf_file, rtt_config, timestamp_offset, None)?;
+    let target = RttActiveTarget::new(rtt, elf_file, rtt_config, timestamp_offset)?;
 
     Ok(target)
 }
 
 /// Return a Vec of memory ranges that consolidate the adjacent memory ranges of the input ranges.
-/// Note: The concept of "adjacent" is calculated to include a gap of up to specicied number of bytes between ranges.
+/// Note: The concept of "adjacent" is calculated to include a gap of up to specified number of bytes between ranges.
 /// This serves to consolidate memory ranges that are separated by a small gap, but are still close enough for the purpose of the caller.
 fn consolidate_memory_ranges(
     mut discrete_memory_ranges: Vec<Range<u64>>,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, ops::Range, path::Path};
 
 use super::session_data::{self, ActiveBreakpoint, BreakpointType, SourceLocationScope};
-use crate::util::rtt::{self, ChannelDataFormat, ChannelMode, RttActiveTarget};
+use crate::util::rtt::{self, ChannelDataConfig, ChannelMode, RttActiveTarget};
 use crate::{
     cmd::dap_server::{
         debug_adapter::{
@@ -195,7 +195,7 @@ impl<'p> CoreHandle<'p> {
 
         for any_channel in target_rtt.active_channels.iter() {
             if let Some(up_channel) = &any_channel.up_channel {
-                if matches!(any_channel.data_format, ChannelDataFormat::Defmt { .. }) {
+                if matches!(any_channel.data_format, ChannelDataConfig::Defmt { .. }) {
                     // For defmt, we set the channel to be blocking when full.
                     up_channel.set_mode(&mut self.core, ChannelMode::BlockIfFull)?;
                 }
@@ -207,7 +207,7 @@ impl<'p> CoreHandle<'p> {
                 debug_adapter.rtt_window(
                     up_channel.number(),
                     any_channel.channel_name.clone(),
-                    any_channel.data_format,
+                    &any_channel.data_format,
                 );
             }
         }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, ops::Range, path::Path};
 
 use super::session_data::{self, ActiveBreakpoint, BreakpointType, SourceLocationScope};
-use crate::util::rtt::{self, ChannelMode, DataFormat, RttActiveTarget};
+use crate::util::rtt::{self, ChannelDataFormat, ChannelMode, RttActiveTarget};
 use crate::{
     cmd::dap_server::{
         debug_adapter::{
@@ -195,7 +195,7 @@ impl<'p> CoreHandle<'p> {
 
         for any_channel in target_rtt.active_channels.iter() {
             if let Some(up_channel) = &any_channel.up_channel {
-                if any_channel.data_format == DataFormat::Defmt {
+                if matches!(any_channel.data_format, ChannelDataFormat::Defmt { .. }) {
                     // For defmt, we set the channel to be blocking when full.
                     up_channel.set_mode(&mut self.core, ChannelMode::BlockIfFull)?;
                 }

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -193,23 +193,22 @@ impl<'p> CoreHandle<'p> {
             return Ok(());
         };
 
-        for any_channel in target_rtt.active_channels.iter() {
-            if let Some(up_channel) = &any_channel.up_channel {
-                if any_channel.data_format == DataFormat::Defmt {
-                    // For defmt, we set the channel to be blocking when full.
-                    up_channel.set_mode(&mut self.core, ChannelMode::BlockIfFull)?;
-                }
-                debugger_rtt_channels.push(debug_rtt::DebuggerRttChannel {
-                    channel_number: up_channel.number(),
-                    // This value will eventually be set to true by a VSCode client request "rttWindowOpened"
-                    has_client_window: false,
-                });
-                debug_adapter.rtt_window(
-                    up_channel.number(),
-                    up_channel.channel_name.clone(),
-                    any_channel.data_format,
-                );
+        for up_channel in target_rtt.active_up_channels.values() {
+            let data_format = DataFormat::from(&up_channel.data_format);
+            if data_format == DataFormat::Defmt {
+                // For defmt, we set the channel to be blocking when full.
+                up_channel.set_mode(&mut self.core, ChannelMode::BlockIfFull)?;
             }
+            debugger_rtt_channels.push(debug_rtt::DebuggerRttChannel {
+                channel_number: up_channel.number(),
+                // This value will eventually be set to true by a VSCode client request "rttWindowOpened"
+                has_client_window: false,
+            });
+            debug_adapter.rtt_window(
+                up_channel.number(),
+                up_channel.channel_name.clone(),
+                data_format,
+            );
         }
 
         self.core_data.rtt_connection = Some(debug_rtt::RttConnection {

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
@@ -53,11 +53,7 @@ impl DebuggerRttChannel {
             return false;
         }
 
-        let Some(rtt_channel) = rtt_target
-            .active_channels
-            .iter_mut()
-            .find(|active_channel| active_channel.number() == Some(self.channel_number))
-        else {
+        let Some(rtt_channel) = rtt_target.active_up_channels.get_mut(&self.channel_number) else {
             return false;
         };
 
@@ -78,7 +74,9 @@ impl DebuggerRttChannel {
 
         let mut out = StringCollector { data: None };
 
-        if let Err(e) = rtt_channel.get_rtt_data(core, rtt_target.defmt_state.as_ref(), &mut out) {
+        if let Err(e) =
+            rtt_channel.poll_process_rtt_data(core, rtt_target.defmt_state.as_ref(), &mut out)
+        {
             debug_adapter
                 .show_error_message(&DebuggerError::Other(e))
                 .ok();

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debug_rtt.rs
@@ -69,9 +69,7 @@ impl DebuggerRttChannel {
                     }
                 })
                 .and_then(|(channel_number, channel_data)| {
-                    if debug_adapter
-                        .rtt_output(channel_number.parse::<usize>().unwrap_or(0), channel_data)
-                    {
+                    if debug_adapter.rtt_output(channel_number, channel_data) {
                         Some(true)
                     } else {
                         None

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -346,7 +346,7 @@ fn attach_to_rtt(
     for _ in 0..RTT_RETRIES {
         match rtt::attach_to_rtt(core, memory_map, &scan_regions, path) {
             Ok(Some(target_rtt)) => {
-                let app = RttActiveTarget::new(target_rtt, path, &rtt_config, timestamp_offset);
+                let app = RttActiveTarget::new(target_rtt, path, rtt_config, timestamp_offset);
 
                 match app {
                     Ok(app) => return Some(app),

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -162,7 +162,7 @@ fn run_loop(
         memory_map,
         rtt_scan_regions,
         path,
-        rtt_config,
+        &rtt_config,
         timestamp_offset,
     );
 
@@ -339,7 +339,7 @@ fn attach_to_rtt(
     memory_map: &[MemoryRegion],
     scan_regions: &[Range<u64>],
     path: &Path,
-    rtt_config: RttConfig,
+    rtt_config: &RttConfig,
     timestamp_offset: UtcOffset,
 ) -> Option<rtt::RttActiveTarget> {
     let scan_regions = ScanRegion::Ranges(scan_regions.to_vec());

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -553,6 +553,7 @@ impl RttActiveTarget {
     ) -> Result<Self> {
         let defmt_state = DefmtState::try_from_elf(elf_file)?;
 
+        // TODO: do not collect into a single vector. Instead, keep separate maps.
         let mut active_channels = Vec::new();
         // For each channel configured in the RTT Control Block (`Rtt`), check if there are additional user configuration in a `RttChannelConfig`. If not, apply defaults.
         for channel in rtt.up_channels.into_iter() {

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -135,14 +135,6 @@ pub enum ChannelDataConfig {
     },
 }
 
-impl ChannelDataConfig {
-    pub fn clear(&mut self) {
-        if let ChannelDataConfig::String { last_line_done, .. } = self {
-            *last_line_done = true;
-        }
-    }
-}
-
 impl std::fmt::Debug for ChannelDataConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -408,8 +400,6 @@ impl RttActiveUpChannel {
 pub struct RttActiveDownChannel {
     pub down_channel: DownChannel,
     pub channel_name: String,
-    /// Data that will be written to the down_channel (host to target)
-    input_data: String,
 }
 
 impl RttActiveDownChannel {
@@ -423,7 +413,6 @@ impl RttActiveDownChannel {
         Self {
             down_channel,
             channel_name,
-            input_data: String::new(),
         }
     }
 
@@ -431,22 +420,8 @@ impl RttActiveDownChannel {
         self.down_channel.number()
     }
 
-    pub fn input(&self) -> &str {
-        self.input_data.as_ref()
-    }
-
-    pub fn input_mut(&mut self) -> &mut String {
-        &mut self.input_data
-    }
-
-    pub fn push_rtt(&mut self, core: &mut Core<'_>) -> Result<(), Error> {
-        self.input_data += "\n";
-        let result = self
-            .down_channel
-            .write(core, self.input_data.as_bytes())
-            .map(|_| ());
-        self.input_data.clear();
-        result
+    pub fn push_rtt(&mut self, core: &mut Core<'_>, data: &str) -> Result<(), Error> {
+        self.down_channel.write(core, data.as_bytes()).map(|_| ())
     }
 }
 
@@ -514,14 +489,6 @@ impl RttActiveChannel {
         } else {
             Ok(())
         }
-    }
-
-    pub fn _push_rtt(&mut self, core: &mut Core) -> Result<()> {
-        if let Some(down_channel) = self.down_channel.as_mut() {
-            down_channel.push_rtt(core)?;
-        }
-
-        Ok(())
     }
 }
 

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -167,13 +167,10 @@ impl RttActiveChannel {
         };
         let name = up_channel
             .as_ref()
-            .and_then(|up| up.name().map(Into::into))
-            .or_else(|| {
-                down_channel
-                    .as_ref()
-                    .and_then(|down| down.name().map(Into::into))
-            })
-            .or_else(|| full_config.clone().channel_name)
+            .and_then(|up| up.name())
+            .or_else(|| down_channel.as_ref().and_then(|down| down.name()))
+            .or_else(|| full_config.channel_name.as_deref())
+            .map(ToString::to_string)
             .unwrap_or_else(|| {
                 format!(
                     "Unnamed {:?} RTT channel - {}",

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -87,9 +87,7 @@ pub struct RttConfig {
     pub channels: Vec<RttChannelConfig>,
 }
 
-/// The User specified configuration for each active RTT Channel. The configuration is passed via a
-/// DAP Client configuration (`launch.json`). If no configuration is specified, the defaults will be
-/// `DataFormat::String` and `show_timestamps=false`.
+/// The User specified configuration for each active RTT Channel.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RttChannelConfig {
@@ -110,6 +108,16 @@ pub struct RttChannelConfig {
     #[serde(default)]
     /// Control the output format for DataFormat::Defmt.
     pub defmt_log_format: Option<String>,
+}
+
+/// The User specified configuration for each active RTT Channel. The configuration is passed via a
+/// DAP Client configuration (`launch.json`). If no configuration is specified, the defaults will be
+/// `DataFormat::String` and `show_timestamps=false`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RttDownChannelConfig {
+    pub channel_number: Option<usize>,
+    pub operating_mode: Option<String>,
 }
 
 pub enum ChannelDataConfig {

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -64,11 +64,14 @@ fn default_include_location() -> bool {
     true
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Default, docsplay::Display)]
 pub enum DataFormat {
     #[default]
+    /// string
     String,
+    /// binary
     BinaryLE,
+    /// defmt
     Defmt,
 }
 
@@ -231,7 +234,7 @@ impl RttActiveUpChannel {
             .map(ToString::to_string)
             .unwrap_or_else(|| {
                 format!(
-                    "Unnamed {:?} RTT channel - {}",
+                    "Unnamed {} RTT up channel - {}",
                     channel_config.data_format,
                     up_channel.number()
                 )

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -124,13 +124,8 @@ pub enum ChannelDataConfig {
 
 impl ChannelDataConfig {
     pub fn clear(&mut self) {
-        match self {
-            ChannelDataConfig::String {
-                ref mut last_line_done,
-                ..
-            } => *last_line_done = true,
-            ChannelDataConfig::BinaryLE => {}
-            ChannelDataConfig::Defmt { .. } => {}
+        if let ChannelDataConfig::String { last_line_done, .. } = self {
+            *last_line_done = true;
         }
     }
 }

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -105,6 +105,9 @@ pub struct RttChannelConfig {
     #[serde(default = "default_include_location")]
     // Control the inclusion of source location information for DataFormat::Defmt.
     pub show_location: bool,
+
+    #[serde(default)]
+    pub defmt_log_format: Option<String>,
 }
 
 pub enum ChannelDataConfig {
@@ -209,19 +212,22 @@ impl RttActiveChannel {
                 };
 
                 // Format options:
-                // 1. Custom format
-                // 2. Default with timestamp with location
-                // 3. Default with timestamp without location
-                // 4. Default without timestamp with location
-                // 5. Default without timestamp without location
-                let format = rtt_config.log_format.as_deref().unwrap_or(
-                    match (channel_config.show_location, has_timestamp) {
+                // 1. Custom format for the channel
+                // 2. Custom default format
+                // 3. Default with timestamp with location
+                // 4. Default with timestamp without location
+                // 5. Default without timestamp with location
+                // 6. Default without timestamp without location
+                let format = channel_config
+                    .defmt_log_format
+                    .as_deref()
+                    .or(rtt_config.log_format.as_deref())
+                    .unwrap_or(match (channel_config.show_location, has_timestamp) {
                         (true, true) => "{t} {L} {s}\n└─ {m} @ {F}:{l}",
                         (true, false) => "{L} {s}\n└─ {m} @ {F}:{l}",
                         (false, true) => "{t} {L} {s}",
                         (false, false) => "{L} {s}",
-                    },
-                );
+                    });
                 let mut format = defmt_decoder::log::format::FormatterConfig::custom(format);
                 format.is_timestamp_available = has_timestamp;
                 let formatter = defmt_decoder::log::format::Formatter::new(format);

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use defmt_decoder::DecodeError;
 pub use probe_rs::rtt::ChannelMode;
-use probe_rs::rtt::{DownChannel, Rtt, ScanRegion, UpChannel};
+use probe_rs::rtt::{DownChannel, Error, Rtt, ScanRegion, UpChannel};
 use probe_rs::Core;
 use probe_rs_target::MemoryRegion;
 use serde::{Deserialize, Serialize};
@@ -107,6 +107,7 @@ pub struct RttChannelConfig {
     pub show_location: bool,
 
     #[serde(default)]
+    // Control the output format for DataFormat::Defmt.
     pub defmt_log_format: Option<String>,
 }
 
@@ -133,26 +134,11 @@ impl std::fmt::Debug for ChannelDataConfig {
     }
 }
 
-impl ChannelDataConfig {
-    pub fn kind(&self) -> DataFormat {
-        match self {
-            ChannelDataConfig::String { .. } => DataFormat::String,
-            ChannelDataConfig::BinaryLE => DataFormat::BinaryLE,
-            ChannelDataConfig::Defmt { .. } => DataFormat::Defmt,
-        }
-    }
-}
-
-/// This is the primary interface through which RTT channel data is read and written. Every actual
-/// RTT channel has a configuration and buffer that is used for this purpose.
 #[derive(Debug)]
-pub struct RttActiveChannel {
-    pub up_channel: Option<UpChannel>,
-    pub down_channel: Option<DownChannel>,
+pub struct RttActiveUpChannel {
+    pub up_channel: UpChannel,
     pub channel_name: String,
     pub data_format: ChannelDataConfig,
-    /// Data that will be written to the down_channel (host to target)
-    _input_data: String,
     rtt_buffer: RttBuffer,
 
     /// UTC offset used for creating timestamps
@@ -162,39 +148,16 @@ pub struct RttActiveChannel {
     timestamp_offset: UtcOffset,
 }
 
-/// A fully configured RttActiveChannel. The configuration will always try to 'default' based on
-/// information read from the RTT control block in the binary. Where insufficient information is
-/// available, it will use the supplied configuration, with final hardcoded defaults where no other
-/// information was available.
-impl RttActiveChannel {
-    fn new(
-        number: usize,
-        up_channel: Option<UpChannel>,
-        down_channel: Option<DownChannel>,
+impl RttActiveUpChannel {
+    pub fn new(
+        up_channel: UpChannel,
         rtt_config: &RttConfig,
+        channel_config: &RttChannelConfig,
         timestamp_offset: UtcOffset,
         defmt_state: Option<&DefmtState>,
     ) -> Self {
-        let channel_config = rtt_config
-            .channels
-            .iter()
-            .find(|channel| channel.channel_number == Some(number))
-            .cloned()
-            .unwrap_or_default();
-
-        let buffer_size = up_channel
-            .as_ref()
-            .map(|up| up.buffer_size())
-            .or_else(|| down_channel.as_ref().map(|down| down.buffer_size()))
-            .unwrap_or(1024); // If no explicit config is requested, assign a default
-
-        let defmt_enabled = up_channel
-            .as_ref()
-            .map(|up| up.name() == Some("defmt"))
-            .or(down_channel
-                .as_ref()
-                .map(|down| down.name() == Some("defmt")))
-            .unwrap_or(false); // If no explicit config is requested, assign a default
+        let buffer_size = up_channel.buffer_size();
+        let defmt_enabled = up_channel.name() == Some("defmt");
 
         let data_format = match channel_config.data_format {
             DataFormat::String if !defmt_enabled => ChannelDataConfig::String {
@@ -235,102 +198,90 @@ impl RttActiveChannel {
             }
         };
 
-        let name = up_channel
-            .as_ref()
-            .and_then(|up| up.name())
-            .or_else(|| down_channel.as_ref().and_then(|down| down.name()))
-            .or_else(|| channel_config.channel_name.as_deref())
+        let channel_name = up_channel
+            .name()
+            .or(channel_config.channel_name.as_deref())
             .map(ToString::to_string)
             .unwrap_or_else(|| {
                 format!(
-                    "Unnamed {:?} RTT channel - {number}",
-                    channel_config.data_format
+                    "Unnamed {:?} RTT channel - {}",
+                    channel_config.data_format,
+                    up_channel.number()
                 )
             });
+
         Self {
             up_channel,
-            down_channel,
-            channel_name: name,
+            channel_name,
             data_format,
-            _input_data: String::new(),
             rtt_buffer: RttBuffer::new(buffer_size),
             timestamp_offset,
         }
     }
 
-    /// Returns the number of the `UpChannel`.
-    pub fn number(&self) -> Option<usize> {
-        self.up_channel.as_ref().map(|uc| uc.number())
+    pub fn number(&self) -> usize {
+        self.up_channel.number()
     }
 
     /// Polls the RTT target for new data on the channel represented by `self`.
     /// Processes all the new data into the channel internal buffer and returns the number of bytes that was read.
     pub fn poll_rtt(&mut self, core: &mut Core) -> Option<usize> {
-        if let Some(channel) = self.up_channel.as_mut() {
-            // Retry loop, in case the probe is temporarily unavailable, e.g. user pressed the `reset` button.
-            for _loop_count in 0..10 {
-                match channel.read(core, self.rtt_buffer.0.as_mut()) {
-                    Ok(0) => return None,
-                    Ok(count) => return Some(count),
-                    Err(probe_rs::rtt::Error::Probe(_)) => {
-                        std::thread::sleep(std::time::Duration::from_millis(50));
-                    }
-                    Err(err) => {
-                        tracing::error!("\nError reading from RTT: {}", err);
-                        return None;
-                    }
+        // Retry loop, in case the probe is temporarily unavailable, e.g. user pressed the `reset` button.
+        for _loop_count in 0..10 {
+            match self.up_channel.read(core, self.rtt_buffer.0.as_mut()) {
+                Ok(0) => return None,
+                Ok(count) => return Some(count),
+                Err(probe_rs::rtt::Error::Probe(_)) => {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                Err(err) => {
+                    tracing::error!("\nError reading from RTT: {}", err);
+                    return None;
                 }
             }
         }
+
         None
     }
 
     /// Retrieves available data from the channel and if available, returns `Some(channel_number:String, formatted_data:String)`.
-    /// If no data is available, or we encounter a recoverable error, it returns `None` value fore `formatted_data`.
+    /// If no data is available, or we encounter a recoverable error, it returns `None` value for `formatted_data`.
     /// Non-recoverable errors are propagated to the caller.
-    pub fn get_rtt_data(
+    pub fn poll_process_rtt_data(
         &mut self,
         core: &mut Core,
         defmt_state: Option<&DefmtState>,
-    ) -> Result<Option<(String, String)>> {
+    ) -> Result<Option<(usize, String)>> {
         self.poll_rtt(core)
             .map(|bytes_read| {
-                Ok((
-                    self.number().unwrap_or(0).to_string(), // If the Channel doesn't have a number, then send the output to channel 0
-                    {
-                        let mut formatted_data = String::new();
-                        match &self.data_format {
-                            ChannelDataConfig::String { show_timestamps } => {
-                                self.get_string(bytes_read, &mut formatted_data, *show_timestamps)
-                            }
-                            ChannelDataConfig::BinaryLE => {
-                                self.get_binary_le(bytes_read, &mut formatted_data)
-                            }
-                            ChannelDataConfig::Defmt { formatter } => self.get_defmt(
-                                bytes_read,
-                                &mut formatted_data,
-                                defmt_state,
-                                formatter,
-                            )?,
-                        };
-                        formatted_data
-                    },
-                ))
+                Ok((self.number(), {
+                    let mut formatted_data = String::new();
+                    match &self.data_format {
+                        ChannelDataConfig::String { show_timestamps } => {
+                            self.process_string(bytes_read, &mut formatted_data, *show_timestamps)
+                        }
+                        ChannelDataConfig::BinaryLE => {
+                            self.process_binary_le(bytes_read, &mut formatted_data)
+                        }
+                        ChannelDataConfig::Defmt { formatter } => self.process_defmt(
+                            bytes_read,
+                            &mut formatted_data,
+                            defmt_state,
+                            formatter,
+                        )?,
+                    };
+                    formatted_data
+                }))
             })
             .transpose()
     }
 
-    pub fn _push_rtt(&mut self, core: &mut Core) {
-        if let Some(down_channel) = self.down_channel.as_mut() {
-            self._input_data += "\n";
-            down_channel
-                .write(core, self._input_data.as_bytes())
-                .unwrap();
-            self._input_data.clear();
-        }
-    }
-
-    fn get_string(&self, bytes_read: usize, formatted_data: &mut String, show_timestamps: bool) {
+    fn process_string(
+        &self,
+        bytes_read: usize,
+        formatted_data: &mut String,
+        show_timestamps: bool,
+    ) {
         let incoming = String::from_utf8_lossy(&self.rtt_buffer.0[..bytes_read]);
         if show_timestamps {
             let timestamp = OffsetDateTime::now_utc().to_offset(self.timestamp_offset);
@@ -343,14 +294,14 @@ impl RttActiveChannel {
         }
     }
 
-    fn get_binary_le(&self, bytes_read: usize, formatted_data: &mut String) {
+    fn process_binary_le(&self, bytes_read: usize, formatted_data: &mut String) {
         for element in &self.rtt_buffer.0[..bytes_read] {
             // Width of 4 allows 0xFF to be printed.
             write!(formatted_data, "{element:#04x}").expect("Writing to String cannot fail");
         }
     }
 
-    fn get_defmt(
+    fn process_defmt(
         &self,
         bytes_read: usize,
         formatted_data: &mut String,
@@ -405,6 +356,130 @@ impl RttActiveChannel {
                     ));
                 }
             }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn set_mode(
+        &self,
+        core: &mut Core<'_>,
+        block_if_full: ChannelMode,
+    ) -> Result<(), Error> {
+        self.up_channel.set_mode(core, block_if_full)
+    }
+}
+
+#[derive(Debug)]
+pub struct RttActiveDownChannel {
+    pub down_channel: DownChannel,
+    pub channel_name: String,
+    /// Data that will be written to the down_channel (host to target)
+    _input_data: String,
+}
+
+impl RttActiveDownChannel {
+    pub fn new(down_channel: DownChannel, channel_config: &RttChannelConfig) -> Self {
+        let channel_name = down_channel
+            .name()
+            .or(channel_config.channel_name.as_deref())
+            .map(ToString::to_string)
+            .unwrap_or_else(|| format!("Unnamed RTT down channel - {}", down_channel.number()));
+
+        Self {
+            down_channel,
+            channel_name,
+            _input_data: String::new(),
+        }
+    }
+
+    pub fn _input(&self) -> &str {
+        self._input_data.as_ref()
+    }
+
+    pub fn _input_mut(&mut self) -> &mut String {
+        &mut self._input_data
+    }
+
+    fn _push_rtt(&mut self, core: &mut Core<'_>) -> Result<(), Error> {
+        self._input_data += "\n";
+        let result = self
+            .down_channel
+            .write(core, self._input_data.as_bytes())
+            .map(|_| ());
+        self._input_data.clear();
+        result
+    }
+}
+
+/// This is the primary interface through which RTT channel data is read and written. Every actual
+/// RTT channel has a configuration and buffer that is used for this purpose.
+#[derive(Debug)]
+pub struct RttActiveChannel {
+    pub data_format: DataFormat,
+    pub up_channel: Option<RttActiveUpChannel>,
+    pub down_channel: Option<RttActiveDownChannel>,
+}
+
+/// A fully configured RttActiveChannel. The configuration will always try to 'default' based on
+/// information read from the RTT control block in the binary. Where insufficient information is
+/// available, it will use the supplied configuration, with final hardcoded defaults where no other
+/// information was available.
+impl RttActiveChannel {
+    fn new(
+        number: usize,
+        up_channel: Option<UpChannel>,
+        down_channel: Option<DownChannel>,
+        rtt_config: &RttConfig,
+        timestamp_offset: UtcOffset,
+        defmt_state: Option<&DefmtState>,
+    ) -> Self {
+        let channel_config = rtt_config
+            .channels
+            .iter()
+            .find(|channel| channel.channel_number == Some(number))
+            .cloned()
+            .unwrap_or_default();
+
+        Self {
+            data_format: channel_config.data_format,
+            up_channel: up_channel.map(|channel| {
+                RttActiveUpChannel::new(
+                    channel,
+                    rtt_config,
+                    &channel_config,
+                    timestamp_offset,
+                    defmt_state,
+                )
+            }),
+            down_channel: down_channel
+                .map(|channel| RttActiveDownChannel::new(channel, &channel_config)),
+        }
+    }
+
+    /// Returns the number of the `UpChannel`.
+    pub fn number(&self) -> Option<usize> {
+        self.up_channel.as_ref().map(|uc| uc.number())
+    }
+
+    /// Retrieves available data from the channel and if available, returns `Some(channel_number:String, formatted_data:String)`.
+    /// If no data is available, or we encounter a recoverable error, it returns `None` value fore `formatted_data`.
+    /// Non-recoverable errors are propagated to the caller.
+    pub fn get_rtt_data(
+        &mut self,
+        core: &mut Core,
+        defmt_state: Option<&DefmtState>,
+    ) -> Result<Option<(usize, String)>> {
+        if let Some(up_channel) = self.up_channel.as_mut() {
+            up_channel.poll_process_rtt_data(core, defmt_state)
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn _push_rtt(&mut self, core: &mut Core) -> Result<()> {
+        if let Some(down_channel) = self.down_channel.as_mut() {
+            down_channel._push_rtt(core)?;
         }
 
         Ok(())
@@ -531,7 +606,7 @@ impl RttActiveTarget {
     pub fn poll_rtt_fallible(
         &mut self,
         core: &mut Core,
-    ) -> Result<HashMap<String, String>, anyhow::Error> {
+    ) -> Result<HashMap<usize, String>, anyhow::Error> {
         let defmt_state = self.defmt_state.as_ref();
         let mut data = HashMap::new();
         for channel in self.active_channels.iter_mut() {
@@ -541,10 +616,6 @@ impl RttActiveTarget {
         }
         Ok(data)
     }
-
-    // pub fn push_rtt(&mut self) {
-    //     self.tabs[self.current_tab].push_rtt();
-    // }
 }
 
 pub(crate) struct RttBuffer(pub Vec<u8>);

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -93,9 +93,11 @@ pub struct RttChannelConfig {
     pub channel_name: Option<String>,
     #[serde(default)]
     pub data_format: DataFormat,
+
     #[serde(default)]
     // Control the inclusion of timestamps for DataFormat::String.
     pub show_timestamps: bool,
+
     #[serde(default = "default_include_location")]
     // Control the inclusion of source location information for DataFormat::Defmt.
     pub show_location: bool,

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -583,7 +583,7 @@ impl RttActiveTarget {
         rtt_config: &RttConfig,
         timestamp_offset: UtcOffset,
     ) -> Result<Self> {
-        let defmt_state = DefmtState::try_from_elf(&elf_file)?;
+        let defmt_state = DefmtState::try_from_elf(elf_file)?;
 
         let mut active_channels = Vec::new();
         // For each channel configured in the RTT Control Block (`Rtt`), check if there are additional user configuration in a `RttChannelConfig`. If not, apply defaults.


### PR DESCRIPTION
Improvement opportunity: configure down channel operating modes, add the option to debugger's rtt config, configure it during channel setup.

This PR removes a good chunk of duplicate code and brings debugger, probe-rs and cargo embed configuration a bit closer to each other. It's also making cargo embed more efficient, as only new log lines need to be rendered.

This didn't turn out exactly like the "mostly just remove code" PR I originally envisioned but the end result - provided I didn't break much - doesn't look too bad, IMO.