### PR TITLE
Add default_bin parameter to `cargo-embed` configuration file

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -41,6 +41,8 @@ chip_descriptions = []
 log_level = "WARN"
 # Use this flag to assert the nreset & ntrst pins during attaching the probe to the chip.
 connect_under_reset = false
+# Set a default binary like you would with --bin
+# default_bin = "foo"
 
 [default.rtt]
 # Whether or not an RTTUI should be opened after flashing.

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -74,6 +74,7 @@ pub struct General {
     pub derives: Option<String>,
     /// Use this flag to assert the nreset & ntrst pins during attaching the probe to the chip.
     pub connect_under_reset: bool,
+    pub default_bin: Option<String>
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -97,7 +97,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
     }
 
     // Parse the commandline options.
-    let opt = {
+    let mut opt = {
         let matches = CliOptions::command()
             .version(crate::meta::CARGO_VERSION)
             .long_version(crate::meta::LONG_VERSION)
@@ -137,6 +137,10 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
     if let Some(index) = args.iter().position(|x| x == config_name) {
         // We remove the argument we found.
         args.remove(index);
+    }
+
+    if let Some (ref default_bin) = config.general.default_bin {
+        opt.cargo_options.bin = Some(default_bin.clone());
     }
 
     let cargo_options = opt.cargo_options.to_cargo_options();

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
@@ -101,7 +101,7 @@ pub(crate) fn render_diagnostics(error: OperationError) {
             ArtifactError::MultipleArtifacts => (
                 source.to_string(),
                 vec![
-                    "Use '--bin' to specify which binary to flash.".into(),
+                    "Use '--bin' or set a default bin to specify which binary to flash.".into(),
                 ],
             ),
             ArtifactError::CargoBuild(Some(101)) => (
@@ -127,7 +127,7 @@ pub(crate) fn render_diagnostics(error: OperationError) {
             ArtifactError::MultipleArtifacts => (
                 error.to_string(),
                 vec![
-                    "Use '--bin' to specify which binary to flash.".into(),
+                    "Use '--bin' or set a default bin to specify which binary to flash.".into(),
                 ],
             ),
             ArtifactError::CargoBuild(Some(101)) => (


### PR DESCRIPTION
as mentioned in https://github.com/probe-rs/probe-rs/issues/1477.

I've chosen to pass the `default_bin`'s value directly to `cargo_options`,  where it will be transformed into the `--bin` command.