### PR TITLE
Rtt initialization cleanup

### DIFF
--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -120,15 +120,11 @@ enum RttControlBlockHeader {
 }
 
 impl RttControlBlockHeader {
-    pub fn try_from_header(is_64_bit: bool, mem: &[u8]) -> Result<Self, Error> {
+    pub fn try_from_header(is_64_bit: bool, mem: &[u8]) -> Option<Self> {
         if is_64_bit {
-            RttControlBlockHeaderInner::<u64>::read_from(mem)
-                .ok_or(Error::ControlBlockNotFound)
-                .map(Self::Header64)
+            RttControlBlockHeaderInner::<u64>::read_from(mem).map(Self::Header64)
         } else {
-            RttControlBlockHeaderInner::<u32>::read_from(mem)
-                .ok_or(Error::ControlBlockNotFound)
-                .map(Self::Header32)
+            RttControlBlockHeaderInner::<u32>::read_from(mem).map(Self::Header32)
         }
     }
 
@@ -235,7 +231,8 @@ impl Rtt {
             }
         };
 
-        let rtt_header = RttControlBlockHeader::try_from_header(is_64_bit, &mem)?;
+        let rtt_header = RttControlBlockHeader::try_from_header(is_64_bit, &mem)
+            .ok_or(Error::ControlBlockNotFound)?;
 
         // Validate that the control block starts with the ID bytes
         let rtt_id = rtt_header.id();

--- a/probe-rs/src/rtt.rs
+++ b/probe-rs/src/rtt.rs
@@ -122,13 +122,13 @@ enum RttControlBlockHeader {
 impl RttControlBlockHeader {
     pub fn try_from_header(is_64_bit: bool, mem: &[u8]) -> Result<Self, Error> {
         if is_64_bit {
-            RttControlBlockHeaderInner::<u32>::read_from(mem)
-                .ok_or(Error::ControlBlockNotFound)
-                .map(Self::Header32)
-        } else {
             RttControlBlockHeaderInner::<u64>::read_from(mem)
                 .ok_or(Error::ControlBlockNotFound)
                 .map(Self::Header64)
+        } else {
+            RttControlBlockHeaderInner::<u32>::read_from(mem)
+                .ok_or(Error::ControlBlockNotFound)
+                .map(Self::Header32)
         }
     }
 
@@ -249,7 +249,7 @@ impl Rtt {
         }
 
         let max_up_channels = rtt_header.max_up_channels();
-        let max_down_channels = rtt_header.max_up_channels();
+        let max_down_channels = rtt_header.max_down_channels();
 
         // *Very* conservative sanity check, most people only use a handful of RTT channels
         if max_up_channels > 255 || max_down_channels > 255 {

--- a/probe-rs/src/rtt/channels.rs
+++ b/probe-rs/src/rtt/channels.rs
@@ -11,6 +11,17 @@ use std::collections::{
 pub struct Channels<T: RttChannel>(pub(crate) BTreeMap<usize, T>);
 
 impl<T: RttChannel> Channels<T> {
+    /// Creates a new empty list of channels.
+    pub fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// Appends a channel to the list.
+    pub fn push(&mut self, channel: T) {
+        let i = self.0.len();
+        self.0.insert(i, channel);
+    }
+
     /// Returns the number of channels on the list.
     pub fn len(&self) -> usize {
         self.0.len()

--- a/probe-rs/src/rtt/channels.rs
+++ b/probe-rs/src/rtt/channels.rs
@@ -1,25 +1,22 @@
 //! List of RTT channels.
 
+use std::vec::IntoIter;
+
 use crate::rtt::RttChannel;
-use std::collections::{
-    btree_map::{IntoValues, Values},
-    BTreeMap,
-};
 
 /// List of RTT channels.
 #[derive(Debug)]
-pub struct Channels<T: RttChannel>(pub(crate) BTreeMap<usize, T>);
+pub struct Channels<T: RttChannel>(pub(crate) Vec<Option<T>>);
 
 impl<T: RttChannel> Channels<T> {
     /// Creates a new empty list of channels.
     pub fn new() -> Self {
-        Self(BTreeMap::new())
+        Self(Vec::new())
     }
 
     /// Appends a channel to the list.
     pub fn push(&mut self, channel: T) {
-        let i = self.0.len();
-        self.0.insert(i, channel);
+        self.0.push(Some(channel));
     }
 
     /// Returns the number of channels on the list.
@@ -34,26 +31,37 @@ impl<T: RttChannel> Channels<T> {
 
     /// Returns a reference to the channel corresponding to the number.
     pub fn get(&mut self, number: usize) -> Option<&T> {
-        self.0.get(&number)
+        self.0.get(number).and_then(|c| c.as_ref())
     }
 
     /// Removes the channel corresponding to the number from the list and returns it.
     pub fn take(&mut self, number: usize) -> Option<T> {
-        self.0.remove(&number)
+        self.0.get_mut(number).and_then(|c| c.take())
     }
 
     /// Gets and iterator over the channels on the list, sorted by number.
-    pub fn iter(&self) -> Values<'_, usize, T> {
-        self.0.values()
+    pub fn iter(&self) -> impl Iterator<Item = &'_ T> + '_ {
+        self.0.iter().filter_map(|c| c.as_ref())
     }
 }
 
 impl<T: RttChannel> IntoIterator for Channels<T> {
     type Item = T;
-    type IntoIter = IntoValues<usize, T>;
+    type IntoIter = ChannelsIter<T>;
 
     /// Consumes the channel list and returns an iterator over the channels.
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_values()
+        ChannelsIter(self.0.into_iter())
+    }
+}
+
+/// Iterator over the channels on the list.
+pub struct ChannelsIter<T: RttChannel>(IntoIter<Option<T>>);
+
+impl<T: RttChannel> Iterator for ChannelsIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().and_then(|c| c)
     }
 }

--- a/probe-rs/src/rtt/channels.rs
+++ b/probe-rs/src/rtt/channels.rs
@@ -8,6 +8,12 @@ use crate::rtt::RttChannel;
 #[derive(Debug)]
 pub struct Channels<T: RttChannel>(pub(crate) Vec<Option<T>>);
 
+impl<T: RttChannel> Default for Channels<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T: RttChannel> Channels<T> {
     /// Creates a new empty list of channels.
     pub fn new() -> Self {


### PR DESCRIPTION
Here I'm hiding a bunch of 32/64bit decision inside the existing structs and also deduplicating some of the code. Other changes include updating some address prints to the `{:#010x}` pattern we use, shortening a message to fix rustfmt, and making some code generally a bit more readable.

I'm also replacing the BTreeMap in Channels with Vec<Option>. The resulting code is a tad bit more complex, but there's really no reason to build a tree here.