### PR TITLE
Don't power down debug port when switching

### DIFF
--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -512,10 +512,6 @@ impl<'interface> ArmCommunicationInterface<Initialized> {
 
             self.probe_mut().raw_flush()?;
 
-            let stop_span = tracing::debug_span!("debug_port_stop").entered();
-            sequence.debug_port_stop(&mut *self.probe_mut())?;
-            drop(stop_span);
-
             // Try to switch to the new DP.
             if let Err(e) = sequence.debug_port_connect(&mut *self.probe_mut(), dp) {
                 tracing::warn!("Failed to switch to DP {:x?}: {}", dp, e);

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -589,7 +589,7 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
         let powered_down = !(ctrl.csyspwrupack() && ctrl.cdbgpwrupack());
 
         if powered_down {
-            tracing::debug!("Debug port is powered down, powering up");
+            tracing::info!("Debug port is powered down, powering up");
             let mut ctrl = Ctrl(0);
             ctrl.set_cdbgpwrupreq(true);
             ctrl.set_csyspwrupreq(true);
@@ -818,6 +818,7 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
     /// [ARM SVD Debug Description]: https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/debug_description.html#debugPortStop
     #[doc(alias = "DebugPortStop")]
     fn debug_port_stop(&self, interface: &mut dyn DapProbe) -> Result<(), ArmError> {
+        tracing::info!("Stopping debug port");
         // Select Bank 0
         interface.raw_write_register(PortType::DebugPort, Select::ADDRESS, 0)?;
 

--- a/probe-rs/src/probe/arm_debug_interface.rs
+++ b/probe-rs/src/probe/arm_debug_interface.rs
@@ -992,7 +992,7 @@ impl<Probe: DebugProbe + RawProtocolIo + JTAGAccess + 'static> RawDapAccess for 
                     // Because we clock the SWDCLK line after receving the WAIT response,
                     // the target might be in weird state. If we perform a line reset,
                     // we should be able to recover from this.
-                    // line_reset(self, dp)?;
+                    line_reset(self)?;
 
                     // Retry operation again
                     continue;


### PR DESCRIPTION
This PR is meant to address [this issue](https://github.com/probe-rs/probe-rs/pull/2282#issuecomment-2067979632). This PR allows me to flash my RP2040 again and to work with it. At least, once per power cycle, which indicates that this isn't the actual problem. But the [description](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/debug_description.html#usage_of_sequences) indicates the DP shouldn't be eagerly powered down and without knowing more, I prefer slightly working over nonfunctional.

Log levels are bumped because why not, line_reset is restored because its removal looks accidental.