### PR TITLE
Fix detection of defmt timestamp

### DIFF
--- a/changelog/fixed-defmt-timestamp-detection.md
+++ b/changelog/fixed-defmt-timestamp-detection.md
@@ -1,0 +1,1 @@
+Fix detection of the defmt timestamp functionality as reported by ELF symbols

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -446,7 +446,8 @@ impl RttActiveTarget {
                     (false, true) => "{t} {L} {s}",
                     (false, false) => "{L} {s}",
                 });
-                let format = defmt_decoder::log::format::FormatterConfig::custom(format);
+                let mut format = defmt_decoder::log::format::FormatterConfig::custom(format);
+                format.is_timestamp_available = has_timestamp;
                 let formatter = defmt_decoder::log::format::Formatter::new(format);
 
                 let locs = {


### PR DESCRIPTION
Recently I noticed the following message while running a binary with a defmt rtt channel that was supposed to have a `defmt_timestamp!` implementation:

```
 WARN defmt_decoder::log::format: logger format contains timestamp but no timestamp implementation was provided; consider removing the timestamp (`{t}` or `{T}`) from the logger format or provide a `defmt::timestamp!` implementation
```

After looking into this issue, I realized that the `FormatterConfig` used for defmt did not have the correct timestamp configuration, so it was causing this message to trigger even if the ELF actually had a timestamp configuration in its debug symbol table.

This change simply fixes it by setting the `is_timestamp_available` of the `FormatterConfig` to the configuration read from the symbol table of the target ELF file.

This issue was introduced during the update from defmt-decoder v0.3.9 to v0.3.10 by commit a003183d2350c1bc1a90b2ace61cec34da28f7d6.