### PR TITLE
Revert "Update all non-major dependencies"

### DIFF
--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -23,7 +23,7 @@ jobs:
         run: rustup target add aarch64-unknown-linux-gnu
 
       - name: Install cross
-        uses: taiki-e/install-action@v2.33.3
+        uses: taiki-e/install-action@v2.32.17
         with:
           tool: cross
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-config2"
-version = "0.1.26"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83ce0be8bd1479e5de6202def660e6c7e27e4e0599bffa4fed05bd380ec2ede"
+checksum = "88d9bdc858a15454c2d0a5138d8dcf4bcabc06fde679abdea8330393fbc0ef05"
 dependencies = [
  "home",
  "serde",
@@ -2577,9 +2577,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nusb"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccb3bb9c89ba9393f2f723da29221a39a3310c3950fbe5896eec05daa82753e"
+checksum = "1ac267a828c32759883a6097809fc4c32d76925099725aae562717cb023b431c"
 dependencies = [
  "atomic-waker",
  "core-foundation",
@@ -3234,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
 dependencies = [
  "base64 0.22.0",
  "bytes",
@@ -3696,9 +3696,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -4000,9 +4000,9 @@ dependencies = [
 
 [[package]]
 name = "svg"
-version = "0.17.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "700efb40f3f559c23c18b446e8ed62b08b56b2bb3197b36d57e0470b4102779e"
+checksum = "583e1c5c326fd6fede8797006de3b95ad6bcd60a592952952c5ba7ddd7e84c83"
 
 [[package]]
 name = "syn"
@@ -4088,7 +4088,7 @@ dependencies = [
  "predicates",
  "probe-rs",
  "probe-rs-target",
- "reqwest 0.12.4",
+ "reqwest 0.12.3",
  "scroll",
  "serde_yaml",
  "tokio",
@@ -4180,18 +4180,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.59"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.59"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ probe-rs = { path = "probe-rs", version = "0.23.0" }
 probe-rs-target = { path = "probe-rs-target", version = "0.23.0" }
 
 docsplay = "0.1.1"
-thiserror = "1.0.59"
+thiserror = "1.0.58"
 anyhow = "1.0.82"
 
 [workspace.metadata.release]

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -105,14 +105,14 @@ object = { version = "0.35", default-features = false, features = [
     "std",
 ] }
 paste = "1"
-nusb = { version = "0.1.8" }
+nusb = { version = "0.1.7" }
 futures-lite = "2"
 async-io = "2"
 scroll = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 static_assertions = "1"
-svg = "0.17"
+svg = "0.16"
 thiserror = { workspace = true }
 tracing = { version = "0.1", features = ["log"] }
 uf2-decode = "0.2"
@@ -160,7 +160,7 @@ rand = { version = "0.8", optional = true }
 rustyline = { version = "14", optional = true }
 sanitize-filename = { version = "0.5", optional = true }
 schemafy = { version = "0.6", optional = true }
-serde_json = { version = "1.0.116", optional = true }
+serde_json = { version = "1.0.115", optional = true }
 signal-hook = { version = "0.3", optional = true }
 svd-parser = { version = "0.14", features = ["expand"], optional = true }
 termtree = { version = "0.4", optional = true }
@@ -182,7 +182,7 @@ ratatui = { version = "0.26.2", default-features = false, features = [
 ], optional = true }
 ansi-parser = { version = "0.9.0", optional = true }
 parking_lot = "0.12.1"
-cargo-config2 = { version = "0.1.26", optional = true }
+cargo-config2 = { version = "0.1.24", optional = true }
 
 [build-dependencies]
 bincode = "1"

--- a/probe-rs/src/bin/probe-rs/util/test_data/binary_cargo_config/Cargo.toml
+++ b/probe-rs/src/bin/probe-rs/util/test_data/binary_cargo_config/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 panic-halt = "0.2.0"
-cortex-m-rt = "0.7.4"
+cortex-m-rt = "0.7.3"
 
 # This package is not part of the probe-rs workspace
 [workspace]

--- a/probe-rs/src/bin/probe-rs/util/test_data/binary_cargo_config_toml/Cargo.toml
+++ b/probe-rs/src/bin/probe-rs/util/test_data/binary_cargo_config_toml/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 panic-halt = "0.2.0"
-cortex-m-rt = "0.7.4"
+cortex-m-rt = "0.7.3"
 
 # This package is not part of the probe-rs workspace
 [workspace]

--- a/probe-rs/tests/gpio-hal-blinky/Cargo.lock
+++ b/probe-rs/tests/gpio-hal-blinky/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "bare-metal",
  "bitfield",
  "critical-section",
- "embedded-hal 0.2.7",
+ "embedded-hal",
  "volatile-register",
 ]
 
@@ -88,9 +88,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "embedded-dma"
-version = "0.2.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994f7e5b5cb23521c22304927195f236813053eb9c065dd2226a32ba64695446"
+checksum = "46c8c02e4347a0267ca60813c952017f4c5948c232474c6010a381a337f1bda4"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -106,28 +106,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-hal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "embedded-storage"
-version = "0.3.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21dea9854beb860f3062d10228ce9b976da520a73474aed3171ec276bc0c032"
+checksum = "723dce4e9f25b6e6c5f35628e144794e5b459216ed7da97b7c4b66cdb3fa82ca"
 
 [[package]]
 name = "fixed"
-version = "1.27.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc715d38bea7b5bf487fcd79bcf8c209f0b58014f3018a7a19c2b855f472048"
+checksum = "02c69ce7e7c0f17aa18fdd9d0de39727adb9c6281f2ad12f57cbe54ae6e76e7d"
 dependencies = [
  "az",
  "bytemuck",
@@ -141,7 +129,7 @@ version = "0.1.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
- "embedded-hal 0.2.7",
+ "embedded-hal",
  "microbit",
  "panic-halt",
 ]
@@ -158,20 +146,20 @@ dependencies = [
 
 [[package]]
 name = "microbit"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea941ae60d022668f789ff6a6439fdb59b5cea202cd2affbb967e9af7425356"
+checksum = "22b772d53b18a80479fb066b72eb242bba80d217312cee590cd93e1263062827"
 dependencies = [
  "microbit-common",
 ]
 
 [[package]]
 name = "microbit-common"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37409f40befaa165d8a94255955475337422f5fe2fecaeeeedde170562ee114b"
+checksum = "45651d001be4281a6f4536c30f3d8522f231bc56fd58d5baf2c630f565d31256"
 dependencies = [
- "embedded-hal 1.0.0",
+ "embedded-hal",
  "nrf51-hal",
  "tiny-led-matrix",
 ]
@@ -193,16 +181,15 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "nrf-hal-common"
-version = "0.17.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56fbecd598c7f16e32bd4783447ca023aa7897d4a4c8e70f6b7c5739c81b4ceb"
+checksum = "bd37b3fd039327b4005cc0d4ef20bce0a41bf521071774d5adb854e4b1230639"
 dependencies = [
  "cast",
  "cfg-if",
  "cortex-m",
  "embedded-dma",
- "embedded-hal 1.0.0",
- "embedded-io",
+ "embedded-hal",
  "embedded-storage",
  "fixed",
  "nb 1.1.0",
@@ -213,19 +200,20 @@ dependencies = [
 
 [[package]]
 name = "nrf51-hal"
-version = "0.17.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb186285d15fdfe7329ebb25e64b898f1c619831c43dc96849f11c3ef244b2a"
+checksum = "509b38924d7f589eb4803bd65c1e198156f520af10f56ff738edcde66291b860"
 dependencies = [
+ "embedded-hal",
  "nrf-hal-common",
  "nrf51-pac",
 ]
 
 [[package]]
 name = "nrf51-pac"
-version = "0.12.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137f187dc6ee482e27312086bd3c3a83e1c273512782cf131a61957f72fc4219"
+checksum = "9a2b2c345355dcf3a92847312cef7f0a8f0b4355a367318444a07118f862f42a"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",

--- a/probe-rs/tests/gpio-hal-blinky/Cargo.toml
+++ b/probe-rs/tests/gpio-hal-blinky/Cargo.toml
@@ -13,4 +13,4 @@ cortex-m = { version = "0.7", features = [
     "inline-asm",
 ] }
 panic-halt = "0.2.0"
-microbit = "0.14.0"
+microbit = "0.13.0"

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -32,7 +32,7 @@ zip = "1.1.1"
 clap = { version = "4.5", features = ["derive"] }
 colored = "2"
 anyhow = "1.0.82"
-reqwest = { version = "0.12.4", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12.3", features = ["json", "rustls-tls"], default-features = false }
 futures = "0.3.30"
 tokio = { version = "1.37.0", features = ["macros", "rt", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.18", features = [


### PR DESCRIPTION
Reverts probe-rs/probe-rs#2398 because it broke [doc builds](https://github.com/probe-rs/probe-rs/actions/runs/8779321943/job/24087171262?pr=2377) I think.