### PR TITLE
Add support for the LPC54102 series

### DIFF
--- a/changelog/added-lpc54102-family.md
+++ b/changelog/added-lpc54102-family.md
@@ -1,1 +1,1 @@
-Add support for the LPC54102 family (4 chips).
+Add support for the LPC54102 family (only the primary Cortex-M4F is supported, not the secondary Cortex-M0+).

--- a/changelog/added-lpc54102-family.md
+++ b/changelog/added-lpc54102-family.md
@@ -1,0 +1,1 @@
+Add support for the LPC54102 family (4 chips).

--- a/probe-rs/targets/LPC54102.yaml
+++ b/probe-rs/targets/LPC54102.yaml
@@ -1,0 +1,241 @@
+name: LPC54102
+generated_from_pack: true
+pack_file_release: 12.0.1
+variants:
+- name: LPC54102J256BD64
+  cores:
+  - name: cm0plus
+    type: armv6m
+    core_access_options: !Arm
+      ap: 1
+      psel: 0
+  - name: cm4
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM0
+    range:
+      start: 0x2000000
+      end: 0x2010000
+    cores:
+    - cm0plus
+    - cm4
+  - !Ram
+    name: SRAM1
+    range:
+      start: 0x2010000
+      end: 0x2018000
+    cores:
+    - cm0plus
+    - cm4
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x3400000
+      end: 0x3402000
+    cores:
+    - cm0plus
+    - cm4
+  - !Nvm
+    name: PROGRAM_FLASH
+    range:
+      start: 0x0
+      end: 0x40000
+    is_boot_memory: true
+    cores:
+    - cm0plus
+    - cm4
+  flash_algorithms:
+  - lpc5410x_256
+- name: LPC54102J256UK49
+  cores:
+  - name: cm0plus
+    type: armv6m
+    core_access_options: !Arm
+      ap: 1
+      psel: 0
+  - name: cm4
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM0
+    range:
+      start: 0x2000000
+      end: 0x2010000
+    cores:
+    - cm0plus
+    - cm4
+  - !Ram
+    name: SRAM1
+    range:
+      start: 0x2010000
+      end: 0x2018000
+    cores:
+    - cm0plus
+    - cm4
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x3400000
+      end: 0x3402000
+    cores:
+    - cm0plus
+    - cm4
+  - !Nvm
+    name: PROGRAM_FLASH
+    range:
+      start: 0x0
+      end: 0x40000
+    is_boot_memory: true
+    cores:
+    - cm0plus
+    - cm4
+  flash_algorithms:
+  - lpc5410x_256
+- name: LPC54102J512BD64
+  cores:
+  - name: cm0plus
+    type: armv6m
+    core_access_options: !Arm
+      ap: 1
+      psel: 0
+  - name: cm4
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM0
+    range:
+      start: 0x2000000
+      end: 0x2010000
+    cores:
+    - cm0plus
+    - cm4
+  - !Ram
+    name: SRAM1
+    range:
+      start: 0x2010000
+      end: 0x2018000
+    cores:
+    - cm0plus
+    - cm4
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x3400000
+      end: 0x3402000
+    cores:
+    - cm0plus
+    - cm4
+  - !Nvm
+    name: PROGRAM_FLASH
+    range:
+      start: 0x0
+      end: 0x80000
+    is_boot_memory: true
+    cores:
+    - cm0plus
+    - cm4
+  flash_algorithms:
+  - lpc5410x_512
+- name: LPC54102J512UK49
+  cores:
+  - name: cm0plus
+    type: armv6m
+    core_access_options: !Arm
+      ap: 1
+      psel: 0
+  - name: cm4
+    type: armv7em
+    core_access_options: !Arm
+      ap: 0
+      psel: 0
+  memory_map:
+  - !Ram
+    name: SRAM0
+    range:
+      start: 0x2000000
+      end: 0x2010000
+    cores:
+    - cm0plus
+    - cm4
+  - !Ram
+    name: SRAM1
+    range:
+      start: 0x2010000
+      end: 0x2018000
+    cores:
+    - cm0plus
+    - cm4
+  - !Ram
+    name: SRAM2
+    range:
+      start: 0x3400000
+      end: 0x3402000
+    cores:
+    - cm0plus
+    - cm4
+  - !Nvm
+    name: PROGRAM_FLASH
+    range:
+      start: 0x0
+      end: 0x80000
+    is_boot_memory: true
+    cores:
+    - cm0plus
+    - cm4
+  flash_algorithms:
+  - lpc5410x_512
+flash_algorithms:
+- name: lpc5410x_256
+  description: LPC5410x IAP 256kB Flash
+  default: true
+  instructions: wAtwR0hJR0hJRAhgR0gAIQFgQWBFSQEggDEIYAIgQQcIcAAgcEcAIHBH+LVATDIgTEQhRgAlByZhxBQxPEg9T0hEDDwAkbhHYGkAKA3RNCBhxDVISEQAaCBgNUgMPEhEAJm4R2BpACgA0AEg+L34tS9NxAsyIE1EEcUpRgwxLEgsTixgD0ZIRAg9sEdoaQAoDtE0IBHFJEgsYEhEAGhoYCNIOUZIRAg9sEdoaQAoANABIPi9+LUURgYADtEDzGJoQBghaIkYQBihaEAY4WhAGCFpQBhAQmBhCDwVTfALTUQyIWhgKWCoYClGFDERTyhGAJG4R2hpACgR0TMgrGBBxQEggAJoYAhISEQAaKhgCEgIPUhEAJm4R2hpACgA0AEg+L0AAOAuAAAEAAAAgAAAQAgAAAAFAgADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  load_address: 0x2000020
+  pc_init: 0x5
+  pc_uninit: 0x27
+  pc_program_page: 0xb5
+  pc_erase_sector: 0x6f
+  pc_erase_all: 0x2b
+  data_section_offset: 0x138
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x40000
+    page_size: 0x400
+    erased_byte_value: 0xff
+    program_page_timeout: 300
+    erase_sector_timeout: 3000
+    sectors:
+    - size: 0x8000
+      address: 0x0
+- name: lpc5410x_512
+  description: LPC5410x IAP 512kB Flash
+  default: true
+  instructions: wAtwR0hJR0hJRAhgR0gAIQFgQWBFSQEggDEIYAIgQQcIcAAgcEcAIHBH+LVATDIgTEQhRgAlDyZhxBQxPEg9T0hEDDwAkbhHYGkAKA3RNCBhxDVISEQAaCBgNUgMPEhEAJm4R2BpACgA0AEg+L34tS9NxAsyIE1EEcUpRgwxLEgsTixgD0ZIRAg9sEdoaQAoDtE0IBHFJEgsYEhEAGhoYCNIOUZIRAg9sEdoaQAoANABIPi9+LUURgYADtEDzGJoQBghaIkYQBihaEAY4WhAGCFpQBhAQmBhCDwVTfALTUQyIWhgKWCoYClGFDERTyhGAJG4R2hpACgR0TMgrGBBxQEggAJoYAhISEQAaKhgCEgIPUhEAJm4R2hpACgA0AEg+L0AAOAuAAAEAAAAgAAAQAgAAAAFAgADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  load_address: 0x2000020
+  pc_init: 0x5
+  pc_uninit: 0x27
+  pc_program_page: 0xb5
+  pc_erase_sector: 0x6f
+  pc_erase_all: 0x2b
+  data_section_offset: 0x138
+  flash_properties:
+    address_range:
+      start: 0x0
+      end: 0x80000
+    page_size: 0x400
+    erased_byte_value: 0xff
+    program_page_timeout: 300
+    erase_sector_timeout: 3000
+    sectors:
+    - size: 0x8000
+      address: 0x0

