### PR TITLE
Fix: Debug unwind stops when LR is zero.

### DIFF
--- a/changelog/fixed-debug-unwind-stops-early.md
+++ b/changelog/fixed-debug-unwind-stops-early.md
@@ -1,0 +1,1 @@
+The debug stack unwind will continue attempting an unwind when encountering a 0(zero) value for the Link Register (LR).

--- a/probe-rs/src/debug/debug_info.rs
+++ b/probe-rs/src/debug/debug_info.rs
@@ -671,16 +671,6 @@ impl DebugInfo {
                 stack_frames.push(exception_frame);
                 // We have everything we need to unwind the next frame in the stack.
                 continue 'unwind;
-            } else {
-                // Check LR values to determine if we can continue unwinding.
-                if unwind_registers
-                    .get_return_address()
-                    .map(|lr| lr.is_zero() || lr.is_max_value())
-                    .unwrap_or(true)
-                {
-                    tracing::trace!("UNWIND: Stack unwind complete - Reached the 'Reset' value of the LR register.");
-                    break;
-                }
             };
 
             // PART 2: Setup the registers for the next iteration (a.k.a. unwind previous frame, a.k.a. "callee", in the call stack).


### PR DESCRIPTION
The unwind processed checked LR against being 0 or max (e.g. 0xFFFF_FFFF for u32). If either condition was true, it would stop trying to unwind. 

In the case of a 0 value, on arm, the Rust compiler sometimes uses LR (register 14) as a scratch, and it is possible to have a legitimate 0 value.

In the case of the max, this was a hangover from when we only supported ARM, and represented the ABI calling standard "reset value". This is not the same for Risc-V.

In addition to being  invalid, neither of these conditions are necessary to control the unwind, as confirmed by manual testing as well as the fairly extensive automated testing we have in this area.