### PR TITLE
Remove direct use of num-traits, remove unused and trivial deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,15 +622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
-name = "chrono"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,7 +2885,6 @@ dependencies = [
  "bitflags 2.5.0",
  "bitvec",
  "clap",
- "clap_complete",
  "docsplay",
  "dunce",
  "espflash",
@@ -5110,9 +5100,7 @@ name = "xtask"
 version = "0.23.0"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
- "regex",
  "serde",
  "serde_json",
  "xshell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,17 +1204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-primitive-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
-dependencies = [
- "num-traits",
- "quote",
- "syn 2.0.60",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2909,7 +2898,6 @@ dependencies = [
  "clap_complete",
  "docsplay",
  "dunce",
- "enum-primitive-derive",
  "espflash",
  "futures-lite",
  "gdbstub",
@@ -2922,7 +2910,6 @@ dependencies = [
  "itm",
  "jep106",
  "miniz_oxide",
- "num-traits",
  "nusb",
  "object 0.35.0",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,7 +2893,6 @@ dependencies = [
  "bitfield",
  "bitflags 2.5.0",
  "bitvec",
- "byteorder",
  "clap",
  "clap_complete",
  "docsplay",

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -60,7 +60,7 @@ dunce = { version = "1" }
 figment = { version = "0.10", features = ["toml", "json", "yaml", "env"] }
 goblin = { version = "0.8" }
 indicatif = { version = "0.17" }
-insta = { version = "1.38", features = ["yaml", "filters"] }
+insta = { version = "1.38", default-features = false, features = ["yaml", "filters"] }
 itm = { version = "0.9.0-rc.1", default-features = false }
 parse_int = "0.6"
 libtest-mimic = { version = "0.7.2" }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/adapter.rs
@@ -20,7 +20,6 @@ use crate::util::rtt;
 use anyhow::{anyhow, Result};
 use base64::{engine::general_purpose as base64_engine, Engine as _};
 use dap_types::*;
-use num_traits::Zero;
 use parse_int::parse;
 use probe_rs::{
     architecture::{
@@ -202,14 +201,14 @@ impl<P: ProtocolAdapter> DebugAdapter<P> {
         }
         // Currently, VSCode sends a request with count=0 after the last successful one ... so
         // let's ignore it.
-        if !result_buffer.is_empty() || (self.vscode_quirks && arguments.count.is_zero()) {
+        if !result_buffer.is_empty() || (self.vscode_quirks && arguments.count == 0) {
             let response = base64_engine::STANDARD.encode(&result_buffer);
             self.send_response(
                 request,
                 Ok(Some(ReadMemoryResponseBody {
                     address: format!("{address:#010x}"),
                     data: Some(response),
-                    unreadable_bytes: if num_bytes_unread.is_zero() {
+                    unreadable_bytes: if num_bytes_unread == 0 {
                         None
                     } else {
                         Some(num_bytes_unread as i64)

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/request_helpers.rs
@@ -9,7 +9,6 @@ use capstone::{
     arch::arm::ArchMode as armArchMode, arch::arm64::ArchMode as aarch64ArchMode,
     arch::riscv::ArchMode as riscvArchMode, prelude::*, Endian,
 };
-use num_traits::Zero;
 use probe_rs::{
     debug::{ColumnType, ObjectRef, SourceLocation},
     CoreType, InstructionSet, MemoryInterface,
@@ -121,7 +120,7 @@ pub(crate) fn disassemble_target_memory(
 
         match cs.disasm_all(&code_buffer, instruction_pointer) {
             Ok(instructions) => {
-                if num_traits::Zero::is_zero(&instructions.len()) {
+                if instructions.len() == 0 {
                     // The capstone library sometimes returns an empty result set, instead of an Err. Catch it here or else we risk an infinte loop looking for a valid instruction.
                     return Err(DebuggerError::Other(anyhow::anyhow!(
                         "Disassembly encountered unsupported instructions at memory reference {:#010x?}",
@@ -202,8 +201,8 @@ pub(crate) fn disassemble_target_memory(
     }
     // Because we need to read on a 32-bit boundary, there are cases when the requested start address
     // is not the first line.
-    if instruction_offset.is_zero()
-        && byte_offset.is_zero()
+    if instruction_offset == 0
+        && byte_offset == 0
         && assembly_lines
             .first()
             .and_then(|first| {

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -71,7 +71,6 @@ uf2-decode = "0.2"
 rmp-serde = "1"
 typed-path = "0.8"
 bitflags = "2"
-byteorder = "1"
 espflash = { version = "3", default-features = false }
 dunce = { version = "1" }
 parse_int = "0.6"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -36,7 +36,6 @@ anyhow = { workspace = true }
 bincode = "1.3"
 bitfield = "0.15"
 bitvec = "1"
-clap_complete = "4.5.2"
 docsplay = { workspace = true }
 gimli = { version = "0.29", default-features = false, features = [
     "endian-reader",

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -38,7 +38,6 @@ bitfield = "0.15"
 bitvec = "1"
 clap_complete = "4.5.2"
 docsplay = { workspace = true }
-enum-primitive-derive = "0.3"
 gimli = { version = "0.29", default-features = false, features = [
     "endian-reader",
     "read",
@@ -52,7 +51,6 @@ itertools = "0.12.1"
 jep106 = "0.2"
 once_cell = "1"
 miniz_oxide = "0.7"
-num-traits = "0.2"
 object = { version = "0.35", default-features = false, features = [
     "elf",
     "read_core",

--- a/probe-rs/src/architecture/arm/ap/generic_ap.rs
+++ b/probe-rs/src/architecture/arm/ap/generic_ap.rs
@@ -2,11 +2,9 @@
 
 use super::{AccessPort, ApRegister, Register};
 use crate::architecture::arm::{communication_interface::RegisterParseError, ApAddress};
-use enum_primitive_derive::Primitive;
-use num_traits::cast::{FromPrimitive, ToPrimitive};
 
 /// Describes the class of an access port defined in the [`ARM Debug Interface v5.2`](https://developer.arm.com/documentation/ihi0031/f/?lang=en) specification.
-#[derive(Debug, Primitive, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ApClass {
     /// This describes a custom AP that is vendor defined and not defined by ARM
     #[default]
@@ -17,10 +15,22 @@ pub enum ApClass {
     MemAp = 0b1000,
 }
 
+impl ApClass {
+    /// Tries to create an `ApClass` from a given `u8`.
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0b0000 => Some(ApClass::Undefined),
+            0b0001 => Some(ApClass::ComAp),
+            0b1000 => Some(ApClass::MemAp),
+            _ => None,
+        }
+    }
+}
+
 /// The type of AP defined in the [`ARM Debug Interface v5.2`](https://developer.arm.com/documentation/ihi0031/f/?lang=en) specification.
 /// The different types correspond to the different access/memory buses of ARM cores.
 #[allow(non_camel_case_types)]
-#[derive(Debug, Primitive, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ApType {
     /// This is the most basic AP that is included in most MCUs and uses SWD or JTAG as an access bus.
     #[default]
@@ -39,6 +49,23 @@ pub enum ApType {
     AmbaAxi5 = 0x7,
     /// A AMBA based protected AHB5 AP (see E1.7).
     AmbaAhb5Hprot = 0x8,
+}
+
+impl ApType {
+    /// Tries to create an `ApType` from a given `u8`.
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0x0 => Some(ApType::JtagComAp),
+            0x1 => Some(ApType::AmbaAhb3),
+            0x2 => Some(ApType::AmbaAhb2Ahb3),
+            0x4 => Some(ApType::AmbaAxi3Axi4),
+            0x5 => Some(ApType::AmbaAhb5),
+            0x6 => Some(ApType::AmbaAhb4),
+            0x7 => Some(ApType::AmbaAxi5),
+            0x8 => Some(ApType::AmbaAhb5Hprot),
+            _ => None,
+        }
+    }
 }
 
 define_ap!(
@@ -87,7 +114,7 @@ define_ap_register!(
     }),
     to: value => (u32::from(value.REVISION) << 28)
         | (((u32::from(value.DESIGNER.cc) << 7) | u32::from(value.DESIGNER.id)) << 17)
-        | (value.CLASS.to_u32().unwrap() << 13)
+        | ((value.CLASS as u32) << 13)
         | (u32::from(value.VARIANT) << 4)
-        | (value.TYPE.to_u32().unwrap())
+        | (value.TYPE as u32)
 );

--- a/probe-rs/src/architecture/arm/core/armv7a.rs
+++ b/probe-rs/src/architecture/arm/core/armv7a.rs
@@ -26,7 +26,6 @@ use crate::{
     InstructionSet, MemoryInterface,
 };
 use anyhow::Result;
-use num_traits::Zero;
 use std::{
     mem::size_of,
     sync::Arc,
@@ -110,8 +109,7 @@ impl<'probe> Armv7a<'probe> {
     }
 
     fn read_fp_reg_count(&mut self) -> Result<(), Error> {
-        if self.state.fp_reg_count.is_zero()
-            && matches!(self.state.current_state, CoreStatus::Halted(_))
+        if self.state.fp_reg_count == 0 && matches!(self.state.current_state, CoreStatus::Halted(_))
         {
             self.prepare_r0_for_clobber()?;
 
@@ -772,7 +770,7 @@ impl<'probe> CoreInterface for Armv7a<'probe> {
     }
 
     fn fpu_support(&mut self) -> Result<bool, crate::error::Error> {
-        Ok(!self.state.fp_reg_count.is_zero())
+        Ok(self.state.fp_reg_count != 0)
     }
 
     fn floating_point_register_count(&mut self) -> Result<usize, crate::error::Error> {

--- a/probe-rs/src/debug/language/parsing.rs
+++ b/probe-rs/src/debug/language/parsing.rs
@@ -1,9 +1,7 @@
-use num_traits::Num;
-
 use crate::debug::DebugError;
 
 /// Extension methods to simply parse a value into a number of bytes.
-pub trait ParseToBytes: Num {
+pub trait ParseToBytes {
     type Out;
 
     fn parse_to_bytes(s: &str) -> Result<Self::Out, DebugError>;
@@ -11,10 +9,7 @@ pub trait ParseToBytes: Num {
 
 macro_rules! impl_parse {
     ($t:ty, $bytes:expr) => {
-        impl ParseToBytes for $t
-        where
-            <$t as Num>::FromStrRadixErr: ::std::fmt::Debug,
-        {
+        impl ParseToBytes for $t {
             type Out = [u8; $bytes];
 
             fn parse_to_bytes(s: &str) -> Result<Self::Out, DebugError> {

--- a/probe-rs/src/debug/variable.rs
+++ b/probe-rs/src/debug/variable.rs
@@ -4,7 +4,6 @@ use super::*;
 use anyhow::anyhow;
 use gimli::{DebugInfoOffset, DwLang, UnitOffset};
 use itertools::Itertools;
-use num_traits::Zero;
 use std::ops::Range;
 
 /// Define the role that a variable plays in a Variant relationship. See section '5.7.10 Variant
@@ -780,7 +779,7 @@ impl Variable {
         };
 
         self.byte_size.map(|byte_size| {
-            if byte_size.is_zero() {
+            if byte_size == 0 {
                 address..address + 4
             } else {
                 address..(address + byte_size)

--- a/probe-rs/src/probe/jlink/speed.rs
+++ b/probe-rs/src/probe/jlink/speed.rs
@@ -3,8 +3,6 @@ use super::error::JlinkError;
 
 use super::Command;
 
-use byteorder::{LittleEndian, ReadBytesExt};
-
 use std::{cmp, fmt};
 
 use super::JLink;
@@ -84,11 +82,13 @@ impl JLink {
 
         let mut buf = [0; 6];
         self.read(&mut buf)?;
-        let mut buf = &buf[..];
+
+        let base_freq_bytes = <[u8; 4]>::try_from(&buf[0..4]).unwrap();
+        let min_div_bytes = <[u8; 2]>::try_from(&buf[4..6]).unwrap();
 
         Ok(SpeedInfo {
-            base_freq: buf.read_u32::<LittleEndian>().unwrap(),
-            min_div: buf.read_u16::<LittleEndian>().unwrap(),
+            base_freq: u32::from_le_bytes(base_freq_bytes),
+            min_div: u16::from_le_bytes(min_div_bytes),
         })
     }
 

--- a/probe-rs/src/probe/jlink/swo.rs
+++ b/probe-rs/src/probe/jlink/swo.rs
@@ -10,7 +10,6 @@ use super::error::JlinkError;
 use super::interface::Interface;
 
 use bitflags::bitflags;
-use byteorder::{LittleEndian, ReadBytesExt};
 
 use std::{cmp, ops::Deref};
 use tracing::warn;
@@ -146,12 +145,18 @@ impl JLink {
         // FIXME: What's the word after the length for?
         let mut buf = &buf[8..];
 
+        let base_freq_bytes = <[u8; 4]>::try_from(&buf[0..4]).unwrap();
+        let min_div_bytes = <[u8; 4]>::try_from(&buf[4..8]).unwrap();
+        let max_div_bytes = <[u8; 4]>::try_from(&buf[8..12]).unwrap();
+        let min_presc_bytes = <[u8; 4]>::try_from(&buf[12..16]).unwrap();
+        let max_presc_bytes = <[u8; 4]>::try_from(&buf[16..20]).unwrap();
+
         Ok(SwoSpeedInfo {
-            base_freq: buf.read_u32::<LittleEndian>().unwrap(),
-            min_div: buf.read_u32::<LittleEndian>().unwrap(),
-            max_div: buf.read_u32::<LittleEndian>().unwrap(),
-            min_presc: buf.read_u32::<LittleEndian>().unwrap(),
-            max_presc: buf.read_u32::<LittleEndian>().unwrap(),
+            base_freq: u32::from_le_bytes(base_freq_bytes),
+            min_div: u32::from_le_bytes(min_div_bytes),
+            max_div: u32::from_le_bytes(max_div_bytes),
+            min_presc: u32::from_le_bytes(min_presc_bytes),
+            max_presc: u32::from_le_bytes(max_presc_bytes),
         })
     }
 

--- a/probe-rs/src/probe/stlink/constants.rs
+++ b/probe-rs/src/probe/stlink/constants.rs
@@ -1,7 +1,5 @@
 #![allow(unused)]
 
-use enum_primitive_derive::Primitive;
-
 pub mod commands {
     // Common commands.
     pub const GET_VERSION: u8 = 0xf1;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,9 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-chrono = { version = "0.4", features = ["std"], default-features = false }
 xshell = "0.2"
-regex = "1"
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 serde_json = "1"


### PR DESCRIPTION
copilot is very eager to generate `from_u8` functions, and it looks like the macro also hid something unused. num-traits remains in the tree indirectly, but I really don't think we need to keep it around just for `.zero()` :)