### PR TITLE
arch/arm: use JEP106Code in GenericAp::IDR

### DIFF
--- a/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
+++ b/probe-rs/src/architecture/arm/ap/memory_ap/mod.rs
@@ -257,6 +257,7 @@ define_ap_register!(
     ///
     /// The control and status word register (CSW) is used
     /// to configure memory access through the memory AP.
+    #[derive(Default)]
     name: CSW,
     address: 0x00,
     fields: [

--- a/probe-rs/src/architecture/arm/ap/register_generation.rs
+++ b/probe-rs/src/architecture/arm/ap/register_generation.rs
@@ -24,7 +24,7 @@ macro_rules! define_ap_register {
         $(#[$outer])*
         #[allow(non_snake_case)]
         #[allow(clippy::upper_case_acronyms)]
-        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         pub struct $name {
             $($(#[$inner])*pub $field: $type,)*
         }


### PR DESCRIPTION
Note: It may be worth doing in `TARGETID` but this is defined using `bitfield!` rather than `define_ap_register` (`TARGETID` is a dp register).