### PR TITLE
Add interactive probe selection

### DIFF
--- a/changelog/added-interactive-probe-selection.md
+++ b/changelog/added-interactive-probe-selection.md
@@ -1,0 +1,1 @@
+Added support for cli interactive probe selection when multiple probes are found

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -182,6 +182,7 @@ fn main_try(args: &[OsString], offset: UtcOffset) -> Result<()> {
         chip,
         chip_description_path: None,
         protocol: Some(config.probe.protocol),
+        non_interactive: false,
         probe: selector,
         speed: config.probe.speed,
         connect_under_reset: config.general.connect_under_reset,

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
@@ -205,6 +205,10 @@ pub(crate) fn render_diagnostics(error: OperationError) {
             error.to_string(),
             vec![],
         ),
+        OperationError::ParseProbeIndex(_e) => (
+            error.to_string(),
+            vec![],
+        ),
     };
 
     use std::io::Write;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/configuration.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/configuration.rs
@@ -141,6 +141,7 @@ impl SessionConfig {
             chip: self.chip.clone(),
             chip_description_path: self.chip_description_path.clone(),
             protocol: self.wire_protocol,
+            non_interactive: true,
             probe: self.probe.clone(),
             speed: self.speed,
             connect_under_reset: self.connect_under_reset,

--- a/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/common_options.rs
@@ -1,5 +1,6 @@
 use std::{
     fs::File,
+    io::Write,
     path::{Path, PathBuf},
 };
 
@@ -79,6 +80,14 @@ pub struct ProbeOptions {
     /// Protocol used to connect to chip. Possible options: [swd, jtag]
     #[arg(long, env = "PROBE_RS_PROTOCOL", help_heading = "PROBE CONFIGURATION")]
     pub protocol: Option<WireProtocol>,
+
+    /// Disable interactive probe selection
+    #[arg(
+        long,
+        env = "PROBE_RS_NON_INTERACTIVE",
+        help_heading = "PROBE CONFIGURATION"
+    )]
+    pub non_interactive: bool,
 
     /// Use this flag to select a specific probe in the list.
     ///
@@ -185,6 +194,34 @@ impl LoadedProbeOptions {
         Ok(target)
     }
 
+    /// Provide a list of numerically identified probes and allow for a stdin selection
+    fn interactive_probe_select(&self, lister: &Lister) -> Result<DebugProbeInfo, OperationError> {
+        let list = lister.list_all();
+        println!("Available Probes:");
+        for (i, l) in list.iter().enumerate() {
+            println!("{}: {}", i, l);
+        }
+
+        print!("Selection: ");
+        std::io::stdout().flush().unwrap();
+
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .expect("Expect input for probe selection");
+
+        let probe_idx = input
+            .trim()
+            .parse::<u32>()
+            .map_err(OperationError::ParseProbeIndex)?;
+
+        let Some(info) = list.get(probe_idx as usize) else {
+            return Err(OperationError::NoProbesFound);
+        };
+
+        Ok(info.clone())
+    }
+
     /// Attaches to specified probe and configures it.
     pub fn attach_probe(&self, lister: &Lister) -> Result<Probe, OperationError> {
         let mut probe = if self.0.dry_run {
@@ -199,14 +236,18 @@ impl LoadedProbeOptions {
                     // only a single probe detected.
                     let list = lister.list_all();
                     if list.len() > 1 {
-                        return Err(OperationError::MultipleProbesFound { list });
+                        if self.0.non_interactive {
+                            return Err(OperationError::MultipleProbesFound { list });
+                        } else {
+                            let info = self.interactive_probe_select(lister)?;
+                            lister.open(info)
+                        }
+                    } else {
+                        let Some(info) = list.first() else {
+                            return Err(OperationError::NoProbesFound);
+                        };
+                        lister.open(info)
                     }
-
-                    let Some(info) = list.first() else {
-                        return Err(OperationError::NoProbesFound);
-                    };
-
-                    lister.open(info)
                 }
             };
 
@@ -497,6 +538,8 @@ pub enum OperationError {
     IOError(#[source] std::io::Error),
     #[error("Failed to parse CLI arguments.")]
     CliArgument(#[from] clap::Error),
+    #[error("Failed to parse interactive probe index selection")]
+    ParseProbeIndex(#[source] std::num::ParseIntError),
 }
 
 /// Used in errors it can print a list of items.


### PR DESCRIPTION
When multiple probes are present rather than erroring out allow for a user to input a probe to use from a list of available probes.

Example shell scenario


``` sh
probe-rs run --chip MIMXRT1060 ~/z/zephyr/build/zephyr/zephyr.elf
Available Probes:
0: DAPLink CMSIS-DAP -- 0d28:0204:0229000005d9a56800000000000000000000000097969905 (CMSIS-DAP)
1: J-Link -- 1366:0105:000683676916 (J-Link)
Selection: 0
 WARN probe_rs::util::rtt: No RTT header info was present in the ELF file. Does your firmware run RTT?
 WARN probe_rs::config::sequences::nxp_armv7m: MIMXRT10xx core type supplied as Armv7m, but the actual core is a Armv7em
      Erasing ✔ [00:00:00] [####################################################################################################################################################################################################################################################] 64.00 KiB/64.00 KiB @ 214.80 KiB/s (eta 0s )
  Programming ✔ [00:00:11] [######################################################################################################################################################################################################################################################] 41.00 KiB/41.00 KiB @ 3.58 KiB/s (eta 0s )    Finished in 12.151s
 WARN probe_rs::config::sequences::nxp_armv7m: MIMXRT10xx core type supplied as Armv7m, but the actual core is a Armv7em
```
