### PR TITLE
smoke-tester: print flashing progress to stdout

### DIFF
--- a/smoke-tester/src/tests.rs
+++ b/smoke-tester/src/tests.rs
@@ -219,7 +219,7 @@ pub fn test_flashing(tracker: &TestTracker, session: &mut Session) -> Result<(),
 
     let progress = FlashProgress::new(|event| {
         log::debug!("Flash Event: {:?}", event);
-        eprint!(".");
+        print!(".");
     });
 
     let mut options = DownloadOptions::default();


### PR DESCRIPTION
Flashing progress is printed to stderr, but then terminated with a newline to stdout. This sometimes caused the progress dots to be printed after the log, making it look a bit funny. This PR hopefully clears this up. Important, I know. 