### PR TITLE
Only read CWD once instead of on every RTT poll event

### DIFF
--- a/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/cargo_embed/rttui/channel.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use crate::{
     cmd::cargo_embed::rttui::tcp::TcpPublisher,
-    util::rtt::{ChannelDataCallbacks, ChannelDataConfig, DefmtState, RttActiveUpChannel},
+    util::rtt::{ChannelDataCallbacks, DefmtState, RttActiveUpChannel},
 };
 
 pub enum ChannelData {
@@ -49,13 +49,12 @@ pub struct UpChannel {
 impl UpChannel {
     pub fn new(rtt_channel: RttActiveUpChannel, tcp_stream: Option<SocketAddr>) -> Self {
         Self {
-            data: match rtt_channel.data_format {
-                ChannelDataConfig::String { .. } | ChannelDataConfig::Defmt { .. } => {
-                    ChannelData::Strings {
-                        messages: Vec::new(),
-                    }
+            data: if rtt_channel.data_format.is_binary() {
+                ChannelData::Binary { data: Vec::new() }
+            } else {
+                ChannelData::Strings {
+                    messages: Vec::new(),
                 }
-                ChannelDataConfig::BinaryLE => ChannelData::Binary { data: Vec::new() },
             },
             tcp_stream: tcp_stream.map(TcpPublisher::new),
             rtt_channel,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/core_data.rs
@@ -1,7 +1,7 @@
 use std::{ops::Range, path::Path};
 
 use super::session_data::{self, ActiveBreakpoint, BreakpointType, SourceLocationScope};
-use crate::util::rtt::{self, ChannelMode, DataFormat, DefmtState, RttActiveTarget};
+use crate::util::rtt::{self, DataFormat, DefmtState, RttActiveTarget};
 use crate::{
     cmd::dap_server::{
         debug_adapter::{
@@ -194,11 +194,6 @@ impl<'p> CoreHandle<'p> {
         };
 
         for up_channel in target_rtt.active_up_channels.values() {
-            let data_format = DataFormat::from(&up_channel.data_format);
-            if data_format == DataFormat::Defmt {
-                // For defmt, we set the channel to be blocking when full.
-                up_channel.set_mode(&mut self.core, ChannelMode::BlockIfFull)?;
-            }
             debugger_rtt_channels.push(debug_rtt::DebuggerRttChannel {
                 channel_number: up_channel.number(),
                 // This value will eventually be set to true by a VSCode client request "rttWindowOpened"
@@ -207,7 +202,7 @@ impl<'p> CoreHandle<'p> {
             debug_adapter.rtt_window(
                 up_channel.number(),
                 up_channel.channel_name.clone(),
-                data_format,
+                DataFormat::from(&up_channel.data_format),
             );
         }
 

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -286,7 +286,7 @@ impl ChannelDataFormat {
                 Ok(frame) => {
                     let loc = locs.as_ref().and_then(|locs| locs.get(&frame.index()));
                     let (file, line, module) = if let Some(loc) = loc {
-                        let relpath = loc.file.strip_prefix(&cwd).unwrap_or(&loc.file);
+                        let relpath = loc.file.strip_prefix(cwd).unwrap_or(&loc.file);
                         (
                             relpath.display().to_string(),
                             Some(loc.line.try_into().unwrap()),

--- a/probe-rs/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs/src/bin/probe-rs/util/rtt.rs
@@ -472,14 +472,6 @@ impl RttActiveUpChannel {
         self.data_format
             .process(self.number(), buffer, defmt_state, collector)
     }
-
-    pub(crate) fn set_mode(
-        &self,
-        core: &mut Core<'_>,
-        block_if_full: ChannelMode,
-    ) -> Result<(), Error> {
-        self.up_channel.set_mode(core, block_if_full)
-    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
... and separate data processing out of the channel impl.