### PR TITLE
RV: Record breakpoint states in memory

### DIFF
--- a/probe-rs/src/architecture/riscv/communication_interface.rs
+++ b/probe-rs/src/architecture/riscv/communication_interface.rs
@@ -2257,3 +2257,14 @@ memory_mapped_bitfield_register! { pub struct Confstrptr0(u32); 0x19, "confstrpt
 memory_mapped_bitfield_register! { pub struct Confstrptr1(u32); 0x1a, "confstrptr1", impl From; }
 memory_mapped_bitfield_register! { pub struct Confstrptr2(u32); 0x1b, "confstrptr2", impl From; }
 memory_mapped_bitfield_register! { pub struct Confstrptr3(u32); 0x1c, "confstrptr3", impl From; }
+
+// TODO: do we want typed registers for these?
+pub(super) struct Csr;
+
+impl Csr {
+    // CSR register addresses
+    pub const TSELECT: u16 = 0x7b0;
+    pub const TDATA1: u16 = 0x7b1;
+    pub const TDATA2: u16 = 0x7b2;
+    pub const TINFO: u16 = 0x7b4;
+}

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -505,7 +505,7 @@ impl<'state> CoreInterface for Riscv32<'state> {
     }
 
     fn available_breakpoint_units(&mut self) -> Result<u32, Error> {
-        Ok(self.triggers().map(|triggers| triggers.len() as u32)?)
+        self.triggers().map(|triggers| triggers.len() as u32)
     }
 
     /// See docs on the [`CoreInterface::hw_breakpoints`] trait
@@ -537,7 +537,8 @@ impl<'state> CoreInterface for Riscv32<'state> {
         // Loop through all triggers, and enable/disable them.
         if state {
             // Write trigger data into registers
-            for (tsel, trigger) in self.triggers()?.to_vec().into_iter().enumerate() {
+            let triggers = self.triggers()?.to_vec();
+            for (tsel, trigger) in triggers.into_iter().enumerate() {
                 match trigger {
                     Trigger::None => {} // trigger should already be disabled
                     Trigger::AddressMatch(addr) => {

--- a/probe-rs/src/core.rs
+++ b/probe-rs/src/core.rs
@@ -661,7 +661,7 @@ impl<'probe> Core<'probe> {
             .inner
             .hw_breakpoints()?
             .iter()
-            .position(|bp| bp.is_some() && bp.unwrap() == address);
+            .position(|&bp| bp == Some(address));
 
         tracing::debug!(
             "Will clear HW breakpoint    #{} with comparator address    {:#08x}",


### PR DESCRIPTION
This PR should reduce the number of breakpoint reads, mostly just speeding up the smoke tester by a bit.