### PR TITLE
Implement target_reset on J-Link

### DIFF
--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -909,9 +909,8 @@ impl DebugProbe for JLink {
     }
 
     fn target_reset(&mut self) -> Result<(), DebugProbeError> {
-        Err(DebugProbeError::NotImplemented {
-            function_name: "target_reset",
-        })
+        self.write_cmd(&[Command::ResetTarget as u8])?;
+        Ok(())
     }
 
     fn target_reset_assert(&mut self) -> Result<(), DebugProbeError> {


### PR DESCRIPTION
I'm not sure about changelog, but I'm also not sure if this is useful. `target_reset` seems to be unused in the binary, and maybe carrying it around may be somewhat redundant?

Closes #993 