### PR TITLE
Remove the kmp dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,12 +2121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kmp"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131bddab59a64213cc1e9f0c5be010d7eb485951358ab7e52017888dec482028"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2798,7 +2792,6 @@ dependencies = [
  "itertools 0.12.1",
  "itm",
  "jep106",
- "kmp",
  "libtest-mimic",
  "miniz_oxide",
  "num-traits",

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -34,7 +34,7 @@ required-features = ["cli"]
 [features]
 default = ["builtin-targets", "rtt"]
 gdb-server = ["dep:gdbstub", "dep:itertools"]
-rtt = ["dep:kmp"]
+rtt = []
 
 cli = [
     "gdb-server",
@@ -128,9 +128,6 @@ parse_int = "0.6"
 hexdump = { version = "0.1", optional = true }
 # path
 probe-rs-target = { workspace = true }
-
-# RTT
-kmp = { version = "0.1", optional = true }
 
 # gdb server
 gdbstub = { version = "0.7", optional = true }

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -282,7 +282,7 @@ impl Rtt {
                     core.read(range.start, mem.as_mut()).ok()?;
                 }
 
-                let offset = kmp::kmp_find(&Self::RTT_ID, mem.as_slice())?;
+                let offset = mem.windows(Self::RTT_ID.len()).position(|w| w == Self::RTT_ID)?;
 
                 let target_ptr = range.start + (offset as u64);
                 let Ok(target_ptr) = target_ptr.try_into() else {


### PR DESCRIPTION
I don't think a KMP algorithm gives us much benefit while looking for the RTT magic string in the host's memory. It's only ever used once (per attach attempt) so we may be able to get away with something more... naive.