### PR TITLE
Slightly clean up the Xtensa code

### DIFF
--- a/probe-rs/src/architecture/xtensa/mod.rs
+++ b/probe-rs/src/architecture/xtensa/mod.rs
@@ -462,7 +462,10 @@ impl<'probe> CoreInterface for Xtensa<'probe> {
     }
 
     fn debug_core_stop(&mut self) -> Result<(), Error> {
-        self.interface.leave_ocd_mode()?;
+        self.interface.restore_registers()?;
+        self.interface.resume()?;
+        self.interface.xdm.leave_ocd_mode()?;
+        tracing::info!("Left OCD mode");
         Ok(())
     }
 }

--- a/probe-rs/src/architecture/xtensa/xdm.rs
+++ b/probe-rs/src/architecture/xtensa/xdm.rs
@@ -411,7 +411,7 @@ impl Xdm {
         self.execute()
     }
 
-    fn status(&mut self) -> Result<DebugStatus, XtensaError> {
+    pub(super) fn status(&mut self) -> Result<DebugStatus, XtensaError> {
         self.read_nexus_register::<DebugStatus>()
     }
 
@@ -450,11 +450,6 @@ impl Xdm {
         });
     }
 
-    pub(super) fn is_in_ocd_mode(&mut self) -> Result<bool, XtensaError> {
-        let reg = self.read_nexus_register::<DebugControlSet>()?;
-        Ok(reg.0.enable_ocd())
-    }
-
     pub(super) fn leave_ocd_mode(&mut self) -> Result<(), XtensaError> {
         // clear all clearable status bits
         self.write_nexus_register({
@@ -487,10 +482,6 @@ impl Xdm {
         }))?;
 
         Ok(())
-    }
-
-    pub(super) fn is_halted(&mut self) -> Result<bool, XtensaError> {
-        self.status().map(|status| status.stopped())
     }
 
     pub(super) fn resume(&mut self) -> Result<(), XtensaError> {


### PR DESCRIPTION
This PR removes direct debug module control from `XtensaCommunicationInterface`. While this is a breaking change, these functions aren't necessary and even shouldn't be used anyway, but they were left over from the initial development pass.