### PR TITLE
probe: add probe_type() to DebugProbeInfo.

### DIFF
--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -783,6 +783,13 @@ impl DebugProbeInfo {
     pub fn is_probe_type<F: ProbeFactory>(&self) -> bool {
         self.probe_factory.type_id() == std::any::TypeId::of::<F>()
     }
+
+    /// Returns a human-readable string describing the probe type.
+    ///
+    /// The exact contents of the string are unstable, this is intended for human consumption only.
+    pub fn probe_type(&self) -> String {
+        format!("{}", self.probe_factory)
+    }
 }
 
 /// An error which can occur while parsing a [`DebugProbeSelector`].


### PR DESCRIPTION
`probe_factory` was made private here https://github.com/probe-rs/probe-rs/pull/2238#discussion_r1504263362

However, that was the only way to get a human-readable description of what probe type this probe is. This PR
keeps it private, and adds a method to get the description instead.
