### PR TITLE
Fix wlink detection

### DIFF
--- a/changelog/fixed-wlink-detection.md
+++ b/changelog/fixed-wlink-detection.md
@@ -1,0 +1,1 @@
+Fix wlink detection fail.

--- a/probe-rs/src/probe/wlink/mod.rs
+++ b/probe-rs/src/probe/wlink/mod.rs
@@ -504,7 +504,7 @@ impl JTAGAccess for WchLink {
 }
 
 fn get_wlink_info(device: &DeviceInfo) -> Option<DebugProbeInfo> {
-    if device.product_string() == Some("WCH-Link") {
+    if matches!(device.product_string(), Some("WCH-Link") | Some("WCH_Link")) {
         Some(DebugProbeInfo::new(
             "WCH-Link",
             VENDOR_ID,


### PR DESCRIPTION
Fix wlink detection after the nusb refactor #1842 .

The nusb driver seems to report a different product string.

Verified on:

- Probe: WCH-Link v2.10(v30) (WCH-LinkE-CH32V305)
- OS: macOS
- Board: CH32V307VCT6 (YD-CH32V307VCT6)
- Code: https://github.com/ch32-rs/ch32-hal

CC @Dirbaio