### PR TITLE
Debugger: Propagate `launch`/`attach` errors to the DAP client.

### DIFF
--- a/changelog/fixed-debugger-silent-fail.md
+++ b/changelog/fixed-debugger-silent-fail.md
@@ -1,0 +1,1 @@
+Do not 'silence' errors that need to be reported to the user. Specifically errors during the `attach` and `launch` requests, where flashing can fail, and the user needs to know about it.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -753,6 +753,8 @@ impl Debugger {
         ) {
             Ok(loader) => loader,
             Err(error) => {
+                // `download-options` need to be dropped, to free the `debug_adapter`,
+                // before we can use it to return the error to the user.
                 drop(download_options);
                 debug_adapter = match Rc::try_unwrap(rc_debug_adapter) {
                     Ok(debug_adapter) => debug_adapter.into_inner(),

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -334,7 +334,9 @@ impl Debugger {
             match self.handle_launch_attach(&launch_attach_request, debug_adapter, lister) {
                 Ok((debug_adapter, session_data)) => (debug_adapter, session_data),
                 Err(_) => {
-                    // The request handler has already reported this error to the user.
+                    // Because the `handle_launch_attach request handler consumes the `debug_adapter`,
+                    // we have to ensure that it reports all its own errors to the user.
+                    // By the time we get here, we assume that has happened, and exit the debug session gracefully.
                     return Ok(());
                 }
             };
@@ -385,6 +387,7 @@ impl Debugger {
     }
 
     /// Process launch or attach request
+    // Note: This function consumes the 'debug_adapter', so all error reporting via that handle must be done before returning from this function.
     #[tracing::instrument(skip_all, name = "Handle Launch/Attach Request")]
     fn handle_launch_attach<P: ProtocolAdapter + 'static>(
         &mut self,
@@ -396,18 +399,21 @@ impl Debugger {
             "attach" => TargetSessionType::AttachRequest,
             "launch" => TargetSessionType::LaunchRequest,
             other => {
-                let error_msg =
-                    format!("Expected request 'launch' or 'attach', but received '{other}'");
-
-                debug_adapter.send_response::<()>(
-                    launch_attach_request,
-                    Err(&DebuggerError::Other(anyhow!(error_msg.clone()))),
-                )?;
-                return Err(DebuggerError::Other(anyhow!(error_msg)));
+                let error = DebuggerError::Other(anyhow!(
+                    "Expected request 'launch' or 'attach', but received '{other}'"
+                ));
+                debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
+                return Err(error);
             }
         };
 
-        self.config = get_arguments(&mut debug_adapter, launch_attach_request)?;
+        self.config = match get_arguments(&mut debug_adapter, launch_attach_request) {
+            Ok(config) => config,
+            Err(error) => {
+                debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
+                return Err(error);
+            }
+        };
 
         if requested_target_session_type == TargetSessionType::AttachRequest {
             // Since VSCode doesn't do field validation checks for relationships in launch.json request types, check it here.
@@ -420,7 +426,6 @@ impl Debugger {
                                             "Please do not use any of the `flashing_enabled`, `reset_after_flashing`, halt_after_reset`, `full_chip_erase`, or `restore_unwritten_bytes` options when using `attach` request type."));
 
                 debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
-
                 return Err(error);
             }
         }
@@ -428,10 +433,9 @@ impl Debugger {
         debug_adapter
             .set_console_log_level(self.config.console_log_level.unwrap_or(ConsoleLog::Console));
 
-        if let Err(e) = self.config.validate_config_files() {
-            debug_adapter.send_response::<()>(launch_attach_request, Err(&e))?;
-
-            return Err(e);
+        if let Err(error) = self.config.validate_config_files() {
+            debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
+            return Err(error);
         }
 
         let mut session_data =
@@ -439,7 +443,6 @@ impl Debugger {
                 Ok(session_data) => session_data,
                 Err(error) => {
                     debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
-
                     return Err(error);
                 }
             };
@@ -447,16 +450,21 @@ impl Debugger {
         debug_adapter.halt_after_reset = self.config.flashing_config.halt_after_reset;
 
         if self.config.flashing_config.flashing_enabled {
-            let target_core_config = self.config.core_configs.first_mut().ok_or_else(|| {
-                DebuggerError::Other(anyhow!(
-                    "Cannot continue unless one target core configuration is defined."
-                ))
-            })?;
+            let target_core_config = match self.config.core_configs.first_mut() {
+                Some(config) => config,
+                None => {
+                    let error = DebuggerError::Other(anyhow!(
+                        "Cannot continue unless one target core configuration is defined."
+                    ));
+                    debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
+                    return Err(error);
+                }
+            };
 
             let Some(path_to_elf) = target_core_config.program_binary.clone() else {
-                let err =  DebuggerError::Other(anyhow!("Please specify use the `program-binary` option in `launch.json` to specify an executable"));
-                debug_adapter.send_response::<()>(launch_attach_request, Err(&err))?;
-                return Err(err);
+                let error =  DebuggerError::Other(anyhow!("Please specify use the `program-binary` option in `launch.json` to specify an executable"));
+                debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
+                return Err(error);
             };
 
             // Store timestamp of flashed binary
@@ -465,29 +473,35 @@ impl Debugger {
             debug_adapter = self.flash(
                 &path_to_elf,
                 debug_adapter,
-                launch_attach_request.seq,
+                launch_attach_request,
                 &mut session_data,
             )?;
         }
 
-        let target_core_config = self.config.core_configs.first_mut().ok_or_else(|| {
-            DebuggerError::Other(anyhow!(
-                "Cannot continue unless one target core configuration is defined."
-            ))
-        })?;
+        let target_core_config = match self.config.core_configs.first_mut() {
+            Some(config) => config,
+            None => {
+                let error = DebuggerError::Other(anyhow!(
+                    "Cannot continue unless one target core configuration is defined."
+                ));
+                debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
+                return Err(error);
+            }
+        };
 
         // First, attach to the core
-        let mut target_core = session_data
-            .attach_core(target_core_config.core_index)
-            .or_else(|error| {
-                debug_adapter.show_error_message(&error)?;
-                Err(error)
-            })?;
+        let mut target_core = match session_data.attach_core(target_core_config.core_index) {
+            Ok(session_data) => session_data,
+            Err(error) => {
+                debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
+                return Err(error);
+            }
+        };
 
         // Immediately after attaching, halt the core, so that we can finish initalization without bumping into user code.
         // Depending on supplied `config`, the core will be restarted at the end of initialization in the `configuration_done` request.
         if let Err(error) = halt_core(&mut target_core.core) {
-            debug_adapter.show_error_message(&error)?;
+            debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
             return Err(error);
         }
 
@@ -498,6 +512,7 @@ impl Debugger {
                 match SvdCache::new(svd_file, &mut debug_adapter, launch_attach_request.seq) {
                     Ok(core_peripherals) => Some(core_peripherals),
                     Err(error) => {
+                        // This is not a fatal error. We can continue the debug session without the SVD file.
                         tracing::error!("{:?}", error);
                         None
                     }
@@ -506,13 +521,22 @@ impl Debugger {
 
         if requested_target_session_type == TargetSessionType::LaunchRequest {
             // This will effectively do a `reset` and `halt` of the core, which is what we want until after the `configuration_done` request.
-            debug_adapter
+            if let Err(error) = debug_adapter
                 .restart(&mut target_core, None)
-                .context("Failed to restart core")?;
+                .context("Failed to restart core")
+            {
+                let error = error.into();
+                debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
+                return Err(error);
+            }
         } else {
             // Ensure ebreak enters debug mode, this is necessary for soft breakpoints to work on architectures like RISC-V.
             // For LaunchRequest, this is done in the `restart` above.
-            target_core.core.debug_on_sw_breakpoint(true)?;
+            if let Err(error) = target_core.core.debug_on_sw_breakpoint(true) {
+                let error = error.into();
+                debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
+                return Err(error);
+            }
         }
 
         drop(target_core);
@@ -550,8 +574,7 @@ impl Debugger {
                     .attach_core(target_core_config.core_index)
                     .map(|mut target_core| target_core.recompute_breakpoints())??;
 
-                debug_adapter =
-                    self.flash(&path_to_elf, debug_adapter, request.seq, session_data)?;
+                debug_adapter = self.flash(&path_to_elf, debug_adapter, request, session_data)?;
             }
         }
 
@@ -585,13 +608,12 @@ impl Debugger {
 
     /// Flash the given binary, and report the progress to the
     /// debug adapter.
-    ///
-    /// The request_id is used to associate the progress with a given debug adapter request.
+    // Note: This function consumes the 'debug_adapter', so all error reporting via that handle must be done before returning from this function.
     fn flash<P: ProtocolAdapter + 'static>(
         &mut self,
         path_to_elf: &Path,
         mut debug_adapter: DebugAdapter<P>,
-        request_id: i64,
+        launch_attach_request: &Request,
         session_data: &mut SessionData,
     ) -> Result<DebugAdapter<P>, DebuggerError> {
         debug_adapter.log_to_console(format!(
@@ -599,7 +621,7 @@ impl Debugger {
             &path_to_elf
         ));
         let progress_id = debug_adapter
-            .start_progress("Flashing device", Some(request_id))
+            .start_progress("Flashing device", Some(launch_attach_request.seq))
             .ok();
 
         let mut download_options = DownloadOptions::default();
@@ -723,12 +745,31 @@ impl Debugger {
 
         download_options.progress = flash_progress;
 
-        let loader = build_loader(
+        let loader = match build_loader(
             &mut session_data.session,
             path_to_elf,
             self.config.flashing_config.format_options.clone(),
             None,
-        )?;
+        ) {
+            Ok(loader) => loader,
+            Err(error) => {
+                drop(download_options);
+                debug_adapter = match Rc::try_unwrap(rc_debug_adapter) {
+                    Ok(debug_adapter) => debug_adapter.into_inner(),
+                    Err(too_many_strong_references) => {
+                        let reference_error = DebuggerError::Other(anyhow!("Unexpected error while dereferencing the `debug_adapter` (It has {} strong references). Please report this as a bug.", Rc::strong_count(&too_many_strong_references)));
+                        tracing::error!("{reference_error:?}");
+                        return Err(reference_error);
+                    }
+                };
+                if let Some(id) = progress_id {
+                    let _ = debug_adapter.end_progress(id);
+                }
+                let error = DebuggerError::Other(error);
+                debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
+                return Err(error);
+            }
+        };
 
         let flash_result = loader
             .commit(&mut session_data.session, download_options)
@@ -737,8 +778,9 @@ impl Debugger {
         debug_adapter = match Rc::try_unwrap(rc_debug_adapter) {
             Ok(debug_adapter) => debug_adapter.into_inner(),
             Err(too_many_strong_references) => {
-                let other_error = DebuggerError::Other(anyhow!("Unexpected error while dereferencing the `debug_adapter` (It has {} strong references). Please report this as a bug.", Rc::strong_count(&too_many_strong_references)));
-                return Err(other_error);
+                let reference_error = DebuggerError::Other(anyhow!("Unexpected error while dereferencing the `debug_adapter` (It has {} strong references). Please report this as a bug.", Rc::strong_count(&too_many_strong_references)));
+                tracing::error!("{reference_error:?}");
+                return Err(reference_error);
             }
         };
 
@@ -756,7 +798,7 @@ impl Debugger {
             }
             Err(error) => {
                 let error = DebuggerError::FileDownload(error);
-                debug_adapter.show_error_message(&error)?;
+                debug_adapter.send_response::<()>(launch_attach_request, Err(&error))?;
                 Err(error)
             }
         }

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -28,7 +28,7 @@ impl FlashProgress {
     }
 
     /// Emit a flashing progress event.
-    fn emit(&self, event: ProgressEvent) {
+    pub fn emit(&self, event: ProgressEvent) {
         (self.handler)(event);
     }
 

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -28,7 +28,7 @@ impl FlashProgress {
     }
 
     /// Emit a flashing progress event.
-    pub fn emit(&self, event: ProgressEvent) {
+    fn emit(&self, event: ProgressEvent) {
         (self.handler)(event);
     }
 


### PR DESCRIPTION
Ensure Flash errors, e.g. `No loadable segments were found in the ELF file.` are not  being "swallowed" by the debugger. Before this PR, the debugger session will terminate midway through flashing, with no error displayed to the user.