### PR TITLE
Chip autodetection framework

### DIFF
--- a/changelog/added-chip-identification.md
+++ b/changelog/added-chip-identification.md
@@ -1,0 +1,1 @@
+`probe-rs` can now automatically detect nRF, ESP32 and certain ATSAM devices without `--chip`

--- a/probe-rs-target/src/chip_detection.rs
+++ b/probe-rs-target/src/chip_detection.rs
@@ -12,6 +12,12 @@ pub enum ChipDetectionMethod {
 
     /// Espressif chip detection information.
     Espressif(EspressifDetection),
+
+    /// Nordic Semiconductor FICR CONFIGID-based chip detection information.
+    NordicConfigId(NordicConfigIdDetection),
+
+    /// Nordic Semiconductor FICR INFO-based chip detection information.
+    NordicFicrInfo(NordicFicrDetection),
 }
 
 impl ChipDetectionMethod {
@@ -27,6 +33,24 @@ impl ChipDetectionMethod {
     /// Returns the Espressif detection information if available.
     pub fn as_espressif(&self) -> Option<&EspressifDetection> {
         if let Self::Espressif(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the Nordic CONFIGID detection information if available.
+    pub fn as_nordic_configid(&self) -> Option<&NordicConfigIdDetection> {
+        if let Self::NordicConfigId(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the Nordic FICR detection information if available.
+    pub fn as_nordic_ficr(&self) -> Option<&NordicFicrDetection> {
+        if let Self::NordicFicrInfo(v) = self {
             Some(v)
         } else {
             None
@@ -57,5 +81,31 @@ pub struct EspressifDetection {
     pub idcode: u32,
 
     /// Magic chip value => Target name.
+    pub variants: HashMap<u32, String>,
+}
+
+/// Nordic FICR CONFIGID-based chip detection information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NordicConfigIdDetection {
+    /// FICR CONFIGID address
+    pub configid_address: u32,
+
+    /// CONFIGID.HWID => Target name.
+    pub hwid: HashMap<u32, String>,
+}
+
+/// Nordic FICR INFO-based chip detection information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NordicFicrDetection {
+    /// FICR INFO.PART address
+    pub part_address: u32,
+
+    /// FICR INFO.VARIANT address
+    pub variant_address: u32,
+
+    /// The value of INFO.PART
+    pub part: u32,
+
+    /// INFO.VARIANT => Target name.
     pub variants: HashMap<u32, String>,
 }

--- a/probe-rs-target/src/chip_detection.rs
+++ b/probe-rs-target/src/chip_detection.rs
@@ -46,8 +46,8 @@ pub struct AtsamDetection {
     /// DSU DID register, Series field
     pub series: u8,
 
-    /// Target => Devsel field value
-    pub variants: HashMap<String, u8>,
+    /// Devsel => Target field value
+    pub variants: HashMap<u8, String>,
 }
 
 /// Espressif chip detection information.

--- a/probe-rs-target/src/chip_detection.rs
+++ b/probe-rs-target/src/chip_detection.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Chip detection method
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ChipDetectionMethod {
+    Atsam(AtsamDetection),
+}
+
+/// Microchip ATSAM chip detection information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AtsamDetection {
+    /// DSU DID register, Processor field
+    pub processor: u8,
+
+    /// DSU DID register, Family field
+    pub family: u8,
+
+    /// DSU DID register, Series field
+    pub series: u8,
+
+    /// Target => Devsel field value
+    pub variants: HashMap<String, u8>,
+}

--- a/probe-rs-target/src/chip_detection.rs
+++ b/probe-rs-target/src/chip_detection.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ChipDetectionMethod {
     /// Microchip ATSAM chip detection information.
-    Atsam(AtsamDetection),
+    AtsamDsu(AtsamDsuDetection),
 
     /// Espressif chip detection information.
     Espressif(EspressifDetection),
@@ -16,8 +16,8 @@ pub enum ChipDetectionMethod {
 
 impl ChipDetectionMethod {
     /// Returns the ATSAM detection information if available.
-    pub fn as_atsam(&self) -> Option<&AtsamDetection> {
-        if let Self::Atsam(v) = self {
+    pub fn as_atsam_dsu(&self) -> Option<&AtsamDsuDetection> {
+        if let Self::AtsamDsu(v) = self {
             Some(v)
         } else {
             None
@@ -34,9 +34,9 @@ impl ChipDetectionMethod {
     }
 }
 
-/// Microchip ATSAM chip detection information.
+/// Microchip ATSAM chip detection information when the device contains a DSU.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AtsamDetection {
+pub struct AtsamDsuDetection {
     /// DSU DID register, Processor field
     pub processor: u8,
 

--- a/probe-rs-target/src/chip_detection.rs
+++ b/probe-rs-target/src/chip_detection.rs
@@ -1,11 +1,37 @@
+//! Chip detection information.
+
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-/// Chip detection method
+/// Vendor-specific chip detection information.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ChipDetectionMethod {
+    /// Microchip ATSAM chip detection information.
     Atsam(AtsamDetection),
+
+    /// Espressif chip detection information.
+    Espressif(EspressifDetection),
+}
+
+impl ChipDetectionMethod {
+    /// Returns the ATSAM detection information if available.
+    pub fn as_atsam(&self) -> Option<&AtsamDetection> {
+        if let Self::Atsam(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the Espressif detection information if available.
+    pub fn as_espressif(&self) -> Option<&EspressifDetection> {
+        if let Self::Espressif(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 /// Microchip ATSAM chip detection information.
@@ -22,4 +48,14 @@ pub struct AtsamDetection {
 
     /// Target => Devsel field value
     pub variants: HashMap<String, u8>,
+}
+
+/// Espressif chip detection information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EspressifDetection {
+    /// Debug module IDCODE
+    pub idcode: u32,
+
+    /// Magic chip value => Target name.
+    pub variants: HashMap<u32, String>,
 }

--- a/probe-rs-target/src/chip_family.rs
+++ b/probe-rs-target/src/chip_family.rs
@@ -1,5 +1,5 @@
 use crate::serialize::hex_jep106_option;
-use crate::CoreAccessOptions;
+use crate::{chip_detection::ChipDetectionMethod, CoreAccessOptions};
 
 use super::chip::Chip;
 use super::flash_algorithm::RawFlashAlgorithm;
@@ -183,6 +183,9 @@ pub struct ChipFamily {
     /// The JEP106 code of the manufacturer.
     #[serde(serialize_with = "hex_jep106_option")]
     pub manufacturer: Option<JEP106Code>,
+    /// The method(s) that may be able to identify targets in this family.
+    #[serde(default)]
+    pub chip_detection: Vec<ChipDetectionMethod>,
     /// The `target-gen` process will set this to `true`.
     /// Please change this to `false` if this file is modified from the generated, or is a manually created target description.
     #[serde(default)]

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 
 mod chip;
-mod chip_detection;
+pub mod chip_detection;
 mod chip_family;
 mod flash_algorithm;
 mod flash_properties;

--- a/probe-rs-target/src/lib.rs
+++ b/probe-rs-target/src/lib.rs
@@ -12,6 +12,7 @@
 //!
 
 mod chip;
+mod chip_detection;
 mod chip_family;
 mod flash_algorithm;
 mod flash_properties;

--- a/probe-rs/src/architecture/arm/communication_interface.rs
+++ b/probe-rs/src/architecture/arm/communication_interface.rs
@@ -867,7 +867,7 @@ impl DapAccess for ArmCommunicationInterface<Initialized> {
 /// Information about the chip target we are currently attached to.
 /// This can be used for discovery, tho, for now it does not work optimally,
 /// as some manufacturers (e.g. ST Microelectronics) violate the spec and thus need special discovery procedures.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct ArmChipInfo {
     /// The JEP106 code of the manufacturer of this chip target.
     pub manufacturer: JEP106Code,

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -41,6 +41,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
             manufacturer: None,
             generated_from_pack: false,
             pack_file_release: None,
+            chip_detection: vec![],
             variants: vec![
                 Chip::generic_arm("Cortex-M0", CoreType::Armv6m),
                 Chip::generic_arm("Cortex-M0+", CoreType::Armv6m),
@@ -55,6 +56,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
             manufacturer: None,
             generated_from_pack: false,
             pack_file_release: None,
+            chip_detection: vec![],
             variants: vec![Chip::generic_arm("Cortex-M3", CoreType::Armv7m)],
             flash_algorithms: vec![],
             source: TargetDescriptionSource::Generic,
@@ -64,6 +66,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
             manufacturer: None,
             generated_from_pack: false,
             pack_file_release: None,
+            chip_detection: vec![],
             variants: vec![
                 Chip::generic_arm("Cortex-M4", CoreType::Armv7em),
                 Chip::generic_arm("Cortex-M7", CoreType::Armv7em),
@@ -76,6 +79,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
             manufacturer: None,
             generated_from_pack: false,
             pack_file_release: None,
+            chip_detection: vec![],
             variants: vec![
                 Chip::generic_arm("Cortex-M23", CoreType::Armv8m),
                 Chip::generic_arm("Cortex-M33", CoreType::Armv8m),
@@ -90,6 +94,7 @@ fn add_generic_targets(vec: &mut Vec<ChipFamily>) {
             manufacturer: None,
             pack_file_release: None,
             generated_from_pack: false,
+            chip_detection: vec![],
             variants: vec![Chip {
                 name: "riscv".to_owned(),
                 part: None,

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -829,14 +829,14 @@ fn get_target_from_selector(
             }
             probe.attach_to_unspecified()?;
 
-            let (returned_probe, found_chip) = crate::vendor::auto_determine_target(probe)?;
+            let (returned_probe, found_target) = crate::vendor::auto_determine_target(probe)?;
             probe = returned_probe;
 
             // Now we can deassert reset in case we asserted it before. This is always okay.
             probe.target_reset_deassert()?;
 
-            if let Some(chip) = found_chip {
-                crate::config::get_target_by_chip_info(chip)?
+            if let Some(target) = found_target {
+                target
             } else {
                 return Err(Error::ChipNotFound(RegistryError::ChipAutodetectFailed));
             }

--- a/probe-rs/src/vendor/espressif/mod.rs
+++ b/probe-rs/src/vendor/espressif/mod.rs
@@ -1,9 +1,16 @@
 //! Espressif vendor support.
 
-use probe_rs_target::Chip;
+use probe_rs_target::{
+    chip_detection::{ChipDetectionMethod, EspressifDetection},
+    Chip,
+};
 
 use crate::{
-    config::DebugSequence,
+    architecture::{
+        riscv::communication_interface::RiscvCommunicationInterface,
+        xtensa::communication_interface::XtensaCommunicationInterface,
+    },
+    config::{registry, DebugSequence},
     vendor::{
         espressif::sequences::{
             esp32::ESP32, esp32c2::ESP32C2, esp32c3::ESP32C3, esp32c6::ESP32C6, esp32h2::ESP32H2,
@@ -11,9 +18,47 @@ use crate::{
         },
         Vendor,
     },
+    Error, MemoryInterface,
 };
 
 pub mod sequences;
+
+const MAGIC_VALUE_ADDRESS: u64 = 0x4000_1000;
+
+fn get_target_by_magic(info: &EspressifDetection, read_magic: u32) -> Option<String> {
+    for (magic, target) in info.variants.iter() {
+        if *magic == read_magic {
+            return Some(target.clone());
+        }
+    }
+    None
+}
+
+fn try_detect_espressif_chip(
+    probe: &mut impl MemoryInterface,
+    idcode: u32,
+) -> Result<Option<String>, Error> {
+    let families = registry::families_ref();
+    for family in families.into_iter() {
+        for info in family
+            .chip_detection
+            .iter()
+            .filter_map(ChipDetectionMethod::as_espressif)
+        {
+            if info.idcode != idcode {
+                continue;
+            }
+            let Ok(read_magic) = probe.read_word_32(MAGIC_VALUE_ADDRESS) else {
+                continue;
+            };
+            if let Some(target) = get_target_by_magic(info, read_magic) {
+                return Ok(Some(target));
+            }
+        }
+    }
+
+    Ok(None)
+}
 
 /// Espressif
 #[derive(docsplay::Display)]
@@ -40,5 +85,21 @@ impl Vendor for Espressif {
         };
 
         Some(sequence)
+    }
+
+    fn try_detect_riscv_chip(
+        &self,
+        probe: &mut RiscvCommunicationInterface,
+        idcode: u32,
+    ) -> Result<Option<String>, Error> {
+        try_detect_espressif_chip(probe, idcode)
+    }
+
+    fn try_detect_xtensa_chip(
+        &self,
+        probe: &mut XtensaCommunicationInterface,
+        idcode: u32,
+    ) -> Result<Option<String>, Error> {
+        try_detect_espressif_chip(probe, idcode)
     }
 }

--- a/probe-rs/src/vendor/espressif/mod.rs
+++ b/probe-rs/src/vendor/espressif/mod.rs
@@ -39,7 +39,7 @@ fn try_detect_espressif_chip(
     idcode: u32,
 ) -> Result<Option<String>, Error> {
     let families = registry::families_ref();
-    for family in families.into_iter() {
+    for family in families.iter() {
         for info in family
             .chip_detection
             .iter()

--- a/probe-rs/src/vendor/espressif/mod.rs
+++ b/probe-rs/src/vendor/espressif/mod.rs
@@ -23,6 +23,13 @@ use crate::{
 
 pub mod sequences;
 
+// A magic number that resides in the ROM of Espressif chips. This points to 4 bytes that are mostly
+// unique to each chip variant. There may be some overlap between revisions (e.g. esp32c3)
+// and chips may be placed on modules that are configured significantly
+// differently (esp32 with 1.8V or 3.3V VDD_SDIO).
+// See:
+// - https://github.com/esp-rs/espflash/blob/5c898ac7a37fd6ec7d7c4562585818ac878e5a2f/espflash/src/flasher/stubs.rs#L23
+// - https://github.com/esp-rs/espflash/blob/5c898ac7a37fd6ec7d7c4562585818ac878e5a2f/espflash/src/flasher/mod.rs#L589-L590
 const MAGIC_VALUE_ADDRESS: u64 = 0x4000_1000;
 
 fn get_target_by_magic(info: &EspressifDetection, read_magic: u32) -> Option<String> {

--- a/probe-rs/src/vendor/microchip/mod.rs
+++ b/probe-rs/src/vendor/microchip/mod.rs
@@ -1,10 +1,15 @@
 //! Microchip vendor support.
 
-use probe_rs_target::Chip;
+use probe_rs_target::{chip_detection::ChipDetectionMethod, Chip};
 
 use crate::{
-    config::DebugSequence,
-    vendor::{microchip::sequences::atsam::AtSAM, Vendor},
+    architecture::arm::{ap::MemoryAp, ApAddress, ArmChipInfo, ArmProbeInterface},
+    config::{registry, DebugSequence},
+    vendor::{
+        microchip::sequences::atsam::{AtSAM, DsuDid},
+        Vendor,
+    },
+    Error,
 };
 
 pub mod sequences;
@@ -27,5 +32,47 @@ impl Vendor for Microchip {
         };
 
         Some(sequence)
+    }
+
+    fn try_detect_arm_chip(
+        &self,
+        interface: &mut dyn ArmProbeInterface,
+        chip_info: ArmChipInfo,
+    ) -> Result<Option<String>, Error> {
+        if chip_info.jep106().get() != Some("Atmel") || chip_info.part != 0xCD0 {
+            return Ok(None);
+        }
+
+        // FIXME: This is a bit shaky but good enough for now.
+        let access_port = MemoryAp::new(ApAddress::with_default_dp(0));
+        // This device has an Atmel DSU - Read and parse the DSU DID register
+        let did = DsuDid(
+            interface
+                .memory_interface(access_port)?
+                .read_word_32(DsuDid::ADDRESS)?,
+        );
+
+        let families = registry::families_ref();
+        for family in families.into_iter() {
+            for info in family
+                .chip_detection
+                .iter()
+                .filter_map(ChipDetectionMethod::as_atsam)
+            {
+                if info.processor != did.processor()
+                    || info.family != did.family()
+                    || info.series != did.series()
+                {
+                    continue;
+                }
+                for (devsel, variant) in info.variants.iter() {
+                    if *devsel == did.devsel() {
+                        return Ok(Some(variant.clone()));
+                    }
+                }
+            }
+        }
+
+        Ok(None)
     }
 }

--- a/probe-rs/src/vendor/microchip/mod.rs
+++ b/probe-rs/src/vendor/microchip/mod.rs
@@ -57,7 +57,7 @@ impl Vendor for Microchip {
             for info in family
                 .chip_detection
                 .iter()
-                .filter_map(ChipDetectionMethod::as_atsam)
+                .filter_map(ChipDetectionMethod::as_atsam_dsu)
             {
                 if info.processor != did.processor() as u8
                     || info.family != did.family() as u8

--- a/probe-rs/src/vendor/microchip/mod.rs
+++ b/probe-rs/src/vendor/microchip/mod.rs
@@ -39,7 +39,7 @@ impl Vendor for Microchip {
         interface: &mut dyn ArmProbeInterface,
         chip_info: ArmChipInfo,
     ) -> Result<Option<String>, Error> {
-        if chip_info.jep106().get() != Some("Atmel") || chip_info.part != 0xCD0 {
+        if chip_info.manufacturer.get() != Some("Atmel") || chip_info.part != 0xCD0 {
             return Ok(None);
         }
 
@@ -53,20 +53,20 @@ impl Vendor for Microchip {
         );
 
         let families = registry::families_ref();
-        for family in families.into_iter() {
+        for family in families.iter() {
             for info in family
                 .chip_detection
                 .iter()
                 .filter_map(ChipDetectionMethod::as_atsam)
             {
-                if info.processor != did.processor()
-                    || info.family != did.family()
-                    || info.series != did.series()
+                if info.processor != did.processor() as u8
+                    || info.family != did.family() as u8
+                    || info.series != did.series() as u8
                 {
                     continue;
                 }
                 for (devsel, variant) in info.variants.iter() {
-                    if *devsel == did.devsel() {
+                    if *devsel == did.devsel() as u8 {
                         return Ok(Some(variant.clone()));
                     }
                 }

--- a/probe-rs/src/vendor/microchip/sequences/atsam.rs
+++ b/probe-rs/src/vendor/microchip/sequences/atsam.rs
@@ -218,7 +218,7 @@ bitfield! {
     pub revision, _ : 11, 8;
 
     /// This bit field identifies a device within a product family and product series.
-    pub devsel, _ : 8, 0;
+    pub devsel, _ : 7, 0;
 }
 
 impl DsuDid {

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -131,6 +131,7 @@ fn try_detect_arm_chip(mut probe: Probe) -> Result<(Probe, Option<Target>), Erro
                 if let Some(found_chip) = found_arm_chip {
                     let vendors = vendors();
                     for vendor in vendors.iter() {
+                        // TODO: only consider families with matching JEP106.
                         if let Some(target_name) =
                             vendor.try_detect_arm_chip(interface.as_mut(), found_chip)?
                         {
@@ -177,6 +178,7 @@ fn try_detect_riscv_chip(probe: &mut Probe) -> Result<Option<Target>, Error> {
                     tracing::debug!("ID code read over JTAG: {idcode:#x}");
                     let vendors = vendors();
                     for vendor in vendors.iter() {
+                        // TODO: only consider families with matching JEP106.
                         if let Some(target_name) =
                             vendor.try_detect_riscv_chip(&mut interface, idcode)?
                         {
@@ -220,6 +222,7 @@ fn try_detect_xtensa_chip(probe: &mut Probe) -> Result<Option<Target>, Error> {
                     tracing::debug!("ID code read over JTAG: {idcode:#x}");
                     let vendors = vendors();
                     for vendor in vendors.iter() {
+                        // TODO: only consider families with matching JEP106.
                         if let Some(target_name) =
                             vendor.try_detect_xtensa_chip(&mut interface, idcode)?
                         {

--- a/probe-rs/src/vendor/mod.rs
+++ b/probe-rs/src/vendor/mod.rs
@@ -280,5 +280,7 @@ pub(crate) fn auto_determine_target(mut probe: Probe) -> Result<(Probe, Option<T
         }
     }
 
+    probe.detach()?;
+
     Ok((probe, found_target))
 }

--- a/probe-rs/src/vendor/nordicsemi/mod.rs
+++ b/probe-rs/src/vendor/nordicsemi/mod.rs
@@ -1,13 +1,23 @@
 //! Nordic Semiconductor vendor support.
 
-use probe_rs_target::Chip;
+use std::collections::{hash_map::Entry, HashMap};
+
+use probe_rs_target::{
+    chip_detection::{NordicConfigIdDetection, NordicFicrDetection},
+    Chip,
+};
 
 use crate::{
-    config::DebugSequence,
+    architecture::arm::{
+        ap::MemoryAp, memory::adi_v5_memory_interface::ArmProbe, ApAddress, ArmChipInfo,
+        ArmProbeInterface,
+    },
+    config::{registry, DebugSequence},
     vendor::{
         nordicsemi::sequences::{nrf52::Nrf52, nrf53::Nrf5340, nrf91::Nrf9160},
         Vendor,
     },
+    Error,
 };
 
 pub mod sequences;
@@ -29,5 +39,101 @@ impl Vendor for NordicSemi {
         };
 
         Some(sequence)
+    }
+
+    fn try_detect_arm_chip(
+        &self,
+        probe: &mut dyn ArmProbeInterface,
+        chip_info: ArmChipInfo,
+    ) -> Result<Option<String>, Error> {
+        if chip_info.manufacturer.get() != Some("Nordic VLSI ASA") {
+            return Ok(None);
+        }
+
+        // FIXME: This is a bit shaky but good enough for now.
+        let access_port = MemoryAp::new(ApAddress::with_default_dp(0));
+        let mut memory_interface = probe.memory_interface(access_port)?;
+
+        // Cache to avoid reading the same register multiple times
+        let mut register_values: HashMap<u32, u32> = HashMap::new();
+
+        let families = registry::families_ref();
+        for family in families.iter() {
+            for info in family.chip_detection.iter() {
+                let target = if let Some(spec) = info.as_nordic_ficr() {
+                    ficr_info_detect(&mut register_values, memory_interface.as_mut(), spec)
+                } else if let Some(spec) = info.as_nordic_configid() {
+                    configid_detect(&mut register_values, memory_interface.as_mut(), spec)
+                } else {
+                    // Family does not have a Nordic specific detection method
+                    continue;
+                };
+
+                if target.is_some() {
+                    // We have a match
+                    return Ok(target);
+                }
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+fn ficr_info_detect(
+    register_values: &mut HashMap<u32, u32>,
+    memory_interface: &mut dyn ArmProbe,
+    spec: &NordicFicrDetection,
+) -> Option<String> {
+    // Read the PART register, if not already read
+    if let Some(part) = read_register_cached(register_values, memory_interface, spec.part_address) {
+        if part != spec.part {
+            return None;
+        }
+
+        // Read the VARIANT register, if not already read
+        if let Some(variant) =
+            read_register_cached(register_values, memory_interface, spec.variant_address)
+        {
+            return spec.variants.get(&variant).cloned();
+        }
+    }
+
+    None
+}
+
+fn configid_detect(
+    register_values: &mut HashMap<u32, u32>,
+    memory_interface: &mut dyn ArmProbe,
+    spec: &NordicConfigIdDetection,
+) -> Option<String> {
+    // Read the CONFIGID register, if not already read
+    if let Some(configid) =
+        read_register_cached(register_values, memory_interface, spec.configid_address)
+    {
+        let hwid = configid & 0xFFFF;
+
+        // Match the HWID
+        return spec.hwid.get(&hwid).cloned();
+    }
+
+    None
+}
+
+fn read_register_cached(
+    register_values: &mut HashMap<u32, u32>,
+    memory_interface: &mut dyn ArmProbe,
+    address: u32,
+) -> Option<u32> {
+    match register_values.entry(address) {
+        Entry::Occupied(value) => Some(*value.get()),
+        Entry::Vacant(e) => {
+            if let Ok(value) = memory_interface.read_word_32(address as u64) {
+                e.insert(value);
+                Some(value)
+            } else {
+                None
+            }
+        }
     }
 }

--- a/probe-rs/targets/SAMD21.yaml
+++ b/probe-rs/targets/SAMD21.yaml
@@ -2,6 +2,45 @@ name: SAMD21
 manufacturer:
   id: 0x1f
   cc: 0x0
+chip_detection:
+ - !Atsam
+    processor: 1
+    family: 0
+    series: 1
+    variants:
+      0x00: ATSAMD21J18A
+      0x01: ATSAMD21J17A
+      0x02: ATSAMD21J16A
+      0x03: ATSAMD21J15A
+      0x05: ATSAMD21G18A
+      0x0F: ATSAMD21G18AU
+      0x06: ATSAMD21G17A
+      0x10: ATSAMD21G17AU
+      0x07: ATSAMD21G16A
+      0x08: ATSAMD21G15A
+      0x0A: ATSAMD21E18A
+      0x0B: ATSAMD21E17A
+      0x0C: ATSAMD21E16A
+      0x0D: ATSAMD21E15A
+      0x20: ATSAMD21J16B
+      0x21: ATSAMD21J15B
+      0x23: ATSAMD21G16B
+      0x24: ATSAMD21G15B
+      0x26: ATSAMD21E16B
+      0x55: ATSAMD21E16BU
+      0x27: ATSAMD21E15B
+      0x56: ATSAMD21E15BU
+      0x57: ATSAMD21G16L
+      0x3E: ATSAMD21E16L
+      0x3F: ATSAMD21E15L
+      0x62: ATSAMD21E16CU
+      0x63: ATSAMD21E15CU
+      0x94: ATSAMD21E17D
+      0x95: ATSAMD21E17DU
+      0x97: ATSAMD21E17L
+      0x93: ATSAMD21G17D
+      0x96: ATSAMD21G17L
+      0x92: ATSAMD21J17D
 variants:
 - name: ATSAMD21E15A
   cores:

--- a/probe-rs/targets/SAMD21.yaml
+++ b/probe-rs/targets/SAMD21.yaml
@@ -3,7 +3,7 @@ manufacturer:
   id: 0x1f
   cc: 0x0
 chip_detection:
- - !Atsam
+ - !AtsamDsu
     processor: 1
     family: 0
     series: 1

--- a/probe-rs/targets/SAMD51.yaml
+++ b/probe-rs/targets/SAMD51.yaml
@@ -2,6 +2,21 @@ name: SAMD51
 manufacturer:
   id: 0x1f
   cc: 0x0
+chip_detection:
+ - !Atsam
+    processor: 6
+    family: 0
+    series: 6
+    variants:
+      ATSAMD51P20A: 0x00
+      ATSAMD51P19A: 0x01
+      ATSAMD51N20A: 0x02
+      ATSAMD51N19A: 0x03
+      ATSAMD51J20A: 0x04
+      ATSAMD51J19A: 0x05
+      ATSAMD51J18A: 0x06
+      ATSAMD51G19A: 0x07
+      ATSAMD51G18A: 0x08
 variants:
 - name: ATSAMD51G18A
   cores:

--- a/probe-rs/targets/SAMD51.yaml
+++ b/probe-rs/targets/SAMD51.yaml
@@ -3,7 +3,7 @@ manufacturer:
   id: 0x1f
   cc: 0x0
 chip_detection:
- - !Atsam
+ - !AtsamDsu
     processor: 6
     family: 0
     series: 6

--- a/probe-rs/targets/SAMD51.yaml
+++ b/probe-rs/targets/SAMD51.yaml
@@ -8,15 +8,15 @@ chip_detection:
     family: 0
     series: 6
     variants:
-      ATSAMD51P20A: 0x00
-      ATSAMD51P19A: 0x01
-      ATSAMD51N20A: 0x02
-      ATSAMD51N19A: 0x03
-      ATSAMD51J20A: 0x04
-      ATSAMD51J19A: 0x05
-      ATSAMD51J18A: 0x06
-      ATSAMD51G19A: 0x07
-      ATSAMD51G18A: 0x08
+      0x00: ATSAMD51P20A
+      0x01: ATSAMD51P19A
+      0x02: ATSAMD51N20A
+      0x03: ATSAMD51N19A
+      0x04: ATSAMD51J20A
+      0x05: ATSAMD51J19A
+      0x06: ATSAMD51J18A
+      0x07: ATSAMD51G19A
+      0x08: ATSAMD51G18A
 variants:
 - name: ATSAMD51G18A
   cores:

--- a/probe-rs/targets/SAMDA1.yaml
+++ b/probe-rs/targets/SAMDA1.yaml
@@ -3,7 +3,7 @@ manufacturer:
   id: 0x1f
   cc: 0x0
 chip_detection:
- - !Atsam
+ - !AtsamDsu
     processor: 1
     family: 0
     series: 1

--- a/probe-rs/targets/SAMDA1.yaml
+++ b/probe-rs/targets/SAMDA1.yaml
@@ -2,6 +2,30 @@ name: SAMDA1
 manufacturer:
   id: 0x1f
   cc: 0x0
+chip_detection:
+ - !Atsam
+    processor: 1
+    family: 0
+    series: 1
+    variants:
+      0x31: ATSAMDA1E14A
+      0x30: ATSAMDA1E15A
+      0x2F: ATSAMDA1E16A
+      0x2E: ATSAMDA1G14A
+      0x2D: ATSAMDA1G15A
+      0x2C: ATSAMDA1G16A
+      0x2B: ATSAMDA1J14A
+      0x2A: ATSAMDA1J15A
+      0x29: ATSAMDA1J16A
+      0x6C: ATSAMDA1E14B
+      0x6B: ATSAMDA1E15B
+      0x6A: ATSAMDA1E16B
+      0x69: ATSAMDA1G14B
+      0x68: ATSAMDA1G15B
+      0x67: ATSAMDA1G16B
+      0x66: ATSAMDA1J14B
+      0x65: ATSAMDA1J15B
+      0x64: ATSAMDA1J16B
 variants:
 - name: ATSAMDA1E14B
   cores:

--- a/probe-rs/targets/SAME51.yaml
+++ b/probe-rs/targets/SAME51.yaml
@@ -3,7 +3,7 @@ manufacturer:
   id: 0x1f
   cc: 0x0
 chip_detection:
- - !Atsam
+ - !AtsamDsu
     processor: 6
     family: 3
     series: 1

--- a/probe-rs/targets/SAME51.yaml
+++ b/probe-rs/targets/SAME51.yaml
@@ -2,6 +2,18 @@ name: SAME51
 manufacturer:
   id: 0x1f
   cc: 0x0
+chip_detection:
+ - !Atsam
+    processor: 6
+    family: 3
+    series: 1
+    variants:
+      0x00: ATSAME51N20A
+      0x01: ATSAME51N19A
+      0x02: ATSAME51J19A
+      0x03: ATSAME51J18A
+      0x04: ATSAME51J20A
+      0x06: ATSAME51G18A
 variants:
 - name: ATSAME51G18A
   cores:

--- a/probe-rs/targets/SAME53.yaml
+++ b/probe-rs/targets/SAME53.yaml
@@ -2,6 +2,17 @@ name: SAME53
 manufacturer:
   id: 0x1f
   cc: 0x0
+chip_detection:
+ - !Atsam
+    processor: 6
+    family: 3
+    series: 3
+    variants:
+      0x02: ATSAME53N20A
+      0x03: ATSAME53N19A
+      0x04: ATSAME53J20A
+      0x05: ATSAME53J19A
+      0x06: ATSAME53J18A
 variants:
 - name: ATSAME53J18A
   cores:

--- a/probe-rs/targets/SAME53.yaml
+++ b/probe-rs/targets/SAME53.yaml
@@ -3,7 +3,7 @@ manufacturer:
   id: 0x1f
   cc: 0x0
 chip_detection:
- - !Atsam
+ - !AtsamDsu
     processor: 6
     family: 3
     series: 3

--- a/probe-rs/targets/SAME54.yaml
+++ b/probe-rs/targets/SAME54.yaml
@@ -3,7 +3,7 @@ manufacturer:
   id: 0x1f
   cc: 0x0
 chip_detection:
- - !Atsam
+ - !AtsamDsu
     processor: 6
     family: 3
     series: 4

--- a/probe-rs/targets/SAME54.yaml
+++ b/probe-rs/targets/SAME54.yaml
@@ -2,6 +2,16 @@ name: SAME54
 manufacturer:
   id: 0x1f
   cc: 0x0
+chip_detection:
+ - !Atsam
+    processor: 6
+    family: 3
+    series: 4
+    variants:
+      0x00: ATSAME54P20A
+      0x01: ATSAME54P19A
+      0x02: ATSAME54N20A
+      0x03: ATSAME54N19A
 variants:
 - name: ATSAME54N19A
   cores:

--- a/probe-rs/targets/esp32.yaml
+++ b/probe-rs/targets/esp32.yaml
@@ -2,6 +2,7 @@ name: esp32
 manufacturer:
   id: 0x12
   cc: 0xc
+# chip_detection deliberately missing to avoid misdetecting 1.8V variants
 variants:
 - name: esp32-3.3v
   cores:

--- a/probe-rs/targets/esp32c2.yaml
+++ b/probe-rs/targets/esp32c2.yaml
@@ -2,6 +2,12 @@ name: esp32c2
 manufacturer:
   id: 0x12
   cc: 0xc
+chip_detection:
+  - !Espressif
+    idcode: 0x0000cc25
+    variants:
+      - 0x6f51306f: esp32c2 # ECO0
+      - 0x7c41a06f: esp32c2 # ECO1
 variants:
 - name: esp32c2
   cores:

--- a/probe-rs/targets/esp32c2.yaml
+++ b/probe-rs/targets/esp32c2.yaml
@@ -6,8 +6,8 @@ chip_detection:
   - !Espressif
     idcode: 0x0000cc25
     variants:
-      - 0x6f51306f: esp32c2 # ECO0
-      - 0x7c41a06f: esp32c2 # ECO1
+      0x6f51306f: esp32c2 # ECO0
+      0x7c41a06f: esp32c2 # ECO1
 variants:
 - name: esp32c2
   cores:

--- a/probe-rs/targets/esp32c3.yaml
+++ b/probe-rs/targets/esp32c3.yaml
@@ -6,10 +6,10 @@ chip_detection:
   - !Espressif
     idcode: 0x00005c25
     variants:
-      - 0x6921506f: esp32c3 # ECO1 + ECO2
-      - 0x1b31506f: esp32c3 # ECO3
-      - 0x4881606f: esp32c3 # ECO6
-      - 0x4361606f: esp32c3 # ECO7
+      0x6921506f: esp32c3 # ECO1 + ECO2
+      0x1b31506f: esp32c3 # ECO3
+      0x4881606f: esp32c3 # ECO6
+      0x4361606f: esp32c3 # ECO7
 variants:
 - name: esp32c3
   cores:

--- a/probe-rs/targets/esp32c3.yaml
+++ b/probe-rs/targets/esp32c3.yaml
@@ -2,6 +2,14 @@ name: esp32c3
 manufacturer:
   id: 0x12
   cc: 0xc
+chip_detection:
+  - !Espressif
+    idcode: 0x00005c25
+    variants:
+      - 0x6921506f: esp32c3 # ECO1 + ECO2
+      - 0x1b31506f: esp32c3 # ECO3
+      - 0x4881606f: esp32c3 # ECO6
+      - 0x4361606f: esp32c3 # ECO7
 variants:
 - name: esp32c3
   cores:

--- a/probe-rs/targets/esp32c6.yaml
+++ b/probe-rs/targets/esp32c6.yaml
@@ -6,7 +6,7 @@ chip_detection:
   - !Espressif
     idcode: 0x0000dc25
     variants:
-      - 0x2CE0806F: esp32c6
+      0x2CE0806F: esp32c6
 variants:
 - name: esp32c6
   cores:

--- a/probe-rs/targets/esp32c6.yaml
+++ b/probe-rs/targets/esp32c6.yaml
@@ -2,6 +2,11 @@ name: esp32c6
 manufacturer:
   id: 0x12
   cc: 0xc
+chip_detection:
+  - !Espressif
+    idcode: 0x0000dc25
+    variants:
+      - 0x2CE0806F: esp32c6
 variants:
 - name: esp32c6
   cores:

--- a/probe-rs/targets/esp32h2.yaml
+++ b/probe-rs/targets/esp32h2.yaml
@@ -6,7 +6,7 @@ chip_detection:
   - !Espressif
     idcode: 0x00010c25
     variants:
-      - 0xD7B73E80: esp32h2
+      0xD7B73E80: esp32h2
 variants:
 - name: esp32h2
   cores:

--- a/probe-rs/targets/esp32h2.yaml
+++ b/probe-rs/targets/esp32h2.yaml
@@ -2,6 +2,11 @@ name: esp32h2
 manufacturer:
   id: 0x12
   cc: 0xc
+chip_detection:
+  - !Espressif
+    idcode: 0x00010c25
+    variants:
+      - 0xD7B73E80: esp32h2
 variants:
 - name: esp32h2
   cores:

--- a/probe-rs/targets/esp32s2.yaml
+++ b/probe-rs/targets/esp32s2.yaml
@@ -6,7 +6,7 @@ chip_detection:
   - !Espressif
     idcode: 0x120034e5
     variants:
-      - 0x000007c6: esp32s2
+      0x000007c6: esp32s2
 variants:
 - name: esp32s2
   cores:

--- a/probe-rs/targets/esp32s2.yaml
+++ b/probe-rs/targets/esp32s2.yaml
@@ -2,6 +2,11 @@ name: esp32s2
 manufacturer:
   id: 0x12
   cc: 0xc
+chip_detection:
+  - !Espressif
+    idcode: 0x120034e5
+    variants:
+      - 0x000007c6: esp32s2
 variants:
 - name: esp32s2
   cores:

--- a/probe-rs/targets/esp32s3.yaml
+++ b/probe-rs/targets/esp32s3.yaml
@@ -2,6 +2,11 @@ name: esp32s3
 manufacturer:
   id: 0x12
   cc: 0xc
+chip_detection:
+  - !Espressif
+    idcode: 0x120034e5
+    variants:
+      - 9: esp32s3
 variants:
 - name: esp32s3
   cores:

--- a/probe-rs/targets/esp32s3.yaml
+++ b/probe-rs/targets/esp32s3.yaml
@@ -6,7 +6,7 @@ chip_detection:
   - !Espressif
     idcode: 0x120034e5
     variants:
-      - 9: esp32s3
+      0x9: esp32s3
 variants:
 - name: esp32s3
   cores:

--- a/probe-rs/targets/nRF51_Series.yaml
+++ b/probe-rs/targets/nRF51_Series.yaml
@@ -2,6 +2,116 @@ name: nRF51 Series
 manufacturer:
   id: 0x44
   cc: 0x2
+chip_detection:
+ - !NordicConfigId
+    configid_address: 0x1000005C
+    hwid:
+      # list adapted from https://devzone.nordicsemi.com/f/nordic-q-a/36392/hwid-for-nrf51822
+      # 0x15: nRF51x22_xxAA
+      # 0x1C: nRF51x22_xxAA
+      0x1D: nRF51822_xxAA
+      0x1E: nRF51422_xxAA
+      0x20: nRF51822_xxAA
+      0x21: nRF51822_xxAA
+      0x22: nRF51822_xxAA
+      0x23: nRF51822_xxAA
+      0x24: nRF51422_xxAA
+      0x26: nRF51822_xxAB
+      0x27: nRF51822_xxAB
+      0x28: nRF51822_xxAA
+      0x29: nRF51822_xxAA
+      0x2A: nRF51822_xxAA
+      0x2B: nRF51822_xxAA
+      0x2C: nRF51822_xxAA
+      0x2D: nRF51422_xxAA
+      0x2E: nRF51422_xxAA
+      0x2F: nRF51822_xxAA
+      0x30: nRF51822_xxAA
+      0x31: nRF51422_xxAA
+      0x32: nRF51422_xxAA
+      0x33: nRF51922_xxAA
+      0x34: nRF51822_xxAA
+      0x38: nRF51822_xxAA
+      0x39: nRF51822_xxAA
+      0x3A: nRF51822_xxAB
+      0x3B: nRF51822_xxAB
+      0x3C: nRF51822_xxAA
+      0x3D: nRF51822_xxAA
+      0x3E: nRF51822_xxAA
+      0x3F: nRF51922_xxAA
+      0x40: nRF51822_xxAA
+      0x41: nRF51822_xxAA
+      0x42: nRF51822_xxAA
+      0x43: nRF51822_xxAA
+      0x44: nRF51822_xxAA
+      0x45: nRF51822_xxAA
+      0x46: nRF51822_xxAA
+      0x47: nRF51822_xxAA
+      0x48: nRF51822_xxAA
+      0x49: nRF51822_xxAA
+      0x4A: nRF51822_xxAA
+      0x4B: nRF51922_xxAA
+      0x4C: nRF51822_xxAB
+      0x4D: nRF51822_xxAA
+      0x4E: nRF51822_xxAA
+      0x4F: nRF51822_xxAA
+      0x50: nRF51422_xxAA
+      0x54: nRF51822_xxAA
+      0x56: nRF51822_xxAB
+      0x57: nRF51822_xxAA
+      0x58: nRF51822_xxAA
+      0x59: nRF51822_xxAA
+      0x5A: nRF51822_xxAA
+      0x5B: nRF51822_xxAA
+      0x5C: nRF51422_xxAA
+      0x5D: nRF51822_xxAA
+      0x5E: nRF51422_xxAA
+      0x5F: nRF51822_xxAB
+      0x60: nRF51822_xxAB
+      0x61: nRF51422_xxAB
+      0x63: nRF51422_xxAA
+      0x63: nRF51822_xxAB
+      0x64: nRF51822_xxAB
+      0x65: nRF51422_xxAB
+      0x66: nRF51422_xxAB
+      0x67: nRF51822_xxAB
+      0x68: nRF51422_xxAB
+      0x6A: nRF51822_xxAA
+      0x6B: nRF51822_xxAA
+      0x6C: nRF51822_xxAC
+      0x6D: nRF51422_xxAC
+      0x6E: nRF51822_xxAC
+      0x6F: nRF51822_xxAA
+      0x70: nRF51822_xxAA
+      0x71: nRF51422_xxAC
+      0x72: nRF51822_xxAA
+      0x73: nRF51422_xxAA
+      0x74: nRF51822_xxAC
+      0x75: nRF51422_xxAC
+      0x76: nRF51822_xxAB
+      0x77: nRF51822_xxAA
+      0x79: nRF51822_xxAA
+      0x7A: nRF51422_xxAA
+      0x7B: nRF51822_xxAB
+      0x7C: nRF51422_xxAB
+      0x7d: nRF51822_xxAB
+      0x80: nRF51822_xxAA
+      0x82: nRF51822_xxAC
+      0x83: nRF51822_xxAC
+      0x84: nRF51822_xxAC
+      0x85: nRF51422_xxAC
+      0x86: nRF51422_xxAC
+      0x87: nRF51822_xxAC
+      0x88: nRF51422_xxAC
+      0x8A: nRF51802_xxAA
+      0x8B: nRF51832_xxAA
+      0x8C: nRF51822_xx00
+      0x8E: nRF51822_xxAA
+      0x8F: nRF51822_xxAA
+      0x91: nRF51822_xxAC
+      0x92: nRF51822_xxAQ
+      0x93: nRF51822_xx00
+      0x94: nRF51802_xxAA
 variants:
 - name: nRF51422_xxAA
   cores:

--- a/probe-rs/targets/nRF52_Series.yaml
+++ b/probe-rs/targets/nRF52_Series.yaml
@@ -2,6 +2,93 @@ name: nRF52 Series
 manufacturer:
   id: 0x44
   cc: 0x2
+chip_detection:
+ - !NordicFicrInfo
+    part_address: 0x10000100
+    variant_address: 0x10000104
+    part: 0x52805
+    variants:
+      0x41414141: nRF52805_xxAA
+      0x41414130: nRF52805_xxAA
+      0x41414241: nRF52805_xxAA
+      0x41414242: nRF52805_xxAA
+      0x41414230: nRF52805_xxAA
+      0x41414231: nRF52805_xxAA
+      0x41414341: nRF52805_xxAA
+      0x41414342: nRF52805_xxAA
+      0x41414330: nRF52805_xxAA
+ - !NordicFicrInfo
+    part_address: 0x10000100
+    variant_address: 0x10000104
+    part: 0x52810
+    variants:
+      0x41414141: nRF52810_xxAA
+      0x41414130: nRF52810_xxAA
+      0x41414241: nRF52810_xxAA
+      0x41414242: nRF52810_xxAA
+      0x41414230: nRF52810_xxAA
+      0x41414341: nRF52810_xxAA
+      0x41414342: nRF52810_xxAA
+      0x41414330: nRF52810_xxAA
+      0x41414530: nRF52810_xxAA
+      0x41414531: nRF52810_xxAA
+ - !NordicFicrInfo
+    part_address: 0x10000100
+    variant_address: 0x10000104
+    part: 0x52811
+    variants:
+      0x41414141: nRF52811_xxAA
+      0x41414130: nRF52811_xxAA
+      0x41414241: nRF52811_xxAA
+      0x41414242: nRF52811_xxAA
+      0x41414230: nRF52811_xxAA
+      0x41414341: nRF52811_xxAA
+      0x41414342: nRF52811_xxAA
+      0x41414330: nRF52811_xxAA
+      0x41414530: nRF52811_xxAA
+      0x41414531: nRF52811_xxAA
+ - !NordicFicrInfo
+    part_address: 0x10000100
+    variant_address: 0x10000104
+    part: 0x52832
+    variants:
+      0x41414141: nRF52832_xxAA
+      0x41414143: nRF52832_xxAA
+      0x41414241: nRF52832_xxAA
+      0x41414242: nRF52832_xxAA
+      0x41414230: nRF52832_xxAA
+      0x41424230: nRF52832_xxAB
+      0x41414530: nRF52832_xxAA
+      0x41424530: nRF52832_xxAB
+      0x41414742: nRF52832_xxAA
+      0x41424742: nRF52832_xxAB
+      0x41414730: nRF52832_xxAA
+      0x41424730: nRF52832_xxAB
+ - !NordicFicrInfo
+    part_address: 0x10000100
+    variant_address: 0x10000104
+    part: 0x52833
+    variants:
+      0x41414141: nRF52833_xxAA
+      0x41414142: nRF52833_xxAA
+      0x41414130: nRF52833_xxAA
+      0x41414131: nRF52833_xxAA
+      0x41414230: nRF52833_xxAA
+ - !NordicFicrInfo
+    part_address: 0x10000100
+    variant_address: 0x10000104
+    part: 0x52840
+    variants:
+      0x41414141: nRF52840_xxAA
+      0x41414242: nRF52840_xxAA
+      0x41414341: nRF52840_xxAA
+      0x41414330: nRF52840_xxAA
+      0x41414441: nRF52840_xxAA
+      0x41414430: nRF52840_xxAA
+      0x41414431: nRF52840_xxAA
+      0x41414541: nRF52840_xxAA
+      0x41414530: nRF52840_xxAA
+      0x41414541: nRF52840_xxAA
 variants:
 - name: nRF52805_xxAA
   cores:

--- a/probe-rs/targets/nRF53_Series.yaml
+++ b/probe-rs/targets/nRF53_Series.yaml
@@ -2,6 +2,14 @@ name: nRF53 Series
 manufacturer:
   id: 0x44
   cc: 0x2
+chip_detection:
+ - !NordicFicrInfo
+    part_address: 0x00FF020C # through application core
+    variant_address: 0x00FF0210 # through application core
+    part: 0x5340
+    variants:
+      0x514B4141: nRF5340_xxAA
+      0x434C4141: nRF5340_xxAA
 variants:
 - name: nRF5340_xxAA
   cores:

--- a/probe-rs/targets/nRF91_Series.yaml
+++ b/probe-rs/targets/nRF91_Series.yaml
@@ -2,6 +2,13 @@ name: nRF91 Series
 manufacturer:
   id: 0x44
   cc: 0x2
+chip_detection:
+ - !NordicFicrInfo
+    part_address: 0x00FF0140 # SIPINFO.PARTNO
+    variant_address: 0x00FF021C # INFO.FLASH
+    part: 0x9160
+    variants:
+      0x400: nRF9160_xxAA
 variants:
 - name: nRF9160_xxAA
   cores:

--- a/target-gen/src/commands/elf.rs
+++ b/target-gen/src/commands/elf.rs
@@ -77,6 +77,7 @@ pub fn cmd_elf(
             name: "<family name>".to_owned(),
             manufacturer: None,
             generated_from_pack: false,
+            chip_detection: vec![],
             pack_file_release: None,
             variants: vec![Chip {
                 cores: vec![Core {
@@ -253,6 +254,7 @@ mod test {
             name: "Test Family".to_owned(),
             manufacturer: None,
             generated_from_pack: false,
+            chip_detection: vec![],
             pack_file_release: None,
             variants: vec![Chip::generic_arm("Test Chip", CoreType::Armv8m)],
             flash_algorithms: vec![],

--- a/target-gen/src/generate.rs
+++ b/target-gen/src/generate.rs
@@ -105,6 +105,7 @@ where
                 name: device.family.clone(),
                 manufacturer: None,
                 generated_from_pack: true,
+                chip_detection: vec![],
                 pack_file_release: pack_file_release.clone(),
                 variants: Vec::new(),
                 flash_algorithms: Vec::new(),


### PR DESCRIPTION
Implemented for ATSAM D21 (DA1) and D51 (E51, E53, E54) series and all the supported Espressif chips, slightly scrappy but illustrates most of what I had in mind.

ARM parts are a bit hacky with the known hard-wired AP address but improving that needs some more flexibility from the ARM probe impl. Also my ATSAM devices all use MemAp 0 so I think it's not an unfair assumption to make in the specific impl.

Cc #2449 although not closing that as device support needs to be added in later.

There are some SAMDA1 devices we recognise but don't support. I suspect the yaml is older than the documentation I found, but updating the target is out of scope of this PR.