### PR TITLE
Fixes to `FunctionDie`: Handling of valid address ranges.

### DIFF
--- a/changelog/changed-function-die-struct.md
+++ b/changelog/changed-function-die-struct.md
@@ -1,0 +1,1 @@
+The `FunctionDie` struct now stores the actual address `Range`'s for which the DIE is valid. This is important because these are not necessarily contiquous, and checking for inclusion between the former `low_pc` and `high_pc` could give false positives.

--- a/changelog/changed-function-die-struct.md
+++ b/changelog/changed-function-die-struct.md
@@ -1,1 +1,0 @@
-The `FunctionDie` struct now stores the actual address `Range`'s for which the DIE is valid. This is important because these are not necessarily contiquous, and checking for inclusion between the former `low_pc` and `high_pc` could give false positives.

--- a/changelog/fixed-unitinfo-function-ranges.md
+++ b/changelog/fixed-unitinfo-function-ranges.md
@@ -1,0 +1,1 @@
+The process of finding function DIE's assigned the `low_pc` and `high_pc` values based on only the last processed `gimli::Range` for the funciton DIE. 

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -431,9 +431,16 @@ impl DebugInfo {
             // Calculate the call site for this function, so that we can use it later to create an additional 'callee' `StackFrame` from that PC.
             let address_size = unit_info.unit.header.address_size() as u64;
 
-            if next_function.low_pc > address_size && next_function.low_pc < u32::MAX.into() {
+            let Some(next_function_low_pc) = next_function.low_pc() else {
+                tracing::warn!(
+                    "UNWIND: Unknown starting address for inlined function {}.",
+                    function_name
+                );
+                continue;
+            };
+            if next_function_low_pc > address_size && next_function_low_pc < u32::MAX.into() {
                 // The first instruction of the inlined function is used as the call site
-                let inlined_call_site = RegisterValue::from(next_function.low_pc);
+                let inlined_call_site = RegisterValue::from(next_function_low_pc);
 
                 tracing::debug!(
                     "UNWIND: Callsite for inlined function {:?}",

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -93,15 +93,12 @@ impl UnitInfo {
                 let inlined_functions =
                     self.find_inlined_functions(debug_info, address, current.offset())?;
 
-                if inlined_functions.is_empty() {
-                    tracing::debug!("No inlined function found!");
-                } else {
-                    tracing::debug!(
-                        "{} inlined functions for address {}",
-                        inlined_functions.len(),
-                        address
-                    );
-                }
+                tracing::debug!(
+                    "{} inlined functions for address {}",
+                    inlined_functions.len(),
+                    address
+                );
+
                 functions.extend(inlined_functions.into_iter());
             }
             return Ok(functions);

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -169,7 +169,7 @@ impl UnitInfo {
 
             let Some(die) = self.unit.entry(unit_ref).ok().and_then(|abstract_die| {
                 FunctionDie::new_inlined(current.clone(), abstract_die.clone(), self).map(
-                    |mut inlined_function_die: FunctionDie<'_, '_, '_>| {
+                    |mut inlined_function_die| {
                         inlined_function_die.ranges = die_ranges;
                         inlined_function_die
                     },


### PR DESCRIPTION
This PR fixes two issues (encountered while wip on a breakpoint PR) related to handling of `FunctionDie` address ranges.

1. `UnitInfo::get_function_dies` assigned the `low_pc` and `high_pc` values based on only the last processed `gimli::Range` for the funciton DIE. 
2. Attempting to coalesce ranges into a `low_pc` and `high_pc` implies that the ranges are contiguous, which are not necessarily the case. 