### PR TITLE
Fix: Ensure debug_port_setup sequence is run before trying debug_port_connect

### DIFF
--- a/probe-rs/src/probe/fake_probe.rs
+++ b/probe-rs/src/probe/fake_probe.rs
@@ -453,14 +453,14 @@ impl UninitializedArmProbe for FakeArmInterface<Uninitialized> {
     fn initialize(
         self: Box<Self>,
         sequence: Arc<dyn ArmDebugSequence>,
-        _dp: DpAddress,
+        dp: DpAddress,
     ) -> Result<Box<dyn ArmProbeInterface>, (Box<dyn UninitializedArmProbe>, Error)> {
         // TODO: Do we need this?
         // sequence.debug_port_setup(&mut self.probe)?;
 
         let interface = FakeArmInterface::<Initialized> {
             probe: self.probe,
-            state: Initialized::new(sequence, false),
+            state: Initialized::new(sequence, dp, false),
         };
 
         Ok(Box::new(interface))
@@ -520,7 +520,7 @@ impl ArmProbeInterface for FakeArmInterface<Initialized> {
     }
 
     fn current_debug_port(&self) -> DpAddress {
-        self.state.current_dp.expect("A DpAddress is selected")
+        self.state.current_dp
     }
 }
 


### PR DESCRIPTION
The nRF51 doesn't like it we don't run the `debug_port_setup` sequence before the `debug_port_connect` sequence is executed.