### PR TITLE
make core interface accessible from outside

### DIFF
--- a/changelog/changed-made-core-public.md
+++ b/changelog/changed-made-core-public.md
@@ -1,0 +1,1 @@
+Made the core interface public for cases where a Session cannot be used.

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -1,3 +1,6 @@
+//! Core module.
+//! This module contains the core abstraction for interacting with a core on a target.
+
 use crate::{
     architecture::arm::sequences::ArmDebugSequence, config::DebugSequence, debug::DebugRegisters,
     error::Error, CoreType, InstructionSet, MemoryInterface, Target,
@@ -390,7 +393,7 @@ impl<'probe> Core<'probe> {
     }
 
     /// Creates a new [`CoreState`]
-    pub(crate) fn create_state(
+    pub fn create_state(
         id: usize,
         options: CoreAccessOptions,
         target: &Target,
@@ -886,15 +889,23 @@ impl<'probe> CoreInterface for Core<'probe> {
     }
 }
 
+/// A struct containing details on how to access a core.
 pub enum ResolvedCoreOptions {
+    /// ARM core access.
     Arm {
+        /// ARM core debug sequence.
         sequence: Arc<dyn ArmDebugSequence>,
+        /// ARM core access options.
         options: ArmCoreAccessOptions,
     },
+    /// RISC-V core access.
     Riscv {
+        /// RISC-V core access options.
         options: RiscvCoreAccessOptions,
     },
+    /// Xtensa core access.
     Xtensa {
+        /// Xtensa core access options.
         options: XtensaCoreAccessOptions,
     },
 }

--- a/probe-rs/src/core/core_state.rs
+++ b/probe-rs/src/core/core_state.rs
@@ -1,3 +1,5 @@
+//! High-level caching of core states.
+
 use crate::{
     architecture::{
         arm::{
@@ -14,24 +16,30 @@ use crate::{
 use super::ResolvedCoreOptions;
 
 #[derive(Debug)]
-pub(crate) struct CombinedCoreState {
-    pub(crate) core_state: CoreState,
 
-    pub(crate) specific_state: SpecificCoreState,
-
-    pub(crate) id: usize,
+/// Combination of core access options and specific core state.
+pub struct CombinedCoreState {
+    /// Core state containing the core access options.
+    pub core_state: CoreState,
+    /// Specific core state containing the architecture specific state.
+    pub specific_state: SpecificCoreState,
+    /// The core ID.
+    pub id: usize,
 }
 
 impl CombinedCoreState {
+    /// Get the core ID.
     pub fn id(&self) -> usize {
         self.id
     }
 
+    /// Get the core type.
     pub fn core_type(&self) -> CoreType {
         self.specific_state.core_type()
     }
 
-    pub(crate) fn attach_arm<'probe>(
+    /// Prepare temporary core object to access the ARM core.
+    pub fn attach_arm<'probe>(
         &'probe mut self,
         target: &'probe Target,
         arm_interface: &'probe mut Box<dyn ArmProbeInterface>,
@@ -150,7 +158,8 @@ impl CombinedCoreState {
         Ok(())
     }
 
-    pub(crate) fn attach_riscv<'probe>(
+    /// Prepare temporary core object to access the RISC-V core.
+    pub fn attach_riscv<'probe>(
         &'probe mut self,
         target: &'probe Target,
         interface: &'probe mut RiscvCommunicationInterface,
@@ -184,7 +193,8 @@ impl CombinedCoreState {
         ))
     }
 
-    pub(crate) fn attach_xtensa<'probe>(
+    /// Prepare temporary core object to access the XTENSA core.
+    pub fn attach_xtensa<'probe>(
         &'probe mut self,
         target: &'probe Target,
         interface: &'probe mut XtensaCommunicationInterface,

--- a/probe-rs/src/core/core_status.rs
+++ b/probe-rs/src/core/core_status.rs
@@ -1,3 +1,5 @@
+//! Module defining core status, halt reason, breakpoint causes and vector catch condition.
+
 use crate::SemihostingCommand;
 
 /// The status of the core.

--- a/probe-rs/src/core/memory_mapped_registers.rs
+++ b/probe-rs/src/core/memory_mapped_registers.rs
@@ -1,3 +1,5 @@
+//! Module defining the [`MemoryMappedRegister`] trait and a macro for creating memory mapped registers with bitfield access.
+
 /// A memory mapped register, for instance ARM debug registers (DHCSR, etc).
 pub trait MemoryMappedRegister<T>: Clone + From<T> + Into<T> + Sized + std::fmt::Debug {
     /// The register's address in the target memory.

--- a/probe-rs/src/core/registers.rs
+++ b/probe-rs/src/core/registers.rs
@@ -409,7 +409,7 @@ impl TryInto<u128> for RegisterValue {
 }
 
 /// Extension trait to support converting errors
-/// from TryInto calls into [probe_rs::Error]
+/// from TryInto calls into [crate::Error]
 pub trait RegisterValueResultExt<T> {
     /// Convert [Result<T,E>] into `Result<T, probe_rs::Error>`
     fn into_crate_error(self) -> Result<T, Error>;

--- a/probe-rs/src/lib.rs
+++ b/probe-rs/src/lib.rs
@@ -74,7 +74,7 @@ extern crate serde;
 pub mod architecture;
 pub mod config;
 
-mod core;
+pub mod core;
 pub mod debug;
 mod error;
 pub mod flashing;


### PR DESCRIPTION
This patch would enable us to integrate probe-rs into our own solution that has to manage low-level and high-level access differently that is currently possible with a Session.

Closes #1713