### PR TITLE
ATSAM: fall back to only setting nRESET

### DIFF
--- a/changelog/fixed-atsamd-jlink-reset.md
+++ b/changelog/fixed-atsamd-jlink-reset.md
@@ -1,0 +1,1 @@
+ATSAMD devices should no longer fail to reset after a chip erase.

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -246,12 +246,12 @@ pub struct ComponentId {
 }
 
 impl ComponentId {
-    /// Retreive the address of the component.
+    /// Retrieve the address of the component.
     pub fn component_address(&self) -> u64 {
         self.component_address
     }
 
-    /// Retreive the peripheral ID of the component.
+    /// Retrieve the peripheral ID of the component.
     pub fn peripheral_id(&self) -> &PeripheralID {
         &self.peripheral_id
     }

--- a/probe-rs/src/probe/arm_debug_interface.rs
+++ b/probe-rs/src/probe/arm_debug_interface.rs
@@ -953,7 +953,7 @@ impl<Probe: DebugProbe + RawProtocolIo + JTAGAccess + 'static> RawDapAccess for 
                         )?;
                         let ctrl = Ctrl::try_from(response)?;
                         tracing::warn!(
-                            "Reading DAP register failed. Ctrl/Stat register value is: {:#?}",
+                            "Reading DAP register {address:#X} failed. Ctrl/Stat register value is: {:#?}",
                             ctrl
                         );
 
@@ -1139,7 +1139,7 @@ impl<Probe: DebugProbe + RawProtocolIo + JTAGAccess + 'static> RawDapAccess for 
 
                     let ctrl = Ctrl::try_from(response)?;
                     tracing::warn!(
-                        "Writing DAP register failed. Ctrl/Stat register value is: {:#?}",
+                        "Writing DAP register {address:#X} failed. Ctrl/Stat register value is: {:#?}",
                         ctrl
                     );
 


### PR DESCRIPTION
Running `probe-rs erase --chip atsamd51p19a` with a J-Link probe always ended up in an error. The problem is that `reset_hardware` tried to set `tms` and `tck` to known values before issuing the reset, but the probe does not have implementation for these, so the reset always failed. Otherwise, the erase was done correctly.

@jgust since you're the original author, do you see potential problems by _not_ setting `tms` and `tck`? Should we do a "try-but-fall-back-to-just-nrst" instead?