### PR TITLE
Smoke tester: do not pass test suite with failing tests

### DIFF
--- a/smoke-tester/src/dut_definition.rs
+++ b/smoke-tester/src/dut_definition.rs
@@ -1,4 +1,4 @@
-//! # DUT Defintions
+//! # DUT Definitions
 //!
 //! This module handles the definition of the different devices under test (DUTs),
 //! which are used by the tester.

--- a/smoke-tester/src/main.rs
+++ b/smoke-tester/src/main.rs
@@ -352,7 +352,7 @@ impl<'dut> TestTracker<'dut> {
         let mut tests_ok = true;
 
         for definition in self.dut_definitions {
-            print_dut_status!(self, blue, "Starting Test",);
+            print_dut_status!(self, blue, "Starting Test");
 
             if let DefinitionSource::File(path) = &definition.source {
                 print!(" - {}", path.display());
@@ -368,7 +368,7 @@ impl<'dut> TestTracker<'dut> {
                         name: definition.chip.name.clone(),
                         succesful: true,
                     });
-                    println_dut_status!(self, green, "Tests Passed",);
+                    println_dut_status!(self, green, "Tests Passed");
                 }
                 Ok(Err(e)) => {
                     tests_ok = false;
@@ -383,7 +383,7 @@ impl<'dut> TestTracker<'dut> {
                         println_dut_status!(self, red, " caused by:    {}", source);
                     }
 
-                    println_dut_status!(self, red, "Tests Failed",);
+                    println_dut_status!(self, red, "Tests Failed");
                 }
                 Err(_join_err) => {
                     tests_ok = false;
@@ -400,9 +400,9 @@ impl<'dut> TestTracker<'dut> {
         }
 
         if tests_ok {
-            println_status!(self, green, "All DUTs passed.",);
+            println_status!(self, green, "All DUTs passed.");
         } else {
-            println_status!(self, red, "Some DUTs failed some tests.",);
+            println_status!(self, red, "Some DUTs failed some tests.");
         }
 
         report

--- a/smoke-tester/src/tests.rs
+++ b/smoke-tester/src/tests.rs
@@ -234,10 +234,14 @@ pub fn test_flashing(tracker: &TestTracker, session: &mut Session) -> Result<(),
         probe_rs_target::BinaryFormat::Idf => Format::Idf(Default::default()),
         probe_rs_target::BinaryFormat::Raw => Default::default(),
     };
-    download_file_with_options(session, test_binary, format, options)
-        .map_err(|err| TestFailure::Error(Box::new(err)))?;
+
+    let result = download_file_with_options(session, test_binary, format, options);
 
     println!();
+
+    if let Err(err) = result {
+        return Err(TestFailure::Error(Box::new(err)));
+    }
 
     println_test_status!(
         tracker,


### PR DESCRIPTION
I'm not entirely sure how the results were supposed to be tallied up but it seems all of them were instead accidentally ignored.