### PR TITLE
Fix breakpoint search

### DIFF
--- a/changelog/fixed-breakpoint-handling-dwarf4.md
+++ b/changelog/fixed-breakpoint-handling-dwarf4.md
@@ -1,0 +1,1 @@
+* Fix breakpoint search for binaries using DWARF 4 debug information.

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -69,7 +69,7 @@ cli = [
     "dep:textwrap",
     "dep:addr2line",
     "dep:signal-hook",
-    "dep:libtest-mimic"
+    "dep:libtest-mimic",
 ]
 
 # Enable all built in targets.
@@ -158,7 +158,7 @@ goblin = { version = "0.8", optional = true }
 indicatif = { version = "0.17", optional = true }
 insta = { version = "1", features = ["yaml", "filters"], optional = true }
 itm = { version = "0.9.0-rc.1", default-features = false, optional = true }
-libtest-mimic = { version = "0.7.0" , optional = true }
+libtest-mimic = { version = "0.7.0", optional = true }
 rand = { version = "0.8", optional = true }
 rustyline = { version = "14", optional = true }
 sanitize-filename = { version = "0.5", optional = true }

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -989,11 +989,7 @@ impl DebugInfo {
     }
 }
 
-/// Uses the [std::fs::canonicalize] function to canonicalize both paths before applying the [std::path::PathBuf::eq]
-/// to test if the secondary path is equal or a suffix of the primary path.
-/// If for some reason (e.g., the paths don't exist) the canonicalization fails, the original equality check is used.
-/// We do this to maximize the chances of finding a match where the secondary path can be given as
-/// an absolute, relative, or partial path.
+/// Uses the [`TypedPathBuf::normalize`] function to normalize both paths before comparing them
 pub(crate) fn canonical_path_eq(
     primary_path: &TypedPathBuf,
     secondary_path: &TypedPathBuf,

--- a/probe-rs/tests/source_location.rs
+++ b/probe-rs/tests/source_location.rs
@@ -1,6 +1,6 @@
 use probe_rs::debug::{debug_info::DebugInfo, ColumnType, SourceLocation};
 use std::path::PathBuf;
-use typed_path::UnixPathBuf;
+use typed_path::{TypedPath, UnixPathBuf};
 
 const TEST_DATA: [(u64, u64, ColumnType); 8] = [
     // Target address, line, column
@@ -111,4 +111,16 @@ fn find_non_existing_unit_by_path() {
     assert!(debug_info
         .get_breakpoint_location(&unit_path, 14, None)
         .is_err());
+}
+
+#[test]
+fn regression_pr2324() {
+    let path = "C:\\_Hobby\\probe-rs-test-c-firmware/Atmel/hpl/core/hpl_init.c";
+
+    let di = DebugInfo::from_file("tests/debug-unwind-tests/atsamd51p19a.elf").unwrap();
+    let path = TypedPath::derive(path).to_path_buf();
+
+    let addr = di.get_breakpoint_location(&path, 58, None).unwrap();
+
+    assert_eq!(addr.address, 0x2e4);
 }


### PR DESCRIPTION
#2223 seems to have broken the breakpoint handling for a C binary I have.

When DWARF v4 is used, there seem to be duplicate file entries in the line program headers, due to how the compilation file is handled.