### PR TITLE
Update docs based on restructuring

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,8 @@ For example, `added-ultra-fast-flashing.md` would lead to an entry in the `## Ad
 
 ## How to build cargo-embed/ cargo-flash from source
 
-`cargo-embed` is a so called [cargo subcommand](https://doc.rust-lang.org/book/ch14-05-extending-cargo.html). It is a programm named `cargo-embed` which is installed in the users path. Thus when applying some small fixes to `cargo-embed` you can run `cargo build --features cli` and then use the executable in the target folder named cargo-embed directly. You can also use [cargo install --path probe-rs --features cli](https://doc.rust-lang.org/cargo/commands/cargo-install.html) to install your current checkout locally overriding what you previously had installed using `cargo install cargo-embed`.
+`cargo-embed` is a so called [cargo subcommand](https://doc.rust-lang.org/book/ch14-05-extending-cargo.html). It is a program named `cargo-embed` which is installed in the users path. Thus when applying some small fixes to `cargo-embed` you can run `cargo build` and then use the executable in the target folder named cargo-embed directly. You can also use [cargo install --path probe-rs-tools](https://doc.rust-lang.org/cargo/commands/cargo-install.html) to install your current checkout locally overriding what you previously had installed using `cargo install cargo-embed`.
 
 The steps are the same for cargo-embed or cargo-flash. Both use probe-rs inside and wrap it with a user friendly command line interface.
 
-If you want to use a different version of probe-rs you can use [cargo patch](https://doc.rust-lang.org/edition-guide/rust-2018/cargo-and-crates-io/replacing-dependencies-with-patch.html) in your local clone of cargo-embed/ cargo-flash and set it to a specific version from Github or a local checkout of probe-rs. This is helpfull for testing patches.
+If you want to use a different version of probe-rs you can use [cargo patch](https://doc.rust-lang.org/edition-guide/rust-2018/cargo-and-crates-io/replacing-dependencies-with-patch.html) in your local clone of cargo-embed/ cargo-flash and set it to a specific version from Github or a local checkout of probe-rs. This is helpful for testing patches.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ irm https://github.com/probe-rs/probe-rs/releases/latest/download/probe-rs-insta
 The tools can also be installed from source. After installing the necessary [prerequisites](#building), the latest released version can be installed using `cargo install`:
 
 ```bash
-cargo install probe-rs --locked --features cli
+cargo install probe-rs-tools --locked
 ```
 
 This will compile the tools and place them into the cargo `bin` directory. See the [Cargo book](https://doc.rust-lang.org/cargo/commands/cargo-install.html) for details.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -202,7 +202,7 @@ fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
                                             \
                     You can also set the [default.probe] config attribute \
                     (in your Embed.toml) to select which probe to use. \
-                    For usage examples see https://github.com/probe-rs/cargo-embed/blob/master/src/config/default.toml .",
+                    For usage examples see https://github.com/probe-rs/probe-rs/blob/master/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml .",
                     list.iter().enumerate().fold(String::new(), |mut s, (num, link)| { let _ = writeln!(s, "[{num}]: {link}"); s })));
         }
         Err(OperationError::AttachingFailed {


### PR DESCRIPTION
 * Install target folder is now in probe-rs-tools
 * Cargo embed was moved into main repo