### PR TITLE
Add serde alias for `FormatOptions::binary_format`

### DIFF
--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -110,7 +110,7 @@ pub struct FormatOptions {
     /// If a target has a preferred format, we use that.
     /// Finally, if neither of the above cases are true, we default to ELF.
     #[clap(value_enum, ignore_case = true, long)]
-    #[serde(deserialize_with = "format_from_str")]
+    #[serde(deserialize_with = "format_from_str", alias = "format")]
     binary_format: Option<Format>,
     /// The address in memory where the binary will be put at. This is only considered when `bin` is selected as the format.
     #[clap(long, value_parser = parse_u64)]

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -110,6 +110,7 @@ pub struct FormatOptions {
     /// If a target has a preferred format, we use that.
     /// Finally, if neither of the above cases are true, we default to ELF.
     #[clap(value_enum, ignore_case = true, long)]
+    // TODO: remove this alias in the next release after 0.24 and release of https://github.com/probe-rs/vscode/pull/86
     #[serde(deserialize_with = "format_from_str", alias = "format")]
     binary_format: Option<Format>,
     /// The address in memory where the binary will be put at. This is only considered when `bin` is selected as the format.


### PR DESCRIPTION
#2240 introduces a change that negatively impacts  the DAP clients like the VSCode extension. This PR introduces a temporary fix to ensure those clients can continue to work without requiring an immediate release.

Once we have released the current master branch, we can release https://github.com/probe-rs/vscode/pull/86, and then remove this alias.

