### PR TITLE
Fix flashing RISC-V chips after setting breakpoints

### DIFF
--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -468,10 +468,6 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
     fn set_hw_breakpoint(&mut self, bp_unit_index: usize, addr: u64) -> Result<(), crate::Error> {
         let addr = valid_32bit_address(addr)?;
 
-        if !self.hw_breakpoints_enabled() {
-            self.enable_breakpoints(true)?;
-        }
-
         // select requested trigger
         let tselect = 0x7a0;
         let tdata1 = 0x7a1;

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -514,8 +514,9 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         // Match address
         instruction_breakpoint.set_select(false);
 
-        self.write_csr(tdata1, instruction_breakpoint.0)?;
+        self.write_csr(tdata1, 0)?;
         self.write_csr(tdata2, addr)?;
+        self.write_csr(tdata1, instruction_breakpoint.0)?;
 
         Ok(())
     }

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -477,7 +477,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         let tdata1 = 0x7a1;
         let tdata2 = 0x7a2;
 
-        tracing::debug!("Setting breakpoint {}", bp_unit_index);
+        tracing::info!("Setting breakpoint {}", bp_unit_index);
 
         self.write_csr(tselect, bp_unit_index as u32)?;
 
@@ -523,6 +523,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
 
     fn clear_hw_breakpoint(&mut self, unit_index: usize) -> Result<(), crate::Error> {
         // this can be called w/o halting the core via Session::new - temporarily halt if not halted
+        tracing::info!("Clearing breakpoint {}", unit_index);
 
         let was_running = !self.core_halted()?;
         if was_running {

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -443,7 +443,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
             let mut tdata_value = Mcontrol(self.read_csr(tdata1)?);
 
             // Only modify the trigger if it is for an execution debug action in all modes(probe-rs enabled it) or no modes (we previously disabled it).
-            if tdata_value.type_() == 0b10
+            if tdata_value.type_() == 2
                 && tdata_value.action() == 1
                 && tdata_value.match_() == 0
                 && tdata_value.execute()
@@ -499,6 +499,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
         instruction_breakpoint.set_action(1);
 
         // Match exactly the value in tdata2
+        instruction_breakpoint.set_type(2);
         instruction_breakpoint.set_match(0);
 
         instruction_breakpoint.set_m(true);

--- a/probe-rs/src/architecture/riscv/mod.rs
+++ b/probe-rs/src/architecture/riscv/mod.rs
@@ -308,7 +308,7 @@ impl<'probe> CoreInterface for Riscv32<'probe> {
                 // We may have been halted by either an EBREAK or a C.EBREAK instruction.
                 // We need to read back the instruction to determine how many bytes we need to skip.
                 let instruction = self.read_word_32(debug_pc.try_into().unwrap())?;
-                if instruction & 0x3 == 0x10 {
+                if instruction & 0x3 != 0x3 {
                     // Compressed instruction.
                     debug_pc.increment_address(2)?;
                 } else {


### PR DESCRIPTION
My guess is that my chip (ESP32C2 and likes) are RV32C, but the flash algo encodes a 4-byte EBREAK anyway. This is I believe completely valid, however stepping through half of that EBREAK is not. We could do multiple things: read back the instruction at DPC and decide how much we need to advance it, use a different flash algo header if the chip is RV32C, or what this PR does: remove the shortcut altogether.

I'm hoping the performance implication aren't unbearably bad with this PR