### PR TITLE
Move custom ROM table parsing into vendor impl

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -62,6 +62,7 @@ futures-lite = { version = "2", default-features = false }
 async-io = "2"
 scroll = "0.12"
 svg = "0.17"
+termtree = "0.4"
 tracing = { version = "0.1", features = ["log"] }
 uf2-decode = "0.2"
 typed-path = "0.8"
@@ -97,7 +98,6 @@ clap = { version = "4", features = ["derive"] }
 itm = { version = "0.9.0-rc.1", default-features = false }
 pretty_assertions = "1"
 test-case = "3"
-termtree = "0.4"
 insta = { version = "1.38", default-features = false, features = ["yaml"] }
 
 [[package.metadata.release.pre-release-replacements]]

--- a/probe-rs/src/architecture/arm/memory/romtable.rs
+++ b/probe-rs/src/architecture/arm/memory/romtable.rs
@@ -755,7 +755,6 @@ impl PeripheralID {
             ("ARM Ltd", 0xD21, 0x11, 0x0000) => Some(PartInfo::new("Cortex-M33 TPIU", PeripheralType::Tpiu)),
             ("ARM Ltd", 0xD21, 0x14, 0x1A14) => Some(PartInfo::new("Cortex-M33 CTI", PeripheralType::Cti)),
             ("ARM Ltd", 0x9A3, 0x13, 0x0000) => Some(PartInfo::new("Cortex-M0 MTB", PeripheralType::Mtb)),
-            ("Atmel", 0xCD0, 1, 0) => Some(PartInfo::new("Atmel DSU", PeripheralType::Custom)),
             _ => None,
         }
     }


### PR DESCRIPTION
I'm not 100% sure this should be specialised to string trees but that was the simplest solution.