--- a/probe-rs/targets/LPC54102.yaml
+++ b/probe-rs/targets/LPC54102.yaml
@@ -4,11 +4,11 @@ pack_file_release: 12.0.1
 variants:
 - name: LPC54102J256BD64
   cores:
-  - name: cm0plus
-    type: armv6m
-    core_access_options: !Arm
-      ap: 1
-      psel: 0
+  # - name: cm0plus
+  #   type: armv6m
+  #   core_access_options: !Arm
+  #     ap: 1
+  #     psel: 0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
@@ -21,7 +21,7 @@ variants:
       start: 0x2000000
       end: 0x2010000
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   - !Ram
     name: SRAM1
@@ -29,7 +29,7 @@ variants:
       start: 0x2010000
       end: 0x2018000
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   - !Ram
     name: SRAM2
@@ -37,7 +37,7 @@ variants:
       start: 0x3400000
       end: 0x3402000
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   - !Nvm
     name: PROGRAM_FLASH
@@ -46,17 +46,17 @@ variants:
       end: 0x40000
     is_boot_memory: true
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   flash_algorithms:
   - lpc5410x_256
 - name: LPC54102J256UK49
   cores:
-  - name: cm0plus
-    type: armv6m
-    core_access_options: !Arm
-      ap: 1
-      psel: 0
+  # - name: cm0plus
+  #   type: armv6m
+  #   core_access_options: !Arm
+  #     ap: 1
+  #     psel: 0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
@@ -69,7 +69,7 @@ variants:
       start: 0x2000000
       end: 0x2010000
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   - !Ram
     name: SRAM1
