### PR TITLE
ESP32: Remove external flash address ranges

### DIFF
--- a/changelog/fixed-erasing-esp32.md
+++ b/changelog/fixed-erasing-esp32.md
@@ -1,0 +1,1 @@
+It is now possible to `probe-rs erase` ESP32 chips

--- a/probe-rs-target/src/memory.rs
+++ b/probe-rs-target/src/memory.rs
@@ -15,6 +15,9 @@ pub struct NvmRegion {
     pub is_boot_memory: bool,
     /// List of cores that can access this region
     pub cores: Vec<String>,
+    /// True if the memory region is an alias of a different memory region.
+    #[serde(default)]
+    pub is_alias: bool,
 }
 
 impl NvmRegion {

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -399,6 +399,7 @@ mod tests {
             is_boot_memory: true,
             range: 0..1 << 16,
             cores: vec!["main".into()],
+            is_alias: false,
         };
 
         (region, flash_algorithm)
@@ -427,6 +428,7 @@ mod tests {
             is_boot_memory: true,
             range: 0..1 << 16,
             cores: vec!["main".into()],
+            is_alias: false,
         };
 
         (region, flash_algorithm)

--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -18,8 +18,16 @@ pub fn erase_all(session: &mut Session, progress: Option<FlashProgress>) -> Resu
     tracing::debug!("Regions:");
     for region in &session.target().memory_map {
         if let MemoryRegion::Nvm(region) = region {
+            if region.is_alias {
+                tracing::debug!(
+                    "Skipping alias memory region {:#010X}..{:#010X}",
+                    region.range.start,
+                    region.range.end
+                );
+                continue;
+            }
             tracing::debug!(
-                "    region: {:08x}-{:08x} ({} bytes)",
+                "    region: {:#010X}..{:#010X} ({} bytes)",
                 region.range.start,
                 region.range.end,
                 region.range.end - region.range.start
@@ -104,6 +112,14 @@ pub fn erase_sectors(
     tracing::debug!("Regions:");
     for region in &session.target().memory_map {
         if let MemoryRegion::Nvm(region) = region {
+            if region.is_alias {
+                tracing::debug!(
+                    "Skipping alias memory region {:#010X}..{:#010X}",
+                    region.range.start,
+                    region.range.end
+                );
+                continue;
+            }
             tracing::debug!(
                 "    region: {:08x}-{:08x} ({} bytes)",
                 region.range.start,

--- a/probe-rs/src/flashing/error.rs
+++ b/probe-rs/src/flashing/error.rs
@@ -103,7 +103,7 @@ pub enum FlashError {
     // TODO: 1 Add information about flash (name, address)
     // TODO: 2 Add source of target definition (built-in, yaml)
     /// No flash algorithm was linked to this target.
-    #[error("Trying to write to flash region 0x{:X}..0x{:X}, but no suitable (default) flash loader algorithm is linked to the given target: {name}.", .range.start, .range.end)]
+    #[error("Trying to write to flash region {:#010X}..{:#010X}, but no suitable (default) flash loader algorithm is linked to the given target: {name}.", .range.start, .range.end)]
     NoFlashLoaderAlgorithmAttached {
         /// The name of the chip.
         name: String,

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -251,7 +251,7 @@ impl FlashLoader {
             };
 
             tracing::info!(
-                "    {} at {:08X?} ({} byte{})",
+                "    {} at {:#010X} ({} byte{})",
                 source,
                 section.address,
                 section.data.len(),
@@ -303,7 +303,7 @@ impl FlashLoader {
         tracing::debug!("Contents of builder:");
         for (&address, data) in &self.builder.data {
             tracing::debug!(
-                "    data: {:08x}-{:08x} ({} bytes)",
+                "    data: {:#010X}..{:#010X} ({} bytes)",
                 address,
                 address + data.len() as u64,
                 data.len()
@@ -315,7 +315,7 @@ impl FlashLoader {
             let Range { start, end } = algorithm.flash_properties.address_range;
 
             tracing::debug!(
-                "    algo {}: {:08x}-{:08x} ({} bytes)",
+                "    algo {}: {:#010X}..{:#010X} ({} bytes)",
                 algorithm.name,
                 start,
                 end,
@@ -343,8 +343,16 @@ impl FlashLoader {
         tracing::debug!("Regions:");
         for region in &self.memory_map {
             if let MemoryRegion::Nvm(region) = region {
+                if region.is_alias {
+                    tracing::debug!(
+                        "Skipping alias memory region {:#010X}..{:#010X}",
+                        region.range.start,
+                        region.range.end
+                    );
+                    continue;
+                }
                 tracing::debug!(
-                    "    region: {:08x}-{:08x} ({} bytes)",
+                    "    region: {:#010X}..{:#010X} ({} bytes)",
                     region.range.start,
                     region.range.end,
                     region.range.end - region.range.start
@@ -425,7 +433,7 @@ impl FlashLoader {
 
             for region in regions {
                 tracing::debug!(
-                    "    programming region: {:08x}-{:08x} ({} bytes)",
+                    "    programming region: {:#010X}..{:#010X} ({} bytes)",
                     region.range.start,
                     region.range.end,
                     region.range.end - region.range.start
@@ -448,7 +456,7 @@ impl FlashLoader {
         for region in &self.memory_map {
             if let MemoryRegion::Ram(region) = region {
                 tracing::debug!(
-                    "    region: {:08x}-{:08x} ({} bytes)",
+                    "    region: {:#010X}..{:#010X} ({} bytes)",
                     region.range.start,
                     region.range.end,
                     region.range.end - region.range.start
@@ -470,7 +478,7 @@ impl FlashLoader {
                 for (address, data) in self.builder.data_in_range(&region.range) {
                     some = true;
                     tracing::debug!(
-                        "     -- writing: {:08x}-{:08x} ({} bytes)",
+                        "     -- writing: {:#010X}..{:#010X} ({} bytes)",
                         address,
                         address + data.len() as u64,
                         data.len()
@@ -489,7 +497,7 @@ impl FlashLoader {
             tracing::debug!("Verifying!");
             for (&address, data) in &self.builder.data {
                 tracing::debug!(
-                    "    data: {:08x}-{:08x} ({} bytes)",
+                    "    data: {:#010X}..{:#010X} ({} bytes)",
                     address,
                     address + data.len() as u64,
                     data.len()

--- a/probe-rs/targets/esp32.yaml
+++ b/probe-rs/targets/esp32.yaml
@@ -22,6 +22,20 @@ variants:
         is_boot_memory: true
         cores:
           - main
+      - !Nvm # External instruction bus
+        range:
+          start: 0x400C2000
+          end: 0x40C00000
+        is_alias: true
+        cores:
+          - main
+      - !Nvm # External Data Bus
+        range:
+          start: 0x3F400000
+          end: 0x3FC00000
+        is_alias: true
+        cores:
+          - main
       - !Ram # SRAM2, Data bus
         range:
           start: 0x3FFAE000

--- a/probe-rs/targets/esp32c2.yaml
+++ b/probe-rs/targets/esp32c2.yaml
@@ -37,12 +37,14 @@ variants:
         range:
           start: 0x42000000
           end: 0x42400000
+        is_alias: true
         cores:
           - main
       - !Nvm # External Data Bus (see Table 3.2 - External Memory Address Mapping of TRM)
         range:
           start: 0x3c000000
           end: 0x3c400000
+        is_alias: true
         cores:
           - main
     flash_algorithms:

--- a/probe-rs/targets/esp32c3.yaml
+++ b/probe-rs/targets/esp32c3.yaml
@@ -25,28 +25,26 @@ variants:
         range: # 384 Kb SRAM on Instruction Bus
           start: 0x40380000
           end: 0x403e0000
-        is_boot_memory: false
         cores:
           - main
       - !Ram
         range: # 384 Kb SRAM on Data Bus
           start: 0x3fc80000
           end: 0x3fce0000
-        is_boot_memory: false
         cores:
           - main
       - !Nvm
         range: # External Flash on Instruction Bus (Read Only)
           start: 0x42000000
           end: 0x43000000
-        is_boot_memory: false
+        is_alias: true
         cores:
           - main
       - !Nvm
         range: # External Flash on Data Bus (Read Only)
           start: 0x3c000000
           end: 0x3d000000
-        is_boot_memory: false
+        is_alias: true
         cores:
           - main
     flash_algorithms:

--- a/probe-rs/targets/esp32c6.yaml
+++ b/probe-rs/targets/esp32c6.yaml
@@ -25,21 +25,19 @@ variants:
         range: # External Flash on Instruction/Data Bus
           start: 0x42000000
           end: 0x42FFFFFF
-        is_boot_memory: false
+        is_alias: true
         cores:
           - main
       - !Ram
         range:
           start: 0x40800000
           end: 0x4087FFFF
-        is_boot_memory: false
         cores:
           - main
       - !Ram
         range:
           start: 0x50000000
           end: 0x50003FFF
-        is_boot_memory: false
         cores:
           - main
     flash_algorithms:

--- a/probe-rs/targets/esp32c6_lp.yaml
+++ b/probe-rs/targets/esp32c6_lp.yaml
@@ -11,7 +11,7 @@ variants:
     cores:
       - name: lp
         type: riscv
-        core_access_options: 
+        core_access_options:
           !Riscv
             hart_id: 1
     memory_map:
@@ -26,21 +26,19 @@ variants:
         range: # External Flash on Instruction/Data Bus
           start: 0x42000000
           end: 0x42FFFFFF
-        is_boot_memory: false
+        is_alias: true
         cores:
           - lp
       - !Ram
         range:
           start: 0x40800000
           end: 0x4087FFFF
-        is_boot_memory: false
         cores:
           - lp
       - !Ram
         range:
           start: 0x50000000
           end: 0x50003FFF
-        is_boot_memory: false
         cores:
           - lp
     flash_algorithms: []

--- a/probe-rs/targets/esp32h2.yaml
+++ b/probe-rs/targets/esp32h2.yaml
@@ -25,14 +25,13 @@ variants:
         range: # External Flash on Instruction/Data Bus
           start: 0x42000000
           end: 0x42FFFFFF
-        is_boot_memory: false
+        is_alias: true
         cores:
           - main
       - !Ram
         range:
           start: 0x40800000
           end: 0x4087FFFF
-        is_boot_memory: false
         cores:
           - main
     flash_algorithms:

--- a/probe-rs/targets/esp32s2.yaml
+++ b/probe-rs/targets/esp32s2.yaml
@@ -20,6 +20,27 @@ variants:
           end: 0x4000000
         cores:
           - main
+      - !Nvm # External instruction bus
+        range:
+          start: 0x40080000
+          end: 0x40800000
+        is_alias: true
+        cores:
+          - main
+      - !Nvm # External Data Bus 1
+        range:
+          start: 0x3F000000
+          end: 0x3F400000
+        is_alias: true
+        cores:
+          - main
+      - !Nvm # External Data Bus 2
+        range:
+          start: 0x3F500000
+          end: 0x3FF80000
+        is_alias: true
+        cores:
+          - main
       - !Ram # SRAM0, Data bus
         range:
           start: 0x3FFB0000

--- a/probe-rs/targets/esp32s3.yaml
+++ b/probe-rs/targets/esp32s3.yaml
@@ -51,12 +51,14 @@ variants:
         range:
           start: 0x42000000
           end: 0x44000000
+        is_alias: true
         cores:
           - cpu0
       - !Nvm # External Data Bus
         range:
           start: 0x3C000000
           end: 0x3E000000
+        is_alias: true
         cores:
           - cpu0
     flash_algorithms:

--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -96,6 +96,7 @@ pub fn cmd_elf(
                         range: 0..0x2000,
                         cores: vec!["main".to_owned()],
                         name: None,
+                        is_alias: false,
                     }),
                     MemoryRegion::Ram(RamRegion {
                         is_boot_memory: true,

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -544,10 +544,11 @@ pub(crate) fn get_mem_map(device: &Device, cores: &[probe_rs_target::Core]) -> V
                     existing_region.cores.extend_from_slice(&cores);
                 } else {
                     mem_map.push(MemoryRegion::Nvm(NvmRegion {
-                    name: Some(region.name.clone()),
-                    range: region.memory_start..region.memory_end,
-                    is_boot_memory: region.is_boot_memory,
-                    cores,
+                        name: Some(region.name.clone()),
+                        range: region.memory_start..region.memory_end,
+                        is_boot_memory: region.is_boot_memory,
+                        cores,
+                        is_alias: false,
                     }));
                 }
             },


### PR DESCRIPTION
@Yatekii @MabezDev The issue I'm trying to solve here is that `probe-rs erase` fails if it encounters NVM regions whose addresses are not covered by flash algos. In case of ESP chips, the flash loaders are working with physical addresses in the flash chip, but the NVM addresses were defines as the CPU saw them. I'm not entirely sure, but I believe these memory ranges are read-only (because the write API basically operates by issuing commands to the flash ICs directly). Maybe a better approach would be to allow defining regions as read only, or to define them as alias regions - whichever we chose, we can re-add these regions after probe-rs becomes smart enough.