### PR TITLE
feat: chose core based on rtt controll block

### DIFF
--- a/changelog/added-autodetect-rtt-core.md
+++ b/changelog/added-autodetect-rtt-core.md
@@ -1,0 +1,1 @@
+Autodetect the core to attach the RTT server by looking at which core can access the RAM where the RTT control block is

--- a/probe-rs/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run/mod.rs
@@ -12,7 +12,6 @@ use std::time::{Duration, Instant};
 use anyhow::{anyhow, Result};
 use probe_rs::debug::{DebugInfo, DebugRegisters};
 use probe_rs::rtt::ScanRegion;
-use probe_rs::Session;
 use probe_rs::{
     exception_handler_for_core, probe::list::Lister, Core, CoreInterface, Error, HaltReason,
     Session, VectorCatchCondition,

--- a/probe-rs/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run/mod.rs
@@ -1,6 +1,7 @@
 mod normal_run_mode;
 use normal_run_mode::*;
 
+use std::fs::File;
 use std::io::Write;
 use std::ops::Range;
 use std::path::Path;
@@ -11,6 +12,7 @@ use std::time::{Duration, Instant};
 use anyhow::{anyhow, Result};
 use probe_rs::debug::{DebugInfo, DebugRegisters};
 use probe_rs::rtt::ScanRegion;
+use probe_rs::Session;
 use probe_rs::{
     exception_handler_for_core, probe::list::Lister, Core, CoreInterface, Error, HaltReason,
     Session, VectorCatchCondition,
@@ -72,6 +74,43 @@ pub struct SharedOptions {
     pub(crate) rtt_scan_memory: bool,
 }
 
+// For multi-core targets, it infers the target core from the RTT symbol.
+fn get_target_core_id(session: &mut Session, elf_file: &Path) -> usize {
+    let maybe_core_id = || {
+        let mut file = File::open(elf_file).ok()?;
+        let address = RttActiveTarget::get_rtt_symbol(&mut file)?;
+
+        tracing::debug!("RTT symbol found at 0x{:08x}", address);
+
+        let target_memory = session
+            .target()
+            .memory_map
+            .iter()
+            .filter_map(|region| {
+                if let MemoryRegion::Ram(region) = region {
+                    Some(region)
+                } else {
+                    None
+                }
+            })
+            .find(|region| region.range.contains(&address))?;
+
+        tracing::debug!("RTT symbol is in RAM region {:?}", target_memory.name);
+
+        let core_name = target_memory.cores.first()?;
+        let core_id = session
+            .target()
+            .cores
+            .iter()
+            .position(|core| core.name == *core_name)?;
+
+        tracing::debug!("RTT symbol is in core {}", core_id);
+
+        Some(core_id)
+    };
+    maybe_core_id().unwrap_or(0)
+}
+
 impl Cmd {
     pub fn run(
         self,
@@ -83,9 +122,10 @@ impl Cmd {
 
         let (mut session, probe_options) =
             self.shared_options.probe_options.simple_attach(lister)?;
+        let path = Path::new(&self.shared_options.path);
+        let core_id = get_target_core_id(&mut session, path);
 
         if run_download {
-            let path = Path::new(&self.shared_options.path);
             let loader = build_loader(&mut session, path, self.shared_options.format_options)?;
             run_flash_download(
                 &mut session,
@@ -95,9 +135,10 @@ impl Cmd {
                 loader,
                 self.shared_options.chip_erase,
             )?;
+
             // reset the core to leave it in a consistent state after flashing
             session
-                .core(0)?
+                .core(core_id)?
                 .reset_and_halt(Duration::from_millis(100))?;
         }
 
@@ -110,6 +151,7 @@ impl Cmd {
         run_mode.run(
             session,
             RunLoop {
+                core_id,
                 memory_map,
                 rtt_scan_regions,
                 timestamp_offset,
@@ -138,6 +180,7 @@ fn detect_run_mode(cmd: &Cmd) -> Result<Box<dyn RunMode>, anyhow::Error> {
 }
 
 struct RunLoop {
+    core_id: usize,
     memory_map: Vec<MemoryRegion>,
     rtt_scan_regions: Vec<Range<u64>>,
     path: String,

--- a/probe-rs/src/bin/probe-rs/cmd/run/normal_run_mode.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run/normal_run_mode.rs
@@ -25,7 +25,7 @@ impl NormalRunMode {
 }
 impl RunMode for NormalRunMode {
     fn run(&self, mut session: Session, run_loop: RunLoop) -> anyhow::Result<()> {
-        let mut core = session.core(0)?;
+        let mut core = session.core(run_loop.core_id)?;
 
         let halt_handler = |halt_reason: HaltReason, _core: &mut Core| match halt_reason {
             HaltReason::Breakpoint(BreakpointCause::Semihosting(cmd)) => {


### PR DESCRIPTION
Hi!
I would like to use the rtt on the nrf5340 net core, which is currently impossible because the rtt is hard coded to attach to the `core[0]`. I describe my problem [here](https://github.com/probe-rs/probe-rs/discussions/2294).
This PR implements the @Dirbaio idea to autodetect it by looking at which core can access the RAM where the RTT control block is.
This solves my issue with the nrf5340 net core.

I'm new to the code base, so the code could be probably well-placed. I'm open to refactories feedback.

### Must

- [X] The code compiles without `errors` or `warnings`.
- [X] All tests pass and in the best case you also added new tests.
- [X] `cargo fmt` was run.
- [x] Add a changelog fragment describing your changes in `changelogs/`. See https://github.com/probe-rs/probe-rs/blob/master/CONTRIBUTING.md#changelog-entries. 

### Nice to have

- [X] You add a description of your work to this PR.
- [ ] You added proper docs (in code, rustdoc and README.md) for your newly added features and code.