### PR TITLE
Restore `--probe` in cargo embed

### DIFF
--- a/changelog/changed-probe-selector.md
+++ b/changelog/changed-probe-selector.md
@@ -1,0 +1,1 @@
+Renamed `--probe-selector` to `--probe` in `cargo embed`

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -42,7 +42,7 @@ struct Opt {
     ///
     ///  Use '--probe VID:PID' or '--probe VID:PID:Serial' if you have more than one probe with the same VID:PID.
     #[arg(long)]
-    probe_selector: Option<DebugProbeSelector>,
+    probe: Option<DebugProbeSelector>,
     #[arg(long)]
     disable_progressbars: bool,
     /// Work directory for the command.
@@ -155,7 +155,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
     let lister = Lister::new();
 
     // If we got a probe selector in the config, open the probe matching the selector if possible.
-    let selector = if let Some(selector) = opt.probe_selector {
+    let selector = if let Some(selector) = opt.probe {
         Some(selector)
     } else {
         match (config.probe.usb_vid.as_ref(), config.probe.usb_pid.as_ref()) {
@@ -186,7 +186,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
         chip,
         chip_description_path: None,
         protocol: Some(config.probe.protocol),
-        probe_selector: selector,
+        probe: selector,
         speed: config.probe.speed,
         connect_under_reset: config.general.connect_under_reset,
         dry_run: false,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/configuration.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/configuration.rs
@@ -18,8 +18,7 @@ pub struct SessionConfig {
     pub(crate) cwd: Option<PathBuf>,
 
     /// The debug probe selector associated with the debug probe to use. Use 'list' command to see available probes
-    #[serde(alias = "probe")]
-    pub(crate) probe_selector: Option<DebugProbeSelector>,
+    pub(crate) probe: Option<DebugProbeSelector>,
 
     /// The target to be selected.
     pub(crate) chip: Option<String>,
@@ -142,7 +141,7 @@ impl SessionConfig {
             chip: self.chip.clone(),
             chip_description_path: self.chip_description_path.clone(),
             protocol: self.wire_protocol,
-            probe_selector: self.probe_selector.clone(),
+            probe: self.probe.clone(),
             speed: self.speed,
             connect_under_reset: self.connect_under_reset,
             dry_run: false,

--- a/probe-rs/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs/src/bin/probe-rs/util/common_options.rs
@@ -143,12 +143,8 @@ pub struct ProbeOptions {
     ///
     /// Use '--probe VID:PID' or '--probe VID:PID:Serial' if you have more than one
     /// probe with the same VID:PID.",
-    #[arg(
-        long = "probe",
-        env = "PROBE_RS_PROBE",
-        help_heading = "PROBE CONFIGURATION"
-    )]
-    pub probe_selector: Option<DebugProbeSelector>,
+    #[arg(long, env = "PROBE_RS_PROBE", help_heading = "PROBE CONFIGURATION")]
+    pub probe: Option<DebugProbeSelector>,
     /// The protocol speed in kHz.
     #[arg(long, env = "PROBE_RS_SPEED", help_heading = "PROBE CONFIGURATION")]
     pub speed: Option<u32>,
@@ -247,7 +243,7 @@ impl LoadedProbeOptions {
         } else {
             // If we got a probe selector as an argument, open the probe
             // matching the selector if possible.
-            let probe = match &self.0.probe_selector {
+            let probe = match &self.0.probe {
                 Some(selector) => lister.open(selector),
                 None => {
                     // Only automatically select a probe if there is


### PR DESCRIPTION
@Tiwalun as `--probe` is consistent across the other tools I'm assuming the rename in #1769 was not intended.

Fixes #2261 by re-renaming the option.