### PR TITLE
Update Embed.toml flashing options

### DIFF
--- a/changelog/added-embed-config-opts.md
+++ b/changelog/added-embed-config-opts.md
@@ -1,0 +1,1 @@
+Added `verify` and `disable_double_buffering` options to Embed.toml

--- a/changelog/removed-halt_afterwards.md
+++ b/changelog/removed-halt_afterwards.md
@@ -1,0 +1,1 @@
+Removed `halt_afterwards` from Embed.toml

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -23,6 +23,10 @@ restore_unwritten_bytes = false
 # flash_layout_output_path = "out.svg"
 # Triggers a full chip erase instead of a page by page erase.
 do_chip_erase = false
+# Whether to disable double buffering
+disable_double_buffering = false
+# Whether to verify flash contents after downloading
+verify = false
 
 [default.reset]
 # Whether or not the target should be reset.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -13,9 +13,6 @@ protocol = "Swd"
 [default.flashing]
 # Whether or not the target should be flashed.
 enabled = true
-# Whether or not the target should be halted after reset.
-# DEPRECATED, moved to reset section
-halt_afterwards = false
 # Whether or not bytes erased but not rewritten with data from the ELF
 # should be restored with their contents before erasing.
 restore_unwritten_bytes = false

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -46,11 +46,6 @@ pub struct Probe {
 #[serde(deny_unknown_fields)]
 pub struct Flashing {
     pub enabled: bool,
-    #[deprecated(
-        since = "0.9.0",
-        note = "The 'halt_afterwards' key has moved to the 'reset' section"
-    )]
-    pub halt_afterwards: bool,
     pub restore_unwritten_bytes: bool,
     pub flash_layout_output_path: Option<String>,
     pub do_chip_erase: bool,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -54,6 +54,8 @@ pub struct Flashing {
     pub restore_unwritten_bytes: bool,
     pub flash_layout_output_path: Option<String>,
     pub do_chip_erase: bool,
+    pub disable_double_buffering: bool,
+    pub verify: bool,
 }
 
 /// The reset config struct holding all the possible reset options.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -263,14 +263,7 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
     if config.reset.enabled {
         let mut core = session.core(core_id)?;
         let halt_timeout = Duration::from_millis(500);
-        #[allow(deprecated)] // Remove in 0.10
-        if config.flashing.halt_afterwards {
-            logging::eprintln(format!(
-                "     {} The 'flashing.halt_afterwards' option in the config has moved to the 'reset' section",
-                "Warning".yellow().bold()
-            ));
-            core.reset_and_halt(halt_timeout)?;
-        } else if config.reset.halt_afterwards {
+        if config.reset.halt_afterwards {
             core.reset_and_halt(halt_timeout)?;
         } else {
             core.reset()?;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -242,10 +242,10 @@ fn main_try(mut args: Vec<OsString>, offset: UtcOffset) -> Result<()> {
 
         let download_options = BinaryDownloadOptions {
             disable_progressbars: opt.disable_progressbars,
-            disable_double_buffering: false,
+            disable_double_buffering: config.flashing.disable_double_buffering,
             restore_unwritten: config.flashing.restore_unwritten_bytes,
             flash_layout_output_path: None,
-            verify: false,
+            verify: config.flashing.verify,
         };
         let format_options = FormatOptions::default();
         let loader = build_loader(&mut session, path, format_options, image_instr_set)?;


### PR DESCRIPTION
- Remove long-deprecated `halt_afterwards`
- Add `verify`
- Add `disable_double_buffering` (https://github.com/probe-rs/probe-rs/issues/1891#issuecomment-2031103939)