### PR TITLE
fix probe-rs attach timeout error

### DIFF
--- a/changelog/fixed-probe-rs-attach-timeout.md
+++ b/changelog/fixed-probe-rs-attach-timeout.md
@@ -1,0 +1,1 @@
+fix `probe-rs attach` "Timeout occurred during operation." error.

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -115,18 +115,18 @@ impl Cmd {
 
         if core.core_halted()? {
             core.run()?;
-        } else {
-            run_loop(
-                &mut core,
-                &memory_map,
-                &rtt_scan_regions,
-                path,
-                timestamp_offset,
-                self.always_print_stacktrace,
-                self.no_location,
-                self.log_format.as_deref(),
-            )?;
         }
+
+        run_loop(
+            &mut core,
+            &memory_map,
+            &rtt_scan_regions,
+            path,
+            timestamp_offset,
+            self.always_print_stacktrace,
+            self.no_location,
+            self.log_format.as_deref(),
+        )?;
 
         Ok(())
     }

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -111,8 +111,8 @@ impl Cmd {
                     Err(e) => tracing::error!("Failed to enable_vector_catch: {:?}", e),
                 }
             }
+            core.run()?;
         }
-        core.run()?;
 
         run_loop(
             &mut core,

--- a/probe-rs/src/bin/probe-rs/cmd/run.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run.rs
@@ -111,19 +111,22 @@ impl Cmd {
                     Err(e) => tracing::error!("Failed to enable_vector_catch: {:?}", e),
                 }
             }
-            core.run()?;
         }
 
-        run_loop(
-            &mut core,
-            &memory_map,
-            &rtt_scan_regions,
-            path,
-            timestamp_offset,
-            self.always_print_stacktrace,
-            self.no_location,
-            self.log_format.as_deref(),
-        )?;
+        if core.core_halted()? {
+            core.run()?;
+        } else {
+            run_loop(
+                &mut core,
+                &memory_map,
+                &rtt_scan_regions,
+                path,
+                timestamp_offset,
+                self.always_print_stacktrace,
+                self.no_location,
+                self.log_format.as_deref(),
+            )?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Try fix 

- #2183.

This error could be introduced by

- #1899.

ps.
Actually I don't understand why this happened, or why move the line can fix it, XD. I just find the PR that breaks "attach" cmd, and compare the changes and move this line back into the if block.