### PR TITLE
Fix target-gen serialize

### DIFF
--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -155,6 +155,7 @@ pub fn serialize_to_yaml_string(family: &ChipFamily) -> Result<String> {
             || reader_line.ends_with(": false\n")
         {
             // Skip the line
+            reader_line.clear();
             continue;
         }
 

--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -152,6 +152,7 @@ pub fn serialize_to_yaml_string(family: &ChipFamily) -> Result<String> {
     while reader.read_line(&mut reader_line)? > 0 {
         if reader_line.ends_with(": null\n")
             || reader_line.ends_with(": []\n")
+            || reader_line.ends_with(": {}\n")
             || reader_line.ends_with(": false\n")
         {
             // Skip the line
@@ -171,4 +172,37 @@ pub fn serialize_to_yaml_string(family: &ChipFamily) -> Result<String> {
     }
 
     Ok(yaml_string)
+}
+
+#[cfg(test)]
+mod test {
+    use probe_rs_target::TargetDescriptionSource;
+
+    use super::*;
+
+    #[test]
+    fn test_serialize_to_yaml_string_cuts_off_unnecessary_defaults() {
+        let family = ChipFamily {
+            name: "Test Family".to_owned(),
+            manufacturer: None,
+            generated_from_pack: false,
+            pack_file_release: None,
+            variants: vec![Chip::generic_arm("Test Chip", CoreType::Armv8m)],
+            flash_algorithms: vec![],
+            source: TargetDescriptionSource::BuiltIn,
+        };
+        let yaml_string = serialize_to_yaml_string(&family).unwrap();
+        let expectation = "name: Test Family
+variants:
+- name: Test Chip
+  cores:
+  - name: main
+    type: armv8m
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  default_binary_format: raw
+";
+        assert_eq!(yaml_string, expectation);
+    }
 }


### PR DESCRIPTION
I broke this in #2428, sorry about that. The buffer needs to be cleared even if the line is skipped.