### PR TITLE
Fix cargo-embed's defmt processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -63,7 +63,7 @@ checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
- "version_check",
+ "version_check 0.9.4",
  "zerocopy",
 ]
 
@@ -81,6 +81,16 @@ name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
+name = "ansi-parser"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb2392079bf27198570d6af79ecbd9ec7d8f16d3ec6b60933922fdb66287127"
+dependencies = [
+ "heapless 0.5.6",
+ "nom 4.2.3",
+]
 
 [[package]]
 name = "anstream"
@@ -147,6 +157,18 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.7",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -330,7 +352,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -815,7 +837,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -895,7 +917,7 @@ dependencies = [
  "dissimilar",
  "gimli",
  "log",
- "nom",
+ "nom 7.1.3",
  "object 0.32.2",
  "ryu",
  "serde",
@@ -1149,7 +1171,7 @@ checksum = "59f50b6c32370067087b46087cd5333f2dfe678f0b01223fa70fde6f15449844"
 dependencies = [
  "csv",
  "deku",
- "heapless",
+ "heapless 0.8.0",
  "md5",
  "parse_int",
  "regex",
@@ -1237,7 +1259,7 @@ dependencies = [
  "serde_yaml",
  "toml",
  "uncased",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -1398,12 +1420,30 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -1503,6 +1543,15 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -1531,11 +1580,23 @@ dependencies = [
 
 [[package]]
 name = "heapless"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
+dependencies = [
+ "as-slice",
+ "generic-array 0.13.3",
+ "hash32 0.1.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
  "serde",
  "stable_deref_trait",
 ]
@@ -1914,7 +1975,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2339,6 +2400,16 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+dependencies = [
+ "memchr",
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
@@ -2691,6 +2762,7 @@ name = "probe-rs"
 version = "0.23.0"
 dependencies = [
  "addr2line",
+ "ansi-parser",
  "anyhow",
  "async-io",
  "base64 0.22.0",
@@ -2801,7 +2873,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -2812,7 +2884,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -2833,7 +2905,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.53",
- "version_check",
+ "version_check 0.9.4",
  "yansi 1.0.1",
 ]
 
@@ -4334,7 +4406,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -4432,6 +4504,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"

--- a/changelog/fixed-cargo-embed-defmt.md
+++ b/changelog/fixed-cargo-embed-defmt.md
@@ -1,0 +1,1 @@
+Fixed cargo-embed not processing defmt data correctly

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -183,6 +183,7 @@ tracing-appender = { version = "0.2", optional = true }
 ratatui = { version = "0.26.1", default-features = false, features = [
     "crossterm",
 ], optional = true }
+ansi-parser = "0.8.0"
 
 [build-dependencies]
 bincode = "1"

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
@@ -119,7 +119,7 @@ impl Tab {
         Ok(())
     }
 
-    pub fn update_messages(&mut self, width: usize, up_channels: &BTreeMap<usize, UpChannel<'_>>) {
+    pub fn update_messages(&mut self, width: usize, up_channels: &BTreeMap<usize, UpChannel>) {
         let up_channel = up_channels
             .get(&self.up_channel)
             .expect("up channel disappeared");

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/tab.rs
@@ -134,13 +134,40 @@ impl Tab {
         let old_message_count = self.messages.len();
         match &up_channel.data {
             ChannelData::Strings { messages, .. } => {
+                // We strip ANSI sequences because they interfere with text wrapping.
+                //  - It's not obvious how we could tell defmt_parser to not emit ANSI sequences.
+                //  - Calling textwrap on a string with ANSI sequences may break a sequence into
+                // multiple lines, which is incorrect.
+                //  - We can only interpret the sequences by emitting ratatui span styles, but at
+                // that point we can no longer wrap the text using textwrap.
+                //  - Leaving sequences in the output intact is just a bad experience.
+                fn text_block(output: ansi_parser::Output) -> Option<&str> {
+                    match output {
+                        ansi_parser::Output::TextBlock(text) => Some(text),
+                        _ => None,
+                    }
+                }
+                fn strip_ansi(s: impl AsRef<str>) -> String {
+                    use ansi_parser::AnsiParser;
+                    s.as_ref()
+                        .ansi_parse()
+                        .filter_map(text_block)
+                        .collect::<String>()
+                }
+
                 let new = messages
                     .iter()
                     .skip(self.last_processed)
-                    .flat_map(|m| textwrap::wrap(m, width));
+                    .map(strip_ansi)
+                    .flat_map(|m| {
+                        textwrap::wrap(&m, width)
+                            .into_iter()
+                            .map(|cow| cow.to_string())
+                            .collect::<Vec<_>>()
+                    });
                 self.last_processed = messages.len();
 
-                self.messages.extend(new.map(String::from));
+                self.messages.extend(new);
             }
             ChannelData::Binary { data } => {
                 let mut string = self.messages.pop().unwrap_or_default();


### PR DESCRIPTION
This PR removes code that interfered with the defmt data processing. The PR also stips ansi escape sequences from the log output because we don't currently process them, they interfere with text wrapping and look bad when not interpreted.

This PR intends to fix #2322. @FlareFlo can I ask you to test that your issue is no longer present with this? ~Your broken output does not reproduce on my F429, so I'm not sure if it was fixed already or I'm just lucky.~ The broken output reproduces with probe-rs v0.23.0, but not with this PR for me.