### PR TITLE
Update rust-toolchain.toml to allow patch-level forwards compatibility

### DIFF
--- a/changelog/fixed-rust-toolchain.md
+++ b/changelog/fixed-rust-toolchain.md
@@ -1,0 +1,1 @@
+removed patch part of Rust toolchain version spec to allow forwards compatibility with newer releases

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77.0"
+channel = "1.77"
 
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
removed the patch part of `channel` to enable forwards compatibility (i.e. `channel = "1.77"` as proposed allows Rust 1.77.2, whereas `channel = "1.77.0"` does not)