### PR TITLE
Rename esp32 variant

### DIFF
--- a/probe-rs/targets/esp32.yaml
+++ b/probe-rs/targets/esp32.yaml
@@ -3,7 +3,7 @@ manufacturer:
   cc: 0x0C
   id: 0x12
 variants:
-  - name: esp32-3.3v
+  - name: esp32
     scan_chain:
       - name: main
         ir_len: 5


### PR DESCRIPTION
 Rename ESP32 variant to `esp32` instead of `esp32-3.3v`.  This should make things in [`esp-hal` HIL a bit simpler](https://github.com/esp-rs/esp-hal/blob/main/xtask/src/lib.rs#L282-L283)