### PR TITLE
Don't generate meta.rs file

### DIFF
--- a/probe-rs/build.rs
+++ b/probe-rs/build.rs
@@ -7,7 +7,7 @@ use probe_rs_target::ChipFamily;
 
 fn main() {
     #[cfg(feature = "cli")]
-    generate_meta();
+    generate_bin_versions();
     println!("cargo:rerun-if-changed=build.rs");
 
     // Only rerun build.rs if something inside targets/ or `PROBE_RS_TARGETS_DIR`
@@ -84,35 +84,11 @@ fn visit_dirs(dir: &Path, targets: &mut Vec<PathBuf>) -> io::Result<()> {
     Ok(())
 }
 
-/// Generates a `meta.rs` file in a crates `OUT_DIR`.
-///
-/// This is intended to be used in the `build.rs` of a crate.
-///
-///
-///
-/// # Examples
-///
-/// ```no_run
-/// crate::util::meta::generate_meta();
-/// println!("cargo:rerun-if-changed=build.rs");
-/// ```
 #[cfg(feature = "cli")]
-pub fn generate_meta() {
+fn generate_bin_versions() {
     const CARGO_VERSION: &str = env!("CARGO_PKG_VERSION");
     const GIT_VERSION: &str = git_version::git_version!(fallback = "crates.io");
-    let long_version: String = format!("{CARGO_VERSION}\ngit commit: {GIT_VERSION}");
 
-    let out_dir = std::env::var_os("OUT_DIR").unwrap();
-    let dest_path = std::path::Path::new(&out_dir).join("meta.rs");
-    std::fs::write(
-        dest_path,
-        format!(
-            r#"#[allow(dead_code)]mod meta {{
-pub const CARGO_VERSION: &str = "{CARGO_VERSION}";
-pub const GIT_VERSION: &str = "{GIT_VERSION}";
-pub const LONG_VERSION: &str = "{long_version}";
-}}        "#
-        ),
-    )
-    .unwrap();
+    println!("cargo:rustc-env=PROBE_RS_VERSION={CARGO_VERSION}");
+    println!("cargo:rustc-env=PROBE_RS_LONG_VERSION={CARGO_VERSION} (git commit: {GIT_VERSION})");
 }

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -3,7 +3,7 @@ mod error;
 mod rttui;
 
 use anyhow::{anyhow, Context, Result};
-use clap::{CommandFactory, FromArgMatches};
+use clap::Parser;
 use colored::*;
 use parking_lot::FairMutex;
 use probe_rs::gdb_server::GdbInstanceConfiguration;
@@ -35,8 +35,13 @@ use crate::util::{cargo::build_artifact, common_options::CargoOptions, logging, 
 use crate::FormatOptions;
 
 #[derive(Debug, clap::Parser)]
-#[command(after_long_help = CargoOptions::help_message("cargo embed"))]
-#[command(bin_name = "cargo embed", display_name = "cargo-embed")]
+#[clap(
+    name = "cargo embed",
+    bin_name = "cargo embed",
+    version = env!("PROBE_RS_VERSION"),
+    long_version = env!("PROBE_RS_LONG_VERSION"),
+    after_long_help = CargoOptions::help_message("cargo embed")
+)]
 struct CliOptions {
     /// Name of the configuration profile to use.
     #[arg()]
@@ -101,14 +106,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
     }
 
     // Parse the commandline options.
-    let opt = {
-        let matches = CliOptions::command()
-            .version(crate::meta::CARGO_VERSION)
-            .long_version(crate::meta::LONG_VERSION)
-            .get_matches_from(&args);
-
-        CliOptions::from_arg_matches(&matches)?
-    };
+    let opt = CliOptions::parse_from(&args);
 
     // Change the work dir if the user asked to do so.
     if let Some(ref work_dir) = opt.work_dir {

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -1,5 +1,6 @@
 mod diagnostics;
 
+use clap::Parser;
 use colored::*;
 use diagnostics::render_diagnostics;
 use probe_rs::probe::list::Lister;
@@ -12,14 +13,17 @@ use crate::util::common_options::{
 };
 use crate::util::flash;
 use crate::util::logging::{setup_logging, LevelFilter};
-use clap::{CommandFactory, FromArgMatches};
-
 use crate::util::{cargo::build_artifact, logging};
 
 /// Common options when flashing a target device.
 #[derive(Debug, clap::Parser)]
-#[command(after_long_help = CargoOptions::help_message("cargo flash"))]
-#[command(bin_name = "cargo flash", display_name = "cargo-flash")]
+#[clap(
+    name = "cargo flash",
+    bin_name = "cargo flash",
+    version = env!("PROBE_RS_VERSION"),
+    long_version = env!("PROBE_RS_LONG_VERSION"),
+    after_long_help = CargoOptions::help_message("cargo flash")
+)]
 struct CliOptions {
     /// Use this flag to reset and halt (instead of just a reset) the attached core after flashing the target.
     #[arg(long)]
@@ -77,14 +81,7 @@ fn main_try(mut args: Vec<OsString>, lister: &Lister) -> Result<(), OperationErr
     }
 
     // Parse the commandline options.
-    let opt = {
-        let matches = CliOptions::command()
-            .version(crate::meta::CARGO_VERSION)
-            .long_version(crate::meta::LONG_VERSION)
-            .get_matches_from(&args);
-
-        CliOptions::from_arg_matches(&matches)?
-    };
+    let opt = CliOptions::parse_from(&args);
 
     // Initialize the logger with the loglevel given on the commandline.
     let _log_guard = setup_logging(None, opt.log);

--- a/probe-rs/src/bin/probe-rs/main.rs
+++ b/probe-rs/src/bin/probe-rs/main.rs
@@ -1,8 +1,6 @@
 mod cmd;
 mod util;
 
-include!(concat!(env!("OUT_DIR"), "/meta.rs"));
-
 use std::cmp::Reverse;
 use std::ffi::OsStr;
 use std::fs;
@@ -30,8 +28,8 @@ const MAX_LOG_FILES: usize = 20;
 #[clap(
     name = "probe-rs",
     about = "The probe-rs CLI",
-    version = meta::CARGO_VERSION,
-    long_version = meta::LONG_VERSION
+    version = env!("PROBE_RS_VERSION"),
+    long_version = env!("PROBE_RS_LONG_VERSION")
 )]
 struct Cli {
     /// Location for log file


### PR DESCRIPTION
Instead of a meta.rs, use env vars for the binary versions. The `meta.rs` file was only generated for the binaries, so library users are not affected by this change. However, `--version` now prints the git hash in the same line as the crate version as I did not find a way to place a newline into an env variable.