### PR TITLE
Armv8a: Add fast memory access functions

### DIFF
--- a/changelog/added-armv8a-fast-memory-access.md
+++ b/changelog/added-armv8a-fast-memory-access.md
@@ -1,0 +1,1 @@
+Armv8a: add fast memory access functions for AArch64

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -774,6 +774,7 @@ impl<'probe> Armv8a<'probe> {
 
             // write aligned part
             armv8a.write_cpu_memory_aarch64_fast_inner(address, aligned)?;
+            address += u64::try_from(aligned.len()).unwrap();
 
             // write unaligned part
             for byte in tail {
@@ -861,6 +862,7 @@ impl<'probe> Armv8a<'probe> {
 
             // read aligned part
             armv8a.read_cpu_memory_aarch64_fast_inner(address, aligned)?;
+            address += u64::try_from(aligned.len()).unwrap();
 
             // read unaligned part
             for byte in tail {

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -812,15 +812,9 @@ impl<'probe> Armv8a<'probe> {
         // enable memory access(MA) mode
         self.set_memory_access_mode(true)?;
 
-        for (i, d) in data.chunks(4).enumerate() {
+        for d in data.chunks(4) {
             let word = u32::from_le_bytes([d[0], d[1], d[2], d[3]]);
             // memory write loop
-            tracing::debug!(
-                "writing {:#016x} ({} / {} bytes)",
-                address + u64::try_from(i * 4).unwrap(),
-                i * 4,
-                data.len()
-            );
             let dbgdtr_rx_address = Dbgdtrrx::get_mmio_address_from_base(self.base_address)?;
             self.memory.write_word_32(dbgdtr_rx_address, word)?;
         }
@@ -892,8 +886,6 @@ impl<'probe> Armv8a<'probe> {
             });
         }
 
-        let data_len = data.len();
-
         // Save x0
         self.prepare_for_clobber(0)?;
 
@@ -918,14 +910,8 @@ impl<'probe> Armv8a<'probe> {
 
         let (data, last) = data.split_at_mut(data.len() - std::mem::size_of::<u32>());
 
-        for (i, d) in data.chunks_mut(4).enumerate() {
+        for d in data.chunks_mut(4) {
             // memory read loop
-            tracing::debug!(
-                "reading {:#016x} ({} / {} bytes)",
-                address + u64::try_from(i * 4).unwrap(),
-                i * 4,
-                data_len
-            );
             let tmp = self.memory.read_word_32(dbgdtr_tx_address)?.to_le_bytes();
             d.copy_from_slice(&tmp);
         }

--- a/probe-rs/src/architecture/arm/core/armv8a.rs
+++ b/probe-rs/src/architecture/arm/core/armv8a.rs
@@ -826,6 +826,13 @@ impl<'probe> Armv8a<'probe> {
         let edscr_address = Edscr::get_mmio_address_from_base(self.base_address)?;
         if Edscr(self.memory.read_word_32(edscr_address)?).err() {
             // under-run or abort
+
+            // clear error flag
+            let edrcr_address = Edrcr::get_mmio_address_from_base(self.base_address)?;
+            let mut edrcr = Edrcr(0);
+            edrcr.set_cse(true);
+            self.memory.write_word_32(edrcr_address, edrcr.into())?;
+
             return Err(Error::Arm(ArmError::Armv8a(Armv8aError::DataAbort)));
         }
 
@@ -927,6 +934,12 @@ impl<'probe> Armv8a<'probe> {
         let address = Edscr::get_mmio_address_from_base(self.base_address)?;
         let edscr = Edscr(self.memory.read_word_32(address)?);
         if edscr.err() {
+            // clear error flag
+            let edrcr_address = Edrcr::get_mmio_address_from_base(self.base_address)?;
+            let mut edrcr = Edrcr(0);
+            edrcr.set_cse(true);
+            self.memory.write_word_32(edrcr_address, edrcr.into())?;
+
             Err(Error::Arm(ArmError::Armv8a(Armv8aError::DataAbort)))
         } else {
             Ok(())

--- a/probe-rs/src/architecture/arm/core/instructions.rs
+++ b/probe-rs/src/architecture/arm/core/instructions.rs
@@ -254,6 +254,16 @@ pub(crate) mod aarch64 {
         ret
     }
 
+    pub(crate) fn build_ldrb(reg_target: u16, reg_source: u16, imm: u16) -> u32 {
+        let mut ret = 0b0011_1000_0100_0000_0000_0100_0000_0000;
+
+        ret |= (imm as u32) << 12;
+        ret |= (reg_source as u32) << 5;
+        ret |= reg_target as u32;
+
+        ret
+    }
+
     pub(crate) fn build_mrs(op0: u8, op1: u8, crn: u8, crm: u8, op2: u8, reg: u16) -> u32 {
         let mut ret = 0b1101_0101_0011_0000_0000_0000_0000_0000;
 
@@ -292,6 +302,16 @@ pub(crate) mod aarch64 {
 
     pub(crate) fn build_strw(reg_target: u16, reg_source: u16, imm: u16) -> u32 {
         let mut ret = 0b1011_1000_0000_0000_0000_0100_0000_0000;
+
+        ret |= (imm as u32) << 12;
+        ret |= (reg_source as u32) << 5;
+        ret |= reg_target as u32;
+
+        ret
+    }
+
+    pub(crate) fn build_strb(reg_target: u16, reg_source: u16, imm: u16) -> u32 {
+        let mut ret = 0b0011_1000_0000_0000_0000_0100_0000_0000;
 
         ret |= (imm as u32) << 12;
         ret |= (reg_source as u32) << 5;

--- a/probe-rs/src/memory/mod.rs
+++ b/probe-rs/src/memory/mod.rs
@@ -112,9 +112,9 @@ pub trait MemoryInterface {
     ///
     ///  Generally faster than `read_8`.
     fn read(&mut self, address: u64, data: &mut [u8]) -> Result<(), Error> {
-        if self.supports_native_64bit_access() && address % 8 == 0 && data.len() % 8 == 0 {
+        if self.supports_native_64bit_access() {
             // Avoid heap allocation and copy if we don't need it.
-            self.read_mem_64bit(address, data)?;
+            self.read_8(address, data)?;
         } else if address % 4 == 0 && data.len() % 4 == 0 {
             // Avoid heap allocation and copy if we don't need it.
             self.read_mem_32bit(address, data)?;


### PR DESCRIPTION
Add fast memory access functions for AArch64.

The memory access speed will be about 100 times faster than using current codes.


# speed comparisons

I compared the memory access speeds using the download command.
The result is about 100 times faster than the master branch.

## master(b8a261e460859ef526d415e8a97149152ebc2405)

```
tnishinaga@devubuntu:~/projects/probe-rs$ RUST_LOG=info cargo run --bin probe-rs --features cli download --chip RaspberryPi4B --protocol jtag --speed 1000 /home/tnishinaga/projects/baremetal_raspi4/XX_jtag_startup/target/aarch64-unknown-none/debug/jtag_kernel

skip

 INFO probe_rs::flashing::download: Found loadable segment, physical address: 0x00080000, virtual address: 0x00080000, flags: 0x5
 INFO probe_rs::flashing::download: Matching section: ".text.boot"
 INFO probe_rs::flashing::download: Matching section: ".text"
 INFO probe_rs::flashing::loader: Found 1 loadable sections:
 INFO probe_rs::flashing::loader:     Multiple sections at 00080000 (80 bytes)
    Finished in 277.848s
```

## this branch

```
tnishinaga@devubuntu:~/projects/probe-rs$ RUST_LOG=info cargo run --bin probe-rs --features cli download --chip RaspberryPi4B --protocol jtag --speed 1000 /home/tnishinaga/projects/baremetal_raspi4/XX_jtag_startup/target/aarch64-unknown-none/debug/jtag_kernel

skip

INFO probe_rs::flashing::download: Found loadable segment, physical address: 0x00080000, virtual address: 0x00080000, flags: 0x5
 INFO probe_rs::flashing::download: Matching section: ".text.boot"
 INFO probe_rs::flashing::download: Matching section: ".text"
 INFO probe_rs::flashing::loader: Found 1 loadable sections:
 INFO probe_rs::flashing::loader:     Multiple sections at 00080000 (80 bytes)
    Finished in 2.035s
```