### PR TITLE
cmd/info: Only try other multidrop addresses if the default failed

### DIFF
--- a/changelog/changed-cmd-info-default-dp.md
+++ b/changelog/changed-cmd-info-default-dp.md
@@ -1,0 +1,1 @@
+Only enumerate alternate multi-drop addresses if the Default address failed


### PR DESCRIPTION
This avoids uneccessary noise when a specific target is selected or when a valid default is found.

Caveat: on RP2040, running `info` several times will (in sequence):

1. Fail to select Default and enumerate the alternate multi-drop as expected
2. Detect instance 0 and the default DP and enumerate it only
3. Detect a dubious instance 0xF as the default DP and not find any AP
4. all subsequent run will be the same as 3 (until a power cycle of the target).

This is acceptable because:
- this command is not expected to be run several times
- the rp2040 is really the only multi-drop target known to this day