### PR TITLE
Remove log feature from probe-rs tracing dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,9 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3628,7 +3628,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -3649,7 +3648,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/changelog/removed-tracing-log.md
+++ b/changelog/removed-tracing-log.md
@@ -1,0 +1,1 @@
+probe-rs should no longer emit `log` events via `tracing`. You can re-enable this by adding `tracing = { version = "0.1", features = ["log"] }` to your crate's Cargo.toml.

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -34,7 +34,7 @@ object = { version = "0.35", default-features = false, features = [
 scroll = "0.12"
 serde = { version = "1", features = ["derive"] }
 thiserror = { workspace = true }
-tracing = { version = "0.1", features = ["log"] }
+tracing = "0.1"
 typed-path = "0.8"
 # path
 probe-rs-target = { workspace = true }

--- a/probe-rs/Cargo.toml
+++ b/probe-rs/Cargo.toml
@@ -62,7 +62,7 @@ futures-lite = { version = "2", default-features = false }
 async-io = "2"
 scroll = "0.12"
 svg = "0.17"
-tracing = { version = "0.1", features = ["log"] }
+tracing = "0.1"
 uf2-decode = "0.2"
 typed-path = "0.8"
 espflash = { version = "3", default-features = false }


### PR DESCRIPTION
This allows the application to control whether or not it wants log tracing instead of being always enabled by the library crate. probe-rs-tools already specifies this feature.

More context from the Matrix chat: https://matrix.to/#/!vhKMWjizPZBgKeknOo:matrix.org/$ywmxH6VFKCSGCu4mSi-BavtEKc52QQadJ0k55mkw-9g?via=matrix.org&via=chat.berline.rs&via=tchncs.de