### PR TITLE
Trim zip features a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,27 +382,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4310,7 +4289,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd56a4d5921bc2f99947ac5b3abe5f510b1be7376fdc5e9fce4a23c6a93e87c"
 dependencies = [
  "arbitrary",
- "bzip2",
  "crc32fast",
  "crossbeam-utils",
  "deflate64",

--- a/probe-rs-tools/Cargo.toml
+++ b/probe-rs-tools/Cargo.toml
@@ -92,12 +92,8 @@ clap_complete = "4.5.2"
 regex = "1.10.4"
 semver = "1"
 zip = { version = "2.0.0", default-features = false, features = [
-    "bzip2",
-    "deflate64",
     "deflate",
-    "lzma",
     "time",
-    "zstd",
 ] }
 urlencoding = "2"
 

--- a/target-gen/Cargo.toml
+++ b/target-gen/Cargo.toml
@@ -29,7 +29,6 @@ scroll = "0.12.0"
 serde_yaml = "0.9"
 log = "0.4.21"
 zip = { version = "2.0.0", default-features = false, features = [
-    "bzip2",
     "deflate64",
     "deflate",
     "lzma",


### PR DESCRIPTION
The binary only does compression, so I'm removing the decompression-only features as well as unused compression methods.

I don't think we need to work with bzip2 in target-gen, so I'm removing that to get rid of a dependency, but I'm not adamant on this point.