### PR TITLE
Some more RTT churn

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -10,7 +10,9 @@ use probe_rs::gdb_server::GdbInstanceConfiguration;
 use probe_rs::probe::list::Lister;
 use probe_rs::rtt::ScanRegion;
 use probe_rs::{probe::DebugProbeSelector, Session};
+use probe_rs_target::MemoryRegion;
 use std::ffi::OsString;
+use std::fs;
 use std::{
     fs::File,
     io::Write,
@@ -26,7 +28,9 @@ use crate::util::cargo::target_instruction_set;
 use crate::util::common_options::{BinaryDownloadOptions, OperationError, ProbeOptions};
 use crate::util::flash::{build_loader, run_flash_download};
 use crate::util::logging::setup_logging;
-use crate::util::rtt::{self, RttActiveTarget, RttChannelConfig, RttConfig};
+use crate::util::rtt::{
+    self, try_attach_to_rtt_shared, DefmtState, RttActiveTarget, RttChannelConfig, RttConfig,
+};
 use crate::util::{cargo::build_artifact, common_options::CargoOptions, logging, rtt::DataFormat};
 use crate::FormatOptions;
 
@@ -377,10 +381,16 @@ fn run_rttui_app(
         }
     }
 
-    let Some(rtt) = rtt_attach(
+    let memory_map = {
+        let session_handle = session.lock();
+        session_handle.target().memory_map.clone()
+    };
+
+    let Some(rtt) = attach_to_rtt_shared(
         session,
         core_id,
         config.rtt.timeout,
+        &memory_map,
         &ScanRegion::Ram,
         elf_path,
         &rtt_config,
@@ -446,13 +456,11 @@ fn run_rttui_app(
     }
 }
 
-/// Try to attach to RTT, with the given timeout
-// TODO: this is largely the same as `cmd::run::attach_to_rtt`. If we can figure out how to get
-// around the mutex issue required here, we should try to merge them.
-fn rtt_attach(
+fn attach_to_rtt_shared(
     session: &FairMutex<Session>,
     core_id: usize,
     timeout: Duration,
+    memory_map: &[MemoryRegion],
     rtt_region: &ScanRegion,
     elf_file: &Path,
     rtt_config: &RttConfig,
@@ -461,56 +469,21 @@ fn rtt_attach(
     // Try to find the RTT control block symbol in the ELF file.
     // If we find it, we can use the exact address to attach to the RTT control block. Otherwise, we
     // fall back to the caller-provided scan regions.
-    let mut file = File::open(elf_file)?;
-    let scan_region = if let Some(address) = RttActiveTarget::get_rtt_symbol(&mut file) {
+    let elf = fs::read(elf_file)?;
+    let scan_region = if let Some(address) = RttActiveTarget::get_rtt_symbol_from_bytes(&elf) {
         ScanRegion::Exact(address as u32)
     } else {
         rtt_region.clone()
     };
 
-    let t = std::time::Instant::now();
-    let mut rtt_init_attempt = 1;
-    let mut last_error = None;
-    while t.elapsed() < timeout {
-        tracing::debug!("Initializing RTT (attempt {})...", rtt_init_attempt);
-        rtt_init_attempt += 1;
+    let rtt = try_attach_to_rtt_shared(session, core_id, &memory_map, timeout, &scan_region)?;
 
-        // Lock the session mutex in a block, so it gets dropped as soon as possible.
-        //
-        // GDB is also using the session
-        {
-            let mut session_handle = session.lock();
-            let memory_map = session_handle.target().memory_map.clone();
-            let mut core = session_handle.core(core_id)?;
+    let Some(rtt) = rtt else {
+        return Ok(None);
+    };
+    let mut session_handle = session.lock();
+    let mut core = session_handle.core(core_id)?;
 
-            match rtt::attach_to_rtt(&mut core, &memory_map, &scan_region) {
-                Ok(Some(rtt)) => {
-                    let app = RttActiveTarget::new(
-                        &mut core,
-                        rtt,
-                        elf_file,
-                        rtt_config,
-                        timestamp_offset,
-                    );
-
-                    match app {
-                        Ok(app) => return Ok(Some(app)),
-                        Err(error) => last_error = Some(error),
-                    }
-                }
-                Ok(None) => return Ok(None),
-                Err(e) => last_error = Some(e),
-            }
-        }
-
-        tracing::debug!("Failed to initialize RTT. Retrying until timeout.");
-        std::thread::sleep(Duration::from_millis(10));
-    }
-
-    // Timeout
-    if let Some(err) = last_error {
-        Err(err)
-    } else {
-        Err(anyhow!("Error setting up RTT"))
-    }
+    let defmt_state = DefmtState::try_from_bytes(&elf)?;
+    RttActiveTarget::new(&mut core, rtt, defmt_state, rtt_config, timestamp_offset).map(Some)
 }

--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -456,6 +456,7 @@ fn run_rttui_app(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn attach_to_rtt_shared(
     session: &FairMutex<Session>,
     core_id: usize,
@@ -476,7 +477,7 @@ fn attach_to_rtt_shared(
         rtt_region.clone()
     };
 
-    let rtt = try_attach_to_rtt_shared(session, core_id, &memory_map, timeout, &scan_region)?;
+    let rtt = try_attach_to_rtt_shared(session, core_id, memory_map, timeout, &scan_region)?;
 
     let Some(rtt) = rtt else {
         return Ok(None);

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -1,7 +1,7 @@
-use std::{fs::File, ops::Range, path::Path};
+use std::{ops::Range, path::Path};
 
 use super::session_data::{self, ActiveBreakpoint, BreakpointType, SourceLocationScope};
-use crate::util::rtt::{self, ChannelMode, DataFormat, RttActiveTarget};
+use crate::util::rtt::{self, ChannelMode, DataFormat, DefmtState, RttActiveTarget};
 use crate::{
     cmd::dap_server::{
         debug_adapter::{
@@ -437,10 +437,10 @@ fn try_attach_rtt(
     rtt_config: &RttConfig,
     timestamp_offset: UtcOffset,
 ) -> Result<RttActiveTarget, Error> {
-    let mut open_file = File::open(elf_file)
+    let elf = std::fs::read(elf_file)
         .map_err(|error| anyhow!("Error attempting to attach to RTT: {}", error))?;
 
-    let header_address = RttActiveTarget::get_rtt_symbol(&mut open_file)
+    let header_address = RttActiveTarget::get_rtt_symbol_from_bytes(&elf)
         .ok_or_else(|| anyhow!("No RTT control block found in ELF file"))?;
 
     let scan_region = ScanRegion::Exact(header_address as u32);
@@ -451,7 +451,8 @@ fn try_attach_rtt(
         .map_err(|error| anyhow!("Error attempting to attach to RTT: {}", error))?;
 
     tracing::info!("RTT initialized.");
-    let target = RttActiveTarget::new(core, rtt, elf_file, rtt_config, timestamp_offset)?;
+    let defmt_state = DefmtState::try_from_bytes(&elf)?;
+    let target = RttActiveTarget::new(core, rtt, defmt_state, rtt_config, timestamp_offset)?;
 
     Ok(target)
 }

--- a/probe-rs/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/run/mod.rs
@@ -3,7 +3,7 @@ use normal_run_mode::*;
 mod test_run_mode;
 use test_run_mode::*;
 
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::ops::Range;
 use std::path::Path;
@@ -25,7 +25,9 @@ use time::UtcOffset;
 
 use crate::util::common_options::{BinaryDownloadOptions, ProbeOptions};
 use crate::util::flash::{build_loader, run_flash_download};
-use crate::util::rtt::{self, ChannelDataCallbacks, RttActiveTarget, RttConfig};
+use crate::util::rtt::{
+    self, try_attach_to_rtt, ChannelDataCallbacks, DefmtState, RttActiveTarget, RttConfig,
+};
 use crate::FormatOptions;
 
 #[derive(clap::Parser)]
@@ -272,7 +274,7 @@ impl RunLoop {
             core,
             Duration::from_secs(1),
             self.memory_map.as_slice(),
-            self.rtt_scan_regions.as_slice(),
+            &ScanRegion::Ranges(self.rtt_scan_regions.clone()),
             Path::new(&self.path),
             &rtt_config,
             self.timestamp_offset,
@@ -470,55 +472,31 @@ fn poll_rtt<S: Write + ?Sized>(
     Ok(had_data)
 }
 
-/// Attach to the RTT buffers.
 fn attach_to_rtt(
     core: &mut Core<'_>,
     timeout: Duration,
     memory_map: &[MemoryRegion],
-    scan_regions: &[Range<u64>],
-    path: &Path,
+    rtt_region: &ScanRegion,
+    elf_file: &Path,
     rtt_config: &RttConfig,
     timestamp_offset: UtcOffset,
-) -> Result<Option<rtt::RttActiveTarget>> {
+) -> Result<Option<RttActiveTarget>> {
     // Try to find the RTT control block symbol in the ELF file.
     // If we find it, we can use the exact address to attach to the RTT control block. Otherwise, we
     // fall back to the caller-provided scan regions.
-    let mut file = File::open(path)?;
-    let scan_region = if let Some(address) = RttActiveTarget::get_rtt_symbol(&mut file) {
+    let elf = fs::read(elf_file)?;
+    let scan_region = if let Some(address) = RttActiveTarget::get_rtt_symbol_from_bytes(&elf) {
         ScanRegion::Exact(address as u32)
     } else {
-        ScanRegion::Ranges(scan_regions.to_vec())
+        rtt_region.clone()
     };
 
-    let t = std::time::Instant::now();
-    let mut rtt_init_attempt = 1;
-    let mut last_error = None;
-    while t.elapsed() < timeout {
-        tracing::debug!("Initializing RTT (attempt {})...", rtt_init_attempt);
-        rtt_init_attempt += 1;
+    let rtt = try_attach_to_rtt(core, timeout, memory_map, &scan_region)?;
 
-        match rtt::attach_to_rtt(core, memory_map, &scan_region) {
-            Ok(Some(target_rtt)) => {
-                let app =
-                    RttActiveTarget::new(core, target_rtt, path, rtt_config, timestamp_offset);
+    let Some(rtt) = rtt else {
+        return Ok(None);
+    };
 
-                match app {
-                    Ok(app) => return Ok(Some(app)),
-                    Err(error) => last_error = Some(error),
-                }
-            }
-            Ok(None) => return Ok(None),
-            Err(e) => last_error = Some(e),
-        }
-
-        tracing::debug!("Failed to initialize RTT. Retrying until timeout.");
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
-
-    // Timeout
-    if let Some(err) = last_error {
-        Err(err)
-    } else {
-        Err(anyhow!("Error setting up RTT"))
-    }
+    let defmt_state = DefmtState::try_from_bytes(&elf)?;
+    RttActiveTarget::new(core, rtt, defmt_state, rtt_config, timestamp_offset).map(Some)
 }

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -8,12 +8,13 @@ use probe_rs_target::MemoryRegion;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
+use std::time::{Duration, Instant};
 use std::{
     fmt,
     fmt::Write,
-    fs,
     io::{Read, Seek},
     path::Path,
+    thread,
 };
 use time::{macros::format_description, OffsetDateTime, UtcOffset};
 
@@ -51,7 +52,7 @@ pub fn get_target_core_id(session: &mut Session, elf_file: impl AsRef<Path>) -> 
 /// Try to find the RTT control block in the ELF file and attach to it.
 ///
 /// This function can return `Ok(None)` to indicate that RTT is not available on the target.
-pub fn attach_to_rtt(
+fn attach_to_rtt(
     core: &mut Core,
     memory_map: &[MemoryRegion],
     rtt_region: &ScanRegion,
@@ -495,17 +496,10 @@ pub struct DefmtState {
     pub locs: Option<defmt_decoder::Locations>,
 }
 impl DefmtState {
-    pub fn try_from_elf(elf: &Path) -> Result<Option<Self>> {
-        let elf = fs::read(elf).map_err(|err| {
-            anyhow!(
-                "Error reading program binary while initalizing RTT: {}",
-                err
-            )
-        })?;
-
-        if let Some(table) = defmt_decoder::Table::parse(&elf)? {
+    pub fn try_from_bytes(buffer: &[u8]) -> Result<Option<Self>> {
+        if let Some(table) = defmt_decoder::Table::parse(buffer)? {
             let locs = {
-                let locs = table.get_locations(&elf)?;
+                let locs = table.get_locations(buffer)?;
 
                 if !table.is_empty() && locs.is_empty() {
                     tracing::warn!("Insufficient DWARF info; compile your program with `debug = 2` to enable location info.");
@@ -537,12 +531,10 @@ impl RttActiveTarget {
     pub fn new(
         core: &mut Core,
         rtt: probe_rs::rtt::Rtt,
-        elf_file: &Path,
+        defmt_state: Option<DefmtState>,
         rtt_config: &RttConfig,
         timestamp_offset: UtcOffset,
     ) -> Result<Self> {
-        let defmt_state = DefmtState::try_from_elf(elf_file)?;
-
         let mut active_up_channels = HashMap::new();
         let mut active_down_channels = HashMap::new();
 
@@ -593,18 +585,26 @@ impl RttActiveTarget {
     pub fn get_rtt_symbol<T: Read + Seek>(file: &mut T) -> Option<u64> {
         let mut buffer = Vec::new();
         if file.read_to_end(&mut buffer).is_ok() {
-            if let Ok(binary) = goblin::elf::Elf::parse(buffer.as_slice()) {
-                for sym in &binary.syms {
-                    if binary.strtab.get_at(sym.st_name) == Some("_SEGGER_RTT") {
-                        return Some(sym.st_value);
-                    }
-                }
+            if let Some(rtt) = Self::get_rtt_symbol_from_bytes(buffer.as_slice()) {
+                return Some(rtt);
             }
         }
 
         tracing::warn!(
             "No RTT header info was present in the ELF file. Does your firmware run RTT?"
         );
+        None
+    }
+
+    pub fn get_rtt_symbol_from_bytes(buffer: &[u8]) -> Option<u64> {
+        if let Ok(binary) = goblin::elf::Elf::parse(buffer) {
+            for sym in &binary.syms {
+                if binary.strtab.get_at(sym.st_name) == Some("_SEGGER_RTT") {
+                    return Some(sym.st_value);
+                }
+            }
+        }
+
         None
     }
 
@@ -636,4 +636,73 @@ impl fmt::Debug for RttBuffer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
+}
+
+fn try_attach_to_rtt_inner(
+    mut attach: impl FnMut(&[MemoryRegion], &ScanRegion) -> Result<Option<Rtt>>,
+    timeout: Duration,
+    memory_map: &[MemoryRegion],
+    rtt_region: &ScanRegion,
+) -> Result<Option<Rtt>> {
+    let t = Instant::now();
+    let mut rtt_init_attempt = 1;
+    let mut last_error = None;
+    while t.elapsed() < timeout {
+        tracing::debug!("Initializing RTT (attempt {})...", rtt_init_attempt);
+        rtt_init_attempt += 1;
+
+        match attach(memory_map, rtt_region) {
+            Ok(rtt) => return Ok(rtt),
+            Err(e) => last_error = Some(e),
+        }
+
+        tracing::debug!("Failed to initialize RTT. Retrying until timeout.");
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    // Timeout
+    if let Some(err) = last_error {
+        Err(err)
+    } else {
+        Err(anyhow!("Error setting up RTT"))
+    }
+}
+
+// TODO: these should be part of the library, but that requires refactoring the errors to not use
+// anyhow. Also, we probably should only have one variant of this function and pass the closure
+// in as an argument.
+
+/// Try to attach to RTT, with the given timeout.
+pub fn try_attach_to_rtt(
+    core: &mut Core<'_>,
+    timeout: Duration,
+    memory_map: &[MemoryRegion],
+    rtt_region: &ScanRegion,
+) -> Result<Option<Rtt>> {
+    try_attach_to_rtt_inner(
+        |memory_map, rtt_region| attach_to_rtt(core, memory_map, rtt_region),
+        timeout,
+        memory_map,
+        rtt_region,
+    )
+}
+
+/// Try to attach to RTT, with the given timeout.
+pub fn try_attach_to_rtt_shared(
+    session: &parking_lot::FairMutex<Session>,
+    core_id: usize,
+    memory_map: &[MemoryRegion],
+    timeout: Duration,
+    rtt_region: &ScanRegion,
+) -> Result<Option<Rtt>> {
+    try_attach_to_rtt_inner(
+        |memory_map, rtt_region| {
+            let mut session_handle = session.lock();
+            let mut core = session_handle.core(core_id)?;
+            attach_to_rtt(&mut core, memory_map, rtt_region)
+        },
+        timeout,
+        memory_map,
+        rtt_region,
+    )
 }

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -710,6 +710,7 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
         self.core.run()?;
 
         if let Some(rtt_address) = self.flash_algorithm.rtt_control_block {
+            // FIXME: replace this with try_attach_to_rtt once it's been moved to the library
             let now = Instant::now();
             let mut last_error = None;
             while self.rtt.is_none() {

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -265,19 +265,16 @@ impl Rtt {
                     None => return None,
                 };
 
-                let range_len_usize: usize = match range_len.try_into() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        // FIXME: This is not ideal because it means that we
-                        // won't consider a >4GiB region if probe-rs is running
-                        // on a 32-bit host, but it would be relatively unusual
-                        // to use a 32-bit host to debug a 64-bit target.
-                        tracing::warn!("ignoring region of length {} because it is too long to buffer in host memory", range_len);
-                        return None;
-                    }
+                let Ok(range_len) = range_len.try_into() else {
+                    // FIXME: This is not ideal because it means that we
+                    // won't consider a >4GiB region if probe-rs is running
+                    // on a 32-bit host, but it would be relatively unusual
+                    // to use a 32-bit host to debug a 64-bit target.
+                    tracing::warn!("ignoring region of length {} because it is too long to buffer in host memory", range_len);
+                    return None;
                 };
 
-                let mut mem = vec![0; range_len_usize];
+                let mut mem = vec![0; range_len];
                 {
                     core.read(range.start, mem.as_mut()).ok()?;
                 }
@@ -297,17 +294,11 @@ impl Rtt {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        if instances.is_empty() {
-            return Err(Error::ControlBlockNotFound);
+        match instances.len() {
+            0 => Err(Error::ControlBlockNotFound),
+            1 => Ok(instances.remove(0)),
+            _ => Err(Error::MultipleControlBlocksFound(instances)),
         }
-
-        if instances.len() > 1 {
-            return Err(Error::MultipleControlBlocksFound(
-                instances.into_iter().map(|i| i.ptr).collect(),
-            ));
-        }
-
-        Ok(instances.remove(0))
     }
 
     /// Returns the memory address of the control block in target memory.
@@ -356,14 +347,14 @@ pub enum ScanRegion {
 #[derive(thiserror::Error, Debug, docsplay::Display)]
 pub enum Error {
     /// RTT control block not found in target memory.
-    /// - Make sure RTT is initialized on the target, AND that there are NO target breakpoints before RTT initalization.
+    /// - Make sure RTT is initialized on the target, AND that there are NO target breakpoints before RTT initialization.
     /// - For VSCode and probe-rs-debugger users, using `halt_after_reset:true` in your `launch.json` file will prevent RTT
     ///   initialization from happening on time.
     /// - Depending on the target, sleep modes can interfere with RTT.
     ControlBlockNotFound,
 
     /// Multiple control blocks found in target memory: {display_list(_0)}.
-    MultipleControlBlocksFound(Vec<u32>),
+    MultipleControlBlocksFound(Vec<Rtt>),
 
     /// The control block has been corrupted. {0}
     ControlBlockCorrupted(String),
@@ -378,21 +369,31 @@ pub enum Error {
     MemoryRead(String),
 }
 
-fn display_list(list: &[u32]) -> String {
+fn display_list(list: &[Rtt]) -> String {
     list.iter()
-        .map(|x| format!("{:#x}", x))
+        .map(|rtt| format!("{:#10X}", rtt.ptr))
         .collect::<Vec<_>>()
         .join(", ")
 }
 
 #[cfg(test)]
 mod test {
+    use super::*;
+
     #[test]
     fn test_how_control_block_list_looks() {
-        let error = super::Error::MultipleControlBlocksFound(vec![0x2000, 0x3000]);
+        fn rtt(ptr: u32) -> Rtt {
+            Rtt {
+                ptr,
+                up_channels: Channels(std::collections::BTreeMap::new()),
+                down_channels: Channels(std::collections::BTreeMap::new()),
+            }
+        }
+
+        let error = Error::MultipleControlBlocksFound(vec![rtt(0x2000), rtt(0x3000)]);
         assert_eq!(
             error.to_string(),
-            "Multiple control blocks found in target memory: 0x2000, 0x3000."
+            "Multiple control blocks found in target memory: 0x00002000, 0x00003000."
         );
     }
 }

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -371,7 +371,7 @@ pub enum Error {
 
 fn display_list(list: &[Rtt]) -> String {
     list.iter()
-        .map(|rtt| format!("{:#10X}", rtt.ptr))
+        .map(|rtt| format!("{:#010X}", rtt.ptr))
         .collect::<Vec<_>>()
         .join(", ")
 }


### PR DESCRIPTION
This PR moves the common RTT attach logic out of the different binaries, and does a bit of cleanup. I've also marked a place that contains one more implementation of the loop-until-timeout logic that we'll be able to clean up in the near future. The shared Session in `cargo-embed` complicates things a bit but I'm hoping that by providing two small "how do I get the core (and try to attach to it once)" functions the end result won't be terrible.

Also, we no longer read the .elf files multiple times.