### PR TITLE
Configure defmt channels to block

### DIFF
--- a/changelog/added-rtt-mode.md
+++ b/changelog/added-rtt-mode.md
@@ -1,0 +1,1 @@
+Users can now specify RTT channel operating mode for the debugger.

--- a/changelog/changed-defmt-mode.md
+++ b/changelog/changed-defmt-mode.md
@@ -1,0 +1,1 @@
+By default, `defmt` RTT channels are configured to `BlockIfFull`.

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -9,7 +9,6 @@ use parking_lot::FairMutex;
 use probe_rs::gdb_server::GdbInstanceConfiguration;
 use probe_rs::probe::list::Lister;
 use probe_rs::rtt::ScanRegion;
-use probe_rs::Core;
 use probe_rs::{probe::DebugProbeSelector, Session};
 use std::ffi::OsString;
 use std::{
@@ -331,6 +330,7 @@ fn run_rttui_app(
                 .show_location
                 .unwrap_or(config.rtt.show_location),
             defmt_log_format: channel_config.defmt_log_format.clone(),
+            mode: channel_config.mode,
         });
         if channel_config.format == DataFormat::Defmt {
             require_defmt = true;
@@ -351,11 +351,12 @@ fn run_rttui_app(
                 show_timestamps: false,
                 show_location: false,
                 defmt_log_format: None,
+                mode: None,
             });
         }
     }
 
-    let Some(mut rtt) = rtt_attach(
+    let Some(rtt) = rtt_attach(
         session,
         core_id,
         config.rtt.timeout,
@@ -377,13 +378,6 @@ fn run_rttui_app(
         tracing::warn!(
             "RTT channels with format = defmt found, but no defmt metadata found in the ELF file."
         );
-    }
-
-    // Configure rtt channels according to configuration
-    {
-        let mut session_handle = session.lock();
-        let mut core = session_handle.core(core_id)?;
-        configure_rtt_modes(&mut core, &config, &mut rtt)?;
     }
 
     tracing::info!("RTT initialized.");
@@ -434,29 +428,6 @@ fn run_rttui_app(
     }
 }
 
-fn configure_rtt_modes(
-    core: &mut Core,
-    config: &config::Config,
-    rtt: &mut RttActiveTarget,
-) -> Result<(), anyhow::Error> {
-    let default_up_mode = config.rtt.up_mode;
-
-    // TODO: also configure down channels
-    for up_channel in rtt.active_up_channels.values() {
-        if let Some(mode) = config
-            .rtt
-            .up_channel_config(up_channel.number())
-            .and_then(|ch| ch.mode.or(default_up_mode))
-        {
-            // Only set the mode when the config file says to,
-            // when not set explicitly, the firmware picks.
-            tracing::debug!("Setting RTT channel {} to {:?}", up_channel.number(), &mode);
-            up_channel.set_mode(core, mode)?;
-        }
-    }
-    Ok(())
-}
-
 /// Try to attach to RTT, with the given timeout
 fn rtt_attach(
     session: &FairMutex<Session>,
@@ -487,7 +458,13 @@ fn rtt_attach(
 
             match rtt::attach_to_rtt(&mut core, &memory_map, rtt_region, elf_file) {
                 Ok(Some(rtt)) => {
-                    let app = RttActiveTarget::new(rtt, elf_file, rtt_config, timestamp_offset);
+                    let app = RttActiveTarget::new(
+                        &mut core,
+                        rtt,
+                        elf_file,
+                        rtt_config,
+                        timestamp_offset,
+                    );
 
                     match app {
                         Ok(app) => return Ok(Some(app)),

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -451,7 +451,7 @@ fn try_attach_rtt(
         .map_err(|error| anyhow!("Error attempting to attach to RTT: {}", error))?;
 
     tracing::info!("RTT initialized.");
-    let target = RttActiveTarget::new(rtt, elf_file, rtt_config, timestamp_offset)?;
+    let target = RttActiveTarget::new(core, rtt, elf_file, rtt_config, timestamp_offset)?;
 
     Ok(target)
 }

--- a/probe-rs/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run/mod.rs
@@ -482,7 +482,8 @@ fn attach_to_rtt(
     for _ in 0..RTT_RETRIES {
         match rtt::attach_to_rtt(core, memory_map, &scan_regions, path) {
             Ok(Some(target_rtt)) => {
-                let app = RttActiveTarget::new(target_rtt, path, rtt_config, timestamp_offset);
+                let app =
+                    RttActiveTarget::new(core, target_rtt, path, rtt_config, timestamp_offset);
 
                 match app {
                     Ok(app) => return Some(app),


### PR DESCRIPTION
This PR attempts to resolve (external) https://github.com/knurling-rs/defmt/issues/818

In case the user somehow saturates the uplink, they can change the mode - which in turn may break the parsing in an unrecoverable way.