### PR TITLE
Don't swallow file open errors

### DIFF
--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -33,11 +33,10 @@ pub fn attach_to_rtt(
     let exact_rtt_region;
     let mut rtt_region = rtt_region;
 
-    if let Ok(mut file) = File::open(elf_file) {
-        if let Some(address) = RttActiveTarget::get_rtt_symbol(&mut file) {
-            exact_rtt_region = ScanRegion::Exact(address as u32);
-            rtt_region = &exact_rtt_region;
-        }
+    let mut file = File::open(elf_file)?;
+    if let Some(address) = RttActiveTarget::get_rtt_symbol(&mut file) {
+        exact_rtt_region = ScanRegion::Exact(address as u32);
+        rtt_region = &exact_rtt_region;
     }
 
     tracing::info!("Initializing RTT");


### PR DESCRIPTION
Currently, passing an incorrect path to `probe-rs attach` (which requires a path) silently ignores it. With this PR, we at least display an `ERROR probe_rs::cmd::run: Failed to attach to RTT, continuing...` error.