### PR TITLE
Prevent cargo-embed from receiving duplicated inputs on windows

### DIFF
--- a/changelog/fixed-windows-crossterm-double-press.md
+++ b/changelog/fixed-windows-crossterm-double-press.md
@@ -1,0 +1,1 @@
+Prevent duplicate inputs being registered in cargo-embed on Windows.

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/app.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use crossterm::{
-    event::{self, KeyCode},
+    event::{self, KeyCode, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -217,6 +217,11 @@ impl<'defmt> App<'defmt> {
                 return true;
             }
         };
+
+        // Ignore key release events emitted by Crossterm on Windows
+        if event.kind != KeyEventKind::Press {
+            return false;
+        }
 
         match event.code {
             KeyCode::Char('c') if event.modifiers.contains(KeyModifiers::CONTROL) => {


### PR DESCRIPTION
On Windows, Crossterm emits both `Press` and `Release` events for each keypress (see the related discussion at https://github.com/ratatui-org/ratatui/issues/347)

This change ensures that only `Press` events are processed by the input system.