### PR TITLE
smoke-tester: normalize chip name to lower case

### DIFF
--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -22,18 +22,18 @@ jobs:
       - name: Install target for cross-compilation
         run: rustup target add aarch64-unknown-linux-gnu
 
-      - name: Install cross 
+      - name: Install cross
         uses: taiki-e/install-action@v2.32.17
         with:
           tool: cross
 
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2.7.3
-      
+
       - name: Build smoke-tester
         run:
           cross build --release --target aarch64-unknown-linux-gnu -p smoke_tester
-      
+
       - uses: actions/upload-artifact@v4
         with:
           name: smoke_tester

--- a/probe-rs/targets/esp32c6.yaml
+++ b/probe-rs/targets/esp32c6.yaml
@@ -34,12 +34,6 @@ variants:
           end: 0x4087FFFF
         cores:
           - main
-      - !Ram
-        range:
-          start: 0x50000000
-          end: 0x50003FFF
-        cores:
-          - main
     flash_algorithms:
       - esp32c6-flashloader
 flash_algorithms:

--- a/smoke-tester/README.md
+++ b/smoke-tester/README.md
@@ -22,8 +22,7 @@ chip = "nrf51822_xxAB"
 
 probe_selector = "0d28:0204:9900360150494e4500492002000000600000000097969901"
 
-# Optional binary (ELF format), used to test flashing.
-# The path is relative to the .toml file.
+# Optional binary (ELF format), used to test flashing. Needs to be specified as an absolute path.
 flash_test_binary = "gpio_hal_blinky"
 ```
 

--- a/smoke-tester/src/dut_definition.rs
+++ b/smoke-tester/src/dut_definition.rs
@@ -190,7 +190,10 @@ impl DutDefinition {
 }
 
 fn lookup_unique_target(chip: &str) -> Result<Target> {
-    let targets = search_chips(chip)?;
+    let targets = search_chips(chip)?
+        .into_iter()
+        .map(|chip| chip.to_ascii_lowercase())
+        .collect::<Vec<_>>();
 
     ensure!(
         !targets.is_empty(),
@@ -199,7 +202,7 @@ fn lookup_unique_target(chip: &str) -> Result<Target> {
     );
 
     if targets.len() > 1 {
-        let target_string = String::from(chip).to_ascii_uppercase();
+        let target_string = chip.to_ascii_lowercase();
         if targets.contains(&target_string) {
             // Multiple chips returned, but one was an exact match so we're using it
             let target = get_target_by_name(target_string)?;


### PR DESCRIPTION
Previously, esp32c6 and probably other prefix-named chips failed with something like the following:

```
./smoke_tester --dut-definitions duts
For tests, chip definition must be exact. Chip name ESP32C6 matches multiple chips:
        esp32c6_lp
        esp32c6
Error: Failed to parse definition 'duts/c6.toml'
```