### PR TITLE
Enable timestamps by default in probe-rs

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
@@ -265,7 +265,6 @@ impl RunLoop {
         let mut rtt_config = rtt::RttConfig::default();
         rtt_config.channels.push(rtt::RttChannelConfig {
             channel_number: Some(0),
-            show_timestamps: true,
             show_location: !self.no_location,
             log_format: self.log_format.clone(),
             ..Default::default()

--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
@@ -265,6 +265,7 @@ impl RunLoop {
         let mut rtt_config = rtt::RttConfig::default();
         rtt_config.channels.push(rtt::RttChannelConfig {
             channel_number: Some(0),
+            show_timestamps: true,
             show_location: !self.no_location,
             log_format: self.log_format.clone(),
             ..Default::default()

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -144,7 +144,7 @@ impl Default for RttChannelConfig {
             channel_number: Default::default(),
             data_format: Default::default(),
             mode: Default::default(),
-            show_timestamps: true,
+            show_timestamps: default_show_timestamps(),
             show_location: Default::default(),
             log_format: Default::default(),
         }

--- a/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
+++ b/probe-rs-tools/src/bin/probe-rs/util/rtt.rs
@@ -114,7 +114,7 @@ impl RttConfig {
 }
 
 /// The User specified configuration for each active RTT Channel.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RttChannelConfig {
     pub channel_number: Option<usize>,
@@ -136,6 +136,19 @@ pub struct RttChannelConfig {
     #[serde(default)]
     /// Controls the output format for DataFormat::Defmt.
     pub log_format: Option<String>,
+}
+
+impl Default for RttChannelConfig {
+    fn default() -> Self {
+        RttChannelConfig {
+            channel_number: Default::default(),
+            data_format: Default::default(),
+            mode: Default::default(),
+            show_timestamps: true,
+            show_location: Default::default(),
+            log_format: Default::default(),
+        }
+    }
 }
 
 pub enum ChannelDataFormat {


### PR DESCRIPTION
This looks like an oversight to me, because otherwise there is no way to get timestamps from defmt. Note that setting this to true is not enough to enable timestamps in defmt, the defmt table still needs to have timestamps. Also the default for serde is true.