### PR TITLE
Generate new yamls for ATSAMD51, L10, L11

### DIFF
--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -377,7 +377,7 @@ fn cortex_m_reset_system(interface: &mut dyn ArmProbe) -> Result<(), ArmError> {
 
     let start = Instant::now();
 
-    while start.elapsed() < Duration::from_micros(50_0000) {
+    while start.elapsed() < Duration::from_micros(500_000) {
         let dhcsr = match interface.read_word_32(Dhcsr::get_mmio_address()) {
             Ok(val) => Dhcsr(val),
             // Some combinations of debug probe and target (in

--- a/probe-rs/src/config/sequences/atsam_l1x.rs
+++ b/probe-rs/src/config/sequences/atsam_l1x.rs
@@ -1,0 +1,399 @@
+//! Sequences for ATSAM L1x target families
+
+use crate::{
+    architecture::arm::{
+        ap::MemoryAp,
+        armv8m::Dhcsr,
+        communication_interface::{DapProbe, SwdSequence},
+        memory::adi_v5_memory_interface::ArmProbe,
+        sequences::{ArmDebugSequence, ArmDebugSequenceError},
+        ArmError, ArmProbeInterface, Pins,
+    },
+    probe::DebugProbeError,
+    MemoryMappedRegister,
+};
+use bitfield::bitfield;
+use probe_rs_target::CoreType;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use anyhow::Result;
+
+bitfield! {
+    /// Device Service Unit Control Register, DSU - CTRL
+    #[derive(Copy, Clone)]
+    pub struct DsuCtrl(u8);
+    impl Debug;
+    /// Memory Built-In Self-Test
+    ///
+    /// Writing a '0' to this bit has no effect.\
+    /// Writing a '1' to this bit starts the memory BIST algorithm.
+    pub _, set_mbist: 3;
+    /// 32-bit Cyclic Redundancy Check
+    ///
+    /// Writing a '0' to this bit has no effect.\
+    /// Writing a '1' to this bit starts the cyclic redundancy check algorithm.
+    pub _, set_crc: 2;
+    /// Software Reset
+    ///
+    /// Writing a '0' to this bit has no effect.\
+    /// Writing a '1' to this bit resets the module.
+    pub _, set_swrst: 0;
+}
+
+impl DsuCtrl {
+    /// The DSU CTRL register address
+    pub const ADDRESS: u64 = 0x4100_2100;
+}
+
+impl From<u8> for DsuCtrl {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DsuCtrl> for u8 {
+    fn from(value: DsuCtrl) -> Self {
+        value.0
+    }
+}
+
+bitfield! {
+    /// Device Service Unit Status A Register, DSU - STATUSA
+    #[derive(Copy, Clone)]
+    pub struct DsuStatusA(u8);
+    impl Debug;
+    /// Boot ROM Phase Extension
+    ///
+    /// This bit is set when a debug adapter Cold-Plugging is detected, which extends the Boot ROM
+    /// phase.
+    ///
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit clears the Boot ROM Phase Extension bit
+    pub brext, set_brext: 5;
+
+    /// Protection Error
+    ///
+    /// This bit is set when a command that is not allowed in Protected state is issued.
+    ///
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit clears the Protection Error bit.
+    pub perr, set_perr: 4;
+
+    /// Failure
+    ///
+    /// This bit is set when a DSU operation failure is detected.
+    ///
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit clears the Failure bit.
+    pub fail, set_fail: 3;
+
+    /// Bus Error
+    ///
+    /// This bit is set when a bus error is detected.
+    ///
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit clears the Bus Error bit.
+    pub berr, set_berr: 2;
+
+    /// CPU Reset Phase Extension
+    ///
+    /// This bit is set when a debug adapter Cold-Plugging is detected, which extends the CPU Reset
+    /// phase.
+    ///
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit clears the CPU Reset Phase Extension bit.
+    pub crstext, set_crstext: 1;
+
+    /// Done
+    ///
+    /// This bit is set when a DSU operation is completed.
+    ///
+    /// Writing a '0' to this bit has no effect.
+    /// Writing a '1' to this bit clears the Done bit.
+    pub done, set_done: 0;
+}
+
+impl From<u8> for DsuStatusA {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DsuStatusA> for u8 {
+    fn from(value: DsuStatusA) -> Self {
+        value.0
+    }
+}
+
+impl DsuStatusA {
+    /// The DSU STATUSA register address
+    pub const ADDRESS: u64 = 0x4100_2101;
+}
+
+bitfield! {
+    /// Device Service Unit Status B Register, DSU - STATUSB
+    #[derive(Copy, Clone)]
+    pub struct DsuStatusB(u8);
+    impl Debug;
+
+    /// BOOT Communication Channel 1 Dirty
+    ///
+    /// This bit is set when BCC1 is written.
+    /// This bit is cleared when BCC1 is read.
+    pub bccd1, _: 7;
+
+    /// BOOT Communication Channel 0 Dirty
+    ///
+    /// This bit is set when BCC0 is written.
+    /// This bit is cleared when BCC0 is read.
+    pub bccd0, _: 6;
+
+    /// Debug Communication Channel 1 Dirty
+    ///
+    /// This bit is set when DCC1 is written.
+    /// This bit is cleared when DCC1 is read.
+    pub dccd1, _: 5;
+
+    /// Debug Communication Channel 0 Dirty
+    ///
+    /// This bit is set when DCC0 is written.
+    /// This bit is cleared when DCC0 is read.
+    pub dccd0, _: 4;
+
+    /// Hot-Plugging Enable
+    ///
+    /// This bit is set when Hot-Plugging is enabled.
+    /// This bit is cleared when Hot-Plugging is disabled. This is the case when
+    /// the SWCLK function is changed. Only a power-reset or a external reset
+    /// can set it again.
+    pub hpe, _: 3;
+
+    /// Debugger Present
+    ///
+    /// This bit is set when a debugger probe is detected.
+    /// This bit is never cleared.
+    pub dbgpres, _: 2;
+
+    /// Debugger Access Level
+    ///
+    /// Indicates the debugger access level:
+    /// - 0x0: Debugger can only access the DSU external address space.
+    /// - 0x1: Debugger can access only Non-Secure regions (SAM L11 only).
+    /// - 0x2: Debugger can access secure and Non-Secure regions.
+    /// Writing in this bitfield has no effect.
+    pub dal, _: 1, 0;
+
+}
+
+impl From<u8> for DsuStatusB {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DsuStatusB> for u8 {
+    fn from(value: DsuStatusB) -> Self {
+        value.0
+    }
+}
+
+impl DsuStatusB {
+    /// The DSU STATUSB register address
+    pub const ADDRESS: u64 = 0x4100_2102;
+}
+
+/// A wrapper for different types that can perform SWD Commands (SWJ_Pins SWJ_Sequence)
+struct SwdSequenceShim<'a>(&'a mut dyn DapProbe);
+
+impl<'a> From<&'a mut dyn DapProbe> for SwdSequenceShim<'a> {
+    fn from(p: &'a mut dyn DapProbe) -> Self {
+        Self(p)
+    }
+}
+
+impl<'a> SwdSequence for SwdSequenceShim<'a> {
+    fn swj_sequence(&mut self, bit_len: u8, bits: u64) -> Result<(), DebugProbeError> {
+        self.0.swj_sequence(bit_len, bits)
+    }
+
+    fn swj_pins(
+        &mut self,
+        pin_out: u32,
+        pin_select: u32,
+        pin_wait: u32,
+    ) -> Result<u32, DebugProbeError> {
+        self.0.swj_pins(pin_out, pin_select, pin_wait)
+    }
+}
+
+/// Marker struct indicating initialization sequencing for Atmel/Microchip ATSAM family parts.
+#[derive(Debug)]
+pub struct AtSAML1x {}
+
+impl AtSAML1x {
+    /// Create the sequencer for the ATSAM family of parts.
+    pub fn create() -> Arc<Self> {
+        Arc::new(Self {})
+    }
+
+    /// Perform a hardware reset in a way that puts the core into CPU Reset Extension
+    ///
+    /// CPU Reset Extension is a vendor specific feature that allows the CPU core to remain
+    /// in reset while the rest of the debugging subsystem can run and initialize itself.
+    ///
+    /// For more details see: 12.6.2 CPU Reset Extension in the SAM D5/E5 Family Data Sheet
+    ///
+    /// # Errors
+    /// Subject to probe communication errors
+    pub fn reset_hardware_with_extension(
+        &self,
+        interface: &mut dyn SwdSequence,
+    ) -> Result<(), ArmError> {
+        let mut pins = Pins(0);
+        pins.set_nreset(true);
+        pins.set_swdio_tms(true);
+        pins.set_swclk_tck(true);
+
+        // First set nReset, SWDIO and SWCLK to low.
+        let mut pin_values = Pins(0);
+        interface.swj_pins(pin_values.0 as u32, pins.0 as u32, 0)?;
+        std::thread::sleep(Duration::from_millis(10));
+
+        // Next release nReset, but keep SWDIO and SWCLK low. This should put the device into
+        // reset extension.
+        pin_values.set_nreset(true);
+        interface.swj_pins(pin_values.0 as u32, pins.0 as u32, 0)?;
+        std::thread::sleep(Duration::from_millis(20));
+
+        Ok(())
+    }
+
+    /// Release the CPU core from Reset Extension
+    ///
+    /// Clear the DSU Reset Extension bit, which releases the core from reset extension.
+    ///
+    /// # Errors
+    /// Subject to probe communication errors
+    pub fn release_reset_extension(&self, memory: &mut dyn ArmProbe) -> Result<(), ArmError> {
+        // Enable debug mode if it is not already enabled
+        let mut dhcsr = Dhcsr(0);
+        dhcsr.enable_write();
+        dhcsr.set_c_debugen(true);
+        memory.write_word_32(Dhcsr::ADDRESS_OFFSET, dhcsr.0)?;
+
+        // clear the reset extension bit
+        let mut dsu_statusa = DsuStatusA(0);
+        dsu_statusa.set_crstext(true);
+        memory.write_8(DsuStatusA::ADDRESS, &[dsu_statusa.0])?;
+
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_millis(100) {
+            let current_dsu_statusa = DsuStatusA::from(memory.read_word_8(DsuStatusA::ADDRESS)?);
+            if !current_dsu_statusa.crstext() {
+                return Ok(());
+            }
+        }
+
+        Err(ArmError::Timeout)
+    }
+
+    /// Perform a normal hardware reset without triggering a Reset extension
+    ///
+    /// # Errors
+    /// Subject to probe communication errors
+    pub fn reset_hardware(&self, interface: &mut dyn SwdSequence) -> Result<(), ArmError> {
+        let mut pins = Pins(0);
+        pins.set_nreset(true);
+        pins.set_swdio_tms(true);
+        pins.set_swclk_tck(true);
+
+        let mut pin_values = pins;
+
+        pin_values.set_nreset(false);
+        interface.swj_pins(pin_values.0 as u32, pins.0 as u32, 0)?;
+        std::thread::sleep(Duration::from_millis(10));
+
+        pin_values.set_nreset(true);
+        interface.swj_pins(pin_values.0 as u32, pins.0 as u32, 0)?;
+        std::thread::sleep(Duration::from_millis(10));
+
+        Ok(())
+    }
+
+    /// Some probes only support setting `nRESET` directly, but not the SWDIO/SWCLK pins. For those,
+    /// we can use this fallback method.
+    fn ensure_target_reset(
+        &self,
+        result: Result<(), ArmError>,
+        interface: &mut dyn SwdSequence,
+    ) -> Result<(), ArmError> {
+        // Fall back if the probe's swj_pins does not support the full set of pins
+        match result {
+            Err(ArmError::Probe(DebugProbeError::CommandNotSupportedByProbe {
+                command_name: "swj_pins",
+            })) => {
+                tracing::warn!("Using fallback reset method");
+
+                let mut pins = Pins(0);
+                pins.set_nreset(true);
+
+                interface.swj_pins(0, pins.0 as u32, 0)?;
+                std::thread::sleep(Duration::from_millis(10));
+
+                interface.swj_pins(pins.0 as u32, pins.0 as u32, 0)?;
+                std::thread::sleep(Duration::from_millis(10));
+
+                Ok(())
+            }
+            other => other,
+        }
+    }
+}
+
+impl ArmDebugSequence for AtSAML1x {
+    fn debug_core_start(
+        &self,
+        interface: &mut dyn ArmProbeInterface,
+        core_ap: MemoryAp,
+        _core_type: CoreType,
+        _debug_base: Option<u64>,
+        _cti_base: Option<u64>,
+    ) -> Result<(), ArmError> {
+        let mut core = interface.memory_interface(core_ap)?;
+
+        self.release_reset_extension(&mut *core)
+    }
+
+    /// `reset_hardware_assert` for ATSAM devices
+    ///
+    /// Instead of keeping `nReset` asserted, the device is instead put into CPU Reset Extension
+    /// which will keep the CPU Core in reset until manually released by the debugger probe.
+    fn reset_hardware_assert(&self, interface: &mut dyn DapProbe) -> Result<(), ArmError> {
+        let mut shim = SwdSequenceShim::from(interface);
+        let result = self.reset_hardware_with_extension(&mut shim);
+
+        self.ensure_target_reset(result, &mut shim)
+    }
+
+    /// `reset_hardware_deassert` for ATSAM devices
+    ///
+    /// Instead of de-asserting `nReset` here (this was already done during the CPU Reset Extension process),
+    /// the device is released from Reset Extension.
+    fn reset_hardware_deassert(&self, memory: &mut dyn ArmProbe) -> Result<(), ArmError> {
+        let mut pins = Pins(0);
+        pins.set_nreset(true);
+
+        let current_pins = Pins(memory.swj_pins(pins.0 as u32, pins.0 as u32, 0)? as u8);
+        if !current_pins.nreset() {
+            return Err(ArmDebugSequenceError::SequenceSpecific(
+                "Expected nReset to already be de-asserted".into(),
+            )
+            .into());
+        }
+
+        self.release_reset_extension(memory)
+    }
+}

--- a/probe-rs/src/config/sequences/atsam_l1x.rs
+++ b/probe-rs/src/config/sequences/atsam_l1x.rs
@@ -1,4 +1,8 @@
-//! Sequences for ATSAM L1x target families
+//! Sequences for ATSAML10/L11 target families
+//!
+//! ATSAML10/L11 devices are Cortex-M23 (ARMv8-M Baseline) based microcontrollers,
+//! using the ARM Debug Interface Architecture v5 Specification. L11 devices include
+//! the ARM TrustZone security technology.
 
 use crate::{
     architecture::arm::{

--- a/probe-rs/src/config/sequences/mod.rs
+++ b/probe-rs/src/config/sequences/mod.rs
@@ -17,6 +17,7 @@ pub mod esp32s3;
 
 // ARM devices
 pub mod atsam;
+pub mod atsam_l1x;
 pub mod cc13xx_cc26xx;
 pub mod efm32xg2;
 pub mod infineon;

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -1,6 +1,7 @@
 use super::{
     sequences::{
         atsam::AtSAM,
+        atsam_l1x::AtSAML1x,
         cc13xx_cc26xx::CC13xxCC26xx,
         efm32xg2::EFM32xG2,
         esp32::ESP32,
@@ -183,9 +184,10 @@ impl Target {
             || chip.name.starts_with("ATSAMDA")
             || chip.name.starts_with("ATSAMD5")
             || chip.name.starts_with("ATSAME5")
-            || chip.name.starts_with("ATSAML1")
         {
             DebugSequence::Arm(AtSAM::create())
+        } else if chip.name.starts_with("ATSAML1") {
+            DebugSequence::Arm(AtSAML1x::create())
         } else if chip.name.starts_with("XMC4") {
             DebugSequence::Arm(XMC4000::create())
         } else if chip.name.starts_with("CC13") || chip.name.starts_with("CC26") {

--- a/probe-rs/src/config/target.rs
+++ b/probe-rs/src/config/target.rs
@@ -183,6 +183,7 @@ impl Target {
             || chip.name.starts_with("ATSAMDA")
             || chip.name.starts_with("ATSAMD5")
             || chip.name.starts_with("ATSAME5")
+            || chip.name.starts_with("ATSAML1")
         {
             DebugSequence::Arm(AtSAM::create())
         } else if chip.name.starts_with("XMC4") {

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -161,7 +161,7 @@ impl<'session> Flasher<'session> {
         let cpu_info = core
             .halt(Duration::from_millis(100))
             .map_err(FlashError::Core)?;
-        tracing::debug!("PC = {:010x}", cpu_info.pc);
+        tracing::debug!("PC = {:#010x}", cpu_info.pc);
         tracing::debug!("Reset and halt");
         core.reset_and_halt(Duration::from_millis(500))
             .map_err(FlashError::Core)?;

--- a/probe-rs/targets/SAMD51.yaml
+++ b/probe-rs/targets/SAMD51.yaml
@@ -1,297 +1,479 @@
 name: SAMD51
-manufacturer:
-  id: 0x1F
-  cc: 0x0
+generated_from_pack: true
+pack_file_release: 1.2.139
 variants:
-  - name: ATSAMD51G18A
+- name: ATSAMD51G18A
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20020000
     cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x0
-            end: 0x40000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - atsamd51_256
-  - name: ATSAMD51G19A
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x0
+      end: 0x40000
+    is_boot_memory: true
     cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20030000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x0
-            end: 0x80000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - atsamd51_512
-  - name: ATSAMD51J18A
+    - main
+  - !Generic
+    name: IRAM2
+    range:
+      start: 0x20000000
+      end: 0x20008000
     cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20020000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x0
-            end: 0x40000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - atsamd51_256
-  - name: ATSAMD51J19A
+    - main
+  - !Generic
+    name: IRAM3
+    range:
+      start: 0x20000000
+      end: 0x20008000
     cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20030000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x0
-            end: 0x80000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - atsamd51_512
-  - name: ATSAMD51J20A
+    - main
+  - !Generic
+    name: IRAM4
+    range:
+      start: 0x47000000
+      end: 0x47002000
     cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20040000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x0
-            end: 0x100000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - atsamd51_1024
-  - name: ATSAMD51N19A
+    - main
+  flash_algorithms:
+  - atsamd51_256
+- name: ATSAMD51G19A
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20030000
     cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20030000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x0
-            end: 0x80000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - atsamd51_512
-  - name: ATSAMD51N20A
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x0
+      end: 0x80000
+    is_boot_memory: true
     cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20040000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x0
-            end: 0x100000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - atsamd51_1024
-  - name: ATSAMD51P19A
+    - main
+  - !Generic
+    name: IRAM2
+    range:
+      start: 0x20000000
+      end: 0x20008000
     cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20030000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x0
-            end: 0x80000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - atsamd51_512
-  - name: ATSAMD51P20A
+    - main
+  - !Generic
+    name: IRAM3
+    range:
+      start: 0x20000000
+      end: 0x20008000
     cores:
-      - name: main
-        type: armv7em
-        core_access_options:
-          !Arm
-            ap: 0x0
-            psel: 0x0
-    memory_map:
-      - !Ram
-          range:
-            start: 0x20000000
-            end: 0x20040000
-          is_boot_memory: false
-          cores:
-            - main
-      - !Nvm
-          range:
-            start: 0x0
-            end: 0x100000
-          is_boot_memory: true
-          cores:
-            - main
-    flash_algorithms:
-      - atsamd51_1024
+    - main
+  - !Generic
+    name: IRAM4
+    range:
+      start: 0x47000000
+      end: 0x47002000
+    cores:
+    - main
+  flash_algorithms:
+  - atsamd51_512
+- name: ATSAMD51J18A
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20020000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x0
+      end: 0x40000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IRAM2
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM3
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM4
+    range:
+      start: 0x47000000
+      end: 0x47002000
+    cores:
+    - main
+  flash_algorithms:
+  - atsamd51_256
+- name: ATSAMD51J19A
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x0
+      end: 0x80000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IRAM2
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM3
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM4
+    range:
+      start: 0x47000000
+      end: 0x47002000
+    cores:
+    - main
+  flash_algorithms:
+  - atsamd51_512
+- name: ATSAMD51J20A
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x0
+      end: 0x100000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IRAM2
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM3
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM4
+    range:
+      start: 0x47000000
+      end: 0x47002000
+    cores:
+    - main
+  flash_algorithms:
+  - atsamd51_1024
+- name: ATSAMD51N19A
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x0
+      end: 0x80000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IRAM2
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM3
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM4
+    range:
+      start: 0x47000000
+      end: 0x47002000
+    cores:
+    - main
+  flash_algorithms:
+  - atsamd51_512
+- name: ATSAMD51N20A
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x0
+      end: 0x100000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IRAM2
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM3
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM4
+    range:
+      start: 0x47000000
+      end: 0x47002000
+    cores:
+    - main
+  flash_algorithms:
+  - atsamd51_1024
+- name: ATSAMD51P19A
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20030000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x0
+      end: 0x80000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IRAM2
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM3
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM4
+    range:
+      start: 0x47000000
+      end: 0x47002000
+    cores:
+    - main
+  flash_algorithms:
+  - atsamd51_512
+- name: ATSAMD51P20A
+  cores:
+  - name: main
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: IRAM1
+    range:
+      start: 0x20000000
+      end: 0x20040000
+    cores:
+    - main
+  - !Nvm
+    name: IROM1
+    range:
+      start: 0x0
+      end: 0x100000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Generic
+    name: IRAM2
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM3
+    range:
+      start: 0x20000000
+      end: 0x20008000
+    cores:
+    - main
+  - !Generic
+    name: IRAM4
+    range:
+      start: 0x47000000
+      end: 0x47002000
+    cores:
+    - main
+  flash_algorithms:
+  - atsamd51_1024
 flash_algorithms:
-  - name: atsamd51_256
-    description: ATSAMD51 256kB Flash
-    cores:
-      - main
-    default: true
-    instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 0x1
-    pc_uninit: 0x25
-    pc_program_page: 0x51
-    pc_erase_sector: 0x29
-    data_section_offset: 0xa0
-    flash_properties:
-      address_range:
-        start: 0x0
-        end: 0x40000
-      page_size: 0x200
-      erased_byte_value: 0xff
-      program_page_timeout: 0x64
-      erase_sector_timeout: 0x3e8
-      sectors:
-        - size: 0x2000
-          address: 0x0
-  - name: atsamd51_512
-    description: ATSAMD51 512kB Flash
-    cores:
-      - main
-    default: true
-    instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 0x1
-    pc_uninit: 0x25
-    pc_program_page: 0x51
-    pc_erase_sector: 0x29
-    data_section_offset: 0xa0
-    flash_properties:
-      address_range:
-        start: 0x0
-        end: 0x80000
-      page_size: 0x200
-      erased_byte_value: 0xff
-      program_page_timeout: 0x64
-      erase_sector_timeout: 0x3e8
-      sectors:
-        - size: 0x2000
-          address: 0x0
-  - name: atsamd51_1024
-    description: ATSAMD51 1024kB Flash
-    cores:
-      - main
-    default: true
-    instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
-    pc_init: 0x1
-    pc_uninit: 0x25
-    pc_program_page: 0x51
-    pc_erase_sector: 0x29
-    data_section_offset: 0xa0
-    flash_properties:
-      address_range:
-        start: 0x0
-        end: 0x100000
-      page_size: 0x200
-      erased_byte_value: 0xff
-      program_page_timeout: 0x64
-      erase_sector_timeout: 0x3e8
-      sectors:
-        - size: 0x2000
-          address: 0x0
+- name: atsamd51_256
+  description: ATSAMD51 256kB Flash
+  default: true
+  instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x25
+  pc_program_page: 0x51
+  pc_erase_sector: 0x29
+  data_section_offset: 0xa0
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x40000
+    page_size: 0x200
+    erased_byte_value: 0xff
+    program_page_timeout: 100
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x2000
+      address: 0x0
+- name: atsamd51_512
+  description: ATSAMD51 512kB Flash
+  default: true
+  instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x25
+  pc_program_page: 0x51
+  pc_erase_sector: 0x29
+  data_section_offset: 0xa0
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x80000
+    page_size: 0x200
+    erased_byte_value: 0xff
+    program_page_timeout: 100
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x2000
+      address: 0x0
+- name: atsamd51_1024
+  description: ATSAMD51 1024kB Flash
+  default: true
+  instructions: ASGJB4prUgcB1SFKCmDPIiBJEgIKgE4iCoIfSUlECGAAIHBHACBwRxpJSGEbSoqASorSB/zQSGEYSBE4iIBIisAH/NAIik4hCEAA0AEgcEcwtRJLD0zbHKOAY4rbB/zQyRyJCANGiQAC4CDKCR8gwwAp+tFgYQlIDziggGCKwAf80CCKTiEIQADQASAwvQAAIgABAABAAEEEAAAAEqUAAAAAAAAAAAAA
+  pc_init: 0x1
+  pc_uninit: 0x25
+  pc_program_page: 0x51
+  pc_erase_sector: 0x29
+  data_section_offset: 0xa0
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x100000
+    page_size: 0x200
+    erased_byte_value: 0xff
+    program_page_timeout: 100
+    erase_sector_timeout: 1000
+    sectors:
+    - size: 0x2000
+      address: 0x0

--- a/probe-rs/targets/SAMD51.yaml
+++ b/probe-rs/targets/SAMD51.yaml
@@ -1,5 +1,5 @@
 name: SAMD51
-generated_from_pack: true
+generated_from_pack: false # true but with manual edits
 pack_file_release: 1.2.139
 variants:
 - name: ATSAMD51G18A
@@ -26,24 +26,18 @@ variants:
     cores:
     - main
   - !Generic
-    name: IRAM2
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM3
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM4
+    name: Backup SRAM
     range:
       start: 0x47000000
       end: 0x47002000
+    cores:
+    - main
+  - !Nvm
+    name: NVM user row
+    range:
+      start: 0x00804000
+      end: 0x00804200
+    is_boot_memory: false
     cores:
     - main
   flash_algorithms:
@@ -72,24 +66,18 @@ variants:
     cores:
     - main
   - !Generic
-    name: IRAM2
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM3
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM4
+    name: Backup SRAM
     range:
       start: 0x47000000
       end: 0x47002000
+    cores:
+    - main
+  - !Nvm
+    name: NVM user row
+    range:
+      start: 0x00804000
+      end: 0x00804200
+    is_boot_memory: false
     cores:
     - main
   flash_algorithms:
@@ -118,24 +106,18 @@ variants:
     cores:
     - main
   - !Generic
-    name: IRAM2
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM3
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM4
+    name: Backup SRAM
     range:
       start: 0x47000000
       end: 0x47002000
+    cores:
+    - main
+  - !Nvm
+    name: NVM user row
+    range:
+      start: 0x00804000
+      end: 0x00804200
+    is_boot_memory: false
     cores:
     - main
   flash_algorithms:
@@ -164,24 +146,18 @@ variants:
     cores:
     - main
   - !Generic
-    name: IRAM2
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM3
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM4
+    name: Backup SRAM
     range:
       start: 0x47000000
       end: 0x47002000
+    cores:
+    - main
+  - !Nvm
+    name: NVM user row
+    range:
+      start: 0x00804000
+      end: 0x00804200
+    is_boot_memory: false
     cores:
     - main
   flash_algorithms:
@@ -210,24 +186,18 @@ variants:
     cores:
     - main
   - !Generic
-    name: IRAM2
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM3
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM4
+    name: Backup SRAM
     range:
       start: 0x47000000
       end: 0x47002000
+    cores:
+    - main
+  - !Nvm
+    name: NVM user row
+    range:
+      start: 0x00804000
+      end: 0x00804200
+    is_boot_memory: false
     cores:
     - main
   flash_algorithms:
@@ -256,24 +226,18 @@ variants:
     cores:
     - main
   - !Generic
-    name: IRAM2
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM3
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM4
+    name: Backup SRAM
     range:
       start: 0x47000000
       end: 0x47002000
+    cores:
+    - main
+  - !Nvm
+    name: NVM user row
+    range:
+      start: 0x00804000
+      end: 0x00804200
+    is_boot_memory: false
     cores:
     - main
   flash_algorithms:
@@ -302,24 +266,18 @@ variants:
     cores:
     - main
   - !Generic
-    name: IRAM2
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM3
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM4
+    name: Backup SRAM
     range:
       start: 0x47000000
       end: 0x47002000
+    cores:
+    - main
+  - !Nvm
+    name: NVM user row
+    range:
+      start: 0x00804000
+      end: 0x00804200
+    is_boot_memory: false
     cores:
     - main
   flash_algorithms:
@@ -348,24 +306,18 @@ variants:
     cores:
     - main
   - !Generic
-    name: IRAM2
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM3
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM4
+    name: Backup SRAM
     range:
       start: 0x47000000
       end: 0x47002000
+    cores:
+    - main
+  - !Nvm
+    name: NVM user row
+    range:
+      start: 0x00804000
+      end: 0x00804200
+    is_boot_memory: false
     cores:
     - main
   flash_algorithms:
@@ -394,24 +346,18 @@ variants:
     cores:
     - main
   - !Generic
-    name: IRAM2
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM3
-    range:
-      start: 0x20000000
-      end: 0x20008000
-    cores:
-    - main
-  - !Generic
-    name: IRAM4
+    name: Backup SRAM
     range:
       start: 0x47000000
       end: 0x47002000
+    cores:
+    - main
+  - !Nvm
+    name: NVM user row
+    range:
+      start: 0x00804000
+      end: 0x00804200
+    is_boot_memory: false
     cores:
     - main
   flash_algorithms:

--- a/probe-rs/targets/SAMD51.yaml
+++ b/probe-rs/targets/SAMD51.yaml
@@ -1,4 +1,7 @@
 name: SAMD51
+manufacturer:
+  id: 41
+  cc: 0
 generated_from_pack: false # true but with manual edits
 pack_file_release: 1.2.139
 variants:

--- a/probe-rs/targets/SAML10.yaml
+++ b/probe-rs/targets/SAML10.yaml
@@ -19,7 +19,7 @@ variants:
     is_boot_memory: true
     cores:
     - main
-  - !Nvm
+  - !Generic
     name: Data Flash
     range:
       start: 0x400000
@@ -51,7 +51,7 @@ variants:
     is_boot_memory: true
     cores:
     - main
-  - !Nvm
+  - !Generic
     name: Data Flash
     range:
       start: 0x400000
@@ -83,7 +83,7 @@ variants:
     is_boot_memory: true
     cores:
     - main
-  - !Nvm
+  - !Generic
     name: Data Flash
     range:
       start: 0x400000

--- a/probe-rs/targets/SAML10.yaml
+++ b/probe-rs/targets/SAML10.yaml
@@ -1,0 +1,162 @@
+name: SAML10
+manufacturer:
+  id: 41
+  cc: 0
+variants:
+- name: ATSAML10x14
+  cores:
+  - name: main
+    type: armv8m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Nvm
+    name: Flash
+    range:
+      start: 0x0
+      end: 0x4000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Nvm
+    name: Data Flash
+    range:
+      start: 0x400000
+      end: 0x400800
+    cores:
+    - main
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20001000
+    cores:
+    - main
+  flash_algorithms:
+  - atsaml10x14
+- name: ATSAML10x15
+  cores:
+  - name: main
+    type: armv8m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Nvm
+    name: Flash
+    range:
+      start: 0x0
+      end: 0x8000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Nvm
+    name: Data Flash
+    range:
+      start: 0x400000
+      end: 0x400800
+    cores:
+    - main
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  flash_algorithms:
+  - atsaml10x15
+- name: ATSAML10x16
+  cores:
+  - name: main
+    type: armv8m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Nvm
+    name: Flash
+    range:
+      start: 0x0
+      end: 0x10000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Nvm
+    name: Data Flash
+    range:
+      start: 0x400000
+      end: 0x400800
+    cores:
+    - main
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  flash_algorithms:
+  - atsaml10x16
+flash_algorithms:
+- name: atsaml10x14
+  description: ''
+  default: true
+  instructions: gLUAr0DyIBDA8gAAASEBcFIeAyoW0ooHk2tbBwTUQPIiA8DyAQMTYETyBALE8gASQPIeA8DyBAMTYD4jE3QBcAAggL0A8Fj4QPIgEcDyAAEIeAEoAtEAIAhwcEcBIHBHQPIgEcDyAAEJeAEpEdFE8gABxPIAEQqLUgf81chhSvICUAiACItAB/zVCX0+IAhAcEcBIHBH8LUDr0DyIBPA8gADG3gBKyXRRPIAA8TyABMci2QH/NWMCBHQAyShQ0lCFHhVeC0CLBmVeC0E1ng2BnUZLBkEYAkdEh0AKfDR2GFK8gRQGIAYi0AH/NUZfT4gCEDwvQEg8L2AtQCvAN7+3gDU1NQ=
+  pc_init: 0x1
+  pc_uninit: 0x49
+  pc_program_page: 0x97
+  pc_erase_sector: 0x61
+  data_section_offset: 0x124
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x4000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 2000
+    sectors:
+    - size: 0x100
+      address: 0x0
+- name: atsaml10x15
+  description: ''
+  default: true
+  instructions: gLUAr0DyIBDA8gAAASEBcFIeAyoW0ooHk2tbBwTUQPIiA8DyAQMTYETyBALE8gASQPIeA8DyBAMTYD4jE3QBcAAggL0A8Fj4QPIgEcDyAAEIeAEoAtEAIAhwcEcBIHBHQPIgEcDyAAEJeAEpEdFE8gABxPIAEQqLUgf81chhSvICUAiACItAB/zVCX0+IAhAcEcBIHBH8LUDr0DyIBPA8gADG3gBKyXRRPIAA8TyABMci2QH/NWMCBHQAyShQ0lCFHhVeC0CLBmVeC0E1ng2BnUZLBkEYAkdEh0AKfDR2GFK8gRQGIAYi0AH/NUZfT4gCEDwvQEg8L2AtQCvAN7+3gDU1NQ=
+  pc_init: 0x1
+  pc_uninit: 0x49
+  pc_program_page: 0x97
+  pc_erase_sector: 0x61
+  data_section_offset: 0x124
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x8000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 2000
+    sectors:
+    - size: 0x100
+      address: 0x0
+- name: atsaml10x16
+  description: ''
+  default: true
+  instructions: gLUAr0DyIBDA8gAAASEBcFIeAyoW0ooHk2tbBwTUQPIiA8DyAQMTYETyBALE8gASQPIeA8DyBAMTYD4jE3QBcAAggL0A8Fj4QPIgEcDyAAEIeAEoAtEAIAhwcEcBIHBHQPIgEcDyAAEJeAEpEdFE8gABxPIAEQqLUgf81chhSvICUAiACItAB/zVCX0+IAhAcEcBIHBH8LUDr0DyIBPA8gADG3gBKyXRRPIAA8TyABMci2QH/NWMCBHQAyShQ0lCFHhVeC0CLBmVeC0E1ng2BnUZLBkEYAkdEh0AKfDR2GFK8gRQGIAYi0AH/NUZfT4gCEDwvQEg8L2AtQCvAN7+3gDU1NQ=
+  pc_init: 0x1
+  pc_uninit: 0x49
+  pc_program_page: 0x97
+  pc_erase_sector: 0x61
+  data_section_offset: 0x124
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x10000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 2000
+    sectors:
+    - size: 0x100
+      address: 0x0

--- a/probe-rs/targets/SAML11.yaml
+++ b/probe-rs/targets/SAML11.yaml
@@ -19,7 +19,7 @@ variants:
     is_boot_memory: true
     cores:
     - main
-  - !Nvm
+  - !Generic
     name: Data Flash
     range:
       start: 0x400000
@@ -51,7 +51,7 @@ variants:
     is_boot_memory: true
     cores:
     - main
-  - !Nvm
+  - !Generic
     name: Data Flash
     range:
       start: 0x400000
@@ -83,7 +83,7 @@ variants:
     is_boot_memory: true
     cores:
     - main
-  - !Nvm
+  - !Generic
     name: Data Flash
     range:
       start: 0x400000

--- a/probe-rs/targets/SAML11.yaml
+++ b/probe-rs/targets/SAML11.yaml
@@ -1,0 +1,162 @@
+name: SAML11
+manufacturer:
+  id: 41
+  cc: 0
+variants:
+- name: ATSAML11x14
+  cores:
+  - name: main
+    type: armv8m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Nvm
+    name: Flash
+    range:
+      start: 0x0
+      end: 0x4000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Nvm
+    name: Data Flash
+    range:
+      start: 0x400000
+      end: 0x400800
+    cores:
+    - main
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  flash_algorithms:
+  - atsaml11x14
+- name: ATSAML11x15
+  cores:
+  - name: main
+    type: armv8m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Nvm
+    name: Flash
+    range:
+      start: 0x0
+      end: 0x8000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Nvm
+    name: Data Flash
+    range:
+      start: 0x400000
+      end: 0x400800
+    cores:
+    - main
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20002000
+    cores:
+    - main
+  flash_algorithms:
+  - atsaml11x15
+- name: ATSAML11x16
+  cores:
+  - name: main
+    type: armv8m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Nvm
+    name: Flash
+    range:
+      start: 0x0
+      end: 0x10000
+    is_boot_memory: true
+    cores:
+    - main
+  - !Nvm
+    name: Data Flash
+    range:
+      start: 0x400000
+      end: 0x400800
+    cores:
+    - main
+  - !Ram
+    name: SRAM
+    range:
+      start: 0x20000000
+      end: 0x20004000
+    cores:
+    - main
+  flash_algorithms:
+  - atsaml11x16
+flash_algorithms:
+- name: atsaml11x14
+  description: ''
+  default: true
+  instructions: gLUAr0DyIBDA8gAAASEBcFIeAyoW0ooHk2tbBwTUQPIiA8DyAQMTYETyBALE8gASQPIeA8DyBAMTYD4jE3QBcAAggL0A8Fj4QPIgEcDyAAEIeAEoAtEAIAhwcEcBIHBHQPIgEcDyAAEJeAEpEdFE8gABxPIAEQqLUgf81chhSvICUAiACItAB/zVCX0+IAhAcEcBIHBH8LUDr0DyIBPA8gADG3gBKyXRRPIAA8TyABMci2QH/NWMCBHQAyShQ0lCFHhVeC0CLBmVeC0E1ng2BnUZLBkEYAkdEh0AKfDR2GFK8gRQGIAYi0AH/NUZfT4gCEDwvQEg8L2AtQCvAN7+3gDU1NQ=
+  pc_init: 0x1
+  pc_uninit: 0x49
+  pc_program_page: 0x97
+  pc_erase_sector: 0x61
+  data_section_offset: 0x124
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x4000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 2000
+    sectors:
+    - size: 0x100
+      address: 0x0
+- name: atsaml11x15
+  description: ''
+  default: true
+  instructions: gLUAr0DyIBDA8gAAASEBcFIeAyoW0ooHk2tbBwTUQPIiA8DyAQMTYETyBALE8gASQPIeA8DyBAMTYD4jE3QBcAAggL0A8Fj4QPIgEcDyAAEIeAEoAtEAIAhwcEcBIHBHQPIgEcDyAAEJeAEpEdFE8gABxPIAEQqLUgf81chhSvICUAiACItAB/zVCX0+IAhAcEcBIHBH8LUDr0DyIBPA8gADG3gBKyXRRPIAA8TyABMci2QH/NWMCBHQAyShQ0lCFHhVeC0CLBmVeC0E1ng2BnUZLBkEYAkdEh0AKfDR2GFK8gRQGIAYi0AH/NUZfT4gCEDwvQEg8L2AtQCvAN7+3gDU1NQ=
+  pc_init: 0x1
+  pc_uninit: 0x49
+  pc_program_page: 0x97
+  pc_erase_sector: 0x61
+  data_section_offset: 0x124
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x4000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 2000
+    sectors:
+    - size: 0x100
+      address: 0x0
+- name: atsaml11x16
+  description: ''
+  default: true
+  instructions: gLUAr0DyIBDA8gAAASEBcFIeAyoW0ooHk2tbBwTUQPIiA8DyAQMTYETyBALE8gASQPIeA8DyBAMTYD4jE3QBcAAggL0A8Fj4QPIgEcDyAAEIeAEoAtEAIAhwcEcBIHBHQPIgEcDyAAEJeAEpEdFE8gABxPIAEQqLUgf81chhSvICUAiACItAB/zVCX0+IAhAcEcBIHBH8LUDr0DyIBPA8gADG3gBKyXRRPIAA8TyABMci2QH/NWMCBHQAyShQ0lCFHhVeC0CLBmVeC0E1ng2BnUZLBkEYAkdEh0AKfDR2GFK8gRQGIAYi0AH/NUZfT4gCEDwvQEg8L2AtQCvAN7+3gDU1NQ=
+  pc_init: 0x1
+  pc_uninit: 0x49
+  pc_program_page: 0x97
+  pc_erase_sector: 0x61
+  data_section_offset: 0x124
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x4000
+    page_size: 0x100
+    erased_byte_value: 0xff
+    program_page_timeout: 1000
+    erase_sector_timeout: 2000
+    sectors:
+    - size: 0x100
+      address: 0x0


### PR DESCRIPTION
This is just an experimental run with target-gen, we'll have to add a few things for it to properly handle `.atpack` files.

TODO:
 - [x] [flash algos](https://github.com/bugadani/atsaml10-flashloader)
 - [ ] new debug sequences?
 - [x] ~see if I managed to break D51~ no, still works
 - [x] add back JEP106 codes
 - [ ] changelog