### PR TITLE
`halted_access`: Only read cpu status once

### DIFF
--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -446,8 +446,9 @@ impl Session {
         let mut resume_state = vec![];
         for (core, _) in self.list_cores() {
             let mut c = self.core(core)?;
-            tracing::info!("Core status: {:?}", c.status()?);
-            if !c.core_halted()? {
+            let status = c.status()?;
+            tracing::info!("Core status: {:?}", status);
+            if !status.is_halted() {
                 tracing::info!("Halting core...");
                 resume_state.push(core);
                 c.halt(Duration::from_millis(100))?;


### PR DESCRIPTION
This PR does two things:
 - saves a register read
 - extracts reading core status out of a tracing macro. This prevents printing messages for disabled levels