### PR TITLE
Check new fragments, comment if changelog fragment is invalid

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,7 +28,6 @@ jobs:
           cache-on-failure: "true"
 
       - name: Check that fragments are valid
-        run:  cargo xtask check-changelog
+        run:  cargo xtask check-changelog --pr ${{ github.event.number }} --comment-error
         env:
           GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.number }}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -289,14 +289,11 @@ fn check_new_changelog_fragments(list: &mut FragmentList, info: &PrInfo) -> Resu
 }
 
 #[derive(Debug, serde::Deserialize)]
-struct PrFile {
-    path: PathBuf,
-    additions: usize,
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct Label {
-    name: String,
+struct PrInfo {
+    number: u64,
+    author: PrAuthor,
+    labels: Vec<Label>,
+    files: Vec<PrFile>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -305,12 +302,16 @@ struct PrAuthor {
 }
 
 #[derive(Debug, serde::Deserialize)]
-struct PrInfo {
-    number: u64,
-    author: PrAuthor,
-    labels: Vec<Label>,
-    files: Vec<PrFile>,
+struct Label {
+    name: String,
 }
+
+#[derive(Debug, serde::Deserialize)]
+struct PrFile {
+    path: PathBuf,
+    additions: usize,
+}
+
 impl PrInfo {
     fn load(pr_number: u64) -> Result<Self> {
         let sh = Shell::new()?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -139,57 +139,67 @@ impl FragmentList {
     }
 
     fn display(&self) -> String {
-        let mut message = String::new();
-        if self.invalid_fragments.is_empty() {
-            writeln!(
-                &mut message,
-                "Found {} valid fragments:",
-                self.fragments.len()
-            )
-            .unwrap();
-
-            for (group, fragments) in self.fragments.iter() {
-                if fragments.is_empty() {
-                    continue;
-                }
-
-                writeln!(&mut message, " {group}:").unwrap();
-
-                for fragment in fragments {
-                    writeln!(
-                        &mut message,
-                        "  - {} (#{}) by @{}",
-                        fragment.path.display(),
-                        fragment.pr_number.as_deref().unwrap_or("<unknown>"),
-                        fragment.author.as_deref().unwrap_or("<unknown>")
-                    )
-                    .unwrap();
-                }
-            }
+        if self.is_ok() {
+            self.ok_message()
         } else {
-            message.push_str(
-                "The following changelog fragments \
-                do not match the expected pattern:\n",
-            );
+            self.error_message()
+        }
+    }
 
-            for invalid_fragment in self.invalid_fragments.iter() {
-                writeln!(&mut message, " - {}", invalid_fragment.display()).unwrap();
+    fn ok_message(&self) -> String {
+        let mut message = String::new();
+        writeln!(
+            &mut message,
+            "Found {} valid fragments:",
+            self.fragments.len()
+        )
+        .unwrap();
+
+        for (group, fragments) in self.fragments.iter() {
+            if fragments.is_empty() {
+                continue;
             }
-            message.push('\n');
 
-            message.push_str(
-                "Files should start with one of the categories followed \
-                by a dash, and end with '.md'\n\
-                For example: 'added-foo-bar.md'\n\
-                \n",
-            );
+            writeln!(&mut message, " {group}:").unwrap();
 
-            message.push_str("Valid categories are:\n");
-            for category in CHANGELOG_CATEGORIES {
-                writeln!(&mut message, " - {}", category.to_lowercase()).unwrap();
+            for fragment in fragments {
+                writeln!(
+                    &mut message,
+                    "  - {} (#{}) by @{}",
+                    fragment.path.display(),
+                    fragment.pr_number.as_deref().unwrap_or("<unknown>"),
+                    fragment.author.as_deref().unwrap_or("<unknown>")
+                )
+                .unwrap();
             }
         }
 
+        message
+    }
+
+    fn error_message(&self) -> String {
+        let mut message = String::new();
+        message.push_str(
+            "The following changelog fragments \
+            do not match the expected pattern:\n",
+        );
+
+        for invalid_fragment in self.invalid_fragments.iter() {
+            writeln!(&mut message, " - {}", invalid_fragment.display()).unwrap();
+        }
+        message.push('\n');
+
+        message.push_str(
+            "Files should start with one of the categories followed \
+            by a dash, and end with '.md'\n\
+            For example: 'added-foo-bar.md'\n\
+            \n",
+        );
+
+        message.push_str("Valid categories are:\n");
+        for category in CHANGELOG_CATEGORIES {
+            writeln!(&mut message, " - {}", category.to_lowercase()).unwrap();
+        }
         message
     }
 }


### PR DESCRIPTION
Unfortunately as of https://github.com/probe-rs/probe-rs/pull/2504 the xtask can not check new fragments properly from the file system because the checked out sources don't contain the PR's changes.

This PR rewrites changelog checks into two parts:
 - local checks that go through all changelog/ files
 - PR check that goes through changes in a PR. This also allows commenting back the results, via a switch so the script can be called locally without litering on a PR.

The PR also changes how the github API is called, which means we no longer have to pass the token to it explicitly.

Demo is #2517