@@ -77,7 +77,7 @@ variants:
       start: 0x2010000
       end: 0x2018000
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   - !Ram
     name: SRAM2
@@ -85,7 +85,7 @@ variants:
       start: 0x3400000
       end: 0x3402000
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   - !Nvm
     name: PROGRAM_FLASH
@@ -94,17 +94,17 @@ variants:
       end: 0x40000
     is_boot_memory: true
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   flash_algorithms:
   - lpc5410x_256
 - name: LPC54102J512BD64
   cores:
-  - name: cm0plus
-    type: armv6m
-    core_access_options: !Arm
-      ap: 1
-      psel: 0
+  # - name: cm0plus
+  #   type: armv6m
+  #   core_access_options: !Arm
+  #     ap: 1
+  #     psel: 0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
@@ -117,7 +117,7 @@ variants:
       start: 0x2000000
       end: 0x2010000
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   - !Ram
     name: SRAM1
@@ -125,7 +125,7 @@ variants:
       start: 0x2010000
       end: 0x2018000
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   - !Ram
     name: SRAM2
@@ -133,7 +133,7 @@ variants:
       start: 0x3400000
       end: 0x3402000
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   - !Nvm
     name: PROGRAM_FLASH
@@ -142,17 +142,17 @@ variants:
       end: 0x80000
     is_boot_memory: true
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   flash_algorithms:
   - lpc5410x_512
 - name: LPC54102J512UK49
   cores:
-  - name: cm0plus
-    type: armv6m
-    core_access_options: !Arm
-      ap: 1
-      psel: 0
+  # - name: cm0plus
+  #   type: armv6m
+  #   core_access_options: !Arm
+  #     ap: 1
+  #     psel: 0
   - name: cm4
     type: armv7em
     core_access_options: !Arm
@@ -165,7 +165,7 @@ variants:
       start: 0x2000000
       end: 0x2010000
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   - !Ram
     name: SRAM1
@@ -173,7 +173,7 @@ variants:
       start: 0x2010000
       end: 0x2018000
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   - !Ram
     name: SRAM2
@@ -181,7 +181,7 @@ variants:
       start: 0x3400000
       end: 0x3402000
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   - !Nvm
     name: PROGRAM_FLASH
@@ -190,7 +190,7 @@ variants:
       end: 0x80000
     is_boot_memory: true
     cores:
-    - cm0plus
+    # - cm0plus
     - cm4
   flash_algorithms:
   - lpc5410x_512


### PR DESCRIPTION
This commit adds the YAML file generated by the great `target-gen`-tool provided in this repository (using the following command):
```shell
$ target-gen arm -f LPC54102 probe-rs/targets
```
This is a sub-series of the LPC54xxx microcontrollers: the [datasheet] groups the LPC54102 chips of this commit together with the LPC54101- chips, which are different as they don't have a secondary Cortex-M0+- core. Therefore they have a different CMSIS-pack and should be in a separate file.

[datasheet]: https://www.nxp.com/docs/en/data-sheet/LPC5410X.pdf