### PR TITLE
clippy: Address some lints from nightly’s clippy

### DIFF
--- a/probe-rs/examples/tcp_itm.rs
+++ b/probe-rs/examples/tcp_itm.rs
@@ -115,14 +115,10 @@ impl TcpPublisher {
     fn write_to_all_sockets(sockets: &mut Vec<(TcpStream, SocketAddr)>, message: impl AsRef<str>) {
         let mut to_remove = vec![];
         for (i, (socket, _addr)) in sockets.iter_mut().enumerate() {
-            match socket.write(message.as_ref().as_bytes()) {
-                Ok(_) => (),
-                Err(err) => {
-                    if err.kind() == std::io::ErrorKind::WouldBlock {
-                    } else {
-                        to_remove.push(i);
-                        tracing::error!("Writing to a tcp socket experienced an error: {:?}", err)
-                    }
+            if let Err(err) = socket.write_all(message.as_ref().as_bytes()) {
+                if err.kind() != std::io::ErrorKind::WouldBlock {
+                    to_remove.push(i);
+                    tracing::error!("Writing to a tcp socket experienced an error: {:?}", err)
                 }
             }
         }

--- a/probe-rs/src/core/dump.rs
+++ b/probe-rs/src/core/dump.rs
@@ -53,6 +53,7 @@ impl CoreDump {
         let mut file = OpenOptions::new()
             .create(true)
             .write(true)
+            .truncate(true)
             .open(path)
             .map_err(|e| {
                 CoreDumpError::CoreDumpFileWrite(e, dunce::canonicalize(path).unwrap_or_default())


### PR DESCRIPTION
examples/tcp_itm: unused_io_amount
src/core/dump: suspicious_open_options