### PR TITLE
Rename defmt_log_format to log_format, apply show_timestamps to defmt

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -66,8 +66,9 @@ log_path = "./logs"
 #              * Defmt  - Format output on the host, see https://defmt.ferrous-systems.com/
 #              * BinaryLE - Display as raw hex
 # show_location (Optional) - Whether to show the location of defmt messages in the UI.
-# show_timestamps (Optional) - Whether to show the timestamps of String messages in the UI.
+# show_timestamps (Optional) - Whether to show the timestamps of String and Defmt messages in the UI, if available.
 # socket   (Optional) - Server socket address (for optional external frontend or endpoint).
+# log_format (Optional) - Control the output format for `format = Defmt`.
 up_channels = [
     # { channel = 0, mode = "BlockIfFull", format = "Defmt", show_location = true },
     # { channel = 1, mode = "BlockIfFull", format = "String", show_timestamps = false, socket = "127.0.0.1:12345" },

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/mod.rs
@@ -87,11 +87,11 @@ pub struct UpChannelConfig {
     pub socket: Option<SocketAddr>,
     // TODO: it should be possible to move these into DataFormat
     #[serde(default)]
-    /// Control the inclusion of timestamps for DataFormat::String.
+    /// Controls the inclusion of timestamps for [`DataFormat::String`] and [`DataFormat::Defmt`].
     pub show_timestamps: Option<bool>,
     #[serde(default)]
-    /// Control the output format for DataFormat::Defmt.
-    pub defmt_log_format: Option<String>,
+    /// Controls the output format for DataFormat::Defmt.
+    pub log_format: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -336,10 +336,10 @@ fn run_rttui_app(
             show_location: channel_config
                 .show_location
                 .unwrap_or(default_channel_config.show_location),
-            defmt_log_format: channel_config
-                .defmt_log_format
+            log_format: channel_config
+                .log_format
                 .clone()
-                .or_else(|| default_channel_config.defmt_log_format.clone()),
+                .or_else(|| default_channel_config.log_format.clone()),
             mode: channel_config.mode.or(default_channel_config.mode),
         };
         if rtt_channel_config.data_format == DataFormat::Defmt {
@@ -357,11 +357,7 @@ fn run_rttui_app(
             // Set up channel defaults, we don't read from it anyway.
             rtt_config.channels.push(RttChannelConfig {
                 channel_number: Some(channel_config.channel),
-                data_format: DataFormat::String,
-                show_timestamps: false,
-                show_location: false,
-                defmt_log_format: None,
-                mode: None,
+                ..Default::default()
             });
         }
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -315,7 +315,6 @@ fn run_rttui_app(
     // Transform channel configurations
     let mut rtt_config = RttConfig {
         enabled: true,
-        log_format: None,
         channels: vec![],
     };
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
@@ -262,13 +262,11 @@ impl RunLoop {
         }
         let start = Instant::now();
 
-        let mut rtt_config = rtt::RttConfig {
-            log_format: self.log_format.clone(),
-            ..Default::default()
-        };
+        let mut rtt_config = rtt::RttConfig::default();
         rtt_config.channels.push(rtt::RttChannelConfig {
             channel_number: Some(0),
             show_location: !self.no_location,
+            log_format: self.log_format.clone(),
             ..Default::default()
         });
 

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -138,16 +138,6 @@ pub struct RttChannelConfig {
     pub log_format: Option<String>,
 }
 
-/// The User specified configuration for each active RTT Channel. The configuration is passed via a
-/// DAP Client configuration (`launch.json`). If no configuration is specified, the defaults will be
-/// `DataFormat::String` and `show_timestamps=false`.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct RttDownChannelConfig {
-    pub channel_number: Option<usize>,
-    pub operating_mode: Option<String>,
-}
-
 pub enum ChannelDataFormat {
     String {
         /// UTC offset used for creating timestamps, if enabled.

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -100,7 +100,7 @@ pub struct RttConfig {
     pub enabled: bool,
 
     /// The default format string to use for decoding defmt logs.
-    #[serde(default, rename = "defmtLogFormat")]
+    #[serde(default, rename = "logFormat")]
     pub log_format: Option<String>,
 
     /// Configure data_format and show_timestamps for select channels
@@ -130,16 +130,16 @@ pub struct RttChannelConfig {
     pub mode: Option<ChannelMode>,
 
     #[serde(default = "default_show_timestamps")]
-    /// Control the inclusion of timestamps for DataFormat::String.
+    /// Controls the inclusion of timestamps for [`DataFormat::String`] and [`DataFormat::Defmt`].
     pub show_timestamps: bool,
 
     #[serde(default)]
-    /// Control the inclusion of source location information for DataFormat::Defmt.
+    /// Controls the inclusion of source location information for DataFormat::Defmt.
     pub show_location: bool,
 
     #[serde(default)]
-    /// Control the output format for DataFormat::Defmt.
-    pub defmt_log_format: Option<String>,
+    /// Controls the output format for DataFormat::Defmt.
+    pub log_format: Option<String>,
 }
 
 /// The User specified configuration for each active RTT Channel. The configuration is passed via a
@@ -374,7 +374,7 @@ impl RttActiveUpChannel {
                 // 2. Custom default format
                 // 3. Default with optional timestamp and location
                 let format = if let Some(format) = channel_config
-                    .defmt_log_format
+                    .log_format
                     .as_deref()
                     .or(rtt_config.log_format.as_deref())
                 {
@@ -388,7 +388,7 @@ impl RttActiveUpChannel {
                 ChannelDataFormat::Defmt {
                     formatter: Formatter::new(FormatterConfig {
                         format,
-                        is_timestamp_available: has_timestamp,
+                        is_timestamp_available: has_timestamp && channel_config.show_timestamps,
                     }),
                     cwd: std::env::current_dir().unwrap(),
                 }

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -99,10 +99,6 @@ pub struct RttConfig {
     #[serde(default, rename = "rttEnabled")]
     pub enabled: bool,
 
-    /// The default format string to use for decoding defmt logs.
-    #[serde(default, rename = "logFormat")]
-    pub log_format: Option<String>,
-
     /// Configure data_format and show_timestamps for select channels
     #[serde(default = "Vec::new", rename = "rttChannelFormats")]
     pub channels: Vec<RttChannelConfig>,
@@ -345,7 +341,6 @@ impl RttActiveUpChannel {
     pub fn new(
         core: &mut Core,
         up_channel: UpChannel,
-        rtt_config: &RttConfig,
         channel_config: &RttChannelConfig,
         timestamp_offset: UtcOffset,
         defmt_state: Option<&DefmtState>,
@@ -371,13 +366,8 @@ impl RttActiveUpChannel {
 
                 // Format options:
                 // 1. Custom format for the channel
-                // 2. Custom default format
-                // 3. Default with optional timestamp and location
-                let format = if let Some(format) = channel_config
-                    .log_format
-                    .as_deref()
-                    .or(rtt_config.log_format.as_deref())
-                {
+                // 2. Default with optional timestamp and location
+                let format = if let Some(format) = channel_config.log_format.as_deref() {
                     FormatterFormat::Custom(format)
                 } else {
                     FormatterFormat::Default {
@@ -566,7 +556,6 @@ impl RttActiveTarget {
                 RttActiveUpChannel::new(
                     core,
                     channel,
-                    rtt_config,
                     &channel_config,
                     timestamp_offset,
                     defmt_state.as_ref(),


### PR DESCRIPTION
 - Rename motivated by https://github.com/probe-rs/vscode/pull/90#discussion_r1595789887 - it's not required, but it doesn't hurt to remain consistent.
 - I've removed the remaining "default" log format configuration that was missed in #2377
 - Removed an unused struct
 - Defmt timestamp output now respects `show_timestamps`

I'm hoping the general "changed-embed-toml.md" changelog still applies here so I did not add a new one.