### PR TITLE
Trim dependency features, clean up some code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,21 +176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_fs"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec"
-dependencies = [
- "anstyle",
- "doc-comment",
- "globwalk",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "tempfile",
-]
-
-[[package]]
 name = "async-io"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,25 +693,6 @@ name = "crossbeam-channel"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1405,30 +1371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "globset"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags 2.5.0",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "goblin"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,22 +1600,6 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "ignore"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata 0.4.6",
- "same-file",
- "walkdir",
- "winapi-util",
 ]
 
 [[package]]
@@ -2937,15 +2863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "sanitize-filename"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3412,7 +3329,6 @@ version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "assert_fs",
  "clap",
  "cmsis-pack",
  "colored",
@@ -3426,6 +3342,7 @@ dependencies = [
  "reqwest",
  "scroll",
  "serde_yaml",
+ "tempfile",
  "tokio",
  "tracing-subscriber",
  "xshell",
@@ -3972,16 +3889,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,17 +43,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,16 +520,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,15 +575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79f4473f5144e20d9aceaf2972478f06ddf687831eafeeb434fbaf0acc4144ad"
 dependencies = [
  "error-code",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -674,12 +644,6 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "core-foundation"
@@ -985,7 +949,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1182,9 +1145,9 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fd-lock"
@@ -1220,7 +1183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -1572,15 +1534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,15 +1716,6 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
-
-[[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array 0.14.7",
-]
 
 [[package]]
 name = "insta"
@@ -1957,16 +1901,6 @@ checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
 dependencies = [
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "libz-ng-sys"
-version = "1.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5"
-dependencies = [
- "cmake",
- "libc",
 ]
 
 [[package]]
@@ -2368,16 +2302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,12 +2402,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
 name = "predicates"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,6 +2465,7 @@ dependencies = [
  "docsplay",
  "dunce",
  "espflash",
+ "fastrand",
  "futures-lite",
  "gdbstub",
  "gimli 0.29.0",
@@ -2566,7 +2485,6 @@ dependencies = [
  "pretty_assertions",
  "pretty_env_logger",
  "probe-rs-target",
- "rand",
  "rmp-serde",
  "scroll",
  "serde",
@@ -2621,6 +2539,7 @@ dependencies = [
  "directories",
  "docsplay",
  "dunce",
+ "fastrand",
  "figment",
  "gimli 0.29.0",
  "git-version",
@@ -2640,7 +2559,6 @@ dependencies = [
  "probe-rs",
  "probe-rs-mi",
  "probe-rs-target",
- "rand",
  "ratatui",
  "regex",
  "rustyline",
@@ -2719,36 +2637,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "ratatui"
@@ -3263,17 +3151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,12 +3199,6 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "similar"
@@ -3959,12 +3830,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
 name = "typed-path"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4518,20 +4383,6 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]
 
 [[package]]
 name = "zip"
@@ -4539,38 +4390,18 @@ version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c700ea425e148de30c29c580c1f9508b93ca57ad31c9f4e96b83c194c37a7a8f"
 dependencies = [
- "aes",
  "arbitrary",
  "bzip2",
- "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "deflate64",
  "displaydoc",
  "flate2",
- "hmac",
  "indexmap",
  "lzma-rs",
- "pbkdf2",
- "rand",
- "sha1",
  "thiserror",
  "time",
- "zeroize",
- "zopfli",
  "zstd",
-]
-
-[[package]]
-name = "zopfli"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1f48f3508a3a3f2faee01629564400bc12260f6214a056d06a3aaaa6ef0736"
-dependencies = [
- "crc32fast",
- "log",
- "simd-adler32",
- "typed-arena",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,12 +1071,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,15 +2162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,16 +2717,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,7 +3021,6 @@ dependencies = [
  "log",
  "memchr",
  "nix 0.28.0",
- "radix_trie",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,10 +1308,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand",
  "futures-core",
- "futures-io",
- "parking",
  "pin-project-lite",
 ]
 
@@ -2575,7 +2572,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "static_assertions",
  "svg",
  "termtree",
  "test-case",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,7 +2566,6 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "parse_int",
- "paste",
  "pretty_assertions",
  "pretty_env_logger",
  "probe-rs-target",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1866,6 +1866,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itm"
 version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,7 +2557,7 @@ dependencies = [
  "hidapi",
  "ihex",
  "insta",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "itm",
  "jep106",
  "miniz_oxide",
@@ -2623,7 +2632,7 @@ dependencies = [
  "goblin",
  "indicatif",
  "insta",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "itm",
  "jep106",
  "libtest-mimic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,10 +1788,8 @@ version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eab73f58e59ca6526037208f0e98851159ec1633cf17b6cd2e1f2c3fd5d53cc"
 dependencies = [
- "console",
  "lazy_static",
  "linked-hash-map",
- "regex",
  "serde",
  "similar",
 ]

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -56,7 +56,7 @@ defmt-decoder = { version = "=0.3.11", features = [
 directories = { version = "5" }
 dunce = { version = "1" }
 figment = { version = "0.10", features = ["toml", "json", "yaml", "env"] }
-goblin = { version = "0.8" }
+goblin = { version = "0.8", default-features = false, features = ["elf32", "elf64", "endian_fd"] }
 indicatif = { version = "0.17" }
 insta = { version = "1.38", default-features = false, features = [
     "yaml",

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -58,10 +58,7 @@ dunce = { version = "1" }
 figment = { version = "0.10", features = ["toml", "json", "yaml", "env"] }
 goblin = { version = "0.8", default-features = false, features = ["elf32", "elf64", "endian_fd"] }
 indicatif = { version = "0.17" }
-insta = { version = "1.38", default-features = false, features = [
-    "yaml",
-    "filters",
-] }
+insta = { version = "1.38", default-features = false, features = ["yaml"] }
 itm = { version = "0.9.0-rc.1", default-features = false }
 parse_int = "0.6"
 libtest-mimic = { version = "0.7.2" }

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -67,14 +67,12 @@ rustyline = { version = "14", default-features = false, features = ["with-dirs",
 sanitize-filename = { version = "0.5" }
 schemafy = { version = "0.6" }
 serde_json = { version = "1.0.116" }
-signal-hook = "0.3"
+signal-hook = { version = "0.3", default-features = false }
 svd-parser = { version = "0.14", features = ["expand"] }
 termtree = { version = "0.4" }
-textwrap = { version = "0.16" }
+textwrap = { version = "0.16", default-features = false, features = ["unicode-linebreak", "unicode-width"] }
 time = { version = "0.3", default-features = false, features = [
-    "alloc",
     "formatting",
-    "large-dates",
     "macros",
     "local-offset",
 ] }

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -43,33 +43,33 @@ probe-rs-mi = { workspace = true }
 itertools = "0.13"
 
 # CLI-only
-addr2line = { version = "0.22" }
-bytesize = { version = "1" }
-capstone = { version = "0.12" }
-cargo_metadata = { version = "0.18" }
+addr2line = "0.22"
+bytesize = "1"
+capstone = "0.12"
+cargo_metadata = "0.18"
 clap = { version = "4", features = ["derive", "env"] }
-colored = { version = "2" }
-crossterm = { version = "<= 0.27" }
+colored = "2"
+crossterm = "<= 0.27"
 defmt-decoder = { version = "=0.3.11", features = [
     "unstable",
 ] } # pinned because "unstable" has potential for breaking changes
-directories = { version = "5" }
-dunce = { version = "1" }
+directories = "5"
+dunce = "1"
 figment = { version = "0.10", features = ["toml", "json", "yaml", "env"] }
 goblin = { version = "0.8", default-features = false, features = ["elf32", "elf64", "endian_fd"] }
-indicatif = { version = "0.17" }
+indicatif = "0.17"
 insta = { version = "1.38", default-features = false, features = ["yaml"] }
 itm = { version = "0.9.0-rc.1", default-features = false }
 parse_int = "0.6"
-libtest-mimic = { version = "0.7.2" }
-rand = { version = "0.8" }
+libtest-mimic = "0.7.2"
+rand = "0.8"
 rustyline = { version = "14", default-features = false, features = ["with-dirs", "with-file-history"] }
-sanitize-filename = { version = "0.5" }
-schemafy = { version = "0.6" }
-serde_json = { version = "1.0.116" }
+sanitize-filename = "0.5"
+schemafy = "0.6"
+serde_json = "1.0.116"
 signal-hook = { version = "0.3", default-features = false }
 svd-parser = { version = "0.14", features = ["expand"] }
-termtree = { version = "0.4" }
+termtree = "0.4"
 textwrap = { version = "0.16", default-features = false, features = ["unicode-linebreak", "unicode-width"] }
 time = { version = "0.3", default-features = false, features = [
     "formatting",
@@ -77,7 +77,7 @@ time = { version = "0.3", default-features = false, features = [
     "local-offset",
 ] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-tracing-appender = { version = "0.2" }
+tracing-appender = "0.2"
 ratatui = { version = "0.26.2", default-features = false, features = [
     "crossterm",
 ] }
@@ -95,7 +95,7 @@ zip = "1.1.4"
 urlencoding = "2"
 
 [build-dependencies]
-git-version = { version = "0.3" }
+git-version = "0.3"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -62,7 +62,7 @@ insta = { version = "1.38", default-features = false, features = ["yaml"] }
 itm = { version = "0.9.0-rc.1", default-features = false }
 parse_int = "0.6"
 libtest-mimic = "0.7.2"
-rand = "0.8"
+fastrand = "2.1"
 rustyline = { version = "14", default-features = false, features = ["with-dirs", "with-file-history"] }
 sanitize-filename = "0.5"
 schemafy = "0.6"
@@ -91,7 +91,14 @@ cargo-config2 = "0.1.26"
 clap_complete = "4.5.2"
 regex = "1.10.4"
 semver = "1"
-zip = "1.1.4"
+zip = { version = "1.1.4", default-features = false, features = [
+    "bzip2",
+    "deflate64",
+    "deflate",
+    "lzma",
+    "time",
+    "zstd",
+] }
 urlencoding = "2"
 
 [build-dependencies]

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -40,7 +40,7 @@ typed-path = "0.8"
 probe-rs-target = { workspace = true }
 probe-rs-mi = { workspace = true }
 
-itertools = { version = "0.12" }
+itertools = "0.13"
 
 # CLI-only
 addr2line = { version = "0.22" }

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -63,7 +63,7 @@ itm = { version = "0.9.0-rc.1", default-features = false }
 parse_int = "0.6"
 libtest-mimic = { version = "0.7.2" }
 rand = { version = "0.8" }
-rustyline = { version = "14" }
+rustyline = { version = "14", default-features = false, features = ["with-dirs", "with-file-history"] }
 sanitize-filename = { version = "0.5" }
 schemafy = { version = "0.6" }
 serde_json = { version = "1.0.116" }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/benchmark.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/benchmark.rs
@@ -5,7 +5,6 @@ use std::{
 
 use anyhow::Context;
 use probe_rs::{probe::list::Lister, MemoryInterface};
-use rand::prelude::*;
 
 use crate::util::common_options::LoadedProbeOptions;
 use crate::util::common_options::ProbeOptions;
@@ -230,7 +229,7 @@ impl DataType {
     }
 
     pub fn fill_data(&mut self, data_size_words: usize) {
-        let mut rng = rand::thread_rng();
+        let mut rng = fastrand::Rng::new();
         match self {
             DataType::U8(ref mut test_data, ref mut read_data) => {
                 *test_data = vec![0u8; data_size_words];
@@ -240,12 +239,16 @@ impl DataType {
             DataType::U32(ref mut test_data, ref mut read_data) => {
                 *test_data = vec![0u32; data_size_words];
                 *read_data = vec![0u32; data_size_words];
-                rng.fill(&mut test_data[..]);
+                for out in test_data.iter_mut() {
+                    *out = rng.u32(..);
+                }
             }
             DataType::U64(ref mut test_data, ref mut read_data) => {
                 *test_data = vec![0u64; data_size_words];
                 *read_data = vec![0u64; data_size_words];
-                rng.fill(&mut test_data[..]);
+                for out in test_data.iter_mut() {
+                    *out = rng.u64(..);
+                }
             }
         }
     }

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/mod.rs
@@ -4,7 +4,7 @@ mod rttui;
 
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
-use colored::*;
+use colored::Colorize;
 use parking_lot::FairMutex;
 use probe_rs::gdb_server::GdbInstanceConfiguration;
 use probe_rs::probe::list::Lister;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/diagnostics.rs
@@ -1,5 +1,5 @@
 /// Error handling
-use colored::*;
+use colored::{ColoredString, Colorize};
 use std::error::Error;
 use std::fmt::Write;
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_flash/mod.rs
@@ -1,7 +1,7 @@
 mod diagnostics;
 
 use clap::Parser;
-use colored::*;
+use colored::Colorize;
 use diagnostics::render_diagnostics;
 use probe_rs::probe::list::Lister;
 use std::ffi::OsString;

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/dap_types.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/dap_types.rs
@@ -1,17 +1,13 @@
-// Ignore clippy warning in the `schemafy!` output
-#![allow(clippy::derive_partial_eq_without_eq)]
-
 // use crate::dap_types2 as debugserver_types;
 use crate::cmd::dap_server::DebuggerError;
 use crate::util::rtt;
 use num_traits::Num;
 use parse_int::parse;
-use schemafy::schemafy;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
 // Convert the MSDAP `debugAdaptor.json` file into Rust types.
-schemafy!(root: debugserver_types "src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/debugProtocol.json");
+schemafy::schemafy!(root: debugserver_types "src/bin/probe-rs/cmd/dap_server/debug_adapter/dap/debugProtocol.json");
 
 /// Memory addresses come in as strings, but we want to use them as u64s.
 pub struct MemoryAddress(pub u64);

--- a/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/dap_server/mod.rs
@@ -1,6 +1,5 @@
 // Bad things happen to the VSCode debug extenison and debug_adapter if we panic at the wrong time.
 #![warn(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
-// Uses Schemafy to generate DAP types from Json
 mod debug_adapter;
 mod peripherals;
 mod server;

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -101,7 +101,7 @@ itm = { version = "0.9.0-rc.1", default-features = false }
 pretty_assertions = "1"
 test-case = "3"
 termtree = "0.4"
-insta = { version = "1.38", features = ["yaml", "filters"] }
+insta = { version = "1.38", default-features = false, features = ["yaml"] }
 
 [[package.metadata.release.pre-release-replacements]]
 file = "../CHANGELOG.md"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -30,12 +30,15 @@ builtin-targets = []
 test = []
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow.workspace = true
+docsplay.workspace = true
+thiserror.workspace = true
+probe-rs-target.workspace = true
+
 bincode = "1.3"
 bitfield = "0.15"
 bitflags = "2"
 bitvec = "1"
-docsplay = { workspace = true }
 gimli = { version = "0.29", default-features = false, features = [
     "endian-reader",
     "read",
@@ -54,19 +57,18 @@ object = { version = "0.35", default-features = false, features = [
     "read_core",
     "std",
 ] }
-nusb = { version = "0.1.9" }
+nusb = "0.1.9"
 futures-lite = { version = "2", default-features = false }
 async-io = "2"
 scroll = "0.12"
 svg = "0.17"
-thiserror = { workspace = true }
 tracing = { version = "0.1", features = ["log"] }
 uf2-decode = "0.2"
 typed-path = "0.8"
 espflash = { version = "3", default-features = false }
-dunce = { version = "1" }
+dunce = "1"
 parse_int = "0.6"
-parking_lot = { version = "0.12.2" }
+parking_lot = "0.12.2"
 zerocopy = "0.7.32"
 zerocopy-derive = "0.7.32"
 
@@ -76,15 +78,14 @@ rmp-serde = "1"
 
 # optional
 hexdump = { version = "0.1", optional = true }
-# path
-probe-rs-target = { workspace = true }
 
 # gdb server
 gdbstub = { version = "0.7", optional = true }
 
 [build-dependencies]
+probe-rs-target.workspace = true
+
 bincode = "1"
-probe-rs-target = { workspace = true }
 serde_yaml = "0.9"
 
 [dev-dependencies]

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -46,7 +46,7 @@ hidapi = { version = "2", default-features = false, features = [
     "linux-native",
 ] }
 ihex = "3.0"
-itertools = "0.12.1"
+itertools = "0.13"
 jep106 = "0.2"
 once_cell = "1"
 miniz_oxide = "0.7"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -90,7 +90,7 @@ serde_yaml = "0.9"
 
 [dev-dependencies]
 pretty_env_logger = "0.5"
-rand = "0.8"
+fastrand = "2.1"
 serde_json = "1"
 serde = "1"
 clap = { version = "4", features = ["derive"] }

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -54,12 +54,11 @@ object = { version = "0.35", default-features = false, features = [
     "std",
 ] }
 nusb = { version = "0.1.9" }
-futures-lite = "2"
+futures-lite = { version = "2", default-features = false }
 async-io = "2"
 scroll = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
-static_assertions = "1"
 svg = "0.17"
 thiserror = { workspace = true }
 tracing = { version = "0.1", features = ["log"] }

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -23,10 +23,8 @@ exclude = ["tests/"]
 default = ["builtin-targets"]
 gdb-server = ["dep:gdbstub"]
 
-
 # Enable all built in targets.
 builtin-targets = []
-
 
 # Enable helpers for testing
 test = []
@@ -55,7 +53,6 @@ object = { version = "0.35", default-features = false, features = [
     "read_core",
     "std",
 ] }
-paste = "1"
 nusb = { version = "0.1.9" }
 futures-lite = "2"
 async-io = "2"
@@ -90,7 +87,6 @@ bincode = "1"
 probe-rs-target = { workspace = true }
 serde_yaml = "0.9"
 
-
 [dev-dependencies]
 pretty_env_logger = "0.5"
 rand = "0.8"
@@ -111,7 +107,6 @@ replace = "## [{{version}}]\n\nReleased {{date}}"
 file = "../CHANGELOG.md"
 search = "\\[unreleased\\]: https://github.com/probe-rs/probe-rs/compare/v([a-z0-9.-]+)\\.\\.\\.master"
 replace = "[unreleased]: https://github.com/probe-rs/probe-rs/compare/v{{version}}...master\n[{{version}}]: https://github.com/probe-rs/probe-rs/compare/v$1...v{{version}}"
-
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/probe-rs-tools-{ target }-v{ version }{ archive-suffix }"

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -33,6 +33,7 @@ test = []
 anyhow = { workspace = true }
 bincode = "1.3"
 bitfield = "0.15"
+bitflags = "2"
 bitvec = "1"
 docsplay = { workspace = true }
 gimli = { version = "0.29", default-features = false, features = [
@@ -57,21 +58,21 @@ nusb = { version = "0.1.9" }
 futures-lite = { version = "2", default-features = false }
 async-io = "2"
 scroll = "0.12"
-serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.9"
 svg = "0.17"
 thiserror = { workspace = true }
 tracing = { version = "0.1", features = ["log"] }
 uf2-decode = "0.2"
-rmp-serde = "1"
 typed-path = "0.8"
-bitflags = "2"
 espflash = { version = "3", default-features = false }
 dunce = { version = "1" }
 parse_int = "0.6"
 parking_lot = { version = "0.12.2" }
 zerocopy = "0.7.32"
 zerocopy-derive = "0.7.32"
+
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
+rmp-serde = "1"
 
 # optional
 hexdump = { version = "0.1", optional = true }

--- a/probe-rs/examples/ram_download.rs
+++ b/probe-rs/examples/ram_download.rs
@@ -5,8 +5,6 @@ use clap::Parser;
 use std::num::ParseIntError;
 use std::time::{Duration, Instant};
 
-use rand::prelude::*;
-
 use anyhow::{anyhow, Context, Result};
 
 #[derive(clap::Parser)]
@@ -65,11 +63,13 @@ fn main() -> Result<()> {
 
     let data_size_bytes = data_size_words * 4;
 
-    let mut rng = rand::thread_rng();
+    let mut rng = fastrand::Rng::new();
 
     let mut sample_data = vec![0u32; data_size_words];
 
-    rng.fill(&mut sample_data[..]);
+    for out in sample_data.iter_mut() {
+        *out = rng.u32(..);
+    }
 
     core.halt(Duration::from_millis(100))
         .expect("Halting failed");

--- a/probe-rs/src/architecture/arm/component/itm.rs
+++ b/probe-rs/src/architecture/arm/component/itm.rs
@@ -88,7 +88,6 @@ mod register {
     use crate::memory_mapped_bitfield_register;
 
     memory_mapped_bitfield_register! {
-        #[allow(non_camel_case_types)]
         pub struct ITM_TER(u32);
         0xE00,"ITM_TER",
         impl From;

--- a/probe-rs/src/architecture/arm/component/scs.rs
+++ b/probe-rs/src/architecture/arm/component/scs.rs
@@ -41,7 +41,6 @@ mod register {
 
     memory_mapped_bitfield_register! {
         /// B3.2.3 CPUID Base Register
-        #[allow(non_camel_case_types)]
         pub struct CPUID(u32);
         0xD00, "CPUID",
         impl From;

--- a/probe-rs/src/core/memory_mapped_registers.rs
+++ b/probe-rs/src/core/memory_mapped_registers.rs
@@ -80,6 +80,8 @@ macro_rules! memory_mapped_bitfield_register {
             $(#[$outer])*
             #[doc= concat!("A [`bitfield::bitfield!`] register mapping for the register `",  $reg_name, "` located at address `", stringify!($addr), "`.")]
             #[derive(Copy, Clone)]
+            #[allow(clippy::upper_case_acronyms)]
+            #[allow(non_camel_case_types)]
             ($vis_modifier) struct $struct_name($reg_type);
             impl Debug;
             $($rest)*

--- a/probe-rs/src/core/memory_mapped_registers.rs
+++ b/probe-rs/src/core/memory_mapped_registers.rs
@@ -76,15 +76,13 @@ macro_rules! memory_mapped_bitfield_register {
     };
     ($(#[$outer:meta])* $vis_modifier:vis struct $struct_name:ident($reg_type:ty); $addr:expr, $reg_name:expr, $($rest:tt)*) => {
         // Using paste here, because as of bitfield = "0.14.0" they do not use the 'vis' specifier, and balks at being passed a visibility token.
-        paste::paste!{
-            bitfield::bitfield!{
-                $(#[$outer])*
-                #[doc= concat!("A [`bitfield::bitfield!`] register mapping for the register `",  $reg_name, "` located at address `", stringify!($addr), "`.")]
-                #[derive(Copy, Clone)]
-                $vis_modifier struct $struct_name($reg_type);
-                impl Debug;
-                $($rest)*
-            }
+        bitfield::bitfield!{
+            $(#[$outer])*
+            #[doc= concat!("A [`bitfield::bitfield!`] register mapping for the register `",  $reg_name, "` located at address `", stringify!($addr), "`.")]
+            #[derive(Copy, Clone)]
+            ($vis_modifier) struct $struct_name($reg_type);
+            impl Debug;
+            $($rest)*
         }
 
         impl $crate::MemoryMappedRegister<$reg_type> for $struct_name {

--- a/probe-rs/src/session.rs
+++ b/probe-rs/src/session.rs
@@ -778,7 +778,11 @@ impl Session {
 }
 
 // This test ensures that [Session] is fully [Send] + [Sync].
-static_assertions::assert_impl_all!(Session: Send);
+const _: fn() = || {
+    fn assert_impl_all<T: ?Sized + Send>() {}
+
+    assert_impl_all::<Session>();
+};
 
 // TODO tiwalun: Enable again, after rework of Session::new is done.
 impl Drop for Session {

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -17,7 +17,7 @@ license.workspace = true
 [dependencies]
 probe-rs = { path = "../probe-rs", version = "0.24.0", default-features = false }
 probe-rs-target = { path = "../probe-rs-target", version = "0.24.0", default-features = false }
-cmsis-pack = { version = "0.7.0" }
+cmsis-pack = "0.7.0"
 goblin = { version = "0.8.2", default-features = false, features = [
     "elf32",
     "elf64",
@@ -43,7 +43,7 @@ tracing-subscriber = { version = "0.3.18", features = [
     "tracing-log",
 ] }
 xshell = { version = "0.2", default-features = false }
-parse_int = { version = "0.6.0" }
+parse_int = "0.6"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -26,7 +26,7 @@ goblin = { version = "0.8.2", default-features = false, features = [
     "std",
 ] }
 scroll = "0.12.0"
-serde_yaml = "^0.9.34"
+serde_yaml = "0.9"
 log = "0.4.21"
 zip = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -28,7 +28,14 @@ goblin = { version = "0.8.2", default-features = false, features = [
 scroll = "0.12.0"
 serde_yaml = "0.9"
 log = "0.4.21"
-zip = "1.0.0"
+zip = { version = "1.1.4", default-features = false, features = [
+    "bzip2",
+    "deflate64",
+    "deflate",
+    "lzma",
+    "time",
+    "zstd",
+] }
 clap = { version = "4.5", features = ["derive"] }
 colored = "2"
 anyhow = "1.0.82"

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -55,4 +55,4 @@ parse_int = "0.6"
 [dev-dependencies]
 assert_cmd = "2.0.14"
 predicates = "3.1.0"
-assert_fs = "1.1.1"
+tempfile = "3.0"

--- a/target-gen/tests/extract_pack.rs
+++ b/target-gen/tests/extract_pack.rs
@@ -18,7 +18,7 @@ fn missing_output_directory() {
 #[test]
 fn extract_target_specs() {
     // create a temporary directory
-    let temp = assert_fs::TempDir::new().unwrap();
+    let temp = tempfile::TempDir::new().unwrap();
 
     let mut cmd = Command::cargo_bin("target-gen").unwrap();
 


### PR DESCRIPTION
Note that the textwrap change may end up changing the default wrap algorithm depending on the outcome of https://github.com/zkat/miette/pull/379 but the effect shouldn't be important.

Also includes parts of https://github.com/probe-rs/probe-rs/pull/2441

The big change is caused by removing rand and crypto crates:
 - we don't need it in examples and benchmark, fastrand should be just enough
 - we don't currently decompress encrypted ZIPs, which require rand and a bunch of crypto