### PR TITLE
cargo-embed: select core based on rtt control block

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -8,6 +8,7 @@ use colored::*;
 use probe_rs::gdb_server::GdbInstanceConfiguration;
 use probe_rs::probe::list::Lister;
 use probe_rs::rtt::ScanRegion;
+use probe_rs::Core;
 use probe_rs::{probe::DebugProbeSelector, Session};
 use std::ffi::OsString;
 use std::{
@@ -26,7 +27,7 @@ use crate::util::common_options::{
 };
 use crate::util::flash::{build_loader, run_flash_download};
 use crate::util::logging::setup_logging;
-use crate::util::rtt::{RttActiveTarget, RttChannelConfig, RttConfig};
+use crate::util::rtt::{self, RttActiveTarget, RttChannelConfig, RttConfig};
 use crate::util::{build_artifact, common_options::CargoOptions, logging, rtt::DataFormat};
 use crate::FormatOptions;
 
@@ -235,8 +236,9 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
         )?;
     }
 
+    let core_id = rtt::get_target_core_id(&mut session, path);
     if config.reset.enabled {
-        let mut core = session.core(0)?;
+        let mut core = session.core(core_id)?;
         let halt_timeout = Duration::from_millis(500);
         #[allow(deprecated)] // Remove in 0.10
         if config.flashing.halt_afterwards {
@@ -284,7 +286,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
 
     if config.rtt.enabled {
         // GDB is also using the session, so we do not lock on the outside.
-        run_rttui_app(name, &session, config, path, offset)?;
+        run_rttui_app(name, &session, core_id, config, path, offset)?;
     }
 
     if let Some(gdb_thread_handle) = gdb_thread_handle {
@@ -303,6 +305,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
 fn run_rttui_app(
     name: &str,
     session: &Mutex<Session>,
+    core_id: usize,
     config: config::Config,
     elf_path: &Path,
     timezone_offset: UtcOffset,
@@ -353,6 +356,7 @@ fn run_rttui_app(
 
     let Some(mut rtt) = rtt_attach(
         session,
+        core_id,
         config.rtt.timeout,
         &ScanRegion::Ram,
         elf_path,
@@ -375,7 +379,11 @@ fn run_rttui_app(
     }
 
     // Configure rtt channels according to configuration
-    configure_rtt_modes(session, &config, &mut rtt)?;
+    {
+        let mut session_handle = session.lock().unwrap();
+        let mut core = session_handle.core(core_id)?;
+        configure_rtt_modes(&mut core, &config, &mut rtt)?;
+    }
 
     tracing::info!("RTT initialized.");
 
@@ -411,7 +419,7 @@ fn run_rttui_app(
 
         {
             let mut session_handle = session.lock().unwrap();
-            let mut core = session_handle.core(0)?;
+            let mut core = session_handle.core(core_id)?;
 
             if app.handle_event(&mut core) {
                 logging::println("Shutting down.");
@@ -426,12 +434,10 @@ fn run_rttui_app(
 }
 
 fn configure_rtt_modes(
-    session: &Mutex<Session>,
+    core: &mut Core,
     config: &config::Config,
     rtt: &mut RttActiveTarget,
 ) -> Result<(), anyhow::Error> {
-    let mut session_handle = session.lock().unwrap();
-    let mut core = session_handle.core(0)?;
     let default_up_mode = config.rtt.up_mode;
 
     // TODO: also configure down channels
@@ -444,7 +450,7 @@ fn configure_rtt_modes(
             // Only set the mode when the config file says to,
             // when not set explicitly, the firmware picks.
             tracing::debug!("Setting RTT channel {} to {:?}", up_channel.number(), &mode);
-            up_channel.set_mode(&mut core, mode)?;
+            up_channel.set_mode(core, mode)?;
         }
     }
     Ok(())
@@ -453,6 +459,7 @@ fn configure_rtt_modes(
 /// Try to attach to RTT, with the given timeout
 fn rtt_attach(
     session: &Mutex<Session>,
+    core_id: usize,
     timeout: Duration,
     rtt_region: &ScanRegion,
     elf_file: &Path,
@@ -475,9 +482,9 @@ fn rtt_attach(
         {
             let mut session_handle = session.lock().unwrap();
             let memory_map = session_handle.target().memory_map.clone();
-            let mut core = session_handle.core(0)?;
+            let mut core = session_handle.core(core_id)?;
 
-            match crate::util::rtt::attach_to_rtt(&mut core, &memory_map, rtt_region, elf_file) {
+            match rtt::attach_to_rtt(&mut core, &memory_map, rtt_region, elf_file) {
                 Ok(Some(rtt)) => {
                     let app = RttActiveTarget::new(rtt, elf_file, rtt_config, timestamp_offset);
 

--- a/probe-rs/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run/mod.rs
@@ -97,14 +97,17 @@ impl Cmd {
 
         let (mut session, probe_options) =
             self.shared_options.probe_options.simple_attach(lister)?;
-        let path = Path::new(&self.shared_options.path);
-        let core_id = rtt::get_target_core_id(&mut session, path);
+        let core_id = rtt::get_target_core_id(&mut session, &self.shared_options.path);
 
         if run_download {
-            let loader = build_loader(&mut session, path, self.shared_options.format_options)?;
+            let loader = build_loader(
+                &mut session,
+                &self.shared_options.path,
+                self.shared_options.format_options,
+            )?;
             run_flash_download(
                 &mut session,
-                path,
+                &self.shared_options.path,
                 &self.shared_options.download_options,
                 &probe_options,
                 loader,

--- a/probe-rs/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs/src/bin/probe-rs/util/flash.rs
@@ -29,7 +29,7 @@ fn init_progress_bar(bar: &ProgressBar) {
 /// This function also manages the update and display of progress bars.
 pub fn run_flash_download(
     session: &mut Session,
-    path: &Path,
+    path: impl AsRef<Path>,
     download_options: &BinaryDownloadOptions,
     probe_options: &LoadedProbeOptions,
     loader: FlashLoader,
@@ -150,7 +150,7 @@ pub fn run_flash_download(
             source: error,
             target: Box::new(session.target().clone()),
             target_spec: probe_options.chip(),
-            path: path.to_path_buf(),
+            path: path.as_ref().to_path_buf(),
         })?;
 
     // If we don't do this, the progress bars disappear.

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -18,7 +18,7 @@ use std::{
 use time::{macros::format_description, OffsetDateTime, UtcOffset};
 
 /// Infer the target core from the RTT symbol. Useful for multi-core targets.
-pub fn get_target_core_id(session: &mut Session, elf_file: &Path) -> usize {
+pub fn get_target_core_id(session: &mut Session, elf_file: impl AsRef<Path>) -> usize {
     let maybe_core_id = || {
         let mut file = File::open(elf_file).ok()?;
         let address = RttActiveTarget::get_rtt_symbol(&mut file)?;


### PR DESCRIPTION
Follow-up to #2297