### PR TITLE
Validate RTT channel pointers during attach, and make the logs less chatty

### DIFF
--- a/changelog/fixed-corrupted-rtt.md
+++ b/changelog/fixed-corrupted-rtt.md
@@ -1,0 +1,1 @@
+Fixed the most frequent `RTT: Control block corrupted` errors

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -380,9 +380,6 @@ fn run_rttui_app(
     )
     .context("Failed to attach to RTT")?
     else {
-        // Because we pass `ScanRegion::Ram` to `rtt_attach`, this branch should never be
-        // reached. However, we might change how we attach to RTT in the future, so let's try
-        // and stay friendly and not panic.
         tracing::info!("RTT not found, skipping RTT initialization.");
         return Ok(());
     };
@@ -442,6 +439,8 @@ fn run_rttui_app(
 }
 
 /// Try to attach to RTT, with the given timeout
+// TODO: this is largely the same as `cmd::run::attach_to_rtt`. If we can figure out how to get
+// around the mutex issue required here, we should try to merge them.
 fn rtt_attach(
     session: &FairMutex<Session>,
     core_id: usize,
@@ -465,7 +464,7 @@ fn rtt_attach(
     let mut rtt_init_attempt = 1;
     let mut last_error = None;
     while t.elapsed() < timeout {
-        tracing::info!("Initializing RTT (attempt {})...", rtt_init_attempt);
+        tracing::debug!("Initializing RTT (attempt {})...", rtt_init_attempt);
         rtt_init_attempt += 1;
 
         // Lock the session mutex in a block, so it gets dropped as soon as possible.

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -55,21 +55,7 @@ pub fn attach_to_rtt(
     core: &mut Core,
     memory_map: &[MemoryRegion],
     rtt_region: &ScanRegion,
-    elf_file: &Path,
 ) -> Result<Option<Rtt>> {
-    // Try to find the RTT control block symbol in the ELF file.
-
-    // If we find it, we can use the exact address to attach to the RTT control block. Otherwise, we
-    // fall back to the caller-provided scan regions.
-    let exact_rtt_region;
-    let mut rtt_region = rtt_region;
-
-    let mut file = File::open(elf_file)?;
-    if let Some(address) = RttActiveTarget::get_rtt_symbol(&mut file) {
-        exact_rtt_region = ScanRegion::Exact(address as u32);
-        rtt_region = &exact_rtt_region;
-    }
-
     tracing::debug!("Initializing RTT");
 
     if let ScanRegion::Ranges(rngs) = &rtt_region {

--- a/probe-rs/src/rtt/channel.rs
+++ b/probe-rs/src/rtt/channel.rs
@@ -79,14 +79,22 @@ impl Channel {
             read_c_string(core, memory_map, name_ptr)?
         };
 
-        Ok(Some(Channel {
+        let chan = Channel {
             number,
             core_id: core.id(),
             ptr,
             name,
             buffer_ptr,
             size: mem.pread_with(Self::O_SIZE, LE).unwrap(),
-        }))
+        };
+
+        // TODO remove hard code
+        // We call read_pointers to validate that the channel is valid
+        // it's possible that the channel is not fully initialized
+        chan.read_pointers(core, "up")?;
+        chan.read_pointers(core, "down")?;
+
+        Ok(Some(chan))
     }
 
     /// Validate that the Core id of a request is the same as the Core id against which the Channel was created.


### PR DESCRIPTION
> An attempt to solve the "Corrupted RTT channel" errors which sometimes appear when attaching to a RTT control block which hasn't been fully initialized.

Previously, probe-rs attached to partially initialized RTT control blocks. This meant that subsequent polls sometimes reported corrupted control block errors, because the read and/or write pointers were out of range. We now read and verify these pointers and delay initializing if they are clearly wrong.

This isn't a perfect solution. Problem is that we might still end up incorrectly accepting memory garbage with some low probability. At least now we reject garbage that is clearly incorrect, reducing the frequency of errors reported to users. I'm hoping defmt-rtt eventually fixes their initialization.

Thanks to @MabezDev for figuring out the root cause.

Other changes:

We only need to print errors if we actually gave up trying to attach. Additionally, there are at least 2 but maybe more retry-to-attach implementations, this PR brings two of those a bit closer to each other.

Closes #2320
Closes #1217
Closes #1336
Most likely resolves #1148, too