### PR TITLE
Provide prebuilts with musl libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,10 @@ ci = ["github"]
 targets = [
     "aarch64-apple-darwin",
     "aarch64-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
     "x86_64-apple-darwin",
     "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
     "x86_64-pc-windows-msvc",
 ]
 # Build only the required packages, and individually
@@ -67,6 +69,7 @@ install-updater = false
 # Select custom runner for ARM Linux
 [workspace.metadata.dist.github-custom-runners]
 aarch64-unknown-linux-gnu = "buildjet-2vcpu-ubuntu-2204-arm"
+aarch64-unknown-linux-musl = "buildjet-2vcpu-ubuntu-2204-arm"
 
 [workspace.metadata.dist.dependencies.apt]
 libudev-dev = '*'

--- a/changelog/added-musl.md
+++ b/changelog/added-musl.md
@@ -1,0 +1,1 @@
+Provide prebuilts with musl libc


### PR DESCRIPTION
This will build binaries that can hopefully run on a raspberry pi. The installer script will still not properly install these because we build with 22.04 (see [this](https://github.com/axodotdev/cargo-dist/issues/519)) but at least a binary should be available.