### PR TITLE
Disable all DPs but only when disconnecting

### DIFF
--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -179,6 +179,7 @@ impl ArmDebugState for Initialized {
 
         // Stop all intentionally-connected DPs.
         for dp in self.dps.keys() {
+            // Try to select the debug port we want to shut down.
             if self.sequence.debug_port_connect(probe, *dp).is_ok() {
                 self.sequence.debug_port_stop(probe, *dp).ok();
             } else {

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -173,7 +173,19 @@ impl ArmDebugState for Uninitialized {}
 impl ArmDebugState for Initialized {
     fn disconnect(&mut self, probe: &mut dyn DapProbe) {
         let stop_span = tracing::debug_span!("debug_port_stop").entered();
-        self.sequence.debug_port_stop(probe).ok();
+
+        // Stop the current DP, which may not be one of the known ones (i.e. RP2040 rescue DP).
+        self.sequence.debug_port_stop(probe, self.current_dp).ok();
+
+        // Stop all intentionally-connected DPs.
+        for dp in self.dps.keys() {
+            if self.sequence.debug_port_connect(probe, *dp).is_ok() {
+                self.sequence.debug_port_stop(probe, *dp).ok();
+            } else {
+                tracing::warn!("Failed to stop DP {:x?}", dp);
+            }
+        }
+        probe.raw_flush().ok();
         drop(stop_span);
     }
 }
@@ -562,10 +574,6 @@ impl<'interface> ArmCommunicationInterface<Initialized> {
             switched_dp = true;
 
             self.probe_mut().raw_flush()?;
-
-            let stop_span = tracing::debug_span!("debug_port_stop").entered();
-            sequence.debug_port_stop(&mut *self.probe_mut())?;
-            drop(stop_span);
 
             // Try to switch to the new DP.
             if let Err(e) = sequence.debug_port_connect(&mut *self.probe_mut(), dp) {


### PR DESCRIPTION
This PR contains three changes:
 - Delays flushing the probe's batched commands. This change breaks RP2040 with CMSIS-DAP probes, which is somewhat intentional. Previously, the probes were working because the power-down request didn't take effect.
 - Implements waiting for the de-assertion of the acknowledge bits.
 - Only disable DPs when we disconnect. Disable the current DP _and_ all known DPs. This may disable one DP multiple times which shouldn't be an issue, but it will make sure the RP2040's rescue DP is disabled as well.