### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ irm https://github.com/probe-rs/probe-rs/releases/latest/download/probe-rs-insta
 The tools can also be installed from source. After installing the necessary [prerequisites](#building), the latest released version can be installed using `cargo install`:
 
 ```bash
-cargo install probe-rs --locked --features cli
+cargo install probe-rs-tools --locked --features cli
 ```
 
 This will compile the tools and place them into the cargo `bin` directory. See the [Cargo book](https://doc.rust-lang.org/cargo/commands/cargo-install.html) for details.


### PR DESCRIPTION
#2364 changed the crate name of the probe-rs cli tools, but did not update the readme instructions for how to build this crate.