### PR TITLE
Display multiple progress bars if necessary

### DIFF
--- a/changelog/fixed-multiple-chip-erase.md
+++ b/changelog/fixed-multiple-chip-erase.md
@@ -1,0 +1,1 @@
+Fixed an issue that could cause the chip to be erased in the middle of the flashing process.

--- a/changelog/fixed-multiple-progress-bars.md
+++ b/changelog/fixed-multiple-progress-bars.md
@@ -1,0 +1,1 @@
+Fixed progress bar display issues when programming multiple memory regions.

--- a/probe-rs-target/src/memory.rs
+++ b/probe-rs-target/src/memory.rs
@@ -66,6 +66,13 @@ pub struct SectorInfo {
     pub size: u64,
 }
 
+impl SectorInfo {
+    /// Returns the address range of the sector.
+    pub fn address_range(&self) -> Range<u64> {
+        self.base_address..self.base_address + self.size
+    }
+}
+
 /// Information about a group of flash sectors, which
 /// is used as part of the [`FlashProperties`] struct.
 ///
@@ -94,6 +101,13 @@ pub struct PageInfo {
     pub base_address: u64,
     /// Size of the page
     pub size: u32,
+}
+
+impl PageInfo {
+    /// Returns the address range of the sector.
+    pub fn address_range(&self) -> Range<u64> {
+        self.base_address..self.base_address + self.size as u64
+    }
 }
 
 /// Holds information about the entire flash.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/server/debugger.rs
