### PR TITLE
Clean up build script and builtin targets

### DIFF
--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -35,7 +35,7 @@ docsplay.workspace = true
 thiserror.workspace = true
 probe-rs-target.workspace = true
 
-bincode = "1.3"
+bincode = "1"
 bitfield = "0.15"
 bitflags = "2"
 bitvec = "1"

--- a/probe-rs/build.rs
+++ b/probe-rs/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs::{read_dir, read_to_string};
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use probe_rs_target::ChipFamily;
 
@@ -15,35 +15,33 @@ fn main() {
     println!("cargo:rerun-if-changed=targets");
     println!("cargo:rerun-if-env-changed=PROBE_RS_TARGETS_DIR");
 
-    let mut families: Vec<ChipFamily> = Vec::new();
+    let mut families = Vec::new();
 
     // Test if we have to generate built-in targets
     if env::var("CARGO_FEATURE_BUILTIN_TARGETS").is_ok() {
-        let mut files = vec![];
-        visit_dirs(Path::new("targets"), &mut files).unwrap();
+        let mut process_target_yaml = |file: &Path| {
+            let string = read_to_string(file).unwrap_or_else(|error| {
+                panic!(
+                    "Failed to read target file {} because:\n{error}",
+                    file.display()
+                )
+            });
+
+            match serde_yaml::from_str::<ChipFamily>(&string) {
+                Ok(family) => families.push(family),
+                Err(error) => panic!(
+                    "Failed to parse target file: {} because:\n{error}",
+                    file.display()
+                ),
+            }
+        };
+
+        visit_dirs("targets", &mut process_target_yaml).unwrap();
 
         // Check if there are any additional targets to generate for
-        match env::var("PROBE_RS_TARGETS_DIR") {
-            Ok(additional_target_dir) => {
-                println!("cargo:rerun-if-changed={additional_target_dir}");
-                visit_dirs(Path::new(&additional_target_dir), &mut files).unwrap();
-            }
-            Err(_err) => {
-                // Do nothing as you dont have to add any other targets
-            }
-        }
-
-        for file in files {
-            let string = read_to_string(&file).expect(
-                "Algorithm definition file could not be read. This is a bug. Please report it.",
-            );
-
-            let yaml: Result<ChipFamily, _> = serde_yaml::from_str(&string);
-
-            match yaml {
-                Ok(familiy) => families.push(familiy),
-                Err(e) => panic!("Failed to parse target file: {file:?} because:\n{e}"),
-            }
+        if let Ok(additional_target_dir) = env::var("PROBE_RS_TARGETS_DIR") {
+            println!("cargo:rerun-if-changed={additional_target_dir}");
+            visit_dirs(additional_target_dir, &mut process_target_yaml).unwrap();
         }
     }
 
@@ -54,28 +52,35 @@ fn main() {
     let dest_path = Path::new(&out_dir).join("targets.bincode");
     std::fs::write(dest_path, &families_bin).unwrap();
 
-    let _: Vec<ChipFamily> = match bincode::deserialize(&families_bin) {
-        Ok(chip_families) => chip_families,
-        Err(deserialize_error) => panic!(
+    // Check if we can deserialize the bincode again, otherwise the binary will not be usable.
+    if let Err(deserialize_error) = bincode::deserialize::<Vec<ChipFamily>>(&families_bin) {
+        panic!(
             "Failed to deserialize supported target definitions from bincode: {deserialize_error:?}"
-        ),
-    };
+        );
+    }
 }
 
-/// One possible implementation of walking a directory only visiting files.
-fn visit_dirs(dir: &Path, targets: &mut Vec<PathBuf>) -> io::Result<()> {
-    if dir.is_dir() {
+/// Call `process` on all files in a directory and its subdirectories.
+fn visit_dirs(dir: impl AsRef<Path>, process: &mut impl FnMut(&Path)) -> io::Result<()> {
+    // Inner function to avoid generating multiple implementations for the different path types.
+    fn visit_dirs_impl(dir: &Path, process: &mut impl FnMut(&Path)) -> io::Result<()> {
         for entry in read_dir(dir)? {
             let entry = entry?;
             let path = entry.path();
             if path.is_dir() {
-                visit_dirs(&path, targets)?;
-            } else if let Some(extension) = path.extension() {
-                if extension.eq_ignore_ascii_case("yaml") {
-                    targets.push(path);
-                }
+                visit_dirs_impl(&path, process)?;
+            } else {
+                process(&path);
             }
         }
+
+        Ok(())
     }
-    Ok(())
+
+    let dir = dir.as_ref();
+    if !dir.is_dir() {
+        return Ok(());
+    }
+
+    visit_dirs_impl(dir, process)
 }

--- a/probe-rs/src/config/registry.rs
+++ b/probe-rs/src/config/registry.rs
@@ -123,17 +123,10 @@ struct Registry {
 
 impl Registry {
     fn from_builtin_families() -> Self {
-        #[cfg(feature = "builtin-targets")]
-        let mut families = {
-            const BUILTIN_TARGETS: &[u8] =
-                include_bytes!(concat!(env!("OUT_DIR"), "/targets.bincode"));
+        const BUILTIN_TARGETS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/targets.bincode"));
 
-            bincode::deserialize(BUILTIN_TARGETS)
-                .expect("Failed to deserialize builtin targets. This is a bug")
-        };
-
-        #[cfg(not(feature = "builtin-targets"))]
-        let mut families = vec![];
+        let mut families = bincode::deserialize(BUILTIN_TARGETS)
+            .expect("Failed to deserialize builtin targets. This is a bug");
 
         add_generic_targets(&mut families);
 


### PR DESCRIPTION
Simplify registry a tiny bit by always deserializing *something*. The impact should be negligible, and I think the result's simplicity is preferable.

Alternative:
Do some of the cleanups in this PR, but make `bincode` optional via `builtin-targets`. This would not change the library code, but allow stripping out a dependency.