### PR TITLE
Add `list_break` command to debug tool

### DIFF
--- a/changelog/added-list-break-to-debug.md
+++ b/changelog/added-list-break-to-debug.md
@@ -1,0 +1,1 @@
+Add the `list_break` command to `probe-rs debug` to list the set breakpoints.

--- a/probe-rs/src/bin/probe-rs/cmd/debug.rs
+++ b/probe-rs/src/bin/probe-rs/cmd/debug.rs
@@ -16,6 +16,7 @@ use probe_rs::flashing::FileDownloadError;
 use probe_rs::probe::list::Lister;
 use probe_rs::probe::DebugProbeError;
 use probe_rs::CoreDumpError;
+use probe_rs::CoreInterface;
 use probe_rs::{
     debug::{debug_info::DebugInfo, registers::DebugRegisters, stack_frame::StackFrame},
     Core, CoreType, InstructionSet, MemoryInterface, RegisterValue,
@@ -538,6 +539,22 @@ impl DebugCli {
                 let address = get_int_argument(args, 0)?;
 
                 cli_data.core.clear_hw_breakpoint(address)?;
+
+                Ok(CliState::Continue)
+            },
+        });
+
+        cli.add_command(Command {
+            name: "list_break",
+            help_text: "List all set breakpoints",
+            function: |cli_data, _| {
+                cli_data
+                    .core
+                    .hw_breakpoints()?
+                    .into_iter()
+                    .enumerate()
+                    .flat_map(|(idx, bpt)| bpt.map(|bpt| (idx, bpt)))
+                    .for_each(|(idx, bpt)| println!("Breakpoint {idx} - {bpt:#010X}"));
 
                 Ok(CliState::Continue)
             },

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -836,7 +836,7 @@ impl<'probe> CoreInterface for Core<'probe> {
     }
 
     fn hw_breakpoints(&mut self) -> Result<Vec<Option<u64>>, Error> {
-        todo!()
+        self.inner.hw_breakpoints()
     }
 
     fn enable_breakpoints(&mut self, state: bool) -> Result<(), Error> {


### PR DESCRIPTION
I found it helpful to list breakpoints when I'm troubleshooting probe-rs target integration. Here's a little demo, where `>>` denotes the command submitted to `probe-rs debug`:

    Core is running.
    >> list_break
    Core is running.
    >> break 0x30001030
    Set new breakpoint at address 0x30001030
    Core is running.
    >> break 0x00001234
    Set new breakpoint at address 0x001234
    Core is running.
    >> list_break
    Breakpoint 0 - 0x30001030
    Breakpoint 1 - 0x00001234
    Core is running.
    >> clear_break 0x30001030
    Core is running.
    >> list_break
    Breakpoint 1 - 0x00001234
    Core is running.

Notice that we start counting at zero. Furthermore, the user still needs to use the instruction address to clear the breakpoint; they can't clear breakpoints by the breakpoint number.