### PR TITLE
Debug: Fix incorrect function dies being returned in stack unwind

### DIFF
--- a/changelog/fixed-find-incorrect-function-die.md
+++ b/changelog/fixed-find-incorrect-function-die.md
@@ -1,0 +1,1 @@
+`UnitInfo::get_function_dies()` sometimes retrieved the wrong function die, because of insufficient range filtering.

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -105,38 +105,6 @@ impl DebugInfo {
         })
     }
 
-    /// Get the name of the function at the given address.
-    ///
-    /// If no function is found, `None` will be returned.
-    ///
-    /// ## Inlined functions
-    /// Multiple nested inline functions could exist at the given address.
-    /// This function will currently return the innermost function in that case.
-    // TODO: This function takes a memory interface. This seems odd, but gimli sometimes needs to read memory to resolve.
-    // Maybe this can be factored out if we can be sure that memory is never read for this use case.
-    // Until we have more tests we cannot be sure though and it should stay like this.
-    pub fn function_name(
-        &self,
-        address: u64,
-        find_inlined: bool,
-    ) -> Result<Option<String>, DebugError> {
-        for unit_info in &self.unit_infos {
-            let mut functions = unit_info.get_function_dies(self, address, find_inlined)?;
-
-            // Use the last functions from the list, this is the function which most closely
-            // corresponds to the PC in case of multiple inlined functions.
-            if let Some(die_cursor_state) = functions.pop() {
-                let function_name = die_cursor_state.function_name(self);
-
-                if function_name.is_some() {
-                    return Ok(function_name);
-                }
-            }
-        }
-
-        Ok(None)
-    }
-
     /// Try get the [`SourceLocation`] for a given address.
     pub fn get_source_location(&self, address: u64) -> Option<SourceLocation> {
         for unit_info in &self.unit_infos {

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__full_unwind.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__nRF52833_xxAA__full_unwind.snap
@@ -4542,7 +4542,7 @@ expression: stack_frames
       type_name: Unknown
       value: "<unknown>"
   canonical_frame_address: 536887296
-- function_name: "encrypt_block : ERROR: UNWIND: Tried to unwind `RegisterRule` at CFA = None."
+- function_name: "<unknown function @ 0x0000013c> : ERROR: UNWIND: Tried to unwind `RegisterRule` at CFA = None."
   source_location: ~
   registers:
     - core_register:
@@ -4733,36 +4733,7 @@ expression: stack_frames
       value: ~
   pc:
     U32: 316
-  frame_base: 0
+  frame_base: ~
   is_inlined: false
-  local_variables:
-    Child Variables:
-      name: LocalScopeRoot
-      type_name: Unknown
-      value: "<unknown> {\n\tself: &mut nrf_hal_common::ecb::Ecb = &mut nrf_hal_common::ecb::Ecb @ 0x200040C8,\n\tblock: <unknown> = < <value optimized away by compiler, out of scope, or dropped> >,\n\tkey: <unknown> = < <value optimized away by compiler, out of scope, or dropped> >}"
-      children:
-        - name:
-            Named: self
-          type_name:
-            Pointer: "&mut nrf_hal_common::ecb::Ecb"
-          value: "&mut nrf_hal_common::ecb::Ecb @ 0x200040C8"
-          children:
-            - name:
-                Named: "*self"
-              type_name:
-                Struct: Ecb
-              value: "Ecb {\n\tregs: <unknown> = < Failed to read referenced variable address from memory location 0x200040C8 : The coredump does not include the memory for address 0x200040c8 of size 0x4. >}"
-              children:
-                - name:
-                    Named: regs
-                  type_name: Unknown
-                  value: "< Failed to read referenced variable address from memory location 0x200040C8 : The coredump does not include the memory for address 0x200040c8 of size 0x4. >"
-        - name:
-            Named: block
-          type_name: Unknown
-          value: "< <value optimized away by compiler, out of scope, or dropped> >"
-        - name:
-            Named: key
-          type_name: Unknown
-          value: "< <value optimized away by compiler, out of scope, or dropped> >"
+  local_variables: ~
   canonical_frame_address: ~

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__print_stacktrace.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__print_stacktrace.snap
@@ -75,7 +75,7 @@ Frame:
   column: Some(Column(1))
  frame_base:      Some(20003ff8)
 Frame:
- function:        fold<usize, u32, core::iter::adapters::map::map_fold::{closure_env#0}<&usize, u32, u32, microbit_common::display::nonblocking::control::{impl#0}::initialise_for_display::{closure#2}::{closure_env#0}, core::iter::traits::accum::{impl#36}::sum::{closure_env#0}<core::iter::adapters::map::Map<core::slice::iter::Iter<usize>, microbit_common::display::nonblocking::control::{impl#0}::initialise_for_display::{closure#2}::{closure_env#0}>>>> : ERROR: UNWIND: Failed to read value for register R7/FP from address 0x0000000000000000 (4 bytes): The coredump does not include the memory for address 0x0 of size 0x4
+ function:        <unknown function @ 0x000000ce> : ERROR: UNWIND: Tried to unwind `RegisterRule` at CFA = None.
  source_location:
 None
  frame_base:      None

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_handler.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_handler.snap
@@ -40,13 +40,12 @@ Frame:
   column: Some(Column(1))
  frame_base:      Some(2001fff8)
 Frame:
- function:        memmove
+ function:        <unknown function @ 0x0000013c>
  source_location:
 None
- frame_base:      Some(00000000)
+ frame_base:      None
 Frame:
- function:        memmove
+ function:        <unknown function @ 0x0000013c>
  source_location:
 None
- frame_base:      Some(00000000)
-
+ frame_base:      None

--- a/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_trampoline.snap
+++ b/probe-rs/src/debug/snapshots/probe_rs__debug__debug_info__test__unwinding_in_exception_trampoline.snap
@@ -32,13 +32,12 @@ Frame:
   column: Some(Column(1))
  frame_base:      Some(2001fff8)
 Frame:
- function:        memmove
+ function:        <unknown function @ 0x0000013c>
  source_location:
 None
- frame_base:      Some(00000000)
+ frame_base:      None
 Frame:
- function:        memmove
+ function:        <unknown function @ 0x0000013c>
  source_location:
 None
- frame_base:      Some(00000000)
-
+ frame_base:      None

--- a/probe-rs/src/debug/unit_info.rs
+++ b/probe-rs/src/debug/unit_info.rs
@@ -77,7 +77,7 @@ impl UnitInfo {
                 die.ranges.push(gimli_range.begin..gimli_range.end);
             }
 
-            if !die.range_contains(address) {
+            if !die.range_contains(address) || die.low_pc().unwrap_or(0) == 0 {
                 continue;
             }
 
@@ -140,7 +140,10 @@ impl UnitInfo {
                 die_ranges.push(gimli_range.begin..gimli_range.end);
             }
 
-            if !die_ranges.iter().any(|range| range.contains(&address)) {
+            if !die_ranges
+                .iter()
+                .any(|range| range.contains(&address) && range.start != 0)
+            {
                 continue;
             }
 


### PR DESCRIPTION
The logic for finding function dies returned on the first function die where the range contained the program counter, even if the die has a starting address of 0. Depending on the order of the compilation units in the debug information, this would result in the incorrect die being identified as the active function for that program counter.