### PR TITLE
Fix flashing ESP32-C2 and C3

### DIFF
--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -432,6 +432,11 @@ impl RiscvCommunicationInterface {
         // Reset error bits from previous connections
         self.dtm.clear_error_state()?;
 
+        // enable the debug module
+        let mut control = Dmcontrol(0);
+        control.set_dmactive(true);
+        self.write_dm_register(control)?;
+
         // read the  version of the debug module
         let status: Dmstatus = self.read_dm_register()?;
 
@@ -464,13 +469,10 @@ impl RiscvCommunicationInterface {
 
         tracing::debug!("dmstatus: {:?}", status);
 
-        // enable the debug module
-        let mut control = Dmcontrol(0);
-        control.set_dmactive(true);
-        self.write_dm_register(control)?;
-
         // Select all harts to determine the width
         // of the hartsel register.
+        let mut control = Dmcontrol(0);
+        control.set_dmactive(true);
         control.set_hartsel(0xffff_ffff);
 
         self.write_dm_register(control)?;

--- a/probe-rs/src/config/sequences/esp32c3.rs
+++ b/probe-rs/src/config/sequences/esp32c3.rs
@@ -72,7 +72,7 @@ impl RiscvDebugSequence for ESP32C3 {
         interface: &mut RiscvCommunicationInterface,
         timeout: Duration,
     ) -> Result<(), crate::Error> {
-        interface.reset_hart_and_halt(timeout)?;
+        interface.halt(timeout)?;
 
         // Reset all peripherals except for the RTC block.
 

--- a/probe-rs/src/flashing/flash_algorithm.rs
+++ b/probe-rs/src/flashing/flash_algorithm.rs
@@ -346,7 +346,7 @@ impl FlashAlgorithm {
                 return Err(FlashError::InvalidFlashAlgorithmStackSize);
             }
         };
-        tracing::debug!("The flash algorithm will be configured with {stack_size} bytes of stack");
+        tracing::info!("The flash algorithm will be configured with {stack_size} bytes of stack");
 
         // We have the stack size, let's lay out the data block(s)
         // Determine the bounds of the data region.
@@ -375,7 +375,7 @@ impl FlashAlgorithm {
             // ... or the top of the region if data is in a different region.
             ram_region.range.end
         };
-        tracing::debug!("Stack top: {:#010X?}", stack_top_addr);
+        tracing::info!("Stack top: {:#010X}", stack_top_addr);
 
         // Data buffer 1
         let first_buffer_start = data_range.start;

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -161,7 +161,7 @@ impl<'session> Flasher<'session> {
         let cpu_info = core
             .halt(Duration::from_millis(100))
             .map_err(FlashError::Core)?;
-        tracing::debug!("PC = 0x{:08x}", cpu_info.pc);
+        tracing::debug!("PC = {:010x}", cpu_info.pc);
         tracing::debug!("Reset and halt");
         core.reset_and_halt(Duration::from_millis(500))
             .map_err(FlashError::Core)?;
@@ -169,7 +169,7 @@ impl<'session> Flasher<'session> {
         // TODO: Possible special preparation of the target such as enabling faster clocks for the flash e.g.
 
         // Load flash algorithm code into target RAM.
-        tracing::debug!("Downloading algorithm code to {:#08x}", algo.load_address);
+        tracing::debug!("Downloading algorithm code to {:#010x}", algo.load_address);
 
         core.write_32(algo.load_address, algo.instructions.as_slice())
             .map_err(FlashError::Core)?;
@@ -182,11 +182,11 @@ impl<'session> Flasher<'session> {
         {
             if original != read_back {
                 tracing::error!(
-                    "Failed to verify flash algorithm. Data mismatch at address {:#08x}",
+                    "Failed to verify flash algorithm. Data mismatch at address {:#010x}",
                     algo.load_address + (4 * offset) as u64
                 );
-                tracing::error!("Original instruction: {:#08x}", original);
-                tracing::error!("Readback instruction: {:#08x}", read_back);
+                tracing::error!("Original instruction: {:#010x}", original);
+                tracing::error!("Readback instruction: {:#010x}", read_back);
 
                 tracing::error!("Original: {:x?}", &algo.instructions);
                 tracing::error!("Readback: {:x?}", &data);
@@ -544,7 +544,7 @@ impl Debug for Registers {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{:08x}({:?}, {:?}, {:?}, {:?}",
+            "{:#010x} ({:?}, {:?}, {:?}, {:?})",
             self.pc, self.r0, self.r1, self.r2, self.r3
         )
     }
@@ -645,7 +645,7 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
     }
 
     fn call_function(&mut self, registers: &Registers, init: bool) -> Result<(), FlashError> {
-        tracing::debug!("Calling routine {:?}, init={})", &registers, init);
+        tracing::debug!("Calling routine {:?}, init={})", registers, init);
 
         let algo = &self.flash_algorithm;
         let regs: &'static CoreRegisters = self.core.registers();
@@ -692,7 +692,7 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
                     let value: u32 = self.core.read_core_reg(description)?;
 
                     tracing::debug!(
-                        "content of {} {:#x}: 0x{:08x} should be: 0x{:08x}",
+                        "content of {} {:#x}: {:#010x} should be: {:#010x}",
                         description.name(),
                         description.id.0,
                         value,
@@ -841,7 +841,7 @@ impl<'probe> ActiveFlasher<'probe, Erase> {
     }
 
     pub(super) fn erase_sector(&mut self, address: u64) -> Result<(), FlashError> {
-        tracing::info!("Erasing sector at address 0x{:08x}", address);
+        tracing::info!("Erasing sector at address {:#010x}", address);
         let t1 = Instant::now();
 
         let result = self
@@ -883,7 +883,7 @@ impl<'p> ActiveFlasher<'p, Program> {
     /// Transfers the buffer bytes to RAM.
     fn load_data(&mut self, address: u64, bytes: &[u8]) -> Result<(), FlashError> {
         tracing::debug!(
-            "Loading {} bytes of data into RAM at address {:#08x}\n",
+            "Loading {} bytes of data into RAM at address {:#010x}\n",
             bytes.len(),
             address
         );

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -844,24 +844,19 @@ impl<'probe> ActiveFlasher<'probe, Erase> {
         tracing::info!("Erasing sector at address {:#010x}", address);
         let t1 = Instant::now();
 
-        let result = self
-            .call_function_and_wait(
-                &Registers {
-                    pc: into_reg(self.flash_algorithm.pc_erase_sector)?,
-                    r0: Some(into_reg(address)?),
-                    r1: None,
-                    r2: None,
-                    r3: None,
-                },
-                false,
-                Duration::from_millis(
-                    self.flash_algorithm.flash_properties.erase_sector_timeout as u64,
-                ),
-            )
-            .map_err(|error| FlashError::EraseFailed {
-                sector_address: address,
-                source: Box::new(error),
-            })?;
+        let result = self.call_function_and_wait(
+            &Registers {
+                pc: into_reg(self.flash_algorithm.pc_erase_sector)?,
+                r0: Some(into_reg(address)?),
+                r1: None,
+                r2: None,
+                r3: None,
+            },
+            false,
+            Duration::from_millis(
+                self.flash_algorithm.flash_properties.erase_sector_timeout as u64,
+            ),
+        )?;
         tracing::info!(
             "Done erasing sector. Result is {}. This took {:?}",
             result,

--- a/probe-rs/src/probe/ftdi/mod.rs
+++ b/probe-rs/src/probe/ftdi/mod.rs
@@ -541,7 +541,7 @@ impl TryFrom<(FtdiDevice, Option<ChipType>)> for FtdiProperties {
             },
             ChipType::FT232H => Self {
                 buffer_size: 1024,
-                max_clock: 6_000,
+                max_clock: 30_000,
                 has_divide_by_5: true,
             },
             ChipType::FT2232C => Self {

--- a/probe-rs/targets/esp32c2.yaml
+++ b/probe-rs/targets/esp32c2.yaml
@@ -61,7 +61,7 @@ flash_algorithms:
     pc_erase_all: 0x1c
     data_section_offset: 0x4038c2a0
     load_address: 0x4038C000
-    data_load_address: 0x3FCC0000
+    data_load_address: 0x403A0000
     transfer_encoding: miniz
     flash_properties:
       address_range:

--- a/probe-rs/targets/esp32c3.yaml
+++ b/probe-rs/targets/esp32c3.yaml
@@ -61,7 +61,7 @@ flash_algorithms:
     pc_erase_all: 0x1c
     data_section_offset: 0x403902a4
     load_address: 0x40390000
-    data_load_address: 0x3FCC0000
+    data_load_address: 0x403C0000
     transfer_encoding: miniz
     flash_properties:
       address_range:


### PR DESCRIPTION
The load-bearing commit is the last one.

 - It seems the stack pointer can't point to the last 16 bytes of the RAM for some reason.
 - We need to place the data into the same memory region as the loader, to force the stack pointer below the data blocks. (Layout assumes stack is below data if they are in the same region)

@MabezDev [this](https://github.com/esp-rs/esp-flash-loader/blob/353abbe4102785aee214ce38f182d618fdfe08df/src/main.rs#L21) has stopped being true in #2375. The algos still work because I've allocated more space for the decompressor state than what the stacks take up, but I guess the current issue highlights how fragile this is.

Xtensas are unaffected because they ignore the stack pointer calculated by probe-rs.