### PR TITLE
Make dap-server bind address configurable

### DIFF
--- a/changelog/added-dap-server-ip-option.md
+++ b/changelog/added-dap-server-ip-option.md
@@ -1,0 +1,1 @@
+Users can now specify IP address for dap-server to bind.

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
@@ -14,7 +14,7 @@ use probe_rs::{
     probe::DebugProbeError, CoreDumpError, Error,
 };
 use server::startup::debug;
-use std::{fs::File, io::stderr, path::Path};
+use std::{fs::File, io::stderr, net::{IpAddr, Ipv4Addr, SocketAddr}, path::Path};
 use time::UtcOffset;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::{
@@ -75,6 +75,10 @@ pub struct Cmd {
     #[clap(long)]
     port: u16,
 
+    /// IP address to listen for incoming DAP connections, e.g. "127.0.0.1"
+    #[clap(long, default_value_t = Ipv4Addr::LOCALHOST.into())]
+    ip: IpAddr,
+
     /// Some editors and IDEs expect the debug adapter processes to exit at the end of every debug
     /// session (on receiving a `Disconnect` or `Terminate` request).
     ///
@@ -92,10 +96,11 @@ pub fn run(
     log_file: Option<&Path>,
 ) -> Result<()> {
     let log_info_message = setup_logging(log_file)?;
+    let addr = SocketAddr::new(cmd.ip, cmd.port);
 
     debug(
         lister,
-        cmd.port,
+        addr,
         cmd.single_session,
         &log_info_message,
         time_offset,

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/mod.rs
@@ -14,7 +14,12 @@ use probe_rs::{
     probe::DebugProbeError, CoreDumpError, Error,
 };
 use server::startup::debug;
-use std::{fs::File, io::stderr, net::{IpAddr, Ipv4Addr, SocketAddr}, path::Path};
+use std::{
+    fs::File,
+    io::stderr,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::Path,
+};
 use time::UtcOffset;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::{

--- a/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/dap_server/server/startup.rs
@@ -5,7 +5,7 @@ use probe_rs::probe::list::Lister;
 use serde::Deserialize;
 use std::{
     fs,
-    net::{Ipv4Addr, TcpListener},
+    net::TcpListener,
     path::Path,
     time::{Duration, UNIX_EPOCH},
 };
@@ -33,7 +33,7 @@ impl std::str::FromStr for TargetSessionType {
 
 pub fn debug(
     lister: &Lister,
-    port: u16,
+    addr: std::net::SocketAddr,
     single_session: bool,
     log_info_message: &str,
     timestamp_offset: UtcOffset,
@@ -41,8 +41,6 @@ pub fn debug(
     let mut debugger = Debugger::new(timestamp_offset);
 
     log_to_console_and_tracing("Starting as a DAP Protocol server");
-
-    let addr = std::net::SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::LOCALHOST), port);
 
     // Tell the user if (and where) RUST_LOG messages are written.
     log_to_console_and_tracing(log_info_message);


### PR DESCRIPTION
In certain environments, such as WSL, Visual Studio Code and the probe-rs dap-server may run on separate (virtual) hosts.

To accommodate these scenarios, the probe-rs dap-server requires the ability to bind to an address other than the loopback interface.

This patch adds an `--ip` option for the dap-server subcommand, enabling users to specify the desired binding address.
