### PR TITLE
Change probe info format

### DIFF
--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -739,14 +739,12 @@ impl std::fmt::Display for DebugProbeInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "{} (VID: {:04x}, PID: {:04x}, {}{})",
+            "{} -- {:04x}:{:04x}:{} ({})",
             self.identifier,
             self.vendor_id,
             self.product_id,
-            self.serial_number
-                .as_ref()
-                .map_or("".to_owned(), |v| format!("Serial: {v}, ")),
-            self.probe_factory
+            self.serial_number.as_deref().unwrap_or(""),
+            self.probe_factory,
         )
     }
 }

--- a/probe-rs/src/probe/jlink/mod.rs
+++ b/probe-rs/src/probe/jlink/mod.rs
@@ -1206,12 +1206,7 @@ fn list_jlink_devices() -> Vec<DebugProbeInfo> {
         .filter(is_jlink)
         .map(|info| {
             DebugProbeInfo::new(
-                format!(
-                    "J-Link{}",
-                    info.product_string()
-                        .map(|p| format!(" ({p})"))
-                        .unwrap_or_default()
-                ),
+                info.product_string().unwrap_or("J-Link").to_string(),
                 info.vendor_id(),
                 info.product_id(),
                 info.serial_number().map(|s| s.to_string()),


### PR DESCRIPTION
Before:

```
The following debug probes were found:
[0]: J-Link (J-Link) (VID: 1366, PID: 0101, Serial: 000260113020, J-Link)
```

After:

```
The following debug probes were found:
[0]: J-Link -- 1366:0101:000260113020 (J-Link)
```

It's more compact, and the probe selector is immediately copy-paste-ready.