### PR TITLE
Fix dap progress reporting UX

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1869,7 +1869,8 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             "progressUpdate",
             Some(ProgressUpdateEventBody {
                 message: message.map(|msg| match percentage {
-                    None | Some(100.0) => msg.to_string(),
+                    None => msg.to_string(),
+                    Some(percentage) if percentage == 100.0 => msg.to_string(),
                     Some(percentage) => format!("{msg} ({percentage:02.0}%)"),
                 }),
                 percentage,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1868,12 +1868,10 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         self.send_event(
             "progressUpdate",
             Some(ProgressUpdateEventBody {
-                message: message.map(|msg| {
-                    if let Some(percentage) = percentage {
-                        format!("{msg} ({percentage:02.0}%)")
-                    } else {
-                        format!("{msg} ...")
-                    }
+                message: message.map(|msg| match percentage {
+                    Some(100.0) => msg.to_string(),
+                    Some(percentage) => format!("{msg} ({percentage:02.0}%)"),
+                    None => format!("{msg} ..."),
                 }),
                 percentage,
                 progress_id: progress_id.to_string(),

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -1869,9 +1869,8 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
             "progressUpdate",
             Some(ProgressUpdateEventBody {
                 message: message.map(|msg| match percentage {
-                    Some(100.0) => msg.to_string(),
+                    None | Some(100.0) => msg.to_string(),
                     Some(percentage) => format!("{msg} ({percentage:02.0}%)"),
-                    None => format!("{msg} ..."),
                 }),
                 percentage,
                 progress_id: progress_id.to_string(),

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_variables.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/peripherals/svd_variables.rs
@@ -29,7 +29,7 @@ impl SvdCache {
         let mut svd_opened_file = File::open(svd_file)?;
 
         let progress_id = debug_adapter.start_progress(
-            format!("Loading SVD file : {}", svd_file.display()).as_str(),
+            format!("Loading SVD file: {}", svd_file.display()).as_str(),
             Some(dap_request_id),
         )?;
 
@@ -43,7 +43,7 @@ impl SvdCache {
                 debug_adapter
                     .update_progress(
                         None,
-                        Some(format!("Done loading SVD file :{:?}", &svd_file)),
+                        Some(format!("Done loading SVD file: {}", svd_file.display())),
                         progress_id,
                     )
                     .ok();
@@ -107,8 +107,7 @@ pub(crate) fn variable_cache_from_svd<P: ProtocolAdapter>(
                 .update_progress(
                     None,
                     Some(format!(
-                        "SVD loading peripheral group:{}",
-                        peripheral_group_name
+                        "SVD loading peripheral group: {peripheral_group_name}",
                     )),
                     progress_id,
                 )

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -30,7 +30,6 @@ use probe_rs::{
 use std::{
     cell::RefCell,
     fs,
-    ops::Mul,
     path::Path,
     rc::Rc,
     thread,
@@ -642,7 +641,7 @@ impl Debugger {
                     }
                     ProgressEvent::StartedFilling => {
                         debug_adapter
-                            .update_progress(Some(0.0), Some("Reading Old Pages ..."), id)
+                            .update_progress(None, Some("Reading Old Pages"), id)
                             .ok();
                     }
                     ProgressEvent::PageFilled { size, .. } => {
@@ -651,11 +650,7 @@ impl Debugger {
                             / flash_progress.total_fill_size as f64;
 
                         debug_adapter
-                            .update_progress(
-                                Some(progress),
-                                Some(format!("Reading Old Pages ({progress})")),
-                                id,
-                            )
+                            .update_progress(Some(progress), Some("Reading Old Pages"), id)
                             .ok();
                     }
                     ProgressEvent::FailedFilling => {
@@ -670,7 +665,7 @@ impl Debugger {
                     }
                     ProgressEvent::StartedErasing => {
                         debug_adapter
-                            .update_progress(Some(0.0), Some("Erasing Sectors ..."), id)
+                            .update_progress(None, Some("Erasing Sectors"), id)
                             .ok();
                     }
                     ProgressEvent::SectorErased { size, .. } => {
@@ -678,11 +673,7 @@ impl Debugger {
                         let progress = flash_progress.sector_size_done as f64
                             / flash_progress.total_sector_size as f64;
                         debug_adapter
-                            .update_progress(
-                                Some(progress),
-                                Some(format!("Erasing Sectors ({progress})")),
-                                id,
-                            )
+                            .update_progress(Some(progress), Some("Erasing Sectors"), id)
                             .ok();
                     }
                     ProgressEvent::FailedErasing => {
@@ -698,7 +689,7 @@ impl Debugger {
                     ProgressEvent::StartedProgramming { length } => {
                         flash_progress.total_page_size = length as usize;
                         debug_adapter
-                            .update_progress(Some(0.0), Some("Programming Pages ..."), id)
+                            .update_progress(None, Some("Programming Pages"), id)
                             .ok();
                     }
                     ProgressEvent::PageProgrammed { size, .. } => {
@@ -706,14 +697,7 @@ impl Debugger {
                         let progress = flash_progress.page_size_done as f64
                             / flash_progress.total_page_size as f64;
                         debug_adapter
-                            .update_progress(
-                                Some(progress),
-                                Some(format!(
-                                    "Programming Pages ({:02.0}%)",
-                                    progress.mul(100_f64)
-                                )),
-                                id,
-                            )
+                            .update_progress(Some(progress), Some("Programming Pages"), id)
                             .ok();
                     }
                     ProgressEvent::FailedProgramming => {

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context};
 use probe_rs::{
-    flashing::{DownloadOptions, FileDownloadError, FlashProgress},
+    flashing::{DownloadOptions, FileDownloadError, FlashProgress, ProgressEvent},
     probe::list::Lister,
     Architecture, CoreStatus,
 };
@@ -627,7 +627,7 @@ impl Debugger {
                 let mut flash_progress = progress_state.borrow_mut();
                 let mut debug_adapter = rc_debug_adapter_clone.borrow_mut();
                 match event {
-                    probe_rs::flashing::ProgressEvent::Initialized { flash_layout } => {
+                    ProgressEvent::Initialized { flash_layout } => {
                         flash_progress.total_page_size =
                             flash_layout.pages().iter().map(|s| s.size() as usize).sum();
 
@@ -640,12 +640,12 @@ impl Debugger {
                         flash_progress.total_fill_size =
                             flash_layout.fills().iter().map(|s| s.size() as usize).sum();
                     }
-                    probe_rs::flashing::ProgressEvent::StartedFilling => {
+                    ProgressEvent::StartedFilling => {
                         debug_adapter
                             .update_progress(Some(0.0), Some("Reading Old Pages ..."), id)
                             .ok();
                     }
-                    probe_rs::flashing::ProgressEvent::PageFilled { size, .. } => {
+                    ProgressEvent::PageFilled { size, .. } => {
                         flash_progress.fill_size_done += size as usize;
                         let progress = flash_progress.fill_size_done as f64
                             / flash_progress.total_fill_size as f64;
@@ -658,22 +658,22 @@ impl Debugger {
                             )
                             .ok();
                     }
-                    probe_rs::flashing::ProgressEvent::FailedFilling => {
+                    ProgressEvent::FailedFilling => {
                         debug_adapter
                             .update_progress(Some(1.0), Some("Reading Old Pages Failed!"), id)
                             .ok();
                     }
-                    probe_rs::flashing::ProgressEvent::FinishedFilling => {
+                    ProgressEvent::FinishedFilling => {
                         debug_adapter
                             .update_progress(Some(1.0), Some("Reading Old Pages Complete!"), id)
                             .ok();
                     }
-                    probe_rs::flashing::ProgressEvent::StartedErasing => {
+                    ProgressEvent::StartedErasing => {
                         debug_adapter
                             .update_progress(Some(0.0), Some("Erasing Sectors ..."), id)
                             .ok();
                     }
-                    probe_rs::flashing::ProgressEvent::SectorErased { size, .. } => {
+                    ProgressEvent::SectorErased { size, .. } => {
                         flash_progress.sector_size_done += size as usize;
                         let progress = flash_progress.sector_size_done as f64
                             / flash_progress.total_sector_size as f64;
@@ -685,23 +685,23 @@ impl Debugger {
                             )
                             .ok();
                     }
-                    probe_rs::flashing::ProgressEvent::FailedErasing => {
+                    ProgressEvent::FailedErasing => {
                         debug_adapter
                             .update_progress(Some(1.0), Some("Erasing Sectors Failed!"), id)
                             .ok();
                     }
-                    probe_rs::flashing::ProgressEvent::FinishedErasing => {
+                    ProgressEvent::FinishedErasing => {
                         debug_adapter
                             .update_progress(Some(1.0), Some("Erasing Sectors Complete!"), id)
                             .ok();
                     }
-                    probe_rs::flashing::ProgressEvent::StartedProgramming { length } => {
+                    ProgressEvent::StartedProgramming { length } => {
                         flash_progress.total_page_size = length as usize;
                         debug_adapter
                             .update_progress(Some(0.0), Some("Programming Pages ..."), id)
                             .ok();
                     }
-                    probe_rs::flashing::ProgressEvent::PageProgrammed { size, .. } => {
+                    ProgressEvent::PageProgrammed { size, .. } => {
                         flash_progress.page_size_done += size as usize;
                         let progress = flash_progress.page_size_done as f64
                             / flash_progress.total_page_size as f64;
@@ -716,17 +716,17 @@ impl Debugger {
                             )
                             .ok();
                     }
-                    probe_rs::flashing::ProgressEvent::FailedProgramming => {
+                    ProgressEvent::FailedProgramming => {
                         debug_adapter
                             .update_progress(Some(1.0), Some("Flashing Pages Failed!"), id)
                             .ok();
                     }
-                    probe_rs::flashing::ProgressEvent::FinishedProgramming => {
+                    ProgressEvent::FinishedProgramming => {
                         debug_adapter
                             .update_progress(Some(1.0), Some("Flashing Pages Complete!"), id)
                             .ok();
                     }
-                    probe_rs::flashing::ProgressEvent::DiagnosticMessage { .. } => (),
+                    ProgressEvent::DiagnosticMessage { .. } => (),
                 }
             })
         });


### PR DESCRIPTION
Previously, for "Erasing Sectors" and "Reading Old Pages" we displayed a non-rounded number between 0 and 1 as the progress. This PR fixes this issue by moving the % display into `update_progress`.