### PR TITLE
ATSAM: bring out of reset extension

### DIFF
--- a/probe-rs/src/config/sequences/atsam.rs
+++ b/probe-rs/src/config/sequences/atsam.rs
@@ -338,7 +338,6 @@ impl AtSAM {
         let mut dhcsr = Dhcsr(0);
         dhcsr.enable_write();
         dhcsr.set_c_debugen(true);
-        dhcsr.set_c_halt(true);
         memory.write_word_32(Dhcsr::ADDRESS_OFFSET, dhcsr.0)?;
 
         // clear the reset extension bit

--- a/probe-rs/src/config/sequences/atsam.rs
+++ b/probe-rs/src/config/sequences/atsam.rs
@@ -16,6 +16,7 @@ use crate::{
     Permissions,
 };
 use bitfield::bitfield;
+use probe_rs_target::CoreType;
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -402,6 +403,19 @@ impl AtSAM {
 }
 
 impl ArmDebugSequence for AtSAM {
+    fn debug_core_start(
+        &self,
+        interface: &mut dyn ArmProbeInterface,
+        core_ap: MemoryAp,
+        _core_type: CoreType,
+        _debug_base: Option<u64>,
+        _cti_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        let mut core = interface.memory_interface(core_ap)?;
+
+        self.release_reset_extension(&mut *core)
+    }
+
     /// `reset_hardware_assert` for ATSAM devices
     ///
     /// Instead of keeping `nReset` asserted, the device is instead put into CPU Reset Extension


### PR DESCRIPTION
Chip erase ended up putting my device into Reset Extension and ReattachRequired was not able to recover from that state. This PR should remedy this error.