### PR TITLE
cargo-embed: Respect RUST_LOG unless configured

### DIFF
--- a/changelog/fixed-cargo-embed-log.md
+++ b/changelog/fixed-cargo-embed-log.md
@@ -1,0 +1,1 @@
+Use `RUST_LOG` as the log filter if `Embed.toml` does not specify a level.

--- a/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml
@@ -39,7 +39,8 @@ halt_afterwards = false
 chip_descriptions = []
 # The default log level to be used. Possible values are one of:
 #   "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"
-log_level = "WARN"
+#   If not set, the `RUST_LOG` environment variable will be used.
+# log_level = "WARN"
 # Use this flag to assert the nreset & ntrst pins during attaching the probe to the chip.
 connect_under_reset = false
 


### PR DESCRIPTION
The log level was already optional in code, but had a default value. As RUST_LOG allows more flexible filtering and still defaults to WARN, this PR removes the TOML's default.

The PR also replaces the std RwLock to parking_lot's Mutex, which is somewhat cleaner.