### PR TITLE
Do not attempt to execute an empty batch

### DIFF
--- a/changelog/fixed-panic-empty-batch.md
+++ b/changelog/fixed-panic-empty-batch.md
@@ -1,0 +1,1 @@
+Fixed a problem where CMSIS-DAP probes may cause a panic.

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
@@ -138,8 +138,6 @@ impl InnerTransferResponse {
 pub struct TransferRequest {
     /// Zero based device index of the selected JTAG device. For SWD mode the value is ignored.
     pub dap_index: u8,
-    /// Number of transfers: 1 .. 255. For each transfer a Transfer Request BYTE is sent. Depending on the request an additional Transfer Data WORD is sent.
-    pub transfer_count: u8,
     transfers: Vec<InnerTransferRequest>,
 }
 
@@ -147,7 +145,6 @@ impl TransferRequest {
     pub fn empty() -> Self {
         Self {
             dap_index: 0,
-            transfer_count: 0,
             transfers: vec![],
         }
     }
@@ -167,7 +164,6 @@ impl TransferRequest {
     pub fn add_read(&mut self, port: PortType, addr: u8) {
         self.transfers
             .push(InnerTransferRequest::new(port, RW::R, addr as u8, None));
-        self.transfer_count += 1;
     }
 
     pub fn add_write(&mut self, port: PortType, addr: u8, data: u32) {
@@ -177,7 +173,6 @@ impl TransferRequest {
             addr as u8,
             Some(data),
         ));
-        self.transfer_count += 1;
     }
 }
 
@@ -192,7 +187,7 @@ impl Request for TransferRequest {
         buffer[0] = self.dap_index;
         size += 1;
 
-        buffer[1] = self.transfer_count;
+        buffer[1] = self.transfers.len() as u8;
         size += 1;
 
         for transfer in self.transfers.iter() {

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
@@ -15,7 +15,7 @@ pub enum RW {
 /// Contains information about requested access from host debugger.
 #[allow(non_snake_case)]
 #[derive(Clone, Debug)]
-pub struct InnerTransferRequest {
+struct InnerTransferRequest {
     /// 0 = Debug PortType (DP), 1 = Access PortType (AP).
     pub APnDP: PortType,
     /// 0 = Write Register, 1 = Read Register.
@@ -140,16 +140,44 @@ pub struct TransferRequest {
     pub dap_index: u8,
     /// Number of transfers: 1 .. 255. For each transfer a Transfer Request BYTE is sent. Depending on the request an additional Transfer Data WORD is sent.
     pub transfer_count: u8,
-    pub transfers: Vec<InnerTransferRequest>,
+    transfers: Vec<InnerTransferRequest>,
 }
 
 impl TransferRequest {
-    pub fn new(transfers: &[InnerTransferRequest]) -> Self {
+    pub fn empty() -> Self {
         Self {
             dap_index: 0,
-            transfer_count: transfers.len() as u8,
-            transfers: transfers.into(),
+            transfer_count: 0,
+            transfers: vec![],
         }
+    }
+
+    pub fn read(port: PortType, addr: u8) -> Self {
+        let mut req = Self::empty();
+        req.add_read(port, addr);
+        req
+    }
+
+    pub fn write(port: PortType, addr: u8, data: u32) -> Self {
+        let mut req = Self::empty();
+        req.add_write(port, addr, data);
+        req
+    }
+
+    pub fn add_read(&mut self, port: PortType, addr: u8) {
+        self.transfers
+            .push(InnerTransferRequest::new(port, RW::R, addr as u8, None));
+        self.transfer_count += 1;
+    }
+
+    pub fn add_write(&mut self, port: PortType, addr: u8, data: u32) {
+        self.transfers.push(InnerTransferRequest::new(
+            port,
+            RW::W,
+            addr as u8,
+            Some(data),
+        ));
+        self.transfer_count += 1;
     }
 }
 

--- a/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
+++ b/probe-rs/src/probe/cmsisdap/commands/transfer/mod.rs
@@ -163,16 +163,12 @@ impl TransferRequest {
 
     pub fn add_read(&mut self, port: PortType, addr: u8) {
         self.transfers
-            .push(InnerTransferRequest::new(port, RW::R, addr as u8, None));
+            .push(InnerTransferRequest::new(port, RW::R, addr, None));
     }
 
     pub fn add_write(&mut self, port: PortType, addr: u8, data: u32) {
-        self.transfers.push(InnerTransferRequest::new(
-            port,
-            RW::W,
-            addr as u8,
-            Some(data),
-        ));
+        self.transfers
+            .push(InnerTransferRequest::new(port, RW::W, addr, Some(data)));
     }
 }
 


### PR DESCRIPTION
... also fix an issue where aborting the transfer wasn't done correctly: the command was batched and the batch was not executed.

I guess we should get the CMSIS-DAP implementation aligned with arm_debug_interface, there are a few differences in fault/wait handling.