### PR TITLE
probe-rs-tools: do not panic when missing git

### DIFF
--- a/changelog/fixed-probe-rs-tools-missing-git-panic.md
+++ b/changelog/fixed-probe-rs-tools-missing-git-panic.md
@@ -1,0 +1,1 @@
+- Fixed probe-rs-tools compilation panicing when "git" is not installed.

--- a/probe-rs-tools/build.rs
+++ b/probe-rs-tools/build.rs
@@ -8,11 +8,14 @@ fn main() {
 fn generate_bin_versions() {
     const CARGO_VERSION: &str = env!("CARGO_PKG_VERSION");
     const GIT_VERSION: &str = git_version::git_version!(fallback = "crates.io");
-    let output = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .unwrap();
-    let git_rev = String::from_utf8(output.stdout).unwrap();
+
+    let git_rev = {
+        if let Ok(output) = Command::new("git").args(["rev-parse", "HEAD"]).output() {
+            String::from_utf8(output.stdout).unwrap()
+        } else {
+            "crates.io".to_string()
+        }
+    };
 
     println!("cargo:rustc-env=PROBE_RS_VERSION={CARGO_VERSION}");
     println!("cargo:rustc-env=PROBE_RS_LONG_VERSION={CARGO_VERSION} (git commit: {GIT_VERSION})");


### PR DESCRIPTION
If `git` doesn't exist during the build the build script will panic.

It is common not to have `git` installed in isolated build environments, such as docker containers or the nixpkgs sandbox.