@@ -679,18 +679,26 @@ impl Debugger {
                 let mut flash_progress = progress_state.borrow_mut();
                 let mut debug_adapter = rc_debug_adapter_clone.borrow_mut();
                 match event {
-                    ProgressEvent::Initialized { flash_layout } => {
-                        flash_progress.total_page_size =
-                            flash_layout.pages().iter().map(|s| s.size() as usize).sum();
+                    ProgressEvent::Initialized { phases, .. } => {
+                        for phase_layout in phases {
+                            flash_progress.total_page_size += phase_layout
+                                .pages()
+                                .iter()
+                                .map(|s| s.size() as usize)
+                                .sum::<usize>();
 
-                        flash_progress.total_sector_size = flash_layout
-                            .sectors()
-                            .iter()
-                            .map(|s| s.size() as usize)
-                            .sum();
+                            flash_progress.total_sector_size += phase_layout
+                                .sectors()
+                                .iter()
+                                .map(|s| s.size() as usize)
+                                .sum::<usize>();
 
-                        flash_progress.total_fill_size =
-                            flash_layout.fills().iter().map(|s| s.size() as usize).sum();
+                            flash_progress.total_fill_size += phase_layout
+                                .fills()
+                                .iter()
+                                .map(|s| s.size() as usize)
+                                .sum::<usize>();
+                        }
                     }
                     ProgressEvent::StartedFilling => {
                         debug_adapter

--- a/probe-rs-tools/src/bin/probe-rs/cmd/erase.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/erase.rs
@@ -1,4 +1,7 @@
-use probe_rs::{flashing::erase_all, probe::list::Lister};
+use probe_rs::{
+    flashing::{erase_all, FlashProgress},
+    probe::list::Lister,
+};
 
 use crate::util::common_options::ProbeOptions;
 
@@ -12,7 +15,7 @@ impl Cmd {
     pub fn run(self, lister: &Lister) -> anyhow::Result<()> {
         let (mut session, _probe_options) = self.common.simple_attach(lister)?;
 
-        erase_all(&mut session, None)?;
+        erase_all(&mut session, FlashProgress::empty())?;
 
         Ok(())
     }

--- a/probe-rs-tools/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/flash.rs
@@ -3,12 +3,14 @@ use crate::FormatOptions;
 use super::common_options::{BinaryDownloadOptions, LoadedProbeOptions, OperationError};
 use super::logging;
 
+use std::cell::RefCell;
 use std::fs::File;
 use std::time::Duration;
 use std::{path::Path, time::Instant};
 
 use colored::Colorize;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use probe_rs::flashing::FlashLayout;
 use probe_rs::InstructionSet;
 use probe_rs::{
     flashing::{DownloadOptions, FileDownloadError, FlashLoader, FlashProgress, ProgressEvent},
@@ -16,13 +18,6 @@ use probe_rs::{
 };
 
 use anyhow::Context;
-
-fn init_progress_bar(bar: &ProgressBar) {
-    let style = bar.style().progress_chars("##-");
-    bar.set_style(style);
-    bar.enable_steady_tick(Duration::from_millis(100));
-    bar.reset_elapsed();
-}
 
 /// Performs the flash download with the given loader. Ensure that the loader has the data to load already stored.
 /// This function also manages the update and display of progress bars.
@@ -34,9 +29,6 @@ pub fn run_flash_download(
     loader: FlashLoader,
     do_chip_erase: bool,
 ) -> Result<(), OperationError> {
-    // Start timer.
-    let instant = Instant::now();
-
     let mut options = DownloadOptions::default();
     options.keep_unwritten_bytes = download_options.restore_unwritten;
     options.dry_run = probe_options.dry_run();
@@ -49,99 +41,97 @@ pub fn run_flash_download(
         let multi_progress = MultiProgress::new();
         logging::set_progress_bar(multi_progress.clone());
 
-        let style = ProgressStyle::default_bar()
-                    .tick_chars("⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈✔")
-                    .progress_chars("--")
-                    .template("{msg:.green.bold} {spinner} [{elapsed_precise}] [{wide_bar}] {bytes:>8}/{total_bytes:>8} @ {bytes_per_sec:>10} (eta {eta:3})").expect("Error in progress bar creation. This is a bug, please report it.");
-
-        // Create a new progress bar for the fill progress if filling is enabled.
-        let fill_progress = if download_options.restore_unwritten {
-            let fill_progress = multi_progress.add(ProgressBar::new(0));
-            fill_progress.set_style(style.clone());
-            fill_progress.set_message("Reading flash");
-            Some(fill_progress)
-        } else {
-            None
-        };
-
-        // Create a new progress bar for the erase progress.
-        let erase_progress = multi_progress.add(ProgressBar::new(0));
-        erase_progress.set_style(style.clone());
-        erase_progress.set_message("      Erasing");
-
-        // Create a new progress bar for the program progress.
-        let program_progress = multi_progress.add(ProgressBar::new(0));
-        program_progress.set_style(style);
-        program_progress.set_message("  Programming");
+        let progress_bars = RefCell::new(ProgressBars {
+            erase: ProgressBarGroup::new("      Erasing"),
+            fill: ProgressBarGroup::new("Reading flash"),
+            program: ProgressBarGroup::new("  Programming"),
+        });
 
         // Register callback to update the progress.
         let flash_layout_output_path = download_options.flash_layout_output_path.clone();
-        let progress = FlashProgress::new(move |event| match event {
-            ProgressEvent::Initialized { flash_layout } => {
-                if let Some(fp) = fill_progress.as_ref() {
-                    let total_fill_size: u64 = flash_layout.fills().iter().map(|s| s.size()).sum();
-                    fp.set_length(total_fill_size);
-                }
+        let progress = FlashProgress::new(move |event| {
+            let mut progress_bars = progress_bars.borrow_mut();
 
-                let total_sector_size: u64 = flash_layout.sectors().iter().map(|s| s.size()).sum();
-                erase_progress.set_length(total_sector_size);
+            match event {
+                ProgressEvent::Initialized {
+                    chip_erase,
+                    phases,
+                    restore_unwritten,
+                } => {
+                    // Build progress bars.
+                    if chip_erase {
+                        progress_bars
+                            .erase
+                            .add(multi_progress.add(ProgressBar::new(0)));
+                    }
 
-                let visualizer = flash_layout.visualize();
-                flash_layout_output_path
-                    .as_ref()
-                    .map(|path| visualizer.write_svg(path));
-            }
-            ProgressEvent::StartedProgramming { length } => {
-                init_progress_bar(&program_progress);
-                program_progress.set_length(length);
-            }
-            ProgressEvent::StartedErasing => {
-                init_progress_bar(&erase_progress);
-            }
-            ProgressEvent::StartedFilling => {
-                if let Some(fp) = fill_progress.as_ref() {
-                    init_progress_bar(fp);
+                    if phases.len() > 1 {
+                        progress_bars.erase.append_phase();
+                        progress_bars.program.append_phase();
+                        progress_bars.fill.append_phase();
+                    }
+
+                    let mut flash_layout = FlashLayout::default();
+                    for phase_layout in phases {
+                        flash_layout.merge_from(phase_layout.clone());
+
+                        if restore_unwritten {
+                            let fill_size =
+                                flash_layout.fills().iter().map(|s| s.size()).sum::<u64>();
+                            progress_bars
+                                .fill
+                                .add(multi_progress.add(ProgressBar::new(fill_size)));
+                        }
+
+                        if !chip_erase {
+                            let sector_size =
+                                flash_layout.sectors().iter().map(|s| s.size()).sum::<u64>();
+                            progress_bars
+                                .erase
+                                .add(multi_progress.add(ProgressBar::new(sector_size)));
+                        }
+
+                        progress_bars
+                            .program
+                            .add(multi_progress.add(ProgressBar::new(0)));
+                    }
+
+                    // TODO: progress bar for verifying?
+
+                    // Visualise flash layout to file if requested.
+                    let visualizer = flash_layout.visualize();
+                    flash_layout_output_path
+                        .as_ref()
+                        .map(|path| visualizer.write_svg(path));
                 }
-            }
-            ProgressEvent::PageProgrammed { size, .. } => {
-                program_progress.inc(size as u64);
-            }
-            ProgressEvent::SectorErased { size, .. } => {
-                erase_progress.inc(size);
-            }
-            ProgressEvent::PageFilled { size, .. } => {
-                if let Some(fp) = fill_progress.as_ref() {
-                    fp.inc(size);
+                ProgressEvent::StartedProgramming { length } => {
+                    progress_bars.program.set_length(length);
                 }
-            }
-            ProgressEvent::FailedErasing => {
-                erase_progress.abandon();
-                program_progress.abandon();
-            }
-            ProgressEvent::FinishedErasing => {
-                erase_progress.finish();
-            }
-            ProgressEvent::FailedProgramming => {
-                program_progress.abandon();
-            }
-            ProgressEvent::FinishedProgramming => {
-                program_progress.finish();
-            }
-            ProgressEvent::FailedFilling => {
-                if let Some(fp) = fill_progress.as_ref() {
-                    fp.abandon();
+                ProgressEvent::StartedErasing => {}
+                ProgressEvent::StartedFilling => {}
+                ProgressEvent::PageProgrammed { size, .. } => {
+                    progress_bars.program.inc(size as u64);
                 }
-            }
-            ProgressEvent::FinishedFilling => {
-                if let Some(fp) = fill_progress.as_ref() {
-                    fp.finish();
+                ProgressEvent::SectorErased { size, .. } => progress_bars.erase.inc(size),
+                ProgressEvent::PageFilled { size, .. } => progress_bars.fill.inc(size),
+                ProgressEvent::FailedErasing => {
+                    progress_bars.erase.abandon();
+                    progress_bars.program.abandon();
                 }
+                ProgressEvent::FinishedErasing => progress_bars.erase.finish(),
+                ProgressEvent::FailedProgramming => progress_bars.program.abandon(),
+                ProgressEvent::FinishedProgramming => progress_bars.program.finish(),
+                ProgressEvent::FailedFilling => progress_bars.fill.abandon(),
+                ProgressEvent::FinishedFilling => progress_bars.fill.finish(),
+                ProgressEvent::DiagnosticMessage { .. } => {}
             }
-            ProgressEvent::DiagnosticMessage { .. } => (),
         });
 
         options.progress = Some(progress);
     }
+
+    // Start timer.
+    let flash_timer = Instant::now();
 
     loader
         .commit(session, options)
@@ -155,12 +145,10 @@ pub fn run_flash_download(
     // If we don't do this, the progress bars disappear.
     logging::clear_progress_bar();
 
-    // Stop timer.
-    let elapsed = instant.elapsed();
     logging::eprintln(format!(
         "    {} in {}s",
         "Finished".green().bold(),
-        elapsed.as_millis() as f32 / 1000.0,
+        flash_timer.elapsed().as_secs_f32(),
     ));
 
     Ok(())
@@ -188,4 +176,84 @@ pub fn build_loader(
     loader.load_image(session, &mut file, format, image_instruction_set)?;
 
     Ok(loader)
+}
+
+struct ProgressBars {
+    erase: ProgressBarGroup,
+    fill: ProgressBarGroup,
+    program: ProgressBarGroup,
+}
+
+struct ProgressBarGroup {
+    message: String,
+    bars: Vec<ProgressBar>,
+    selected: usize,
+    append_phase: bool,
+}
+
+impl ProgressBarGroup {
+    fn new(message: &str) -> Self {
+        Self {
+            message: message.to_string(),
+            bars: vec![],
+            selected: 0,
+            append_phase: false,
+        }
+    }
+
+    fn add(&mut self, bar: ProgressBar) {
+        let msg_template = "{msg:.green.bold} {spinner} [{elapsed_precise}] [{wide_bar}] {bytes:>8}/{total_bytes:>8} @ {bytes_per_sec:>10} (eta {eta:3})";
+        let style = ProgressStyle::default_bar()
+            .tick_chars("⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈✔")
+            .progress_chars("--")
+            .template(msg_template)
+            .expect("Error in progress bar creation. This is a bug, please report it.");
+
+        if self.append_phase {
+            bar.set_message(format!("{} {}", self.message, self.bars.len() + 1));
+        } else {
+            bar.set_message(self.message.clone());
+        }
+        bar.set_style(style);
+        bar.enable_steady_tick(Duration::from_millis(100));
+        bar.reset_elapsed();
+
+        self.bars.push(bar);
+    }
+
+    fn set_length(&mut self, length: u64) {
+        if let Some(bar) = self.bars.get(self.selected) {
+            bar.set_length(length);
+        }
+    }
+
+    fn inc(&mut self, size: u64) {
+        if let Some(bar) = self.bars.get(self.selected) {
+            let style = bar.style().progress_chars("##-");
+            bar.set_style(style);
+            bar.inc(size);
+        }
+    }
+
+    fn abandon(&mut self) {
+        if let Some(bar) = self.bars.get(self.selected) {
+            bar.abandon();
+        }
+        self.next();
+    }
+
+    fn finish(&mut self) {
+        if let Some(bar) = self.bars.get(self.selected) {
+            bar.finish();
+        }
+        self.next();
+    }
+
+    fn next(&mut self) {
+        self.selected += 1;
+    }
+
+    fn append_phase(&mut self) {
+        self.append_phase = true;
+    }
 }

--- a/probe-rs-tools/src/bin/probe-rs/util/flash.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/flash.rs
@@ -73,8 +73,6 @@ pub fn run_flash_download(
 
                     let mut flash_layout = FlashLayout::default();
                     for phase_layout in phases {
-                        flash_layout.merge_from(phase_layout.clone());
-
                         if restore_unwritten {
                             let fill_size =
                                 flash_layout.fills().iter().map(|s| s.size()).sum::<u64>();
@@ -94,6 +92,8 @@ pub fn run_flash_download(
                         progress_bars
                             .program
                             .add(multi_progress.add(ProgressBar::new(0)));
+
+                        flash_layout.merge_from(phase_layout);
                     }
 
                     // TODO: progress bar for verifying?

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -305,7 +305,7 @@ impl FlashBuilder {
             let range = info.base_address..page_end;
 
             // Ignore the page if it's outside the NvmRegion.
-            if !region.range.contains_range(&range.clone()) {
+            if !region.range.contains_range(&range) {
                 continue;
             }
 

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -107,6 +107,14 @@ pub struct FlashLayout {
 }
 
 impl FlashLayout {
+    /// Merge another flash layout into this one.
+    pub fn merge_from(&mut self, other: FlashLayout) {
+        self.sectors.extend(other.sectors);
+        self.pages.extend(other.pages);
+        self.fills.extend(other.fills);
+        self.data_blocks.extend(other.data_blocks);
+    }
+
     /// List of sectors which are erased during flashing.
     pub fn sectors(&self) -> &[FlashSector] {
         &self.sectors

--- a/probe-rs/src/flashing/builder.rs
+++ b/probe-rs/src/flashing/builder.rs
@@ -277,7 +277,7 @@ impl FlashBuilder {
         let mut data_blocks: Vec<FlashDataBlockSpan> = Vec::new();
 
         for info in flash_algorithm.iter_sectors() {
-            let range = info.base_address..info.base_address + info.size;
+            let range = info.address_range();
 
             // Ignore the sector if it's outside the NvmRegion.
             if !region.range.contains_range(&range) {
@@ -285,7 +285,7 @@ impl FlashBuilder {
             }
 
             let page = flash_algorithm.page_info(info.base_address).unwrap();
-            let page_range = page.base_address..page.base_address + page.size as u64;
+            let page_range = page.address_range();
             let sector_has_data = self.has_data_in_range(&range);
             let page_has_data = self.has_data_in_range(&page_range);
 
@@ -301,8 +301,7 @@ impl FlashBuilder {
         }
 
         for info in flash_algorithm.iter_pages() {
-            let page_end = info.base_address + info.size as u64;
-            let range = info.base_address..page_end;
+            let range = info.address_range();
 
             // Ignore the page if it's outside the NvmRegion.
             if !region.range.contains_range(&range) {
@@ -310,7 +309,7 @@ impl FlashBuilder {
             }
 
             let sector = flash_algorithm.sector_info(info.base_address).unwrap();
-            let sector_range = sector.base_address..sector.base_address + sector.size;
+            let sector_range = sector.address_range();
             let sector_has_data = self.has_data_in_range(&sector_range);
             let page_has_data = self.has_data_in_range(&range);
 
@@ -342,10 +341,10 @@ impl FlashBuilder {
             }
 
             // Fill the hole between the last data block (or page start if there are no blocks) and page end.
-            if fill_start_addr < page_end {
+            if fill_start_addr < range.end {
                 fills.push(FlashFill {
                     address: fill_start_addr,
-                    size: page_end - fill_start_addr,
+                    size: range.end - fill_start_addr,
                     page_index: pages.len(),
                 });
             }

--- a/probe-rs/src/flashing/encoder.rs
+++ b/probe-rs/src/flashing/encoder.rs
@@ -140,4 +140,8 @@ impl FlashEncoder {
     pub fn sectors(&self) -> &[FlashSector] {
         self.encoder.sectors()
     }
+
+    pub fn program_size(&self) -> u64 {
+        self.pages().iter().map(|p| p.data().len() as u64).sum()
+    }
 }

--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -11,7 +11,7 @@ use super::FlashProgress;
 ///
 /// The optional progress will only be used to emit RTT messages.
 /// No actual indication for the state of the erase all operation will be given.
-pub fn erase_all(session: &mut Session, progress: Option<FlashProgress>) -> Result<(), FlashError> {
+pub fn erase_all(session: &mut Session, progress: FlashProgress) -> Result<(), FlashError> {
     tracing::debug!("Erasing all...");
 
     let mut algos: HashMap<(String, String), Vec<NvmRegion>> = HashMap::new();
@@ -92,9 +92,10 @@ pub fn erase_all(session: &mut Session, progress: Option<FlashProgress>) -> Resu
 }
 
 /// Erases `sectors` sectors starting from `start_sector` from flash.
+// TODO: currently no progress is reported by anything in this function.
 pub fn erase_sectors(
     session: &mut Session,
-    progress: Option<FlashProgress>,
+    progress: FlashProgress,
     start_sector: usize,
     sectors: usize,
 ) -> Result<(), FlashError> {

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -789,10 +789,10 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
                 let mut buffer = vec![0; channel.buffer_size()];
                 match channel.read(&mut self.core, &mut buffer) {
                     Ok(read) if read > 0 => {
-                        let message = String::from_utf8_lossy(&buffer[..read]);
+                        let message = String::from_utf8_lossy(&buffer[..read]).to_string();
                         let channel = channel.name().unwrap_or("unnamed");
                         tracing::debug!("RTT({channel}): {message}");
-                        self.progress.message(message.as_ref());
+                        self.progress.message(message);
                     }
                     Ok(_) => (),
                     Err(error) => tracing::debug!("Reading RTT failed: {error}"),

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -799,10 +799,10 @@ impl<'probe, O: Operation> ActiveFlasher<'probe, O> {
                 let mut buffer = vec![0; channel.buffer_size()];
                 match channel.read(&mut self.core, &mut buffer) {
                     Ok(read) if read > 0 => {
-                        let message = String::from_utf8_lossy(&buffer[..read]).to_string();
+                        let message = String::from_utf8_lossy(&buffer[..read]);
                         let channel = channel.name().unwrap_or("unnamed");
                         tracing::debug!("RTT({channel}): {message}");
-                        self.progress.message(message);
+                        self.progress.message(message.as_ref());
                     }
                     Ok(_) => (),
                     Err(error) => tracing::debug!("Reading RTT failed: {error}"),

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -180,19 +180,21 @@ impl<'session> Flasher<'session> {
 
         for (offset, (original, read_back)) in algo.instructions.iter().zip(data.iter()).enumerate()
         {
-            if original != read_back {
-                tracing::error!(
-                    "Failed to verify flash algorithm. Data mismatch at address {:#010x}",
-                    algo.load_address + (4 * offset) as u64
-                );
-                tracing::error!("Original instruction: {:#010x}", original);
-                tracing::error!("Readback instruction: {:#010x}", read_back);
-
-                tracing::error!("Original: {:x?}", &algo.instructions);
-                tracing::error!("Readback: {:x?}", &data);
-
-                return Err(FlashError::FlashAlgorithmNotLoaded);
+            if original == read_back {
+                continue;
             }
+
+            tracing::error!(
+                "Failed to verify flash algorithm. Data mismatch at address {:#010x}",
+                algo.load_address + (4 * offset) as u64
+            );
+            tracing::error!("Original instruction: {:#010x}", original);
+            tracing::error!("Readback instruction: {:#010x}", read_back);
+
+            tracing::error!("Original: {:x?}", &algo.instructions);
+            tracing::error!("Readback: {:x?}", &data);
+
+            return Err(FlashError::FlashAlgorithmNotLoaded);
         }
 
         tracing::debug!("RAM contents match flashing algo blob.");

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -460,7 +460,7 @@ impl FlashLoader {
             }
         }
 
-        progress.initialized(complete_layout);
+        progress.initialized(&complete_layout);
 
         // Iterate all flash algorithms we need to use and do the flashing.
         for ((algo_name, core), regions) in algos {

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -462,11 +462,7 @@ impl FlashLoader {
             phases.push(phase_layout);
         }
 
-        progress.initialized(
-            do_chip_erase,
-            options.keep_unwritten_bytes,
-            phases.as_slice(),
-        );
+        progress.initialized(do_chip_erase, options.keep_unwritten_bytes, phases);
 
         // Iterate all flash algorithms we need to use and do the flashing.
         for ((algo_name, core), regions) in algos {

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -398,17 +398,13 @@ impl FlashLoader {
             }
 
             let algo = Self::get_flash_algorithm_for_region(region, session.target())?;
+            let core_name = region
+                .cores
+                .first()
+                .ok_or_else(|| FlashError::NoNvmCoreAccess(region.clone()))?
+                .clone();
 
-            let entry = algos
-                .entry((
-                    algo.name.clone(),
-                    region
-                        .cores
-                        .first()
-                        .ok_or_else(|| FlashError::NoNvmCoreAccess(region.clone()))?
-                        .clone(),
-                ))
-                .or_default();
+            let entry = algos.entry((algo.name.clone(), core_name)).or_default();
             entry.push(region.clone());
 
             tracing::debug!("     -- using algorithm: {}", algo.name);

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -27,6 +27,13 @@ impl FlashProgress {
         }
     }
 
+    /// Create a new `FlashProgress` structure with an empty handler.
+    pub fn empty() -> Self {
+        Self {
+            handler: Arc::new(|_| {}),
+        }
+    }
+
     /// Emit a flashing progress event.
     fn emit(&self, event: ProgressEvent) {
         (self.handler)(event);

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -40,8 +40,17 @@ impl FlashProgress {
     }
 
     /// Signalize that the flashing algorithm was set up and is initialized.
-    pub(super) fn initialized<'a>(&self, flash_layout: &'a FlashLayout) {
-        self.emit(ProgressEvent::Initialized { flash_layout });
+    pub(super) fn initialized<'a>(
+        &self,
+        chip_erase: bool,
+        restore_unwritten: bool,
+        phases: &'a [FlashLayout],
+    ) {
+        self.emit(ProgressEvent::Initialized {
+            chip_erase,
+            restore_unwritten,
+            phases,
+        });
     }
 
     /// Signalize that the erasing procedure started.
@@ -131,9 +140,18 @@ impl FlashProgress {
 pub enum ProgressEvent<'a> {
     /// The flash layout has been built and the flashing procedure was initialized.
     Initialized {
-        /// The layout of the flash contents as it will be used by the flash procedure.
+        /// Whether the chip erase feature is enabled.
+        /// If this is true, the chip will be erased before any other operation. No separate erase
+        /// progress bars are necessary in this case.
+        chip_erase: bool,
+
+        /// The layout of the flash contents as it will be used by the flash procedure, grouped by
+        /// phases (fill, erase, program sequences).
         /// This is an exact report of what the flashing procedure will do during the flashing process.
-        flash_layout: &'a FlashLayout,
+        phases: &'a [FlashLayout],
+
+        /// Whether the unwritten flash contents will be restored after erasing.
+        restore_unwritten: bool,
     },
     /// Filling of flash pages has started.
     StartedFilling,

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -40,11 +40,11 @@ impl FlashProgress {
     }
 
     /// Signalize that the flashing algorithm was set up and is initialized.
-    pub(super) fn initialized<'a>(
+    pub(super) fn initialized(
         &self,
         chip_erase: bool,
         restore_unwritten: bool,
-        phases: &'a [FlashLayout],
+        phases: Vec<FlashLayout>,
     ) {
         self.emit(ProgressEvent::Initialized {
             chip_erase,
@@ -113,7 +113,7 @@ impl FlashProgress {
         self.emit(ProgressEvent::FinishedFilling);
     }
 
-    pub(super) fn message<'a>(&self, message: &'a str) {
+    pub(super) fn message(&self, message: String) {
         self.emit(ProgressEvent::DiagnosticMessage { message });
     }
 }
@@ -137,7 +137,7 @@ impl FlashProgress {
 /// If an error occurs in any stage, one of the `Failed*` event will be returned,
 /// and no further events will be returned.
 #[derive(Debug)]
-pub enum ProgressEvent<'a> {
+pub enum ProgressEvent {
     /// The flash layout has been built and the flashing procedure was initialized.
     Initialized {
         /// Whether the chip erase feature is enabled.
@@ -148,7 +148,7 @@ pub enum ProgressEvent<'a> {
         /// The layout of the flash contents as it will be used by the flash procedure, grouped by
         /// phases (fill, erase, program sequences).
         /// This is an exact report of what the flashing procedure will do during the flashing process.
-        phases: &'a [FlashLayout],
+        phases: Vec<FlashLayout>,
 
         /// Whether the unwritten flash contents will be restored after erasing.
         restore_unwritten: bool,
@@ -200,6 +200,6 @@ pub enum ProgressEvent<'a> {
     /// a message was received from the algo.
     DiagnosticMessage {
         /// The message that was emitted.
-        message: &'a str,
+        message: String,
     },
 }

--- a/probe-rs/src/flashing/progress.rs
+++ b/probe-rs/src/flashing/progress.rs
@@ -40,7 +40,7 @@ impl FlashProgress {
     }
 
     /// Signalize that the flashing algorithm was set up and is initialized.
-    pub(super) fn initialized(&self, flash_layout: FlashLayout) {
+    pub(super) fn initialized<'a>(&self, flash_layout: &'a FlashLayout) {
         self.emit(ProgressEvent::Initialized { flash_layout });
     }
 
@@ -104,7 +104,7 @@ impl FlashProgress {
         self.emit(ProgressEvent::FinishedFilling);
     }
 
-    pub(super) fn message(&self, message: String) {
+    pub(super) fn message<'a>(&self, message: &'a str) {
         self.emit(ProgressEvent::DiagnosticMessage { message });
     }
 }
@@ -128,12 +128,12 @@ impl FlashProgress {
 /// If an error occurs in any stage, one of the `Failed*` event will be returned,
 /// and no further events will be returned.
 #[derive(Debug)]
-pub enum ProgressEvent {
+pub enum ProgressEvent<'a> {
     /// The flash layout has been built and the flashing procedure was initialized.
     Initialized {
         /// The layout of the flash contents as it will be used by the flash procedure.
         /// This is an exact report of what the flashing procedure will do during the flashing process.
-        flash_layout: FlashLayout,
+        flash_layout: &'a FlashLayout,
     },
     /// Filling of flash pages has started.
     StartedFilling,
@@ -182,6 +182,6 @@ pub enum ProgressEvent {
     /// a message was received from the algo.
     DiagnosticMessage {
         /// The message that was emitted.
-        message: String,
+        message: &'a str,
     },
 }

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -264,9 +264,9 @@ pub fn run_flash_erase(
     erase_type: EraseType,
 ) -> Result<()> {
     if let EraseSectors(start_sector, sectors) = erase_type {
-        erase_sectors(session, Some(progress), start_sector, sectors)?;
+        erase_sectors(session, progress, start_sector, sectors)?;
     } else {
-        erase_all(session, Some(progress))?;
+        erase_all(session, progress)?;
     }
 
     Ok(())


### PR DESCRIPTION
I would very much like to print the actual ranges instead of numbers, but we don't have the info for Programming at the point of initialization right now - we only calculate that range right before programming. The flasher does too many things right now for my taste but I don't have the brains to come up with something more suitable.

Also hidden in here is a fix that avoids multiple chip erases.